### PR TITLE
Framework: Trilframe 512 add son nightly cuda build

### DIFF
--- a/packages/framework/pr_tools/LaunchDriver.py
+++ b/packages/framework/pr_tools/LaunchDriver.py
@@ -102,14 +102,15 @@ def main(argv):
   # Specify, and override the driver script for ATDM ATS2 builds. Note that
   # args.build_name is a required argument so it will be valid by the time it
   # reaches this check.
-  if args.build_name.startswith("rhel8"):
-    cmd += " --on_rhel8"
 
   if args.build_name.startswith("ats2_cuda"):
       args.driver = "./Trilinos/packages/framework/pr_tools/PullRequestLinuxCudaVortexDriver.sh"
 
   cmd = launch_env + launch_cmd + args.driver + driver_args
 
+  if args.build_name.startswith("rhel8"):
+    cmd += " --on_rhel8"
+    
   if args.in_container:
      cmd += " --no-bootstrap"
 

--- a/packages/framework/pr_tools/LaunchDriver.py
+++ b/packages/framework/pr_tools/LaunchDriver.py
@@ -102,6 +102,9 @@ def main(argv):
   # Specify, and override the driver script for ATDM ATS2 builds. Note that
   # args.build_name is a required argument so it will be valid by the time it
   # reaches this check.
+  if args.build_name.startswith("rhel8"):
+    cmd += " --on_rhel8"
+
   if args.build_name.startswith("ats2_cuda"):
       args.driver = "./Trilinos/packages/framework/pr_tools/PullRequestLinuxCudaVortexDriver.sh"
 

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -8,6 +8,7 @@ source ${SCRIPTPATH:?}/common.bash
 on_weaver=$(echo "$@" | grep '\-\-on_weaver' &> /dev/null && echo "1")
 on_ats2=$(echo "$@" | grep '\-\-on_ats2' &> /dev/null && echo "1")
 on_kokkos_develop=$(echo "$@" | grep '\-\-kokkos\-develop' &> /dev/null && echo "1")
+on_rhel8=$(echo "$@" | grep '\-\-on_rhel8' &> /dev/null && echo "1")
 
 bootstrap=$(echo "$@" | grep '\-\-\no\-bootstrap' &> /dev/null && echo "0" || echo "1")
 
@@ -46,6 +47,14 @@ function bootstrap_modules() {
         module load git/2.10.1
         module load python/3.7.3
         get_python_packages pip3
+
+        module list
+    elif [[ ${on_rhel8} == "1" ]]; then
+        source /projects/sems/modulefiles/utils/sems-modules-init.sh
+        module unload sems-git
+        module unload sems-python
+        module load sems-git/2.37.0
+        module load sems-python/3.9.0
 
         module list
     else


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

The PRLaunchDriver is using a rhel8 system and when it runs `module load sems-archive-git/2.10.1` the jenkins job errors out with `ERROR: Unable to locate a modulefile for 'sems-archive-git/2.10.1'`. These changes fix that error.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

Related to [Ticket #512](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-512)

