### PR TITLE
Tpetra, MueLu: use new Node traits to simplify code

### DIFF
--- a/packages/muelu/src/Interface/MueLu_MLParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_MLParameterListInterpreter_def.hpp
@@ -192,27 +192,7 @@ namespace MueLu {
 
     // pull out "use kokkos refactor"
     bool setKokkosRefactor = false;
-    bool useKokkosRefactor;
-# ifdef HAVE_MUELU_SERIAL
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSerialWrapperNode).name())
-      useKokkosRefactor = false;
-# endif
-# ifdef HAVE_MUELU_OPENMP
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosOpenMPWrapperNode).name())
-      useKokkosRefactor = true;
-# endif
-# ifdef HAVE_MUELU_CUDA
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosCudaWrapperNode).name())
-      useKokkosRefactor = true;
-# endif
-# ifdef HAVE_MUELU_HIP
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosHIPWrapperNode).name())
-      useKokkosRefactor = true;
-# endif
-# ifdef HAVE_MUELU_SYCL
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSYCLWrapperNode).name())
-      useKokkosRefactor = true;
-#endif
+    bool useKokkosRefactor = !Node::is_serial;
     if (paramList.isType<bool>("use kokkos refactor")) {
       useKokkosRefactor = paramList.get<bool>("use kokkos refactor");
       setKokkosRefactor = true;

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -254,26 +254,7 @@ namespace MueLu {
     }
 
     // Check for Kokkos
-# ifdef HAVE_MUELU_SERIAL
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSerialWrapperNode).name())
-      useKokkos_ = false;
-# endif
-# ifdef HAVE_MUELU_OPENMP
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosOpenMPWrapperNode).name())
-      useKokkos_ = true;
-# endif
-# ifdef HAVE_MUELU_CUDA
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosCudaWrapperNode).name())
-      useKokkos_ = true;
-# endif
-# ifdef HAVE_MUELU_HIP
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosHIPWrapperNode).name())
-      useKokkos_ = true;
-# endif
-# ifdef HAVE_MUELU_SYCL
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSYCLWrapperNode).name())
-      useKokkos_ = true;
-# endif    
+    useKokkos_ = !Node::is_serial;
     (void)MUELU_TEST_AND_SET_VAR(paramList, "use kokkos refactor", bool, useKokkos_);
 
     // Check for timer synchronization

--- a/packages/muelu/src/MueCentral/MueLu_FactoryManager_decl.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_FactoryManager_decl.hpp
@@ -119,52 +119,14 @@ namespace MueLu {
     //! @brief Constructor.
     FactoryManager() {
       SetIgnoreUserData(false); // set IgnorUserData flag to false (default behaviour)
-# ifdef HAVE_MUELU_SERIAL
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSerialWrapperNode).name())
-        useKokkos_ = false;
-# endif
-# ifdef HAVE_MUELU_OPENMP
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosOpenMPWrapperNode).name())
-        useKokkos_ = true;
-# endif
-# ifdef HAVE_MUELU_CUDA
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosCudaWrapperNode).name())
-        useKokkos_ = true;
-# endif
-# ifdef HAVE_MUELU_HIP
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosHIPWrapperNode).name())
-        useKokkos_ = true;
-# endif
-# ifdef HAVE_MUELU_SYCL
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSYCLWrapperNode).name())
-        useKokkos_ = true;
-# endif
+      useKokkos_ = !Node::is_serial;
     }
 
     //! Constructor used by HierarchyFactory (temporary, will be removed)
     FactoryManager(const std::map<std::string, RCP<const FactoryBase> >& factoryTable) {
       factoryTable_ = factoryTable;
       SetIgnoreUserData(false); // set IgnorUserData flag to false (default behaviour) //TODO: use parent class constructor instead
-# ifdef HAVE_MUELU_SERIAL
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSerialWrapperNode).name())
-        useKokkos_ = false;
-# endif
-# ifdef HAVE_MUELU_OPENMP
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosOpenMPWrapperNode).name())
-        useKokkos_ = true;
-# endif
-# ifdef HAVE_MUELU_CUDA
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosCudaWrapperNode).name())
-        useKokkos_ = true;
-# endif
-# ifdef HAVE_MUELU_HIP
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosHIPWrapperNode).name())
-        useKokkos_ = true;
-# endif
-# ifdef HAVE_MUELU_SYCL
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSYCLWrapperNode).name())
-        useKokkos_ = true;
-# endif
+      useKokkos_ = !Node::is_serial;
     }
 
     //! Destructor.

--- a/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
@@ -197,26 +197,7 @@ namespace MueLu {
         !precList22_.isParameter("reuse: type"))
       precList22_.set("reuse: type", "full");
 
