### PR TITLE
ROL: Allow use of MPI_COMM_WORLD as default arg

### DIFF
--- a/packages/rol/src/oed/utilities/OED_SplitComm.hpp
+++ b/packages/rol/src/oed/utilities/OED_SplitComm.hpp
@@ -58,7 +58,7 @@ private:
   ROL::Ptr<Comm> comm_sample_;
 
 public:
-  SplitComm(const int m, Mpi_Comm global_comm = MPI_COMM_WORLD) {
+  SplitComm(const int m, Mpi_Comm global_comm = MPI_COMM_WORLD) { // CHECK: ALLOW MPI_COMM_WORLD
     Ordinal rank, Ngroups, size;
     MPI_Comm_rank(global_comm, &rank);
     MPI_Comm_size(global_comm, &size);


### PR DESCRIPTION
@trilinos/rol 

## Motivation
Currently, the use of `MPI_COMM_WORLD` blocks the dev->master promotion. This is a perfectly reasonable use of it, so let's set the hint.