### PR TITLE
Improve release note for using GNUInstallDirs by default (#12104)

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -8,16 +8,15 @@
 CMake
 
   - Change the default for `Trilinos_MUST_FIND_ALL_TPL_LIBS` from `OFF` to
-    `ON`. It was
-    turned off by default because it breaks backward compatibility but it also
-    causes problems for new users and new configurations.
+    `ON`. It was turned off by default because it breaks backward
+    compatibility but it also causes problems for new users and new
+    configurations.
 
     Users that do not want this new behavior can set
     `-D Trilinos_MUST_FIND_ALL_TPL_LIBS=OFF`, which is backward compatible.
 
   - Change the default for `Trilinos_USE_GNUINSTALLDIRS` from `OFF` to `ON`,
-    in the goal to
-    move Trilinos and TriBITS to modern CMake.
+    in the goal to move Trilinos and TriBITS to modern CMake.
 
     TriBITS has had the ability to use that paths selected by the standard
     CMake module `GNUInstallDirs.cmake` for a long time. But it is turned off
@@ -25,7 +24,14 @@ CMake
     sake of backward compatibility.
 
     This may break people's existing configurations because it will install
-    libs in `<prefix>/libs64/` instead of in `<instead>/libs/`. See
+    libs in `<prefix>/libs64/` instead of in `<prefix>/libs/` on many systems
+    (e.g. Linux systems).  To revert back to using `<prefix>/lib` but still
+    use `GNUInstallDirs.cmake` for Trilinos, set `-D
+    CMAKE_INSTALL_LIBDIR:STRING=lib`.  NOTE: The setting `-D
+    Trilinos_USE_GNUINSTALLDIRS=OFF` is deprecated and may be removed in the
+    future. (I.e. the usage of `GNUInstallDirs.cmake` may be hard-coded in the
+    future so please try adjusting to the usage of `GNUInstallDirs.cmake` by
+    Trilinos.)  See
     https://github.com/trilinos/Trilinos/issues/12104#issuecomment-1691945033
     for additional details and instructions.
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -25,13 +25,24 @@ CMake
 
     This may break people's existing configurations because it will install
     libs in `<prefix>/libs64/` instead of in `<prefix>/libs/` on many systems
-    (e.g. Linux systems).  To revert back to using `<prefix>/lib` but still
-    use `GNUInstallDirs.cmake` for Trilinos, set `-D
-    CMAKE_INSTALL_LIBDIR:STRING=lib`.  NOTE: The setting `-D
-    Trilinos_USE_GNUINSTALLDIRS=OFF` is deprecated and may be removed in the
-    future. (I.e. the usage of `GNUInstallDirs.cmake` may be hard-coded in the
-    future so please try adjusting to the usage of `GNUInstallDirs.cmake` by
-    Trilinos.)  See
+    (e.g. Linux systems).  For example, this will break downstream CMake
+    projects that call `find_package(Trilinos ...)` before defining the
+    compilers (e.g. so they can get the compilers from Trilinos).  If the
+    compilers are not defined, `find_package()` will not search
+    `<prefix>/lib64`.  To revert back to using `<prefix>/lib` but still use
+    `GNUInstallDirs.cmake` for Trilinos, set `-D
+    CMAKE_INSTALL_LIBDIR:STRING=lib` when configuring Trilinos.  To avoid the
+    `find_package(Trilinos ...)` problem not searching `<prefix>/lib64`,
+    consider explicitly specifying the compiler to and having the downstream
+    CMake project define the compilers first with `project(<ProjectName>
+    COMPILERS C CXX ...)` before calling `find_package(Trilinos ...)`.  (That
+    is, don't try to get the compilers from the installed Trilinos, see
+    https://github.com/trilinos/Trilinos/issues/12306.)
+
+    NOTE: The setting `-D Trilinos_USE_GNUINSTALLDIRS=OFF` is deprecated and
+    may be removed in the future. (I.e. the usage of `GNUInstallDirs.cmake`
+    may be hard-coded in the future so please try adjusting to the usage of
+    `GNUInstallDirs.cmake` by Trilinos.)  See
     https://github.com/trilinos/Trilinos/issues/12104#issuecomment-1691945033
     for additional details and instructions.
 


### PR DESCRIPTION
Follow-on from PR:

* #12258 

Hopefully this improved release note will help customers transition to Trilinos using the standard GNUInstallDirs module.  I also added a mention that Trilinos may only support GNUIntallDirs in the future so customers should get used to working with it.

Hopefully this will help customers avoid situations like:

* sandialabs/albany#982

