### PR TITLE
Intrepid2: add hierarchical bases for H(div) pyramids

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometry.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometry.hpp
@@ -98,6 +98,7 @@ namespace Intrepid2
       , FOUR_TRIANGLES      /// square --> four triangles, with a new vertex at center
       , FIVE_TETRAHEDRA     /// cube   --> five tetrahedra
       , SIX_TETRAHEDRA      /// cube   --> six tetrahedra
+      , SIX_PYRAMIDS        /// cube   --> six pyramids
     };
     
     /*! Distinguish between "classic" (counterclockwise in 2D, counterclockwise bottom followed by counterclockwise top in 3D) Shards ordering and a more natural tensor ordering.  The tensor ordering is such that the lowest-order bit in the composite vertex number corresponds to the x dimension, the second-lowest-order bit corresponds to the y dimension, etc.  (There is not yet a non-"classic" Shards ordering, but we hope to add one.) */
@@ -221,6 +222,10 @@ namespace Intrepid2
     
     //! The shards CellTopology for each cell within the CellGeometry object.  Note that this is always a lowest-order CellTopology, even for higher-order curvilinear geometry.  Higher-order geometry for CellGeometry is expressed in terms of the basis returned by basisForNodes().
     const shards::CellTopology & cellTopology() const;
+    
+    //! Returns a global node number corresponding to the specified (cell, node) combination.  If uniform grid (possibly subdivided), this number is computed dynamically; for more general meshes, this simply returns the result of a lookup in the cellToNodes container provided at construction.
+    KOKKOS_INLINE_FUNCTION
+    ordinal_type cellToNode(ordinal_type cellIndex, ordinal_type cellNodeNumber) const;
     
     //! Indicates the type of geometric variation from one cell to the next.  If all cells are known to have the same geometry, returns CONSTANT.
     //! Returns CONSTANT for uniform grids with no subdivisions, MODULAR for uniform grids with subdivisions, GENERAL for all others.

