### PR TITLE
PIRO: fix to allow disabling tempus in piro build

### DIFF
--- a/packages/piro/src/Piro_PerformAnalysis.cpp
+++ b/packages/piro/src/Piro_PerformAnalysis.cpp
@@ -50,7 +50,6 @@
 #include "Thyra_DetachedVectorView.hpp"
 
 #include "Piro_SteadyStateSolver.hpp"
-#include "Piro_TransientSolver.hpp"
 
 #ifdef HAVE_PIRO_NOX
 #include "Piro_NOXSolver.hpp"
@@ -76,6 +75,7 @@
 #endif
 
 #ifdef HAVE_PIRO_TEMPUS
+#include "Piro_TransientSolver.hpp"
 #include "Piro_TempusSolver.hpp"
 #ifdef HAVE_PIRO_ROL
 #include "Piro_ThyraProductME_TempusFinalObjective.hpp"

--- a/packages/piro/test/CMakeLists.txt
+++ b/packages/piro/test/CMakeLists.txt
@@ -18,29 +18,31 @@ IF (Piro_ENABLE_NOX)
     ADDED_TESTS_NAMES_OUT ThyraSolverTpetra_NAME
   )
 
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    AnalysisDriverTempus
-    EXCLUDE_IF_NOT_TRUE ${PACKAGE_NAME}_ENABLE_ROL
-    EXCLUDE_IF_NOT_TRUE ${PACKAGE_NAME}_ENABLE_Teko
-    EXCLUDE_IF_NOT_TRUE ${PACKAGE_NAME}_ENABLE_Ifpack2
-    EXCLUDE_IF_NOT_TRUE Ifpack2_ENABLE_Amesos2
-    SOURCES
-    Main_AnalysisDriver_Tempus.cpp
-    MockModelEval_A_Tpetra.cpp
-    MockModelEval_A_Tpetra.hpp
-    MockModelEval_B_Tpetra.cpp
-    MockModelEval_B_Tpetra.hpp
-    MockModelEval_B_Tpetra_2_parameters.cpp
-    MockModelEval_B_Tpetra_2_parameters.hpp
-    MatrixBased_LOWS.cpp
-    MatrixBased_LOWS.hpp
-    MassSpringDamperModel.cpp
-    MassSpringDamperModel.hpp
-    NUM_MPI_PROCS 1-4
-    ARGS -v
-    PASS_REGULAR_EXPRESSION "TEST PASSED"
-    ADDED_TESTS_NAMES_OUT AnalysisDriverTpetra_NAME 
-  )
+  IF (Piro_ENABLE_Tempus)
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      AnalysisDriverTempus
+      EXCLUDE_IF_NOT_TRUE ${PACKAGE_NAME}_ENABLE_ROL
+      EXCLUDE_IF_NOT_TRUE ${PACKAGE_NAME}_ENABLE_Teko
+      EXCLUDE_IF_NOT_TRUE ${PACKAGE_NAME}_ENABLE_Ifpack2
+      EXCLUDE_IF_NOT_TRUE Ifpack2_ENABLE_Amesos2
+      SOURCES
+      Main_AnalysisDriver_Tempus.cpp
+      MockModelEval_A_Tpetra.cpp
+      MockModelEval_A_Tpetra.hpp
+      MockModelEval_B_Tpetra.cpp
+      MockModelEval_B_Tpetra.hpp
+      MockModelEval_B_Tpetra_2_parameters.cpp
+      MockModelEval_B_Tpetra_2_parameters.hpp
+      MatrixBased_LOWS.cpp
+      MatrixBased_LOWS.hpp
+      MassSpringDamperModel.cpp
+      MassSpringDamperModel.hpp
+      NUM_MPI_PROCS 1-4
+      ARGS -v
+      PASS_REGULAR_EXPRESSION "TEST PASSED"
+      ADDED_TESTS_NAMES_OUT AnalysisDriverTpetra_NAME
+    )
+  ENDIF (Piro_ENABLE_Tempus)
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     AnalysisDriverTpetra


### PR DESCRIPTION
Fix so that we can compile piro without tempus.