### PR TITLE
Galeri: add Tpetra tests

### DIFF
--- a/packages/galeri/CMakeLists.txt
+++ b/packages/galeri/CMakeLists.txt
@@ -33,7 +33,7 @@ ENDIF()
 
 TRIBITS_ADD_TEST_DIRECTORIES(test)
 
-TRIBITS_ADD_EXAMPLE_DIRECTORIES(example example-fem example-xpetra)
+TRIBITS_ADD_EXAMPLE_DIRECTORIES(example example-fem example-xpetra example-tpetra)
 
 #
 # Exclude files for source package.

--- a/packages/galeri/example-tpetra/CMakeLists.txt
+++ b/packages/galeri/example-tpetra/CMakeLists.txt
@@ -1,0 +1,53 @@
+IF(${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Xpetra)
+  IF (Tpetra_INST_INT_INT)
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      Map_Tpetra
+      SOURCES Map_Tpetra.cpp
+      NUM_MPI_PROCS 1
+      COMM serial mpi
+      )
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      CrsMatrix_Tpetra
+      SOURCES CrsMatrix_Tpetra.cpp
+      NUM_MPI_PROCS 1
+      COMM serial mpi
+      )
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      LinearProblem_Tpetra
+      SOURCES LinearProblem_Tpetra.cpp
+      NUM_MPI_PROCS 1
+      COMM serial mpi
+      )
+
+  ENDIF()
+
+  IF (Tpetra_INST_INT_LONG_LONG)
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      Map_Tpetra_LL
+      SOURCES Map_Tpetra.cpp
+      NUM_MPI_PROCS 1
+      COMM serial mpi
+      TARGET_DEFINES -DGALERI_TEST_USE_LONGLONG_GO
+      )
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      CrsMatrix_Tpetra_LL
+      SOURCES CrsMatrix_Tpetra.cpp
+      NUM_MPI_PROCS 1
+      COMM serial mpi
+      TARGET_DEFINES -DGALERI_TEST_USE_LONGLONG_GO
+      )
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      LinearProblem_Tpetra_LL
+      SOURCES LinearProblem_Tpetra.cpp
+      NUM_MPI_PROCS 1
+      COMM serial mpi
+      TARGET_DEFINES -DGALERI_TEST_USE_LONGLONG_GO
+      )
+  ENDIF()
+ENDIF()

--- a/packages/galeri/example-tpetra/CrsMatrix_Tpetra.cpp
+++ b/packages/galeri/example-tpetra/CrsMatrix_Tpetra.cpp
@@ -1,0 +1,114 @@
+// @HEADER
+// ************************************************************************
+//
+//           Galeri: Finite Element and Matrix Generation Package
+//                 Copyright (2006) ETHZ/Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions about Galeri? Contact Marzio Sala (marzio.sala _AT_ gmail.com)
+//
+// ************************************************************************
+// @HEADER
+
+#include "Galeri_XpetraMaps.hpp"
+#include "Galeri_MatrixTraits.hpp"
+#include "Galeri_XpetraMatrixTypes.hpp"
+
+#include "Teuchos_DefaultComm.hpp"
+#include "Teuchos_ParameterList.hpp"
+
+#ifndef GALERI_TEST_USE_LONGLONG_GO
+#define GO int
+#else
+#define GO long long
+#endif
+#define Scalar int
+#define LO int
+#define Node Tpetra::KokkosClassic::DefaultNode::DefaultNodeType
+
+using namespace Galeri;
+
+int main(int argc, char *argv[])
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  typedef Tpetra::Map<LO, GO, Node> Tpetra_Map;
+  typedef Tpetra::CrsMatrix<Scalar, LO, GO, Node> Tpetra_CrsMatrix;
+
+#ifdef HAVE_MPI
+  MPI_Init(&argc, &argv);
+#endif
+
+  // Create comm
+  RCP<const Teuchos::Comm<int>> comm = Teuchos::DefaultComm<int>::getComm();
+
+  std::string mapType = "Cartesian2D";
+  auto mapParameters = Teuchos::ParameterList("Tpetra::Map");
+  // here we specify the global dimension of the problem
+  int nx = 5 * comm->getSize();
+  int ny = 5 * comm->getSize();
+  mapParameters.set("nx", nx);
+  mapParameters.set("ny", ny);
+
+  try
+  {
+    // Creation of the map
+    auto map = RCP{Galeri::Xpetra::CreateMap<Scalar, GO, Tpetra_Map>(mapType, comm, mapParameters)};
+
+    // Creates a diagonal matrix with 1's on the diagonal
+    auto matrix = Galeri::Xpetra::BigStar2D<Scalar, LO, GO, Tpetra_Map, Tpetra_CrsMatrix>(map, nx, ny, 20, -8, -8, -8, -8, 2, 2, 2, 2, 1, 1, 1, 1);
+
+    // print out the matrix
+    auto out = Teuchos::getFancyOStream(Teuchos::rcpFromRef(std::cout));
+    matrix->describe(*out, Teuchos::EVerbosityLevel::VERB_EXTREME);
+  }
+  catch (Exception &rhs)
+  {
+    if (comm->getRank() == 0)
+    {
+      cerr << "Caught exception: ";
+      rhs.Print();
+
+#ifdef HAVE_MPI
+      MPI_Finalize();
+#endif
+      return (EXIT_FAILURE);
+    }
+  }
+
+#ifdef HAVE_MPI
+  MPI_Finalize();
+#endif
+
+  return (EXIT_SUCCESS);
+}

