### PR TITLE
Tpetra: Fixing vortex compile issue

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_fill.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_fill.hpp
@@ -78,7 +78,7 @@ fill (const ExecutionSpace& execSpace,
 {
   static_assert (std::is_integral<IndexType>::value,
                  "IndexType must be a built-in integer type.");
-    auto X_j = Kokkos::subview (X, Kokkos::pair{IndexType(0), numRows}, Kokkos::pair{IndexType(0), numCols});
+    auto X_j = Kokkos::subview (X, Kokkos::make_pair(IndexType(0), numRows), Kokkos::make_pair(IndexType(0), numCols));
     Kokkos::deep_copy(execSpace, X_j, alpha);
 }
 
@@ -101,7 +101,7 @@ fill (const ExecutionSpace& execSpace,
                  "IndexType must be a built-in integer type.");
   for (IndexType k = 0; k < numCols; ++k) {
     const IndexType j = whichVectors[k];
-    auto X_j = Kokkos::subview (X, Kokkos::pair{IndexType(0), numRows}, j);
+    auto X_j = Kokkos::subview (X, Kokkos::make_pair(IndexType(0), numRows), j);
     Kokkos::deep_copy(execSpace, X_j, alpha);
   }
 }


### PR DESCRIPTION
Issue: n/a
Test:n/a
Stakeholder feedback: Email

```
.../Trilinos/vortex/Trilinos/packages/tpetra/core/src/Tpetra_Details_fill.hpp: In function 'void Tpetra::Details::Blas::fill(const ExecutionSpace&, const ViewType&, const ValueType&, IndexType, IndexType)':
.../Trilinos/vortex/Trilinos/packages/tpetra/core/src/Tpetra_Details_fill.hpp:81:31: error: 'pair' was not declared in this scope
     auto X_j = Kokkos::subview (X, Kokkos::pair{IndexType(0), numRows}, Kokkos::pair{IndexType(0), numCols});
                               ^~~~
.../Trilinos/vortex/Trilinos/packages/tpetra/core/src/Tpetra_Details_fill.hpp:81:31: note: suggested alternatives:
/my/path/gcc/gcc-8.3.1/rh/usr/include/c++/8/bits/stl_pair.h:208:8: note:   'std::pair'
     struct pair
```
