### PR TITLE
Panzer and NOX cleanup

### DIFF
--- a/packages/nox/test/epetra/MultiPhysics/Problem_Manager.C
+++ b/packages/nox/test/epetra/MultiPhysics/Problem_Manager.C
@@ -1033,7 +1033,7 @@ Problem_Manager::computeBlockJacobian(int probId, int depId)
     OffBlock_Manager::idToFind = depId;
 
     std::vector<OffBlock_Manager *>::iterator iter =
-      find_if( managerVec.begin(), managerVec.end(), mem_fun( &OffBlock_Manager::isMember) );
+      find_if( managerVec.begin(), managerVec.end(), mem_fn( &OffBlock_Manager::isMember) );
 
     if( managerVec.end() == iter )
     {
@@ -1096,7 +1096,7 @@ Problem_Manager::getBlockJacobianMatrix(int probId, int depId)
     OffBlock_Manager::idToFind = depId;
 
     std::vector<OffBlock_Manager *>::iterator iter =
-      find_if( offVec.begin(), offVec.end(), mem_fun( &OffBlock_Manager::isMember) );
+      find_if( offVec.begin(), offVec.end(), mem_fn( &OffBlock_Manager::isMember) );
 
     if( offVec.end() == iter )
     {

--- a/packages/panzer/adapters-stk/src/Panzer_STKConnManager.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STKConnManager.cpp
@@ -214,6 +214,13 @@ STKConnManager::addSubcellConnectivities(stk::mesh::Entity element,
    LocalOrdinal numIds = 0;
    stk::mesh::BulkData& bulkData = *stkMeshDB_->getBulkData();
    const stk::mesh::EntityRank rank = static_cast<stk::mesh::EntityRank>(subcellRank);
+
+#ifdef PANZER_DEBUG
+   TEUCHOS_TEST_FOR_EXCEPTION(maxIds > bulkData.num_connectivity(element, rank),
+                              std::runtime_error,
+                              "ERROR: The maxIds (num vertices from basis cell topology) is greater than the num vertices in the stk mesh topology!");
+#endif
+
    const size_t num_rels = (maxIds > 0) ? maxIds : bulkData.num_connectivity(element, rank);
    stk::mesh::Entity const* relations = bulkData.begin(element, rank);
    for(std::size_t sc=0; sc<num_rels; ++sc) {

--- a/packages/panzer/adapters-stk/src/responses/Panzer_STK_ResponseEvaluatorFactory_SolutionWriter.hpp
+++ b/packages/panzer/adapters-stk/src/responses/Panzer_STK_ResponseEvaluatorFactory_SolutionWriter.hpp
@@ -118,7 +118,7 @@ private:
    void deleteRemovedFields(const std::vector<std::string> & removedFields,
                             std::vector<std::pair<std::string,Teuchos::RCP<const panzer::PureBasis> > > & fields) const;
 
-   struct RemovedFieldsSearchUnaryFunctor : public std::unary_function<std::pair<std::string,const panzer::PureBasis>,bool> {
+   struct RemovedFieldsSearchUnaryFunctor {
      std::vector<std::string> removedFields_;
      bool operator() (const std::pair<std::string,Teuchos::RCP<const panzer::PureBasis> > & field) 
      { return std::find(removedFields_.begin(),removedFields_.end(),field.first)!=removedFields_.end(); }


### PR DESCRIPTION
Fix deprecated functions in c++17 standard in Panzer and NOX.

Add debug check to panzer connection manager to make sure topologies are consistent.
