### PR TITLE
change std::unary_function and std::binary_function call to C++17 com…

### DIFF
--- a/packages/amesos2/src/Amesos2_Superludist_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_TypeMap.hpp
@@ -111,7 +111,7 @@ extern "C" {
 
 } // end extern "C"
 
-// Declare and specialize a std::binary_funtion class for
+// Declare and specialize a std::__binary_funtion class for
 // multiplication of SLUD types
 template <typename slu_scalar_t, typename slu_mag_t>
 struct slu_dist_mult {};
@@ -124,7 +124,7 @@ struct slu_dist_mult<T,T> : std::multiplies<T> {};
 // For namespace/macro reasons, we prefix our variables with amesos_*
 template <>
 struct slu_dist_mult<double,double>
-  : std::binary_function<double,double,double> {
+  : std::__binary_function<double,double,double> {
   double operator()(double a, double b) {
     return( a*b );
   }
@@ -134,7 +134,7 @@ struct slu_dist_mult<double,double>
 
   template <>
   struct slu_dist_mult<Z::doublecomplex,double>
-    : std::binary_function<Z::doublecomplex,double,Z::doublecomplex> {
+    : std::__binary_function<Z::doublecomplex,double,Z::doublecomplex> {
     Z::doublecomplex operator()(Z::doublecomplex amesos_z, double amesos_d) {
       Z::doublecomplex amesos_zr;
       zd_mult(&amesos_zr, &amesos_z, amesos_d);	// zd_mult is a macro, so no namespacing
@@ -144,7 +144,7 @@ struct slu_dist_mult<double,double>
 
   template <>
   struct slu_dist_mult<Z::doublecomplex,Z::doublecomplex>
-    : std::binary_function<Z::doublecomplex,Z::doublecomplex,Z::doublecomplex> {
+    : std::__binary_function<Z::doublecomplex,Z::doublecomplex,Z::doublecomplex> {
     Z::doublecomplex operator()(Z::doublecomplex amesos_z1, Z::doublecomplex amesos_z2) {
       Z::doublecomplex amesos_zr;
       zz_mult(&amesos_zr, &amesos_z1, &amesos_z2);    // zz_mult is a macro, so no namespacing

--- a/packages/amesos2/src/Amesos2_Superludist_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_TypeMap.hpp
@@ -111,7 +111,7 @@ extern "C" {
 
 } // end extern "C"
 
-// Declare and specialize a std::__binary_funtion class for
+
 // multiplication of SLUD types
 template <typename slu_scalar_t, typename slu_mag_t>
 struct slu_dist_mult {};
@@ -124,7 +124,7 @@ struct slu_dist_mult<T,T> : std::multiplies<T> {};
 // For namespace/macro reasons, we prefix our variables with amesos_*
 template <>
 struct slu_dist_mult<double,double>
-  : std::__binary_function<double,double,double> {
+{
   double operator()(double a, double b) {
     return( a*b );
   }
@@ -134,7 +134,7 @@ struct slu_dist_mult<double,double>
 
   template <>
   struct slu_dist_mult<Z::doublecomplex,double>
-    : std::__binary_function<Z::doublecomplex,double,Z::doublecomplex> {
+  {
     Z::doublecomplex operator()(Z::doublecomplex amesos_z, double amesos_d) {
       Z::doublecomplex amesos_zr;
       zd_mult(&amesos_zr, &amesos_z, amesos_d);	// zd_mult is a macro, so no namespacing
@@ -144,7 +144,7 @@ struct slu_dist_mult<double,double>
 
   template <>
   struct slu_dist_mult<Z::doublecomplex,Z::doublecomplex>
-    : std::__binary_function<Z::doublecomplex,Z::doublecomplex,Z::doublecomplex> {
+  {
     Z::doublecomplex operator()(Z::doublecomplex amesos_z1, Z::doublecomplex amesos_z2) {
       Z::doublecomplex amesos_zr;
       zz_mult(&amesos_zr, &amesos_z1, &amesos_z2);    // zz_mult is a macro, so no namespacing

--- a/packages/amesos2/src/Amesos2_Superlumt_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_Superlumt_TypeMap.hpp
@@ -90,7 +90,7 @@ namespace Z {
 
 } // end extern "C"
 
-  // Declare and specialize a std::binary_funtion class for
+  // Declare and specialize a std::__binary_funtion class for
   // multiplication of SLUMT types
   template <typename slu_scalar_t, typename slu_mag_t>
   struct slu_mt_mult {};
@@ -105,7 +105,7 @@ namespace Z {
   // For namespace/macro reasons, we prefix our variables with amesos_*
   template <>
   struct slu_mt_mult<C::complex,float>
-    : std::binary_function<C::complex,float,C::complex> {
+    : std::__binary_function<C::complex,float,C::complex> {
     C::complex operator()(C::complex amesos_c, float amesos_f) {
       C::complex amesos_cr;
       cs_mult(&amesos_cr, &amesos_c, amesos_f);	// cs_mult is a macro, so no namespacing
@@ -115,7 +115,7 @@ namespace Z {
 
   template <>
   struct slu_mt_mult<C::complex,C::complex>
-    : std::binary_function<C::complex,C::complex,C::complex> {
+    : std::__binary_function<C::complex,C::complex,C::complex> {
     C::complex operator()(C::complex amesos_c1, C::complex amesos_c2) {
       C::complex amesos_cr;
       cc_mult(&amesos_cr, &amesos_c1, &amesos_c2); // cc_mult is a macro, so no namespacing
@@ -125,7 +125,7 @@ namespace Z {
     
   template <>
   struct slu_mt_mult<Z::doublecomplex,double>
-    : std::binary_function<Z::doublecomplex,double,Z::doublecomplex> {
+    : std::__binary_function<Z::doublecomplex,double,Z::doublecomplex> {
     Z::doublecomplex operator()(Z::doublecomplex amesos_z, double amesos_d) {
       Z::doublecomplex amesos_zr;
       zd_mult(&amesos_zr, &amesos_z, amesos_d);	// zd_mult is a macro, so no namespacing
@@ -135,7 +135,7 @@ namespace Z {
 
   template <>
   struct slu_mt_mult<Z::doublecomplex,Z::doublecomplex>
-    : std::binary_function<Z::doublecomplex,Z::doublecomplex,Z::doublecomplex> {
+    : std::__binary_function<Z::doublecomplex,Z::doublecomplex,Z::doublecomplex> {
     Z::doublecomplex operator()(Z::doublecomplex amesos_z1, Z::doublecomplex amesos_z2) {
       Z::doublecomplex amesos_zr;
       zz_mult(&amesos_zr, &amesos_z1, &amesos_z2);    // zz_mult is a macro, so no namespacing

--- a/packages/amesos2/src/Amesos2_Superlumt_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_Superlumt_TypeMap.hpp
@@ -90,7 +90,6 @@ namespace Z {
 
 } // end extern "C"
 
-  // Declare and specialize a std::__binary_funtion class for
   // multiplication of SLUMT types
   template <typename slu_scalar_t, typename slu_mag_t>
   struct slu_mt_mult {};
@@ -105,7 +104,7 @@ namespace Z {
   // For namespace/macro reasons, we prefix our variables with amesos_*
   template <>
   struct slu_mt_mult<C::complex,float>
-    : std::__binary_function<C::complex,float,C::complex> {
+  {
     C::complex operator()(C::complex amesos_c, float amesos_f) {
       C::complex amesos_cr;
       cs_mult(&amesos_cr, &amesos_c, amesos_f);	// cs_mult is a macro, so no namespacing
@@ -115,7 +114,7 @@ namespace Z {
 
   template <>
   struct slu_mt_mult<C::complex,C::complex>
-    : std::__binary_function<C::complex,C::complex,C::complex> {
+  {
     C::complex operator()(C::complex amesos_c1, C::complex amesos_c2) {
       C::complex amesos_cr;
       cc_mult(&amesos_cr, &amesos_c1, &amesos_c2); // cc_mult is a macro, so no namespacing
@@ -125,7 +124,7 @@ namespace Z {
     
   template <>
   struct slu_mt_mult<Z::doublecomplex,double>
-    : std::__binary_function<Z::doublecomplex,double,Z::doublecomplex> {
+  {
     Z::doublecomplex operator()(Z::doublecomplex amesos_z, double amesos_d) {
       Z::doublecomplex amesos_zr;
       zd_mult(&amesos_zr, &amesos_z, amesos_d);	// zd_mult is a macro, so no namespacing
@@ -135,7 +134,7 @@ namespace Z {
 
   template <>
   struct slu_mt_mult<Z::doublecomplex,Z::doublecomplex>
-    : std::__binary_function<Z::doublecomplex,Z::doublecomplex,Z::doublecomplex> {
+  {
     Z::doublecomplex operator()(Z::doublecomplex amesos_z1, Z::doublecomplex amesos_z2) {
       Z::doublecomplex amesos_zr;
       zz_mult(&amesos_zr, &amesos_z1, &amesos_z2);    // zz_mult is a macro, so no namespacing

--- a/packages/belos/src/BelosTsqrOrthoManagerImpl.hpp
+++ b/packages/belos/src/BelosTsqrOrthoManagerImpl.hpp
@@ -56,7 +56,7 @@
 #  include "Teuchos_TimeMonitor.hpp"
 #endif // BELOS_TEUCHOS_TIME_MONITOR
 #include <algorithm>
-#include <functional> // std::binary_function
+#include <functional> // std::__binary_function
 
 namespace Belos {
 
@@ -128,7 +128,7 @@ namespace Belos {
   /// yourself.
   template<class Scalar>
   class ReorthogonalizationCallback :
-    public std::binary_function<Teuchos::ArrayView<typename Teuchos::ScalarTraits<Scalar>::magnitudeType>,
+    public std::__binary_function<Teuchos::ArrayView<typename Teuchos::ScalarTraits<Scalar>::magnitudeType>,
                                 Teuchos::ArrayView<typename Teuchos::ScalarTraits<Scalar>::magnitudeType>,
                                 void>
   {

--- a/packages/belos/src/BelosTsqrOrthoManagerImpl.hpp
+++ b/packages/belos/src/BelosTsqrOrthoManagerImpl.hpp
@@ -56,7 +56,7 @@
 #  include "Teuchos_TimeMonitor.hpp"
 #endif // BELOS_TEUCHOS_TIME_MONITOR
 #include <algorithm>
-#include <functional> // std::__binary_function
+#include <functional> 
 
 namespace Belos {
 
@@ -127,10 +127,7 @@ namespace Belos {
   /// metrics you want to collect and how you want to display them
   /// yourself.
   template<class Scalar>
-  class ReorthogonalizationCallback :
-    public std::__binary_function<Teuchos::ArrayView<typename Teuchos::ScalarTraits<Scalar>::magnitudeType>,
-                                Teuchos::ArrayView<typename Teuchos::ScalarTraits<Scalar>::magnitudeType>,
-                                void>
+  class ReorthogonalizationCallback
   {
   public:
     //! The template parameter of this class; the type of an inner product result.

--- a/packages/panzer/adapters-stk/src/responses/Panzer_STK_ResponseEvaluatorFactory_SolutionWriter.hpp
+++ b/packages/panzer/adapters-stk/src/responses/Panzer_STK_ResponseEvaluatorFactory_SolutionWriter.hpp
@@ -118,7 +118,7 @@ private:
    void deleteRemovedFields(const std::vector<std::string> & removedFields,
                             std::vector<std::pair<std::string,Teuchos::RCP<const panzer::PureBasis> > > & fields) const;
 
-   struct RemovedFieldsSearchUnaryFunctor : public std::unary_function<std::pair<std::string,const panzer::PureBasis>,bool> {
+   struct RemovedFieldsSearchUnaryFunctor : public std::__unary_function<std::pair<std::string,const panzer::PureBasis>,bool> {
      std::vector<std::string> removedFields_;
      bool operator() (const std::pair<std::string,Teuchos::RCP<const panzer::PureBasis> > & field) 
      { return std::find(removedFields_.begin(),removedFields_.end(),field.first)!=removedFields_.end(); }

--- a/packages/panzer/adapters-stk/src/responses/Panzer_STK_ResponseEvaluatorFactory_SolutionWriter.hpp
+++ b/packages/panzer/adapters-stk/src/responses/Panzer_STK_ResponseEvaluatorFactory_SolutionWriter.hpp
@@ -118,7 +118,7 @@ private:
    void deleteRemovedFields(const std::vector<std::string> & removedFields,
                             std::vector<std::pair<std::string,Teuchos::RCP<const panzer::PureBasis> > > & fields) const;
 
-   struct RemovedFieldsSearchUnaryFunctor : public std::__unary_function<std::pair<std::string,const panzer::PureBasis>,bool> {
+   struct RemovedFieldsSearchUnaryFunctor {
      std::vector<std::string> removedFields_;
      bool operator() (const std::pair<std::string,Teuchos::RCP<const panzer::PureBasis> > & field) 
      { return std::find(removedFields_.begin(),removedFields_.end(),field.first)!=removedFields_.end(); }

--- a/packages/percept/src/adapt/IElementBasedAdapterPredicate.hpp
+++ b/packages/percept/src/adapt/IElementBasedAdapterPredicate.hpp
@@ -23,16 +23,13 @@
      * The Selector pattern as shown below is useful for selecting only entities that belong to particular
      *   mesh Parts, for example, or any other definition of Selector.
      *
-     * We follow the unary_function pattern to enable the structs to be used in STL algorithms that know about
-     *   unary_functions.
-     *
      * The following are a couple of examples of what refine and unrefine predicates might look like.
      *
      * Following these examples we show the prototype for the operations that are performed on these predicates.
      */
 
     // Example
-    struct IElementBasedAdapterPredicate : public std::__unary_function<const stk::mesh::Entity , int> {
+    struct IElementBasedAdapterPredicate {
       PerceptMesh& m_eMesh;
       stk::mesh::Selector * m_eb_selector;
       stk::mesh::FieldBase *m_field;

--- a/packages/percept/src/adapt/IElementBasedAdapterPredicate.hpp
+++ b/packages/percept/src/adapt/IElementBasedAdapterPredicate.hpp
@@ -32,7 +32,7 @@
      */
 
     // Example
-    struct IElementBasedAdapterPredicate : public std::unary_function<const stk::mesh::Entity , int> {
+    struct IElementBasedAdapterPredicate : public std::__unary_function<const stk::mesh::Entity , int> {
       PerceptMesh& m_eMesh;
       stk::mesh::Selector * m_eb_selector;
       stk::mesh::FieldBase *m_field;

--- a/packages/percept/src/adapt/PredicateBasedElementAdapter.hpp
+++ b/packages/percept/src/adapt/PredicateBasedElementAdapter.hpp
@@ -25,7 +25,7 @@
      *  The functor @class RefinePredicate should supply an operator() that returns an entry from AdaptInstruction,
      *    either to do nothing, refine, unrefine, or both refine & unrefine (useful for unit testing, etc.)
      */
-    typedef std::__unary_function<stk::mesh::Entity , bool> AdapterPredicateFunctor;
+    using AdapterPredicateFunctor = std::__unary_function<stk::mesh::Entity , bool> ;
 
     /// This class (and derived classes) supports basic element-based marking, 
     ///   a flavor of quality-improved element-based marking,

--- a/packages/percept/src/adapt/PredicateBasedElementAdapter.hpp
+++ b/packages/percept/src/adapt/PredicateBasedElementAdapter.hpp
@@ -25,7 +25,7 @@
      *  The functor @class RefinePredicate should supply an operator() that returns an entry from AdaptInstruction,
      *    either to do nothing, refine, unrefine, or both refine & unrefine (useful for unit testing, etc.)
      */
-    typedef std::unary_function<stk::mesh::Entity , bool> AdapterPredicateFunctor;
+    typedef std::__unary_function<stk::mesh::Entity , bool> AdapterPredicateFunctor;
 
     /// This class (and derived classes) supports basic element-based marking, 
     ///   a flavor of quality-improved element-based marking,

--- a/packages/percept/src/adapt/PredicateTemplateAdapter.hpp
+++ b/packages/percept/src/adapt/PredicateTemplateAdapter.hpp
@@ -38,7 +38,7 @@
      *
      *  Note: the steps above are now embedded in Stage_2_Mark_TE_Parents, so we only have 2 stages now.
      */
-    typedef std::unary_function<stk::mesh::Entity , bool> AdapterPredicateFunctor;
+    typedef std::__unary_function<stk::mesh::Entity , bool> AdapterPredicateFunctor;
     enum PTA_Stage {
       Stage_None,
       Stage_1_Mark_NTE,

--- a/packages/percept/src/adapt/PredicateTemplateAdapter.hpp
+++ b/packages/percept/src/adapt/PredicateTemplateAdapter.hpp
@@ -38,7 +38,7 @@
      *
      *  Note: the steps above are now embedded in Stage_2_Mark_TE_Parents, so we only have 2 stages now.
      */
-    typedef std::__unary_function<stk::mesh::Entity , bool> AdapterPredicateFunctor;
+    using AdapterPredicateFunctor = std::__unary_function<stk::mesh::Entity , bool>;
     enum PTA_Stage {
       Stage_None,
       Stage_1_Mark_NTE,

--- a/packages/percept/src/adapt/SDCEntityType.hpp
+++ b/packages/percept/src/adapt/SDCEntityType.hpp
@@ -114,19 +114,19 @@
       int operator()(sdc_type& sdc)
       {
         size_t sum = 0;
-        const typename sdc_type::const_iterator i_begin = sdc.begin();
-        const typename sdc_type::const_iterator i_end = sdc.end();
+        const typename sdc_type<T,N>::const_iterator i_begin = sdc.begin();
+        const typename sdc_type<T,N>::const_iterator i_end = sdc.end();
 
         if (s_compare_using_entity_impl)
           {
-            for (typename sdc_type::const_iterator i = i_begin; i != i_end; ++i)
+            for (typename sdc_type<T,N>::const_iterator i = i_begin; i != i_end; ++i)
               {
                 sum += size_t(i->local_offset());
               }
           }
         else
           {
-            for ( typename sdc_type::const_iterator i = i_begin; i != i_end; ++i)
+            for ( typename sdc_type<T,N>::const_iterator i = i_begin; i != i_end; ++i)
               {
                 sum += static_cast<size_t>(m_eMesh->identifier(*i));
               }
@@ -143,14 +143,14 @@
       using base_type = SubDimCell<T, N, CompareClass, HC>; 
 
       percept::PerceptMesh* m_eMesh;
-      MySubDimCell(percept::PerceptMesh* eMesh) : base_type(), m_eMesh(eMesh) {
-        base_type::m_HashCode = HC(eMesh);
-        base_type::m_CompareClass = CompareClass(eMesh);
+      MySubDimCell(percept::PerceptMesh* eMesh) : base_type<T,N,CompareClass,HC>(), m_eMesh(eMesh) {
+        base_type<T,N,CompareClass,HC>::m_HashCode = HC(eMesh);
+        base_type<T,N,CompareClass,HC>::m_CompareClass = CompareClass(eMesh);
       }
-      MySubDimCell(percept::PerceptMesh* eMesh, unsigned num_ids) : base_type(num_ids), m_eMesh(eMesh)
+      MySubDimCell(percept::PerceptMesh* eMesh, unsigned num_ids) : base_type<T,N,CompareClass,HC>(num_ids), m_eMesh(eMesh)
       {
-        base_type::m_HashCode = HC(eMesh);
-        base_type::m_CompareClass = CompareClass(eMesh);
+        base_type<T,N,CompareClass,HC>::m_HashCode = HC(eMesh);
+        base_type<T,N,CompareClass,HC>::m_CompareClass = CompareClass(eMesh);
       }
       MySubDimCell()
       {

--- a/packages/percept/src/adapt/SDCEntityType.hpp
+++ b/packages/percept/src/adapt/SDCEntityType.hpp
@@ -45,7 +45,7 @@
       SDC_DATA_SPACING
     };
 
-    typedef stk::mesh::Entity SDCEntityType;
+    using SDCEntityType = stk::mesh::Entity;
 
     class MyEntityLess {
     public:
@@ -105,7 +105,8 @@
     {
     public:
 
-      typedef  percept::NoMallocArray<T, N> sdc_type;
+      template<class T, std::size_t N=4>
+      using sdc_type = percept::NoMallocArray<T, N>;
 
       percept::PerceptMesh* m_eMesh;
       MySDCHashCode(percept::PerceptMesh* eMesh=0) : m_eMesh(eMesh) {}
@@ -138,7 +139,8 @@
     class MySubDimCell : public SubDimCell<T, N, CompareClass, HC>
     {
     public:
-      typedef SubDimCell<T, N, CompareClass, HC> base_type;
+      template<class T, std::size_t N=4, class CompareClass = SubDimCellCompare<T>, class HC = MySDCHashCode<T, N> >
+      using base_type = SubDimCell<T, N, CompareClass, HC>; 
 
       percept::PerceptMesh* m_eMesh;
       MySubDimCell(percept::PerceptMesh* eMesh) : base_type(), m_eMesh(eMesh) {
@@ -162,7 +164,7 @@
     template<>
     struct my_fast_hash<SDCEntityType, 2>
     {
-      typedef MySubDimCell<SDCEntityType, 2, CompareSDCEntityType> _Tp ;
+      using _Tp = MySubDimCell<SDCEntityType, 2, CompareSDCEntityType>;
 
       inline std::size_t
       operator()(const _Tp& x) const
@@ -176,7 +178,7 @@
     template<>
     struct my_fast_hash<SDCEntityType, 4>
     {
-      typedef MySubDimCell<SDCEntityType, 4, CompareSDCEntityType> _Tp ;
+      using _Tp =  MySubDimCell<SDCEntityType, 4, CompareSDCEntityType>;
 
       inline std::size_t
       operator()(const _Tp& x) const
@@ -190,7 +192,7 @@
     template<>
     struct my_fast_equal_to<SDCEntityType, 2>     
     {
-      typedef MySubDimCell<SDCEntityType, 2, CompareSDCEntityType> _Tp ;
+      using _Tp = MySubDimCell<SDCEntityType, 2, CompareSDCEntityType>;
       inline bool
       operator()(const _Tp& x, const _Tp& y) const
       {
@@ -210,7 +212,7 @@
     template<>
     struct my_fast_equal_to<SDCEntityType, 4> 
     {
-      typedef MySubDimCell<SDCEntityType, 4, CompareSDCEntityType> _Tp ;
+      using _Tp =  MySubDimCell<SDCEntityType, 4, CompareSDCEntityType>;
       inline bool
       operator()(const _Tp& x, const _Tp& y) const
       {

--- a/packages/percept/src/adapt/SDCEntityType.hpp
+++ b/packages/percept/src/adapt/SDCEntityType.hpp
@@ -160,7 +160,7 @@
 
 
     template<>
-    struct my_fast_hash<SDCEntityType, 2> : public std::__unary_function< MySubDimCell<SDCEntityType, 2, CompareSDCEntityType>, std::size_t>
+    struct my_fast_hash<SDCEntityType, 2>
     {
       typedef MySubDimCell<SDCEntityType, 2, CompareSDCEntityType> _Tp ;
 
@@ -174,7 +174,7 @@
 
 
     template<>
-    struct my_fast_hash<SDCEntityType, 4> : public std::__unary_function< MySubDimCell<SDCEntityType, 4, CompareSDCEntityType>, std::size_t>
+    struct my_fast_hash<SDCEntityType, 4>
     {
       typedef MySubDimCell<SDCEntityType, 4, CompareSDCEntityType> _Tp ;
 
@@ -188,8 +188,7 @@
 
 
     template<>
-    struct my_fast_equal_to<SDCEntityType, 2> :  public std::__binary_function< MySubDimCell<SDCEntityType, 2, CompareSDCEntityType>,
-                                                                              MySubDimCell<SDCEntityType, 2, CompareSDCEntityType>, bool>
+    struct my_fast_equal_to<SDCEntityType, 2>     
     {
       typedef MySubDimCell<SDCEntityType, 2, CompareSDCEntityType> _Tp ;
       inline bool
@@ -209,8 +208,7 @@
     };
 
     template<>
-    struct my_fast_equal_to<SDCEntityType, 4> :  public std::__binary_function< MySubDimCell<SDCEntityType, 4, CompareSDCEntityType>,
-                                                                              MySubDimCell<SDCEntityType, 4, CompareSDCEntityType>, bool>
+    struct my_fast_equal_to<SDCEntityType, 4> 
     {
       typedef MySubDimCell<SDCEntityType, 4, CompareSDCEntityType> _Tp ;
       inline bool

--- a/packages/percept/src/adapt/SDCEntityType.hpp
+++ b/packages/percept/src/adapt/SDCEntityType.hpp
@@ -160,7 +160,7 @@
 
 
     template<>
-    struct my_fast_hash<SDCEntityType, 2> : public std::unary_function< MySubDimCell<SDCEntityType, 2, CompareSDCEntityType>, std::size_t>
+    struct my_fast_hash<SDCEntityType, 2> : public std::__unary_function< MySubDimCell<SDCEntityType, 2, CompareSDCEntityType>, std::size_t>
     {
       typedef MySubDimCell<SDCEntityType, 2, CompareSDCEntityType> _Tp ;
 
@@ -174,7 +174,7 @@
 
 
     template<>
-    struct my_fast_hash<SDCEntityType, 4> : public std::unary_function< MySubDimCell<SDCEntityType, 4, CompareSDCEntityType>, std::size_t>
+    struct my_fast_hash<SDCEntityType, 4> : public std::__unary_function< MySubDimCell<SDCEntityType, 4, CompareSDCEntityType>, std::size_t>
     {
       typedef MySubDimCell<SDCEntityType, 4, CompareSDCEntityType> _Tp ;
 
@@ -188,7 +188,7 @@
 
 
     template<>
-    struct my_fast_equal_to<SDCEntityType, 2> :  public std::binary_function< MySubDimCell<SDCEntityType, 2, CompareSDCEntityType>,
+    struct my_fast_equal_to<SDCEntityType, 2> :  public std::__binary_function< MySubDimCell<SDCEntityType, 2, CompareSDCEntityType>,
                                                                               MySubDimCell<SDCEntityType, 2, CompareSDCEntityType>, bool>
     {
       typedef MySubDimCell<SDCEntityType, 2, CompareSDCEntityType> _Tp ;
@@ -209,7 +209,7 @@
     };
 
     template<>
-    struct my_fast_equal_to<SDCEntityType, 4> :  public std::binary_function< MySubDimCell<SDCEntityType, 4, CompareSDCEntityType>,
+    struct my_fast_equal_to<SDCEntityType, 4> :  public std::__binary_function< MySubDimCell<SDCEntityType, 4, CompareSDCEntityType>,
                                                                               MySubDimCell<SDCEntityType, 4, CompareSDCEntityType>, bool>
     {
       typedef MySubDimCell<SDCEntityType, 4, CompareSDCEntityType> _Tp ;

--- a/packages/percept/src/adapt/SubDimCell.hpp
+++ b/packages/percept/src/adapt/SubDimCell.hpp
@@ -219,7 +219,6 @@
 
     template<class T, std::size_t N>
     struct my_fast_equal_to
-                                                           SubDimCell<T,N>, bool>
     {
       typedef SubDimCell<T,N> _Tp ;
       inline bool

--- a/packages/percept/src/adapt/SubDimCell.hpp
+++ b/packages/percept/src/adapt/SubDimCell.hpp
@@ -30,7 +30,6 @@
     class SDCHashCode
     {
     public:
-      template<class T, std::size_t N=4>
       using base_type = percept::NoMallocArray<T,N>;
 
       int operator()(base_type& sdc);
@@ -46,12 +45,10 @@
       HC m_HashCode;
       CompareClass m_CompareClass;
 
-      template<class T, std::size_t N=4>
       using based_type = percept::NoMallocArray<T,N>;
 
       using size_type = std::size_t; 
 
-      template<class T, std::size_t N=4, class CompareClass = SubDimCellCompare<T>, class HC = SDCHashCode<T,N>  >
       using VAL = SubDimCell<T,N,CompareClass,HC>;
 
       //repo always init to 0 size: SubDimCell(unsigned n=4) : base_type(n), m_hash(0u) {}
@@ -165,7 +162,6 @@
     template<class T, std::size_t N>
     struct my_hash
     {
-      template<class T, std::size_t N>
       using _Tp = SubDimCell<T,N>;
 
       inline std::size_t
@@ -193,7 +189,6 @@
     template<class T, std::size_t N>
     struct my_fast_hash
     {
-      template<class T, std::size_t N>
       using _TP = SubDimCell<T,N>;
 
       inline std::size_t
@@ -229,7 +224,6 @@
     template<class T, std::size_t N>
     struct my_fast_equal_to
     {
-      template<class T, std::size_t N>
       using _Tp = SubDimCell<T,N>;
 
       inline bool

--- a/packages/percept/src/adapt/SubDimCell.hpp
+++ b/packages/percept/src/adapt/SubDimCell.hpp
@@ -30,9 +30,10 @@
     class SDCHashCode
     {
     public:
+      template <T,N>
       using base_type = percept::NoMallocArray<T,N>;
 
-      int operator()(base_type& sdc);
+      int operator()(base_type<T,N>& sdc);
     };
 
     /// We assume we don't have any sub-dimensional entities with more than 4 nodes
@@ -45,20 +46,22 @@
       HC m_HashCode;
       CompareClass m_CompareClass;
 
+      template<class T, std::size_t N=4>
       using based_type = percept::NoMallocArray<T,N>;
 
       using size_type = std::size_t; 
 
+      template<class T, std::size_t N=4, class CompareClass = SubDimCellCompare<T>, class HC = SDCHashCode<T,N>  >
       using VAL = SubDimCell<T,N,CompareClass,HC>;
 
-      //repo always init to 0 size: SubDimCell(unsigned n=4) : base_type(n), m_hash(0u) {}
-      SubDimCell() : base_type(), m_hash(0u), m_HashCode(), m_CompareClass() {}
-      SubDimCell(unsigned n) : base_type(), m_hash(0u), m_HashCode(), m_CompareClass() {}
+      //repo always init to 0 size: SubDimCell(unsigned n=4) : base_type<T,N,CompareClass,HC>(n), m_hash(0u) {}
+      SubDimCell() : base_type<T,N,CompareClass,HC>(), m_hash(0u), m_HashCode(), m_CompareClass() {}
+      SubDimCell(unsigned n) : base_type<T,N,CompareClass,HC>(), m_hash(0u), m_HashCode(), m_CompareClass() {}
       // behaves like std::set
       void insert(T val)
       {
         bool found = false;
-        for (size_type i = 0; i < base_type::size(); i++)
+        for (size_type i = 0; i < base_type<T,N,CompareClass,HC>::size(); i++)
           {
             if (val == (*this)[i])
               {
@@ -68,7 +71,7 @@
           }
         if (!found)
           {
-            base_type::insert(val);
+            base_type<T,N,CompareClass,HC>::insert(val);
             sort();
           }
         updateHashCode();
@@ -76,7 +79,7 @@
 
       void sort()
       {
-        std::sort( base_type::begin(), base_type::end(), m_CompareClass );
+        std::sort( base_type<T,N,CompareClass,HC>::begin(), base_type<T,N,CompareClass,HC>::end(), m_CompareClass );
       }
 
       void updateHashCode()
@@ -99,7 +102,7 @@
       void clear()
       {
         m_hash = 0u;
-        base_type::clear();
+        base_type<T,N,CompareClass,HC>::clear();
       }
 
       bool operator==(const VAL& rhs) const;
@@ -113,11 +116,11 @@
     };
 
     template<class T, std::size_t N>
-    inline int SDCHashCode<T,N>::operator()(SDCHashCode<T,N>::base_type& sdc)
+    inline int SDCHashCode<T,N>::operator()(SDCHashCode<T,N>::base_type<T,N>& sdc)
     {
       std::size_t sum = 0;
 
-      for (typename base_type::iterator i = sdc.begin(); i != sdc.end(); i++)
+      for (typename base_type<T,N>::iterator i = sdc.begin(); i != sdc.end(); i++)
         {
           sum += (size_t)(*i);
         }
@@ -128,9 +131,9 @@
     inline bool SubDimCell<T,N,CompareClass,HC>::
     operator==(const VAL& rhs) const
     {
-      if (base_type::size() != rhs.size())
+      if (base_type<T,N,CompareClass,HC>::size() != rhs.size())
         return false;
-      for (size_type i = 0; i < base_type::size(); i++)
+      for (size_type i = 0; i < base_type<T,N,CompareClass,HC>::size(); i++)
         {
           if ((*this)[i] != rhs[i])
             return false;
@@ -142,13 +145,13 @@
     inline bool SubDimCell<T,N,CompareClass, HC>::
     operator<(const VAL& rhs) const
     {
-      if (base_type::size() < rhs.size())
+      if (base_type<T,N,CompareClass,HC>::size() < rhs.size())
         return true;
-      else if (base_type::size() > rhs.size())
+      else if (base_type<T,N,CompareClass,HC>::size() > rhs.size())
         return false;
       else
         {
-          for (size_type i = 0; i < base_type::size(); i++)
+          for (size_type i = 0; i < base_type<T,N,CompareClass,HC>::size(); i++)
             {
               if ((*this)[i] < rhs[i])
                 return true;

--- a/packages/percept/src/adapt/SubDimCell.hpp
+++ b/packages/percept/src/adapt/SubDimCell.hpp
@@ -30,7 +30,9 @@
     class SDCHashCode
     {
     public:
-      typedef percept::NoMallocArray<T,N> base_type;
+      template<class T, std::size_t N=4>
+      using base_type = percept::NoMallocArray<T,N>;
+
       int operator()(base_type& sdc);
     };
 
@@ -43,10 +45,14 @@
     public:
       HC m_HashCode;
       CompareClass m_CompareClass;
-      typedef percept::NoMallocArray<T,N> base_type;
-      typedef std::size_t    size_type;
 
-      typedef SubDimCell<T,N,CompareClass,HC> VAL;
+      template<class T, std::size_t N=4>
+      using based_type = percept::NoMallocArray<T,N>;
+
+      using size_type = std::size_t; 
+
+      template<class T, std::size_t N=4, class CompareClass = SubDimCellCompare<T>, class HC = SDCHashCode<T,N>  >
+      using VAL = SubDimCell<T,N,CompareClass,HC>;
 
       //repo always init to 0 size: SubDimCell(unsigned n=4) : base_type(n), m_hash(0u) {}
       SubDimCell() : base_type(), m_hash(0u), m_HashCode(), m_CompareClass() {}
@@ -159,7 +165,8 @@
     template<class T, std::size_t N>
     struct my_hash
     {
-      typedef SubDimCell<T,N> _Tp ;
+      template<class T, std::size_t N>
+      using _Tp = SubDimCell<T,N>;
 
       inline std::size_t
       operator()(const _Tp& x) const
@@ -186,7 +193,8 @@
     template<class T, std::size_t N>
     struct my_fast_hash
     {
-      typedef SubDimCell<T,N> _Tp ;
+      template<class T, std::size_t N>
+      using _TP = SubDimCell<T,N>;
 
       inline std::size_t
       operator()(const _Tp& x) const
@@ -199,7 +207,9 @@
     template<class T, std::size_t N>
     struct my_equal_to
     {
-      typedef SubDimCell<T,N> _Tp ;
+      template<class T, std::size_t N>
+      using _Tp = SubDimCell<T,N>;
+
       bool
       operator()(const _Tp& x, const _Tp& y) const
       {
@@ -220,7 +230,9 @@
     template<class T, std::size_t N>
     struct my_fast_equal_to
     {
-      typedef SubDimCell<T,N> _Tp ;
+      template<class T, std::size_t N>
+      using _Tp = SubDimCell<T,N>;
+
       inline bool
       operator()(const _Tp& x, const _Tp& y) const
       {

--- a/packages/percept/src/adapt/SubDimCell.hpp
+++ b/packages/percept/src/adapt/SubDimCell.hpp
@@ -157,7 +157,7 @@
 #define GET(x,i) x[i]
 
     template<class T, std::size_t N>
-    struct my_hash : public std::unary_function< SubDimCell<T,N>, std::size_t>
+    struct my_hash : public std::__unary_function< SubDimCell<T,N>, std::size_t>
     {
       typedef SubDimCell<T,N> _Tp ;
 
@@ -184,7 +184,7 @@
     };
 
     template<class T, std::size_t N>
-    struct my_fast_hash : public std::unary_function< SubDimCell<T,N>, std::size_t>
+    struct my_fast_hash : public std::__unary_function< SubDimCell<T,N>, std::size_t>
     {
       typedef SubDimCell<T,N> _Tp ;
 
@@ -197,7 +197,7 @@
     };
 
     template<class T, std::size_t N>
-    struct my_equal_to :  public std::binary_function<SubDimCell<T,N>,
+    struct my_equal_to :  public std::__binary_function<SubDimCell<T,N>,
                                                       SubDimCell<T,N>, bool>
     {
       typedef SubDimCell<T,N> _Tp ;
@@ -219,7 +219,7 @@
     };
 
     template<class T, std::size_t N>
-    struct my_fast_equal_to :  public std::binary_function<SubDimCell<T,N>,
+    struct my_fast_equal_to :  public std::__binary_function<SubDimCell<T,N>,
                                                            SubDimCell<T,N>, bool>
     {
       typedef SubDimCell<T,N> _Tp ;

--- a/packages/percept/src/adapt/SubDimCell.hpp
+++ b/packages/percept/src/adapt/SubDimCell.hpp
@@ -157,7 +157,7 @@
 #define GET(x,i) x[i]
 
     template<class T, std::size_t N>
-    struct my_hash : public std::__unary_function< SubDimCell<T,N>, std::size_t>
+    struct my_hash
     {
       typedef SubDimCell<T,N> _Tp ;
 
@@ -184,7 +184,7 @@
     };
 
     template<class T, std::size_t N>
-    struct my_fast_hash : public std::__unary_function< SubDimCell<T,N>, std::size_t>
+    struct my_fast_hash
     {
       typedef SubDimCell<T,N> _Tp ;
 
@@ -197,8 +197,7 @@
     };
 
     template<class T, std::size_t N>
-    struct my_equal_to :  public std::__binary_function<SubDimCell<T,N>,
-                                                      SubDimCell<T,N>, bool>
+    struct my_equal_to
     {
       typedef SubDimCell<T,N> _Tp ;
       bool
@@ -219,7 +218,7 @@
     };
 
     template<class T, std::size_t N>
-    struct my_fast_equal_to :  public std::__binary_function<SubDimCell<T,N>,
+    struct my_fast_equal_to
                                                            SubDimCell<T,N>, bool>
     {
       typedef SubDimCell<T,N> _Tp ;

--- a/packages/percept/src/adapt/SubDimCell.hpp
+++ b/packages/percept/src/adapt/SubDimCell.hpp
@@ -207,7 +207,6 @@
     template<class T, std::size_t N>
     struct my_equal_to
     {
-      template<class T, std::size_t N>
       using _Tp = SubDimCell<T,N>;
 
       bool

--- a/packages/percept/src/adapt/markers/Marker.cpp
+++ b/packages/percept/src/adapt/markers/Marker.cpp
@@ -94,7 +94,7 @@ void Marker::setSelector(stk::mesh::Selector *sel)
 
 stk::mesh::Selector *Marker::getSelector() { return m_globalSelector; }
 
-struct CompareErrIndRefFieldVec : public std::binary_function<ErrIndInfoTuple, ErrIndInfoTuple, bool> {
+struct CompareErrIndRefFieldVec : public std::__binary_function<ErrIndInfoTuple, ErrIndInfoTuple, bool> {
   bool operator()( ErrIndInfoTuple a,  ErrIndInfoTuple b)
   {
     return std::get<0>(a)  < std::get<0>(b);

--- a/packages/percept/src/adapt/markers/Marker.cpp
+++ b/packages/percept/src/adapt/markers/Marker.cpp
@@ -94,7 +94,8 @@ void Marker::setSelector(stk::mesh::Selector *sel)
 
 stk::mesh::Selector *Marker::getSelector() { return m_globalSelector; }
 
-struct CompareErrIndRefFieldVec : public std::__binary_function<ErrIndInfoTuple, ErrIndInfoTuple, bool> {
+struct CompareErrIndRefFieldVec 
+{
   bool operator()( ErrIndInfoTuple a,  ErrIndInfoTuple b)
   {
     return std::get<0>(a)  < std::get<0>(b);

--- a/packages/piro/src/Piro_Provider.hpp
+++ b/packages/piro/src/Piro_Provider.hpp
@@ -83,7 +83,7 @@ ProviderImpl<T, Functor>::getInstance(const Teuchos::RCP<Teuchos::ParameterList>
 
 template <typename T>
 struct ProviderFunctorBase :
-  public std::unary_function<const Teuchos::RCP<Teuchos::ParameterList> &, Teuchos::RCP<T> > {};
+  public std::__unary_function<const Teuchos::RCP<Teuchos::ParameterList> &, Teuchos::RCP<T> > {};
 
 
 template <typename T>

--- a/packages/piro/src/Piro_Provider.hpp
+++ b/packages/piro/src/Piro_Provider.hpp
@@ -82,12 +82,7 @@ ProviderImpl<T, Functor>::getInstance(const Teuchos::RCP<Teuchos::ParameterList>
 }
 
 template <typename T>
-struct ProviderFunctorBase:
-  public std::__unary_function<const Teuchos::RCP<Teuchos::ParameterList> &, Teuchos::RCP<T> > {};
-
-
-template <typename T>
-struct NullProviderFunctor : public ProviderFunctorBase<T> {
+struct NullProviderFunctor {
   Teuchos::RCP<T> operator()(const Teuchos::RCP<Teuchos::ParameterList> &/*params*/) const
   {
     return Teuchos::null;
@@ -96,7 +91,7 @@ struct NullProviderFunctor : public ProviderFunctorBase<T> {
 
 
 template <typename T>
-class SharingProviderFunctor : public ProviderFunctorBase<T> {
+class SharingProviderFunctor {
 public:
   SharingProviderFunctor() :
     instance_(Teuchos::null)
@@ -141,7 +136,7 @@ makeSharingProviderFunctor(const Teuchos::RCP<T> &instance)
  *  as sources of auxiliary objects for the different %Piro solvers.
  */
 template <typename T>
-class Provider : public ProviderFunctorBase<T> {
+class Provider {
 public:
   //! \name Constructors
   //@{

--- a/packages/piro/src/Piro_Provider.hpp
+++ b/packages/piro/src/Piro_Provider.hpp
@@ -82,7 +82,7 @@ ProviderImpl<T, Functor>::getInstance(const Teuchos::RCP<Teuchos::ParameterList>
 }
 
 template <typename T>
-struct ProviderFunctorBase :
+struct ProviderFunctorBase:
   public std::__unary_function<const Teuchos::RCP<Teuchos::ParameterList> &, Teuchos::RCP<T> > {};
 
 

--- a/packages/piro/src/Piro_ProviderHelpers.hpp
+++ b/packages/piro/src/Piro_ProviderHelpers.hpp
@@ -55,7 +55,7 @@ namespace Piro {
 //! \cond DETAILS
 
 template <typename T>
-struct ConstructorProviderFunctor : public ProviderFunctorBase<T> {
+struct ConstructorProviderFunctor {
 public:
   Teuchos::RCP<T> operator()(const Teuchos::RCP<Teuchos::ParameterList> &params) const {
     return Teuchos::rcp(new T(params));
@@ -63,7 +63,7 @@ public:
 };
 
 template <typename T>
-struct DefaultConstructorProviderFunctor : public ProviderFunctorBase<T> {
+struct DefaultConstructorProviderFunctor {
 public:
   Teuchos::RCP<T> operator()(const Teuchos::RCP<Teuchos::ParameterList> &/*params*/) const {
     return Teuchos::rcp(new T);
@@ -71,7 +71,7 @@ public:
 };
 
 template <typename T>
-struct ReferenceAcceptingConstructorProviderFunctor : public ProviderFunctorBase<T> {
+struct ReferenceAcceptingConstructorProviderFunctor {
 public:
   Teuchos::RCP<T> operator()(const Teuchos::RCP<Teuchos::ParameterList> &params) const {
     return Teuchos::rcp(new T(*params));
@@ -80,7 +80,7 @@ public:
 
 
 template <typename T, typename F>
-class CachingProviderFunctor : public ProviderFunctorBase<T> {
+class CachingProviderFunctor {
 public:
   CachingProviderFunctor() :
     otherFunctor_(),
@@ -113,7 +113,7 @@ makeCachingProviderFunctor(F otherFunctor)
 
 
 template <typename T, typename NullaryFunctor>
-class NullaryProviderFunctorAdapter : public ProviderFunctorBase<T> {
+class NullaryProviderFunctorAdapter {
 public:
   NullaryProviderFunctorAdapter() :
     nullaryFunctor_()
@@ -141,7 +141,7 @@ makeNullaryProviderFunctorAdapter(NullaryFunctor nf)
 
 
 template <typename T, typename ReferenceAcceptingFunctor>
-class ReferenceAcceptingProviderFunctorAdapter : public ProviderFunctorBase<T> {
+class ReferenceAcceptingProviderFunctorAdapter {
 public:
   ReferenceAcceptingProviderFunctorAdapter() :
     referenceAcceptingFunctor_()

--- a/packages/stokhos/src/Stokhos_KL_ProductEigenPair.hpp
+++ b/packages/stokhos/src/Stokhos_KL_ProductEigenPair.hpp
@@ -123,10 +123,8 @@ namespace Stokhos {
 
     //! Predicate class for sorting product eigenfunctions based on eigenvalue
     template <typename E, typename D>
-    struct ProductEigenPairGreater :
-      public std::__binary_function<ProductEigenPair<E,D>,
-                                  ProductEigenPair<E,D>,
-                                  bool> {
+    struct ProductEigenPairGreater
+    {
       bool operator() (const ProductEigenPair<E,D>& a,
                        const ProductEigenPair<E,D>& b) {
         return a.eig_val > b.eig_val;

--- a/packages/stokhos/src/Stokhos_KL_ProductEigenPair.hpp
+++ b/packages/stokhos/src/Stokhos_KL_ProductEigenPair.hpp
@@ -124,7 +124,7 @@ namespace Stokhos {
     //! Predicate class for sorting product eigenfunctions based on eigenvalue
     template <typename E, typename D>
     struct ProductEigenPairGreater :
-      public std::binary_function<ProductEigenPair<E,D>,
+      public std::__binary_function<ProductEigenPair<E,D>,
                                   ProductEigenPair<E,D>,
                                   bool> {
       bool operator() (const ProductEigenPair<E,D>& a,


### PR DESCRIPTION
Trilinos defaults to c++17 standard, but there are functions, e.g. [unary_function](https://en.cppreference.com/w/cpp/utility/functional/unary_function) and [binary_function](https://en.cppreference.com/w/cpp/utility/functional/binary_function) that are removed in c++17 and replaced with __binary_function and __unary_function, these must be replaced

The incomplete compatibility with the default c++17 standard creates problems for more pedantic compilers (I'm looking at you apple-clang).


https://github.com/trilinos/Trilinos/labels/pkg%3A%20Panzer
https://github.com/trilinos/Trilinos/labels/pkg%3A%20Percept
https://github.com/trilinos/Trilinos/labels/pkg%3A%20Piro
https://github.com/trilinos/Trilinos/labels/pkg%3A%20Stokhos
https://github.com/trilinos/Trilinos/labels/pkg%3A%20Amesos2
https://github.com/trilinos/Trilinos/labels/pkg%3A%20Belos
@rppawlo
@ikalash
 @rppawlo

## Motivation
#12378 #12201

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes #12378 #12201
* Reviewers @cgcgcg 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->