### PR TITLE
Framework: Relocate CXX standard setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,6 @@ SET(Trilinos_USE_GNUINSTALLDIRS_DEFAULT ON)
 
 SET(Trilinos_MUST_FIND_ALL_TPL_LIBS_DEFAULT TRUE)
 
-# Set up C++ language standard selection
-include(SetTrilinosCxxStandard)
-
 # Some CMake and TriBiTS tweaks just for Trilinos
 include(TrilinosTweaks)
 

--- a/cmake/CallbackSetupExtraOptions.cmake
+++ b/cmake/CallbackSetupExtraOptions.cmake
@@ -92,3 +92,6 @@ include("${Trilinos_SOURCE_DIR}/commonTools/build_stats/BuildStatsWrappers.cmake
 generate_build_stats_wrappers()
 remove_build_stats_file_on_configure()
 remove_build_stats_timing_files_on_fresh_configure()
+
+# Set up C++ language standard selection
+include(SetTrilinosCxxStandard)


### PR DESCRIPTION
Need to process CXX standard after a potential CONFIGURE_OPTIONS_FILE has been processed.  This manifested a small bug where the configure message about which CXX standard was being used showed 17 even though the entry in the Trilinos_CONFIGURE_OPTIONS_FILE read 20 (and in fact it did use 20).

## Motivation
Want diagnostic messages to align with the actual behavior.

## Testing
Tested using `-DTrilinos_CONFIGURE_OPTIONS_FILE` and it now behaves correctly.
