### PR TITLE
Tempus: Change Usage of InArgs/OutArgs

### DIFF
--- a/packages/nox/src-loca/src-thyra/LOCA_Thyra_Group.C
+++ b/packages/nox/src-loca/src-thyra/LOCA_Thyra_Group.C
@@ -163,24 +163,24 @@ LOCA::Thyra::Group::computeF()
   if (this->isF())
     return NOX::Abstract::Group::Ok;
 
-  in_args_.set_x(x_vec_->getThyraRCPVector().assert_not_null());
-  if (in_args_.supports(::Thyra::ModelEvaluatorBase::IN_ARG_x_dot))
-    in_args_.set_x_dot(x_dot_vec);
+  auto in_args = model_->createInArgs();
+  auto out_args = model_->createOutArgs();
+
+  if (this->usingBasePoint())
+    in_args = this->base_point_;
+
+  in_args.set_x(x_vec_->getThyraRCPVector().assert_not_null());
+  if (in_args.supports(::Thyra::ModelEvaluatorBase::IN_ARG_x_dot))
+    in_args.set_x_dot(x_dot_vec);
   for (size_t i=0; i < param_index.size(); ++i)
-    in_args_.set_p(param_index[i], param_thyra_vec[i]);
-  out_args_.set_f(f_vec_->getThyraRCPVector().assert_not_null());
+    in_args.set_p(param_index[i], param_thyra_vec[i]);
+  out_args.set_f(f_vec_->getThyraRCPVector().assert_not_null());
 
-  model_->evalModel(in_args_, out_args_);
-
-  in_args_.set_x(Teuchos::null);
-
-  for (const auto& p : param_index)
-    in_args_.set_p(p, Teuchos::null);
-  out_args_.set_f(Teuchos::null);
+  model_->evalModel(in_args, out_args);
 
   is_valid_f_ = true;
 
-  if (out_args_.isFailed())
+  if (out_args.isFailed())
     return NOX::Abstract::Group::Failed;
 
   return NOX::Abstract::Group::Ok;
@@ -194,33 +194,28 @@ LOCA::Thyra::Group::computeJacobian()
 
   shared_jacobian_->getObject(this);
 
-  in_args_.set_x(x_vec_->getThyraRCPVector());
-  if (in_args_.supports(::Thyra::ModelEvaluatorBase::IN_ARG_x_dot))
-    in_args_.set_x_dot(x_dot_vec);
-  if (in_args_.supports(::Thyra::ModelEvaluatorBase::IN_ARG_alpha))
-    in_args_.set_alpha(0.0);
-  if (in_args_.supports(::Thyra::ModelEvaluatorBase::IN_ARG_beta))
-    in_args_.set_beta(1.0);
+  auto in_args = model_->createInArgs();
+  auto out_args = model_->createOutArgs();
+
+  if (this->usingBasePoint())
+    in_args = this->base_point_;
+
+  in_args.set_x(x_vec_->getThyraRCPVector());
+  if (in_args.supports(::Thyra::ModelEvaluatorBase::IN_ARG_x_dot))
+    in_args.set_x_dot(x_dot_vec);
+  if (in_args.supports(::Thyra::ModelEvaluatorBase::IN_ARG_alpha))
+    in_args.set_alpha(0.0);
+  if (in_args.supports(::Thyra::ModelEvaluatorBase::IN_ARG_beta))
+    in_args.set_beta(1.0);
   for (size_t i=0; i < param_index.size(); ++i)
-    in_args_.set_p(param_index[i], param_thyra_vec[i]);
-  out_args_.set_W_op(lop_);
+    in_args.set_p(param_index[i], param_thyra_vec[i]);
+  out_args.set_W_op(lop_);
 
-  model_->evalModel(in_args_, out_args_);
-
-  in_args_.set_x(Teuchos::null);
-  // nschloe (I apologize for this hack):
-  // Curiously, the *_args_ are persistent object in the NOX groups and
-  // accessible from anywhere. We make use of this here by *not* resetting the
-  // parameters
-  //    in_args_.set_p(param_index, Teuchos::null);
-  // and thus passing the the param_thyra_vec into the preconditioner builder,
-  // which resides in NOX::Thyra::Group::updateLOWS.  This only works because
-  // this function right here is called *before* NOX::Thyra::Group::updateLOWS.
-  out_args_.set_W_op(Teuchos::null);
+  model_->evalModel(in_args, out_args);
 
   is_valid_jacobian_ = true;
 
-  if (out_args_.isFailed())
+  if (out_args.isFailed())
     return NOX::Abstract::Group::Failed;
 
   return NOX::Abstract::Group::Ok;
