### PR TITLE
Tpetra: Fix compiling with SYCL

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Random.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Random.cpp
@@ -83,7 +83,7 @@ void finalize_hip_pool() {
 #endif // KOKKOS_ENABLE_HIP
 
 #ifdef KOKKOS_ENABLE_SYCL
-Kokkos::Random_XorShift64_Pool<typename Kokkos::SYCLDeviceUSMSpace::execution_space> * sycl_pool_=nullptr;
+Kokkos::Random_XorShift64_Pool<typename Kokkos::Experimental::SYCLDeviceUSMSpace::execution_space> * sycl_pool_=nullptr;
 
 void finalize_sycl_pool() {
   if(sycl_pool_ != nullptr) {
@@ -183,9 +183,9 @@ getPool() {
 /********************************************************************************/
 #ifdef KOKKOS_ENABLE_SYCL
 void 
-Static_Random_XorShift64_Pool<typename Kokkos::SYCLDeviceUSMSpace::execution_space>::
+Static_Random_XorShift64_Pool<typename Kokkos::Experimental::SYCLDeviceUSMSpace::execution_space>::
 resetPool(int mpi_rank) {
-  using pool_type = Kokkos::Random_XorShift64_Pool<typename Kokkos::SYCLDeviceUSMSpace::execution_space>;
+  using pool_type = Kokkos::Random_XorShift64_Pool<typename Kokkos::Experimental::SYCLDeviceUSMSpace::execution_space>;
 
   if(isSet())
     delete sycl_pool_;
@@ -196,13 +196,13 @@ resetPool(int mpi_rank) {
 } 
 
 bool 
-Static_Random_XorShift64_Pool<typename Kokkos::SYCLDeviceUSMSpace::execution_space>::
+Static_Random_XorShift64_Pool<typename Kokkos::Experimental::SYCLDeviceUSMSpace::execution_space>::
 isSet() {
   return sycl_pool_!=nullptr;
 }
 
-Kokkos::Random_XorShift64_Pool<typename Kokkos::SYCLDeviceUSMSpace::execution_space> &
-Static_Random_XorShift64_Pool<typename Kokkos::SYCLDeviceUSMSpace::execution_space>::
+Kokkos::Random_XorShift64_Pool<typename Kokkos::Experimental::SYCLDeviceUSMSpace::execution_space> &
+Static_Random_XorShift64_Pool<typename Kokkos::Experimental::SYCLDeviceUSMSpace::execution_space>::
 getPool() {
   TEUCHOS_TEST_FOR_EXCEPTION(!isSet(),std::runtime_error,"Tpetra::Details::Static_Random_XorShift64_Pool: resetPool() must be called before getPool");
   return *sycl_pool_;

--- a/packages/tpetra/core/src/Tpetra_Details_Random.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Random.hpp
@@ -86,11 +86,11 @@ public:
 
 #ifdef KOKKOS_ENABLE_SYCL
 template<>
-class Static_Random_XorShift64_Pool<typename Kokkos::SYCLDeviceUSMSpace::execution_space> {
+class Static_Random_XorShift64_Pool<typename Kokkos::Experimental::SYCLDeviceUSMSpace::execution_space> {
 public:
   static void resetPool(int mpi_rank);
   static bool isSet();
-  static Kokkos::Random_XorShift64_Pool<typename Kokkos::SYCLDeviceUSMSpace::execution_space> & getPool();
+  static Kokkos::Random_XorShift64_Pool<typename Kokkos::Experimental::SYCLDeviceUSMSpace::execution_space> & getPool();
 };
 #endif // KOKKOS_ENABLE_SYCL
 

--- a/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
@@ -1054,7 +1054,6 @@ lowCommunicationMakeColMapAndReindexKokkos (const Teuchos::ArrayView<const size_
         const int PID = owningPIDs_view[j];
         auto outcome = RemoteGIDs_view_map.insert(GID, PID);
         if(outcome.success() && PID == -1) {
-          printf("Cannot figure out if ID is owned.\n");
           Kokkos::abort("Cannot figure out if ID is owned.\n");
         }
       }


### PR DESCRIPTION
@trilinos/tpetra

## Motivation
We need these changes to be able to compile `Tpetra` with the `SYCL` backend.
- `printf` can't be used in `SYCL` kernel code and the code is using both `printf` and `Kokkos::abort` which is redundant since `Kokkos::abort` already prints the error message. A workaround for using `printf` in `SYCL` kernel code is to use `KOKKOS_IMPL_DO_NOT_USE_PRINTF`. In the upcoming release, we have `Kokkos::printf` as a portable alternative.
- All `SYCL` classes in `Kokkos` are still in the `Experimental` namespace.

## Related Issues

* Closes https://github.com/trilinos/Trilinos/issues/12277

## Testing
Compiling `Trilinos` with `Tpetra` on the testbed systems at ANL.