### PR TITLE
Belos: add Tpetra BlockCG test

### DIFF
--- a/packages/belos/tpetra/test/BlockCG/CMakeLists.txt
+++ b/packages/belos/tpetra/test/BlockCG/CMakeLists.txt
@@ -3,41 +3,46 @@ ASSERT_DEFINED(Anasazi_SOURCE_DIR)
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Tpetra_BlockCG_hb_test
   SOURCES test_bl_cg_hb.cpp
-  ARGS "--verbose"
   COMM serial mpi
-  )
+  ARGS
+    "--verbose"
+  STANDARD_PASS_OUTPUT
+)
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Tpetra_PseudoBlockCG_hb_test
   SOURCES test_pseudo_bl_cg_hb.cpp
   ARGS "--verbose"
   COMM serial mpi
-  )
+)
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Tpetra_PseudoBlockStochasticCG_hb_test
   SOURCES test_pseudo_stochastic_cg_hb.cpp
   ARGS
   COMM serial mpi
-  )
+)
 
 ASSERT_DEFINED(${PACKAGE_NAME}_ENABLE_Triutils)
-ASSERT_DEFINED(Tpetra_INST_COMPLEX_DOUBLE)
-ASSERT_DEFINED(Tpetra_INST_FLOAT)
-
 IF (${PACKAGE_NAME}_ENABLE_Triutils)
 
-  IF (Tpetra_INST_FLOAT)
-  
-    TRIBITS_ADD_EXECUTABLE_AND_TEST(
-      Tpetra_BlockCG_DoubleFloat_test
-      SOURCES test_bl_cg_hb_df.cpp
-      ARGS "--verbose"
-      COMM serial mpi
-      )
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    Tpetra_pseudo_cg_hb
+    SOURCES test_pseudo_cg_hb.cpp 
+    COMM serial mpi
+    ARGS "--verbose --filename=bcsstk14.hb"
+    STANDARD_PASS_OUTPUT 
+  )
 
-  ENDIF()
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    Tpetra_resolve_cg_hb
+    SOURCES test_resolve_cg_hb.cpp 
+    COMM serial mpi
+    ARGS "--verbose --filename=bcsstk14.hb"
+    STANDARD_PASS_OUTPUT 
+  )
 
+  ASSERT_DEFINED(Tpetra_INST_COMPLEX_DOUBLE)
   IF (Tpetra_INST_COMPLEX_DOUBLE)
 
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
@@ -45,22 +50,21 @@ IF (${PACKAGE_NAME}_ENABLE_Triutils)
       SOURCES test_bl_cg_complex_hb.cpp
       ARGS "--verbose"
       COMM serial mpi
-      )
+    )
 
-    TRIBITS_COPY_FILES_TO_BINARY_DIR(Tpetra_BlockCG_complex_hb_CopyFiles
+    TRIBITS_COPY_FILES_TO_BINARY_DIR(
+      Tpetra_BlockCG_complex_hb_CopyFiles
       SOURCE_DIR ${Anasazi_SOURCE_DIR}/testmatrices
       SOURCE_FILES mhd1280b.cua
       EXEDEPS Tpetra_BlockCG_complex_hb_test
-      )
+    )
 
-  ENDIF ()
-
-ENDIF()
+  ENDIF()
+ENDIF(${PACKAGE_NAME}_ENABLE_Triutils)
 
 ASSERT_DEFINED(Anasazi_SOURCE_DIR)
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Tpetra_BlockCG_hb_CopyFiles2
   SOURCE_DIR ${Anasazi_SOURCE_DIR}/testmatrices
   SOURCE_FILES bcsstk14.hb
   EXEDEPS Tpetra_BlockCG_hb_test
-  )
-
+)

--- a/packages/belos/tpetra/test/BlockCG/test_bl_cg_complex_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_bl_cg_complex_hb.cpp
@@ -44,7 +44,7 @@
 // The initial guesses are all set to zero.
 //
 // NOTE: No preconditioner is used in this case.
-//
+
 #include "BelosConfigDefs.hpp"
 #include "BelosLinearProblem.hpp"
 #include "BelosTpetraAdapter.hpp"
@@ -54,41 +54,46 @@
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_ParameterList.hpp>
 #include <Teuchos_GlobalMPISession.hpp>
+
 #include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
 // I/O for Harwell-Boeing files
 #include <Trilinos_Util_iohb.h>
 