--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
@@ -1475,10 +1475,10 @@ namespace Intrepid2
   void CellGeometry<PointScalar,spaceDim,DeviceType>::orientations(ScalarView<Orientation,DeviceType> orientationsView, const int &startCell, const int &endCell)
   {
     auto orientationsData = getOrientations();
-    const unsigned numCellsWorkset = (endCell == -1) ? (numCells_ - startCell) : (endCell - startCell);
+    const int numCellsWorkset = (endCell == -1) ? (numCells_ - startCell) : (endCell - startCell);
     
     using ExecutionSpace = typename DeviceType::execution_space;
-    auto policy = Kokkos::RangePolicy<>(ExecutionSpace(),0,numCellsWorkset);
+    auto policy = Kokkos::RangePolicy<ExecutionSpace>(ExecutionSpace(),0,numCellsWorkset);
     Kokkos::parallel_for("copy orientations", policy, KOKKOS_LAMBDA(const int cellOrdinal)
     {
       orientationsView(cellOrdinal) = orientationsData(cellOrdinal);

--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
@@ -1475,7 +1475,7 @@ namespace Intrepid2
   void CellGeometry<PointScalar,spaceDim,DeviceType>::orientations(ScalarView<Orientation,DeviceType> orientationsView, const int &startCell, const int &endCell)
   {
     auto orientationsData = getOrientations();
-    int numCellsWorkset = (endCell == -1) ? (numCells_ - startCell) : (endCell - startCell);
+    const unsigned numCellsWorkset = (endCell == -1) ? (numCells_ - startCell) : (endCell - startCell);
     
     using ExecutionSpace = typename DeviceType::execution_space;
     auto policy = Kokkos::RangePolicy<>(ExecutionSpace(),0,numCellsWorkset);

--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
@@ -173,6 +173,7 @@ namespace Intrepid2
         return 4;
       case FIVE_TETRAHEDRA:
         return 5;
+      case SIX_PYRAMIDS:
       case SIX_TETRAHEDRA:
         return 6;
     }
@@ -747,6 +748,69 @@ namespace Intrepid2
   
   template<class PointScalar, int spaceDim, typename DeviceType>
   KOKKOS_INLINE_FUNCTION
+  ordinal_type CellGeometry<PointScalar,spaceDim,DeviceType>::cellToNode(ordinal_type cell, ordinal_type node) const
+  {
+    if (cellToNodes_.is_allocated())
+    {
+      return cellToNodes_(cell,node);
+    }
+    else if (cellGeometryType_ == UNIFORM_GRID)
+    {
+      const ordinal_type numSubdivisions    = numCellsPerGridCell(subdivisionStrategy_);
+      const ordinal_type gridCell           = cell / numSubdivisions;
+      const ordinal_type subdivisionOrdinal = cell % numSubdivisions;
+      
+      Kokkos::Array<ordinal_type,spaceDim> gridCellCoords;
+      ordinal_type gridCellDivided = gridCell;
+      ordinal_type numGridNodes    = 1;
+      ordinal_type numGridCells    = 1;
+      for (int d=0; d<spaceDim; d++)
+      {
+        gridCellCoords[d] = gridCellDivided % gridCellCounts_[d];
+        gridCellDivided   = gridCellDivided / gridCellCounts_[d];
+        numGridCells *= gridCellCounts_[d];
+        numGridNodes *= (gridCellCounts_[d] + 1);
+      }
+      
+      const ordinal_type gridCellNode = gridCellNodeForSubdivisionNode(gridCell, subdivisionOrdinal, node);
+      
+      // most subdivision strategies don't add internal node(s), but a couple do.  If so, the gridCellNode
+      // will be equal to the number of vertices in the grid cell.
+      const ordinal_type numInteriorNodes = ((subdivisionStrategy_ == FOUR_TRIANGLES) || (subdivisionStrategy_ == SIX_PYRAMIDS)) ? 1 : 0;
+      
+      // the global nodes list the grid-cell-interior nodes first.
+      const ordinal_type gridNodeNumberingOffset = numInteriorNodes * numGridCells;
+      
+      const ordinal_type numNodesPerGridCell = 1 << spaceDim;
+      if (gridCellNode >= numNodesPerGridCell)
+      {
+        const ordinal_type interiorGridNodeOffset = gridCellNode - numNodesPerGridCell;
+        return numNodesPerGridCell * gridCell + interiorGridNodeOffset;
+      }
+      else
+      {
+        // use gridCellCoords, plus hypercubeComponentNodeNumber(gridCellNode, d), to set up a Cartesian vertex numbering of the grid as a whole.  Then, add gridNodeNumberingOffset to account for interior nodes.
+        // let x be the fastest-moving index
+        ordinal_type d_index_stride = 1; // number of node indices we move by moving 1 node in dimension d
+        ordinal_type cartesianNodeNumber = 0;
+        for (int d=0; d<spaceDim; d++)
+        {
+          const ordinal_type d_index = gridCellCoords[d] + hypercubeComponentNodeNumber(gridCellNode,d);
+          cartesianNodeNumber += d_index * d_index_stride;
+          d_index_stride *= (gridCellCounts_[d] + 1);
+        }
+        return cartesianNodeNumber + gridNodeNumberingOffset;
+      }
+    }
+    else
+    {
+      // cellToNode() not supported
+      return -1;
+    }
+  }
+
+  template<class PointScalar, int spaceDim, typename DeviceType>
+  KOKKOS_INLINE_FUNCTION
   DataVariationType CellGeometry<PointScalar,spaceDim,DeviceType>::cellVariationType() const
   {
     if (cellGeometryType_ == UNIFORM_GRID)
@@ -1266,6 +1330,65 @@ namespace Intrepid2
         const int gridCellNodeNumber = nodeLookup[subdivisionNodeNumber];
         return gridCellNodeNumber;
       }
+      case SIX_PYRAMIDS:
+      {
+        Kokkos::Array<int,5> nodeLookup; // nodeLookup[4] = 8; // center
+        // we order the subcell divisions as bottom, top, left, right, front, back
+         if (nodeOrdering_ == HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS)
+         {
+          switch (subdivisionOrdinal)
+          {
+            case 0: // bottom (min z)
+              nodeLookup = {0,1,2,3,8};
+              break;
+            case 1: // top (max z)
+              nodeLookup = {4,5,6,7,8};
+              break;
+            case 2: // left (min y)
+              nodeLookup = {0,1,5,4,8};
+              break;
+            case 3: // right (max y)
+              nodeLookup = {3,2,6,7,8};
+              break;
+            case 4: // front (max x)
+              nodeLookup = {1,2,6,5,8};
+              break;
+            case 5: // back (min x)
+              nodeLookup = {0,3,7,4,8};
+              break;
+            default:
+              INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(true, std::invalid_argument, "Invalid subdivisionOrdinal!");
+          }
+        }
+        else // tensor ordering
+        {
+          switch (subdivisionOrdinal)
+          {
+            case 0: // bottom (min z)
+              nodeLookup = {0,1,3,2,8};
+              break;
+            case 1: // top (max z)
+              nodeLookup = {4,5,7,6,8};
+              break;
+            case 2: // left (min y)
+              nodeLookup = {0,1,5,4,8};
+              break;
+            case 3: // right (max y)
+              nodeLookup = {2,3,7,6,8};
+              break;
+            case 4: // front (max x)
+              nodeLookup = {1,3,7,5,8};
+              break;
+            case 5: // back (min x)
+              nodeLookup = {0,2,6,4,8};
+              break;
+            default:
+              INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(true, std::invalid_argument, "Invalid subdivisionOrdinal!");
+        }
+        }
+        const int gridCellNodeNumber = nodeLookup[subdivisionNodeNumber];
+        return gridCellNodeNumber;
+      }
       default:
         INTREPID2_TEST_FOR_EXCEPTION_DEVICE_SAFE(true, std::invalid_argument, "Subdivision strategy not yet implemented!");
         // some compilers complain about missing return
@@ -1282,13 +1405,25 @@ namespace Intrepid2
     
     if (subdivisionStrategy_ == FOUR_TRIANGLES)
     {
-      // this is the one case in which the gridCellNode may not actually be a node in the grid cell
+      // this is a case in which the gridCellNode may not actually be a node in the grid cell
       if (gridCellNode == 4) // center vertex
       {
         // d == 0 means quad vertices 0 and 1 suffice;
         // d == 1 means quad vertices 0 and 3 suffice
         const int gridVertex0 = 0;
         const int gridVertex1 = (d == 0) ? 1 : 3;
+        return 0.5 * (gridCellCoordinate(gridCellOrdinal, gridVertex0, d) + gridCellCoordinate(gridCellOrdinal, gridVertex1, d));
+      }
+    }
+    else if (subdivisionStrategy_ == SIX_PYRAMIDS)
+    {
+      // this is a case in which the gridCellNode may not actually be a node in the grid cell
+      if (gridCellNode == 8) // center vertex
+      {
+        // can compute the center vertex coord in dim d by averaging diagonally opposite vertices'
+        // coords in dimension d.
+        const int gridVertex0 = 0; // 0 is diagonally opposite to 6 or 7, depending on nodeOrdering_
+        const int gridVertex1 = (nodeOrdering_ == HYPERCUBE_NODE_ORDER_CLASSIC_SHARDS) ? 6 : 7;
         return 0.5 * (gridCellCoordinate(gridCellOrdinal, gridVertex0, d) + gridCellCoordinate(gridCellOrdinal, gridVertex1, d));
       }
     }

--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
@@ -1475,7 +1475,7 @@ namespace Intrepid2
   void CellGeometry<PointScalar,spaceDim,DeviceType>::orientations(ScalarView<Orientation,DeviceType> orientationsView, const int &startCell, const int &endCell)
   {
     auto orientationsData = getOrientations();
-    const int numCellsWorkset = (endCell == -1) ? (numCells_ - startCell) : (endCell - startCell);
+    int numCellsWorkset = (endCell == -1) ? (numCells_ - startCell) : (endCell - startCell);
     
     using ExecutionSpace = typename DeviceType::execution_space;
     auto policy = Kokkos::RangePolicy<>(ExecutionSpace(),0,numCellsWorkset);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasisFamily.hpp
@@ -409,7 +409,7 @@ namespace Intrepid2
     {
       case FUNCTION_SPACE_HVOL:  return rcp(new typename BasisFamily::HVOL_PYR (polyOrder, pointType));
 //      case FUNCTION_SPACE_HCURL: return rcp(new typename BasisFamily::HCURL_PYR(polyOrder, pointType));
-//      case FUNCTION_SPACE_HDIV:  return rcp(new typename BasisFamily::HDIV_PYR (polyOrder, pointType));
+      case FUNCTION_SPACE_HDIV:  return rcp(new typename BasisFamily::HDIV_PYR (polyOrder, pointType));
       case FUNCTION_SPACE_HGRAD: return rcp(new typename BasisFamily::HGRAD_PYR(polyOrder, pointType));
       default:
         INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Unsupported function space");

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
@@ -54,6 +54,7 @@
 #include "Intrepid2_HierarchicalBasis_HCURL_TET.hpp"
 #include "Intrepid2_HierarchicalBasis_HDIV_TRI.hpp"
 #include "Intrepid2_HierarchicalBasis_HDIV_TET.hpp"
+#include "Intrepid2_HierarchicalBasis_HDIV_PYR.hpp"
 #include "Intrepid2_IntegratedLegendreBasis_HGRAD_LINE.hpp"
 #include "Intrepid2_IntegratedLegendreBasis_HGRAD_TRI.hpp"
 #include "Intrepid2_IntegratedLegendreBasis_HGRAD_TET.hpp"
@@ -115,7 +116,7 @@ namespace Intrepid2 {
     // we will fill these in as we implement them
     using HGRAD = IntegratedLegendreBasis_HGRAD_PYR<DeviceType,OutputScalar,PointScalar,defineVertexFunctions>;
     using HCURL = void;
-    using HDIV  = void;
+    using HDIV  = HierarchicalBasis_HDIV_PYR<DeviceType,OutputScalar,PointScalar>;
     using HVOL  = LegendreBasis_HVOL_PYR<DeviceType,OutputScalar,PointScalar>;
   };
   

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HDIV_PYR.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HDIV_PYR.hpp
@@ -1,0 +1,1074 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Mauro Perego  (mperego@sandia.gov) or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/** \file   Intrepid2_HierarchicalBasis_HDIV_PYR.hpp
+    \brief  H(div) basis on the pyramid based on integrated Legendre polynomials.
+    \author Created by N.V. Roberts.
+ 
+ Note that although this basis is derived from integrated Legendre polynomials, it is not itself a polynomial basis, but a set of rational functions.
+ 
+ The construction is also hierarchical, in the sense that the basis for p-1 is included in the basis for p.
+ */
+
+#ifndef Intrepid2_HierarchicalBasis_HDIV_PYR_h
+#define Intrepid2_HierarchicalBasis_HDIV_PYR_h
+
+#include <Kokkos_DynRankView.hpp>
+
+#include <Intrepid2_config.h>
+
+#include "Intrepid2_Basis.hpp"
+#include "Intrepid2_DerivedBasis_HVOL_QUAD.hpp"
+#include "Intrepid2_LegendreBasis_HVOL_LINE.hpp"
+#include "Intrepid2_LegendreBasis_HVOL_TRI.hpp"
+#include "Intrepid2_Polynomials.hpp"
+#include "Intrepid2_PyramidCoords.hpp"
+#include "Intrepid2_Utils.hpp"
+
+#include "Teuchos_RCP.hpp"
+
+namespace Intrepid2
+{
+  /** \class  Intrepid2::Hierarchical_HDIV_PYR_Functor
+      \brief  Functor for computing values for the HierarchicalBasis_HDIV_PYR class.
+   
+   This functor is not intended for use outside of HierarchicalBasis_HDIV_PYR.
+  */
+  template<class DeviceType, class OutputScalar, class PointScalar,
+           class OutputFieldType, class InputPointsType>
+  struct Hierarchical_HDIV_PYR_Functor
+  {
+    using ExecutionSpace      = typename DeviceType::execution_space;
+    using ScratchSpace        = typename ExecutionSpace::scratch_memory_space;
+    using OutputScratchView   = Kokkos::View<OutputScalar*,ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    using OutputScratchView2D = Kokkos::View<OutputScalar**,ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    using PointScratchView    = Kokkos::View<PointScalar*, ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    
+    using TeamPolicy = Kokkos::TeamPolicy<ExecutionSpace>;
+    using TeamMember = typename TeamPolicy::member_type;
+    
+    EOperator opType_;
+    
+    OutputFieldType  output_;      // F,P
+    InputPointsType  inputPoints_; // P,D
+    
+    int polyOrder_;
+    bool defineVertexFunctions_;
+    int numFields_, numPoints_;
+    
+    size_t fad_size_output_;
+    
+    static const int numVertices   = 5;
+    static const int numMixedEdges = 4;
+    static const int numTriEdges   = 4;
+    static const int numEdges      = 8;
+    // the following ordering of the edges matches that used by ESEAS
+    // (it *looks* like this is what ESEAS uses; the basis comparison tests will clarify whether I've read their code correctly)
+    // see also PyramidEdgeNodeMap in Shards_BasicTopologies.hpp
+    const int edge_start_[numEdges] = {0,1,2,3,0,1,2,3}; // edge i is from edge_start_[i] to edge_end_[i]
+    const int edge_end_[numEdges]   = {1,2,3,0,4,4,4,4}; // edge i is from edge_start_[i] to edge_end_[i]
+    
+    // quadrilateral face comes first
+    static const int numQuadFaces = 1;
+    static const int numTriFaces  = 4;
+    
+    // face ordering matches ESEAS.  (See BlendProjectPyraTF in ESEAS.)
+    const int tri_face_vertex_0[numTriFaces] = {0,1,3,0}; // faces are abc where 0 ≤ a < b < c ≤ 3
+    const int tri_face_vertex_1[numTriFaces] = {1,2,2,3};
+    const int tri_face_vertex_2[numTriFaces] = {4,4,4,4};
+    
+    Hierarchical_HDIV_PYR_Functor(EOperator opType, OutputFieldType output, InputPointsType inputPoints,
+                                   int polyOrder, bool defineVertexFunctions)
+    : opType_(opType), output_(output), inputPoints_(inputPoints),
+      polyOrder_(polyOrder), defineVertexFunctions_(defineVertexFunctions),
+      fad_size_output_(getScalarDimensionForView(output))
+    {
+      numFields_ = output.extent_int(0);
+      numPoints_ = output.extent_int(1);
+      const auto & p = polyOrder;
+      const auto p3  = p * p * p;
+      INTREPID2_TEST_FOR_EXCEPTION(numPoints_ != inputPoints.extent_int(0), std::invalid_argument, "point counts need to match!");
+      INTREPID2_TEST_FOR_EXCEPTION(numFields_ != p3 + 3 * p + 1, std::invalid_argument, "output field size does not match basis cardinality");
+    }
+    
+    //! cross product: c = a x b
+    KOKKOS_INLINE_FUNCTION
+    void cross(Kokkos::Array<OutputScalar,3> &c,
+               const Kokkos::Array<OutputScalar,3> &a,
+               const Kokkos::Array<OutputScalar,3> &b)
+    {
+      c[0] = a[1] * b[2] - a[2] * b[1];
+      c[1] = a[0] * b[2] - a[2] * b[0];
+      c[2] = a[0] * b[1] - a[1] * b[0];
+    }
+    
+    KOKKOS_INLINE_FUNCTION
+    void E_E(Kokkos::Array<OutputScalar,3> &EE,
+             const ordinal_type &i,
+             const OutputScratchView &PHom,
+             const PointScalar &s0, const PointScalar &s1,
+             const Kokkos::Array<PointScalar,3> &s0_grad,
+             const Kokkos::Array<PointScalar,3> &s1_grad)
+    {
+      const auto & P_i = PHom(i);
+      for (ordinal_type d=0; d<3; d++)
+      {
+        EE[d] = P_i * (s0 * s1_grad[d] - s1 * s0_grad[d]);
+      }
+    }
+    
+    //! The "quadrilateral face" H(div) functions defined by Fuentes et al., Appendix E.2., p. 433
+    //! Here, PHom are the homogenized Legendre polynomials [P](s0,s1) and [P](t0,t1), given in Appendix E.1, p. 430
+    KOKKOS_INLINE_FUNCTION
+    void V_QUAD(Kokkos::Array<OutputScalar,3> VQUAD,
+                const ordinal_type &i, const ordinal_type &j,
+                const OutputScratchView &PHom_s,
+                const PointScalar &s0, const PointScalar &s1,
+                const Kokkos::Array<PointScalar,3> &s0_grad,
+                const Kokkos::Array<PointScalar,3> &s1_grad,
+                const OutputScratchView &PHom_t,
+                const PointScalar &t0, const PointScalar &t1,
+                const Kokkos::Array<PointScalar,3> &t0_grad,
+                const Kokkos::Array<PointScalar,3> &t1_grad)
+    {
+      Kokkos::Array<OutputScalar,3> EE_i, EE_j;
+      
+      E_E(EE_i, i, PHom_s, s0, s1, s0_grad, s1_grad);
+      E_E(EE_j, j, PHom_t, t0, t1, t0_grad, t1_grad);
+      
+      // VQUAD = EE_i x EE_j:
+      cross(VQUAD, EE_i, EE_j);
+    }
+    
+    KOKKOS_INLINE_FUNCTION
+    void operator()( const TeamMember & teamMember ) const
+    {
+      // TODO: rewrite this -- copied from H(grad) implementation
+      auto pointOrdinal = teamMember.league_rank();
+      OutputScratchView scratch1D_1, scratch1D_2, scratch1D_3;
+      OutputScratchView scratch1D_4, scratch1D_5, scratch1D_6;
+      OutputScratchView scratch1D_7, scratch1D_8, scratch1D_9;
+      OutputScratchView2D scratch2D_1, scratch2D_2, scratch2D_3;
+      const int numAlphaValues = (polyOrder_-1 > 1) ? (polyOrder_-1) : 1; // make numAlphaValues at least 1 so we can avoid zero-extent allocations…
+      if (fad_size_output_ > 0) {
+        scratch1D_1 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_2 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_3 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_4 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_5 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_6 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_7 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_8 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch1D_9 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        scratch2D_1 = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1, fad_size_output_);
+        scratch2D_2 = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1, fad_size_output_);
+        scratch2D_3 = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1, fad_size_output_);
+      }
+      else {
+        scratch1D_1 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_2 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_3 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_4 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_5 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_6 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_7 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_8 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch1D_9 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        scratch2D_1 = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1);
+        scratch2D_2 = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1);
+        scratch2D_3 = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1);
+      }
+      
+      const auto & x = inputPoints_(pointOrdinal,0);
+      const auto & y = inputPoints_(pointOrdinal,1);
+      const auto & z = inputPoints_(pointOrdinal,2);
+      
+      // Intrepid2 uses (-1,1)^2 for x,y
+      // ESEAS uses (0,1)^2
+      // (Can look at what we do on the HGRAD_LINE for reference; there's a similar difference for line topology.)
+      
+      Kokkos::Array<PointScalar,3> coords;
+      transformToESEASPyramid<>(coords[0], coords[1], coords[2], x, y, z); // map x,y coordinates from (-z,z)^2 to (0,z)^2
+      
+      // pyramid "affine" coordinates and gradients get stored in lambda, lambdaGrad:
+      using Kokkos::Array;
+      Array<PointScalar,5> lambda;
+      Array<Kokkos::Array<PointScalar,3>,5> lambdaGrad;
+      
+      Array<Array<PointScalar,3>,2> mu;
+      Array<Array<Array<PointScalar,3>,3>,2> muGrad;
+      
+      Array<Array<PointScalar,2>,3> nu;
+      Array<Array<Array<PointScalar,3>,2>,3> nuGrad;
+      
+      affinePyramid(lambda, lambdaGrad, mu, muGrad, nu, nuGrad, coords);
+      
+      switch (opType_)
+      {
+        case OPERATOR_VALUE:
+        {
+          // starting the H(div) rewrite here
+          ordinal_type fieldOrdinalOffset = 0;
+          // quadrilateral face
+          // rename scratch1, scratch2
+          auto & Pi = scratch1D_1;
+          auto & Pj = scratch1D_2;
+          
+          auto & s0      =     mu[0][0], s1      =     mu[1][0];
+          auto & s0_grad = muGrad[0][0], s1_grad = muGrad[1][0];
+          auto & t0      =     mu[0][1], t1      =     mu[1][1];
+          auto & t0_grad = muGrad[0][1], t1_grad = muGrad[1][1];
+          
+          Polynomials::shiftedScaledLegendreValues(Pi, polyOrder_-1, s1, s0 + s1);
+          Polynomials::shiftedScaledLegendreValues(Pj, polyOrder_-1, t1, t0 + t1);
+          
+          OutputScalar mu0_cubed = mu[2][0] * mu[2][0] * mu[2][0];
+          
+          // following the ESEAS ordering: j increments first
+          for (int j=0; j<polyOrder_; j++)
+          {
+            for (int i=0; i<polyOrder_; i++)
+            {
+              Kokkos::Array<OutputScalar,3> VQUAD; // output from V_QUAD
+              V_QUAD(VQUAD, i, j,
+                     Pi, s0, s1, s0_grad, s1_grad,
+                     Pj, t0, t1, t0_grad, t1_grad);
+              
+              for (int d=0; d<3; d++)
+              {
+                output_(fieldOrdinalOffset,pointOrdinal,d) = mu0_cubed * VQUAD[d];
+              }
+              fieldOrdinalOffset++;
+            }
+          }
+          
+          // triangle faces
+          
+          /*
+           Face functions for triangular face (d,e,f) given by:
+           1/2 * (    mu_c^{zeta,xi_b} * V_TRI_ij(nu_012^{zeta,xi_a})
+                  + 1/mu_c^{zeta,xi_b} * V_TRI_ij(nu_012^{zeta,xi_a} * mu_c^{zeta,xi_b}) )
+           but the division by mu_c^{zeta,xi_b} should be avoided in computations, so
+           
+           where s0, s1, s2 are nu[0][a-1],nu[1][a-1],nu[2][a-1] (nu_012 above)
+           and (a,b) = (1,2) for faces 0,2; (a,b) = (2,1) for others;
+                   c = 0     for faces 0,3;     c = 1 for others
+           */
+          for (int faceOrdinal=0; faceOrdinal<numTriFaces; faceOrdinal++)
+          {
+            // face 0,2 --> a=1, b=2
+            // face 1,3 --> a=2, b=1
+            int a = (faceOrdinal % 2 == 0) ? 1 : 2;
+            int b = 3 - a;
+            // face 0,3 --> c=0
+            // face 1,2 --> c=1
+            int c = ((faceOrdinal == 0) || (faceOrdinal == 3)) ? 0 : 1;
+            
+            const auto & s0 = nu[0][a-1];
+            const auto & s1 = nu[1][a-1];
+            const auto & s2 = nu[2][a-1];
+            const PointScalar jacobiScaling = s0 + s1 + s2;
+            
+            // TODO: finish this
+//            // compute integrated Jacobi values for each desired value of alpha
+//            // relabel scratch2D_1
+//            auto & jacobi = scratch2D_1;
+//            for (int n=2; n<=polyOrder_; n++)
+//            {
+//              const double alpha = n*2;
+//              const int alphaOrdinal = n-2;
+//              using Kokkos::subview;
+//              using Kokkos::ALL;
+//              auto jacobi_alpha = subview(jacobi, alphaOrdinal, ALL);
+//              Polynomials::shiftedScaledIntegratedJacobiValues(jacobi_alpha, alpha, polyOrder_-2, s2, jacobiScaling);
+//            }
+//            // relabel scratch1D_1
+//            auto & edge_s0s1 = scratch1D_1;
+//            Polynomials::shiftedScaledIntegratedLegendreValues(edge_s0s1, polyOrder_, s1, s0 + s1);
+//
+//            for (int totalPolyOrder=3; totalPolyOrder<=polyOrder_; totalPolyOrder++)
+//            {
+//              for (int i=2; i<totalPolyOrder; i++)
+//              {
+//                const auto & edgeValue = edge_s0s1(i);
+//                const int alphaOrdinal = i-2;
+//
+//                const int j = totalPolyOrder - i;
+//                const auto & jacobiValue = jacobi(alphaOrdinal,j);
+//                output_(fieldOrdinalOffset,pointOrdinal) = mu[c][b-1] * edgeValue * jacobiValue;
+//
+//                fieldOrdinalOffset++;
+//              }
+//            }
+          }
+          
+          // end rewritten portion
+          
+          // TODO: interior functions (below is from H^1 implementation)
+          // interior functions
+          // these are the product of the same quadrilateral function that we blended for the quadrilateral face and
+          // [L_k](mu_{0}^zeta, mu_1^zeta)
+            
+          // rename scratch
+                 Li = scratch1D_1;
+                 Lj = scratch1D_2;
+          auto & Lk = scratch1D_3;
+          Polynomials::shiftedScaledIntegratedLegendreValues(Li, polyOrder_, mu[1][0], mu[0][0] + mu[1][0]);
+          Polynomials::shiftedScaledIntegratedLegendreValues(Lj, polyOrder_, mu[1][1], mu[0][1] + mu[1][1]);
+          Polynomials::shiftedScaledIntegratedLegendreValues(Lk, polyOrder_, mu[1][2], mu[0][2] + mu[1][2]);
+          // following the ESEAS ordering: k increments first
+          for (int k=2; k<=polyOrder_; k++)
+          {
+            for (int j=2; j<=polyOrder_; j++)
+            {
+              for (int i=2; i<=polyOrder_; i++)
+              {
+                output_(fieldOrdinalOffset,pointOrdinal) = Lk(k) * Li(i) * Lj(j);
+                fieldOrdinalOffset++;
+              }
+            }
+          }
+        } // end OPERATOR_VALUE
+          break;
+        case OPERATOR_GRAD:
+        case OPERATOR_D1:
+        {
+          // TODO: rewrite this -- the below comes from the H^1 implementation
+          // vertex functions
+          
+          for (int vertexOrdinal=0; vertexOrdinal<numVertices; vertexOrdinal++)
+          {
+            for (int d=0; d<3; d++)
+            {
+              output_(vertexOrdinal,pointOrdinal,d) = lambdaGrad[vertexOrdinal][d];
+            }
+          }
+          
+          if (!defineVertexFunctions_)
+          {
+            // "DG" basis case
+            // here, the first "vertex" function is 1, so the derivative is 0:
+            output_(0,pointOrdinal,0) = 0.0;
+            output_(0,pointOrdinal,1) = 0.0;
+            output_(0,pointOrdinal,2) = 0.0;
+          }
+
+          // edge functions
+          int fieldOrdinalOffset = numVertices;
+          
+          // mixed edges first
+          auto & P_i_minus_1 = scratch1D_1;
+          auto & L_i_dt      = scratch1D_2; // R_{i-1} = d/dt L_i
+          auto & L_i         = scratch1D_3;
+          
+          for (int edgeOrdinal=0; edgeOrdinal<numMixedEdges; edgeOrdinal++)
+          {
+            // edge 0,2 --> a=1, b=2
+            // edge 1,3 --> a=2, b=1
+            int a = (edgeOrdinal % 2 == 0) ? 1 : 2;
+            int b = 3 - a;
+            
+            Polynomials::shiftedScaledLegendreValues             (P_i_minus_1, polyOrder_-1, nu[1][a-1], nu[0][a-1] + nu[1][a-1]);
+            Polynomials::shiftedScaledIntegratedLegendreValues_dt(L_i_dt,      polyOrder_,   nu[1][a-1], nu[0][a-1] + nu[1][a-1]);
+            Polynomials::shiftedScaledIntegratedLegendreValues   (L_i,         polyOrder_,   nu[1][a-1], nu[0][a-1] + nu[1][a-1]);
+            
+            // edge 0,3 --> c=0
+            // edge 1,2 --> c=1
+            int c = ((edgeOrdinal == 0) || (edgeOrdinal == 3)) ? 0 : 1;
+            for (int i=2; i<=polyOrder_; i++)
+            {
+              // grad (mu[c][b-1] * Li(i)) = grad (mu[c][b-1]) * Li(i) + mu[c][b-1] * grad Li(i)
+              const auto & R_i_minus_1 = L_i_dt(i);
+              
+              for (int d=0; d<3; d++)
+              {
+                // grad [L_i](nu_0,nu_1) = [P_{i-1}](nu_0,nu_1) * grad nu_1 + [R_{i-1}](nu_0,nu_1) * grad (nu_0 + nu_1)
+                
+                OutputScalar grad_Li_d = P_i_minus_1(i-1) * nuGrad[1][a-1][d] + R_i_minus_1 * (nuGrad[0][a-1][d] + nuGrad[1][a-1][d]);
+                output_(fieldOrdinalOffset,pointOrdinal,d) = muGrad[c][b-1][d] * L_i(i) + mu[c][b-1] * grad_Li_d;
+              }
+              fieldOrdinalOffset++;
+            }
+          }
+          
+          // triangle edges next
+          P_i_minus_1 = scratch1D_1;
+          L_i_dt      = scratch1D_2; // R_{i-1} = d/dt L_i
+          L_i         = scratch1D_3;
+          for (int edgeOrdinal=0; edgeOrdinal<numMixedEdges; edgeOrdinal++)
+          {
+            const auto & lambda_a     = lambda    [edgeOrdinal];
+            const auto & lambdaGrad_a = lambdaGrad[edgeOrdinal];
+            Polynomials::shiftedScaledLegendreValues             (P_i_minus_1, polyOrder_-1, lambda[4], lambda_a + lambda[4]);
+            Polynomials::shiftedScaledIntegratedLegendreValues_dt(L_i_dt,      polyOrder_,   lambda[4], lambda_a + lambda[4]);
+            Polynomials::shiftedScaledIntegratedLegendreValues   (L_i,         polyOrder_,   lambda[4], lambda_a + lambda[4]);
+            
+            for (int i=2; i<=polyOrder_; i++)
+            {
+              const auto & R_i_minus_1 = L_i_dt(i);
+              for (int d=0; d<3; d++)
+              {
+                // grad [L_i](s0,s1) = [P_{i-1}](s0,s1) * grad s1 + [R_{i-1}](s0,s1) * grad (s0 + s1)
+                // here, s1 = lambda[4], s0 = lambda_a
+                OutputScalar grad_Li_d = P_i_minus_1(i-1) * lambdaGrad[4][d] + R_i_minus_1 * (lambdaGrad_a[d] + lambdaGrad[4][d]);
+                output_(fieldOrdinalOffset,pointOrdinal,d) = grad_Li_d;
+              }
+              fieldOrdinalOffset++;
+            }
+          }
+          
+          // quadrilateral faces
+          // rename scratch
+          P_i_minus_1 = scratch1D_1;
+          L_i_dt      = scratch1D_2; // R_{i-1} = d/dt L_i
+          L_i         = scratch1D_3;
+          auto & P_j_minus_1 = scratch1D_4;
+          auto & L_j_dt      = scratch1D_5; // R_{j-1} = d/dt L_j
+          auto & L_j         = scratch1D_6;
+          Polynomials::shiftedScaledIntegratedLegendreValues(L_i, polyOrder_, mu[1][0], mu[0][0] + mu[1][0]);
+          Polynomials::shiftedScaledIntegratedLegendreValues(L_j, polyOrder_, mu[1][1], mu[0][1] + mu[1][1]);
+          
+          Polynomials::shiftedScaledLegendreValues             (P_i_minus_1, polyOrder_-1, mu[1][0], mu[0][0] + mu[1][0]);
+          Polynomials::shiftedScaledIntegratedLegendreValues_dt(L_i_dt,      polyOrder_,   mu[1][0], mu[0][0] + mu[1][0]);
+          Polynomials::shiftedScaledIntegratedLegendreValues   (L_i,         polyOrder_,   mu[1][0], mu[0][0] + mu[1][0]);
+          
+          Polynomials::shiftedScaledLegendreValues             (P_j_minus_1, polyOrder_-1, mu[1][1], mu[0][1] + mu[1][1]);
+          Polynomials::shiftedScaledIntegratedLegendreValues_dt(L_j_dt,      polyOrder_,   mu[1][1], mu[0][1] + mu[1][1]);
+          Polynomials::shiftedScaledIntegratedLegendreValues   (L_j,         polyOrder_,   mu[1][1], mu[0][1] + mu[1][1]);
+          
+          // following the ESEAS ordering: j increments first
+          for (int j=2; j<=polyOrder_; j++)
+          {
+            const auto & R_j_minus_1 = L_j_dt(j);
+            
+            for (int i=2; i<=polyOrder_; i++)
+            {
+              const auto & R_i_minus_1 = L_i_dt(i);
+              
+              OutputScalar phi_quad = L_i(i) * L_j(j);
+              
+              for (int d=0; d<3; d++)
+              {
+                // grad [L_j](s0,s1) = [P_{j-1}](s0,s1) * grad s1 + [R_{j-1}](s0,s1) * grad (s0 + s1)
+                // here, s1 = mu[1][1], s0 = mu[0][1]
+                OutputScalar grad_Lj_d = P_j_minus_1(j-1) * muGrad[1][1][d] + R_j_minus_1 * (muGrad[0][1][d] + muGrad[1][1][d]);
+                // for L_i, s1 = mu[1][0], s0 = mu[0][0]
+                OutputScalar grad_Li_d = P_i_minus_1(i-1) * muGrad[1][0][d] + R_i_minus_1 * (muGrad[0][0][d] + muGrad[1][0][d]);
+                
+                OutputScalar grad_phi_quad_d = L_i(i) * grad_Lj_d + L_j(j) * grad_Li_d;
+                
+                output_(fieldOrdinalOffset,pointOrdinal,d) = mu[0][2] * grad_phi_quad_d + phi_quad * muGrad[0][2][d];
+              }
+              
+              fieldOrdinalOffset++;
+            }
+          }
+          
+          // triangle faces
+          for (int faceOrdinal=0; faceOrdinal<numTriFaces; faceOrdinal++)
+          {
+            // face 0,2 --> a=1, b=2
+            // face 1,3 --> a=2, b=1
+            int a = (faceOrdinal % 2 == 0) ? 1 : 2;
+            int b = 3 - a;
+            // face 0,3 --> c=0
+            // face 1,2 --> c=1
+            int c = ((faceOrdinal == 0) || (faceOrdinal == 3)) ? 0 : 1;
+            
+            const auto & s0 = nu[0][a-1];
+            const auto & s1 = nu[1][a-1];
+            const auto & s2 = nu[2][a-1];
+            
+            const auto & s0Grad = nuGrad[0][a-1];
+            const auto & s1Grad = nuGrad[1][a-1];
+            const auto & s2Grad = nuGrad[2][a-1];
+            
+            const PointScalar jacobiScaling = s0 + s1 + s2;
+            
+            // compute integrated Jacobi values for each desired value of alpha
+            // relabel storage:
+            // 1D containers:
+            auto & P_i_minus_1 = scratch1D_1;
+            auto & L_i_dt      = scratch1D_2; // R_{i-1} = d/dt L_i
+            auto & L_i         = scratch1D_3;
+            // 2D containers:
+            auto & L_2i_j_dt      = scratch2D_1;
+            auto & L_2i_j         = scratch2D_2;
+            auto & P_2i_j_minus_1 = scratch2D_3;
+            for (int n=2; n<=polyOrder_; n++)
+            {
+              const double alpha = n*2;
+              const int alphaOrdinal = n-2;
+              using Kokkos::subview;
+              using Kokkos::ALL;
+              auto L_2i_j_dt_alpha      = subview(L_2i_j_dt,      alphaOrdinal, ALL);
+              auto L_2i_j_alpha         = subview(L_2i_j,         alphaOrdinal, ALL);
+              auto P_2i_j_minus_1_alpha = subview(P_2i_j_minus_1, alphaOrdinal, ALL);
+              Polynomials::shiftedScaledIntegratedJacobiValues_dt(L_2i_j_dt_alpha, alpha, polyOrder_-2, s2, jacobiScaling);
+              Polynomials::shiftedScaledIntegratedJacobiValues   (   L_2i_j_alpha, alpha, polyOrder_-2, s2, jacobiScaling);
+              Polynomials::shiftedScaledJacobiValues        (P_2i_j_minus_1_alpha, alpha, polyOrder_-1, s2, jacobiScaling);
+            }
+            Polynomials::shiftedScaledLegendreValues             (P_i_minus_1, polyOrder_-1, s1, s0 + s1);
+            Polynomials::shiftedScaledIntegratedLegendreValues_dt(L_i_dt,      polyOrder_,   s1, s0 + s1);
+            Polynomials::shiftedScaledIntegratedLegendreValues   (L_i,         polyOrder_,   s1, s0 + s1);
+            
+            for (int totalPolyOrder=3; totalPolyOrder<=polyOrder_; totalPolyOrder++)
+            {
+              for (int i=2; i<totalPolyOrder; i++)
+              {
+                const int alphaOrdinal = i-2;
+                const int            j = totalPolyOrder - i;
+                
+                const auto & R_i_minus_1 = L_i_dt(i);
+                OutputScalar     phi_tri = L_2i_j(alphaOrdinal,j) * L_i(i);
+                
+                for (int d=0; d<3; d++)
+                {
+                  // grad [L_i](s0,s1) = [P_{i-1}](s0,s1) * grad s1 + [R_{i-1}](s0,s1) * grad (s0 + s1)
+                  OutputScalar grad_Li_d      = P_i_minus_1(i-1) * s1Grad[d] + R_i_minus_1 * (s0Grad[d] + s1Grad[d]);
+                  OutputScalar grad_L2i_j_d   = P_2i_j_minus_1(alphaOrdinal,j-1) * s2Grad[d] + L_2i_j_dt(alphaOrdinal,j) * (s0Grad[d] + s1Grad[d] + s2Grad[d]);
+                  OutputScalar grad_phi_tri_d = L_i(i) * grad_L2i_j_d + L_2i_j(alphaOrdinal,j) * grad_Li_d;
+                  
+                  output_(fieldOrdinalOffset,pointOrdinal,d) = mu[c][b-1] * grad_phi_tri_d + phi_tri * muGrad[c][b-1][d];
+                }
+                fieldOrdinalOffset++;
+              }
+            }
+          }
+          
+          // interior functions
+          P_i_minus_1 = scratch1D_1;
+          L_i_dt      = scratch1D_2; // R_{i-1} = d/dt L_i
+          L_i         = scratch1D_3;
+          P_j_minus_1 = scratch1D_4;
+          L_j_dt      = scratch1D_5; // R_{j-1} = d/dt L_j
+          L_j         = scratch1D_6;
+          auto & P_k_minus_1 = scratch1D_7;
+          auto & L_k_dt      = scratch1D_8; // R_{k-1} = d/dt L_k
+          auto & L_k         = scratch1D_9;
+          
+          Polynomials::shiftedScaledLegendreValues             (P_i_minus_1, polyOrder_-1, mu[1][0], mu[0][0] + mu[1][0]);
+          Polynomials::shiftedScaledIntegratedLegendreValues_dt(L_i_dt,      polyOrder_,   mu[1][0], mu[0][0] + mu[1][0]);
+          Polynomials::shiftedScaledIntegratedLegendreValues   (L_i,         polyOrder_,   mu[1][0], mu[0][0] + mu[1][0]);
+          
+          Polynomials::shiftedScaledLegendreValues             (P_j_minus_1, polyOrder_-1, mu[1][1], mu[0][1] + mu[1][1]);
+          Polynomials::shiftedScaledIntegratedLegendreValues_dt(L_j_dt,      polyOrder_,   mu[1][1], mu[0][1] + mu[1][1]);
+          Polynomials::shiftedScaledIntegratedLegendreValues   (L_j,         polyOrder_,   mu[1][1], mu[0][1] + mu[1][1]);
+          
+          Polynomials::shiftedScaledLegendreValues             (P_k_minus_1, polyOrder_-1, mu[1][2], mu[0][2] + mu[1][2]);
+          Polynomials::shiftedScaledIntegratedLegendreValues_dt(L_k_dt,      polyOrder_,   mu[1][2], mu[0][2] + mu[1][2]);
+          Polynomials::shiftedScaledIntegratedLegendreValues   (L_k,         polyOrder_,   mu[1][2], mu[0][2] + mu[1][2]);
+          
+          // following the ESEAS ordering: k increments first
+          for (int k=2; k<=polyOrder_; k++)
+          {
+            const auto & R_k_minus_1 = L_k_dt(k);
+            
+            for (int j=2; j<=polyOrder_; j++)
+            {
+              const auto & R_j_minus_1 = L_j_dt(j);
+              
+              for (int i=2; i<=polyOrder_; i++)
+              {
+                const auto & R_i_minus_1 = L_i_dt(i);
+                
+                OutputScalar phi_quad = L_i(i) * L_j(j);
+                
+                for (int d=0; d<3; d++)
+                {
+                  // grad [L_i](s0,s1) = [P_{i-1}](s0,s1) * grad s1 + [R_{i-1}](s0,s1) * grad (s0 + s1)
+                  // for L_i, s1 = mu[1][0], s0 = mu[0][0]
+                  OutputScalar grad_Li_d = P_i_minus_1(i-1) * muGrad[1][0][d] + R_i_minus_1 * (muGrad[0][0][d] + muGrad[1][0][d]);
+                  // for L_j, s1 = mu[1][1], s0 = mu[0][1]
+                  OutputScalar grad_Lj_d = P_j_minus_1(j-1) * muGrad[1][1][d] + R_j_minus_1 * (muGrad[0][1][d] + muGrad[1][1][d]);
+                  // for L_k, s1 = mu[1][2], s0 = mu[0][2]
+                  OutputScalar grad_Lk_d = P_k_minus_1(k-1) * muGrad[1][2][d] + R_k_minus_1 * (muGrad[0][2][d] + muGrad[1][2][d]);
+                  
+                  OutputScalar grad_phi_quad_d = L_i(i) * grad_Lj_d + L_j(j) * grad_Li_d;
+                  
+                  output_(fieldOrdinalOffset,pointOrdinal,d) = L_k(k) * grad_phi_quad_d + phi_quad * grad_Lk_d;
+                }
+                
+                fieldOrdinalOffset++;
+              }
+            }
+          }
+
+          for (int basisOrdinal=0; basisOrdinal<numFields_; basisOrdinal++)
+          {
+            // transform derivatives to account for the ref space transformation: Intrepid2 uses (-z,z)^2; ESEAS uses (0,z)^2
+            const auto dx_eseas = output_(basisOrdinal,pointOrdinal,0);
+            const auto dy_eseas = output_(basisOrdinal,pointOrdinal,1);
+            const auto dz_eseas = output_(basisOrdinal,pointOrdinal,2);
+            
+            auto &dx_int2 = output_(basisOrdinal,pointOrdinal,0);
+            auto &dy_int2 = output_(basisOrdinal,pointOrdinal,1);
+            auto &dz_int2 = output_(basisOrdinal,pointOrdinal,2);
+            
+            transformFromESEASPyramidGradient(dx_int2, dy_int2, dz_int2, dx_eseas, dy_eseas, dz_eseas);
+          }
+          
+        } // end OPERATOR_GRAD block
+          break;
+        case OPERATOR_D2:
+        case OPERATOR_D3:
+        case OPERATOR_D4:
+        case OPERATOR_D5:
+        case OPERATOR_D6:
+        case OPERATOR_D7:
+        case OPERATOR_D8:
+        case OPERATOR_D9:
+        case OPERATOR_D10:
+          INTREPID2_TEST_FOR_ABORT( true,
+                                   ">>> ERROR: (Intrepid2::Hierarchical_HDIV_PYR_Functor) Computing of second and higher-order derivatives is not currently supported");
+        default:
+          // unsupported operator type
+          device_assert(false);
+      }
+    }
+    
+    // Provide the shared memory capacity.
+    // This function takes the team_size as an argument,
+    // which allows team_size-dependent allocations.
+    size_t team_shmem_size (int team_size) const
+    {
+      // we use shared memory to create a fast buffer for basis computations
+      // for the (integrated) Legendre computations, we just need p+1 values stored.  For interior functions on the pyramid, we have up to 3 scratch arrays with (integrated) Legendre values stored, for each of the 3 directions (i,j,k indices): a total of 9.
+      // for the (integrated) Jacobi computations, though, we want (p+1)*(# alpha values)
+      // alpha is either 2i or 2(i+j), where i=2,…,p or i+j=3,…,p.  So there are at most (p-1) alpha values needed.
+      // We can have up to 3 of the (integrated) Jacobi values needed at once.
+      const int numAlphaValues = std::max(polyOrder_-1, 1); // make it at least 1 so we can avoid zero-extent ranks…
+      size_t shmem_size = 0;
+      if (fad_size_output_ > 0)
+      {
+        // Legendre:
+        shmem_size += 9 * OutputScratchView::shmem_size(polyOrder_ + 1, fad_size_output_);
+        // Jacobi:
+        shmem_size += 3 * OutputScratchView2D::shmem_size(numAlphaValues, polyOrder_ + 1, fad_size_output_);
+      }
+      else
+      {
+        // Legendre:
+        shmem_size += 9 * OutputScratchView::shmem_size(polyOrder_ + 1);
+        // Jacobi:
+        shmem_size += 3 * OutputScratchView2D::shmem_size(numAlphaValues, polyOrder_ + 1);
+      }
+      
+      return shmem_size;
+    }
+  };
+  
+  /** \class  Intrepid2::HierarchicalBasis_HDIV_PYR
+      \brief  Basis defining integrated Legendre basis on the line, a polynomial subspace of H(grad) on the line.
+
+              This is used in the construction of hierarchical bases on higher-dimensional topologies.  For
+              mathematical details of the construction, see:
+   
+               Federico Fuentes, Brendan Keith, Leszek Demkowicz, Sriram Nagaraj.
+               "Orientation embedded high order shape functions for the exact sequence elements of all shapes."
+               Computers & Mathematics with Applications, Volume 70, Issue 4, 2015, Pages 353-458, ISSN 0898-1221.
+               https://doi.org/10.1016/j.camwa.2015.04.027.
+   
+               Note that the template argument defineVertexFunctions controls whether this basis is defined in a
+               strictly hierarchical way.  If defineVertexFunctions is false, then the first basis function is the
+               constant 1.0, and this basis will be suitable for discontinuous discretizations.  If defineVertexFunctions
+               is true, then the first basis function will instead be 1.0-x-y, and the basis will be suitable for
+               continuous discretizations.
+  */
+  template<typename DeviceType,
+           typename OutputScalar = double,
+           typename PointScalar  = double,
+           bool defineVertexFunctions = true>  // if defineVertexFunctions is true, first four basis functions are 1-x-y-z, x, y, and z.  Otherwise, they are 1, x, y, and z.
+  class HierarchicalBasis_HDIV_PYR
+  : public Basis<DeviceType,OutputScalar,PointScalar>
+  {
+  public:
+    using BasisBase = Basis<DeviceType,OutputScalar,PointScalar>;
+
+    using typename BasisBase::OrdinalTypeArray1DHost;
+    using typename BasisBase::OrdinalTypeArray2DHost;
+
+    using typename BasisBase::OutputViewType;
+    using typename BasisBase::PointViewType;
+    using typename BasisBase::ScalarViewType;
+
+    using typename BasisBase::ExecutionSpace;
+
+  protected:
+    int polyOrder_; // the maximum order of the polynomial
+    EPointType pointType_;
+  public:
+    /** \brief  Constructor.
+        \param [in] polyOrder - the polynomial order of the basis.
+     
+     The basis will have polyOrder^3 + 3 * polyOrder + 1 members.
+     
+     If defineVertexFunctions is false, then all basis functions are identified with the interior of the element, and the first basis function is 1.
+     
+     If defineVertexFunctions is true, then the first basis functions are nodal functions of the vertices of the cell.
+     
+     */
+    HierarchicalBasis_HDIV_PYR(int polyOrder, const EPointType pointType=POINTTYPE_DEFAULT)
+    :
+    polyOrder_(polyOrder),
+    pointType_(pointType)
+    {
+      INTREPID2_TEST_FOR_EXCEPTION(pointType!=POINTTYPE_DEFAULT,std::invalid_argument,"PointType not supported");
+      this->basisCardinality_  = polyOrder * polyOrder * polyOrder + 3 * polyOrder + 1;
+      this->basisDegree_       = polyOrder;
+      this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Pyramid<> >() );
+      this->basisType_         = BASIS_FEM_HIERARCHICAL;
+      this->basisCoordinates_  = COORDINATES_CARTESIAN;
+      this->functionSpace_     = FUNCTION_SPACE_HDIV;
+      
+      const int degreeLength = 1;
+      this->fieldOrdinalPolynomialDegree_ = OrdinalTypeArray2DHost("Integrated Legendre H(grad) pyramid polynomial degree lookup", this->basisCardinality_, degreeLength);
+      this->fieldOrdinalH1PolynomialDegree_ = OrdinalTypeArray2DHost("Integrated Legendre H(grad) pyramid polynomial H^1 degree lookup", this->basisCardinality_, degreeLength);
+      
+      int fieldOrdinalOffset = 0;
+      // **** vertex functions **** //
+      const int numVertices = this->basisCellTopology_.getVertexCount();
+      for (int i=0; i<numVertices; i++)
+      {
+        // for H(grad) on Pyramid, if defineVertexFunctions is false, first five basis members are linear
+        // if not, then the only difference is that the first member is constant
+        this->fieldOrdinalPolynomialDegree_  (i,0) = 1;
+        this->fieldOrdinalH1PolynomialDegree_(i,0) = 1;
+      }
+      if (!defineVertexFunctions)
+      {
+        this->fieldOrdinalPolynomialDegree_  (0,0) = 0;
+        this->fieldOrdinalH1PolynomialDegree_(0,0) = 0;
+      }
+      fieldOrdinalOffset += numVertices;
+      
+      // **** edge functions **** //
+      const int numFunctionsPerEdge = polyOrder - 1; // bubble functions: all but the vertices
+      const int numEdges            = this->basisCellTopology_.getEdgeCount();
+      for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
+      {
+        for (int i=0; i<numFunctionsPerEdge; i++)
+        {
+          this->fieldOrdinalPolynomialDegree_(i+fieldOrdinalOffset,0)   = i+2; // vertex functions are 1st order; edge functions start at order 2
+          this->fieldOrdinalH1PolynomialDegree_(i+fieldOrdinalOffset,0) = i+2; // vertex functions are 1st order; edge functions start at order 2
+        }
+        fieldOrdinalOffset += numFunctionsPerEdge;
+      }
+      
+      // **** face functions **** //
+      // one quad face
+      const int numFunctionsPerQuadFace =  (polyOrder-1)*(polyOrder-1);
+      
+      // following the ESEAS ordering: j increments first
+      for (int j=2; j<=polyOrder_; j++)
+      {
+        for (int i=2; i<=polyOrder_; i++)
+        {
+          this->fieldOrdinalPolynomialDegree_  (fieldOrdinalOffset,0) = std::max(i,j);
+          this->fieldOrdinalH1PolynomialDegree_(fieldOrdinalOffset,0) = std::max(i,j);
+          fieldOrdinalOffset++;
+        }
+      }
+      
+      const int numFunctionsPerTriFace = ((polyOrder-1)*(polyOrder-2))/2;
+      const int numTriFaces = 4;
+      for (int faceOrdinal=0; faceOrdinal<numTriFaces; faceOrdinal++)
+      {
+        for (int totalPolyOrder=3; totalPolyOrder<=polyOrder_; totalPolyOrder++)
+        {
+          const int totalFaceDofs         = (totalPolyOrder-2)*(totalPolyOrder-1)/2;
+          const int totalFaceDofsPrevious = (totalPolyOrder-3)*(totalPolyOrder-2)/2;
+          const int faceDofsForPolyOrder  = totalFaceDofs - totalFaceDofsPrevious;
+          for (int i=0; i<faceDofsForPolyOrder; i++)
+          {
+            this->fieldOrdinalPolynomialDegree_  (fieldOrdinalOffset,0) = totalPolyOrder;
+            this->fieldOrdinalH1PolynomialDegree_(fieldOrdinalOffset,0) = totalPolyOrder;
+            fieldOrdinalOffset++;
+          }
+        }
+      }
+
+      // **** interior functions **** //
+      const int numFunctionsPerVolume = (polyOrder-1)*(polyOrder-1)*(polyOrder-1);
+      const int numVolumes = 1; // interior
+      for (int volumeOrdinal=0; volumeOrdinal<numVolumes; volumeOrdinal++)
+      {
+        // following the ESEAS ordering: k increments first
+        for (int k=2; k<=polyOrder_; k++)
+        {
+          for (int j=2; j<=polyOrder_; j++)
+          {
+            for (int i=2; i<=polyOrder_; i++)
+            {
+              const int max_ij  = std::max(i,j);
+              const int max_ijk = std::max(max_ij,k);
+              this->fieldOrdinalPolynomialDegree_  (fieldOrdinalOffset,0) = max_ijk;
+              this->fieldOrdinalH1PolynomialDegree_(fieldOrdinalOffset,0) = max_ijk;
+              fieldOrdinalOffset++;
+            }
+          }
+        }
+      }
+      
+      INTREPID2_TEST_FOR_EXCEPTION(fieldOrdinalOffset != this->basisCardinality_, std::invalid_argument, "Internal error: basis enumeration is incorrect");
+      
+      // initialize tags
+      {
+        // Intrepid2 vertices:
+        // 0: (-1,-1, 0)
+        // 1: ( 1,-1, 0)
+        // 2: ( 1, 1, 0)
+        // 3: (-1, 1, 0)
+        // 4: ( 0, 0, 1)
+        
+        // ESEAS vertices:
+        // 0: ( 0, 0, 0)
+        // 1: ( 1, 0, 0)
+        // 2: ( 1, 1, 0)
+        // 3: ( 0, 1, 0)
+        // 4: ( 0, 0, 1)
+        
+        // The edge numbering appears to match between ESEAS and Intrepid2
+        
+        // ESEAS numbers pyramid faces differently from Intrepid2
+        // See BlendProjectPyraTF in ESEAS.
+        // See PyramidFaceNodeMap in Shards_BasicTopologies
+        // ESEAS:     0123, 014, 124, 324, 034
+        // Intrepid2: 014, 124, 234, 304, 0321
+        
+        const int intrepid2FaceOrdinals[5] {4,0,1,2,3}; // index is the ESEAS face ordinal; value is the intrepid2 ordinal
+        
+        const auto & cardinality = this->basisCardinality_;
+        
+        // Basis-dependent initializations
+        const ordinal_type tagSize  = 4; // size of DoF tag, i.e., number of fields in the tag
+        const ordinal_type posScDim = 0; // position in the tag, counting from 0, of the subcell dim
+        const ordinal_type posScOrd = 1; // position in the tag, counting from 0, of the subcell ordinal
+        const ordinal_type posDfOrd = 2; // position in the tag, counting from 0, of DoF ordinal relative to the subcell
+        
+        OrdinalTypeArray1DHost tagView("tag view", cardinality*tagSize);
+        const int vertexDim = 0, edgeDim = 1, faceDim = 2, volumeDim = 3;
+
+        if (defineVertexFunctions) {
+          {
+            int tagNumber = 0;
+            for (int vertexOrdinal=0; vertexOrdinal<numVertices; vertexOrdinal++)
+            {
+              tagView(tagNumber*tagSize+0) = vertexDim;             // vertex dimension
+              tagView(tagNumber*tagSize+1) = vertexOrdinal;         // vertex id
+              tagView(tagNumber*tagSize+2) = 0;                     // local dof id
+              tagView(tagNumber*tagSize+3) = 1;                     // total number of dofs at this vertex
+              tagNumber++;
+            }
+            for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
+            {
+              for (int functionOrdinal=0; functionOrdinal<numFunctionsPerEdge; functionOrdinal++)
+              {
+                tagView(tagNumber*tagSize+0) = edgeDim;               // edge dimension
+                tagView(tagNumber*tagSize+1) = edgeOrdinal;           // edge id
+                tagView(tagNumber*tagSize+2) = functionOrdinal;       // local dof id
+                tagView(tagNumber*tagSize+3) = numFunctionsPerEdge;   // total number of dofs on this edge
+                tagNumber++;
+              }
+            }
+            {
+              // quad face
+              const int faceOrdinalESEAS = 0;
+              const int faceOrdinalIntrepid2 = intrepid2FaceOrdinals[faceOrdinalESEAS];
+              
+              for (int functionOrdinal=0; functionOrdinal<numFunctionsPerQuadFace; functionOrdinal++)
+              {
+                tagView(tagNumber*tagSize+0) = faceDim;                 // face dimension
+                tagView(tagNumber*tagSize+1) = faceOrdinalIntrepid2;    // face id
+                tagView(tagNumber*tagSize+2) = functionOrdinal;         // local dof id
+                tagView(tagNumber*tagSize+3) = numFunctionsPerQuadFace; // total number of dofs on this face
+                tagNumber++;
+              }
+            }
+            for (int triFaceOrdinalESEAS=0; triFaceOrdinalESEAS<numTriFaces; triFaceOrdinalESEAS++)
+            {
+              const int faceOrdinalESEAS     = triFaceOrdinalESEAS + 1;
+              const int faceOrdinalIntrepid2 = intrepid2FaceOrdinals[faceOrdinalESEAS];
+              for (int functionOrdinal=0; functionOrdinal<numFunctionsPerTriFace; functionOrdinal++)
+              {
+                tagView(tagNumber*tagSize+0) = faceDim;                // face dimension
+                tagView(tagNumber*tagSize+1) = faceOrdinalIntrepid2;   // face id
+                tagView(tagNumber*tagSize+2) = functionOrdinal;        // local dof id
+                tagView(tagNumber*tagSize+3) = numFunctionsPerTriFace; // total number of dofs on this face
+                tagNumber++;
+              }
+            }
+            for (int volumeOrdinal=0; volumeOrdinal<numVolumes; volumeOrdinal++)
+            {
+              for (int functionOrdinal=0; functionOrdinal<numFunctionsPerVolume; functionOrdinal++)
+              {
+                tagView(tagNumber*tagSize+0) = volumeDim;               // volume dimension
+                tagView(tagNumber*tagSize+1) = volumeOrdinal;           // volume id
+                tagView(tagNumber*tagSize+2) = functionOrdinal;         // local dof id
+                tagView(tagNumber*tagSize+3) = numFunctionsPerVolume;   // total number of dofs in this volume
+                tagNumber++;
+              }
+            }
+            INTREPID2_TEST_FOR_EXCEPTION(tagNumber != this->basisCardinality_, std::invalid_argument, "Internal error: basis tag enumeration is incorrect");
+          }
+        } else {
+          for (ordinal_type i=0;i<cardinality;++i) {
+            tagView(i*tagSize+0) = volumeDim;   // volume dimension
+            tagView(i*tagSize+1) = 0;           // volume ordinal
+            tagView(i*tagSize+2) = i;           // local dof id
+            tagView(i*tagSize+3) = cardinality; // total number of dofs on this face
+          }
+        }
+        
+        // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
+        // tags are constructed on host
+        this->setOrdinalTagData(this->tagToOrdinal_,
+                                this->ordinalToTag_,
+                                tagView,
+                                this->basisCardinality_,
+                                tagSize,
+                                posScDim,
+                                posScOrd,
+                                posDfOrd);
+      }
+    }
+    
+    /** \brief  Returns basis name
+     
+     \return the name of the basis
+     */
+    const char* getName() const override {
+      return "Intrepid2_HierarchicalBasis_HDIV_PYR";
+    }
+    
+    /** \brief True if orientation is required
+    */
+    virtual bool requireOrientation() const override {
+      return (this->getDegree() > 2);
+    }
+
+    // since the getValues() below only overrides the FEM variant, we specify that
+    // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
+    // (It's an error to use the FVD variant on this basis.)
+    using BasisBase::getValues;
+    
+    /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
+
+        Returns values of <var>operatorType</var> acting on FEM basis functions for a set of
+        points in the <strong>reference cell</strong> for which the basis is defined.
+
+        \param  outputValues      [out] - variable rank array with the basis values
+        \param  inputPoints       [in]  - rank-2 array (P,D) with the evaluation points
+        \param  operatorType      [in]  - the operator acting on the basis functions
+
+        \remark For rank and dimension specifications of the output array see Section
+        \ref basis_md_array_sec.  Dimensions of <var>ArrayScalar</var> arguments are checked
+        at runtime if HAVE_INTREPID2_DEBUG is defined.
+
+        \remark A FEM basis spans a COMPLETE or INCOMPLETE polynomial space on the reference cell
+        which is a smooth function space. Thus, all operator types that are meaningful for the
+        approximated function space are admissible. When the order of the operator exceeds the
+        degree of the basis, the output array is filled with the appropriate number of zeros.
+    */
+    virtual void getValues( OutputViewType outputValues, const PointViewType  inputPoints,
+                           const EOperator operatorType = OPERATOR_VALUE ) const override
+    {
+      auto numPoints = inputPoints.extent_int(0);
+      
+      using FunctorType = Hierarchical_HDIV_PYR_Functor<DeviceType, OutputScalar, PointScalar, OutputViewType, PointViewType>;
+      
+      FunctorType functor(operatorType, outputValues, inputPoints, polyOrder_, defineVertexFunctions);
+      
+      const int outputVectorSize = getVectorSizeForHierarchicalParallelism<OutputScalar>();
+      const int pointVectorSize  = getVectorSizeForHierarchicalParallelism<PointScalar>();
+      const int vectorSize = std::max(outputVectorSize,pointVectorSize);
+      const int teamSize = 1; // because of the way the basis functions are computed, we don't have a second level of parallelism...
+
+      auto policy = Kokkos::TeamPolicy<ExecutionSpace>(numPoints,teamSize,vectorSize);
+      Kokkos::parallel_for("Hierarchical_HDIV_PYR_Functor", policy, functor);
+    }
+
+    /** \brief returns the basis associated to a subCell.
+
+        The bases of the subCell are the restriction to the subCell
+        of the bases of the parent cell.
+        \param [in] subCellDim - dimension of subCell
+        \param [in] subCellOrd - position of the subCell among of the subCells having the same dimension
+        \return pointer to the subCell basis of dimension subCellDim and position subCellOrd
+     */
+    BasisPtr<DeviceType,OutputScalar,PointScalar>
+    getSubCellRefBasis(const ordinal_type subCellDim, const ordinal_type subCellOrd) const override{
+      const auto & p = this->basisDegree_;
+      if (subCellDim == 2)
+      {
+        if (subCellOrd == 4) // quad basis
+        {
+          using HVOL_LINE = LegendreBasis_HVOL_LINE<DeviceType,OutputScalar,PointScalar>;
+          using HVOL_QUAD = Basis_Derived_HVOL_QUAD<HVOL_LINE>;
+          return Teuchos::rcp(new HVOL_QUAD(p-1));
+        }
+        else // tri basis
+        {
+          using HVOL_Tri = LegendreBasis_HVOL_TRI<DeviceType,OutputScalar,PointScalar>;
+          return Teuchos::rcp(new HVOL_Tri(p-1));
+        }
+      }
+      INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Input parameters out of bounds");
+    }
+
+    /** \brief Creates and returns a Basis object whose DeviceType template argument is Kokkos::HostSpace::device_type, but is otherwise identical to this.
+     
+        \return Pointer to the new Basis object.
+     */
+    virtual BasisPtr<typename Kokkos::HostSpace::device_type, OutputScalar, PointScalar>
+    getHostBasis() const override {
+      using HostDeviceType = typename Kokkos::HostSpace::device_type;
+      using HostBasisType  = HierarchicalBasis_HDIV_PYR<HostDeviceType, OutputScalar, PointScalar, defineVertexFunctions>;
+      return Teuchos::rcp( new HostBasisType(polyOrder_, pointType_) );
+    }
+  };
+} // end namespace Intrepid2
+
+// do ETI with default (double) type
+extern template class Intrepid2::HierarchicalBasis_HDIV_PYR<Kokkos::DefaultExecutionSpace::device_type,double,double>;
+
+#endif /* Intrepid2_HierarchicalBasis_HDIV_PYR_h */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HDIV_PYR.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HDIV_PYR.hpp
@@ -540,7 +540,6 @@ namespace Intrepid2
       {
         case OPERATOR_VALUE:
         {
-          // starting the H(div) rewrite here
           ordinal_type fieldOrdinalOffset = 0;
           // quadrilateral face
           {
@@ -1312,8 +1311,8 @@ namespace Intrepid2
       this->functionSpace_     = FUNCTION_SPACE_HDIV;
       
       const int degreeLength = 1;
-      this->fieldOrdinalPolynomialDegree_ = OrdinalTypeArray2DHost("Integrated Legendre H(grad) pyramid polynomial degree lookup", this->basisCardinality_, degreeLength);
-      this->fieldOrdinalH1PolynomialDegree_ = OrdinalTypeArray2DHost("Integrated Legendre H(grad) pyramid polynomial H^1 degree lookup", this->basisCardinality_, degreeLength);
+      this->fieldOrdinalPolynomialDegree_ = OrdinalTypeArray2DHost("Integrated Legendre H(div) pyramid polynomial degree lookup", this->basisCardinality_, degreeLength);
+      this->fieldOrdinalH1PolynomialDegree_ = OrdinalTypeArray2DHost("Integrated Legendre H(div) pyramid polynomial H^1 degree lookup", this->basisCardinality_, degreeLength);
       
       int fieldOrdinalOffset = 0;
       

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HDIV_PYR.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HDIV_PYR.hpp
@@ -490,7 +490,6 @@ namespace Intrepid2
       OutputScratchView scratch1D_1, scratch1D_2, scratch1D_3;
       OutputScratchView scratch1D_4, scratch1D_5, scratch1D_6;
       OutputScratchView scratch1D_7, scratch1D_8, scratch1D_9;
-      const int numAlphaValues = (polyOrder_-1 > 1) ? (polyOrder_-1) : 1; // make numAlphaValues at least 1 so we can avoid zero-extent allocations…
       if (fad_size_output_ > 0) {
         scratch1D_1 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
         scratch1D_2 = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HDIV_PYR_ETI.cpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasis_HDIV_PYR_ETI.cpp
@@ -1,0 +1,51 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Mauro Perego  (mperego@sandia.gov) or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/** \file   Intrepid2_HierarchicalBasis_HDIV_PYR_ETI.cpp
+    \brief  \brief ETI instantiation for Intrepid2 HierarchicalBasis_HDIV_PYR class.
+    \author Created by N.V. Roberts.
+ */
+
+#include "Intrepid2_HierarchicalBasis_HDIV_PYR.hpp"
+
+using DefaultDeviceType = Kokkos::DefaultExecutionSpace::device_type;
+template class Intrepid2::HierarchicalBasis_HDIV_PYR<Kokkos::DefaultExecutionSpace::device_type,double,double>;

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HDIV.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HDIV.hpp
@@ -104,7 +104,8 @@ check_getCoeffMatrix_HDIV(const subcellBasisType& subcellBasis,
       cellBaseKey != shards::Triangle<>::key &&
       cellBaseKey != shards::Hexahedron<>::key &&
       cellBaseKey != shards::Wedge<>::key &&
-      cellBaseKey != shards::Tetrahedron<>::key,
+      cellBaseKey != shards::Tetrahedron<>::key &&
+      cellBaseKey != shards::Pyramid<>::key,
       std::logic_error,
       ">>> ERROR (Intrepid::OrientationTools::getCoeffMatrix_HDIV): " \
       "cellBasis must have quad, triangle, hexhedron or tetrahedron topology.");

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionStructDef.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionStructDef.hpp
@@ -601,6 +601,9 @@ void ProjectionStruct<DeviceType,ValueType>::createHDivProjectionStruct(const Ba
     hcurlBasis = new Basis_HCURL_TET_In_FEM<HostDeviceType,ValueType,ValueType>(cellBasis->getDegree());
   else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Wedge<6> >()->key)
     hcurlBasis = new typename DerivedNodalBasisFamily<HostDeviceType,ValueType,ValueType>::HCURL_WEDGE(cellBasis->getDegree());
+// TODO: uncomment the next two lines once H(curl) pyramid implemented
+//  else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Pyramid<5> >()->key)
+//    hcurlBasis = new typename DerivedNodalBasisFamily<DeviceType,ValueType,ValueType>::HCURL_PYR(cellBasis->getDegree());
   else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Quadrilateral<4> >()->key)
     hcurlBasis = new Basis_HGRAD_QUAD_Cn_FEM<HostDeviceType,ValueType,ValueType>(cellBasis->getDegree());
   else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Triangle<3> >()->key)

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHDIV.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHDIV.hpp
@@ -431,6 +431,9 @@ ProjectionTools<DeviceType>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsV
     hcurlBasis = new Basis_HCURL_TET_In_FEM<DeviceType,scalarType,scalarType>(cellBasis->getDegree());
   else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Wedge<6> >()->key)
     hcurlBasis = new typename DerivedNodalBasisFamily<DeviceType,scalarType,scalarType>::HCURL_WEDGE(cellBasis->getDegree());
+// TODO: uncomment the next two lines once H(curl) pyramid implemented
+//  else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Pyramid<5> >()->key)
+//    hcurlBasis = new typename DerivedNodalBasisFamily<DeviceType,scalarType,scalarType>::HCURL_PYR(cellBasis->getDegree());
   else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Quadrilateral<4> >()->key)
     hcurlBasis = new Basis_HGRAD_QUAD_Cn_FEM<DeviceType,scalarType,scalarType>(cellBasis->getDegree());
   else if(cellTopo.getKey() == shards::getCellTopologyData<shards::Triangle<3> >()->key)

