### PR TITLE
MueLu: change default for "aggregation: deterministic" to true

### DIFF
--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -637,7 +637,7 @@
     <parameter>
       <name>aggregation: deterministic</name>
       <type>bool</type>
-      <default>false</default>
+      <default>true</default>
       <description>Boolean indicating whether or not aggregation will be run deterministically in the kokkos refactored path (only used in uncoupled aggregation).</description>
       <comment-ML>parameter not existing in ML</comment-ML>
     </parameter>

--- a/packages/muelu/doc/UsersGuide/options_aggregation.tex
+++ b/packages/muelu/doc/UsersGuide/options_aggregation.tex
@@ -40,7 +40,7 @@
           
 \cbb{aggregation: greedy Dirichlet}{bool}{false}{Force the aggregate to be Dirichlet if any DOFs in the aggregate are Dirichlet (default is aggregates are Dirichlet only if all DOFs in the aggregate are Dirichlet).}
           
-\cbb{aggregation: deterministic}{bool}{false}{Boolean indicating whether or not aggregation will be run deterministically in the kokkos refactored path (only used in uncoupled aggregation).}
+\cbb{aggregation: deterministic}{bool}{true}{Boolean indicating whether or not aggregation will be run deterministically in the kokkos refactored path (only used in uncoupled aggregation).}
           
 \cbb{aggregation: coloring algorithm}{string}{serial}{Choice of distance 2 independent set or coloring algorithm used by Uncoupled Aggregation, when using kokkos refactored aggregation. See Table \ref{t:coloring_algs} for more information.}
           

--- a/packages/muelu/doc/UsersGuide/paramlist.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist.tex
@@ -93,7 +93,7 @@
           
 \cbb{aggregation: greedy Dirichlet}{bool}{false}{Force the aggregate to be Dirichlet if any DOFs in the aggregate are Dirichlet (default is aggregates are Dirichlet only if all DOFs in the aggregate are Dirichlet).}
           
-\cbb{aggregation: deterministic}{bool}{false}{Boolean indicating whether or not aggregation will be run deterministically in the kokkos refactored path (only used in uncoupled aggregation).}
+\cbb{aggregation: deterministic}{bool}{true}{Boolean indicating whether or not aggregation will be run deterministically in the kokkos refactored path (only used in uncoupled aggregation).}
           
 \cbb{aggregation: coloring algorithm}{string}{serial}{Choice of distance 2 independent set or coloring algorithm used by Uncoupled Aggregation, when using kokkos refactored aggregation. See Table \ref{t:coloring_algs} for more information.}
           

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -124,7 +124,7 @@
         
 \cbb{aggregation: greedy Dirichlet}{bool}{false}{Force the aggregate to be Dirichlet if any DOFs in the aggregate are Dirichlet (default is aggregates are Dirichlet only if all DOFs in the aggregate are Dirichlet).}
         
-\cbb{aggregation: deterministic}{bool}{false}{Boolean indicating whether or not aggregation will be run deterministically in the kokkos refactored path (only used in uncoupled aggregation).}
+\cbb{aggregation: deterministic}{bool}{true}{Boolean indicating whether or not aggregation will be run deterministically in the kokkos refactored path (only used in uncoupled aggregation).}
         
 \cbb{aggregation: coloring algorithm}{string}{serial}{Choice of distance 2 independent set or coloring algorithm used by Uncoupled Aggregation, when using kokkos refactored aggregation. See Table \ref{t:coloring_algs} for more information.}
         

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -235,7 +235,7 @@ namespace MueLu {
   "<Parameter name=\"aggregation: max selected neighbors\" type=\"int\" value=\"0\"/>"
   "<Parameter name=\"aggregation: Dirichlet threshold\" type=\"double\" value=\"0.0\"/>"
   "<Parameter name=\"aggregation: greedy Dirichlet\" type=\"bool\" value=\"false\"/>"
-  "<Parameter name=\"aggregation: deterministic\" type=\"bool\" value=\"false\"/>"
+  "<Parameter name=\"aggregation: deterministic\" type=\"bool\" value=\"true\"/>"
   "<Parameter name=\"aggregation: coloring algorithm\" type=\"string\" value=\"serial\"/>"
   "<Parameter name=\"aggregation: coloring: use color graph\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"aggregation: coloring: localize color graph\" type=\"bool\" value=\"true\"/>"


### PR DESCRIPTION
@trilinos/muelu @cgcgcg 

## DO NOT MERGE - PENDING PERFORMANCE TESTS

## Motivation
This has been a long-needed change, and has been suggested by applications (e.g. @rppawlo in #11026), but it needs careful evaluation. We discussed it at standup today, and we decided we will pursue this if we can be certain from a performance standpoint that we don't horribly increase aggregation time running with default settings. I'll follow-up with performance testing data in this PR once it's done. This is backwards incompatible, so it's appropriate to try to merge before Trilinos 15.0 is released if the performance looks reasonable.

I'll ping other relevant application contacts once I'm certain this is okay to merge.

## Related Issues
Closes #11026.
See also issues linked in #11026, for example.

## Testing
This was never covered by testing before, as our usual "fix" was to manually specify `"aggregation: deterministic" = true` in testing, c.f. #11022 for example. Between the autotester and the performance tests, we should have everything covered.