### PR TITLE
Sacado: Fix clang -Wdtor-name warning

### DIFF
--- a/packages/sacado/src/Sacado_Fad_VectorImp.hpp
+++ b/packages/sacado/src/Sacado_Fad_VectorImp.hpp
@@ -84,12 +84,9 @@ Vector(const Sacado::Fad::Vector< OrdinalType, Sacado::Fad::DVFad<ValueType> >& 
   }
 }
 
-namespace Sacado::Fad
-{
-
 template <typename OrdinalType, typename ValueType>
-Vector< OrdinalType, DVFad<ValueType> >::
-~Vector()
+Sacado::Fad::Vector< OrdinalType, Sacado::Fad::DVFad<ValueType> >::
+~Vector< OrdinalType, Sacado::Fad::DVFad<ValueType> >()
 {
   // Here we must destroy the value and derivative arrays
   if (vec_.size() > 0) {
@@ -101,8 +98,6 @@ Vector< OrdinalType, DVFad<ValueType> >::
     }
   }
 }
-
-} // namespace Sacado::Fad
 
 template <typename OrdinalType, typename ValueType>
 Sacado::Fad::Vector< OrdinalType, Sacado::Fad::DVFad<ValueType> >&

--- a/packages/sacado/src/Sacado_Fad_VectorImp.hpp
+++ b/packages/sacado/src/Sacado_Fad_VectorImp.hpp
@@ -84,8 +84,11 @@ Vector(const Sacado::Fad::Vector< OrdinalType, Sacado::Fad::DVFad<ValueType> >& 
   }
 }
 
+namespace Sacado::Fad
+{
+
 template <typename OrdinalType, typename ValueType>
-Sacado::Fad::Vector< OrdinalType, Sacado::Fad::DVFad<ValueType> >::
+Vector< OrdinalType, DVFad<ValueType> >::
 ~Vector()
 {
   // Here we must destroy the value and derivative arrays
@@ -98,6 +101,8 @@ Sacado::Fad::Vector< OrdinalType, Sacado::Fad::DVFad<ValueType> >::
     }
   }
 }
+
+} // namespace Sacado::Fad
 
 template <typename OrdinalType, typename ValueType>
 Sacado::Fad::Vector< OrdinalType, Sacado::Fad::DVFad<ValueType> >&

--- a/packages/sacado/src/Sacado_Fad_VectorImp.hpp
+++ b/packages/sacado/src/Sacado_Fad_VectorImp.hpp
@@ -84,9 +84,11 @@ Vector(const Sacado::Fad::Vector< OrdinalType, Sacado::Fad::DVFad<ValueType> >& 
   }
 }
 
+namespace Sacado {
+namespace Fad {
 template <typename OrdinalType, typename ValueType>
-Sacado::Fad::Vector< OrdinalType, Sacado::Fad::DVFad<ValueType> >::
-~Vector< OrdinalType, Sacado::Fad::DVFad<ValueType> >()
+Vector< OrdinalType, DVFad<ValueType> >::
+~Vector()
 {
   // Here we must destroy the value and derivative arrays
   if (vec_.size() > 0) {
@@ -97,6 +99,8 @@ Sacado::Fad::Vector< OrdinalType, Sacado::Fad::DVFad<ValueType> >::
       ds_array<ValueType>::destroy_and_release(v, vec_.size()*deriv_size_);
     }
   }
+}
+}
 }
 
 template <typename OrdinalType, typename ValueType>


### PR DESCRIPTION
@trilinos/sacado

@etphipp

## Motivation

When compiling with `clang`, we get the warning:

```
/opt/Trilinos/.../include/Sacado_Fad_VectorImp.hpp:88:66: error: ISO C++ requires the name after '::~' to be found in the same scope as the name before '::~' [clang-diagnostic-dtor-name]
   88 | Sacado::Fad::Vector< OrdinalType, Sacado::Fad::DVFad<ValueType> >::
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
      |                                                                  ::Vector
11957 warnings and 1 error generated.
``` 

This PR solves this issue by putting this piece of code explicitly in the namespace `Sacado::Fad`. 

Note that I've tried fixing it the other way around by writing something like 

```
~Vector<OrdinalType, Sacado::Fad::DVFad<ValueType>()
```

That works with `clang`, but then `gcc` complains. The proposed fix seems to work for both `clang` and `gcc`.