-# ifdef HAVE_MUELU_SERIAL
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSerialWrapperNode).name())
-      useKokkos_ = false;
-# endif
-# ifdef HAVE_MUELU_OPENMP
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosOpenMPWrapperNode).name())
-      useKokkos_ = true;
-# endif
-# ifdef HAVE_MUELU_CUDA
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosCudaWrapperNode).name())
-      useKokkos_ = true;
-# endif
-# ifdef HAVE_MUELU_HIP
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosHIPWrapperNode).name())
-      useKokkos_ = true;
-# endif
-# ifdef HAVE_MUELU_SYCL
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSYCLWrapperNode).name())
-      useKokkos_ = true;
-# endif    
+    useKokkos_ = !Node::is_serial;
     useKokkos_ = list.get("use kokkos refactor",useKokkos_);
   }
 

--- a/packages/muelu/test/interface/CreateOperator.cpp
+++ b/packages/muelu/test/interface/CreateOperator.cpp
@@ -291,26 +291,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
 
     bool useKokkos = false;
     if(lib == Xpetra::UseTpetra) {
-# ifdef HAVE_MUELU_SERIAL
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSerialWrapperNode).name())
-        useKokkos = false;
-# endif
-# ifdef HAVE_MUELU_OPENMP
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosOpenMPWrapperNode).name())
-        useKokkos = true;
-# endif
-# ifdef HAVE_MUELU_CUDA
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosCudaWrapperNode).name())
-        useKokkos = true;
-# endif
-# ifdef HAVE_MUELU_HIP
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosHIPWrapperNode).name())
-        useKokkos = true;
-# endif
-# ifdef HAVE_MUELU_SYCL
-      if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSYCLWrapperNode).name())
-        useKokkos = true;
-# endif      
+      useKokkos = !Node::is_serial;
     }
     clp.setOption("useKokkosRefactor", "noKokkosRefactor", &useKokkos, "use kokkos refactor");
 

--- a/packages/muelu/test/interface/ParameterListInterpreter.cpp
+++ b/packages/muelu/test/interface/ParameterListInterpreter.cpp
@@ -98,43 +98,9 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   std::string xmlForceFile = "";
   bool useKokkos = false;
   if(lib == Xpetra::UseTpetra) {
-# ifdef HAVE_MUELU_SERIAL
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSerialWrapperNode).name())
-      useKokkos = false;
-# endif
-# ifdef HAVE_MUELU_OPENMP
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosOpenMPWrapperNode).name())
-      useKokkos = true;
-# endif
-# ifdef HAVE_MUELU_CUDA
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosCudaWrapperNode).name())
-      useKokkos = true;
-# endif
-# ifdef HAVE_MUELU_HIP
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosHIPWrapperNode).name())
-      useKokkos = true;
-# endif
-# ifdef HAVE_MUELU_SYCL
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSYCLWrapperNode).name())
-      useKokkos = true;
-# endif    
+      useKokkos = !Node::is_serial;
   }
-  bool compareWithGold = true;
-#ifdef KOKKOS_ENABLE_CUDA
-  if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosCudaWrapperNode).name())
-    // Behavior of some algorithms on Cuda is non-deterministic, so we won't check the output.
-    compareWithGold = false;
-#endif
-#ifdef KOKKOS_ENABLE_HIP
-  if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosHIPWrapperNode).name())
-    // Behavior of some algorithms on HIP is non-deterministic, so we won't check the output.
-    compareWithGold = false;
-#endif
-#ifdef KOKKOS_ENABLE_SYCL
-  if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSYCLWrapperNode).name())
-    // Behavior of some algorithms on SYCL is non-deterministic, so we won't check the output.
-    compareWithGold = false;
-#endif
+  bool compareWithGold = !Node::is_gpu;
   clp.setOption("useKokkosRefactor", "noKokkosRefactor", &useKokkos, "use kokkos refactor");
   clp.setOption("heavytests", "noheavytests",  &runHeavyTests, "whether to exercise tests that take a long time to run");
   clp.setOption("xml", &xmlForceFile, "xml input file (useful for debugging)");

--- a/packages/tpetra/core/compat/Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp
+++ b/packages/tpetra/core/compat/Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp
@@ -50,8 +50,14 @@ public:
   static constexpr bool is_serial = false;
 #endif
 
-  //! Whether the ExecutionSpace is CPU-like (its default memory space is HostSpace)
+  //! Whether the ExecutionSpace is CPU-like (its default memory space is HostSpace or HBWSpace)
+#ifdef KOKKOS_HBWSPACE_HPP
+  static constexpr bool is_cpu =
+    std::is_same_v<typename ExecutionSpace::memory_space, Kokkos::HostSpace> ||
+    std::is_same_v<typename ExecutionSpace::memory_space, Kokkos::Experimental::HBWSpace>;
+#else
   static constexpr bool is_cpu = std::is_same_v<typename ExecutionSpace::memory_space, Kokkos::HostSpace>;