--- a/packages/intrepid2/unit-test/MonolithicExecutable/BasisCardinalityTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/BasisCardinalityTests.cpp
@@ -591,6 +591,24 @@ namespace
     }
   }
 
+  TEUCHOS_UNIT_TEST( BasisCardinality, Pyramid_HDIV )
+  {
+    using HierarchicalBasis = HierarchicalBasisFamily<DefaultTestDeviceType>::HDIV_PYR;
+    
+    for (ordinal_type p=1; p<10; p++)
+    {
+      // expected cardinality is p^2 + 2p(p+1) + 3p^2(p-1):
+      // - quadrilateral face: p^2
+      // - triangular faces:   2p(p+1)
+      // - interior bubbles:   3p^2(p-1)
+      const ordinal_type expectedCardinality = p * p + 2 * p * (p+1) + 3 * p * p * (p-1);
+      
+      HierarchicalBasis hierarchicalBasis(p);
+      const ordinal_type actualCardinality = hierarchicalBasis.getCardinality();
+      TEST_EQUALITY(expectedCardinality, actualCardinality);
+    }
+  }
+
   TEUCHOS_UNIT_TEST( BasisCardinality, Pyramid_HVOL )
   {
     using HierarchicalBasis = HierarchicalBasisFamily<DefaultTestDeviceType>::HVOL_PYR;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CMakeLists.txt
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CMakeLists.txt
@@ -16,7 +16,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 # add single-group tests; allows for easier targeted builds and debugging (especially useful under CUDA)
-# since each of these is redundant with Intrepid2_Tests above, we don't build this when all targets are built
+# since each of these is redundant with Intrepid2_Tests above, we don't build them when all targets are built
 
 # BasisEquivalenceTests
 TRIBITS_ADD_EXECUTABLE( BasisEquivalenceTests NOEXESUFFIX SOURCES BasisEquivalenceTests_Wedge.cpp BasisEquivalenceTests_Tri.cpp BasisEquivalenceTests_Tet.cpp BasisEquivalenceTests_Quad.cpp BasisEquivalenceTests_Line.cpp BasisEquivalenceTests_Hypercube.cpp BasisEquivalenceTests_Hex.cpp UnitTestMain.cpp )
@@ -45,3 +45,7 @@ SET_TARGET_PROPERTIES( Intrepid2_DataTests PROPERTIES EXCLUDE_FROM_ALL TRUE)
 # StructuredVersusStandard integration
 TRIBITS_ADD_EXECUTABLE( StructuredVersusStandard NOEXESUFFIX SOURCES StructuredIntegrationTests_StructuredVersusStandard.cpp UnitTestMain.cpp )
 SET_TARGET_PROPERTIES( Intrepid2_StructuredVersusStandard PROPERTIES EXCLUDE_FROM_ALL TRUE)
+
+# SubBasisInclusionTests
+TRIBITS_ADD_EXECUTABLE( SubBasisInclusionTests NOEXESUFFIX SOURCES SubBasisInclusionTests.cpp UnitTestMain.cpp )
+SET_TARGET_PROPERTIES( Intrepid2_SubBasisInclusionTests PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
@@ -410,7 +410,7 @@ namespace
     using PointScalar = double;
     using DeviceType = DefaultTestDeviceType;
     
-    Kokkos::Array<PointScalar,spaceDim> origin{0,0};
+    Kokkos::Array<PointScalar,spaceDim> origin{0,0,0};
     Kokkos::Array<PointScalar,spaceDim> domainExtents{1,2,4};
     Kokkos::Array<int,spaceDim> gridCellCounts{2,4,2};
     
@@ -536,6 +536,32 @@ namespace
     testJacobians<spaceDim,PointScalar>(polyOrder, meshWidth, out, success);
   }
 
+  TEUCHOS_UNIT_TEST( CellGeometry, Jacobian_Linear_Pyramids )
+  {
+    const int spaceDim = 3;
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    using PointScalar = double;
+    using DeviceType = DefaultTestDeviceType;
+    
+    Kokkos::Array<PointScalar,spaceDim> origin{0,0,0};
+    Kokkos::Array<PointScalar,spaceDim> domainExtents{1,2,4};
+    Kokkos::Array<int,spaceDim> gridCellCounts{2,4,2};
+    CellGeometry<PointScalar, spaceDim, DeviceType>::SubdivisionStrategy subdivisionStrategy = CellGeometry<PointScalar, spaceDim, DeviceType>::SIX_PYRAMIDS;
+    CellGeometry<PointScalar, spaceDim, DeviceType> uniformGridCellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
+    
+    const std::vector<bool> copyAffineValues {false, true};
+    
+    for (auto copyAffine : copyAffineValues)
+    {
+      if (copyAffine) out << "testing affine path.\n";
+      else            out << "testing non-affine path (with affine geometry).\n";
+      auto nodalCellGeometry = getNodalCellGeometry(uniformGridCellGeometry,copyAffine);
+      testJacobiansAgree(nodalCellGeometry, relTol, absTol, out, success);
+    }
+  }
+
   TEUCHOS_UNIT_TEST( CellGeometry, Jacobian_Linear_Quads )
   {
     const int spaceDim = 2;
@@ -624,9 +650,6 @@ namespace
   TEUCHOS_UNIT_TEST( CellGeometry, Nodes_Uniform_Pyramids )
   {
     const int spaceDim = 3;
-    const double relTol=1e-13;
-    const double absTol=1e-13;
-    
     using PointScalar = double;
     using HostDeviceType = Kokkos::HostSpace::device_type;
     
@@ -642,7 +665,7 @@ namespace
     ordinal_type numCells = cellGeometry.numCells();
     TEST_EQUALITY(numCells, expectedNumCells);
     
-    ordinal_type expectedNumNodes = 9; // 1 interior vertex, 8 vertices for the hexahedron
+//    ordinal_type expectedNumNodes = 9; // 1 interior vertex, 8 vertices for the hexahedron
     // TODO: check global node numbers.  We expect to have interior nodes listed first (there's just one per grid cell), followed by a Cartesian numbering of the vertices with x as the fastest-moving index.
     
   }

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CellGeometryTests.cpp
@@ -401,6 +401,29 @@ namespace
     TEST_EQUALITY(8,         cellGeometry.numNodesPerCell());
   }
 
+  TEUCHOS_UNIT_TEST( CellGeometry, Jacobian_Uniform_Pyramids )
+  {
+    const int spaceDim = 3;
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    using PointScalar = double;
+    using DeviceType = DefaultTestDeviceType;
+    
+    Kokkos::Array<PointScalar,spaceDim> origin{0,0};
+    Kokkos::Array<PointScalar,spaceDim> domainExtents{1,2,4};
+    Kokkos::Array<int,spaceDim> gridCellCounts{2,4,2};
+    
+    using CellGeometryType = CellGeometry<PointScalar, spaceDim, DeviceType>;
+    
+    std::vector<CellGeometryType::SubdivisionStrategy> subdivisionStrategies = {CellGeometryType::SIX_PYRAMIDS};
+    for (const auto & subdivisionStrategy : subdivisionStrategies)
+    {
+      CellGeometry<PointScalar, spaceDim, DeviceType> cellGeometry(origin, domainExtents, gridCellCounts, subdivisionStrategy);
+      testJacobiansAgree(cellGeometry, relTol, absTol, out, success);
+    }
+  }
+
   TEUCHOS_UNIT_TEST( CellGeometry, Jacobian_Uniform_Quads )
   {
     const int spaceDim = 2;
@@ -469,7 +492,7 @@ namespace
     using PointScalar = double;
     using DeviceType = DefaultTestDeviceType;
     
-    Kokkos::Array<PointScalar,spaceDim> origin{0,0};
+    Kokkos::Array<PointScalar,spaceDim> origin{0,0,0};
     Kokkos::Array<PointScalar,spaceDim> domainExtents{1,2,4};
     Kokkos::Array<int,spaceDim> gridCellCounts{2,4,2};
     
@@ -596,6 +619,32 @@ namespace
         testJacobiansAgree(nodalCellGeometry, relTol, absTol, out, success);
       }
     }
