### PR TITLE
KokkosKernels: fix block_layout type alias in RocSparse TPL

### DIFF
--- a/packages/kokkos-kernels/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/sparse/tpls/KokkosSparse_spmv_bsrmatrix_tpl_spec_decl.hpp
@@ -914,7 +914,7 @@ void spmv_block_impl_rocsparse(
   */
   // KokkosSparse Bsr matrix blocks are layoutright (row-major)
   static_assert(
-      std::is_same_v<typename AMatrix::block_layout, Kokkos::LayoutRight>,
+      std::is_same_v<typename AMatrix::block_layout_type, Kokkos::LayoutRight>,
       "A blocks must be stored layout-right");
   rocsparse_direction dir = rocsparse_direction_row;
 


### PR DESCRIPTION
This was a fix in Kokkos Kernels that did not make it into Trilinos

Fix for https://github.com/trilinos/Trilinos/issues/12296