### PR TITLE
Framework: Remove deleted packages from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,19 +8,9 @@
 
 /packages/belos/             @trilinos/belos
 
-/packages/claps/             @trilinos/claps
-
-/packages/domi/              @trilinos/domi
-
 /packages/epetra/            @trilinos/epetra
 
 /packages/epetraext/         @trilinos/epetraext
-
-/packages/fei/               @trilinos/fei
-
-#/packages/galeri/            @trilinos/
-
-/packages/globipack/         @trilinos/globipack
 
 /packages/ifpack/            @trilinos/ifpack
 
@@ -36,15 +26,7 @@
 
 /packages/kokkos-kernels/    @trilinos/kokkos-kernels
 
-/packages/komplex/           @trilinos/komplex
-
-#/packages/meshinggenie/      @trilinos/
-
-#/packages/minitensor/        @trilinos/
-
 /packages/ml/                @trilinos/ml
-
-/packages/moertel/           @trilinos/moertel
 
 /packages/muelu/             @trilinos/muelu
 
@@ -52,15 +34,11 @@
 
 /packages/nox/               @trilinos/nox
 
-/packages/optipack/          @trilinos/optipack
-
 /packages/pamgen/            @trilinos/pamgen
 
 /packages/panzer/            @trilinos/panzer
 
 /packages/phalanx/           @trilinos/phalanx
-
-#/packages/pike/              @trilinos/
 
 /packages/piro/              @trilinos/piro
 
@@ -71,8 +49,6 @@
 /packages/rol/               @trilinos/rol
 
 /packages/rtop/              @trilinos/rtop
-
-/packages/rythmos/           @trilinos/rythmos
 
 /packages/sacado/            @trilinos/sacado
 
@@ -94,17 +70,9 @@
 
 /packages/teuchos/           @trilinos/teuchos
 
-#/packages/ThreadPool/        @trilinos/
-
 /packages/thyra/             @trilinos/thyra
 
 /packages/tpetra/            @trilinos/tpetra
-
-/packages/TriKota/           @trilinos/trikota
-
-#/packages/trilinoscouplings/ @trilinos/
-
-#/packages/trios/             @trilinos/
 
 /packages/triutils/          @trilinos/triutils
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,8 @@
 
 /packages/epetraext/         @trilinos/epetraext
 
+/packages/framework/         @trilinos/framework
+
 /packages/ifpack/            @trilinos/ifpack
 
 /packages/ifpack2/           @trilinos/ifpack2

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,6 +74,8 @@
 
 /packages/tpetra/            @trilinos/tpetra
 
+/packages/trilinoscouplings/ @trilinos/trilinoscouplings
+
 /packages/triutils/          @trilinos/triutils
 
 /packages/xpetra/            @trilinos/xpetra


### PR DESCRIPTION
Also remove commented lines.

@trilinos/framework

## Motivation
Want a valid CODEOWNERS now that we can re-enable CODEOWNERS capability.


## Related Issues

* Closes #11812 