--- a/packages/galeri/example-tpetra/LinearProblem_Tpetra.cpp
+++ b/packages/galeri/example-tpetra/LinearProblem_Tpetra.cpp
@@ -1,0 +1,140 @@
+// @HEADER
+// ************************************************************************
+//
+//           Galeri: Finite Element and Matrix Generation Package
+//                 Copyright (2006) ETHZ/Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions about Galeri? Contact Marzio Sala (marzio.sala _AT_ gmail.com)
+//
+// ************************************************************************
+// @HEADER
+
+#include "Galeri_XpetraMaps.hpp"
+#include "Galeri_MatrixTraits.hpp"
+#include "Galeri_XpetraMatrixTypes.hpp"
+#include "Galeri_XpetraProblemFactory.hpp"
+
+#include "Teuchos_DefaultComm.hpp"
+#include "Teuchos_ParameterList.hpp"
+
+#ifndef GALERI_TEST_USE_LONGLONG_GO
+#define GO int
+#else
+#define GO long long
+#endif
+#define Scalar int
+#define LO int
+#define Node Tpetra::KokkosClassic::DefaultNode::DefaultNodeType
+
+using namespace Galeri;
+
+int main(int argc, char *argv[])
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  typedef Tpetra::Map<LO, GO, Node> Tpetra_Map;
+  typedef Tpetra::CrsMatrix<Scalar, LO, GO, Node> Tpetra_CrsMatrix;
+  typedef Tpetra::MultiVector<Scalar, LO, GO, Node> Tpetra_MultiVector;
+  typedef Teuchos::ScalarTraits<Scalar> ScalarTraits;
+
+#ifdef HAVE_MPI
+  MPI_Init(&argc, &argv);
+#endif
+
+  // Create comm
+  RCP<const Teuchos::Comm<int>> comm = Teuchos::DefaultComm<int>::getComm();
+
+  // Here we create the linear problem
+  //
+  //   Matrix * LHS = RHS
+  //
+  // with Matrix arising from a 5-point formula discretization.
+
+  std::string mapType = "Cartesian2D";
+  auto mapParameters = Teuchos::ParameterList("Tpetra::Map");
+  // dimension of the problem is nx x ny
+  mapParameters.set("nx", 10 * comm->getSize());
+  mapParameters.set("ny", 10);
+  // total number of processors is mx x my
+  mapParameters.set("mx", comm->getSize());
+  mapParameters.set("my", 1);
+
+  auto out = Teuchos::getFancyOStream(Teuchos::rcpFromRef(std::cout));
+
+  try
+  {
+    // Creation of the map
+    auto map = RCP{Galeri::Xpetra::CreateMap<Scalar, GO, Tpetra_Map>(mapType, comm, mapParameters)};
+
+    // Creation of linear problem
+    auto problem = Galeri::Xpetra::BuildProblem<Scalar, LO, GO, Tpetra_Map, Tpetra_CrsMatrix, Tpetra_MultiVector>("Laplace2D", map, mapParameters);
+
+    // Build Matrix and MultiVectors
+    auto matrix = problem->BuildMatrix();
+    auto LHS = rcp(new Tpetra_MultiVector(matrix->getDomainMap(), 1));
+    auto RHS = rcp(new Tpetra_MultiVector(matrix->getRangeMap(), 1));
+    auto ExactSolution = rcp(new Tpetra_MultiVector(matrix->getDomainMap(), 1));
+
+    ExactSolution->randomize(0, 100);
+    LHS->putScalar(ScalarTraits::zero());
+
+    matrix->apply(*ExactSolution, *RHS);
+
+    matrix->describe(*out, Teuchos::EVerbosityLevel::VERB_EXTREME);
+    LHS->describe(*out, Teuchos::EVerbosityLevel::VERB_EXTREME);
+    RHS->describe(*out, Teuchos::EVerbosityLevel::VERB_EXTREME);
+    ExactSolution->describe(*out, Teuchos::EVerbosityLevel::VERB_EXTREME);
+
+    // at this point any LinearSolver can be used which understands the Tpetra objects. For example: Amesos2 or Ifpack2
+  }
+  catch (Galeri::Exception &rhs)
+  {
+    if (comm->getRank() == 0)
+    {
+      cerr << "Caught exception: ";
+      rhs.Print();
+
+#ifdef HAVE_MPI
+      MPI_Finalize();
+#endif
+      return (EXIT_FAILURE);
+    }
+  }
+
+#ifdef HAVE_MPI
+  MPI_Finalize();
+#endif
+
+  return (EXIT_SUCCESS);
+}

