### PR TITLE
Container changes

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1160,6 +1160,8 @@ use COMMON
 
 [RHEL7_POST]
 
+[RHEL8_POST]
+
 [RHEL7_TEST_DISABLES|INTEL]
 #Failing tests under C++14
 #Remove line if test has been fixed
@@ -1566,8 +1568,11 @@ opt-set-cmake-var TPL_BLAS_LIBRARIES        STRING FORCE : ${CBLAS_ROOT|ENV}/lib
 opt-set-cmake-var TPL_LAPACK_LIBRARY_DIRS   STRING FORCE : ${LAPACK_ROOT|ENV}/lib
 opt-set-cmake-var TPL_LAPACK_LIBRARIES      STRING FORCE : -L${LAPACK_ROOT|ENV}/lib;-lgfortran;-lgomp;${LAPACK_ROOT|ENV}/lib/liblapack.a
 
-[RHEL7_COMPILER|GNU]
+[COMPILER|GNU]
 opt-set-cmake-var MPI_EXEC FILEPATH : mpirun
+
+[RHEL7_COMPILER|GNU]
+use COMPILER|GNU
 
 [RHEL7_COMPILER|INTEL]
 opt-set-cmake-var MPI_EXEC FILEPATH : mpirun
@@ -1615,6 +1620,9 @@ opt-set-cmake-var TPL_HDF5_LIBRARIES STRING : ${SEMS_HDF5_LIBRARY_PATH|ENV}/libh
 use LIB-TYPE|STATIC
 
 [RHEL8_SEMS_LIB-TYPE|SHARED]
+use LIB-TYPE|SHARED
+
+[RHEL8_LIB-TYPE|SHARED]
 use LIB-TYPE|SHARED
 
 [RHEL7_SEMS_V2_LIB-TYPE|STATIC]
@@ -2819,6 +2827,46 @@ use RHEL7_POST
 use rhel7_sems-gnu-8.3.0-openmpi-1.10.7-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
+[rhel8_gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+#uses a containerized environment
+use COMPILER|GNU
+use NODE-TYPE|SERIAL
+use BUILD-TYPE|DEBUG
+
+use RHEL8_LIB-TYPE|SHARED
+use KOKKOS-ARCH|NO-KOKKOS-ARCH
+
+use USE-ASAN|NO
+use USE-FPIC|NO
+use USE-MPI|YES
+use USE-PT|NO
+use USE-COMPLEX|NO
+use USE-RDC|NO
+use USE-UVM|NO
+use USE-DEPRECATED|YES
+use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
+
+use COMMON_SPACK_TPLS
+
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none
+opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL         : ON
+opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
+opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
+opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL         : ON
+opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL     : ON
+opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+
+opt-set-cmake-var TPL_ENABLE_SuperLU BOOL FORCE: OFF
+
+
+use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
+
+use RHEL8_POST
+
+
+[rhel8_gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+use rhel8_gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use PACKAGE-ENABLES|ALL
 
 [rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use BUILD-TYPE|RELEASE-DEBUG

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -173,6 +173,7 @@ gnu
 
 [rhel8]
 oneapi-intelmpi
+gcc-openmpi
 sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.1.4
 
 [ats2]

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -33,6 +33,7 @@ function bootstrap_modules() {
     message_std "PRDriver> " "Job is $JOB_BASE_NAME"
 
     vortex_regex=".*(vortex).*"
+    container_regex=".*(container).*"
     if [[ ${NODE_NAME:?} =~ ${vortex_regex} || ${on_ats2} == "1" ]]; then
         execute_command_checked "module load git/2.20.0"
         execute_command_checked "module load python/3.7.2"
@@ -41,6 +42,9 @@ function bootstrap_modules() {
         mkdir -p /tmp/trilinos
 
         module list
+    elif [[ ${NODE_NAME:?} =~ ${container_regex} ]]; then
+	echo "Nothing done for bootstrap in a container"
+	module list
     elif [[ ${on_weaver} == "1" ]]; then
         module unload git
         module unload python


### PR DESCRIPTION
@trilinos/framework 

## Motivation
This adds a gcc build configuration that works with an environment container.  This will be run on PRs to compare to the production process.  This on;y add the build configuration there will be another PR for the addition of the necessary github actions

## Testing
The cdash history of this build can be found here:
[gcc container build on testing.sandia.gov](https://testing.sandia.gov/cdash/index.php?project=Trilinos&filtercount=2&showfilters=1&filtercombine=and&field1=site&compare1=63&value1=trilinos-container-gcc-8&field2=buildstarttime&compare2=84&value2=now)