### PR TITLE
Tpetra: in TAFC iterate over domainMap efficiently

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
@@ -1204,14 +1204,11 @@ lowCommunicationMakeColMapAndReindex (
   //     each domain GID is a column GID.  we want to do this to
   //     maintain a consistent ordering of GIDs between the columns
   //     and the domain.
-  Teuchos::ArrayView<const GO> domainGlobalElements = domainMap.getLocalElementList();
-  auto domainGlobalElements_view = Details::create_mirror_view_from_raw_host_array(exec, domainGlobalElements.getRawPtr(), domainGlobalElements.size(), true, "domainGlobalElements");
-  
   if (static_cast<size_t> (NumLocalColGIDs) == numDomainElements) {
     if (NumLocalColGIDs > 0) {
       // Load Global Indices into first numMyCols elements column GID list
-      Kokkos::parallel_for(Kokkos::RangePolicy<execution_space>(0, domainGlobalElements.size()), KOKKOS_LAMBDA(const int i) {
-        ColIndices_view[i] = domainGlobalElements_view[i];
+      Kokkos::parallel_for(Kokkos::RangePolicy<execution_space>(0, numDomainElements), KOKKOS_LAMBDA(const int i) {
+        ColIndices_view[i] = domainMap_local.getGlobalElement(i);
       });
     }
   }
@@ -1220,7 +1217,7 @@ lowCommunicationMakeColMapAndReindex (
     LO NumLocalAgain = 0;
     Kokkos::parallel_scan(Kokkos::RangePolicy<execution_space>(0, numDomainElements), KOKKOS_LAMBDA(const int i, LO& update, const bool final) {
       if(final && LocalGIDs_view[i]) {
-        ColIndices_view[update] = domainGlobalElements_view[i];
+        ColIndices_view[update] = domainMap_local.getGlobalElement(i);
       }
       if(LocalGIDs_view[i]) {
         update++;
@@ -1450,14 +1447,11 @@ lowCommunicationMakeColMapAndReindex (
   //     each domain GID is a column GID.  we want to do this to
   //     maintain a consistent ordering of GIDs between the columns
   //     and the domain.
-  Teuchos::ArrayView<const GO> domainGlobalElements = domainMap.getLocalElementList();
-  auto domainGlobalElements_view = Details::create_mirror_view_from_raw_host_array(exec, domainGlobalElements.getRawPtr(), domainGlobalElements.size(), true, "domainGlobalElements");
-  
   if (static_cast<size_t> (NumLocalColGIDs) == numDomainElements) {
     if (NumLocalColGIDs > 0) {
       // Load Global Indices into first numMyCols elements column GID list
-      Kokkos::parallel_for(Kokkos::RangePolicy<execution_space>(0, domainGlobalElements.size()), KOKKOS_LAMBDA(const int i) {
-        ColIndices_view[i] = domainGlobalElements_view[i];
+      Kokkos::parallel_for(Kokkos::RangePolicy<execution_space>(0, numDomainElements), KOKKOS_LAMBDA(const int i) {
+        ColIndices_view[i] = domainMap_local.getGlobalElement(i);
       });
     }
   }
@@ -1466,7 +1460,7 @@ lowCommunicationMakeColMapAndReindex (
     LO NumLocalAgain = 0;
     Kokkos::parallel_scan(Kokkos::RangePolicy<execution_space>(0, numDomainElements), KOKKOS_LAMBDA(const int i, LO& update, const bool final) {
       if(final && LocalGIDs_view[i]) {
-        ColIndices_view[update] = domainGlobalElements_view[i];
+        ColIndices_view[update] = domainMap_local.getGlobalElement(i);
       }
       if(LocalGIDs_view[i]) {
         update++;


### PR DESCRIPTION
Iterate over domainMap efficiently on device using local map ``getGlobalElement(lid)``, instead of getting a host view of GIDs and copying that to device. This avoids a copy and is faster if the domain map is contiguous (where ``getGlobalElement()`` is just an addition).

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Covered by several CrsMatrix unit tests: Bug10008_2, Bug10008_3, Bug8447.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->