### PR TITLE
teko: Guard ProbingPreconditionerFactory by TEKO_HAVE_EPETRA

### DIFF
--- a/packages/teko/src/Teko_PreconditionerFactory.cpp
+++ b/packages/teko/src/Teko_PreconditionerFactory.cpp
@@ -61,8 +61,8 @@
 #include "Teko_DiagonallyScaledPreconditionerFactory.hpp"
 #ifdef TEKO_HAVE_EPETRA
 #include "Teko_DiagonalPreconditionerFactory.hpp"
-#endif
 #include "Teko_ProbingPreconditionerFactory.hpp"
+#endif
 #include "Teko_IdentityPreconditionerFactory.hpp"
 #include "NS/Teko_LSCPreconditionerFactory.hpp"
 #include "NS/Teko_SIMPLEPreconditionerFactory.hpp"
@@ -328,7 +328,7 @@ void PreconditionerFactory::initializePrecFactoryBuilder()
    clone = rcp(new AutoClone<IdentityPreconditionerFactory>());
    precFactoryBuilder_.addClone("Identity",clone);
 
-#ifdef Teko_ENABLE_Isorropia
+#if defined(Teko_ENABLE_Isorropia) && defined(TEKO_HAVE_EPETRA)
    clone = rcp(new AutoClone<ProbingPreconditionerFactory>());
    precFactoryBuilder_.addClone("Probing Preconditioner",clone);
 #endif


### PR DESCRIPTION
@trilinos/teko

## Motivation
The TEKO_HAVE_EPETRA switch controls whether ProbingPreconditionerFactory gets compiled, but not all includes of this header were appropriately guarded by the preprocessor macro. Correct this to fix the compilation of teko with TEKO_HAVE_EPETRA disabled.

## Testing
Build testing in the `!TEKO_HAVE_EPETRA` case was performed locally. This patch should not affect any runtime behavior.

## Additional Information
Found while attempting to enable `Teko` in the Julia distribution of Trilinos at https://github.com/JuliaPackaging/Yggdrasil/pull/7386.