### PR TITLE
KokkosKernels: controls: don't print a noisy warning

### DIFF
--- a/packages/kokkos-kernels/sparse/src/KokkosKernels_Controls.hpp
+++ b/packages/kokkos-kernels/sparse/src/KokkosKernels_Controls.hpp
@@ -64,8 +64,6 @@ class Controls {
                            const std::string& orUnset = "") const {
     auto search = kernel_parameters.find(name);
     if (kernel_parameters.end() == search) {
-      std::cerr << "WARNING: Controls::getParameter for name \"" << name
-                << "\" was unset" << std::endl;
       return orUnset;
     } else {
       return search->second;


### PR DESCRIPTION
Match a change made in kokkos-kernels upstream 86d8371fdb3d528095a86635b9add53a36bb516e

The next kokkos-kernels snapshot will include this change