+  }
+
+  TEUCHOS_UNIT_TEST( CellGeometry, Nodes_Uniform_Pyramids )
+  {
+    const int spaceDim = 3;
+    const double relTol=1e-13;
+    const double absTol=1e-13;
+    
+    using PointScalar = double;
+    using HostDeviceType = Kokkos::HostSpace::device_type;
+    
+    Kokkos::Array<PointScalar,spaceDim> origin{0,0,0};
+    Kokkos::Array<PointScalar,spaceDim> domainExtents{1,1,1};
+    Kokkos::Array<int,spaceDim> gridCellCounts{1,1,1};
+    
+    using CellGeometryType = CellGeometry<PointScalar, spaceDim, HostDeviceType>;
+    CellGeometryType cellGeometry(origin, domainExtents, gridCellCounts, CellGeometryType::SIX_PYRAMIDS);
+    
+    ordinal_type numGridCells = gridCellCounts[0] * gridCellCounts[1] * gridCellCounts[2];
+    ordinal_type expectedNumCells = 6 * numGridCells;
+    ordinal_type numCells = cellGeometry.numCells();
+    TEST_EQUALITY(numCells, expectedNumCells);
+    
+    ordinal_type expectedNumNodes = 9; // 1 interior vertex, 8 vertices for the hexahedron
+    // TODO: check global node numbers.  We expect to have interior nodes listed first (there's just one per grid cell), followed by a Cartesian numbering of the vertices with x as the fastest-moving index.
+    
   }
 
 //TODO: write this test, using ProjectedGeometry.