+#endif
   //! Whether the ExecutionSpace is GPU-like (its default memory space is not HostSpace)
   static constexpr bool is_gpu = !is_cpu;
 

--- a/packages/tpetra/core/src/Tpetra_Details_KokkosTeuchosTimerInjection.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_KokkosTeuchosTimerInjection.cpp
@@ -68,7 +68,7 @@ namespace {
     else if (eid.type == DeviceType::HIP)          device_label+="HIP";
     else if (eid.type == DeviceType::OpenMPTarget) device_label+="OpenMPTarget";
     else if (eid.type == DeviceType::HPX)          device_label+="HPX";
-    else if (eid.type == DeviceType::Threads)      device_label+="Threats";
+    else if (eid.type == DeviceType::Threads)      device_label+="Threads";
     else if (eid.type == DeviceType::SYCL)         device_label+="SYCL";
     else if (eid.type == DeviceType::OpenACC)      device_label+="OpenACC";
     else if (eid.type == DeviceType::Unknown)      device_label+="Unknown";

--- a/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
@@ -44,6 +44,7 @@
 #include <Tpetra_Details_temporaryViewUtils.hpp>
 #include <Kokkos_DualView.hpp>
 #include "Teuchos_TestForException.hpp"
+#include "Tpetra_Details_ExecutionSpaces.hpp"
 #include <sstream>
 
 //#define DEBUG_UVM_REMOVAL  // Works only with gcc > 4.8
@@ -651,20 +652,9 @@ private:
     if(!wdvTrackingEnabled)
       return false;
 
-    // We check to see if the memory is not aliased *or* if it is a supported accelerator (for shared host/device memory).
-    bool useSync = !memoryIsAliased();
-#if defined(KOKKOS_ENABLE_CUDA)
-    useSync = std::is_same_v<typename DualViewType::execution_space, Kokkos::Cuda> || useSync;
-#endif
-#if defined(KOKKOS_ENABLE_HIP)
-    useSync = std::is_same_v<typename DualViewType::execution_space, Kokkos::HIP> || useSync;
-#endif
-#if defined(KOKKOS_ENABLE_SYCL)
-    useSync = std::is_same_v<typename DualViewType::execution_space, Kokkos::Experimental::SYCL> || useSync;
-#endif
-    return useSync;
-      
-
+    // We check to see if the memory is not aliased *or* if it is a supported
+    // (heterogeneous memory) accelerator (for shared host/device memory).
+    return !memoryIsAliased() || Spaces::is_gpu_exec_space<typename DualViewType::execution_space>();
   }
 
 

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
@@ -56,6 +56,7 @@
 #include "Tpetra_CrsMatrix_decl.hpp"
 #include "Tpetra_Details_getEntryOnHost.hpp"
 #include "Tpetra_Details_DefaultTypes.hpp"
+#include "Tpetra_Details_ExecutionSpaces.hpp"
 
 /// \file Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
 /// \brief Definition of functions for unpacking the entries of a
@@ -721,12 +722,7 @@ unpackAndCombineIntoCrsMatrix(
 
   using policy = Kokkos::TeamPolicy<XS, Kokkos::IndexType<LO>>;
   const size_t team_size = Tpetra::Details::Behavior::hierarchicalUnpackTeamSize();
-#if defined(KOKKOS_ENABLE_CUDA)
-  constexpr bool is_cuda = std::is_same<XS, Kokkos::Cuda>::value;
-#else
-  constexpr bool is_cuda = false;
-#endif
-  if (!is_cuda || team_size == Teuchos::OrdinalTraits<size_t>::invalid())
+  if (!Spaces::is_gpu_exec_space<XS>() || team_size == Teuchos::OrdinalTraits<size_t>::invalid())
   {
     Kokkos::parallel_for(policy(static_cast<LO>(num_batches), Kokkos::AUTO), f);
   }


### PR DESCRIPTION
- Fix ``Node::is_gpu``, ``is_cpu``: assume that ``Kokkos::Experimental::HBWSpace`` is also a possible default memory space of a CPU-like execution space.
- Use ``Node::is_serial`` to decide whether a Kokkos version of something should be used, vs. serial
- Use ``Tpetra::Details::Spaces::is_gpu_exec_space<ES>()`` to also simplify some logic, in places where a Node type is not available (like in WrappedDualView)

Out of the possible places that @cgcgcg and @csiefer2 listed in #12284 , this takes care of all the easy improvements. There are some others, like Tpetra_Details_Random.cpp, where we manually ETI things for different backends. These cases can also be simplified, but it's a different kind of thing.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fix an issue noticed by @lucbv  - some CPU architectures like KNL or SPR might have HBWSpace (not HostSpace) as the default memspace, but they're still CPUs.

Shorten/simplify code, and be more robust by not hardcoding a set of specific Kokkos backends to do a certain thing.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows #12284 
* Precedes 
* Related to 
* Part of #12451
* Composed of 

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->