### PR TITLE
Framework: Enhance find_package(Trilinos) test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ SET(${PROJECT_NAME}_ENABLE_CPACK_PACKAGING_DEFAULT ON)
 # Don't allow disabled subpackages to be excluded from tarball
 SET(${PROJECT_NAME}_EXCLUDE_DISABLED_SUBPACKAGES_FROM_DISTRIBUTION_DEFAULT FALSE)
 
+
 SET(Trilinos_USE_GNUINSTALLDIRS_DEFAULT ON)
 
 # Set up C++ language standard selection

--- a/packages/TrilinosInstallTests/CMakeLists.txt
+++ b/packages/TrilinosInstallTests/CMakeLists.txt
@@ -253,6 +253,12 @@ tribits_add_advanced_test(find_package_Trilinos
       "-- Configuring done"
       "-- Generating done"
     ALWAYS_FAIL_ON_NONZERO_RETURN
+
+  TEST_1
+    MESSAGE "Build a dummy project that calls find_package(Trilinos)"
+    CMND "${CMAKE_COMMAND}"
+    ARGS --build .
+
   ADDED_TEST_NAME_OUT  find_package_Trilinos_name
   )
   # NOTE: The above test will run find_package(Trilinos) for **all** of the

--- a/packages/TrilinosInstallTests/find_package_Trilinos/CMakeLists.txt
+++ b/packages/TrilinosInstallTests/find_package_Trilinos/CMakeLists.txt
@@ -9,3 +9,6 @@ find_package(Trilinos REQUIRED)
 message("Trilinos_FOUND = '${Trilinos_FOUND}'")
 message("Trilinos_SELECTED_PACAKGES_LIST = '${Trilinos_SELECTED_PACAKGES_LIST}'")
 message("Trilinos_LIBRARIES = '${Trilinos_LIBRARIES}'")
+
+add_executable(hello hello.c)
+target_link_libraries(hello PUBLIC ${Trilinos_LIBRARIES})

--- a/packages/TrilinosInstallTests/find_package_Trilinos/CMakeLists.txt
+++ b/packages/TrilinosInstallTests/find_package_Trilinos/CMakeLists.txt
@@ -10,5 +10,5 @@ message("Trilinos_FOUND = '${Trilinos_FOUND}'")
 message("Trilinos_SELECTED_PACAKGES_LIST = '${Trilinos_SELECTED_PACAKGES_LIST}'")
 message("Trilinos_LIBRARIES = '${Trilinos_LIBRARIES}'")
 
-add_executable(hello hello.c)
+add_executable(hello hello.cpp)
 target_link_libraries(hello PUBLIC ${Trilinos_LIBRARIES})

--- a/packages/TrilinosInstallTests/find_package_Trilinos/hello.c
+++ b/packages/TrilinosInstallTests/find_package_Trilinos/hello.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+    printf("Hello, world!");
+}

--- a/packages/TrilinosInstallTests/find_package_Trilinos/hello.c
+++ b/packages/TrilinosInstallTests/find_package_Trilinos/hello.c
@@ -1,5 +1,0 @@
-#include <stdio.h>
-
-int main(int argc, char** argv) {
-    printf("Hello, world!");
-}

--- a/packages/TrilinosInstallTests/find_package_Trilinos/hello.cpp
+++ b/packages/TrilinosInstallTests/find_package_Trilinos/hello.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello World!";
+    return 0;
+}


### PR DESCRIPTION
Enhance find_package(Trilinos) test to catch issues like #12371
@trilinos/framework

## Motivation
Turning on LINK_LIBRARIES_ONLY_TARGETS caused an issue with a downstream customer when we did not set up the installation correctly with respect to imported targets.


## Related Issues
#12362 
#12371 
#10081 

## Testing
Tested with the changes from #12362 and it immediately caught the issue.