### PR TITLE
Tpetra: Cleaning up CUDA cmake logic (part 1)

### DIFF
--- a/packages/tpetra/CMakeCuda.txt
+++ b/packages/tpetra/CMakeCuda.txt
@@ -24,36 +24,10 @@ IF (Tpetra_ENABLE_CUDA AND (NOT Kokkos_ENABLE_CUDA))
 ENDIF ()
 
 # Checks that only matter if building with CUDA enabled.
-IF (Tpetra_ENABLE_CUDA)
-  # As of 10 Aug 2017, Tpetra requires CUDA >= 7.5.
-  IF (DEFINED CUDA_VERSION AND (CUDA_VERSION VERSION_LESS "7.5"))
-    MESSAGE(FATAL_ERROR "If building with CUDA, Tpetra and downstream packages require at least CUDA 7.5, and preferably CUDA >= 8.0.  Your CUDA_VERSION is ${CUDA_VERSION}.  For details, please refer to Trilinos issue #1278: https://github.com/trilinos/Trilinos/issues/1278")
-  ENDIF ()
-
+IF (Tpetra_ENABLE_CUDA) 
   message("CUDA_VERSION=${CUDA_VERSION}")
-
-  # mfh 30 Sep 2017: Make sure that either Trilinos_CXX_FLAGS
-  # or CMAKE_CXX_FLAGS includes the "--expt-extended-lambda"
-  # or "-expt-extended-lambda" (either is valid; see #1797
-  # discussion) flag.
-  # jjw 25 Oct 2019: It is no longer necessary to verify flags in this way
-  # As long as Kokkos_ENABLE_CUDA_LAMBDA is set, then Kokkos will transitively add all
-  # flags necessary for correctness via target_link_libraries
-  #SET (TpetraCore_FOUND_CUDA_LAMBDA_FLAG OFF)
-  #IF (DEFINED Trilinos_CXX_FLAGS AND Trilinos_CXX_FLAGS MATCHES "-expt-extended-lambda")
-  #  # mfh 30 Sep 2017: Even if you put the flag in Trilinos_CXX_FLAGS,
-  #  # Trilinos seems to move that flag into CMAKE_CXX_FLAGS for some
-  #  # reason.  Nevertheless, it doesn't hurt to check both.
-  #  SET(TpetraCore_FOUND_CUDA_LAMBDA_FLAG ON)
-  #ELSEIF (DEFINED CMAKE_CXX_FLAGS AND CMAKE_CXX_FLAGS MATCHES "-expt-extended-lambda")
-  #  SET(TpetraCore_FOUND_CUDA_LAMBDA_FLAG ON)
-  #ENDIF ()
-  #IF (NOT TpetraCore_FOUND_CUDA_LAMBDA_FLAG)
-  #  MESSAGE (FATAL_ERROR "If building with CUDA, Tpetra and downstream packages require, at least with CUDA_VERSION >= 7.5 and <= 9.0, that you add \"--expt-extended-lambda\" to CMAKE_CXX_FLAGS.  You must also set Kokkos_ENABLE_CUDA_LAMBDA:BOOL=ON, if it is not already ON by default.")
-  #ENDIF ()
-
   IF (NOT DEFINED Kokkos_ENABLE_CUDA_LAMBDA OR NOT Kokkos_ENABLE_CUDA_LAMBDA)
-    MESSAGE (FATAL_ERROR "If building with CUDA, Tpetra and downstream packages require that you set the CMake option Kokkos_ENABLE_CUDA_LAMBDA:BOOL=ON, if it is not already ON by default.  For details, please refer to Trilinos issue #1682 (https://github.com/trilinos/Trilinos/issues/1682).  You must also use at least with CUDA_VERSION >= 7.5.")
+    MESSAGE (FATAL_ERROR "If building with CUDA, Tpetra and downstream packages require that you set the CMake option Kokkos_ENABLE_CUDA_LAMBDA:BOOL=ON (this is the default behavior).")
   ENDIF ()
 ENDIF ()
 


### PR DESCRIPTION
Issue: #12451 
Stakeholder feedback: Verified supported versions on Kokkos slack
Tests: n/a

We don't support CUDA 7.5 any more, so we can clean up a lot of that logic.