--- a/packages/intrepid2/unit-test/MonolithicExecutable/SubBasisInclusionTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/SubBasisInclusionTests.cpp
@@ -34,8 +34,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Kyungjoo Kim  (kyukim@sandia.gov),
-//                    Mauro Perego  (mperego@sandia.gov), or
+// Questions? Contact Mauro Perego  (mperego@sandia.gov) or
 //                    Nate Roberts  (nvrober@sandia.gov)
 //
 // ************************************************************************
@@ -364,7 +363,8 @@ namespace
     
     // so far, only HGRAD, HVOL implemented for hierarchical pyramid.  Once we have full exact sequence, we can
     // switch to calling runSubBasisTests(tetTopo, out, success).
-    std::vector<Intrepid2::EFunctionSpace> functionSpaces = {FUNCTION_SPACE_HGRAD, FUNCTION_SPACE_HVOL};
+//    std::vector<Intrepid2::EFunctionSpace> functionSpaces = {FUNCTION_SPACE_HGRAD, FUNCTION_SPACE_HDIV, FUNCTION_SPACE_HVOL};
+    std::vector<Intrepid2::EFunctionSpace> functionSpaces = {FUNCTION_SPACE_HDIV};
     auto cellTopo = pyrTopo;
     
     const int maxDegree = 5;

--- a/packages/intrepid2/unit-test/MonolithicExecutable/SubBasisInclusionTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/SubBasisInclusionTests.cpp
@@ -363,8 +363,8 @@ namespace
     
     // so far, only HGRAD, HVOL implemented for hierarchical pyramid.  Once we have full exact sequence, we can
     // switch to calling runSubBasisTests(tetTopo, out, success).
-//    std::vector<Intrepid2::EFunctionSpace> functionSpaces = {FUNCTION_SPACE_HGRAD, FUNCTION_SPACE_HDIV, FUNCTION_SPACE_HVOL};
-    std::vector<Intrepid2::EFunctionSpace> functionSpaces = {FUNCTION_SPACE_HDIV};
+    // NOTE: due to the way that lower-degree polynomials get added in the higher-degree bases as p increases (combined with the way that the bases are ordered), the strategy within runSubBasisTests for mapping basis ordinals from the "sub-basis" to the full basis WILL NOT WORK for H(curl) and H(div) pyramids.  We could specify the mapping in some fairly manual way (with awareness of implementation details).  Better still would be to provide a mapping within Basis that would specify how one basis is included in the other.  For now, we simply omit these tests.
+    std::vector<Intrepid2::EFunctionSpace> functionSpaces = {FUNCTION_SPACE_HGRAD, FUNCTION_SPACE_HVOL};
     auto cellTopo = pyrTopo;
     
     const int maxDegree = 5;

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_QuadFace_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_QuadFace_newBasis.hpp
@@ -685,8 +685,7 @@ int OrientationPyrQuadFaceNewBasis(const bool verbose) {
 
 
         //HDIV Case
-        //TODO: uncomment after we implement H(div) basis for pyramids
-        /*{
+        {
           FunDiv fun;
           DynRankView ConstructWithLabel(funAtPhysRefCoords, numCells, numRefCoords, dim);
           for(ordinal_type i=0; i<numCells; ++i) {
@@ -752,7 +751,7 @@ int OrientationPyrQuadFaceNewBasis(const bool verbose) {
             testResults.test(errorFlag,tol);
             delete basisPtr;
           }
-        }*/
+        }
       } //rotation of first cell vertices
     } while(std::next_permutation(&reorder[0]+2, &reorder[0]+5)); //reorder vertices of common face
 

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_TriFace_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_TriFace_newBasis.hpp
@@ -689,8 +689,7 @@ int OrientationPyrTriFaceNewBasis(const bool verbose) {
 
 
         //HDIV Case
-        //TODO: uncomment after we implement H(div) basis for pyramids
-        /*{
+        {
           FunDiv fun;
           DynRankView ConstructWithLabel(funAtPhysRefCoords, numCells, numRefCoords, dim);
           for(ordinal_type i=0; i<numCells; ++i) {
@@ -756,7 +755,7 @@ int OrientationPyrTriFaceNewBasis(const bool verbose) {
             testResults.test(errorFlag,tol);
             delete basisPtr;
           }
-        }*/
+        }
       } //rotation of first cell vertices
     } while(std::next_permutation(&reorder[0]+2, &reorder[0]+5)); //reorder vertices of common face
 