--- a/packages/galeri/example-tpetra/Map_Tpetra.cpp
+++ b/packages/galeri/example-tpetra/Map_Tpetra.cpp
@@ -1,0 +1,110 @@
+// @HEADER
+// ************************************************************************
+//
+//           Galeri: Finite Element and Matrix Generation Package
+//                 Copyright (2006) ETHZ/Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions about Galeri? Contact Marzio Sala (marzio.sala _AT_ gmail.com)
+//
+// ************************************************************************
+// @HEADER
+
+#include "Galeri_XpetraMaps.hpp"
+
+#include "Teuchos_DefaultComm.hpp"
+#include "Teuchos_ParameterList.hpp"
+
+#ifndef GALERI_TEST_USE_LONGLONG_GO
+#define GO int
+#else
+#define GO long long
+#endif
+
+using namespace Galeri;
+
+int main(int argc, char *argv[])
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  typedef Tpetra::Map<int, GO> Tpetra_Map;
+
+#ifdef HAVE_MPI
+  MPI_Init(&argc, &argv);
+#endif
+
+  // Create comm
+  RCP<const Teuchos::Comm<int>> comm = Teuchos::DefaultComm<int>::getComm();
+
+  // Creates an Tpetra_Map corresponding to a 2D Cartesian grid
+  // on the unit square. For parallel runs, the nodes are divided into
+  // strips, so that the total number of subdomains is comm->getSize() x 1.
+
+  // Type of the object
+  std::string mapType = "Cartesian2D";
+  // Container for parameters
+  Teuchos::ParameterList galeriList;
+  galeriList.set("nx", 2 * comm->getSize());
+  galeriList.set("ny", 2);
+  galeriList.set("mx", comm->getSize());
+  galeriList.set("my", 1);
+
+  try
+  {
+    // Creation of the map
+    auto map = Galeri::Xpetra::CreateMap<int, GO, Tpetra_Map>(mapType, comm, galeriList);
+
+    // print out the map
+    auto out = Teuchos::getFancyOStream(Teuchos::rcpFromRef(std::cout));
+    map->describe(*out, Teuchos::EVerbosityLevel::VERB_EXTREME);
+  }
+  catch (Exception &rhs)
+  {
+    if (comm->getRank() == 0)
+    {
+      cerr << "Caught exception: ";
+      rhs.Print();
+
+#ifdef HAVE_MPI
+      MPI_Finalize();
+#endif
+      return (EXIT_FAILURE);
+    }
+  }
+
+#ifdef HAVE_MPI
+  MPI_Finalize();
+#endif
+
+  return (EXIT_SUCCESS);
+}

