### PR TITLE
add SET(LINK_LIBRARIES_ONLY_TARGETS TRUE) to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,8 @@ include(SetupTribitsInstall)
 
 SET(Trilinos_MUST_FIND_ALL_TPL_LIBS_DEFAULT TRUE)
 
+SET(LINK_LIBRARIES_ONLY_TARGETS TRUE)
+
 IF(${PROJECT_NAME}_ENABLE_YouCompleteMe)
   INCLUDE(CodeCompletion)
 ENDIF()


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Addressees #10081 by adding `SET(LINK_LIBRARIES_ONLY_TARGETS TRUE)` to `CMakeLists.txt`

## Related Issues
#10081 