--- a/packages/intrepid2/unit-test/Projection/CMakeLists.txt
+++ b/packages/intrepid2/unit-test/Projection/CMakeLists.txt
@@ -16,6 +16,7 @@ SET(Intrepid2_TEST_ETI_FILE "")
 LIST(APPEND Intrepid2_TEST_ETI_FILE 
   "test_project_fields"
   "test_convergence_HEX"
+  "test_convergence_PYR"
   "test_convergence_QUAD"
   "test_convergence_TET"
   "test_convergence_TRI"

--- a/packages/intrepid2/unit-test/Projection/eti/test_convergence_PYR_ETI.in
+++ b/packages/intrepid2/unit-test/Projection/eti/test_convergence_PYR_ETI.in
@@ -1,0 +1,62 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Mauro Perego  (mperego@sandia.gov), or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/** \file test_01.cpp
+    \brief  Test for checking convergence for pyramid elements.
+    \author Created by Mauro Perego
+*/
+
+#include "test_convergence_PYR.hpp"
+#include "Kokkos_Core.hpp"
+
+
+int main(int argc, char *argv[]) {
+
+  const bool verbose = (argc-1) > 0;
+  Kokkos::initialize();
+  
+  const int r_val = Intrepid2::Test::ConvergencePyr<@ETI_VALUETYPE@,@ETI_DEVICE@>(verbose);
+
+  Kokkos::finalize();
+  return r_val;
+}
+

--- a/packages/intrepid2/unit-test/Projection/test_convergence_PYR.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_PYR.hpp
@@ -1,0 +1,1327 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Mauro Perego  (mperego@sandia.gov), or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+
+/** \file
+    \brief  Test for checking accuracy of interpolation-based projections for pyramid elements
+
+    The test considers a structured pyramid mesh of the cube [-1,1]^3, formed by first
+    building a hexahedral mesh with N^3 hexes and then splitting each hex into 6 pyramids meeting
+    in the center of the hexahedron.
+    The test checks the accuracy of the HGRAD, HCURL, HDIV, HVOL projections of analytic
+    target functions for Hierarchical basis functions as N increases.
+    The accuracy is computed in the H^1, H^{curl}, H^{div} and L^2 norms respectively.
+    The optimal order of convergence equates the basis degree.
+
+    \author Created by Nate Roberts, based on tests of other element types by Mauro Perego
+ */
+
+#include "Intrepid2_config.h"
+
+#ifdef HAVE_INTREPID2_DEBUG
+#define INTREPID2_TEST_FOR_DEBUG_ABORT_OVERRIDE_TO_CONTINUE
+#endif
+
+#include "Intrepid2_CellGeometry.hpp"
+#include "Intrepid2_Orientation.hpp"
+#include "Intrepid2_OrientationTools.hpp"
+#include "Intrepid2_ProjectionTools.hpp"
+#include "Intrepid2_HGRAD_PYR_C1_FEM.hpp"
+#include "Intrepid2_PointTools.hpp"
+#include "Intrepid2_CellTools.hpp"
+#include "Intrepid2_FunctionSpaceTools.hpp"
+#include "struct_mesh_utils.hpp"
+
+#define Intrepid2_Experimental
+
+
+#include "Teuchos_oblackholestream.hpp"
+#include "Teuchos_RCP.hpp"
+#include <array>
+#include <set>
+#include <random>
+#include <algorithm>
+
+namespace Intrepid2 {
+
+namespace Test {
+
+#define INTREPID2_TEST_ERROR_EXPECTED( S )              \
+    try {                                                               \
+      ++nthrow;                                                         \
+      S ;                                                               \
+    }                                                                   \
+    catch (std::exception &err) {                                        \
+      ++ncatch;                                                         \
+      *outStream << "Expected Error ----------------------------------------------------------------\n"; \
+      *outStream << err.what() << '\n';                                 \
+      *outStream << "-------------------------------------------------------------------------------" << "\n\n"; \
+    }
+
+template<typename ValueType, typename DeviceType>
+int ConvergencePyr(const bool verbose) {
+
+  using ExecSpaceType = typename DeviceType::execution_space;
+
+  typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
+  typedef Kokkos::DynRankView<ordinal_type,DeviceType> DynRankViewInt;
+#define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
+
+  Teuchos::RCP<std::ostream> outStream;
+  Teuchos::oblackholestream bhs; // outputs nothing
+
+  if (verbose)
+    outStream = Teuchos::rcp(&std::cout, false);
+  else
+    outStream = Teuchos::rcp(&bhs,       false);
+
+  Teuchos::oblackholestream oldFormatState;
+  oldFormatState.copyfmt(std::cout);
+
+  using HostSpaceType = Kokkos::DefaultHostExecutionSpace;
+
+  *outStream << "DeviceSpace::  ";   ExecSpaceType().print_configuration(*outStream, false);
+  *outStream << "HostSpace::    ";   HostSpaceType().print_configuration(*outStream, false);
+  *outStream << "\n";
+
+  int errorFlag = 0;
+  const ValueType relTol = 1e-4;
+
+  struct Fun {
+    KOKKOS_INLINE_FUNCTION
+    ValueType
+    operator()(const ValueType& x, const ValueType& y, const ValueType& z) {
+      return sin(x*2)*sin(y*2)*sin(z*2)+sin(x*y*z*8);
+    }
+  };
+
+  struct GradFun {
+    KOKKOS_INLINE_FUNCTION
+    ValueType
+    operator()(const ValueType& x, const ValueType& y, const ValueType& z, const int comp=0) {
+      switch (comp) {
+      case 0:
+        return  cos(x*2)*sin(y*2)*sin(z*2)*2+cos(x*y*z*8)*y*z*8;
+      case 1:
+        return sin(x*2)*cos(y*2)*sin(z*2)*2+cos(x*y*z*8)*x*z*8;
+      case 2:
+        return sin(x*2)*sin(y*2)*cos(z*2)*2+cos(x*y*z*8)*x*y*8;
+      default:
+        return 0;
+      }
+    }
+  };
+
+  struct FunCurl {
+    KOKKOS_INLINE_FUNCTION
+    ValueType
+    operator()(const ValueType& x, const ValueType& y, const ValueType& z, const int comp=0) {
+      ValueType f0 = sin(x*2)*sin(y*2)*sin(z*2)+sin(x*y*z*8);
+      ValueType f1 = cos(x*2)*cos(y*2)*cos(z*2);
+      ValueType f2 = cos(x*y*z*8);
+      //fun = f + a \times x
+      switch (comp) {
+      case 0:
+        return f0;
+      case 1:
+        return f1;
+      case 2:
+        return f2;
+      default:
+        return 0;
+      }
+    }
+  };
+
+  struct CurlFunCurl {
+    KOKKOS_INLINE_FUNCTION
+    ValueType
+    operator()(const ValueType& x, const ValueType& y, const ValueType& z, const int comp=0) {
+      ValueType gf0[3] = {cos(x*2)*sin(y*2)*sin(z*2)*2+cos(x*y*z*8)*y*z*8, sin(x*2)*cos(y*2)*sin(z*2)*2+cos(x*y*z*8)*x*z*8, sin(x*2)*sin(y*2)*cos(z*2)*2+cos(x*y*z*8)*x*y*8};
+      ValueType gf1[3] = {-sin(x*2)*cos(y*2)*cos(z*2)*2, -cos(x*2)*sin(y*2)*cos(z*2)*2, -cos(x*2)*cos(y*2)*sin(z*2)*2};
+      ValueType gf2[3] = {-sin(x*y*z*8)*y*z*8, -sin(x*y*z*8)*x*z*8, -sin(x*y*z*8)*x*y*8};
+      switch (comp) {
+      case 0:
+        return gf2[1] - gf1[2];
+      case 1:
+        return gf0[2] - gf2[0];
+      case 2:
+        return gf1[0] - gf0[1];
+      default:
+        return 0;
+      }
+    }
+  };
+
+
+  struct FunDiv {
+    KOKKOS_INLINE_FUNCTION
+    ValueType
+    operator()(const ValueType& x, const ValueType& y, const ValueType& z, const int comp=0) {
+      ValueType f0 = sin(x*2)*sin(y*2)*sin(z*2)+sin(x*y*z*8);
+      ValueType f1 = cos(x*2)*cos(y*2)*cos(z*2);
+      ValueType f2 = cos(x*y*z*8);
+      //fun = f + a x
+      switch (comp) {
+      case 0:
+        return f0;
+      case 1:
+        return f1;
+      case 2:
+        return f2;
+      default:
+        return 0;
+      }
+    }
+  };
+
+  struct DivFunDiv {
+    KOKKOS_INLINE_FUNCTION
+    ValueType
+    operator()(const ValueType& x, const ValueType& y, const ValueType& z) {
+      ValueType gxf0 = cos(x*2)*sin(y*2)*sin(z*2)*2+cos(x*y*z*8)*y*z*8;
+      ValueType gyf1 = -cos(x*2)*sin(y*2)*cos(z*2)*2;
+      ValueType gzf2 = -sin(x*y*z*8)*x*y*8;
+      return gxf0+gyf1+gzf2;
+    }
+  };
+
+  typedef CellTools<DeviceType> ct;
+  typedef OrientationTools<DeviceType> ots;
+  typedef Experimental::ProjectionTools<DeviceType> pts;
+  typedef RealSpaceTools<DeviceType> rst;
+  typedef FunctionSpaceTools<DeviceType> fst;
+
+  // TODO: uncomment dim for hdiv, hcurl
+//  constexpr ordinal_type dim = 3;
+  const ordinal_type basisDegree = 3;
+  ordinal_type cub_degree = 7;
+
+
+
+  // ************************************ GET INPUTS **************************************
+
+
+  int NX = 2;
+  constexpr int numRefinements = 4;
+
+  // Expected values of the projection errors in H1, Hcurl, Hdiv and L2 norms for HGRAD, HDIV, HCURL and HVOL elements respectively.
+  // These values have been computed running the code with numRefinements=4 and the convergence rates are close to the optimal ones.
+  // Note that these values are independent of the basis choice (Hierarchical or Nodal) as long as they generate the same functional space.
+  // We currently only test two mesh refinements to make the test run faster, so this is used as a regression test rather than
+  // a convergence test, but the test can be use for verifying optimal accuracy as well.
+  ValueType hgradNorm[numRefinements];
+//  ValueType hcurlNorm[numRefinements];
+//  ValueType hdivNorm[numRefinements];
+  ValueType hvolNorm[numRefinements];
+
+  ValueType hgrad_errors[4] = {3.75305, 1.06193, 0.0929745, 0.0113946};
+//  ValueType hcurl_errors[4] = {5.85886, 1.76968, 0.298939, 0.040406}; // TODO: update these values (these are copied from the HEX tests)
+//  ValueType hdiv_errors[4] = {4.45611, 1.10965, 0.175198, 0.023302}; // TODO: update these values (these are copied from the HEX tests)
+  ValueType hvol_errors[4] = {0.490937, 0.0386927, 0.00663563, 0.000797464};
+
+  ValueType hgrad_errors_L2[4] = {3.28826, 1.1899, 0.102338, 0.0128353};
+//  ValueType hcurl_errors_L2[4] = {6.2418, 2.00039, 0.411311, 0.0847072}; // TODO: update these values (these are copied from the HEX tests)
+//  ValueType hdiv_errors_L2[4] = {4.60503, 1.2758, 0.260201, 0.0561971}; // TODO: update these values (these are copied from the HEX tests)
+  ValueType hvol_errors_L2[4] = {0.490937, 0.0386927, 0.00663563, 0.000797464};
+
+  for(int iter= 0; iter<numRefinements; iter++, NX *= 2) {
+    int NY            = NX;
+    int NZ            = NX;
+
+    // *********************************** CELL TOPOLOGY **********************************
+
+    // Get cell topology for base tetrahedron
+    typedef shards::CellTopology    CellTopology;
+    CellTopology cellTopo(shards::getCellTopologyData<shards::Pyramid<5> >() );
+
+    // Get dimensions
+    ordinal_type numNodesPerElem = cellTopo.getNodeCount();
+
+    // *********************************** GENERATE MESH ************************************
+    const int dim = 3;
+    
+    Kokkos::Array<ValueType,dim> origin{-1,-1,-1};
+    Kokkos::Array<ValueType,dim> domainExtents{2,2,2};
+    Kokkos::Array<int,dim> gridCellCounts{NX,NY,NZ};
+    
+    using CellGeometryType = CellGeometry<ValueType, dim, DeviceType>;
+    
+    CellGeometryType cellGeometry(origin, domainExtents, gridCellCounts, CellGeometryType::SIX_PYRAMIDS);
+    
+    //computing vertices coords
+    ordinal_type numElems = cellGeometry.numCells();
+    DynRankView ConstructWithLabel(physVertexes, numElems, numNodesPerElem, dim);
+    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+    KOKKOS_LAMBDA (const int &i) {
+      for(ordinal_type j=0; j<numNodesPerElem; ++j)
+        for(ordinal_type k=0; k<dim; ++k)
+        {
+          physVertexes(i,j,k) = cellGeometry(i,j,k);
+        }
+    });
+    ExecSpaceType().fence();
+
+    DefaultCubatureFactory cub_factory;
+    auto cell_cub = cub_factory.create<DeviceType, ValueType, ValueType>(cellTopo.getBaseKey(), cub_degree);
+    ordinal_type numRefCoords = cell_cub->getNumPoints();
+    DynRankView ConstructWithLabel(refPoints, numRefCoords, dim);
+    DynRankView ConstructWithLabel(weights, numRefCoords);
+    cell_cub->getCubature(refPoints, weights);
+
+    using basisType = Basis<DeviceType,ValueType,ValueType>;
+    using CG_HBasis = HierarchicalBasisFamily<DeviceType,ValueType,ValueType>;
+
+    std::vector<bool> useL2Proj;
+    useL2Proj.push_back(false);
+    useL2Proj.push_back(true); // use L2 projection for all the bases
+
+    *outStream
+    << "===============================================================================\n"
+    << "|                                                                             |\n"
+    << "|                 Test 1 (Convergence - HGRAD)                                |\n"
+    << "|                                                                             |\n"
+    << "===============================================================================\n";
+
+    try {
+      // compute orientations for cells (one-time computation)
+      Kokkos::DynRankView<Orientation,DeviceType> elemOrts("elemOrts", numElems);
+      cellGeometry.orientations(elemOrts);
+      
+      for (auto useL2Projection:useL2Proj) { //
+
+      std::vector<basisType*> basis_set;
+      basis_set.push_back(new typename  CG_HBasis::HGRAD_PYR(basisDegree));
+
+      for (auto basisPtr:basis_set) {
+        auto& basis = *basisPtr;
+        *outStream << " " << basis.getName() << std::endl;
+        ordinal_type basisCardinality = basis.getCardinality();
+
+        //Compute Reference coordinates
+        DynRankView ConstructWithLabel(physRefCoords, numElems, numRefCoords, dim);
+        {
+          Basis_HGRAD_PYR_C1_FEM<DeviceType,ValueType,ValueType> linearBasis; //used for computing physical coordinates
+          DynRankView ConstructWithLabel(linearBasisValuesAtRefCoords, numNodesPerElem, numRefCoords);
+          linearBasis.getValues(linearBasisValuesAtRefCoords, refPoints);
+          ExecSpaceType().fence();
+          Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+          KOKKOS_LAMBDA (const int &i) {
+            for(ordinal_type d=0; d<dim; ++d)
+              for(ordinal_type j=0; j<numRefCoords; ++j)
+                for(ordinal_type k=0; k<numNodesPerElem; ++k)
+                  physRefCoords(i,j,d) += cellGeometry(i,k,d)*linearBasisValuesAtRefCoords(k,j);
+          });
+          ExecSpaceType().fence();
+        }
+
+        DynRankView ConstructWithLabel(funAtRefCoords, numElems, numRefCoords);
+        DynRankView ConstructWithLabel(funGradAtPhysRefCoords, numElems, numRefCoords, dim);
+
+        Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+        KOKKOS_LAMBDA (const int &i) {
+          Fun fun;
+          GradFun gradFun;
+          for(ordinal_type j=0; j<numRefCoords; ++j) {
+            funAtRefCoords(i,j) = fun(physRefCoords(i,j,0), physRefCoords(i,j,1), physRefCoords(i,j,2));
+            for(ordinal_type d=0; d<dim; ++d)
+              funGradAtPhysRefCoords(i,j,d) = gradFun(physRefCoords(i,j,0), physRefCoords(i,j,1), physRefCoords(i,j,2),d);
+          }
+        });
+        ExecSpaceType().fence();
+
+        // compute projection-based interpolation of fun into HGRAD
+        DynRankView ConstructWithLabel(basisCoeffsHGrad, numElems, basisCardinality);
+        {
+          ordinal_type targetCubDegree(basis.getDegree()),targetDerivCubDegree(basis.getDegree());
+
+          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          if(useL2Projection) {
+            projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
+          } else {
+            projStruct.createHGradProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
+          }
+          
+          auto evaluationPoints = projStruct.getAllEvalPoints();
+          auto evaluationGradPoints = projStruct.getAllDerivEvalPoints();
+          ordinal_type numPoints = evaluationPoints.extent(0), numGradPoints = evaluationGradPoints.extent(0);
+
+          DynRankView ConstructWithLabel(targetAtEvalPoints, numElems, numPoints);
+          DynRankView ConstructWithLabel(targetGradAtEvalPoints, numElems, numGradPoints, dim);
+
+          DynRankView ConstructWithLabel(physEvalPoints, numElems, numPoints, dim);
+          DynRankView ConstructWithLabel(physEvalGradPoints, numElems, numGradPoints, dim);
+          {
+            DynRankView ConstructWithLabel(linearBasisValuesAtEvalPoint, numElems, numNodesPerElem);
+            DynRankView ConstructWithLabel(linearBasisValuesAtEvalGradPoint, numElems, numNodesPerElem);
+
+            Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+            KOKKOS_LAMBDA (const int &i) {
+              auto basisValuesAtEvalPoint = Kokkos::subview(linearBasisValuesAtEvalPoint,i,Kokkos::ALL());
+              for(ordinal_type j=0; j<numPoints; ++j){
+                auto evalPoint = Kokkos::subview(evaluationPoints,j,Kokkos::ALL());
+                Impl::Basis_HGRAD_PYR_C1_FEM::template Serial<OPERATOR_VALUE>::getValues(basisValuesAtEvalPoint, evalPoint);
+                for(ordinal_type k=0; k<numNodesPerElem; ++k)
+                  for(ordinal_type d=0; d<dim; ++d)
+                    physEvalPoints(i,j,d) += cellGeometry(i,k,d)*basisValuesAtEvalPoint(k);
+              }
+
+              auto basisValuesAtEvalGradPoint = Kokkos::subview(linearBasisValuesAtEvalGradPoint,i,Kokkos::ALL());
+              for(ordinal_type j=0; j<numGradPoints; ++j) {
+                auto evalGradPoint = Kokkos::subview(evaluationGradPoints,j,Kokkos::ALL());
+                Impl::Basis_HGRAD_PYR_C1_FEM::template Serial<OPERATOR_VALUE>::getValues(basisValuesAtEvalGradPoint, evalGradPoint);
+                for(ordinal_type k=0; k<numNodesPerElem; ++k)
+                  for(ordinal_type d=0; d<dim; ++d)
+                    physEvalGradPoints(i,j,d) += cellGeometry(i,k,d)*basisValuesAtEvalGradPoint(k);
+              }
+            });
+            ExecSpaceType().fence();
+          }
+
+          //transform the target function and its derivative to the reference element (inverse of pullback operator)
+          DynRankView ConstructWithLabel(jacobian, numElems, numGradPoints, dim, dim);
+          if(numGradPoints>0)
+            ct::setJacobian(jacobian, evaluationGradPoints, physVertexes, cellTopo);
+          
+          Kokkos::deep_copy(targetGradAtEvalPoints,0.);
+          Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+          KOKKOS_LAMBDA (const int &ic) {
+            Fun fun;
+            GradFun gradFun;
+            for(int i=0;i<numPoints;i++) {
+              targetAtEvalPoints(ic,i) = fun(physEvalPoints(ic,i,0), physEvalPoints(ic,i,1), physEvalPoints(ic,i,2));
+            }
+            for(int i=0;i<numGradPoints;i++) {
+              for(int d=0;d<dim;d++)
+                for(int j=0;j<dim;j++)
+                  targetGradAtEvalPoints(ic,i,j) += jacobian(ic,i,d,j)*gradFun(physEvalGradPoints(ic,i,0), physEvalGradPoints(ic,i,1), physEvalGradPoints(ic,i,2), d);//funHGradCoeffs(k)
+            }
+          });
+          ExecSpaceType().fence();
+
+          if(useL2Projection) {
+            pts::getL2BasisCoeffs(basisCoeffsHGrad,
+                targetAtEvalPoints,
+                elemOrts,
+                &basis,
+                &projStruct);
+          } else {
+            pts::getHGradBasisCoeffs(basisCoeffsHGrad,
+                targetAtEvalPoints,
+                targetGradAtEvalPoints,
+                elemOrts,
+                &basis,
+                &projStruct);
+          }
+        }
+
+        //check that fun values at reference points coincide with those computed using basis functions
+        DynRankView ConstructWithLabel(basisValuesAtRefCoordsOriented, numElems, basisCardinality, numRefCoords);
+        DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoordsOriented, numElems, basisCardinality, numRefCoords);
+        DynRankView basisValuesAtRefCoordsCells("inValues", numElems, basisCardinality, numRefCoords);
+
+        DynRankView ConstructWithLabel(basisValuesAtRefCoords, basisCardinality, numRefCoords);
+        basis.getValues(basisValuesAtRefCoords, refPoints);
+        rst::clone(basisValuesAtRefCoordsCells,basisValuesAtRefCoords);
+
+        // modify basis values to account for orientations
+        ots::modifyBasisByOrientation(basisValuesAtRefCoordsOriented,
+            basisValuesAtRefCoordsCells,
+            elemOrts,
+            &basis);
+
+        // transform basis values
+        deep_copy(transformedBasisValuesAtRefCoordsOriented,
+            basisValuesAtRefCoordsOriented);
+
+        DynRankView ConstructWithLabel(basisGradsAtRefCoordsOriented, numElems, basisCardinality, numRefCoords, dim);
+        DynRankView ConstructWithLabel(transformedBasisGradsAtRefCoordsOriented, numElems, basisCardinality, numRefCoords, dim);
+        DynRankView basisGradsAtRefCoordsCells("inValues", numElems, basisCardinality, numRefCoords, dim);
+
+        DynRankView ConstructWithLabel(basisGradsAtRefCoords, basisCardinality, numRefCoords, dim);
+        basis.getValues(basisGradsAtRefCoords, refPoints,OPERATOR_GRAD);
+        rst::clone(basisGradsAtRefCoordsCells,basisGradsAtRefCoords);
+
+        // modify basis values to account for orientations
+        ots::modifyBasisByOrientation(basisGradsAtRefCoordsOriented,
+            basisGradsAtRefCoordsCells,
+            elemOrts,
+            &basis);
+
+        // transform basis values to the reference element (pullback)
+        DynRankView ConstructWithLabel(jacobianAtRefCoords, numElems, numRefCoords, dim, dim);
+        DynRankView ConstructWithLabel(jacobianAtRefCoords_inv, numElems, numRefCoords, dim, dim);
+        DynRankView ConstructWithLabel(jacobianAtRefCoords_det, numElems, numRefCoords);
+        ct::setJacobian(jacobianAtRefCoords, refPoints, physVertexes, cellTopo);
+        ct::setJacobianInv (jacobianAtRefCoords_inv, jacobianAtRefCoords);
+        ct::setJacobianDet (jacobianAtRefCoords_det, jacobianAtRefCoords);
+        
+//        {
+//          for (int i=0; i<numElems; i++)
+//          {
+//            for (int j=0; j<numRefCoords; j++)
+//            {
+//              for (int d1=0; d1<dim; d1++)
+//              {
+//                for (int d2=0; d2<dim; d2++)
+//                {
+//                  std::cout << "jacobianAtRefCoords(" << i << "," << j << "," << d1 << "," << d2 << "): " << jacobianAtRefCoords(i,j,d1,d2) << std::endl;
+//                }
+//              }
+//            }
+//          }
+//          for (int i=0; i<numElems; i++)
+//          {
+//            for (int j=0; j<numRefCoords; j++)
+//            {
+//              for (int d1=0; d1<dim; d1++)
+//              {
+//                for (int d2=0; d2<dim; d2++)
+//                {
+//                  std::cout << "jacobianAtRefCoords_inv(" << i << "," << j << "," << d1 << "," << d2 << "): " << jacobianAtRefCoords_inv(i,j,d1,d2) << std::endl;
+//                }
+//              }
+//            }
+//          }
+//          for (int i=0; i<numElems; i++)
+//          {
+//            for (int j=0; j<numRefCoords; j++)
+//            {
+//              std::cout << "jacobianAtRefCoords_det(" << i << "," << j << "): " << jacobianAtRefCoords_det(i,j) << std::endl;
+//            }
+//          }
+//        }
+        
+        
+        fst::HCURLtransformVALUE(transformedBasisGradsAtRefCoordsOriented,
+            jacobianAtRefCoords_inv,
+            basisGradsAtRefCoordsOriented);
+
+        DynRankView ConstructWithLabel(projectedFunAtRefCoords, numElems, numRefCoords);
+        DynRankView ConstructWithLabel(funGradAtRefCoordsOriented, numElems, numRefCoords,dim);
+
+        //compute error of projection in H1 norm
+        ValueType norm2(0);
+        Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+        KOKKOS_LAMBDA (const int &i, double &norm2Update) {
+          for(ordinal_type j=0; j<numRefCoords; ++j) {
+            for(ordinal_type k=0; k<basisCardinality; ++k) {
+              projectedFunAtRefCoords(i,j) += basisCoeffsHGrad(i,k)*transformedBasisValuesAtRefCoordsOriented(i,k,j);
+              for (ordinal_type d=0; d<dim; ++d)
+                funGradAtRefCoordsOriented(i,j,d) += basisCoeffsHGrad(i,k)*transformedBasisGradsAtRefCoordsOriented(i,k,j,d);
+            }
+            {
+//              std::cout << "norm2Update = " << norm2Update << std::endl;
+//              // DEBUGGING
+//              std::cout << "funAtRefCoords("<< i << "," << j<< "): " << funAtRefCoords(i,j) << std::endl;
+//              std::cout << "projectedFunAtRefCoords(" << i << "," << j << "): " << projectedFunAtRefCoords(i,j) << std::endl;
+//              for (ordinal_type d=0; d<dim; ++d)
+//              {
+//                std::cout << "funGradAtPhysRefCoords(" << i << "," << j << "," << d << "): " << funGradAtPhysRefCoords(i,j,d) << std::endl;
+//                std::cout << "funGradAtRefCoordsOriented(" << i << "," << j << "," << d << "): " << funGradAtRefCoordsOriented(i,j,d) << std::endl;
+//              }
+            }
+            const auto absJacobianDet = (jacobianAtRefCoords_det(i,j) < 0) ? -jacobianAtRefCoords_det(i,j) : jacobianAtRefCoords_det(i,j);
+            
+            norm2Update += (funAtRefCoords(i,j) - projectedFunAtRefCoords(i,j))*
+                (funAtRefCoords(i,j) - projectedFunAtRefCoords(i,j))*
+                weights(j)*absJacobianDet;
+            for (ordinal_type d=0; d<dim; ++d)
+              norm2Update += (funGradAtPhysRefCoords(i,j,d) - funGradAtRefCoordsOriented(i,j,d))*
+                (funGradAtPhysRefCoords(i,j,d) - funGradAtRefCoordsOriented(i,j,d))*
+                weights(j)*absJacobianDet;
+          }
+        }, norm2);
+
+        ExecSpaceType().fence();
+
+        hgradNorm[iter] =  std::sqrt(norm2);
+        auto expected_error = useL2Projection ? hgrad_errors_L2[iter] : hgrad_errors[iter];
+        if (std::isnan(hgradNorm[iter]))
+        {
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "For N = " << NX << ", computed error (" << hgradNorm[iter] << ") is nan!";
+          *outStream << std::endl;
+        }
+        else if(std::abs(hgradNorm[iter]-expected_error)/expected_error > relTol){
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "For N = " << NX << ", computed error (" << hgradNorm[iter] << ") is different than expected one (" << expected_error << ")";
+          *outStream << std::endl;
+        }
+        delete basisPtr;
+      }
+      if(useL2Projection)
+        *outStream << "HGRAD Error (L2 Projection): " << hgradNorm[iter] <<std::endl;
+      else
+        *outStream << "HGRAD Error (HGrad Projection): " << hgradNorm[iter] <<std::endl;
+      }
+    } catch (std::exception &err) {
+      std::cout << " Exeption\n";
+      *outStream << err.what() << "\n\n";
+      errorFlag = -1000;
+    }
+
+    // TODO: uncomment the below when H(curl) basis on pyramid is implemented
+    /*
+    *outStream
+    << "===============================================================================\n"
+    << "|                                                                             |\n"
+    << "|                 Test 2 (Convergence - HCURL)                                |\n"
+    << "|                                                                             |\n"
+    << "===============================================================================\n";
+
+
+    try {
+      // compute orientations for cells (one time computation)
+      Kokkos::DynRankView<Orientation,DeviceType> elemOrts("elemOrts", numElems);
+      ots::getOrientation(elemOrts, elemNodes, cellTopo);
+
+      for (auto useL2Projection:useL2Proj) { 
+      
+      std::vector<basisType*> basis_set;
+      basis_set.push_back(new typename  CG_HBasis::HCURL_PYR(basisDegree));
+
+      for (auto basisPtr:basis_set) {
+        auto& basis = *basisPtr;
+        *outStream << " " << basis.getName() << std::endl;
+        ordinal_type basisCardinality = basis.getCardinality();
+
+        //Compute physical Dof Coordinates and Reference coordinates
+        DynRankView ConstructWithLabel(physRefCoords, numElems, numRefCoords, dim);
+        {
+          Basis_HGRAD_PYR_C1_FEM<DeviceType,ValueType,ValueType> linearBasis; //used for computing physical coordinates
+          DynRankView ConstructWithLabel(linearBasisValuesAtRefCoords, numNodesPerElem, numRefCoords);
+          linearBasis.getValues(linearBasisValuesAtRefCoords, refPoints);
+          ExecSpaceType().fence();
+          Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+          KOKKOS_LAMBDA (const int &i) {
+            for(ordinal_type d=0; d<dim; ++d)
+              for(ordinal_type j=0; j<numRefCoords; ++j)
+                for(ordinal_type k=0; k<numNodesPerElem; ++k)
+                  physRefCoords(i,j,d) += nodeCoord(elemNodes(i,k),d)*linearBasisValuesAtRefCoords(k,j);
+          });
+          ExecSpaceType().fence();
+        }
+        //check function reproducibility
+
+        DynRankView ConstructWithLabel(funAtRefCoords, numElems, numRefCoords, dim);
+        DynRankView ConstructWithLabel(funCurlAtPhysRefCoords, numElems, numRefCoords, dim);
+        Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+        KOKKOS_LAMBDA (const int &i) {
+          FunCurl fun;
+          CurlFunCurl curlFun;
+          for(ordinal_type j=0; j<numRefCoords; ++j) {
+            for(ordinal_type k=0; k<dim; ++k) {
+              funAtRefCoords(i,j,k) =         fun(physRefCoords(i,j,0), physRefCoords(i,j,1), physRefCoords(i,j,2), k);
+              funCurlAtPhysRefCoords(i,j,k) = curlFun(physRefCoords(i,j,0), physRefCoords(i,j,1), physRefCoords(i,j,2), k);
+            }
+          }
+        });
+        ExecSpaceType().fence();
+
+        // compute projection-based interpolation of fun into HCURL
+        DynRankView ConstructWithLabel(basisCoeffsHCurl, numElems, basisCardinality);
+        {
+          ordinal_type targetCubDegree(cub_degree),targetDerivCubDegree(cub_degree-1);
+
+          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          if(useL2Projection) {
+            projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
+          } else {
+            projStruct.createHCurlProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
+          }
+
+          auto evaluationPoints = projStruct.getAllEvalPoints();
+          auto evaluationCurlPoints = projStruct.getAllDerivEvalPoints();
+          ordinal_type numPoints = evaluationPoints.extent(0), numCurlPoints = evaluationCurlPoints.extent(0);
+
+          DynRankView ConstructWithLabel(targetAtEvalPoints, numElems, numPoints, dim);
+          DynRankView ConstructWithLabel(targetCurlAtEvalPoints, numElems, numCurlPoints, dim);
+
+
+          DynRankView ConstructWithLabel(physEvalPoints, numElems, numPoints, dim);
+          DynRankView ConstructWithLabel(physEvalCurlPoints, numElems, numCurlPoints, dim);
+          {
+            DynRankView ConstructWithLabel(linearBasisValuesAtEvalPoint, numElems, numNodesPerElem);
+            DynRankView ConstructWithLabel(linearBasisValuesAtEvalCurlPoint, numElems, numNodesPerElem);
+
+            Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+            KOKKOS_LAMBDA (const int &i) {
+              auto basisValuesAtEvalPoint = Kokkos::subview(linearBasisValuesAtEvalPoint,i,Kokkos::ALL());
+              for(ordinal_type j=0; j<numPoints; ++j){
+                auto evalPoint = Kokkos::subview(evaluationPoints,j,Kokkos::ALL());
+                Impl::Basis_HGRAD_PYR_C1_FEM::template Serial<OPERATOR_VALUE>::getValues(basisValuesAtEvalPoint, evalPoint);
+                for(ordinal_type k=0; k<numNodesPerElem; ++k)
+                  for(ordinal_type d=0; d<dim; ++d)
+                    physEvalPoints(i,j,d) += nodeCoord(elemNodes(i,k),d)*basisValuesAtEvalPoint(k);
+              }
+
+              auto basisValuesAtEvalCurlPoint = Kokkos::subview(linearBasisValuesAtEvalCurlPoint,i,Kokkos::ALL());
+              for(ordinal_type j=0; j<numCurlPoints; ++j) {
+                auto evalGradPoint = Kokkos::subview(evaluationCurlPoints,j,Kokkos::ALL());
+                Impl::Basis_HGRAD_PYR_C1_FEM::template Serial<OPERATOR_VALUE>::getValues(basisValuesAtEvalCurlPoint, evalGradPoint);
+                for(ordinal_type k=0; k<numNodesPerElem; ++k)
+                  for(ordinal_type d=0; d<dim; ++d)
+                    physEvalCurlPoints(i,j,d) += nodeCoord(elemNodes(i,k),d)*basisValuesAtEvalCurlPoint(k);
+              }
+            });
+            ExecSpaceType().fence();
+          }
+
+          //transform the target function and its derivative to the reference element (inverse of pullback operator)
+          DynRankView ConstructWithLabel(jacobian, numElems, numPoints, dim, dim);
+          ct::setJacobian(jacobian, evaluationPoints, physVertexes, cellTopo);
+
+
+          DynRankView ConstructWithLabel(jacobianCurl_inv, numElems, numCurlPoints, dim, dim);
+          DynRankView ConstructWithLabel(jacobianCurl_det, numElems, numCurlPoints);
+          if(numCurlPoints>0){
+            DynRankView ConstructWithLabel(jacobianCurl, numElems, numCurlPoints, dim, dim);
+            ct::setJacobian(jacobianCurl, evaluationCurlPoints, physVertexes, cellTopo);
+            ct::setJacobianInv (jacobianCurl_inv, jacobianCurl);
+            ct::setJacobianDet (jacobianCurl_det, jacobianCurl);
+          }
+
+          Kokkos::deep_copy(targetCurlAtEvalPoints,0.);
+          Kokkos::deep_copy(targetAtEvalPoints,0.);
+          Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+          KOKKOS_LAMBDA (const int &ic) {
+            FunCurl fun;
+            CurlFunCurl curlFun;
+            for(int i=0;i<numPoints;i++) {
+              for(int j=0;j<dim;j++)
+                for(int d=0;d<dim;d++)
+                  targetAtEvalPoints(ic,i,j) += jacobian(ic,i,d,j)*fun(physEvalPoints(ic,i,0), physEvalPoints(ic,i,1), physEvalPoints(ic,i,2),d);
+            }
+            for(int i=0;i<numCurlPoints;i++) {
+              for(int d=0;d<dim;d++)
+                for(int j=0;j<dim;j++)
+                  targetCurlAtEvalPoints(ic,i,j) += jacobianCurl_det(ic,i)*jacobianCurl_inv(ic,i,j,d)*curlFun(physEvalCurlPoints(ic,i,0), physEvalCurlPoints(ic,i,1), physEvalCurlPoints(ic,i,2), d);//funHGradCoeffs(k)
+            }
+          });
+          ExecSpaceType().fence();
+
+          if(useL2Projection) {
+            pts::getL2BasisCoeffs(basisCoeffsHCurl,
+                targetAtEvalPoints,
+                elemOrts,
+                &basis,
+                &projStruct);
+          } else {
+            pts::getHCurlBasisCoeffs(basisCoeffsHCurl,
+                targetAtEvalPoints,
+                targetCurlAtEvalPoints,
+                elemOrts,
+                &basis,
+                &projStruct);
+          }
+        }
+
+        //check that fun values at reference points coincide with those computed using basis functions
+        DynRankView ConstructWithLabel(basisValuesAtRefCoordsOriented, numElems, basisCardinality, numRefCoords, dim);
+        DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoordsOriented, numElems, basisCardinality, numRefCoords, dim);
+        DynRankView basisValuesAtRefCoordsCells("inValues", numElems, basisCardinality, numRefCoords, dim);
+
+
+        DynRankView ConstructWithLabel(basisValuesAtRefCoords, basisCardinality, numRefCoords, dim);
+        basis.getValues(basisValuesAtRefCoords, refPoints);
+        rst::clone(basisValuesAtRefCoordsCells,basisValuesAtRefCoords);
+
+        // modify basis values to account for orientations
+        ots::modifyBasisByOrientation(basisValuesAtRefCoordsOriented,
+            basisValuesAtRefCoordsCells,
+            elemOrts,
+            &basis);
+
+        // transform basis values to the reference element (pullback)
+        DynRankView ConstructWithLabel(jacobianAtRefCoords, numElems, numRefCoords, dim, dim);
+        DynRankView ConstructWithLabel(jacobianAtRefCoords_inv, numElems, numRefCoords, dim, dim);
+        DynRankView ConstructWithLabel(jacobianAtRefCoords_det, numElems, numRefCoords);
+        ct::setJacobian(jacobianAtRefCoords, refPoints, physVertexes, cellTopo);
+        ct::setJacobianInv (jacobianAtRefCoords_inv, jacobianAtRefCoords);
+        ct::setJacobianDet (jacobianAtRefCoords_det, jacobianAtRefCoords);
+        fst::HCURLtransformVALUE(transformedBasisValuesAtRefCoordsOriented,
+            jacobianAtRefCoords_inv,
+            basisValuesAtRefCoordsOriented);
+
+
+        DynRankView ConstructWithLabel(basisCurlsAtRefCoordsOriented, numElems, basisCardinality, numRefCoords, dim);
+        DynRankView ConstructWithLabel(transformedBasisCurlsAtRefCoordsOriented, numElems, basisCardinality, numRefCoords, dim);
+        DynRankView basisCurlsAtRefCoordsCells("inValues", numElems, basisCardinality, numRefCoords, dim);
+
+        DynRankView ConstructWithLabel(basisCurlsAtRefCoords, basisCardinality, numRefCoords, dim);
+        basis.getValues(basisCurlsAtRefCoords, refPoints,OPERATOR_CURL);
+        rst::clone(basisCurlsAtRefCoordsCells,basisCurlsAtRefCoords);
+
+        // modify basis values to account for orientations
+        ots::modifyBasisByOrientation(basisCurlsAtRefCoordsOriented,
+            basisCurlsAtRefCoordsCells,
+            elemOrts,
+            &basis);
+
+        fst::HCURLtransformCURL(transformedBasisCurlsAtRefCoordsOriented,
+            jacobianAtRefCoords,
+            jacobianAtRefCoords_det,
+            basisCurlsAtRefCoordsOriented);
+
+        DynRankView ConstructWithLabel(projectedFunAtRefCoords, numElems, numRefCoords, dim);
+        DynRankView ConstructWithLabel(funCurlAtRefCoordsOriented, numElems, numRefCoords,dim);
+
+        //compute error of projection in HCURL norm
+        ValueType norm2(0);
+        Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+        KOKKOS_LAMBDA (const int &i, double &norm2Update) {
+          for(ordinal_type j=0; j<numRefCoords; ++j)
+            for(ordinal_type d=0; d<dim; ++d) {
+              for(ordinal_type k=0; k<basisCardinality; ++k) {
+                projectedFunAtRefCoords(i,j,d) += basisCoeffsHCurl(i,k)*transformedBasisValuesAtRefCoordsOriented(i,k,j,d);
+                funCurlAtRefCoordsOriented(i,j,d) += basisCoeffsHCurl(i,k)*transformedBasisCurlsAtRefCoordsOriented(i,k,j,d);
+              }
+
+              const auto absJacobianDet = (jacobianAtRefCoords_det(i,j) < 0) ? -jacobianAtRefCoords_det(i,j) : jacobianAtRefCoords_det(i,j);
+              norm2Update += (funAtRefCoords(i,j,d) - projectedFunAtRefCoords(i,j,d))*
+                  (funAtRefCoords(i,j,d) - projectedFunAtRefCoords(i,j,d))*
+                  weights(j)*absJacobianDet;
+              norm2Update += (funCurlAtPhysRefCoords(i,j,d) - funCurlAtRefCoordsOriented(i,j,d))*
+                  (funCurlAtPhysRefCoords(i,j,d) - funCurlAtRefCoordsOriented(i,j,d))*
+                  weights(j)*absJacobianDet;
+            }
+        },norm2);
+        ExecSpaceType().fence();
+
+        hcurlNorm[iter] =  std::sqrt(norm2);
+        auto expected_error = useL2Projection ? hcurl_errors_L2[iter] : hcurl_errors[iter];
+        if (std::isnan(hcurlNorm[iter]))
+        {
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "For N = " << NX << ", computed error (" << hcurlNorm[iter] << ") is nan!";
+          *outStream << std::endl;
+        }
+        else if(std::abs(hcurlNorm[iter]-expected_error)/expected_error > relTol){
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "For N = " << NX << ", computed error (" << hcurlNorm[iter] << ") is different than expected one (" << expected_error << ")";
+          *outStream << std::endl;
+        }
+        delete basisPtr;
+      }
+      if(useL2Projection)
+        *outStream << "HCURL Error (L2 Projection): " << hcurlNorm[iter] <<std::endl;
+      else
+        *outStream << "HCURL Error (HCurl Projection): " << hcurlNorm[iter] <<std::endl;
+      }
+    } catch (std::exception &err) {
+      std::cout << " Exeption\n";
+      *outStream << err.what() << "\n\n";
+      errorFlag = -1000;
+    }
+*/
+    // TODO: uncomment the below when H(div) basis on pyramid is implemented
+    /*
+    *outStream
+    << "===============================================================================\n"
+    << "|                                                                             |\n"
+    << "|                 Test 3 (Convergence - HDIV)                                 |\n"
+    << "|                                                                             |\n"
+    << "===============================================================================\n";
+
+
+    try {
+      // compute orientations for cells (one time computation)
+      Kokkos::DynRankView<Orientation,DeviceType> elemOrts("elemOrts", numElems);
+      ots::getOrientation(elemOrts, elemNodes, cellTopo);
+
+      for (auto useL2Projection:useL2Proj) { //
+
+      std::vector<basisType*> basis_set;
+      basis_set.push_back(new typename  CG_HBasis::HDIV_PYR(basisDegree));
+
+      for (auto basisPtr:basis_set) {
+        auto& basis = *basisPtr;
+        *outStream << " " << basis.getName() << std::endl;
+        ordinal_type basisCardinality = basis.getCardinality();
+
+        //Compute physical Dof Coordinates and Reference coordinates
+        DynRankView ConstructWithLabel(physRefCoords, numElems, numRefCoords, dim);
+        DynRankView ConstructWithLabel(physDofCoords, numElems, basisCardinality, dim);
+        {
+          Basis_HGRAD_PYR_C1_FEM<DeviceType,ValueType,ValueType> linearBasis; //used for computing physical coordinates
+          DynRankView ConstructWithLabel(linearBasisValuesAtRefCoords, numNodesPerElem, numRefCoords);
+          linearBasis.getValues(linearBasisValuesAtRefCoords, refPoints);
+          ExecSpaceType().fence();
+          Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+          KOKKOS_LAMBDA (const int &i) {
+            for(ordinal_type d=0; d<dim; ++d)
+              for(ordinal_type j=0; j<numRefCoords; ++j)
+                for(ordinal_type k=0; k<numNodesPerElem; ++k)
+                  physRefCoords(i,j,d) += nodeCoord(elemNodes(i,k),d)*linearBasisValuesAtRefCoords(k,j);
+          });
+          ExecSpaceType().fence();
+        }
+
+        DynRankView ConstructWithLabel(funAtRefCoords, numElems, numRefCoords, dim);
+        DynRankView ConstructWithLabel(funDivAtPhysRefCoords, numElems, numRefCoords);
+        Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+        KOKKOS_LAMBDA (const int &i) {
+          FunDiv fun;
+          DivFunDiv funDiv;
+          for(ordinal_type j=0; j<numRefCoords; ++j) {
+            funDivAtPhysRefCoords(i,j) = funDiv(physRefCoords(i,j,0), physRefCoords(i,j,1), physRefCoords(i,j,2));
+            for(ordinal_type k=0; k<dim; ++k)
+              funAtRefCoords(i,j,k) = fun(physRefCoords(i,j,0), physRefCoords(i,j,1), physRefCoords(i,j,2), k);
+          }
+        });
+        ExecSpaceType().fence();
+
+        // compute projection-based interpolation of fun into HDIV
+        DynRankView ConstructWithLabel(basisCoeffsHDiv, numElems, basisCardinality);
+        {
+          ordinal_type targetCubDegree(basis.getDegree()),targetDerivCubDegree(basis.getDegree()-1);
+
+          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          if(useL2Projection) {
+            projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
+          } else {
+            projStruct.createHDivProjectionStruct(&basis, targetCubDegree, targetDerivCubDegree);
+          }
+
+          auto evaluationPoints = projStruct.getAllEvalPoints();
+          auto evaluationDivPoints = projStruct.getAllDerivEvalPoints();
+          ordinal_type numPoints = evaluationPoints.extent(0), numDivPoints = evaluationDivPoints.extent(0);
+
+          DynRankView ConstructWithLabel(targetAtEvalPoints, numElems, numPoints, dim);
+          DynRankView ConstructWithLabel(targetDivAtEvalPoints, numElems, numDivPoints);
+
+
+          DynRankView ConstructWithLabel(physEvalPoints, numElems, numPoints, dim);
+          DynRankView ConstructWithLabel(physEvalDivPoints, numElems, numDivPoints, dim);
+          {
+            DynRankView ConstructWithLabel(linearBasisValuesAtEvalPoint, numElems, numNodesPerElem);
+            DynRankView ConstructWithLabel(linearBasisValuesAtEvalDivPoint, numElems, numNodesPerElem);
+
+            Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+            KOKKOS_LAMBDA (const int &i) {
+              auto basisValuesAtEvalPoint = Kokkos::subview(linearBasisValuesAtEvalPoint,i,Kokkos::ALL());
+              for(ordinal_type j=0; j<numPoints; ++j){
+                auto evalPoint = Kokkos::subview(evaluationPoints,j,Kokkos::ALL());
+                Impl::Basis_HGRAD_PYR_C1_FEM::template Serial<OPERATOR_VALUE>::getValues(basisValuesAtEvalPoint, evalPoint);
+                for(ordinal_type k=0; k<numNodesPerElem; ++k)
+                  for(ordinal_type d=0; d<dim; ++d)
+                    physEvalPoints(i,j,d) += nodeCoord(elemNodes(i,k),d)*basisValuesAtEvalPoint(k);
+              }
+
+              auto basisValuesAtEvalDivPoint = Kokkos::subview(linearBasisValuesAtEvalDivPoint,i,Kokkos::ALL());
+              for(ordinal_type j=0; j<numDivPoints; ++j) {
+                auto evalGradPoint = Kokkos::subview(evaluationDivPoints,j,Kokkos::ALL());
+                Impl::Basis_HGRAD_PYR_C1_FEM::template Serial<OPERATOR_VALUE>::getValues(basisValuesAtEvalDivPoint, evalGradPoint);
+                for(ordinal_type k=0; k<numNodesPerElem; ++k)
+                  for(ordinal_type d=0; d<dim; ++d)
+                    physEvalDivPoints(i,j,d) += nodeCoord(elemNodes(i,k),d)*basisValuesAtEvalDivPoint(k);
+              }
+            });
+            ExecSpaceType().fence();
+          }
+
+          //transform the target function and its derivative to the reference element (inverse of pullback operator)
+          DynRankView ConstructWithLabel(jacobian, numElems, numPoints, dim, dim);
+          DynRankView ConstructWithLabel(jacobian_det, numElems, numPoints);
+          DynRankView ConstructWithLabel(jacobian_inv, numElems, numPoints, dim, dim);
+          ct::setJacobian(jacobian, evaluationPoints, physVertexes, cellTopo);
+          ct::setJacobianDet (jacobian_det, jacobian);
+          ct::setJacobianInv (jacobian_inv, jacobian);
+
+          DynRankView ConstructWithLabel(jacobianDiv_det, numElems, numDivPoints);
+          if(numDivPoints>0){
+            DynRankView ConstructWithLabel(jacobianDiv, numElems, numDivPoints, dim, dim);
+            ct::setJacobian(jacobianDiv, evaluationDivPoints, physVertexes, cellTopo);
+            ct::setJacobianDet (jacobianDiv_det, jacobianDiv);
+          }
+
+          Kokkos::deep_copy(targetDivAtEvalPoints,0.);
+          Kokkos::deep_copy(targetAtEvalPoints,0.);
+          Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+          KOKKOS_LAMBDA (const int &ic) {
+            FunDiv fun;
+            DivFunDiv divFun;
+            for(int i=0;i<numPoints;i++) {
+              for(int j=0;j<dim;j++)
+                for(int d=0;d<dim;d++)
+                  targetAtEvalPoints(ic,i,j) += jacobian_det(ic,i)*jacobian_inv(ic,i,j,d)*fun(physEvalPoints(ic,i,0), physEvalPoints(ic,i,1), physEvalPoints(ic,i,2),d);
+            }
+            for(int i=0;i<numDivPoints;i++) {
+              targetDivAtEvalPoints(ic,i) += jacobianDiv_det(ic,i)*divFun(physEvalDivPoints(ic,i,0), physEvalDivPoints(ic,i,1), physEvalDivPoints(ic,i,2));//funHGradCoeffs(k)
+            }
+          });
+          ExecSpaceType().fence();
+
+          if(useL2Projection) {
+            pts::getL2BasisCoeffs(basisCoeffsHDiv,
+                targetAtEvalPoints,
+                elemOrts,
+                &basis,
+                &projStruct);
+          } else {
+            pts::getHDivBasisCoeffs(basisCoeffsHDiv,
+                targetAtEvalPoints,
+                targetDivAtEvalPoints,
+                elemOrts,
+                &basis,
+                &projStruct);
+          }
+        }
+
+        //check that fun values at reference points coincide with those computed using basis functions
+        DynRankView ConstructWithLabel(basisValuesAtRefCoordsOriented, numElems, basisCardinality, numRefCoords, dim);
+        DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoordsOriented, numElems, basisCardinality, numRefCoords, dim);
+        DynRankView basisValuesAtRefCoordsCells("inValues", numElems, basisCardinality, numRefCoords, dim);
+
+        DynRankView ConstructWithLabel(basisValuesAtRefCoords, basisCardinality, numRefCoords, dim);
+        basis.getValues(basisValuesAtRefCoords, refPoints);
+        rst::clone(basisValuesAtRefCoordsCells,basisValuesAtRefCoords);
+
+        // modify basis values to account for orientations
+        ots::modifyBasisByOrientation(basisValuesAtRefCoordsOriented,
+            basisValuesAtRefCoordsCells,
+            elemOrts,
+            &basis);
+
+        // transform basis values to the reference element (pullback)
+        DynRankView ConstructWithLabel(jacobianAtRefCoords, numElems, numRefCoords, dim, dim);
+        DynRankView ConstructWithLabel(jacobianAtRefCoords_det, numElems, numRefCoords);
+        ct::setJacobian(jacobianAtRefCoords, refPoints, physVertexes, cellTopo);
+        ct::setJacobianDet (jacobianAtRefCoords_det, jacobianAtRefCoords);
+        fst::HDIVtransformVALUE(transformedBasisValuesAtRefCoordsOriented,
+            jacobianAtRefCoords,
+            jacobianAtRefCoords_det,
+            basisValuesAtRefCoordsOriented);
+
+        DynRankView ConstructWithLabel(basisDivsAtRefCoordsOriented, numElems, basisCardinality, numRefCoords);
+        DynRankView ConstructWithLabel(transformedBasisDivsAtRefCoordsOriented, numElems, basisCardinality, numRefCoords);
+        DynRankView basisDivsAtRefCoordsCells("inValues", numElems, basisCardinality, numRefCoords);
+
+        DynRankView ConstructWithLabel(basisDivsAtRefCoords, basisCardinality, numRefCoords);
+        basis.getValues(basisDivsAtRefCoords, refPoints,OPERATOR_DIV);
+        rst::clone(basisDivsAtRefCoordsCells,basisDivsAtRefCoords);
+
+        // modify basis values to account for orientations
+        ots::modifyBasisByOrientation(basisDivsAtRefCoordsOriented,
+            basisDivsAtRefCoordsCells,
+            elemOrts,
+            &basis);
+
+
+        fst::HDIVtransformDIV(transformedBasisDivsAtRefCoordsOriented,
+            jacobianAtRefCoords_det,
+            basisDivsAtRefCoordsOriented);
+
+
+        DynRankView ConstructWithLabel(projectedFunAtRefCoords, numElems, numRefCoords, dim);
+        DynRankView ConstructWithLabel(funDivAtRefCoordsOriented, numElems, numRefCoords);
+
+        //compute error of projection in HDIV norm
+        ValueType norm2(0);
+        Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+        KOKKOS_LAMBDA (const int &i, double &norm2Update) {
+          for(ordinal_type j=0; j<numRefCoords; ++j) {
+            for(ordinal_type k=0; k<basisCardinality; ++k) {
+              for(ordinal_type d=0; d<dim; ++d)
+                projectedFunAtRefCoords(i,j,d) += basisCoeffsHDiv(i,k)*transformedBasisValuesAtRefCoordsOriented(i,k,j,d);
+              funDivAtRefCoordsOriented(i,j) += basisCoeffsHDiv(i,k)*transformedBasisDivsAtRefCoordsOriented(i,k,j);
+            }
+
+            const auto absJacobianDet = (jacobianAtRefCoords_det(i,j) < 0) ? -jacobianAtRefCoords_det(i,j) : jacobianAtRefCoords_det(i,j);
+            for(ordinal_type d=0; d<dim; ++d) {
+              norm2Update += (funAtRefCoords(i,j,d) - projectedFunAtRefCoords(i,j,d))*
+                  (funAtRefCoords(i,j,d) - projectedFunAtRefCoords(i,j,d))*
+                  weights(j)*absJacobianDet;
+            }
+            norm2Update += (funDivAtPhysRefCoords(i,j) - funDivAtRefCoordsOriented(i,j))*
+                (funDivAtPhysRefCoords(i,j) - funDivAtRefCoordsOriented(i,j))*
+                weights(j)*absJacobianDet;
+          }
+        },norm2);
+        ExecSpaceType().fence();
+        hdivNorm[iter] = std::sqrt(norm2);
+        auto expected_error = useL2Projection ? hdiv_errors_L2[iter] : hdiv_errors[iter];
+        if (std::isnan(hdivNorm[iter]))
+        {
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "For N = " << NX << ", computed error (" << hdivNorm[iter] << ") is nan!";
+          *outStream << std::endl;
+        }
+        else if(std::abs(hdivNorm[iter]-expected_error)/expected_error > relTol){
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "For N = " << NX << ", computed error (" << hdivNorm[iter] << ") is different than expected one (" << expected_error << ")";
+          *outStream << std::endl;
+        }
+        delete basisPtr;
+      }
+      if(useL2Projection)
+        *outStream << "HDIV Error (L2 Projection): " << hdivNorm[iter] <<std::endl;
+      else
+        *outStream << "HDIV Error (HDiv Projection): " << hdivNorm[iter] <<std::endl;
+      }
+    } catch (std::exception &err) {
+      std::cout << " Exeption\n";
+      *outStream << err.what() << "\n\n";
+      errorFlag = -1000;
+    }*/
+
+
+
+    *outStream
+    << "===============================================================================\n"
+    << "|                                                                             |\n"
+    << "|                 Test 4 (Convergence - HVOL)                                 |\n"
+    << "|                                                                             |\n"
+    << "===============================================================================\n";
+
+
+    try {
+      // compute orientations for cells (one-time computation)
+      Kokkos::DynRankView<Orientation,DeviceType> elemOrts("elemOrts", numElems);
+      cellGeometry.orientations(elemOrts);
+
+      for (auto useL2Projection:useL2Proj) { //
+      std::vector<basisType*> basis_set;
+      basis_set.push_back(new typename  CG_HBasis::HVOL_PYR(basisDegree-1));
+
+      for (auto basisPtr:basis_set) {
+        auto& basis = *basisPtr;
+        *outStream << " " << basis.getName() << std::endl;
+        ordinal_type basisCardinality = basis.getCardinality();
+
+        //Compute physical Dof Coordinates and Reference coordinates
+        DynRankView ConstructWithLabel(physRefCoords, numElems, numRefCoords, dim);
+        {
+          Basis_HGRAD_PYR_C1_FEM<DeviceType,ValueType,ValueType> linearBasis; //used for computing physical coordinates
+          DynRankView ConstructWithLabel(linearBasisValuesAtRefCoords, numNodesPerElem, numRefCoords);
+          linearBasis.getValues(linearBasisValuesAtRefCoords, refPoints);
+          ExecSpaceType().fence();
+          Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+          KOKKOS_LAMBDA (const int &i) {
+            for(ordinal_type d=0; d<dim; ++d)
+              for(ordinal_type j=0; j<numRefCoords; ++j)
+                for(ordinal_type k=0; k<numNodesPerElem; ++k)
+                  physRefCoords(i,j,d) += cellGeometry(i,k,d)*linearBasisValuesAtRefCoords(k,j);
+          });
+          ExecSpaceType().fence();
+        }
+
+        //check function reproducibility
+        DynRankView ConstructWithLabel(funAtRefCoords, numElems, numRefCoords);
+        Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+        KOKKOS_LAMBDA (const int &i) {
+          Fun fun;
+          for(ordinal_type j=0; j<numRefCoords; ++j)
+            funAtRefCoords(i,j) = fun(physRefCoords(i,j,0), physRefCoords(i,j,1), physRefCoords(i,j,2));
+        });
+        ExecSpaceType().fence();
+
+        // compute projection-based interpolation of fun into HVOL
+        DynRankView ConstructWithLabel(basisCoeffsHVol, numElems, basisCardinality);
+        {
+          ordinal_type targetCubDegree(basis.getDegree());
+
+          Experimental::ProjectionStruct<DeviceType,ValueType> projStruct;
+          if(useL2Projection) {
+            projStruct.createL2ProjectionStruct(&basis, targetCubDegree);
+          } else {
+            projStruct.createHVolProjectionStruct(&basis, targetCubDegree);
+          }
+
+          auto evaluationPoints = projStruct.getAllEvalPoints();
+          ordinal_type numPoints = evaluationPoints.extent(0);
+
+          DynRankView ConstructWithLabel(targetAtEvalPoints, numElems, numPoints);
+
+
+          DynRankView ConstructWithLabel(physEvalPoints, numElems, numPoints, dim);
+          {
+            DynRankView ConstructWithLabel(linearBasisValuesAtEvalPoint, numElems, numNodesPerElem);
+
+            Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+            KOKKOS_LAMBDA (const int &i) {
+              auto basisValuesAtEvalPoint = Kokkos::subview(linearBasisValuesAtEvalPoint,i,Kokkos::ALL());
+              for(ordinal_type j=0; j<numPoints; ++j){
+                auto evalPoint = Kokkos::subview(evaluationPoints,j,Kokkos::ALL());
+                Impl::Basis_HGRAD_PYR_C1_FEM::template Serial<OPERATOR_VALUE>::getValues(basisValuesAtEvalPoint, evalPoint);
+                for(ordinal_type k=0; k<numNodesPerElem; ++k)
+                  for(ordinal_type d=0; d<dim; ++d)
+                    physEvalPoints(i,j,d) += cellGeometry(i,k,d)*basisValuesAtEvalPoint(k);
+              }
+            });
+            ExecSpaceType().fence();
+          }
+
+          //transform the target function to the reference element (inverse of pullback operator)
+          DynRankView ConstructWithLabel(jacobian, numElems, numPoints, dim, dim);
+          DynRankView ConstructWithLabel(jacobian_det, numElems, numPoints);
+          ct::setJacobian(jacobian, evaluationPoints, physVertexes, cellTopo);
+          ct::setJacobianDet (jacobian_det, jacobian);
+
+          Kokkos::deep_copy(targetAtEvalPoints,0.);
+          Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+          KOKKOS_LAMBDA (const int &ic) {
+            Fun fun;
+            for(int i=0;i<numPoints;i++)
+              targetAtEvalPoints(ic,i) += jacobian_det(ic,i)*fun(physEvalPoints(ic,i,0), physEvalPoints(ic,i,1), physEvalPoints(ic,i,2));
+          });
+          ExecSpaceType().fence();
+          if(useL2Projection) {
+            pts::getL2BasisCoeffs(basisCoeffsHVol,
+                targetAtEvalPoints,
+                elemOrts,
+                &basis,
+                &projStruct);
+          } else {
+            pts::getHVolBasisCoeffs(basisCoeffsHVol,
+                targetAtEvalPoints,
+                elemOrts,
+                &basis,
+                &projStruct);
+          }
+        }
+
+
+        //check that fun values at reference points coincide with those computed using basis functions
+        DynRankView ConstructWithLabel(basisValuesAtRefCoordsOriented, numElems, basisCardinality, numRefCoords);
+        DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoordsOriented, numElems, basisCardinality, numRefCoords);
+        DynRankView basisValuesAtRefCoordsCells("inValues", numElems, basisCardinality, numRefCoords);
+
+        DynRankView ConstructWithLabel(basisValuesAtRefCoords, basisCardinality, numRefCoords);
+        basis.getValues(basisValuesAtRefCoords, refPoints);
+        rst::clone(basisValuesAtRefCoordsCells,basisValuesAtRefCoords);
+
+        // modify basis values to account for orientations
+        ots::modifyBasisByOrientation(basisValuesAtRefCoordsOriented,
+            basisValuesAtRefCoordsCells,
+            elemOrts,
+            &basis);
+
+        // transform basis values to the reference element (pullback)
+        DynRankView ConstructWithLabel(jacobianAtRefCoords, numElems, numRefCoords, dim, dim);
+        DynRankView ConstructWithLabel(jacobianAtRefCoords_det, numElems, numRefCoords);
+        ct::setJacobian(jacobianAtRefCoords, refPoints, physVertexes, cellTopo);
+        ct::setJacobianDet (jacobianAtRefCoords_det, jacobianAtRefCoords);
+        fst::HVOLtransformVALUE(transformedBasisValuesAtRefCoordsOriented,
+            jacobianAtRefCoords_det,
+            basisValuesAtRefCoordsOriented);
+
+        DynRankView ConstructWithLabel(projectedFunAtRefCoords, numElems, numRefCoords);
+
+        //compute error of projection in L2 norm
+        ValueType norm2(0);
+        Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpaceType>(0,numElems),
+        KOKKOS_LAMBDA (const int &i, double &norm2Update) {
+          for(ordinal_type j=0; j<numRefCoords; ++j) {
+            for(ordinal_type k=0; k<basisCardinality; ++k)
+              projectedFunAtRefCoords(i,j) += basisCoeffsHVol(i,k)*transformedBasisValuesAtRefCoordsOriented(i,k,j);
+            const auto absJacobianDet = (jacobianAtRefCoords_det(i,j) < 0) ? -jacobianAtRefCoords_det(i,j) : jacobianAtRefCoords_det(i,j);
+            norm2Update += (funAtRefCoords(i,j) - projectedFunAtRefCoords(i,j))*
+                (funAtRefCoords(i,j) - projectedFunAtRefCoords(i,j))*
+                weights(j)*absJacobianDet;
+          }
+        },norm2);
+        ExecSpaceType().fence();
+
+        hvolNorm[iter] =  std::sqrt(norm2);
+        auto expected_error = useL2Projection ? hvol_errors_L2[iter] : hvol_errors[iter];
+        if (std::isnan(hvolNorm[iter]))
+        {
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "For N = " << NX << ", computed error (" << hvolNorm[iter] << ") is nan!";
+          *outStream << std::endl;
+        }
+        else if(std::abs(hvolNorm[iter]-expected_error)/expected_error > relTol){
+          errorFlag++;
+          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+          *outStream << "For N = " << NX << ", computed error (" << hvolNorm[iter] << ") is different than expected one (" << expected_error << ")";
+          *outStream << std::endl;
+        }
+        delete basisPtr;
+      }
+      if(useL2Projection)
+        *outStream << "HVOL Error (L2 Projection): " << hvolNorm[iter] <<std::endl;
+      else
+        *outStream << "HVOL Error (HVol Projection): " << hvolNorm[iter] <<std::endl;
+      }
+    } catch (std::exception &err) {
+      std::cout << " Exception\n";
+      *outStream << err.what() << "\n\n";
+      errorFlag = -1000;
+    }
+  }
+/*
+  *outStream << "\nHGRAD ERROR:";
+  for(int iter = 0; iter<numRefinements; iter++)
+    *outStream << " " << hgradNorm[iter];
+  *outStream << "\nHCURL ERROR:";
+  for(int iter = 0; iter<numRefinements; iter++)
+    *outStream << " " << hcurlNorm[iter];
+  *outStream << "\nHDIV ERROR:";
+  for(int iter = 0; iter<numRefinements; iter++)
+    *outStream << " " << hdivNorm[iter];
+  *outStream << "\nHVOL ERROR:";
+  for(int iter = 0; iter<numRefinements; iter++)
+    *outStream << " " << hvolNorm[iter];
+  *outStream << std::endl;
+*/
+
+  if (errorFlag != 0)
+    std::cout << "End Result: TEST FAILED = " << errorFlag << "\n";
+  else
+    std::cout << "End Result: TEST PASSED\n";
+
+  // reset format state of std::cout
+  std::cout.copyfmt(oldFormatState);
+  return errorFlag;
+}
+}
+}
+


### PR DESCRIPTION
@trilinos/intrepid2 

## Motivation
This PR adds an arbitrary-order, hierarchical basis for H(div) on the pyramid.  This follows #12079, which added hierarchical bases for H(grad) on the pyramid, and #12136, which added bases for H(vol).

This PR also adds support in CellGeometry for a pyramidal subdivision of regular hexahedral meshes, and support for a rudimentary node numbering within CellGeometry.  This is in support of new projection convergence tests, so far implemented for H(grad) and H(vol).  H(div) support for such projections actually requires H(curl) bases to be implemented as well; those will be coming in a subsequent PR.

Additionally, this PR adds orientation tests against H(div) on the pyramid.

## Testing
This PR has orientation and basis cardinality tests for the new H(div) basis.  The new CellGeometry features have some limited tests against them as well.  It also adds projection convergence tests for H(grad) and H(vol) on the pyramid.

Additionally, I have done offline comparison with the ESEAS implementation of this basis, testing up to 9th order, with excellent agreement.  (There were actually a couple of bugs I found in ESEAS's implementation, which I plan to submit fixes for there shortly.)  I hope to include these tests with Intrepid2 soon; this has been prevented previously by the license for ESEAS, but they are changing the license to one that will allow inclusion.