-using namespace Teuchos;
-using Tpetra::Operator;
-using Tpetra::CrsMatrix;
-using Tpetra::MultiVector;
-using std::endl;
-using std::cout;
-using std::vector;
-using Teuchos::tuple;
+template <typename ScalarType>
+int run(int argc, char *argv[])
+{
+  using BSC = typename Tpetra::MultiVector<ScalarType>::scalar_type;
+  using ST  = typename std::complex<BSC>;
+  
+  using OP = typename Tpetra::Operator<ST>;
+  using MV = typename Tpetra::MultiVector<ST>;
+  using tcrsmatrix_t = Tpetra::CrsMatrix<ST>;
+  
+  using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+  using MVT = typename Belos::MultiVecTraits<ST,MV>;
 
-int main(int argc, char *argv[]) {
-  typedef Tpetra::MultiVector<>::scalar_type BSC;
-  typedef std::complex<BSC>                ST;
-  typedef ScalarTraits<ST>                SCT;
-  typedef SCT::magnitudeType               MT;
-  typedef Tpetra::Operator<ST>             OP;
-  typedef Tpetra::MultiVector<ST>          MV;
-  typedef Belos::OperatorTraits<ST,MV,OP> OPT;
-  typedef Belos::MultiVecTraits<ST,MV>    MVT;
+  using SCT = typename Teuchos::ScalarTraits<ST>;
+  using MT  = typename SCT::magnitudeType;
 
-  GlobalMPISession mpisess(&argc,&argv,&cout);
+  using Tpetra::Operator;
+  using Tpetra::CrsMatrix;
+  using Tpetra::MultiVector;
 
-  const ST one  = SCT::one();
+  using Teuchos::GlobalMPISession;
+  using Teuchos::Comm;
+  using Teuchos::RCP;
+  using Teuchos::CommandLineProcessor;
+  using Teuchos::ParameterList;
 
+  const ST one = SCT::one();
+
+  GlobalMPISession mpisess(&argc,&argv,&std::cout);
   RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
   int MyPID = rank(*comm);
 
-  //
   // Get test parameters from command-line processor
-  //
   bool verbose = false, proc_verbose = false, debug = false;
   int frequency = -1;  // how often residuals are printed by solver
   int numrhs = 1;      // total number of right-hand sides to solve for
@@ -117,13 +122,12 @@ int main(int argc, char *argv[]) {
   }
 
   proc_verbose = ( verbose && (MyPID==0) );
-
   if (proc_verbose) {
     std::cout << Belos::Belos_Version() << std::endl << std::endl;
   }
 
-  Belos::Tpetra::HarwellBoeingReader<Tpetra::CrsMatrix<ST> > reader( comm );
-  RCP<Tpetra::CrsMatrix<ST> > A = reader.readFromFile( filename );
+  Belos::Tpetra::HarwellBoeingReader<tcrsmatrix_t> reader( comm );
+  RCP<tcrsmatrix_t> A = reader.readFromFile( filename );
   RCP<const Tpetra::Map<> > map = A->getMap();
 
   // Create initial vectors
@@ -134,15 +138,12 @@ int main(int argc, char *argv[]) {
   OPT::Apply( *A, *X, *B );
   MVT::MvInit( *X, 0.0 );
 
-  //
-  // ********Other information used by block solver***********
-  // *****************(can be user specified)******************
-  //
+  // Other information used by block solver (can be user specified)
   const int NumGlobalElements = B->getGlobalLength();
   if (maxiters == -1) {
     maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
   }
-  //
+
   ParameterList belosList;
   belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
   belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
@@ -160,9 +161,8 @@ int main(int argc, char *argv[]) {
       belosList.set( "Output Frequency", frequency );
     }
   }
-  //
+  
   // Construct an unpreconditioned linear problem instance.
-  //
   Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
   bool set = problem.setProblem();
   if (set == false) {
@@ -170,16 +170,11 @@ int main(int argc, char *argv[]) {
       std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
     return -1;
   }
-  //
-  // *******************************************************************
-  // *************Start the block CG iteration***********************
-  // *******************************************************************
-  //
+
+  // Start the block CG iteration
   Belos::BlockCGSolMgr<ST,MV,OP> solver( rcpFromRef(problem), rcpFromRef(belosList) );
 
-  //
-  // **********Print out information about problem*******************
-  //
+  // Print out information about problem
   if (proc_verbose) {
     std::cout << std::endl << std::endl;
     std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
@@ -189,13 +184,11 @@ int main(int argc, char *argv[]) {
     std::cout << "Relative residual tolerance: " << tol << std::endl;
     std::cout << std::endl;
   }
-  //
+  
   // Perform solve
-  //
   Belos::ReturnType ret = solver.solve();
-  //
+
   // Compute actual residuals.
-  //
   bool badRes = false;
   std::vector<MT> actual_resids( numrhs );
   std::vector<MT> rhs_norm( numrhs );
@@ -205,12 +198,12 @@ int main(int argc, char *argv[]) {
   MVT::MvNorm( resid, actual_resids );
   MVT::MvNorm( *B, rhs_norm );
   if (proc_verbose) {
-    std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+    std::cout << "---------- Actual Residuals (normalized) ----------" << std::endl<<std::endl;
   }
   for ( int i=0; i<numrhs; i++) {
     MT actRes = actual_resids[i]/rhs_norm[i];
     if (proc_verbose) {
-      std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+      std::cout << "Problem "<<i<<" : \t"<< actRes << std::endl;
     }
     if (actRes > tol) badRes = true;
   }
@@ -221,12 +214,19 @@ int main(int argc, char *argv[]) {
     }
     return -1;
   }
-  //
+  
   // Default return value
-  //
   if (proc_verbose) {
     std::cout << "\nEnd Result: TEST PASSED" << std::endl;
   }
+
   return 0;
-  //
 } // end test_bl_cg_complex_hb.cpp
+
+int main(int argc, char *argv[]) {
+  return run<double>(argc,argv);
+
+  // wrapped with a check: CMake option Trilinos_ENABLE_FLOAT=ON
+  // return run<float>(argc,argv);
+}
+

--- a/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb.cpp
@@ -79,15 +79,15 @@ int run(int argc, char *argv[])
   using Teuchos::RCP;
   using Teuchos::rcpFromRef;
 
-  Teuchos::GlobalMPISession mpisess(&argc,&argv,&std::cout);
-  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
-  int MyPID = rank(*comm);
-
   bool success = false;
   bool verbose = false;
 
   try
   {
+    Teuchos::GlobalMPISession mpisess(&argc,&argv,&std::cout);
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+    int MyPID = rank(*comm);
+
     const ST one = SCT::one();
     
     // Get test parameters from command-line processor

--- a/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb.cpp
@@ -45,11 +45,14 @@
 //
 // NOTE: No preconditioner is used in this case.
 //
+
 #include "BelosConfigDefs.hpp"
 #include "BelosLinearProblem.hpp"
 #include "BelosTpetraAdapter.hpp"
 #include "BelosBlockCGSolMgr.hpp"
 
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
 // I/O for Harwell-Boeing files
 #define HIDE_TPETRA_INOUT_IMPLEMENTATIONS
 #include <Tpetra_MatrixIO.hpp>
@@ -58,41 +61,36 @@
 #include <Teuchos_ParameterList.hpp>
 #include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_StandardCatchMacros.hpp>
-#include <Tpetra_Core.hpp>
-#include <Tpetra_CrsMatrix.hpp>
 
-using namespace Teuchos;
-using Tpetra::Operator;
-using Tpetra::CrsMatrix;
-using Tpetra::MultiVector;
-using std::endl;
-using std::cout;
-using std::vector;
-using Teuchos::tuple;
+template <typename ScalarType>
+int run(int argc, char *argv[])
+{
+  using ST = typename Tpetra::MultiVector<ScalarType>::scalar_type;
+  using OP = typename Tpetra::Operator<ST>;
+  using MV = typename Tpetra::MultiVector<ST>;
 
-int main(int argc, char *argv[]) {
-  typedef Tpetra::MultiVector<>::scalar_type ST;
-  typedef ScalarTraits<ST>                SCT;
-  typedef SCT::magnitudeType               MT;
-  typedef Tpetra::Operator<ST>             OP;
-  typedef Tpetra::MultiVector<ST>          MV;
-  typedef Belos::OperatorTraits<ST,MV,OP> OPT;
-  typedef Belos::MultiVecTraits<ST,MV>    MVT;
+  using SCT = typename Teuchos::ScalarTraits<ST>;
+  using MT = typename SCT::magnitudeType;
+  
+  using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+  using MVT = typename Belos::MultiVecTraits<ST,MV>;
 
-  GlobalMPISession mpisess(&argc,&argv,&cout);
+  using Teuchos::Comm;
+  using Teuchos::RCP;
+  using Teuchos::rcpFromRef;
+
+  Teuchos::GlobalMPISession mpisess(&argc,&argv,&std::cout);
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+  int MyPID = rank(*comm);
 
   bool success = false;
   bool verbose = false;
-  try {
-    const ST one  = SCT::one();
 
-    int MyPID = 0;
-
-    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
-
-    //
+  try
+  {
+    const ST one = SCT::one();
+    
     // Get test parameters from command-line processor
-    //
     bool proc_verbose = false;
     bool debug = false;
     int frequency = -1;  // how often residuals are printed by solver
@@ -102,7 +100,7 @@ int main(int argc, char *argv[]) {
     std::string filename("bcsstk14.hb");
     MT tol = 1.0e-5;     // relative residual tolerance
 
-    CommandLineProcessor cmdp(false,true);
+    Teuchos::CommandLineProcessor cmdp(false,true);
     cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
     cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
     cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
@@ -111,7 +109,7 @@ int main(int argc, char *argv[]) {
     cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
     cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
     cmdp.setOption("block-size",&blocksize,"Block size to be used by the CG solver.");
-    if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
+    if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
       return -1;
     }
     if (debug) {
@@ -121,16 +119,13 @@ int main(int argc, char *argv[]) {
       frequency = -1;  // reset frequency if test is not verbose
     }
 
-    MyPID = rank(*comm);
     proc_verbose = ( verbose && (MyPID==0) );
-
     if (proc_verbose) {
       std::cout << Belos::Belos_Version() << std::endl << std::endl;
     }
-    //
+    
     // Get the data from the HB file and build the Map,Matrix
-    //
-    RCP<CrsMatrix<ST> > A;
+    RCP<Tpetra::CrsMatrix<ST> > A;
     Tpetra::Utils::readHBMatrix(filename,comm,A);
     RCP<const Tpetra::Map<> > map = A->getDomainMap();
 
@@ -142,16 +137,14 @@ int main(int argc, char *argv[]) {
     OPT::Apply( *A, *X, *B );
     MVT::MvInit( *X, 0.0 );
 
-    //
-    // ********Other information used by block solver***********
-    // *****************(can be user specified)******************
-    //
+    // Other information used by block solver (can be user specified)
     const int NumGlobalElements = B->getGlobalLength();
     if (maxiters == -1) {
       maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
     }
+
     //
-    ParameterList belosList;
+    Teuchos::ParameterList belosList;
     belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
     belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
     belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
@@ -168,9 +161,8 @@ int main(int argc, char *argv[]) {
         belosList.set( "Output Frequency", frequency );
       }
     }
-    //
+    
     // Construct an unpreconditioned linear problem instance.
-    //
     Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
     bool set = problem.setProblem();
     if (set == false) {
@@ -178,16 +170,11 @@ int main(int argc, char *argv[]) {
         std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
       return -1;
     }
-    //
-    // *******************************************************************
-    // *************Start the block CG iteration***********************
-    // *******************************************************************
-    //
+    
+    // Start the block CG iteration
     Belos::BlockCGSolMgr<ST,MV,OP> solver( rcpFromRef(problem), rcpFromRef(belosList) );
 
-    //
-    // **********Print out information about problem*******************
-    //
+    // Print out information about problem
     if (proc_verbose) {
       std::cout << std::endl << std::endl;
       std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
@@ -197,13 +184,11 @@ int main(int argc, char *argv[]) {
       std::cout << "Relative residual tolerance: " << tol << std::endl;
       std::cout << std::endl;
     }
-    //
+    
     // Perform solve
-    //
     Belos::ReturnType ret = solver.solve();
-    //
+    
     // Compute actual residuals.
-    //
     bool badRes = false;
     std::vector<MT> actual_resids( numrhs );
     std::vector<MT> rhs_norm( numrhs );
@@ -237,3 +222,11 @@ int main(int argc, char *argv[]) {
 
   return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
 } // end test_bl_cg_hb.cpp
+
+int main(int argc, char *argv[]) {
+  return run<double>(argc,argv);
+
+  // wrapped with a check: CMake option Trilinos_ENABLE_FLOAT=ON
+  // return run<float>(argc,argv);
+}
+

--- a/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb_multiprec.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb_multiprec.cpp
@@ -41,120 +41,126 @@
 //
 // This driver reads a problem from a Harwell-Boeing (HB) file.
 // The right-hand-side corresponds to a randomly generated solution.
-// The initial guesses are all set to zero.
+// The initial guesses are all set to zero. 
 // The problem is solver for multiple scalar types, and timings are reported.
 //
-// NOTE: Diagonal preconditioner is used in this case, if diagonals are safe
-//       to invert.
-//
+// NOTE: No preconditioner is used in this case. 
+
 #include "BelosConfigDefs.hpp"
 #include "BelosLinearProblem.hpp"
 #include "BelosTpetraAdapter.hpp"
-#include "BelosBlockCGSolMgr.hpp"
+#include "BelosPseudoBlockCGSolMgr.hpp"
+
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_DiagPrecond.hpp>
 
 // I/O for Harwell-Boeing files
 #include <Trilinos_Util_iohb.h>
 
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_ScalarTraits.hpp>
-#include <Tpetra_Core.hpp>
-#include <Tpetra_CrsMatrix.hpp>
 #include <Teuchos_TypeNameTraits.hpp>
-
-#include <fstream>
 
 using namespace Teuchos;
 using namespace Belos;
+
 using Tpetra::Operator;
 using Tpetra::CrsMatrix;
+using Tpetra::DiagPrecond;
 using Tpetra::MultiVector;
 using Tpetra::Vector;
 using Tpetra::Map;
+
 using std::endl;
 using std::cout;
 using std::string;
 using std::setw;
 using std::vector;
+
 using Teuchos::tuple;
 
-bool proc_verbose = false, reduce_tol = false, dumpdata = false;
-ParameterList mptestpl;
+bool proc_verbose = false, reduce_tol, precond = true, dumpdata = false;
+RCP<Map<int> > vmap;
+RCP<MultiVector<float,int> > actX;
+ParameterList mptestpl; 
 int rnnzmax;
-int mptestdim, numrhs;
-double *dvals;
+int dim, numrhs; 
+float *fvals;
 int *colptr, *rowind;
 int mptestmypid = 0;
-int mptestnumimages = 1;
 
 ///////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////
-template <class Scalar>
-RCP<LinearProblem<Scalar,Tpetra::MultiVector<Scalar>,Tpetra::Operator<Scalar> > > buildProblem(const RCP<Map<> >& vmap)
+template <class Scalar> 
+RCP<LinearProblem<Scalar,MultiVector<Scalar,int>,Operator<Scalar,int> > > buildProblem()
 {
-  typedef ScalarTraits<Scalar>            SCT;
-  typedef Tpetra::Operator<Scalar>        OP;
-  typedef Tpetra::MultiVector<Scalar>     MV;
-  typedef OperatorTraits<Scalar,MV,OP>    OPT;
-  typedef MultiVecTraits<Scalar,MV>       MVT;
-  using GO = typename MV::global_ordinal_type;
+  using SCT = typename ScalarTraits<Scalar>;
+  using MT = typename SCT::magnitudeType;
+  using OP = typename Operator<Scalar,int>;
+  using MV = typename MultiVector<Scalar,int>;
+  using OPT = typename OperatorTraits<Scalar,MV,OP>;
+  using MVT = typename MultiVecTraits<Scalar,MV>;
 
-  bool precond = true;
-  RCP<CrsMatrix<Scalar> > A = rcp(new CrsMatrix<Scalar>(vmap,rnnzmax));
-  RCP<CrsMatrix<Scalar> > P = rcp(new CrsMatrix<Scalar>(vmap,1));  // Diagonal preconditioner
+  RCP<CrsMatrix<Scalar,int> > A = rcp(new CrsMatrix<Scalar,int>(*vmap,rnnzmax));
   if (mptestmypid == 0) {
     // HB format is compressed column. CrsMatrix is compressed row.
-    const double *dptr = dvals;
+    const float *fptr = fvals;
     const int *rptr = rowind;
-    for (int c=0; c<mptestdim; ++c) {
+    for (int c=0; c<dim; ++c) {
       for (int colnnz=0; colnnz < colptr[c+1]-colptr[c]; ++colnnz) {
-        A->insertGlobalValues(*rptr-1,tuple<GO>(c),tuple<Scalar>(*dptr));
-        if (c != *rptr -1)
-          A->insertGlobalValues(c,tuple<GO>(*rptr-1),tuple<Scalar>(*dptr));
-        else
-        {
-          // If the diagonal values are above the safe minimum, then we can use the diagonal preconditioner
-          if ( (*dptr) > SCT::sfmin())
-            P->insertGlobalValues(c,tuple<GO>(*rptr-1),tuple<Scalar>(SCT::one()/(*dptr)));
-          else
-            precond = false;
-        }
-
+        A->insertGlobalValues(*rptr-1,tuple(c),tuple<Scalar>(*fptr));
+        A->insertGlobalValues(c,tuple(*rptr-1),tuple<Scalar>(*fptr));
         ++rptr;
-        ++dptr;
+        ++fptr;
       }
     }
   }
-  // distribute matrix data to other nodes
+  // Distribute matrix data to other nodes
   A->fillComplete();
-  P->fillComplete();
   // Create initial MV and solution MV
   RCP<MV> B, X;
-  X = rcp( new MV(vmap,numrhs) );
-  MVT::MvRandom( *X );
-  B = rcp( new MV(vmap,numrhs) );
+  X = rcp( new MV(*vmap,numrhs) );
+  // Set LHS to actX
+  {
+    typename MultiVector<Scalar,int>::double_pointer Xvals = X->extractView2D();
+    typename MultiVector<float,int>::const_double_pointer actXvals = actX->extractConstView2D();
+    for (Teuchos_Ordinal j=0; j<numrhs; ++j) {
+      std::copy(actXvals[j], actXvals[j]+actX->myLength(), Xvals[j]);
+    }
+  }
+  B = rcp( new MV(*vmap,numrhs) );
   OPT::Apply( *A, *X, *B );
   MVT::MvInit( *X, 0.0 );
+
   // Construct a linear problem instance with zero initial MV
   RCP<LinearProblem<Scalar,MV,OP> > problem = rcp( new LinearProblem<Scalar,MV,OP>(A,X,B) );
-  if (precond)
-    problem->setRightPrec(P);
   problem->setLabel(Teuchos::typeName(SCT::one()));
+  // Diagonal preconditioner
+  if (precond) {
+    Vector<Scalar,int> diags(A->getRowMap());
+    A->getLocalDiagCopy(diags);
+    for (Teuchos_Ordinal i=0; i<vmap->getNumMyEntries(); ++i) {
+      TEUCHOS_TEST_FOR_EXCEPTION(diags[i] <= SCT::zero(), std::runtime_error,"Matrix is not positive-definite: " << diags[i]);
+      diags[i] = SCT::one() / diags[i];
+    }
+    RCP<Operator<Scalar,int> > P = rcp(new DiagPrecond<Scalar,int>(diags));
+    problem->setRightPrec(P);
+  }
   TEUCHOS_TEST_FOR_EXCEPT(problem->setProblem() == false);
   return problem;
 }
 
-
-///////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////
 template <class Scalar>
-bool runTest(double ltol, double times[], int &numIters, const RCP<Map<> >& vmap)
+bool runTest(double ltol, double times[], int &numIters, RCP<MultiVector<Scalar,int> > &X) 
 {
-  typedef ScalarTraits<Scalar>                  SCT;
-  typedef typename SCT::magnitudeType           MT;
-  typedef Tpetra::Operator<Scalar>              OP;
-  typedef Tpetra::MultiVector<Scalar>           MV;
-  typedef OperatorTraits<Scalar,MV,OP>          OPT;
-  typedef MultiVecTraits<Scalar,MV>             MVT;
+
+  using SCT = typename ScalarTraits<Scalar>;
+  using MT = typename SCT::magnitudeType;
+  using OP = typename Operator<Scalar,int>;
+  using MV = typename MultiVector<Scalar,int>;
+  using OPT = typename OperatorTraits<Scalar,MV,OP>;
+  using MVT = typename MultiVecTraits<Scalar,MV>;
 
   const Scalar ONE  = SCT::one();
   mptestpl.set<MT>( "Convergence Tolerance", ltol );         // Relative convergence tolerance requested
@@ -166,15 +172,15 @@ bool runTest(double ltol, double times[], int &numIters, const RCP<Map<> >& vmap
   Time btimer("Build Timer"), ctimer("Construct Timer"), stimer("Solve Timer");
   ReturnType ret;
   if (mptestmypid==0) cout << "Building problem..." << endl;
-  {
+  { 
     TimeMonitor localtimer(btimer);
-    problem = buildProblem<Scalar>(vmap);
+    problem = buildProblem<Scalar>();
   }
   RCP<SolverManager<Scalar,MV,OP> > solver;
-  if (mptestmypid==0) cout << "Constructing solver..." << endl;
+  if (mptestmypid==0) cout << "Constructing solver..." << endl; 
   {
     TimeMonitor localtimer(ctimer);
-    solver = rcp(new BlockCGSolMgr<Scalar,MV,OP>( problem, rcpFromRef(mptestpl) ));
+    solver = rcp(new PseudoBlockCGSolMgr<Scalar,MV,OP>( problem, rcpFromRef(mptestpl) ));
   }
   if (mptestmypid==0) cout << "Solving problem..." << endl;
   {
@@ -196,15 +202,13 @@ bool runTest(double ltol, double times[], int &numIters, const RCP<Map<> >& vmap
   if (ret == Converged) {
     if (proc_verbose) cout << endl;
     if (mptestmypid==0) cout << "Computing residuals..." << endl;
-    //
     // Compute actual residuals.
-    //
     RCP<const OP> A = problem->getOperator();
-    RCP<MV> X = problem->getLHS();
+    X = problem->getLHS();
     RCP<const MV> B = problem->getRHS();
     std::vector<MT> actual_resids( numrhs );
     std::vector<MT> rhs_norm( numrhs );
-    MV resid(vmap, numrhs);
+    MV resid(*vmap, numrhs);
     OPT::Apply( *A, *X, resid );
     MVT::MvAddMv( -ONE, resid, ONE, *B, resid );
     MVT::MvNorm( resid, actual_resids );
@@ -221,23 +225,19 @@ bool runTest(double ltol, double times[], int &numIters, const RCP<Map<> >& vmap
   return true;
 }
 
-
 ///////////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////////
-int main(int argc, char *argv[])
+int main(int argc, char *argv[]) 
 {
-  Tpetra::ScopeGuard tpetraScope(&argc, &argv);
-
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
   RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
 
-  //
   // Get test parameters from command-line processor
-  //
   bool verbose = false, debug = false;
+  bool printX = false;
   int frequency = -1;  // how often residuals are printed by solver
-  int maxiters = -1;   // maximum number of iterations for solver to use
   numrhs = 1;      // total number of right-hand sides to solve for
   int blocksize = 1;   // blocksize used by solver
+  int maxiters = -1;   // maximum number of iterations for solver to use
   string filename("bcsstk14.hb");
   double tol = 1.0e-5;     // relative residual tolerance
 
@@ -245,13 +245,15 @@ int main(int argc, char *argv[])
   cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
   cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
   cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
-  cmdp.setOption("tol",&tol,"Relative residual tolerance used by solver.");
+  cmdp.setOption("tol",&tol,"Relative residual tolerance used by CG solver.");
   cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
   cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
-  cmdp.setOption("block-size",&blocksize,"Block size to be used by the solver.");
   cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
+  cmdp.setOption("block-size",&blocksize,"Block size to be used by the CG solver.");
   cmdp.setOption("reduce-tol","fixed-tol",&reduce_tol,"Require increased accuracy from higher precision scalar types.");
+  cmdp.setOption("use-precond","no-precond",&precond,"Use a diagonal preconditioner.");
   cmdp.setOption("dump-data","no-dump-data",&dumpdata,"Dump raw data to data.dat.");
+  cmdp.setOption("print-x","no-print-x",&printX,"Print solution multivectors.");
   if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
     return -1;
   }
@@ -262,39 +264,40 @@ int main(int argc, char *argv[])
     frequency = -1;  // reset frequency if test is not verbose
   }
 
-  mptestnumimages = size(*comm);
   mptestmypid = rank(*comm);
   proc_verbose = ( verbose && (mptestmypid==0) );
   if (proc_verbose) cout << Belos_Version() << endl << endl;
-  if (mptestmypid != 0) dumpdata = 0;
 
-  //
   // Get the data (double) from the HB file and build the Map,Matrix
-  //
   int nnz, info;
   nnz = -1;
   if (mptestmypid == 0) {
     int dim2;
-    info = readHB_newmat_double(filename.c_str(),&mptestdim,&dim2,&nnz,&colptr,&rowind,&dvals);
-    // find maximum NNZ over all rows
-    vector<int> rnnz(mptestdim,0);
+    double *dvals;
+    info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
+    // Truncate data into float
+    fvals = new float[nnz];
+    std::copy( dvals, dvals+nnz, fvals );
+    free(dvals);
+    // Find maximum NNZ over all rows
+    vector<int> rnnz(dim,0);
     for (int *ri=rowind; ri<rowind+nnz; ++ri) {
       ++rnnz[*ri-1];
     }
-    for (int c=0; c<mptestdim; ++c) {
+    for (int c=0; c<dim; ++c) {
       rnnz[c] += colptr[c+1]-colptr[c];
     }
     rnnzmax = *std::max_element(rnnz.begin(),rnnz.end());
   }
   else {
-    // address uninitialized data warnings
-    dvals = NULL;
+    // Address uninitialized data warnings
+    fvals = NULL;
     colptr = NULL;
     rowind = NULL;
   }
   broadcast(*comm,0,&info);
   broadcast(*comm,0,&nnz);
-  broadcast(*comm,0,&mptestdim);
+  broadcast(*comm,0,&dim);
   broadcast(*comm,0,&rnnzmax);
   if (info == 0 || nnz < 0) {
     if (mptestmypid == 0) {
@@ -303,18 +306,18 @@ int main(int argc, char *argv[])
     }
     return -1;
   }
-
-  // Select maximum iterations
+  // Create map
+  vmap = rcp(new Map<int>(dim,0,comm));
+  // Create a consistent LHS
+  actX = rcp(new MultiVector<float,int>(*vmap,numrhs));
+  MultiVecTraits<float,MultiVector<float,int> >::MvRandom(*actX);
+  // Create the parameter list
   if (maxiters == -1) {
-    maxiters = mptestdim/blocksize - 1; // maximum number of iterations to run
+    maxiters = dim/blocksize - 1; // maximum number of iterations to run
   }
-
-  // create map
-  RCP<Map<> > vmap = rcp(new Map<>(mptestdim,0,comm));
   //
   mptestpl.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
-  mptestpl.set( "Num Blocks", maxiters );
-  mptestpl.set( "Maximum Iterations", maxiters );
+  mptestpl.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
   int verbLevel = Errors + Warnings;
   if (debug) {
     verbLevel |= Debug;
@@ -329,36 +332,71 @@ int main(int argc, char *argv[])
     }
   }
 
-  //
-  // **********Print out information about problem*******************
-  //
+  // Print out information about problem
   if (mptestmypid==0) {
     cout << "Filename: " << filename << endl;
-    cout << "Dimension of matrix: " << mptestdim << endl;
+    cout << "Dimension of matrix: " << dim << endl;
     cout << "Number of nonzeros: " << nnz << endl;
     cout << "Number of right-hand sides: " << numrhs << endl;
     cout << "Block size used by solver: " << blocksize << endl;
-    cout << "Number of blocks used by solver: " << maxiters << endl;
+    cout << "Max number of CG iterations: " << maxiters << endl; 
     cout << "Relative residual tolerance: " << tol << endl;
     cout << endl;
   }
 
-  // run tests for different scalar types
+  // Run tests for different scalar types
+  RCP<MultiVector<float,int> > Xf;
+  RCP<MultiVector<double,int> > Xd;
   double ltol = tol;
-  double ftime[3] = {0,0,0}; int fiter=0; 
-  bool fpass = true, dpass = true;
-#ifdef HAVE_TPETRA_INST_FLOAT
-  fpass = runTest<float>(ltol,ftime,fiter,vmap);
-#endif
+  double ftime[3]; int fiter; bool fpass = runTest<float>(ltol,ftime,fiter,Xf);
   ltol = (reduce_tol ? ltol*ltol : ltol);
-  double dtime[3] = {0,0,0}; int diter=0;
-#ifdef HAVE_TPETRA_INST_DOUBLE
-  dpass = runTest<double>(ltol,dtime,diter,vmap);
-#endif
+  double dtime[3]; int diter; bool dpass = runTest<double>(ltol,dtime,diter,Xd);
+// #ifdef HAVE_TEUCHOS_QD
+//   unsigned int old_cw; fpu_fix_start(&old_cw); // fix floating point rounding for intel processors; required for proper implementation
+//   ltol = (reduce_tol ? ltol*ltol : ltol);
+//   double ddtime[3]; int dditer; bool ddpass = runTest<dd_real>(ltol,ddtime,dditer);
+//   ltol = (reduce_tol ? ltol*ltol : ltol);
+//   double qdtime[3]; int qditer; bool qdpass = runTest<qd_real>(ltol,qdtime,qditer);
+//   fpu_fix_end(&old_cw);                        // restore previous floating point rounding
+// #endif
 
-  // done with the matrix data now; delete it
+  if (printX) {
+    // doesn't compie; fix
+    // RCP<FancyOStream> fos = Teuchos::getFancyOStream(rcp(&std::cout,false));
+    // if (mptestmypid==0) cout << "X (float): " << endl;
+    // Xf->describe(fos,Teuchos::VERB_EXTREME);
+    // if (mptestmypid==0) cout << "X (double): " << endl;
+    // Xd->describe(fos,Teuchos::VERB_EXTREME);
+  }
+
+  // Test the relative error between Xf and Xd
+  if (mptestmypid==0) {
+    cout << "Relative error |xdi - xfi|/|xdi|" << endl;
+    cout << "--------------------------------" << endl;
+  }
+  for (int j=0; j<numrhs; ++j) {
+    // Compute |xdj-xfj|/|xdj|
+    RCP<Vector<float,int> > xfj = (*Xf)(j);
+    RCP<Vector<double,int> > xdj = (*Xd)(j);
+    double mag = xdj->norm2();
+    ArrayView<double> dval;
+    ArrayView<const float> fval;
+    xdj->extractView1D(dval);
+    xfj->extractConstView1D(fval);
+    for (int i=0; i<xdj->myLength(); ++i) {
+      dval[i] -= (double)fval[i];
+    }
+    double err = xdj->norm2() / mag;
+    if (mptestmypid==0) {
+      cout << err << endl;
+    }
+  }
+  Xf = Teuchos::null;
+  Xd = Teuchos::null;
+
+  // Done with the matrix data now; delete it
   if (mptestmypid == 0) {
-    free( dvals );
+    free( fvals );
     free( colptr );
     free( rowind );
   }
@@ -368,25 +406,34 @@ int main(int argc, char *argv[])
     cout << "---------------------------------------------------------------------------------------" << endl;
     cout << setw(12) << "float"   << "     " << setw(10) <<  ftime[0] << "     " << setw(9) <<  ftime[1] << "     " << setw(10) <<  ftime[2] << "     " << setw(9) <<  fiter << "     " << ( fpass ? "pass" : "fail") << endl;
     cout << setw(12) << "double"  << "     " << setw(10) <<  dtime[0] << "     " << setw(9) <<  dtime[1] << "     " << setw(10) <<  dtime[2] << "     " << setw(9) <<  diter << "     " << ( dpass ? "pass" : "fail") << endl;
+// #ifdef HAVE_TEUCHOS_QD
+//     cout << setw(12) << "dd_real" << "     " << setw(10) << ddtime[0] << "     " << setw(9) << ddtime[1] << "     " << setw(10) << ddtime[2] << "     " << setw(9) << dditer << "     " << (ddpass ? "pass" : "fail") << endl;
+//     cout << setw(12) << "qd_real" << "     " << setw(10) << qdtime[0] << "     " << setw(9) << qdtime[1] << "     " << setw(10) << qdtime[2] << "     " << setw(9) << qditer << "     " << (qdpass ? "pass" : "fail") << endl;
+// #endif
   }
 
   if (dumpdata) {
     std::ofstream fout("data.dat",std::ios_base::app | std::ios_base::out);
-    fout << setw(80) << "filename" << setw(14) << "numimages"       << setw(14) << "blocksize" << setw(14) << "maxiters" << setw(14) << "dim" << setw(14) << "nnz" << setw(8) << "Scalar"   << setw(12) <<  "build"  << setw(12) <<  "init"   << setw(12) <<  "solve"  << setw(12) <<  "numiter" << endl;
-    fout << setw(80) << filename   << setw(14) <<  mptestnumimages  << setw(14) <<  blocksize  << setw(14) << maxiters << setw(14) << mptestdim   << setw(14) << nnz   << setw(8) << "float"    << setw(12) <<  ftime[0] << setw(12) <<  ftime[1] << setw(12) <<  ftime[2] << setw(12) <<  fiter     << endl;
-    fout << setw(80) << filename   << setw(14) <<  mptestnumimages  << setw(14) <<  blocksize  << setw(14) << maxiters << setw(14) << mptestdim   << setw(14) << nnz   << setw(8) << "double"   << setw(12) <<  dtime[0] << setw(12) <<  dtime[1] << setw(12) <<  dtime[2] << setw(12) <<  diter     << endl;
+    fout << setw(14) << nnz << setw(8) << "float"   << setw(12) <<  ftime[0] << setw(12) <<  ftime[1] << setw(12) <<  ftime[2] << setw(12) <<  fiter << endl;
+    fout << setw(14) << nnz << setw(8) << "double"  << setw(12) <<  dtime[0] << setw(12) <<  dtime[1] << setw(12) <<  dtime[2] << setw(12) <<  diter << endl;
+// #ifdef HAVE_TEUCHOS_QD
+//     fout << setw(14) << nnz << setw(8) << "dd_real" << setw(12) << ddtime[0] << setw(12) << ddtime[1] << setw(12) << ddtime[2] << setw(12) << dditer << endl;
+//     fout << setw(14) << nnz << setw(8) << "qd_real" << setw(12) << qdtime[0] << setw(12) << qdtime[1] << setw(12) << qdtime[2] << setw(12) << qditer << endl;
+// #endif
     fout.close();
   }
 
   bool allpass = fpass && dpass;
+// #ifdef HAVE_TEUCHOS_QD
+//   allpass = allpass && ddpass && qdpass;
+// #endif
 
   if (!allpass) {
-    if (mptestmypid==0) cout << "\nEnd Result: TEST FAILED" << endl;
+    if (mptestmypid==0) cout << "\nEnd Result: TEST FAILED" << endl;	
     return -1;
   }
-  //
+  
   // Default return value
-  //
   if (mptestmypid==0) cout << "\nEnd Result: TEST PASSED" << endl;
   return 0;
 }

--- a/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb_multiprec.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb_multiprec.cpp
@@ -104,7 +104,7 @@ RCP<LinearProblem<Scalar,MultiVector<Scalar,int>,Operator<Scalar,int> > > buildP
   RCP<CrsMatrix<Scalar,int> > A = rcp(new CrsMatrix<Scalar,int>(*vmap,rnnzmax));
   if (mptestmypid == 0) {
     // HB format is compressed column. CrsMatrix is compressed row.
-    const float *fptr = fvals;
+    const MT *fptr = fvals;
     const int *rptr = rowind;
     for (int c=0; c<dim; ++c) {
       for (int colnnz=0; colnnz < colptr[c+1]-colptr[c]; ++colnnz) {
@@ -123,7 +123,7 @@ RCP<LinearProblem<Scalar,MultiVector<Scalar,int>,Operator<Scalar,int> > > buildP
   // Set LHS to actX
   {
     typename MultiVector<Scalar,int>::double_pointer Xvals = X->extractView2D();
-    typename MultiVector<float,int>::const_double_pointer actXvals = actX->extractConstView2D();
+    typename MultiVector<Scalar,int>::const_double_pointer actXvals = actX->extractConstView2D();
     for (Teuchos_Ordinal j=0; j<numrhs; ++j) {
       std::copy(actXvals[j], actXvals[j]+actX->myLength(), Xvals[j]);
     }

--- a/packages/belos/tpetra/test/BlockCG/test_pseudo_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_pseudo_cg_hb.cpp
@@ -40,127 +40,119 @@
 //@HEADER
 //
 // This driver reads a problem from a Harwell-Boeing (HB) file.
-// The right-hand-side corresponds to a randomly generated solution.
+// Multiple right-hand-sides are created randomly.
 // The initial guesses are all set to zero.
-//
-// NOTE: No preconditioner is used in this case.
-//
+
+/* Originally convert test here: belos/epetra/test/BlockCG/test_pseudo_cg_hb.cpp */
+
 #include "BelosConfigDefs.hpp"
 #include "BelosLinearProblem.hpp"
 #include "BelosTpetraAdapter.hpp"
 #include "BelosPseudoBlockCGSolMgr.hpp"
 
+#include <Trilinos_Util.h>
+
 #include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
-// I/O for Harwell-Boeing files
-#define HIDE_TPETRA_INOUT_IMPLEMENTATIONS
+#include <Tpetra_Map.hpp>
 #include <Tpetra_MatrixIO.hpp>
 
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_ParameterList.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_StandardCatchMacros.hpp>
 
 template <typename ScalarType>
 int run(int argc, char *argv[])
 {
-  using ST = typename Tpetra::MultiVector<ScalarType>::scalar_type;
+  using ST = ScalarType;
   using OP = typename Tpetra::Operator<ST>;
   using MV = typename Tpetra::MultiVector<ST>;
-
+  using tcrsmatrix_t = Tpetra::CrsMatrix<ST>;
+  
   using SCT = typename Teuchos::ScalarTraits<ST>;
   using MT = typename SCT::magnitudeType;
-  
+
   using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
   using MVT = typename Belos::MultiVecTraits<ST,MV>;
-
+  
+  using Teuchos::ParameterList;
   using Teuchos::Comm;
   using Teuchos::RCP;
-  
-  Teuchos::GlobalMPISession mpisess(&argc,&argv,&std::cout);
-  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
-  int MyPID = rank(*comm);
+  using Teuchos::rcp;
 
+  Teuchos::GlobalMPISession session(&argc, &argv, &std::cout);
+  RCP<const Comm<int>> comm = Tpetra::getDefaultComm();
+  int MyPID = rank(*comm);
+  
   bool success = false;
   bool verbose = false;
 
-  try {
+  try
+  {
     // Get test parameters from command-line processor
     bool proc_verbose = false;
-    bool debug = false;
-    int frequency = -1;  // how often residuals are printed by solver
-    int numrhs = 1;      // total number of right-hand sides to solve for
-    int blocksize = 1;   // blocksize used by solver
-    int maxiters = -1;   // maximum number of iterations for solver to use
+    bool leftprec = true;      // left preconditioning or right.
+    int frequency = -1; // how often residuals are printed by solver
+    int numrhs = 1;  // total number of right-hand sides to solve for
+    int maxiters = -1; // maximum number of iterations for the solver to use
     std::string filename("bcsstk14.hb");
-    MT tol = 1.0e-5;     // relative residual tolerance
+    MT tol = 1.0e-5;  // relative residual tolerance
 
     Teuchos::CommandLineProcessor cmdp(false,true);
     cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
-    cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+    cmdp.setOption("left-prec","right-prec",&leftprec,"Left preconditioning or right.");
     cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
-    cmdp.setOption("tol",&tol,"Relative residual tolerance used by CG solver.");
     cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+    cmdp.setOption("tol",&tol,"Relative residual tolerance used by CG solver.");
     cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
-    cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
-    cmdp.setOption("block-size",&blocksize,"Block size to be used by the CG solver.");
+    cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem size).");
+
     if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
       return -1;
     }
-    if (debug) {
-      verbose = true;
-    }
     if (!verbose) {
-      frequency = -1;  // reset frequency if test is not verbose
+      frequency = -1;  // Reset frequency if verbosity is off
     }
 
-    // Verbose
     proc_verbose = ( verbose && (MyPID==0) );
     if (proc_verbose) {
       std::cout << Belos::Belos_Version() << std::endl << std::endl;
     }
-    
-    // Get the data from the HB file and build the Map,Matrix
-    RCP< Tpetra::CrsMatrix<ST> > A;
+
+    // Get the problem
+    RCP<tcrsmatrix_t> A;
     Tpetra::Utils::readHBMatrix(filename,comm,A);
-    RCP< const Tpetra::Map<> > map = A->getDomainMap();
+    RCP<const Tpetra::Map<> > map = A->getDomainMap();
 
-    // Create initial vectors
+    // Construct initial guess and random right-hand-sides
     RCP<MV> B, X;
-    X = rcp( new MV(map,numrhs) );
-    MVT::MvRandom( *X );
-    B = rcp( new MV(map,numrhs) );
-    OPT::Apply( *A, *X, *B );
-    MVT::MvInit( *X, 0.0 );
+    X = rcp(new MV(map, numrhs));
+    MVT::MvRandom(*X);
+    B = rcp(new MV(map, numrhs));
+    OPT::Apply(*A, *X, *B);
+    MVT::MvInit(*X, 0.0);
 
-    // Other information used by block solver (can be user specified)
+    // Create parameter list for the pseudo block CG solver manager
     const int NumGlobalElements = B->getGlobalLength();
-    if (maxiters == -1) {
-      maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
-    }
-
-    // Belos parameter list
-    Teuchos::ParameterList belosList;
-    belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+    if (maxiters == -1)
+      maxiters = NumGlobalElements; // maximum number of iterations to run
+    
+    //
+    ParameterList belosList;
     belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
     belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
     belosList.set( "Estimate Condition Number", true );
-    int verbLevel = Belos::Errors + Belos::Warnings;
-    if (debug) {
-      verbLevel += Belos::Debug;
-    }
     if (verbose) {
-      verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
-    }
-    belosList.set( "Verbosity", verbLevel );
-    if (verbose) {
-      if (frequency > 0) {
+      belosList.set( "Verbosity", Belos::Errors + Belos::Warnings +
+          Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails );
+      if (frequency > 0)
         belosList.set( "Output Frequency", frequency );
-      }
     }
+    else
+      belosList.set( "Verbosity", Belos::Errors + Belos::Warnings );
     
-    // Construct an unpreconditioned linear problem instance.
-    Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+    // Construct a linear problem
+    Belos::LinearProblem<ST,MV,OP> problem(A, X, B);
     bool set = problem.setProblem();
     if (set == false) {
       if (proc_verbose)
@@ -168,68 +160,55 @@ int run(int argc, char *argv[])
       return -1;
     }
 
-    // Start the block CG iteration
-    Belos::PseudoBlockCGSolMgr<ST,MV,OP> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+    // Create an iterative solver manager.
+    Belos::PseudoBlockCGSolMgr<ST,MV,OP> solver( rcpFromRef(problem), rcpFromRef(belosList));
 
-    // Print out information about problem
+    // Start the block CG iteration
     if (proc_verbose) {
       std::cout << std::endl << std::endl;
       std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
       std::cout << "Number of right-hand sides: " << numrhs << std::endl;
-      std::cout << "Block size used by solver: " << blocksize << std::endl;
-      std::cout << "Max number of CG iterations: " << maxiters << std::endl;
+      std::cout << "Max number of pseudo block CG iterations: " << maxiters << std::endl;
       std::cout << "Relative residual tolerance: " << tol << std::endl;
       std::cout << std::endl;
     }
     
     // Perform solve
     Belos::ReturnType ret = solver.solve();
-  
+    
     // Compute actual residuals.
-    const ST one = SCT::one();
     bool badRes = false;
     std::vector<MT> actual_resids( numrhs );
     std::vector<MT> rhs_norm( numrhs );
     MV resid(map, numrhs);
     OPT::Apply( *A, *X, resid );
-    MVT::MvAddMv( -one, resid, one, *B, resid );
+    MVT::MvAddMv( -1.0, resid, 1.0, *B, resid );
     MVT::MvNorm( resid, actual_resids );
     MVT::MvNorm( *B, rhs_norm );
     if (proc_verbose) {
-      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
-    }
-    for ( int i=0; i<numrhs; i++) {
-      MT actRes = actual_resids[i]/rhs_norm[i];
-      if (proc_verbose) {
+      std::cout << "---------- Actual Residuals (normalized) ----------" << std::endl<<std::endl;
+      for ( int i=0; i<numrhs; i++) {
+        ST actRes = actual_resids[i]/rhs_norm[i];
         std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+        if (actRes > tol) badRes = true;
       }
-      if (actRes > tol) badRes = true;
+      std::cout << std::endl << "Condition Estimate: " << solver.getConditionEstimate() << std::endl;
     }
 
-    if (proc_verbose) {
-      std::cout<<std::endl<<"Condition Estimate: " << SCT::real(solver.getConditionEstimate()) << std::endl;
-      auto ee = solver.getEigenEstimates();
-      std::cout << std::endl << "Eigen estimates:\n" << ee.size() << " " << ee << std::endl;
-      for (int i=0; i < ee.size(); i++) {
-        std::cout << " " << ee[i];
-        if (i > 0 && (i % 10 == 0)) std::cout << std::endl;
-      }
-    }
-
-    success = (ret==Belos::Converged && !badRes);
+    success = ret==Belos::Converged && !badRes;
 
     if (success) {
       if (proc_verbose)
-        std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+        std::cout << std::endl << "End Result: TEST PASSED" << std::endl;
     } else {
       if (proc_verbose)
-        std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+        std::cout << std::endl << "End Result: TEST FAILED" << std::endl;
     }
   }
   TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
 
   return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
-} // end test_pseudo_bl_cg_hb.cpp
+} // end test_pseudo_cg_hb.cpp
 
 int main(int argc, char *argv[]) {
   return run<double>(argc,argv);

--- a/packages/belos/tpetra/test/BlockCG/test_pseudo_stochastic_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_pseudo_stochastic_cg_hb.cpp
@@ -44,12 +44,14 @@
 // The initial guesses are all set to zero.
 //
 // NOTE: No preconditioner is used in this case.
-//
+
 #include "BelosConfigDefs.hpp"
 #include "BelosLinearProblem.hpp"
 #include "BelosTpetraAdapter.hpp"
 #include "BelosPseudoBlockStochasticCGSolMgr.hpp"
 
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
 // I/O for Harwell-Boeing files
 #define HIDE_TPETRA_INOUT_IMPLEMENTATIONS
 #include <Tpetra_MatrixIO.hpp>
@@ -57,39 +59,38 @@
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_ParameterList.hpp>
 #include <Teuchos_StandardCatchMacros.hpp>
-#include <Tpetra_Core.hpp>
-#include <Tpetra_CrsMatrix.hpp>
 
-int
-main (int argc, char *argv[])
+template <typename ScalarType>
+int run (int argc, char *argv[])
 {
+  using ST = typename Tpetra::MultiVector<ScalarType>::scalar_type;
+  using OP = typename Tpetra::Operator<ST>;
+  using MV = typename Tpetra::MultiVector<ST>;
+  
+  using CLP = typename Teuchos::CommandLineProcessor;
+  using STS = typename Teuchos::ScalarTraits<ST>;
+  using MT = typename STS::magnitudeType;
+  
+  using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+  using MVT = typename Belos::MultiVecTraits<ST,MV>;
+
   using Teuchos::Comm;
   using Teuchos::ParameterList;
   using Teuchos::RCP;
   using Teuchos::rcp;
   using Teuchos::rcpFromRef;
-  using std::endl;
-  using std::cout;
-  typedef Tpetra::MultiVector<>::scalar_type ST;
-  typedef Teuchos::ScalarTraits<ST>       STS;
-  typedef STS::magnitudeType               MT;
-  typedef Tpetra::Operator<ST>             OP;
-  typedef Tpetra::MultiVector<ST>          MV;
-  typedef Belos::OperatorTraits<ST,MV,OP> OPT;
-  typedef Belos::MultiVecTraits<ST,MV>    MVT;
-
-  typedef Teuchos::CommandLineProcessor   CLP;
 
   Tpetra::ScopeGuard tpetraScope (&argc, &argv);
 
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+  const int MyPID = comm->getRank();
+
   bool success = false;
   bool verbose = false;
-  try {
-    RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
 
-    //
+  try
+  {
     // Get test parameters from command-line processor
-    //
     bool proc_verbose = false;
     bool debug = false;
     int frequency = -1;
@@ -125,16 +126,12 @@ main (int argc, char *argv[])
       frequency = -1;  // reset frequency if test is not verbose
     }
 
-    const int MyPID = comm->getRank ();
     proc_verbose = verbose && MyPID == 0;
-
     if (proc_verbose) {
-      cout << Belos::Belos_Version () << endl << endl;
+      std::cout << Belos::Belos_Version () << std::endl << std::endl;
     }
 
-    //
     // Get the data from the HB file and build the Map,Matrix
-    //
     RCP<Tpetra::CrsMatrix<ST> > A;
     Tpetra::Utils::readHBMatrix (filename, comm, A);
     RCP<const Tpetra::Map<> > map = A->getDomainMap ();
@@ -147,15 +144,12 @@ main (int argc, char *argv[])
     OPT::Apply (*A, *X, *B);
     MVT::MvInit (*X, STS::zero ());
 
-    //
-    // ********Other information used by block solver***********
-    // *****************(can be user specified)******************
-    //
+    // Other information used by block solver (can be user specified)
     const int NumGlobalElements = B->getGlobalLength();
     if (maxiters == -1) {
       maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
     }
-    //
+
     ParameterList belosList;
     belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
     belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
@@ -173,44 +167,36 @@ main (int argc, char *argv[])
         belosList.set( "Output Frequency", frequency );
       }
     }
-    //
+    
     // Construct an unpreconditioned linear problem instance.
-    //
     Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
     bool set = problem.setProblem ();
     if (! set) {
       if (proc_verbose) {
-        cout << endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << endl;
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
       }
       return EXIT_FAILURE;
     }
-    //
-    // *******************************************************************
-    // *************Start the block CG iteration***********************
-    // *******************************************************************
-    //
-    typedef Belos::PseudoBlockStochasticCGSolMgr<ST,MV,OP> solver_type;
+
+    // Start the block CG iteration
+    using solver_type = typename Belos::PseudoBlockStochasticCGSolMgr<ST,MV,OP>;
     solver_type solver (rcpFromRef (problem), rcpFromRef (belosList));
 
-    //
-    // **********Print out information about problem*******************
-    //
+    // Print out information about problem
     if (proc_verbose) {
-      cout << endl << endl;
-      cout << "Dimension of matrix: " << NumGlobalElements << endl;
-      cout << "Number of right-hand sides: " << numrhs << endl;
-      cout << "Block size used by solver: " << blocksize << endl;
-      cout << "Max number of CG iterations: " << maxiters << endl;
-      cout << "Relative residual tolerance: " << tol << endl;
-      cout << endl;
+      std::cout << std::endl << std::endl;
+      std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+      std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+      std::cout << "Block size used by solver: " << blocksize << std::endl;
+      std::cout << "Max number of CG iterations: " << maxiters << std::endl;
+      std::cout << "Relative residual tolerance: " << tol << std::endl;
+      std::cout << std::endl;
     }
-    //
+    
     // Perform solve
-    //
     Belos::ReturnType ret = solver.solve();
-    //
+    
     // Compute actual residuals.
-    //
     bool badRes = false;
     std::vector<MT> actual_resids (numrhs);
     std::vector<MT> rhs_norm (numrhs);
@@ -220,12 +206,12 @@ main (int argc, char *argv[])
     MVT::MvNorm (resid, actual_resids);
     MVT::MvNorm (*B, rhs_norm);
     if (proc_verbose) {
-      cout << "---------- Actual Residuals (normalized) ----------" << endl << endl;
+      std::cout << "---------- Actual Residuals (normalized) ----------" << std::endl << std::endl;
     }
     for (int i=0; i<numrhs; i++) {
       MT actRes = actual_resids[i]/rhs_norm[i];
       if (proc_verbose) {
-        cout << "Problem " << i << " : \t" << actRes << endl;
+        std::cout << "Problem " << i << " : \t" << actRes << std::endl;
       }
       if (actRes > tol) badRes = true;
     }
@@ -233,11 +219,11 @@ main (int argc, char *argv[])
     success = ret == Belos::Converged && ! badRes;
     if (success) {
       if (proc_verbose) {
-        cout << "\nEnd Result: TEST PASSED" << endl;
+        std::cout << "\nEnd Result: TEST PASSED" << std::endl;
       }
     } else {
       if (proc_verbose) {
-        cout << "\nEnd Result: TEST FAILED" << endl;
+        std::cout << "\nEnd Result: TEST FAILED" << std::endl;
       }
     }
   }
@@ -245,3 +231,12 @@ main (int argc, char *argv[])
 
   return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }
+
+int main(int argc, char *argv[]) {
+  return run<double>(argc,argv);
+
+  // wrapped with a check: CMake option Trilinos_ENABLE_FLOAT=ON
+  // return run<float>(argc,argv);
+}
+
+

--- a/packages/belos/tpetra/test/BlockCG/test_pseudo_stochastic_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_pseudo_stochastic_cg_hb.cpp
@@ -67,7 +67,6 @@ int run (int argc, char *argv[])
   using OP = typename Tpetra::Operator<ST>;
   using MV = typename Tpetra::MultiVector<ST>;
   
-  using CLP = typename Teuchos::CommandLineProcessor;
   using STS = typename Teuchos::ScalarTraits<ST>;
   using MT = typename STS::magnitudeType;
   
@@ -100,7 +99,7 @@ int run (int argc, char *argv[])
     std::string filename ("bcsstk14.hb");
     MT tol = 1.0e-5;
 
-    CLP cmdp (false, true);
+    Teuchos::CommandLineProcessor cmdp (false, true);
     cmdp.setOption ("verbose", "quiet", &verbose, "Print messages and "
                     "results.");
     cmdp.setOption ("debug", "nodebug", &debug, "Run debugging checks.");
@@ -116,7 +115,7 @@ int run (int argc, char *argv[])
                     "linear system (-1 := adapted to problem/block size).");
     cmdp.setOption ("block-size", &blocksize, "Block size to be used by the "
                     "solver.");
-    if (cmdp.parse (argc, argv) != CLP::PARSE_SUCCESSFUL) {
+    if (cmdp.parse (argc, argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
       return -1;
     }
     if (debug) {

--- a/packages/belos/tpetra/test/BlockCG/test_resolve_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_resolve_cg_hb.cpp
@@ -1,0 +1,372 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side from the problem is being used instead of multiple
+// random right-hand-sides.  The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+
+/* Originally convert test here: belos/epetra/test/BlockCG/test_resolve_cg_hb.cpp */
+
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosBlockCGSolMgr.hpp"
+#include "BelosPseudoBlockCGSolMgr.hpp"
+
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_Map.hpp>
+#include <Tpetra_MatrixIO.hpp>
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_StandardCatchMacros.hpp>
+
+template <typename ScalarType>
+int run(int argc, char *argv[])
+{
+  using ST = ScalarType;
+  using OP = typename Tpetra::Operator<ST>;
+  using MV = typename Tpetra::MultiVector<ST>;
+  using tcrsmatrix_t = Tpetra::CrsMatrix<ST>;
+  
+  using SCT = typename Teuchos::ScalarTraits<ST>;
+  using MT  = typename SCT::magnitudeType;
+  
+  using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+  using MVT = typename Belos::MultiVecTraits<ST,MV>;
+  
+  using Teuchos::ParameterList;
+  using Teuchos::Comm;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  
+  Teuchos::GlobalMPISession session(&argc, &argv, NULL);
+  RCP<const Comm<int>> comm = Tpetra::getDefaultComm();
+  int MyPID = rank(*comm);
+
+  bool success = false;
+  bool verbose = false;
+  
+  try
+  {
+    // Get test parameters from command-line processor
+    bool badRes = false;
+    bool proc_verbose = false;
+    bool pseudo = false;   // use pseudo block CG to solve this linear system.
+    int frequency = -1;
+    int blocksize = 1;
+    int numrhs = 1;
+    int maxiters = -1;    // maximum number of iterations allowed per linear system
+    std::string filename("bcsstk14.hb");
+    std::string ortho("DGKS");
+    MT tol = 1.0e-5;  // relative residual tolerance
+
+    Teuchos::CommandLineProcessor cmdp(false,true);
+    cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+    cmdp.setOption("pseudo","regular",&pseudo,"Use pseudo-block CG to solve the linear systems.");
+    cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+    cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+    cmdp.setOption("ortho",&ortho,"Orthogonalization routine used by CG solver.");
+    cmdp.setOption("tol",&tol,"Relative residual tolerance used by CG solver.");
+    cmdp.setOption("blocksize",&blocksize,"Block size used by CG.");
+    cmdp.setOption("maxiters",&maxiters,"Maximum number of iterations per linear system (-1 = adapted to problem/block size).");
+    if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+      return -1;
+    }
+    if (!verbose){
+      frequency = -1;  // reset frequency if test is not verbose
+    }
+
+    proc_verbose = verbose && (MyPID==0);  /* Only print on the zero processor */
+    if (proc_verbose) {
+      std::cout << Belos::Belos_Version() << std::endl << std::endl;
+    }
+
+    // Get the problem
+    RCP<tcrsmatrix_t> A;
+    Tpetra::Utils::readHBMatrix(filename,comm,A);
+    RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+    // Construct initial guess and random right-hand-sides
+    RCP<MV> B, X;
+    X = rcp(new MV(map, numrhs));
+    MVT::MvRandom(*X);
+    B = rcp(new MV(map, numrhs));
+    OPT::Apply(*A, *X, *B);
+    MVT::MvInit(*X, 0.0);
+    
+    // Other information used by block solver (can be user specified)
+    const int NumGlobalElements = B->getGlobalLength();
+    if (maxiters == -1)
+      maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
+    
+    //
+    ParameterList belosList;
+    belosList.set( "Num Blocks", maxiters );               // Maximum number of blocks in Krylov factorization
+    belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+    belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+    belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    belosList.set( "Orthogonalization", ortho );           // Orthogonalization routine
+    if (verbose) {
+      belosList.set( "Verbosity", Belos::Errors + Belos::Warnings +
+          Belos::TimingDetails + Belos::StatusTestDetails );
+      if (frequency > 0)
+        belosList.set( "Output Frequency", frequency );
+    }
+    else
+      belosList.set( "Verbosity", Belos::Errors + Belos::Warnings );
+    
+    // Construct an unpreconditioned linear problem instance.
+    Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+    bool set = problem.setProblem();
+    if (set == false) {
+      if (proc_verbose)
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+
+    // Start the block CG iteration
+    RCP< Belos::SolverManager<ST,MV,OP> > solver;
+    if (pseudo)
+      solver = rcp( new Belos::PseudoBlockCGSolMgr<ST,MV,OP>( rcpFromRef(problem), rcpFromRef(belosList) ) );
+    else
+      solver = rcp( new Belos::BlockCGSolMgr<ST,MV,OP>( rcpFromRef(problem), rcpFromRef(belosList) ) );
+    
+    // Perform solve
+    Belos::ReturnType ret = solver->solve();
+    if (ret!=Belos::Converged) {
+      if (proc_verbose)
+        std::cout << "End Result: TEST FAILED" << std::endl;
+      return -1;
+    }
+    
+    // Get the number of iterations for this solve.
+    int numIters = solver->getNumIters();
+    std::cout << "Number of iterations performed for this solve: " << numIters << std::endl;
+    
+    // Compute actual residuals.
+    std::vector<MT> actual_resids( numrhs );
+    std::vector<MT> rhs_norm( numrhs );
+    MV resid(map, numrhs);
+    OPT::Apply( *A, *X, resid );
+    MVT::MvAddMv( -1.0, resid, 1.0, *B, resid );
+    MVT::MvNorm( resid, actual_resids );
+    MVT::MvNorm( *B, rhs_norm );
+    if (proc_verbose) {
+      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+      for ( int i=0; i<numrhs; i++) {
+        std::cout<<"Problem "<<i<<" : \t"<< actual_resids[i]/rhs_norm[i] <<std::endl;
+      }
+    }
+    
+    // Resolve the first problem by just resetting the solver manager.
+    X->putScalar( 0.0 );
+    solver->reset( Belos::Problem );
+    
+    // Perform solve (again)
+    ret = solver->solve();
+    
+    // Get the number of iterations for this solve.
+    numIters = solver->getNumIters();
+    std::cout << "Number of iterations performed for this solve (manager reset): " << numIters << std::endl;
+    if (ret!=Belos::Converged) {
+      if (proc_verbose)
+        std::cout << "End Result: TEST FAILED" << std::endl;
+      return -1;
+    }
+    
+    // Compute actual residuals.
+    std::vector<MT> actual_resids2( numrhs );
+    MV resid2(map, numrhs);
+    OPT::Apply( *A, *X, resid2 );
+    MVT::MvAddMv( -1.0, resid2, 1.0, *B, resid2 );
+    MVT::MvNorm( resid2, actual_resids );
+    MVT::MvAddMv( -1.0, resid2, 1.0, resid, resid2 );
+    MVT::MvNorm( resid2, actual_resids2 );
+    MVT::MvNorm( *B, rhs_norm );
+    if (proc_verbose) {
+      std::cout<< "---------- Actual Residuals (manager reset) ----------"<<std::endl<<std::endl;
+      for ( int i=0; i<numrhs; i++) {
+        std::cout<<"Problem "<<i<<" : \t"<< actual_resids[i]/rhs_norm[i] <<std::endl;
+        if ( actual_resids2[i] > SCT::prec() ) {
+          badRes = true;
+          std::cout << "Resolve residual vector is too different from first solve residual vector: " << actual_resids2[i] << std::endl;
+        }
+      }
+    }
+    
+    // Resolve the first problem by resetting the solver manager and changing the labels.
+    ParameterList belosList2;
+    belosList2.set( "Timer Label", "Belos Resolve w/ New Label" );   // Change timer labels.
+    solver->setParameters( Teuchos::rcp( &belosList2, false ) );
+
+    problem.setLabel( "Belos Resolve w/ New Label" );
+    X->putScalar( 0.0 );
+    solver->reset( Belos::Problem );
+    
+    // Perform solve (again)
+    ret = solver->solve();
+    
+    // Get the number of iterations for this solve.
+    numIters = solver->getNumIters();
+    std::cout << "Number of iterations performed for this solve (label reset): " << numIters << std::endl;
+    if (ret!=Belos::Converged) {
+      if (proc_verbose)
+        std::cout << "End Result: TEST FAILED" << std::endl;
+      return -1;
+    }
+    
+    // Compute actual residuals.
+    OPT::Apply( *A, *X, resid2 );
+    MVT::MvAddMv( -1.0, resid2, 1.0, *B, resid2 );
+    MVT::MvNorm( resid2, actual_resids );
+    MVT::MvAddMv( -1.0, resid2, 1.0, resid, resid2 );
+    MVT::MvNorm( resid2, actual_resids2 );
+    MVT::MvNorm( *B, rhs_norm );
+    if (proc_verbose) {
+      std::cout<< "---------- Actual Residuals (label reset) ----------"<<std::endl<<std::endl;
+      for ( int i=0; i<numrhs; i++) {
+        std::cout<<"Problem "<<i<<" : \t"<< actual_resids[i]/rhs_norm[i] <<std::endl;
+        if ( actual_resids2[i] > SCT::prec() ) {
+          badRes = true;
+          std::cout << "Resolve residual vector is too different from first solve residual vector: " << actual_resids2[i] << std::endl;
+        }
+      }
+    }
+
+    // Construct a second unpreconditioned linear problem instance.
+    RCP<MV> X2 = MVT::Clone(*X, numrhs);
+    MVT::MvInit( *X2, 0.0 );
+    Belos::LinearProblem<ST,MV,OP> problem2( A, X2, B );
+    problem2.setLabel("Belos Resolve");
+    set = problem2.setProblem();
+    if (set == false) {
+      if (proc_verbose)
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+
+    // Start the block CG iteration
+    // Create the solver without either the problem or parameter list.
+    if (pseudo)
+      solver = rcp( new Belos::PseudoBlockCGSolMgr<ST,MV,OP>() );
+    else
+      solver = rcp( new Belos::BlockCGSolMgr<ST,MV,OP>() );
+    
+    // Set the problem after the solver construction.
+    solver->setProblem( rcpFromRef(problem2) );
+
+    // Get the valid list of parameters from the solver and print it.
+    RCP<const ParameterList> validList = solver->getValidParameters();
+    if (proc_verbose) {
+      if (pseudo)
+        std::cout << std::endl << "Valid parameters from the pseudo-block CG solver manager:" << std::endl;
+      else
+        std::cout << std::endl << "Valid parameters from the block CG solver manager:" << std::endl;
+
+      std::cout << *validList << std::endl;
+    }
+
+    // Set the parameter list after the solver construction.
+    belosList.set( "Timer Label", "Belos Resolve" );         // Set timer label to discern between the two solvers.
+    solver->setParameters( rcp( &belosList, false ) );
+    
+    // Perform solve
+    ret = solver->solve();
+    
+    // Get the number of iterations for this solve.
+    numIters = solver->getNumIters();
+    std::cout << "Number of iterations performed for this solve (new solver): " << numIters << std::endl;
+    
+    // Compute actual residuals.
+    OPT::Apply( *A, *X2, resid2 );
+    MVT::MvAddMv( -1.0, resid2, 1.0, *B, resid2 );
+    MVT::MvNorm( resid2, actual_resids );
+    MVT::MvAddMv( -1.0, resid2, 1.0, resid, resid2 );
+    MVT::MvNorm( resid2, actual_resids2 );
+    MVT::MvNorm( *B, rhs_norm );
+    if (proc_verbose) {
+      std::cout<< "---------- Actual Residuals (new solver) ----------"<<std::endl<<std::endl;
+      for ( int i=0; i<numrhs; i++) {
+        std::cout<<"Problem "<<i<<" : \t"<< actual_resids[i]/rhs_norm[i] <<std::endl;
+        if ( actual_resids2[i] > SCT::prec() ) {
+          badRes = true;
+          std::cout << "Resolve residual vector is too different from first solve residual vector: " << actual_resids2[i] << std::endl;
+        } 
+      }
+    }
+
+    // Print out information about problem
+    if (proc_verbose) {
+      std::cout << std::endl << std::endl;
+      std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+      std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+      std::cout << "Block size used by solver: " << blocksize << std::endl;
+      std::cout << "Max number of CG iterations: " << maxiters << std::endl;
+      std::cout << "Relative residual tolerance: " << tol << std::endl;
+      std::cout << std::endl;
+    }
+
+    success = ret==Belos::Converged && !badRes;
+
+    if (success) {
+      if (proc_verbose)
+        std::cout << "End Result: TEST PASSED" << std::endl;
+    } else {
+      if (proc_verbose)
+        std::cout << "End Result: TEST FAILED" << std::endl;
+    }
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
+} // end test_resolve_cg_hb.cpp
+
+int main(int argc, char *argv[]) {
+  return run<double>(argc,argv);
+
+  // wrapped with a check: CMake option Trilinos_ENABLE_FLOAT=ON
+  // return run<float>(argc,argv);
+}
+


### PR DESCRIPTION
@trilinos/belos 
@hkthorn 

## Motivation
This PR updates the following tests:
- [x] `test_bl_cg_hb.cpp`
- [x] `test_bl_cg_hb_multiprec.cpp`, not in the CMakeLists
- [x] `test_pseudo_bl_cg_hb.cpp`
- [x] `test_pseudo_stochastic_cg_hb.cpp`
- [x] `test_bl_cg_complex_hb.cpp`

This PR converts the following tests:
- [x] `test_pseudo_cg_hb.cpp`
- [x] `test_resolve_cg_hb.cpp`
- `test_pseudo_cg_indefinite.cpp` (see https://github.com/trilinos/Trilinos/pull/12281)

_Note: currently, the following tests cannot be converted due to their use of a preconditioner (the original examples use Ifpack; however, including IfPack2 creates a circular dependency with Belos)_

- test_bl_pcg_set_res
- test_bl_pcg_hb
- test_pseudo_pcg_hb
- test_pseudo_stochastic_pcg_hb