--- a/packages/galeri/test/VerySimple/CMakeLists.txt
+++ b/packages/galeri/test/VerySimple/CMakeLists.txt
@@ -9,3 +9,28 @@ IF (${PACKAGE_NAME}_ENABLE_Epetra)
     )
 
 ENDIF()
+
+IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Xpetra)
+  IF (Tpetra_INST_INT_INT)
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      VerySimple_Tpetra
+      SOURCES cxx_main_tpetra.cpp
+      ARGS -v
+      COMM serial mpi
+      )
+
+  ENDIF()
+
+  IF (Tpetra_INST_INT_LONG_LONG)
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      VerySimple_Tpetra_LL
+      SOURCES cxx_main_tpetra.cpp
+      ARGS -v
+      COMM serial mpi
+      TARGET_DEFINES -DGALERI_TEST_USE_LONGLONG_GO
+      )
+
+  ENDIF()
+ENDIF()

--- a/packages/galeri/test/VerySimple/cxx_main_tpetra.cpp
+++ b/packages/galeri/test/VerySimple/cxx_main_tpetra.cpp
@@ -1,0 +1,140 @@
+// @HEADER
+// ************************************************************************
+//
+//           Galeri: Finite Element and Matrix Generation Package
+//                 Copyright (2006) ETHZ/Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions about Galeri? Contact Marzio Sala (marzio.sala _AT_ gmail.com)
+//
+// ************************************************************************
+// @HEADER
+
+#include "Galeri_XpetraMaps.hpp"
+#include "Galeri_MatrixTraits.hpp"
+#include "Galeri_XpetraMatrixTypes.hpp"
+#include "Galeri_XpetraProblemFactory.hpp"
+
+#include "Teuchos_DefaultComm.hpp"
+#include "Teuchos_ParameterList.hpp"
+
+#ifndef GALERI_TEST_USE_LONGLONG_GO
+#define GO int
+#else
+#define GO long long
+#endif
+#define Scalar int
+#define LO int
+#define Node Tpetra::KokkosClassic::DefaultNode::DefaultNodeType
+
+using namespace Galeri;
+
+int main(int argc, char* argv[])
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  typedef Tpetra::Map<LO, GO, Node> Tpetra_Map;
+  typedef Tpetra::CrsMatrix<Scalar, LO, GO, Node> Tpetra_CrsMatrix;
+  typedef Tpetra::MultiVector<Scalar, LO, GO, Node> Tpetra_MultiVector;
+  typedef Teuchos::ScalarTraits<Scalar> ScalarTraits;
+
+#ifdef HAVE_MPI
+  MPI_Init(&argc, &argv);
+#endif
+
+  // Create comm
+  RCP<const Teuchos::Comm<int>> comm = Teuchos::DefaultComm<int>::getComm();
+
+  // Here we create the linear problem
+  //
+  //   Matrix * LHS = RHS
+  //
+  // with Matrix arising from a 5-point formula discretization.
+
+  std::string mapType = "Cartesian2D";
+  auto mapParameters = Teuchos::ParameterList("Tpetra::Map");
+  // dimension of the problem is nx x ny
+  mapParameters.set("nx", 10 * comm->getSize());
+  mapParameters.set("ny", 10);
+  // total number of processors is mx x my
+  mapParameters.set("mx", comm->getSize());
+  mapParameters.set("my", 1);
+
+  auto out = Teuchos::getFancyOStream(Teuchos::rcpFromRef(std::cout));
+
+  try
+  {
+    // Creation of the map
+    auto map = RCP{Galeri::Xpetra::CreateMap<Scalar, GO, Tpetra_Map>(mapType, comm, mapParameters)};
+
+    // Creation of linear problem
+    auto problem = Galeri::Xpetra::BuildProblem<Scalar, LO, GO, Tpetra_Map, Tpetra_CrsMatrix, Tpetra_MultiVector>("Laplace2D", map, mapParameters);
+
+    // Build Matrix and MultiVectors
+    auto matrix = problem->BuildMatrix();
+    auto LHS = rcp(new Tpetra_MultiVector(matrix->getDomainMap(), 1));
+    auto RHS = rcp(new Tpetra_MultiVector(matrix->getRangeMap(), 1));
+    auto ExactSolution = rcp(new Tpetra_MultiVector(matrix->getDomainMap(), 1));
+
+    ExactSolution->randomize(0, 100);
+    LHS->putScalar(ScalarTraits::zero());
+
+    matrix->apply(*ExactSolution, *RHS);
+
+    matrix->describe(*out, Teuchos::EVerbosityLevel::VERB_EXTREME);
+    LHS->describe(*out, Teuchos::EVerbosityLevel::VERB_EXTREME);
+    RHS->describe(*out, Teuchos::EVerbosityLevel::VERB_EXTREME);
+    ExactSolution->describe(*out, Teuchos::EVerbosityLevel::VERB_EXTREME);
+
+    // at this point any LinearSolver can be used which understands the Tpetra objects. For example: Amesos2 or Ifpack2
+  }
+  catch (Galeri::Exception &rhs)
+  {
+    if (comm->getRank() == 0)
+    {
+      cerr << "Caught exception: ";
+      rhs.Print();
+
+#ifdef HAVE_MPI
+      MPI_Finalize();
+#endif
+      return (EXIT_FAILURE);
+    }
+  }
+
+#ifdef HAVE_MPI
+  MPI_Finalize();
+#endif
+
+  return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
@trilinos/galeri 
@jhux2 

