### PR TITLE
Stokhos (fixes #12279): construct flattened vector by copy constructing WDV

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_Utilities_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_Utilities_MP_Vector.hpp
@@ -241,268 +241,64 @@ namespace Stokhos {
     return flat_graph;
   }
 
-
   // Create a flattened vector by unrolling the MP::Vector scalar type.  The
   // returned vector is a view of the original
-  template <typename Storage, typename LocalOrdinal, typename GlobalOrdinal,
-            typename Node>
-  Teuchos::RCP< const Tpetra::MultiVector<typename Storage::value_type,
-                                          LocalOrdinal,GlobalOrdinal,Node> >
+  template <typename Storage, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+  Teuchos::RCP<Tpetra::MultiVector<typename Storage::value_type, LocalOrdinal, GlobalOrdinal, Node>>
   create_flat_vector_view(
-    const Tpetra::MultiVector<Sacado::MP::Vector<Storage>,
-                              LocalOrdinal,GlobalOrdinal,Node>& vec_const,
-    const Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& flat_map) {
-    using Teuchos::ArrayRCP;
-    using Teuchos::RCP;
-    using Teuchos::rcp;
+    const Tpetra::MultiVector<Sacado::MP::Vector<Storage>, LocalOrdinal, GlobalOrdinal, Node>& vec,
+    const Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& flat_map
+  ) {
+    using BaseScalar = typename Storage::value_type;
+    using FlatVector = Tpetra::MultiVector<BaseScalar, LocalOrdinal, GlobalOrdinal, Node>;
 
-    typedef Sacado::MP::Vector<Storage> Scalar;
-    typedef typename Storage::value_type BaseScalar;
-    typedef Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> Vector;
-    typedef Tpetra::MultiVector<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FlatVector;
-
-    // MP size
-    const LocalOrdinal mp_size = Storage::static_size;
-
-    // Cast-away const since resulting vector is a view and we can't create
-    // a const-vector directly
-    Vector& vec = const_cast<Vector&>(vec_const);
-
-    // Get data
-    ArrayRCP<Scalar> vec_vals = vec.get1dViewNonConst();
-    const size_t vec_size = vec_vals.size();
-
-    // Create view of data
-    BaseScalar *flat_vec_ptr =
-      reinterpret_cast<BaseScalar*>(vec_vals.getRawPtr());
-    ArrayRCP<BaseScalar> flat_vec_vals =
-      Teuchos::arcp(flat_vec_ptr, 0, vec_size*mp_size, false);
+    // Create flattenend view using reshaping conversion copy constructor
+    typename FlatVector::wrapped_dual_view_type flat_vals(vec.getWrappedDualView());
 
     // Create flat vector
-    const size_t stride = vec.getStride();
-    const size_t flat_stride = stride * mp_size;
-    const size_t num_vecs = vec.getNumVectors();
-    RCP<FlatVector> flat_vec =
-      rcp(new FlatVector(flat_map, flat_vec_vals, flat_stride, num_vecs));
-
-      return flat_vec;
+    return Teuchos::make_rcp<FlatVector>(flat_map, flat_vals);
   }
 
-  // Create a flattened vector by unrolling the MP::Vector scalar type.  The
-  // returned vector is a view of the original.  This version creates the
-  // map if necessary
-  template <typename Storage, typename LocalOrdinal, typename GlobalOrdinal,
-            typename Node>
-  Teuchos::RCP< const Tpetra::MultiVector<typename Storage::value_type,
-                                          LocalOrdinal,GlobalOrdinal,Node> >
+  // This version creates the map if necessary
+  template <typename Storage, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+  Teuchos::RCP<Tpetra::MultiVector<typename Storage::value_type, LocalOrdinal, GlobalOrdinal, Node>>
   create_flat_vector_view(
-    const Tpetra::MultiVector<Sacado::MP::Vector<Storage>,
-                              LocalOrdinal,GlobalOrdinal,Node>& vec,
-    Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& flat_map) {
+    const Tpetra::MultiVector<Sacado::MP::Vector<Storage>, LocalOrdinal, GlobalOrdinal, Node>& vec,
+          Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& flat_map
+  ) {
     if (flat_map == Teuchos::null) {
       const LocalOrdinal mp_size = Storage::static_size;
       flat_map = create_flat_map(*(vec.getMap()), mp_size);
     }
-    const Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > const_flat_map = flat_map;
+    const Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> const_flat_map = flat_map;
     return create_flat_vector_view(vec, const_flat_map);
   }
 
-  // Create a flattened vector by unrolling the MP::Vector scalar type.  The
-  // returned vector is a view of the original
-  template <typename Storage, typename LocalOrdinal, typename GlobalOrdinal,
-            typename Node>
-  Teuchos::RCP< Tpetra::MultiVector<typename Storage::value_type,
-                                    LocalOrdinal,GlobalOrdinal,Node> >
+  template <typename Storage, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+  Teuchos::RCP<Tpetra::Vector<typename Storage::value_type, LocalOrdinal, GlobalOrdinal, Node>>
   create_flat_vector_view(
-    Tpetra::MultiVector<Sacado::MP::Vector<Storage>,
-                        LocalOrdinal,GlobalOrdinal,Node>& vec,
-    const Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& flat_map) {
-    using Teuchos::ArrayRCP;
-    using Teuchos::RCP;
-    using Teuchos::rcp;
-
-    typedef Sacado::MP::Vector<Storage> Scalar;
-    typedef typename Storage::value_type BaseScalar;
-    typedef Tpetra::MultiVector<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FlatVector;
-
-    // MP size
-    const LocalOrdinal mp_size = Storage::static_size;
-
-    // Get data
-    ArrayRCP<Scalar> vec_vals = vec.get1dViewNonConst();
-    const size_t vec_size = vec_vals.size();
-
-    // Create view of data
-    BaseScalar *flat_vec_ptr =
-      reinterpret_cast<BaseScalar*>(vec_vals.getRawPtr());
-    ArrayRCP<BaseScalar> flat_vec_vals =
-      Teuchos::arcp(flat_vec_ptr, 0, vec_size*mp_size, false);
-
-    // Create flat vector
-    const size_t stride = vec.getStride();
-    const size_t flat_stride = stride * mp_size;
-    const size_t num_vecs = vec.getNumVectors();
-    RCP<FlatVector> flat_vec =
-      rcp(new FlatVector(flat_map, flat_vec_vals, flat_stride, num_vecs));
-
-      return flat_vec;
+    const Tpetra::Vector<Sacado::MP::Vector<Storage>, LocalOrdinal, GlobalOrdinal, Node>& vec,
+    const Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& flat_map
+  ) {
+    return create_flat_vector_view(
+      dynamic_cast<const Tpetra::MultiVector<Sacado::MP::Vector<Storage>, LocalOrdinal, GlobalOrdinal, Node>&>(vec),
+      flat_map
+    )->getVectorNonConst(0);
   }
 
-  // Create a flattened vector by unrolling the MP::Vector scalar type.  The
-  // returned vector is a view of the original.  This version creates the
-  // map if necessary
-  template <typename Storage, typename LocalOrdinal, typename GlobalOrdinal,
-            typename Node>
-  Teuchos::RCP< Tpetra::MultiVector<typename Storage::value_type,
-                                    LocalOrdinal,GlobalOrdinal,Node> >
+  template <typename Storage, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+  Teuchos::RCP<Tpetra::Vector<typename Storage::value_type, LocalOrdinal, GlobalOrdinal, Node>>
   create_flat_vector_view(
-    Tpetra::MultiVector<Sacado::MP::Vector<Storage>,
-                        LocalOrdinal,GlobalOrdinal,Node>& vec,
-    Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& flat_map) {
+    const Tpetra::Vector<Sacado::MP::Vector<Storage>, LocalOrdinal, GlobalOrdinal, Node>& vec,
+          Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& flat_map
+  ) {
     if (flat_map == Teuchos::null) {
       const LocalOrdinal mp_size = Storage::static_size;
       flat_map = create_flat_map(*(vec.getMap()), mp_size);
     }
-    const Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > const_flat_map = flat_map;
+    const Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> const_flat_map = flat_map;
     return create_flat_vector_view(vec, const_flat_map);
   }
-
-  // Create a flattened vector by unrolling the MP::Vector scalar type.  The
-  // returned vector is a view of the original
-  template <typename Storage, typename LocalOrdinal, typename GlobalOrdinal,
-            typename Node>
-  Teuchos::RCP< const Tpetra::Vector<typename Storage::value_type,
-                                     LocalOrdinal,GlobalOrdinal,Node> >
-  create_flat_vector_view(
-    const Tpetra::Vector<Sacado::MP::Vector<Storage>,
-                         LocalOrdinal,GlobalOrdinal,Node>& vec_const,
-    const Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& flat_map) {
-    const Tpetra::MultiVector<Sacado::MP::Vector<Storage>,LocalOrdinal,GlobalOrdinal,Node>& mv = vec_const;
-    Teuchos::RCP< Tpetra::MultiVector<typename Storage::value_type,LocalOrdinal,GlobalOrdinal,Node> > flat_mv = create_flat_vector_view(mv, flat_map);
-    return flat_mv->getVector(0);
-  }
-
-  // Create a flattened vector by unrolling the MP::Vector scalar type.  The
-  // returned vector is a view of the original.  This version creates the
-  // map if necessary
-  template <typename Storage, typename LocalOrdinal, typename GlobalOrdinal,
-            typename Node>
-  Teuchos::RCP< const Tpetra::Vector<typename Storage::value_type,
-                                     LocalOrdinal,GlobalOrdinal,Node> >
-  create_flat_vector_view(
-    const Tpetra::Vector<Sacado::MP::Vector<Storage>,
-                         LocalOrdinal,GlobalOrdinal,Node>& vec,
-    Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& flat_map) {
-    if (flat_map == Teuchos::null) {
-      const LocalOrdinal mp_size = Storage::static_size;
-      flat_map = create_flat_map(*(vec.getMap()), mp_size);
-    }
-    const Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > const_flat_map = flat_map;
-    return create_flat_vector_view(vec, const_flat_map);
-  }
-
-  // Create a flattened vector by unrolling the MP::Vector scalar type.  The
-  // returned vector is a view of the original
-  template <typename Storage, typename LocalOrdinal, typename GlobalOrdinal,
-            typename Node>
-  Teuchos::RCP< Tpetra::Vector<typename Storage::value_type,
-                               LocalOrdinal,GlobalOrdinal,Node> >
-  create_flat_vector_view(
-    Tpetra::Vector<Sacado::MP::Vector<Storage>,
-                   LocalOrdinal,GlobalOrdinal,Node>& vec,
-    const Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& flat_map) {
-    Tpetra::MultiVector<Sacado::MP::Vector<Storage>,LocalOrdinal,GlobalOrdinal,Node>& mv = vec;
-    Teuchos::RCP< Tpetra::MultiVector<typename Storage::value_type,LocalOrdinal,GlobalOrdinal,Node> > flat_mv = create_flat_vector_view(mv, flat_map);
-    return flat_mv->getVectorNonConst(0);
-  }
-
-  // Create a flattened vector by unrolling the MP::Vector scalar type.  The
-  // returned vector is a view of the original.  This version creates the
-  // map if necessary
-  template <typename Storage, typename LocalOrdinal, typename GlobalOrdinal,
-            typename Node>
-  Teuchos::RCP< Tpetra::Vector<typename Storage::value_type,
-                               LocalOrdinal,GlobalOrdinal,Node> >
-  create_flat_vector_view(
-    Tpetra::Vector<Sacado::MP::Vector<Storage>,
-                   LocalOrdinal,GlobalOrdinal,Node>& vec,
-    Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& flat_map) {
-    if (flat_map == Teuchos::null) {
-      const LocalOrdinal mp_size = Storage::static_size;
-      flat_map = create_flat_map(*(vec.getMap()), mp_size);
-    }
-    const Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > const_flat_map = flat_map;
-    return create_flat_vector_view(vec, const_flat_map);
-  }
-
-
-  // Create a flattened vector by unrolling the MP::Vector scalar type.  The
-  // returned vector is a view of the original
-  template <typename Storage, typename LocalOrdinal, typename GlobalOrdinal,
-            typename Device>
-  Teuchos::RCP< const Tpetra::MultiVector<typename Storage::value_type,
-                                          LocalOrdinal,GlobalOrdinal,
-                                          Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Device> > >
-  create_flat_vector_view(
-    const Tpetra::MultiVector<Sacado::MP::Vector<Storage>,
-                              LocalOrdinal,GlobalOrdinal,
-                              Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Device> >& vec,
-    const Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,
-                                          Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Device> > >& flat_map) {
-    using Teuchos::RCP;
-    using Teuchos::rcp;
-
-    typedef typename Storage::value_type BaseScalar;
-    typedef Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Device> Node;
-    typedef Tpetra::MultiVector<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FlatVector;
-    typedef typename FlatVector::dual_view_type::t_dev flat_view_type;
-
-    // Have to do a nasty const-cast because getLocalViewDevice(ReadWrite) is a
-    // non-const method, yet getLocalViewDevice(ReadOnly) returns a const-view
-    // (i.e., with a constant scalar type), and there is no way to make a
-    // MultiVector out of it!
-    typedef Tpetra::MultiVector<Sacado::MP::Vector<Storage>, LocalOrdinal,GlobalOrdinal, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Device> > mv_type;
-    mv_type& vec_nc = const_cast<mv_type&>(vec);
-
-    // Create flattenend view using special reshaping view assignment operator
-    flat_view_type flat_vals = vec_nc.getLocalViewDevice(Tpetra::Access::ReadWrite);
-
-    // Create flat vector
-    RCP<FlatVector> flat_vec = rcp(new FlatVector(flat_map, flat_vals));
-
-    return flat_vec;
-  }
-
-  // Create a flattened vector by unrolling the MP::Vector scalar type.  The
-  // returned vector is a view of the original
-  template <typename Storage, typename LocalOrdinal, typename GlobalOrdinal,
-            typename Device>
-  Teuchos::RCP< Tpetra::MultiVector<typename Storage::value_type,
-                                    LocalOrdinal,GlobalOrdinal,
-                                    Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Device> > >
-  create_flat_vector_view(
-    Tpetra::MultiVector<Sacado::MP::Vector<Storage>,
-                        LocalOrdinal,GlobalOrdinal,
-                        Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Device> >& vec,
-    const Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,
-                                          Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Device> > >& flat_map) {
-    using Teuchos::RCP;
-    using Teuchos::rcp;
-
-    typedef typename Storage::value_type BaseScalar;
-    typedef Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Device> Node;
-    typedef Tpetra::MultiVector<BaseScalar,LocalOrdinal,GlobalOrdinal,Node> FlatVector;
-    typedef typename FlatVector::dual_view_type::t_dev flat_view_type;
-
-    // Create flattenend view using special reshaping view assignment operator
-    typename FlatVector::wrapped_dual_view_type flat_vals = vec.getWrappedDualView();
-
-    // Create flat vector
-    RCP<FlatVector> flat_vec = rcp(new FlatVector(flat_map, flat_vals));
-
-    return flat_vec;
-  }
-
 
   // Create a flattened matrix by unrolling the MP::Vector scalar type.  The
   // returned matrix is NOT a view of the original (and can't be)

--- a/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_Utilities_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_Utilities_MP_Vector.hpp
@@ -281,7 +281,7 @@ namespace Stokhos {
     const Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& flat_map
   ) {
     return create_flat_vector_view(
-      dynamic_cast<const Tpetra::MultiVector<Sacado::MP::Vector<Storage>, LocalOrdinal, GlobalOrdinal, Node>&>(vec),
+      static_cast<const Tpetra::MultiVector<Sacado::MP::Vector<Storage>, LocalOrdinal, GlobalOrdinal, Node>&>(vec),
       flat_map
     )->getVectorNonConst(0);
   }

--- a/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_Utilities_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_Utilities_MP_Vector.hpp
@@ -495,7 +495,7 @@ namespace Stokhos {
     typedef typename FlatVector::dual_view_type::t_dev flat_view_type;
 
     // Create flattenend view using special reshaping view assignment operator
-    flat_view_type flat_vals = vec.getLocalViewDevice(Tpetra::Access::ReadWrite);
+    typename FlatVector::wrapped_dual_view_type flat_vals = vec.getWrappedDualView();
 
     // Create flat vector
     RCP<FlatVector> flat_vec = rcp(new FlatVector(flat_map, flat_vals));

--- a/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
@@ -166,12 +166,14 @@ public:
       dualView(originalDualView)
   { }
 
+  //! Conversion copy constructor.
   template <class SrcDualViewType>
   WrappedDualView(const WrappedDualView<SrcDualViewType>& src)
     : originalDualView(src.originalDualView),
       dualView(src.dualView)
   { }
   
+  //! Conversion assignment operator.
   template <class SrcDualViewType>
   WrappedDualView& operator=(const WrappedDualView<SrcDualViewType>& src) {
     originalDualView = src.originalDualView;

--- a/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
@@ -154,6 +154,10 @@ private:
   static constexpr bool deviceMemoryIsHostAccessible =
     Kokkos::SpaceAccessibility<Kokkos::DefaultHostExecutionSpace, typename t_dev::memory_space>::accessible;
 
+private:
+  template <typename>
+  friend class WrappedDualView;
+
 public:
   WrappedDualView() {}
 
@@ -161,6 +165,19 @@ public:
     : originalDualView(dualV),
       dualView(originalDualView)
   { }
+
+  template <class SrcDualViewType>
+  WrappedDualView(const WrappedDualView<SrcDualViewType>& src)
+    : originalDualView(src.originalDualView),
+      dualView(src.dualView)
+  { }
+  
+  template <class SrcDualViewType>
+  WrappedDualView& operator=(const WrappedDualView<SrcDualViewType>& src) {
+    originalDualView = src.originalDualView;
+    dualView = src.dualView;
+    return *this;
+  }
 
   // This is an expert-only constructor
   // For WrappedDualView to manage synchronizations correctly,

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -1474,6 +1474,12 @@ namespace Tpetra {
     /// This requires that there are no live host-space views.
     typename dual_view_type::t_dev getLocalViewDevice(Access::OverwriteAllStruct);
 
+    /// \brief Return the wrapped dual view holding this MultiVector's local data.
+    ///
+    /// \warning This method is ONLY for use by experts. We highly recommend accessing the local data
+    /// by using the member functions getLocalViewHost and getLocalViewDevice.
+    wrapped_dual_view_type getWrappedDualView() const;
+
     //! Whether this MultiVector needs synchronization to the given space.
     template<class TargetDeviceType>
     bool need_sync () const {

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -4013,6 +4013,13 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  typename MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::wrapped_dual_view_type 
+  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  getWrappedDualView() const {
+    return view_;
+  };
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::ArrayRCP<Teuchos::ArrayRCP<const Scalar> >
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   get2dView () const

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -4017,7 +4017,7 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   getWrappedDualView() const {
     return view_;
-  };
+  }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::ArrayRCP<Teuchos::ArrayRCP<const Scalar> >


### PR DESCRIPTION
Hi @etphipp,

In the mean time, @romintomasetti and I have looked more into the problem with running `Amesos2` solvers with ensembles on GPU with more than one MPI rank (issue #12279).

This PR is a proposed fix.

### Reproducing the problem using existing Stokhos tests

Running `Amesos2` solvers with ensembles is tested in `stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp`. 

The existing pipeline typically runs fine, and issue #12279 doesn't show up. It seems the reason is that this test selects only one `Amesos2` solver, 
depending on which ones the user enabled and an order of preference. When the user activated `basker`, that's the one that `Stokhos` chooses.
For `basker`, the code goes into the specialisation of `basker` for ensembles -> no problem.

However, when `Amesos2` is compiled without `basker` but with e.g. `klu2`, then `Stokhos` doesn't provide a specialisation for ensembles, and it creates
a "flattened" system that it provides to `Amesos2`. In such a situation, the Stokhos test throws runtime errors when running on GPU with more than one MPI rank.

### The culprit   

We think the culprit is how `Stokhos` creates flattened vectors from vectors of ensembles. 

This is done in the function `create_flat_vector_view` in `stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_Utilities_MP_Vector.hpp`:

- https://github.com/trilinos/Trilinos/blob/fd93b55195def346c69c806bb2b0aab7b6070fc9/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_Utilities_MP_Vector.hpp#L467-L471

Currently, this function works by extracting from the vector of ensembles a device view of the local data. This device view is flattened by using a "reshaping" conversion assignment operator.
Then the flattened vector is created by using the `Tpetra::MultiVector` constructor that takes the (flattened) device view of the local data and the (flattened) map.

We think there are two problems:

- We end up with a flattened vector for which, from the outset, the `use_count` for the device view is higher than the `use_count` for the host view. Indeed, while the flattened vector and the original
vector of ensembles share the same data allocation on device, the used `Tpetra::MultiVector` constructor creates a new data allocation on host. Due to the logic of the underlying wrapped dual view,
this difference in the use counts in turn implies that we can't do `getLocalViewHost` on the flattened vector later in the code.

- The flattened vector and the original vector of ensembles don't share the same dual view, hence they don't share the `modified_flags` and don't know about each other's sync state.

When running an `Amesos2` solver such as `klu2` with ensembles on GPU with more than one MPI rank, the code wants to gather the entire system on the root rank, solve it there,
and then redistribute the pieces of the solution again to the ranks. Some of these steps want to use `getLocalViewHost`, and some of these steps rely on the syncing mechanism of the underlying WDV.
Hence, the issues that we see in #12279.

### Proposed fix

The proposed fix is to create the flattened vector by using a "reshaping" conversion assignment operator/copy constructor for the entire underlying wrapped dual view. This way,
the flattened vector and the vector of ensembles share the same data allocations on host and device, share the use counts, and share the `modified_flags` (sync state).

The `Tpetra::MultiVector` class does not currently have a getter for the underlying WDV (it's a protected member), and the WDV does not currently have templated conversion 
assignment operator/copy constructor. So this PR adds those. Especially adding a getter for the underlying WDV could be controversial :) So we'll likely have to check 
with the `tpetra` team to get their input. But we do think we have a convincing use case here.

Note that the `Kokkos_DualView.hpp` is missing the templated assignment operator, but it has the templated copy constructor.

On the side, this PR also modifies a bit the logic in `stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp` to ensure that all enabled Amesos2 solvers
are tested. And this PR removes some (seemingly) unused code from `stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_Utilities_MP_Vector.hpp`. In particular,
it seems the versions of `create_flat_vector_view` templated on `Node` can be expected to be unused because there are "more specialised" ones templated on `Device`. 

What do you think? Thanks in advance!