### PR TITLE
MueLu: Adding ML-compatability option for Phase1 Aggregation

### DIFF
--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -708,6 +708,15 @@
     </parameter>
 
     <parameter>
+      <name>aggregation: match ML phase1</name>
+      <type>bool</type>
+      <default>false</default>
+      <description>Match ML's phase 1. In particular, setting this to true will ignore boundary neighbors in trying to pick root nodes.</description>
+      <visible>false</visible>
+      <comment-ML>parameter not existing in ML</comment-ML>
+    </parameter>
+
+    <parameter>
       <name>aggregation: match ML phase2a</name>
       <type>bool</type>
       <default>false</default>
@@ -720,7 +729,7 @@
       <name>aggregation: match ML phase2b</name>
       <type>bool</type>
       <default>false</default>
-      <description>Match ML's phase 2a.</description>
+      <description>Match ML's phase 2b.</description>
       <visible>false</visible>
       <comment-ML>parameter not existing in ML</comment-ML>
     </parameter>

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -140,9 +140,11 @@
         
 \cbb{aggregation: enable phase 3}{bool}{true}{Turn on/off phase 3 of aggregation}
         
+\cbb{aggregation: match ML phase1}{bool}{false}{Match ML's phase 1. In particular, setting this to true will ignore boundary neighbors in trying to pick root nodes.}
+        
 \cbb{aggregation: match ML phase2a}{bool}{false}{Match ML's phase 2a. In particular, setting this to true will include the root node into the tentative aggregates in phase 2a.}
         
-\cbb{aggregation: match ML phase2b}{bool}{false}{Match ML's phase 2a.}
+\cbb{aggregation: match ML phase2b}{bool}{false}{Match ML's phase 2b.}
         
 \cbb{aggregation: phase2a agg factor}{double}{0.5}{Agg factor for Phase 2a sizes}
         

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_def.hpp
@@ -170,7 +170,7 @@ namespace MueLu {
             if (aggSize < as<size_t>(maxNodesPerAggregate))
               aggList[aggSize++] = neigh;
 
-          } else if(matchMLBehavior && aggStat[neigh] != IGNORED) {
+          } else if(!matchMLBehavior || aggStat[neigh] != IGNORED) {
             // NOTE: ML checks against BOUNDARY here, but boundary nodes are flagged as IGNORED by
             // the time we get to Phase 1, so we check IGNORED instead
             numAggregatedNeighbours++;

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_def.hpp
@@ -72,6 +72,7 @@ namespace MueLu {
     int maxNeighAlreadySelected = params.get<int>        ("aggregation: max selected neighbors");
     int minNodesPerAggregate    = params.get<int>        ("aggregation: min agg size");
     int maxNodesPerAggregate    = params.get<int>        ("aggregation: max agg size");
+    bool matchMLbehavior        = params.get<bool>("aggregation: match ML phase1");
 
     TEUCHOS_TEST_FOR_EXCEPTION(maxNodesPerAggregate < minNodesPerAggregate, Exceptions::RuntimeError,
       "MueLu::UncoupledAggregationAlgorithm::BuildAggregates: minNodesPerAggregate must be smaller or equal to MaxNodePerAggregate!");
@@ -169,7 +170,9 @@ namespace MueLu {
             if (aggSize < as<size_t>(maxNodesPerAggregate))
               aggList[aggSize++] = neigh;
 
-          } else {
+          } else if(matchMLBehavior && aggStat[neigh] != IGNORED)
+            // NOTE: ML checks against BOUNDARY here, but boundary nodes are flagged as IGNORED by
+            // the time we get to Phase 1, so we check IGNORED instead
             numAggregatedNeighbours++;
           }
         }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_def.hpp
@@ -72,7 +72,7 @@ namespace MueLu {
     int maxNeighAlreadySelected = params.get<int>        ("aggregation: max selected neighbors");
     int minNodesPerAggregate    = params.get<int>        ("aggregation: min agg size");
     int maxNodesPerAggregate    = params.get<int>        ("aggregation: max agg size");
-    bool matchMLbehavior        = params.get<bool>("aggregation: match ML phase1");
+    bool matchMLBehavior        = params.get<bool>("aggregation: match ML phase1");
 
     TEUCHOS_TEST_FOR_EXCEPTION(maxNodesPerAggregate < minNodesPerAggregate, Exceptions::RuntimeError,
       "MueLu::UncoupledAggregationAlgorithm::BuildAggregates: minNodesPerAggregate must be smaller or equal to MaxNodePerAggregate!");

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_def.hpp
@@ -170,7 +170,7 @@ namespace MueLu {
             if (aggSize < as<size_t>(maxNodesPerAggregate))
               aggList[aggSize++] = neigh;
 
-          } else if(matchMLBehavior && aggStat[neigh] != IGNORED)
+          } else if(matchMLBehavior && aggStat[neigh] != IGNORED) {
             // NOTE: ML checks against BOUNDARY here, but boundary nodes are flagged as IGNORED by
             // the time we get to Phase 1, so we check IGNORED instead
             numAggregatedNeighbours++;

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_def.hpp
@@ -96,6 +96,7 @@ namespace MueLu {
     SET_VALID_ENTRY("aggregation: enable phase 2a");
     SET_VALID_ENTRY("aggregation: enable phase 2b");
     SET_VALID_ENTRY("aggregation: enable phase 3");
+    SET_VALID_ENTRY("aggregation: match ML phase1");
     SET_VALID_ENTRY("aggregation: match ML phase2a");
     SET_VALID_ENTRY("aggregation: match ML phase2b");
     SET_VALID_ENTRY("aggregation: phase2a agg factor");

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
@@ -170,8 +170,8 @@ namespace MueLu {
     if (pL.get<bool>("aggregation: enable phase 3" )                 == true)   algos_.push_back(rcp(new AggregationPhase3Algorithm_kokkos            (graphFact)));
 
     // Sanity Checking: match ML behavior is not supported in UncoupledAggregation_Kokkos in Phase 1 or Phase 2b, but is in 2a
-.    TEUCHOS_TEST_FOR_EXCEPTION( params.get<bool>("aggregation: match ML phase1"),std::invalid_argument,"Option: 'aggregation: match ML phase1' is not supported in the Kokkos version of uncoupled aggregation");
-    TEUCHOS_TEST_FOR_EXCEPTION( params.get<bool>("aggregation: match ML phase2b"),std::invalid_argument,"Option: 'aggregation: match ML phase2b' is not supported in the Kokkos version of uncoupled aggregation");
+    TEUCHOS_TEST_FOR_EXCEPTION( pL.get<bool>("aggregation: match ML phase1"),std::invalid_argument,"Option: 'aggregation: match ML phase1' is not supported in the Kokkos version of uncoupled aggregation");
+    TEUCHOS_TEST_FOR_EXCEPTION( pL.get<bool>("aggregation: match ML phase2b"),std::invalid_argument,"Option: 'aggregation: match ML phase2b' is not supported in the Kokkos version of uncoupled aggregation");
 
     std::string mapOnePtName = pL.get<std::string>("OnePt aggregate map name");
     RCP<Map> OnePtMap = Teuchos::null;

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
@@ -169,6 +169,10 @@ namespace MueLu {
     if (pL.get<bool>("aggregation: enable phase 2b")                 == true)   algos_.push_back(rcp(new AggregationPhase2bAlgorithm_kokkos           (graphFact)));
     if (pL.get<bool>("aggregation: enable phase 3" )                 == true)   algos_.push_back(rcp(new AggregationPhase3Algorithm_kokkos            (graphFact)));
 
+    // Sanity Checking: match ML behavior is not supported in UncoupledAggregation_Kokkos in Phase 1 or Phase 2b, but is in 2a
+.    TEUCHOS_TEST_FOR_EXCEPTION( params.get<bool>("aggregation: match ML phase1"),std::invalid_argument,"Option: 'aggregation: match ML phase1' is not supported in the Kokkos version of uncoupled aggregation");
+    TEUCHOS_TEST_FOR_EXCEPTION( params.get<bool>("aggregation: match ML phase2b"),std::invalid_argument,"Option: 'aggregation: match ML phase2b' is not supported in the Kokkos version of uncoupled aggregation");
+
     std::string mapOnePtName = pL.get<std::string>("OnePt aggregate map name");
     RCP<Map> OnePtMap = Teuchos::null;
     if (mapOnePtName.length()) {

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
@@ -101,7 +101,9 @@ namespace MueLu {
     SET_VALID_ENTRY("aggregation: enable phase 2a");
     SET_VALID_ENTRY("aggregation: enable phase 2b");
     SET_VALID_ENTRY("aggregation: enable phase 3");
+    SET_VALID_ENTRY("aggregation: match ML phase1");
     SET_VALID_ENTRY("aggregation: match ML phase2a");
+    SET_VALID_ENTRY("aggregation: match ML phase2b");
     SET_VALID_ENTRY("aggregation: phase3 avoid singletons");
     SET_VALID_ENTRY("aggregation: error on nodes with no on-rank neighbors");
     SET_VALID_ENTRY("aggregation: preserve Dirichlet points");

--- a/packages/muelu/src/Interface/MueLu_ML2MueLuParameterTranslator.cpp
+++ b/packages/muelu/src/Interface/MueLu_ML2MueLuParameterTranslator.cpp
@@ -416,6 +416,9 @@ namespace MueLu {
         adaptingParamList.remove(pname,false);
       }
 
+      // make sure that MueLu's phase1 matches ML's
+      mueluss << "<Parameter name=\"aggregation: match ML phase1\"       type=\"bool\"     value=\"true\"/>" << std::endl;
+
       // make sure that MueLu's phase2a matches ML's
       mueluss << "<Parameter name=\"aggregation: match ML phase2a\"      type=\"bool\"     value=\"true\"/>" << std::endl;
 

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -1149,6 +1149,7 @@ namespace MueLu {
       MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 2a",           bool, aggParams);
       MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 2b",           bool, aggParams);
       MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 3",            bool, aggParams);
+      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: match ML phase1",           bool, aggParams);
       MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: match ML phase2a",          bool, aggParams);
       MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: match ML phase2b",          bool, aggParams);
       MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: phase2a agg factor",      double, aggParams);

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -243,6 +243,7 @@ namespace MueLu {
   "<Parameter name=\"aggregation: enable phase 2a\" type=\"bool\" value=\"true\"/>"
   "<Parameter name=\"aggregation: enable phase 2b\" type=\"bool\" value=\"true\"/>"
   "<Parameter name=\"aggregation: enable phase 3\" type=\"bool\" value=\"true\"/>"
+  "<Parameter name=\"aggregation: match ML phase1\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"aggregation: match ML phase2a\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"aggregation: match ML phase2b\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"aggregation: phase2a agg factor\" type=\"double\" value=\"0.5\"/>"
@@ -706,6 +707,8 @@ namespace MueLu {
          ("aggregation: enable phase 2b","aggregation: enable phase 2b")
       
          ("aggregation: enable phase 3","aggregation: enable phase 3")
+      
+         ("aggregation: match ML phase1","aggregation: match ML phase1")
       
          ("aggregation: match ML phase2a","aggregation: match ML phase2a")
       

--- a/packages/muelu/src/Operators/MueLu_Maxwell1_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_Maxwell1_def.hpp
@@ -113,6 +113,7 @@ namespace MueLu {
       newList.sublist("maxwell1: 22list").set("aggregation: use ml scaling of drop tol",true);
 
       newList.sublist("maxwell1: 22list").set("aggregation: min agg size",3);
+      newList.sublist("maxwell1: 22list").set("aggregation: match ML phase1",true);
       newList.sublist("maxwell1: 22list").set("aggregation: match ML phase2a",true);
       newList.sublist("maxwell1: 22list").set("aggregation: match ML phase2b",true);
 

--- a/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
@@ -1235,8 +1235,12 @@ namespace MueLu {
         UncoupledAggFact->SetParameter("aggregation: min agg size",Teuchos::ParameterEntry(minAggSize));
         int maxAggSize = parameterList_.get("aggregation: max agg size",-1);
         UncoupledAggFact->SetParameter("aggregation: max agg size",Teuchos::ParameterEntry(maxAggSize));
-        bool matchMLbehavior = parameterList_.get("aggregation: match ML phase2a",MasterList::getDefault<bool>("aggregation: match ML phase2a"));
-        UncoupledAggFact->SetParameter("aggregation: match ML phase2a",Teuchos::ParameterEntry(matchMLbehavior));
+        bool matchMLbehavior1 = parameterList_.get("aggregation: match ML phase1",MasterList::getDefault<bool>("aggregation: match ML phase1"));
+        UncoupledAggFact->SetParameter("aggregation: match ML phase1",Teuchos::ParameterEntry(matchMLbehavior1));
+        bool matchMLbehavior2a = parameterList_.get("aggregation: match ML phase2a",MasterList::getDefault<bool>("aggregation: match ML phase2a"));
+        UncoupledAggFact->SetParameter("aggregation: match ML phase2a",Teuchos::ParameterEntry(matchMLbehavior2a));
+        bool matchMLbehavior2b = parameterList_.get("aggregation: match ML phase2b",MasterList::getDefault<bool>("aggregation: match ML phase2b"));
+        UncoupledAggFact->SetParameter("aggregation: match ML phase2b",Teuchos::ParameterEntry(matchMLbehavior2b));
         bool avoidSingletons = parameterList_.get("aggregation: phase3 avoid singletons",true);
         UncoupledAggFact->SetParameter("aggregation: phase3 avoid singletons",Teuchos::ParameterEntry(avoidSingletons));
 


### PR DESCRIPTION
Issue: #11214
Tests: App
Stakeholder feedback: n/a

ML does not consider boundary neighbors to be 'aggregated' in the context of Phase1 aggregation for root node selection.  MueLu did.  Adding the option to do things more ML-style