## Motivation
This PR updates Galeri tests to use Tpetra instead of Epetra. Tests and table/notes written by @thearusable 

Tests found under the `test`, `example*` directories.


| Folder          | Epetra Tests (Main file name)          | Conversion Status                        |
|-----------------|-------------------------------|---------------------------------|
| test/VerySimple | cxx_main.cpp                            | **Partial**                     |
| example             | Map.cpp                                      | **Full**                         |
| example             | CrsMatrix.cpp                             | **Partial**                        |
| example             | VbrMatrix.cpp                            | **NO**                          |
| example             | LinearProblem.cpp                    | **Partial**                          |

- `VbrMatrix.cpp` - This test can't be converted because it's using a `Epetra::VbrMatrix` which doesn't exists in `Tpetra` package. It was present at some point in the past but it was deprecated and removed from the package as stated in the Release Notes: https://github.com/NexGenAnalytics/Trilinos/blob/NGA-FY23-develop/packages/tpetra/ReleaseNotes.txt#L438
- `cxx_main.cpp` / `LinearProblem.cpp` - Those two have a creation of necessary objects for calculations done, but there are no linear solvers in `Galeri`/`Tpetra` package which could be used to solve the problem. I added a comment that those solvers can be found for example in `Amesos2` or `Ifpack2`.
- `CrsMatrix.cpp` - Original tests used a helper method which generated and printed a 2D stencil of the matrix. I didn't found any good replacement for that, and I didn't create my own. 

In the tests there are methods used from `Galeri::Xpetra` namespace so they will require `Xpetra` to be enabled. 
