### PR TITLE
Revert "Framework: Enable CMAKE_LINK_LIBRARIES_ONLY_TARGETS"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,10 +93,6 @@ SET(${PROJECT_NAME}_EXCLUDE_DISABLED_SUBPACKAGES_FROM_DISTRIBUTION_DEFAULT FALSE
 
 SET(Trilinos_USE_GNUINSTALLDIRS_DEFAULT ON)
 
-SET(Trilinos_MUST_FIND_ALL_TPL_LIBS_DEFAULT TRUE)
-
-SET(CMAKE_LINK_LIBRARIES_ONLY_TARGETS ON)
-
 # Set up C++ language standard selection
 include(SetTrilinosCxxStandard)
 
@@ -110,6 +106,8 @@ INSTALL_BUILD_STATS_SCRIPTS()
 
 # Install TriBITS so that other projects can use it
 include(SetupTribitsInstall)
+
+SET(Trilinos_MUST_FIND_ALL_TPL_LIBS_DEFAULT TRUE)
 
 IF(${PROJECT_NAME}_ENABLE_YouCompleteMe)
   INCLUDE(CodeCompletion)

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CMakeLists.txt
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CMakeLists.txt
@@ -77,9 +77,7 @@ ENDIF()
 # LibM not available under MSVC.
 IF(NOT MSVC)
   # Add libm linking for ceil, floor and such.
-  add_library(SuiteSparse::m INTERFACE IMPORTED)
-  set_property(TARGET SuiteSparse::m PROPERTY IMPORTED_LIBNAME "m")
-  LIST(APPEND IMPORTEDLIBS SuiteSparse::m)
+  LIST(APPEND IMPORTEDLIBS m)
 ENDIF()
 
 TRIBITS_ADD_LIBRARY(

--- a/packages/zoltan/src/CMakeLists.txt
+++ b/packages/zoltan/src/CMakeLists.txt
@@ -670,9 +670,7 @@ ENDIF()
 
 IF(NOT MSVC)
   # Add libm linking for ceil, floor and such.
-  add_library(Zoltan::m INTERFACE IMPORTED)
-  set_property(TARGET Zoltan::m PROPERTY IMPORTED_LIBNAME "m")
-  LIST(APPEND IMPORTEDLIBS Zoltan::m)
+  LIST(APPEND IMPORTEDLIBS m)
 ENDIF()
 
 TRIBITS_ADD_LIBRARY(


### PR DESCRIPTION
Reverts:

* trilinos/Trilinos#12362

This change breaks the installed ZoltanConfig.cmake file as per:

* #12371
