### PR TITLE
Framework: Fix location of TriBITS default var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,8 @@ SET(${PROJECT_NAME}_EXCLUDE_DISABLED_SUBPACKAGES_FROM_DISTRIBUTION_DEFAULT FALSE
 
 SET(Trilinos_USE_GNUINSTALLDIRS_DEFAULT ON)
 
+SET(Trilinos_MUST_FIND_ALL_TPL_LIBS_DEFAULT TRUE)
+
 # Set up C++ language standard selection
 include(SetTrilinosCxxStandard)
 
@@ -106,8 +108,6 @@ INSTALL_BUILD_STATS_SCRIPTS()
 
 # Install TriBITS so that other projects can use it
 include(SetupTribitsInstall)
-
-SET(Trilinos_MUST_FIND_ALL_TPL_LIBS_DEFAULT TRUE)
 
 IF(${PROJECT_NAME}_ENABLE_YouCompleteMe)
   INCLUDE(CodeCompletion)


### PR DESCRIPTION
Need default settings for TriBITS to be set prior to TRIBITS_PROJECT() call.

User Support Ticket(s) or Story Referenced: N/A

@trilinos/framework 

## Motivation
Want to ensure cleaner Trilinos configurations with respect to TPLs, and the previous change didn't get this setting turned on in the correct spot.


## Related Issues

This may re-introduce #12376

## Testing
Technically I think that #12376 tests and confirms this is working.