@@ -284,11 +279,17 @@ LOCA::Thyra::Group::computeDfDpMulti(const std::vector<int>& paramIDs,
   // so we are disabling this for now
   implement_dfdp = false;
 
+  auto in_args = model_->createInArgs();
+  auto out_args = model_->createOutArgs();
+
+  if (this->usingBasePoint())
+    in_args = this->base_point_;
+
   // Use default implementation if we don't want to use model evaluator, or
   // it doesn't support it
   if (!implement_dfdp ||
-      !out_args_.supports(::Thyra::ModelEvaluatorBase::OUT_ARG_DfDp,
-              param_index[0]).supports(::Thyra::ModelEvaluatorBase::DERIV_MV_BY_COL)) {
+      !out_args.supports(::Thyra::ModelEvaluatorBase::OUT_ARG_DfDp,
+                         param_index[0]).supports(::Thyra::ModelEvaluatorBase::DERIV_MV_BY_COL)) {
     NOX::Abstract::Group::ReturnType res =
       LOCA::Abstract::Group::computeDfDpMulti(paramIDs, fdfdp, isValidF);
     return res;
@@ -314,31 +315,23 @@ LOCA::Thyra::Group::computeDfDpMulti(const std::vector<int>& paramIDs,
   ::Thyra::ModelEvaluatorBase::DerivativeMultiVector<double> dmv(dfdp_full->getThyraMultiVector(), ::Thyra::ModelEvaluatorBase::DERIV_MV_BY_COL);
   ::Thyra::ModelEvaluatorBase::Derivative<double> deriv(dmv);
 
-  in_args_.set_x(x_vec_->getThyraRCPVector().assert_not_null());
-  if (in_args_.supports(::Thyra::ModelEvaluatorBase::IN_ARG_x_dot))
-    in_args_.set_x_dot(x_dot_vec);
+  in_args.set_x(x_vec_->getThyraRCPVector().assert_not_null());
+  if (in_args.supports(::Thyra::ModelEvaluatorBase::IN_ARG_x_dot))
+    in_args.set_x_dot(x_dot_vec);
   for (size_t i=0; i < param_index.size(); ++i)
-    in_args_.set_p(param_index[i], param_thyra_vec[i]);
+    in_args.set_p(param_index[i], param_thyra_vec[i]);
   if (!isValidF)
-    out_args_.set_f(f.getThyraRCPVector().assert_not_null());
-  out_args_.set_DfDp(param_index[0], deriv);
+    out_args.set_f(f.getThyraRCPVector().assert_not_null());
+  out_args.set_DfDp(param_index[0], deriv);
 
   // Evaluate model
-  model_->evalModel(in_args_, out_args_);
+  model_->evalModel(in_args, out_args);
 
   // Copy back dfdp
   for (int i=0; i<num_vecs; i++)
     (*dfdp)[i] = (*dfdp_full)[paramIDs[i]];
 
-  // Reset inargs/outargs
-  in_args_.set_x(Teuchos::null);
-  for (const auto& p : param_index)
-    in_args_.set_p(p, Teuchos::null);
-  out_args_.set_f(Teuchos::null);
-  out_args_.set_DfDp(param_index[0],
-             ::Thyra::ModelEvaluatorBase::Derivative<double>());
-
-  if (out_args_.isFailed())
+  if (out_args.isFailed())
     return NOX::Abstract::Group::Failed;
 
   return NOX::Abstract::Group::Ok;
@@ -366,26 +359,25 @@ LOCA::Thyra::Group::postProcessContinuationStep(
   // is tricky using that approach.
   //   If there are no responses, then we don't have to call evalModel.
   if (model_->Ng() > 0) {
-    in_args_.set_x(x_vec_->getThyraRCPVector().assert_not_null());
-    if (in_args_.supports(::Thyra::ModelEvaluatorBase::IN_ARG_x_dot))
-      in_args_.set_x_dot(x_dot_vec);
+    auto in_args = model_->createInArgs();
+    auto out_args = model_->createOutArgs();
+
+    if (this->usingBasePoint())
+      in_args = this->base_point_;
+
+    in_args.set_x(x_vec_->getThyraRCPVector().assert_not_null());
+    if (in_args.supports(::Thyra::ModelEvaluatorBase::IN_ARG_x_dot))
+      in_args.set_x_dot(x_dot_vec);
     for (size_t i=0; i < param_index.size(); ++i)
-      in_args_.set_p(param_index[i], param_thyra_vec[i]);
-    out_args_.set_f(f_vec_->getThyraRCPVector().assert_not_null());
+      in_args.set_p(param_index[i], param_thyra_vec[i]);
+    out_args.set_f(f_vec_->getThyraRCPVector().assert_not_null());
     // This is the key part. It makes the model evaluator call the response
     // functions.
     const Teuchos::RCP< ::Thyra::VectorBase<double> >
       g0 = ::Thyra::createMember(model_->get_g_space(0));
-    out_args_.set_g(0, g0);
+    out_args.set_g(0, g0);
 
-    model_->evalModel(in_args_, out_args_);
-
-    in_args_.set_x(Teuchos::null);
-    for (const auto& p : param_index)
-      in_args_.set_p(p, Teuchos::null);
-    out_args_.set_f(Teuchos::null);
-    // Set g back to null to restore the original state of out_args_.
-    out_args_.set_g(0, Teuchos::null);
+    model_->evalModel(in_args, out_args);
   }
 
   if (saveDataStrategy != Teuchos::null)
@@ -441,32 +433,29 @@ LOCA::Thyra::Group::computeShiftedMatrix(double alpha, double beta)
 {
   shared_jacobian_->getObject(this);
 
-  in_args_.set_x(x_vec_->getThyraRCPVector());
-  if (in_args_.supports(::Thyra::ModelEvaluatorBase::IN_ARG_x_dot))
-    in_args_.set_x_dot(x_dot_vec);
+  auto in_args = model_->createInArgs();
+  auto out_args = model_->createOutArgs();
+
+  if (this->usingBasePoint())
+    in_args = this->base_point_;
+
+  in_args.set_x(x_vec_->getThyraRCPVector());
+  if (in_args.supports(::Thyra::ModelEvaluatorBase::IN_ARG_x_dot))
+    in_args.set_x_dot(x_dot_vec);
   for (size_t i=0; i < param_index.size(); ++i)
-    in_args_.set_p(param_index[i], param_thyra_vec[i]);
-  if (in_args_.supports(::Thyra::ModelEvaluatorBase::IN_ARG_alpha))
-    in_args_.set_alpha(-beta);
-  if (in_args_.supports(::Thyra::ModelEvaluatorBase::IN_ARG_beta))
-    in_args_.set_beta(alpha);
-  out_args_.set_W_op(lop_);
+    in_args.set_p(param_index[i], param_thyra_vec[i]);
+  if (in_args.supports(::Thyra::ModelEvaluatorBase::IN_ARG_alpha))
+    in_args.set_alpha(-beta);
+  if (in_args.supports(::Thyra::ModelEvaluatorBase::IN_ARG_beta))
+    in_args.set_beta(alpha);
+  out_args.set_W_op(lop_);
 
-  model_->evalModel(in_args_, out_args_);
-
-  in_args_.set_x(Teuchos::null);
-  for (const auto& p : param_index)
-    in_args_.set_p(p, Teuchos::null);
-  if (in_args_.supports(::Thyra::ModelEvaluatorBase::IN_ARG_alpha))
-    in_args_.set_alpha(0.0);
-  if (in_args_.supports(::Thyra::ModelEvaluatorBase::IN_ARG_beta))
-    in_args_.set_beta(1.0);
-  out_args_.set_W_op(Teuchos::null);
+  model_->evalModel(in_args, out_args);
 
   is_valid_jacobian_ = false;
   is_valid_lows_ = false;
 
-  if (out_args_.isFailed())
+  if (out_args.isFailed())
     return NOX::Abstract::Group::Failed;
 
   return NOX::Abstract::Group::Ok;

--- a/packages/nox/src-thyra/NOX_Thyra_Group.C
+++ b/packages/nox/src-thyra/NOX_Thyra_Group.C
@@ -82,7 +82,13 @@ Group(const NOX::Thyra::Vector& initial_guess,
   updatePreconditioner_(true),
   last_linear_solve_status_(NOX::Abstract::Group::NotConverged),
   last_linear_solve_num_iters_(0),
-  last_linear_solve_achieved_tol_(0.0)
+  last_linear_solve_achieved_tol_(0.0),
+  use_pseudo_transient_terms_(false),
+  x_dot_(Teuchos::null),
+  alpha_(0.0),
+  beta_(1.0),
+  t_(-1.0),
+  use_base_point_(false)
 {
   x_vec_ = Teuchos::rcp(new NOX::Thyra::Vector(initial_guess, DeepCopy));
 
@@ -128,13 +134,9 @@ Group(const NOX::Thyra::Vector& initial_guess,
   // create preconditioner
   prec_factory_ = lows_factory_->getPreconditionerFactory();
 
-  // Create in/out args
-  in_args_ = model_->createInArgs();
-  out_args_ = model_->createOutArgs();
-
   if (Teuchos::nonnull(prec_factory_)) {
     prec_ = prec_factory_->createPrec();
-  } else if (out_args_.supports( ::Thyra::ModelEvaluatorBase::OUT_ARG_W_prec)) {
+  } else if (model->createOutArgs().supports( ::Thyra::ModelEvaluatorBase::OUT_ARG_W_prec)) {
     prec_ = model->create_W_prec();
   }
 
@@ -163,7 +165,13 @@ Group(const NOX::Thyra::Vector& initial_guess,
   updatePreconditioner_(updatePreconditioner),
   last_linear_solve_status_(NOX::Abstract::Group::NotConverged),
   last_linear_solve_num_iters_(0),
-  last_linear_solve_achieved_tol_(0.0)
+  last_linear_solve_achieved_tol_(0.0),
+  use_pseudo_transient_terms_(false),
+  x_dot_(Teuchos::null),
+  alpha_(0.0),
+  beta_(1.0),
+  t_(-1.0),
+  use_base_point_(false)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(jacobianIsEvaluated && Teuchos::is_null(linear_op),std::runtime_error,
                              "ERROR - NOX::Thyra::Group(...) - linear_op is null but JacobianIsEvaluated is true. Impossible combination!");
@@ -206,10 +214,6 @@ Group(const NOX::Thyra::Vector& initial_guess,
   if ( nonnull(prec_factory_) && is_null(prec_) )
     prec_ = prec_factory_->createPrec();
 
-  // Create in/out args
-  in_args_ = model_->createInArgs();
-  out_args_ = model_->createOutArgs();
-
   resetIsValidFlags();
 
   if (jacobianIsEvaluated) {
@@ -232,7 +236,14 @@ NOX::Thyra::Group::Group(const NOX::Thyra::Group& source, NOX::CopyType type) :
   updatePreconditioner_(source.updatePreconditioner_),
   last_linear_solve_status_(source.last_linear_solve_status_),
   last_linear_solve_num_iters_(source.last_linear_solve_num_iters_),
-  last_linear_solve_achieved_tol_(source.last_linear_solve_achieved_tol_)
+  last_linear_solve_achieved_tol_(source.last_linear_solve_achieved_tol_),
+  use_pseudo_transient_terms_(source.use_pseudo_transient_terms_),
+  x_dot_(source.x_dot_),
+  alpha_(source.alpha_),
+  beta_(source.beta_),
+  t_(source.t_),
+  use_base_point_(false),
+  base_point_(source.base_point_)
 {
 
   x_vec_ = Teuchos::rcp(new NOX::Thyra::Vector(*source.x_vec_, type));
@@ -246,9 +257,6 @@ NOX::Thyra::Group::Group(const NOX::Thyra::Group& source, NOX::CopyType type) :
 
   if (nonnull(source.right_weight_vec_))
     scaled_x_vec_ = Teuchos::rcp(new NOX::Thyra::Vector(*source.scaled_x_vec_, type));
-
-  in_args_ = model_->createInArgs();
-  out_args_ = model_->createOutArgs();
 
   if (type == NOX::DeepCopy) {
     is_valid_f_ = source.is_valid_f_;
@@ -345,6 +353,15 @@ NOX::Abstract::Group& NOX::Thyra::Group::operator=(const Group& source)
   last_linear_solve_status_ = source.last_linear_solve_status_;
   last_linear_solve_num_iters_ = source.last_linear_solve_num_iters_;
   last_linear_solve_achieved_tol_ = source.last_linear_solve_achieved_tol_;
+
+  use_pseudo_transient_terms_ = source.use_pseudo_transient_terms_;
+  x_dot_ = source.x_dot_;
+  alpha_ = source.alpha_;
+  beta_ = source.beta_;
+  t_ = source.t_;
+
+  use_base_point_ = source.use_base_point_;
+  base_point_ = source.base_point_;
 
   return *this;
 }
@@ -486,16 +503,28 @@ NOX::Abstract::Group::ReturnType NOX::Thyra::Group::computeF()
   if (this->isF())
     return NOX::Abstract::Group::Ok;
 
-  in_args_.set_x(x_vec_->getThyraRCPVector().assert_not_null());
-  out_args_.set_f(f_vec_->getThyraRCPVector().assert_not_null());
+  auto in_args = model_->createInArgs();
+  auto out_args = model_->createOutArgs();
+
+  if (use_base_point_)
+    in_args = base_point_;
+
+  if (use_pseudo_transient_terms_) {
+    in_args.set_x_dot(x_dot_);
+    in_args.set_alpha(alpha_);
+    in_args.set_beta(beta_);
+    in_args.set_t(t_);
+  }
+
+  in_args.set_x(x_vec_->getThyraRCPVector().assert_not_null());
+  out_args.set_f(f_vec_->getThyraRCPVector().assert_not_null());
+
   //model_->setVerbLevel(Teuchos::VERB_EXTREME);
-  model_->evalModel(in_args_, out_args_);
-  in_args_.set_x(Teuchos::null);
-  out_args_.set_f(Teuchos::null);
+  model_->evalModel(in_args, out_args);
 
   is_valid_f_ = true;
 
-  if (out_args_.isFailed())
+  if (out_args.isFailed())
     return NOX::Abstract::Group::Failed;
 
   return NOX::Abstract::Group::Ok;
@@ -511,15 +540,27 @@ NOX::Abstract::Group::ReturnType NOX::Thyra::Group::computeJacobian()
 
   shared_jacobian_->getObject(this);
 
-  in_args_.set_x(x_vec_->getThyraRCPVector());
-  out_args_.set_W_op(lop_);
-  model_->evalModel(in_args_, out_args_);
-  in_args_.set_x(Teuchos::null);
-  out_args_.set_W_op(Teuchos::null);
+  auto in_args = model_->createInArgs();
+  auto out_args = model_->createOutArgs();
+
+  if (use_base_point_)
+    in_args = base_point_;
+
+  if (use_pseudo_transient_terms_ == true) {
+    in_args.set_x_dot(x_dot_);
+    in_args.set_alpha(alpha_);
+    in_args.set_beta(beta_);
+    in_args.set_t(t_);
+  }
+
+  in_args.set_x(x_vec_->getThyraRCPVector());
+  out_args.set_W_op(lop_);
+
+  model_->evalModel(in_args, out_args);
 
   is_valid_jacobian_ = true;
 
-  if (out_args_.isFailed())
+  if (out_args.isFailed())
     return NOX::Abstract::Group::Failed;
 
   return NOX::Abstract::Group::Ok;
@@ -878,12 +919,24 @@ NOX::Thyra::Group::applyRightPreconditioning(bool /* useTranspose */,
     this->scaleResidualAndJacobian();
     prec_factory_->initializePrec(losb_, prec_.get());
   }
-  else if (out_args_.supports( ::Thyra::ModelEvaluatorBase::OUT_ARG_W_prec)) {
-    in_args_.set_x(x_vec_->getThyraRCPVector().assert_not_null());
-    out_args_.set_W_prec(prec_);
-    model_->evalModel(in_args_, out_args_);
-    in_args_.set_x(Teuchos::null);
-    out_args_.set_W_prec(Teuchos::null);
+  else if (model_->createOutArgs().supports( ::Thyra::ModelEvaluatorBase::OUT_ARG_W_prec)) {
+    auto in_args = model_->createInArgs();
+    auto out_args = model_->createOutArgs();
+
+    if (use_base_point_)
+      in_args = base_point_;
+
+    if (use_pseudo_transient_terms_ == true) {
+      in_args.set_x_dot(x_dot_);
+      in_args.set_alpha(alpha_);
+      in_args.set_beta(beta_);
+      in_args.set_t(t_);
+    }
+
+    in_args.set_x(x_vec_->getThyraRCPVector().assert_not_null());
+    out_args.set_W_prec(prec_);
+
+    model_->evalModel(in_args, out_args);
   }
 
   const NOX::Thyra::Vector & inputThyraVector = dynamic_cast<const NOX::Thyra::Vector&>(input);
@@ -956,13 +1009,25 @@ void NOX::Thyra::Group::updateLOWS() const
                           prec_,
                           shared_jacobian_->getObject(this).ptr());
     }
-    else if ( nonnull(prec_) && (out_args_.supports( ::Thyra::ModelEvaluatorBase::OUT_ARG_W_prec)) ) {
+    else if ( nonnull(prec_) && (model_->createOutArgs().supports( ::Thyra::ModelEvaluatorBase::OUT_ARG_W_prec)) ) {
       // Automatically update using the ModelEvaluator
-      in_args_.set_x(x_vec_->getThyraRCPVector().assert_not_null());
-      out_args_.set_W_prec(prec_);
-      model_->evalModel(in_args_, out_args_);
-      in_args_.set_x(Teuchos::null);
-      out_args_.set_W_prec(Teuchos::null);
+      auto in_args = model_->createInArgs();
+      auto out_args = model_->createOutArgs();
+
+      if (use_base_point_)
+        in_args = base_point_;
+
+      if (use_pseudo_transient_terms_ == true) {
+        in_args.set_x_dot(x_dot_);
+        in_args.set_alpha(alpha_);
+        in_args.set_beta(beta_);
+        in_args.set_t(t_);
+      }
+
+      in_args.set_x(x_vec_->getThyraRCPVector().assert_not_null());
+      out_args.set_W_prec(prec_);
+
+      model_->evalModel(in_args, out_args);
 
       ::Thyra::initializePreconditionedOp<double>(*lows_factory_,
                           lop_,
@@ -1041,14 +1106,40 @@ NOX::Thyra::Group::getModel() const
   return model_;
 }
 
-::Thyra::ModelEvaluatorBase::InArgs<double>&
-NOX::Thyra::Group::getNonconstInArgs()
+void NOX::Thyra::Group::enablePseudoTransientTerms(const Teuchos::RCP<const ::Thyra::VectorBase<double>>& x_dot,
+                                                   const double alpha, const double beta, const double t)
 {
-  return in_args_;
+  use_pseudo_transient_terms_ = true;
+  x_dot_ = x_dot;
+  alpha_ = alpha;
+  beta_ = beta;
+  t_ = t;
 }
 
-const ::Thyra::ModelEvaluatorBase::InArgs<double>&
-NOX::Thyra::Group::getInArgs() const
+void NOX::Thyra::Group::disablePseudoTransientTerms()
 {
-  return in_args_;
+  use_pseudo_transient_terms_ = false;
+  x_dot_ = Teuchos::null;
+  alpha_ = 0.0;
+  beta_ = 1.0;
+  t_ = -1.0;
 }
+
+bool NOX::Thyra::Group::usingPseudoTransientTerms() const
+{ return use_pseudo_transient_terms_; }
+
+void NOX::Thyra::Group::setBasePoint(const ::Thyra::ModelEvaluatorBase::InArgs<double>& base_point_params)
+{
+  use_base_point_ = true;
+  base_point_ = base_point_params;
+}
+
+void NOX::Thyra::Group::unsetBasePoint()
+{
+  use_base_point_ = false;
+  // Set to default to reset RCPs to free memory
+  base_point_ = model_->createInArgs();
+}
+
+bool NOX::Thyra::Group::usingBasePoint() const
+{ return use_base_point_; }

--- a/packages/nox/src-thyra/NOX_Thyra_Group.C
+++ b/packages/nox/src-thyra/NOX_Thyra_Group.C
@@ -331,7 +331,7 @@ NOX::Abstract::Group& NOX::Thyra::Group::operator=(const Group& source)
   if (nonnull(source.right_weight_vec_)) {
     right_weight_vec_ = source.right_weight_vec_;
     inv_right_weight_vec_ = source.inv_right_weight_vec_;
-    *scaled_x_vec_ = *source.scaled_x_vec_;    
+    *scaled_x_vec_ = *source.scaled_x_vec_;
   }
 
   // If valid, this takes ownership of the shared Jacobian
@@ -486,16 +486,18 @@ NOX::Abstract::Group::ReturnType NOX::Thyra::Group::computeF()
   if (this->isF())
     return NOX::Abstract::Group::Ok;
 
-  in_args_.set_x(x_vec_->getThyraRCPVector().assert_not_null());
-  out_args_.set_f(f_vec_->getThyraRCPVector().assert_not_null());
+  auto in_args = model_->createInArgs();
+  auto out_args = model_->createOutArgs();
+  in_args.set_x(x_vec_->getThyraRCPVector().assert_not_null());
+  out_args.set_f(f_vec_->getThyraRCPVector().assert_not_null());
   //model_->setVerbLevel(Teuchos::VERB_EXTREME);
-  model_->evalModel(in_args_, out_args_);
-  in_args_.set_x(Teuchos::null);
-  out_args_.set_f(Teuchos::null);
+  model_->evalModel(in_args, out_args);
+  in_args.set_x(Teuchos::null);
+  out_args.set_f(Teuchos::null);
 
   is_valid_f_ = true;
 
-  if (out_args_.isFailed())
+  if (out_args.isFailed())
     return NOX::Abstract::Group::Failed;
 
   return NOX::Abstract::Group::Ok;
@@ -511,15 +513,15 @@ NOX::Abstract::Group::ReturnType NOX::Thyra::Group::computeJacobian()
 
   shared_jacobian_->getObject(this);
 
-  in_args_.set_x(x_vec_->getThyraRCPVector());
-  out_args_.set_W_op(lop_);
-  model_->evalModel(in_args_, out_args_);
-  in_args_.set_x(Teuchos::null);
-  out_args_.set_W_op(Teuchos::null);
+  auto in_args = model_->createInArgs();
+  auto out_args = model_->createOutArgs();
+  in_args.set_x(x_vec_->getThyraRCPVector());
+  out_args.set_W_op(lop_);
+  model_->evalModel(in_args, out_args);
 
   is_valid_jacobian_ = true;
 
-  if (out_args_.isFailed())
+  if (out_args.isFailed())
     return NOX::Abstract::Group::Failed;
 
   return NOX::Abstract::Group::Ok;
@@ -720,7 +722,7 @@ const NOX::Abstract::Vector& NOX::Thyra::Group::getX() const
 }
 
 const NOX::Abstract::Vector& NOX::Thyra::Group::getScaledX() const
-{ 
+{
   if(nonnull(inv_right_weight_vec_))
     return *scaled_x_vec_;
   else
@@ -836,7 +838,7 @@ applyJacobianInverseMultiVector(Teuchos::ParameterList& p,
   this->unscaleResidualAndJacobian();
 
   if (nonnull(right_weight_vec_)){
-  
+
     const Teuchos::RCP< ::Thyra::ScaledLinearOpBase<double> > result_scaled =
       Teuchos::rcp_dynamic_cast< ::Thyra::ScaledLinearOpBase<double> >(Teuchos::rcpFromRef(result), true);
     result_scaled->scaleLeft(*right_weight_vec_);
@@ -958,11 +960,11 @@ void NOX::Thyra::Group::updateLOWS() const
     }
     else if ( nonnull(prec_) && (out_args_.supports( ::Thyra::ModelEvaluatorBase::OUT_ARG_W_prec)) ) {
       // Automatically update using the ModelEvaluator
-      in_args_.set_x(x_vec_->getThyraRCPVector().assert_not_null());
-      out_args_.set_W_prec(prec_);
-      model_->evalModel(in_args_, out_args_);
-      in_args_.set_x(Teuchos::null);
-      out_args_.set_W_prec(Teuchos::null);
+      auto in_args = model_->createInArgs();
+      auto out_args = model_->createOutArgs();
+      in_args.set_x(x_vec_->getThyraRCPVector().assert_not_null());
+      out_args.set_W_prec(prec_);
+      model_->evalModel(in_args, out_args);
 
       ::Thyra::initializePreconditionedOp<double>(*lows_factory_,
                           lop_,
@@ -1032,7 +1034,7 @@ void NOX::Thyra::Group::computeScaledSolution()
 {
   *scaled_x_vec_ = *x_vec_;
   NOX::Thyra::Vector scaling(inv_right_weight_vec_);
-  scaled_x_vec_->scale(scaling);  
+  scaled_x_vec_->scale(scaling);
 }
 
 Teuchos::RCP< const ::Thyra::ModelEvaluator<double> >

--- a/packages/nox/src-thyra/NOX_Thyra_Group.H
+++ b/packages/nox/src-thyra/NOX_Thyra_Group.H
@@ -326,12 +326,44 @@ namespace NOX {
       //! Print out the group
       void print() const;
 
-      /** FOR POWER USERS ONLY!  Grab the inargs used by nox and allow the user to change it.  Used by pseudo-transient solver to add an x_dot and alpha/beta to the model evaluator call. */
-      ::Thyra::ModelEvaluatorBase::InArgs<double>& getNonconstInArgs();
-
-      const ::Thyra::ModelEvaluatorBase::InArgs<double>& getInArgs() const;
-
       Teuchos::RCP< const ::Thyra::ModelEvaluator<double> > getModel() const;
+
+      /** \brief Set the transient terms on the Group and use them in the underlying evalModelImpl() calls.
+
+          \param x_dot Time derivative term. Can be set to null.
+          \param alpha Model evaluator transient timer derivative multiplier
+          \param beta Model evaluator transient Jacobian multiplier
+          \param t Current time value
+      */
+      void enablePseudoTransientTerms(const Teuchos::RCP<const ::Thyra::VectorBase<double>>& x_dot,
+                                      const double alpha, const double beta, const double t);
+
+      /// Disable the pseudo traansient terms in the underlying evalModel() calls. Sets x_dot, alpha, beta and t back to steady state values.
+      void disablePseudoTransientTerms();
+
+      /// Check for whether the pseudo transient support is enabled for residual and Jacobian evaluations.
+      bool usingPseudoTransientTerms() const;
+
+      /// Set default parameters to be used with inArgs. This is a
+      /// hack to support a bad design in PIRO. PIRO wraps nox as a
+      /// model evaluator. The PIRO inArgs suppots all inargs, but nox
+      /// only knows about nonlinear solver realted inputs. It knows
+      /// nothing about parameters. PIRO should have a model evaluator
+      /// wrapper that populates the extra inArgs as needed to
+      /// override nominal values. Instead, we have to hard code
+      /// storage of all in arg parameters in nox groups. This is only
+      /// used in the ::Thyra::NOXNonlinearSolver and only when
+      /// wrapped within a PIRO model evaluator that calls the
+      /// setBasePoint on ::Thyra::NOXNonlinearSolver. This function
+      /// should eventually be deprecated in favor of addign a wrapper
+      /// ME to the piro nox solver class.
+      void setBasePoint(const ::Thyra::ModelEvaluatorBase::InArgs<double>& base_point_params);
+
+      /// Unset the base point parameters so that they are not used internally.
+      void unsetBasePoint();
+
+      /// Returns true if a base point has been set.
+      bool usingBasePoint() const;
 
     protected:
 
@@ -409,12 +441,6 @@ namespace NOX {
       //! Preconditioner factory
       Teuchos::RCP< ::Thyra::PreconditionerFactoryBase<double> > prec_factory_;
 
-      //! Residual InArgs
-      mutable ::Thyra::ModelEvaluatorBase::InArgs<double> in_args_;
-
-      //! Residual OutArgs
-      mutable ::Thyra::ModelEvaluatorBase::OutArgs<double> out_args_;
-
       /** \brief Optional wieghting vector for function scaling. NOX assumes that this vector can be updated in between nonlinear iterations.
 
            This is pulled out of the initial guess vector
@@ -450,6 +476,28 @@ namespace NOX {
       //! The tolerance achieved by the last linear solver
       mutable double last_linear_solve_achieved_tol_;
 
+      // True if pseudo transient term is enabled
+      bool use_pseudo_transient_terms_;
+      // Only used for pseudo transient
+      Teuchos::RCP<const ::Thyra::VectorBase<double>> x_dot_;
+      // Only used for pseudo transient
+      double alpha_;
+      // Only used for pseudo transient
+      double beta_;
+      // Only used for pseudo transient
+      double t_;
+
+      // True if we will use a default inArgs set on this group. This
+      // is used for the thyra nonlinear solver interface that allows
+      // users to set an inArgs as the base point. It is a hack to
+      // work around bad PIRO design.
+      bool use_base_point_;
+
+      // Will override null parameter values on in_args with
+      // these. This is used for the thyra nonlinear solver interface
+      // that allows users to set an inArgs as the base point. It is a
+      // hack to work around bad PIRO design.
+      ::Thyra::ModelEvaluatorBase::InArgs<double> base_point_;
     };
 
   } // namespace LAPACK

--- a/packages/nox/src-thyra/Thyra_NonlinearSolver_NOX.cpp
+++ b/packages/nox/src-thyra/Thyra_NonlinearSolver_NOX.cpp
@@ -61,7 +61,8 @@ Thyra::NOXNonlinearSolver::NOXNonlinearSolver():
   do_row_sum_scaling_(false),
   when_to_update_(NOX::RowSumScaling::UpdateInvRowSumVectorAtBeginningOfSolve),
   rebuild_solver_(true),
-  updatePreconditioner_(true)
+  updatePreconditioner_(true),
+  use_base_point_(false)
 {
   param_list_ = Teuchos::rcp(new Teuchos::ParameterList);
   valid_param_list_ = Teuchos::rcp(new Teuchos::ParameterList);
@@ -142,6 +143,7 @@ void
 Thyra::NOXNonlinearSolver::setBasePoint(
     const Thyra::ModelEvaluatorBase::InArgs<double> &modelInArgs)
 {
+  use_base_point_ = true;
   basePoint_ = modelInArgs;
 }
 
@@ -227,13 +229,15 @@ solve(VectorBase<double> *x,
     else
       nox_group_ = user_defined_nox_group_;
 
-    nox_group_->getNonconstInArgs() = this->basePoint_;
+    if (use_base_point_)
+      nox_group_->setBasePoint(this->basePoint_);
 
     status_test_ = this->buildStatusTests(*param_list_);
     solver_ = NOX::Solver::buildSolver(nox_group_, status_test_, param_list_);
   }
   else {
-    nox_group_->getNonconstInArgs() = this->basePoint_;
+    if (use_base_point_)
+      nox_group_->setBasePoint(this->basePoint_);
 
     solver_->reset(initial_guess);
   }

--- a/packages/nox/src-thyra/Thyra_NonlinearSolver_NOX.hpp
+++ b/packages/nox/src-thyra/Thyra_NonlinearSolver_NOX.hpp
@@ -200,6 +200,8 @@ private:
   bool updatePreconditioner_;
 
   RCP<NOX::Thyra::Group> user_defined_nox_group_;
+
+  bool use_base_point_;
 };
 
 

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
@@ -341,7 +341,7 @@ StepperBackwardEuler<Scalar>::computeStepResidual(
   const int param_index) const
 {
   typedef Thyra::ModelEvaluatorBase MEB;
-  MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->getOutArgs();
+  MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->createOutArgs();
   outArgs.set_f(Teuchos::rcpFromRef(residual));
   computeStepResidDerivImpl(outArgs, x, t, p, param_index);
 }
@@ -357,7 +357,7 @@ StepperBackwardEuler<Scalar>::computeStepJacobian(
   const int deriv_index) const
 {
   typedef Thyra::ModelEvaluatorBase MEB;
-  MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->getOutArgs();
+  MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->createOutArgs();
   TEUCHOS_ASSERT(outArgs.supports(MEB::OUT_ARG_W_op));
   outArgs.set_W_op(Teuchos::rcpFromRef(jacobian));
   computeStepResidDerivImpl(outArgs, x, t, p, param_index, deriv_index);
@@ -373,7 +373,7 @@ StepperBackwardEuler<Scalar>::computeStepParamDeriv(
   const int param_index) const
 {
   typedef Thyra::ModelEvaluatorBase MEB;
-  MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->getOutArgs();
+  MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->createOutArgs();
   TEUCHOS_ASSERT(outArgs.supports(MEB::OUT_ARG_DfDp, param_index).supports(MEB::DERIV_LINEAR_OP));
   outArgs.set_DfDp(param_index,
                    MEB::Derivative<Scalar>(Teuchos::rcpFromRef(deriv)));
@@ -390,7 +390,7 @@ StepperBackwardEuler<Scalar>::computeStepSolver(
   const int param_index) const
 {
   typedef Thyra::ModelEvaluatorBase MEB;
-  MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->getOutArgs();
+  MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->createOutArgs();
   TEUCHOS_ASSERT(outArgs.supports(MEB::OUT_ARG_W));
   outArgs.set_W(Teuchos::rcpFromRef(jacobian_solver));
   computeStepResidDerivImpl(outArgs, x, t, p, param_index, 0);
@@ -424,7 +424,7 @@ StepperBackwardEuler<Scalar>::computeStepResidDerivImpl(
   timeDer->compute(xn, x_dot);
 
   // evaluate model
-  MEB::InArgs<Scalar> inArgs = this->wrapperModel_->getInArgs();
+  MEB::InArgs<Scalar> inArgs = this->wrapperModel_->createInArgs();
   inArgs.set_x(xn);
   if (inArgs.supports(MEB::IN_ARG_x_dot         )) inArgs.set_x_dot    (x_dot);
   if (inArgs.supports(MEB::IN_ARG_t             )) inArgs.set_t        (tn);

--- a/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
@@ -47,7 +47,7 @@ void StepperDIRK<Scalar>::setup(
   this->setZeroInitialGuess(   zeroInitialGuess);
 
   this->setStageNumber(-1);
-  this->setErrorNorm(); 
+  this->setErrorNorm();
   this->setAppAction(stepperRKAppAction);
   this->setSolver(solver);
 
@@ -219,8 +219,8 @@ void StepperDIRK<Scalar>::takeStep(
         } else {
           // Calculate explicit stage
           typedef Thyra::ModelEvaluatorBase MEB;
-          MEB::InArgs<Scalar>  inArgs  = this->wrapperModel_->getInArgs();
-          MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->getOutArgs();
+          MEB::InArgs<Scalar>  inArgs  = this->wrapperModel_->createInArgs();
+          MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->createOutArgs();
           inArgs.set_x(xTilde_);
           if (inArgs.supports(MEB::IN_ARG_t)) inArgs.set_t(ts);
           if (inArgs.supports(MEB::IN_ARG_x_dot))

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
@@ -655,7 +655,7 @@ void StepperIMEX_RK<Scalar>::evalImplicitModelExplicitly(
   Teuchos::RCP<WrapperModelEvaluatorPairIMEX<Scalar> > wrapperModelPairIMEX =
     Teuchos::rcp_dynamic_cast<WrapperModelEvaluatorPairIMEX<Scalar> >(
       this->wrapperModel_);
-  MEB::InArgs<Scalar>  inArgs  = wrapperModelPairIMEX->getInArgs();
+  MEB::InArgs<Scalar>  inArgs  = wrapperModelPairIMEX->createInArgs();
   inArgs.set_x(X);
   if (inArgs.supports(MEB::IN_ARG_t))           inArgs.set_t(time);
   if (inArgs.supports(MEB::IN_ARG_step_size))   inArgs.set_step_size(stepSize);
@@ -669,7 +669,7 @@ void StepperIMEX_RK<Scalar>::evalImplicitModelExplicitly(
   // x_dot = f(x, t)
   if (inArgs.supports(MEB::IN_ARG_x_dot)) inArgs.set_x_dot(Teuchos::null);
 
-  MEB::OutArgs<Scalar> outArgs = wrapperModelPairIMEX->getOutArgs();
+  MEB::OutArgs<Scalar> outArgs = wrapperModelPairIMEX->createOutArgs();
   outArgs.set_f(G);
 
   wrapperModelPairIMEX->getImplicitModel()->evalModel(inArgs,outArgs);

--- a/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
@@ -18,34 +18,6 @@
 namespace Tempus {
 
 
-template<class Scalar>
-class ImplicitODEParameters
-{
-  public:
-    /// Constructor
-    ImplicitODEParameters()
-      : timeDer_(Teuchos::null), timeStepSize_(Scalar(0.0)),
-        alpha_(Scalar(0.0)), beta_(Scalar(0.0)), evaluationType_(SOLVE_FOR_X),
-        stageNumber_(0)
-    {}
-    /// Constructor
-    ImplicitODEParameters(Teuchos::RCP<TimeDerivative<Scalar> > timeDer,
-                          Scalar timeStepSize, Scalar alpha, Scalar beta,
-                          EVALUATION_TYPE evaluationType = SOLVE_FOR_X,
-                          int stageNumber = 0)
-      : timeDer_(timeDer), timeStepSize_(timeStepSize),
-        alpha_(alpha), beta_(beta), evaluationType_(evaluationType),
-        stageNumber_(stageNumber)
-    {}
-
-    Teuchos::RCP<TimeDerivative<Scalar> > timeDer_;
-    Scalar                                timeStepSize_;
-    Scalar                                alpha_;
-    Scalar                                beta_;
-    EVALUATION_TYPE                       evaluationType_;
-    int                                   stageNumber_;
-};
-
 /** \brief Thyra Base interface for implicit time steppers.
  *
  *  For first-order ODEs, we can write the implicit ODE as
@@ -269,7 +241,7 @@ public:
       const Scalar time,
       const Teuchos::RCP<ImplicitODEParameters<Scalar> > & p,
       const Teuchos::RCP<Thyra::VectorBase<Scalar> > & y = Teuchos::null,
-      const int index = 0     /* index and y are for IMEX_RK_Partition */ );
+      const int index = -1    /* index and y are for IMEX_RK_Partition */ );
 
     /// Evaluate implicit ODE residual, f(x, xDot, t, p).
     void evaluateImplicitODE(

--- a/packages/tempus/src/Tempus_StepperImplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_impl.hpp
@@ -247,21 +247,7 @@ StepperImplicit<Scalar>::solveImplicitODE(
   const Teuchos::RCP<Thyra::VectorBase<Scalar> > & y,
   const int index                                         )
 {
-  typedef Thyra::ModelEvaluatorBase MEB;
-  MEB::InArgs<Scalar>  inArgs  = wrapperModel_->getInArgs();
-  MEB::OutArgs<Scalar> outArgs = wrapperModel_->getOutArgs();
-  inArgs.set_x(x);
-  if ( y != Teuchos::null ) inArgs.set_p(index, y);
-  if (inArgs.supports(MEB::IN_ARG_x_dot    )) inArgs.set_x_dot    (xDot);
-  if (inArgs.supports(MEB::IN_ARG_t        )) inArgs.set_t        (time);
-  if (inArgs.supports(MEB::IN_ARG_step_size))
-    inArgs.set_step_size(p->timeStepSize_);
-  if (inArgs.supports(MEB::IN_ARG_alpha    )) inArgs.set_alpha    (p->alpha_);
-  if (inArgs.supports(MEB::IN_ARG_beta     )) inArgs.set_beta     (p->beta_);
-  if (inArgs.supports(MEB::IN_ARG_stage_number))
-    inArgs.set_stage_number(p->stageNumber_);
-
-  wrapperModel_->setForSolve(p->timeDer_, inArgs, outArgs, p->evaluationType_);
+  wrapperModel_->setForSolve(x, xDot, time, p, y, index);
 
   Thyra::SolveStatus<Scalar> sStatus;
   typedef Teuchos::ScalarTraits<Scalar> ST;
@@ -296,7 +282,7 @@ StepperImplicit<Scalar>::evaluateImplicitODE(
   const Teuchos::RCP<ImplicitODEParameters<Scalar> > & p )
 {
   typedef Thyra::ModelEvaluatorBase MEB;
-  MEB::InArgs<Scalar>  inArgs  = wrapperModel_->getInArgs();
+  MEB::InArgs<Scalar>  inArgs  = wrapperModel_->createInArgs();
   inArgs.set_x(x);
   if (inArgs.supports(MEB::IN_ARG_x_dot    )) inArgs.set_x_dot    (xDot);
   if (inArgs.supports(MEB::IN_ARG_t        )) inArgs.set_t        (time);
@@ -304,10 +290,10 @@ StepperImplicit<Scalar>::evaluateImplicitODE(
   if (inArgs.supports(MEB::IN_ARG_alpha    )) inArgs.set_alpha    (Scalar(0.0));
   if (inArgs.supports(MEB::IN_ARG_beta     )) inArgs.set_beta     (Scalar(0.0));
 
-  MEB::OutArgs<Scalar> outArgs = wrapperModel_->getOutArgs();
+  MEB::OutArgs<Scalar> outArgs = wrapperModel_->createOutArgs();
   outArgs.set_f(f);
 
-  wrapperModel_->setForSolve(Teuchos::null,inArgs,outArgs,p->evaluationType_);
+  wrapperModel_->setForSolve(x, xDot, time, p);
 
   wrapperModel_->evalModel(inArgs, outArgs);
 }

--- a/packages/tempus/src/Tempus_WrapperModelEvaluator.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluator.hpp
@@ -23,6 +23,35 @@ enum EVALUATION_TYPE {
 };
 
 
+template<class Scalar>
+class ImplicitODEParameters
+{
+  public:
+    /// Constructor
+    ImplicitODEParameters()
+      : timeDer_(Teuchos::null), timeStepSize_(Scalar(0.0)),
+        alpha_(Scalar(0.0)), beta_(Scalar(0.0)), evaluationType_(SOLVE_FOR_X),
+        stageNumber_(0)
+    {}
+    /// Constructor
+    ImplicitODEParameters(Teuchos::RCP<TimeDerivative<Scalar> > timeDer,
+                          Scalar timeStepSize, Scalar alpha, Scalar beta,
+                          EVALUATION_TYPE evaluationType = SOLVE_FOR_X,
+                          int stageNumber = 0)
+      : timeDer_(timeDer), timeStepSize_(timeStepSize),
+        alpha_(alpha), beta_(beta), evaluationType_(evaluationType),
+        stageNumber_(stageNumber)
+    {}
+
+    Teuchos::RCP<TimeDerivative<Scalar> > timeDer_;
+    Scalar                                timeStepSize_;
+    Scalar                                alpha_;
+    Scalar                                beta_;
+    EVALUATION_TYPE                       evaluationType_;
+    int                                   stageNumber_;
+};
+
+
 /** \brief A ModelEvaluator which wraps the application ModelEvaluator.
  *
  *  The WrapperModelEvaluator takes a state, \f$x\f$, computes time
@@ -59,23 +88,15 @@ public:
   virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >
     getAppModel() const = 0;
 
-  /// Set InArgs the wrapper ModelEvalutor.
-  virtual void setInArgs(Thyra::ModelEvaluatorBase::InArgs<Scalar> inArgs) = 0;
-
-  /// Get InArgs the wrapper ModelEvalutor.
-  virtual Thyra::ModelEvaluatorBase::InArgs<Scalar> getInArgs() = 0;
-
-  /// Set OutArgs the wrapper ModelEvalutor.
-  virtual void setOutArgs(Thyra::ModelEvaluatorBase::OutArgs<Scalar> outArgs)=0;
-
-  /// Get OutArgs the wrapper ModelEvalutor.
-  virtual Thyra::ModelEvaluatorBase::OutArgs<Scalar> getOutArgs() = 0;
-
   /// Set parameters for application implicit ModelEvaluator solve.
-  virtual void setForSolve(Teuchos::RCP<TimeDerivative<Scalar> > td,
-    Thyra::ModelEvaluatorBase::InArgs<Scalar>  inArgs,
-    Thyra::ModelEvaluatorBase::OutArgs<Scalar> outArgs,
-    EVALUATION_TYPE evaluationType = SOLVE_FOR_X) = 0;
+  virtual void setForSolve(
+    const Teuchos::RCP<Thyra::VectorBase<Scalar> > & x,
+    const Teuchos::RCP<Thyra::VectorBase<Scalar> > & xDot,
+    const Scalar time,
+    const Teuchos::RCP<ImplicitODEParameters<Scalar> > & p,
+    const Teuchos::RCP<Thyra::VectorBase<Scalar> > & y = Teuchos::null,
+    const int index = -1    /* index and y are for IMEX_RK_Partition */ ) = 0;
+
 };
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairIMEX.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairIMEX.hpp
@@ -77,11 +77,6 @@ public:
       const Thyra::ModelEvaluatorBase::OutArgs<Scalar> & out) const = 0;
   //@}
 
-  /// Set parameters for application implicit ModelEvaluator solve.
-  virtual void setForSolve(Teuchos::RCP<TimeDerivative<Scalar> > timeDer,
-    Thyra::ModelEvaluatorBase::InArgs<Scalar>  inArgs,
-    Thyra::ModelEvaluatorBase::OutArgs<Scalar> outArgs,
-    EVALUATION_TYPE evaluationType = SOLVE_FOR_X) = 0;
 };
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairIMEX_Basic_decl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairIMEX_Basic_decl.hpp
@@ -65,31 +65,22 @@ public:
     virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >
       getAppModel() const;
 
-    /// Set InArgs the wrapper ModelEvalutor.
-    virtual void setInArgs(Thyra::ModelEvaluatorBase::InArgs<Scalar> inArgs)
-    { wrapperImplicitInArgs_.setArgs(inArgs); }
-
-    /// Get InArgs the wrapper ModelEvalutor.
-    virtual Thyra::ModelEvaluatorBase::InArgs<Scalar> getInArgs()
-    { return wrapperImplicitInArgs_; }
-
-    /// Set OutArgs the wrapper ModelEvalutor.
-    virtual void setOutArgs(Thyra::ModelEvaluatorBase::OutArgs<Scalar> outArgs)
-    { wrapperImplicitOutArgs_.setArgs(outArgs); }
-
-    /// Get OutArgs the wrapper ModelEvalutor.
-    virtual Thyra::ModelEvaluatorBase::OutArgs<Scalar> getOutArgs()
-    { return wrapperImplicitOutArgs_; }
-
     /// Set parameters for application implicit ModelEvaluator solve.
-    virtual void setForSolve(Teuchos::RCP<TimeDerivative<Scalar> > timeDer,
-      Thyra::ModelEvaluatorBase::InArgs<Scalar>  inArgs,
-      Thyra::ModelEvaluatorBase::OutArgs<Scalar> outArgs,
-      EVALUATION_TYPE /* evaluationType */ = SOLVE_FOR_X)
+    void setForSolve(
+      const Teuchos::RCP<Thyra::VectorBase<Scalar> > & x,
+      const Teuchos::RCP<Thyra::VectorBase<Scalar> > & xDot,
+      const Scalar time,
+      const Teuchos::RCP<ImplicitODEParameters<Scalar> > & p,
+      const Teuchos::RCP<Thyra::VectorBase<Scalar> > & y = Teuchos::null,
+      const int index = -1    /* index and y are for IMEX_RK_Partition */ )
     {
-      timeDer_ = timeDer;
-      wrapperImplicitInArgs_.setArgs(inArgs);
-      wrapperImplicitOutArgs_.setArgs(outArgs);
+      x_ = x;
+      xDot_ = xDot;
+      time_ = time;
+      p_ = p;
+      y_ = y;
+      index_ = index;
+      timeDer_ = p->timeDer_;
     }
 
   //@}
@@ -162,9 +153,13 @@ protected:
   Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > explicitModel_;
   Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > implicitModel_;
 
+  Teuchos::RCP<Thyra::VectorBase<Scalar> > x_;
+  Teuchos::RCP<Thyra::VectorBase<Scalar> > xDot_;
+  Scalar time_;
+  Teuchos::RCP<ImplicitODEParameters<Scalar> > p_;
+  Teuchos::RCP<Thyra::VectorBase<Scalar> > y_;
+  int index_;
   Teuchos::RCP<TimeDerivative<Scalar> >              timeDer_;
-  Thyra::ModelEvaluatorBase::InArgs<Scalar>          wrapperImplicitInArgs_;
-  Thyra::ModelEvaluatorBase::OutArgs<Scalar>         wrapperImplicitOutArgs_;
 };
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairIMEX_Basic_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairIMEX_Basic_impl.hpp
@@ -21,9 +21,20 @@ WrapperModelEvaluatorPairIMEX_Basic<Scalar>::
 initialize()
 {
   using Teuchos::RCP;
+  using Teuchos::rcp_const_cast;
 
-  wrapperImplicitInArgs_  = this->createInArgs();
-  wrapperImplicitOutArgs_ = this->createOutArgs();
+  p_ = Teuchos::rcp(new ImplicitODEParameters<Scalar>());
+  index_ = -1;
+
+  typedef Thyra::ModelEvaluatorBase MEB;
+  MEB::InArgs<Scalar> inArgs = implicitModel_->getNominalValues();
+  x_ = rcp_const_cast<Thyra::VectorBase<Scalar> > (inArgs.get_x());
+
+  if (inArgs.supports(MEB::IN_ARG_x_dot)) {
+    xDot_ = rcp_const_cast<Thyra::VectorBase<Scalar> >(inArgs.get_x_dot());
+  } else {
+    xDot_ = Teuchos::null;
+  }
 
   // A Thyra::VectorSpace requirement
   TEUCHOS_TEST_FOR_EXCEPTION( !(explicitModel_->get_x_space()->isCompatible(
@@ -110,6 +121,18 @@ createInArgs() const
   typedef Thyra::ModelEvaluatorBase MEB;
   //MEB::InArgsSetup<Scalar> inArgs(implicitModel_->createInArgs());
   MEB::InArgsSetup<Scalar> inArgs(implicitModel_->getNominalValues());
+
+  inArgs.set_x(x_);
+  if ( y_ != Teuchos::null ) inArgs.set_p(index_, y_);
+  if (inArgs.supports(MEB::IN_ARG_x_dot    )) inArgs.set_x_dot (xDot_);
+  if (inArgs.supports(MEB::IN_ARG_t        )) inArgs.set_t     (time_);
+  if (inArgs.supports(MEB::IN_ARG_step_size))
+    inArgs.set_step_size(p_->timeStepSize_);
+  if (inArgs.supports(MEB::IN_ARG_alpha    )) inArgs.set_alpha (p_->alpha_);
+  if (inArgs.supports(MEB::IN_ARG_beta     )) inArgs.set_beta  (p_->beta_);
+  if (inArgs.supports(MEB::IN_ARG_stage_number))
+    inArgs.set_stage_number(p_->stageNumber_);
+
   inArgs.setModelEvalDescription(this->description());
   return std::move(inArgs);
 }
@@ -137,17 +160,9 @@ evalModelImpl(const Thyra::ModelEvaluatorBase::InArgs<Scalar>  & inArgs,
   RCP<Thyra::VectorBase<Scalar> >   x_dot = Thyra::createMember(get_x_space());
   timeDer_->compute(x, x_dot);
 
-  MEB::InArgs<Scalar>  appImplicitInArgs (wrapperImplicitInArgs_);
-  MEB::OutArgs<Scalar> appImplicitOutArgs(wrapperImplicitOutArgs_);
-  appImplicitInArgs.set_x(x);
+  MEB::InArgs<Scalar>  appImplicitInArgs (inArgs);
+  MEB::OutArgs<Scalar> appImplicitOutArgs(outArgs);
   appImplicitInArgs.set_x_dot(x_dot);
-  for (int i=0; i<implicitModel_->Np(); ++i) {
-    if (inArgs.get_p(i) != Teuchos::null)
-      appImplicitInArgs.set_p(i, inArgs.get_p(i));
-  }
-
-  appImplicitOutArgs.set_f(outArgs.get_f());
-  appImplicitOutArgs.set_W_op(outArgs.get_W_op());
 
   implicitModel_->evalModel(appImplicitInArgs,appImplicitOutArgs);
 }

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_Basic_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_Basic_impl.hpp
@@ -370,7 +370,6 @@ getNominalValues() const
 {
   typedef Thyra::ModelEvaluatorBase MEB;
   MEB::InArgsSetup<Scalar> inArgs = this->createInArgs();
-  inArgs.set_Np(1);
   return std::move(inArgs);
 }
 

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_decl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_decl.hpp
@@ -152,32 +152,23 @@ public:
       return appModel_->getNominalValues();
     }
 
-    /// Set InArgs the wrapper ModelEvalutor.
-    virtual void setInArgs(Thyra::ModelEvaluatorBase::InArgs<Scalar> inArgs)
-    { wrapperInArgs_.setArgs(inArgs); }
-
     /// Get InArgs the wrapper ModelEvalutor.
     virtual Thyra::ModelEvaluatorBase::InArgs<Scalar> getInArgs()
     { return wrapperInArgs_; }
-
-    /// Set OutArgs the wrapper ModelEvalutor.
-    virtual void setOutArgs(Thyra::ModelEvaluatorBase::OutArgs<Scalar> outArgs)
-    { wrapperOutArgs_.setArgs(outArgs); }
 
     /// Get OutArgs the wrapper ModelEvalutor.
     virtual Thyra::ModelEvaluatorBase::OutArgs<Scalar> getOutArgs()
     { return wrapperOutArgs_; }
 
     /// Set parameters for application implicit ModelEvaluator solve.
-    virtual void setForSolve(Teuchos::RCP<TimeDerivative<Scalar> > timeDer,
-      Thyra::ModelEvaluatorBase::InArgs<Scalar>   inArgs,
-      Thyra::ModelEvaluatorBase::OutArgs<Scalar>  outArgs,
-      EVALUATION_TYPE /* evaluationType */ = SOLVE_FOR_X)
-    {
-      timeDer_ = timeDer;
-      wrapperInArgs_.setArgs(inArgs);
-      wrapperOutArgs_.setArgs(outArgs);
-    }
+    virtual void setForSolve(
+      const Teuchos::RCP<Thyra::VectorBase<Scalar> > & x,
+      const Teuchos::RCP<Thyra::VectorBase<Scalar> > & xDot,
+      const Scalar time,
+      const Teuchos::RCP<ImplicitODEParameters<Scalar> > & p,
+      const Teuchos::RCP<Thyra::VectorBase<Scalar> > & y = Teuchos::null,
+      const int index = -1    /* index and y are for IMEX_RK_Partition */ )
+    {}
 
     Thyra::ModelEvaluatorBase::InArgs<Scalar> createInArgs() const;
     Thyra::ModelEvaluatorBase::OutArgs<Scalar> createOutArgsImpl() const;


### PR DESCRIPTION
Tempus's WrapperModelEvaluators tended to construct InArgs internally and use them in the evalModelImpl().  This caused issues with other packages (e.g., NOX and LOCA) that might have changed/added values to the inArgs.  To avoid copying items from the inArgs from the argument list into the WrapperModelEvaluator::InArgs, the WrapperModelEvaluator::createInArgs was improved to return a complete InArgs.

Changed the setForSolve() interface from passing in inArgs/outArgs to passing in Tempus pieces of the inArgs/outArgs (x, xDot, time, and time derivative information), which are used within the WrapperModelEvaluators.

Eliminated all of the setInArgs() and setOutArgs() functions as this should be done through setForSolve().  Replaced getInArgs() and getOutArgs() with createInArgs() and createOutArgs(), respectively, except for Partitioned IMEX and SecondOrder ODEs which were not converted because of complexities that would require addition work (e.g., useImplicitModel_ modifies the createInArgs() construction path).

@trilinos/tempus 

* Closes #12348 
