### PR TITLE
Fix warning 'Rank' is deprecated

### DIFF
--- a/packages/amesos2/src/Amesos2_Kokkos_View_Copy_Assign.hpp
+++ b/packages/amesos2/src/Amesos2_Kokkos_View_Copy_Assign.hpp
@@ -164,7 +164,7 @@ implement_copy_or_assign_diff_mem_check_types(bool bInitialize, dst_t & dst, con
 }
 
 template<class dst_t, class src_t> // version for different memory spaces
-typename std::enable_if<static_cast<int>(dst_t::Rank) == 1>::type
+typename std::enable_if<static_cast<int>(dst_t::rank) == 1>::type
 implement_copy_or_assign_diff_mem_diff_types_check_dim(dst_t & dst, const src_t & src) {
   Kokkos::View<typename dst_t::value_type*, typename src_t::execution_space>
     intermediate(Kokkos::ViewAllocateWithoutInitializing("intermediate"), src.extent(0));
@@ -173,7 +173,7 @@ implement_copy_or_assign_diff_mem_diff_types_check_dim(dst_t & dst, const src_t 
 }
 
 template<class dst_t, class src_t> // version for different memory spaces
-typename std::enable_if<static_cast<int>(dst_t::Rank) == 2>::type
+typename std::enable_if<static_cast<int>(dst_t::rank) == 2>::type
 implement_copy_or_assign_diff_mem_diff_types_check_dim(dst_t & dst, const src_t & src) {
   Kokkos::View<typename dst_t::value_type**, Kokkos::LayoutLeft, typename src_t::execution_space>
     intermediate(Kokkos::ViewAllocateWithoutInitializing("intermediate"), src.extent(0), src.extent(1));

--- a/packages/ifpack2/src/Ifpack2_Details_ChebyshevKernel_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_ChebyshevKernel_def.hpp
@@ -71,15 +71,15 @@ template<class WVector,
          bool use_beta,
          bool do_X_update>
 struct ChebyshevKernelVectorFunctor {
-  static_assert (static_cast<int> (WVector::Rank) == 1,
+  static_assert (static_cast<int> (WVector::rank) == 1,
                  "WVector must be a rank 1 View.");
-  static_assert (static_cast<int> (DVector::Rank) == 1,
+  static_assert (static_cast<int> (DVector::rank) == 1,
                  "DVector must be a rank 1 View.");
-  static_assert (static_cast<int> (BVector::Rank) == 1,
+  static_assert (static_cast<int> (BVector::rank) == 1,
                  "BVector must be a rank 1 View.");
-  static_assert (static_cast<int> (XVector_colMap::Rank) == 1,
+  static_assert (static_cast<int> (XVector_colMap::rank) == 1,
                  "XVector_colMap must be a rank 1 View.");
-  static_assert (static_cast<int> (XVector_domMap::Rank) == 1,
+  static_assert (static_cast<int> (XVector_domMap::rank) == 1,
                  "XVector_domMap must be a rank 1 View.");
 
   using execution_space = typename AMatrix::execution_space;

--- a/packages/ifpack2/src/Ifpack2_Details_ScaledDampedResidual_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_ScaledDampedResidual_def.hpp
@@ -69,13 +69,13 @@ template<class WVector,
          class Scalar,
          bool use_beta>
 struct ScaledDampedResidualVectorFunctor {
-  static_assert (static_cast<int> (WVector::Rank) == 1,
+  static_assert (static_cast<int> (WVector::rank) == 1,
                  "WVector must be a rank 1 View.");
-  static_assert (static_cast<int> (DVector::Rank) == 1,
+  static_assert (static_cast<int> (DVector::rank) == 1,
                  "DVector must be a rank 1 View.");
-  static_assert (static_cast<int> (BVector::Rank) == 1,
+  static_assert (static_cast<int> (BVector::rank) == 1,
                  "BVector must be a rank 1 View.");
-  static_assert (static_cast<int> (XVector::Rank) == 1,
+  static_assert (static_cast<int> (XVector::rank) == 1,
                  "XVector must be a rank 1 View.");
 
   using execution_space = typename AMatrix::execution_space;

--- a/packages/panzer/disc-fe/src/Panzer_Workset.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_Workset.cpp
@@ -164,7 +164,7 @@ setup(const panzer::LocalMeshPartition & partition,
   // Allocate and fill the cell nodes
   {
     // Double check this
-    TEUCHOS_ASSERT(partition.cell_nodes.Rank == 3);
+    TEUCHOS_ASSERT(partition.cell_nodes.rank == 3);
 
     // Grab the size of the cell node array
     const int num_partition_cells = partition.cell_nodes.extent(0);


### PR DESCRIPTION

@trilinos/amesos2 @trilinos/ifpack2 @trilinos/panzer 

## Motivation
Fixes some deprecation warnings of the type

`warning: 'Rank' is deprecated: Use rank instead. [-Wdeprecated-declarations]`.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
N/A

## Testing
Verified in local build.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->