### PR TITLE
stokhos: revise use of Cuda impl routines from kokkos

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -360,9 +360,6 @@ opt-set-cmake-var Kokkos_CoreUnitTest_Serial1_EXTRA_ARGS STRING : --gtest_filter
 opt-set-cmake-var Kokkos_CoreUnitTest_Default_MPI_1_EXTRA_ARGS STRING : --gtest_filter=-*defaultdevicetype.shared_space
 opt-set-cmake-var Kokkos_CoreUnitTest_Default_EXTRA_ARGS STRING : --gtest_filter=-*defaultdevicetype.shared_space
 
-# Run test in serial to avoid timeouts
-opt-set-cmake-var PanzerMiniEM_Darcy_MueLu_order1_MPI_1_RUN_SERIAL BOOL FORCE : ON
-
 # Options from SEMSDevEnv.cmake
 opt-set-cmake-var Trilinos_ENABLE_PyTrilinos BOOL : OFF
 opt-set-cmake-var Boost_INCLUDE_DIRS PATH : ${SEMS_BOOST_INCLUDE_PATH|ENV}

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -360,6 +360,9 @@ opt-set-cmake-var Kokkos_CoreUnitTest_Serial1_EXTRA_ARGS STRING : --gtest_filter
 opt-set-cmake-var Kokkos_CoreUnitTest_Default_MPI_1_EXTRA_ARGS STRING : --gtest_filter=-*defaultdevicetype.shared_space
 opt-set-cmake-var Kokkos_CoreUnitTest_Default_EXTRA_ARGS STRING : --gtest_filter=-*defaultdevicetype.shared_space
 
+# Run test in serial to avoid timeouts
+opt-set-cmake-var PanzerMiniEM_Darcy_MueLu_order1_MPI_1_RUN_SERIAL BOOL FORCE : ON
+
 # Options from SEMSDevEnv.cmake
 opt-set-cmake-var Trilinos_ENABLE_PyTrilinos BOOL : OFF
 opt-set-cmake-var Boost_INCLUDE_DIRS PATH : ${SEMS_BOOST_INCLUDE_PATH|ENV}

--- a/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
+++ b/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
@@ -207,6 +207,7 @@ TRIBITS_ADD_TEST(
    POSTFIX_AND_ARGS_0
    "order1" --solver=MueLu --numTimeSteps=1 --linAlgebra=Tpetra --inputFile=darcyTet.xml --x-elements=15  --y-elements=15 --z-elements=15
    NUM_MPI_PROCS 1
+   RUN_SERIAL
    )
 
 TRIBITS_ADD_TEST(

--- a/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_CooProductTensor.hpp
+++ b/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_CooProductTensor.hpp
@@ -279,7 +279,7 @@ public:
     const size_type size_rows = sizeof(rows_type) * num_thread;
     const size_type size_vals = sizeof(VectorScalar) * num_thread;
     const size_type shcap =
-      Kokkos::Cuda().impl_internal_space_instance()->m_maxShmemPerBlock / 2;
+      Kokkos::Cuda().impl_internal_space_instance()->m_deviceProp.sharedMemPerBlock / 2;
     size_type bs =
       ((shcap-size_rows-size_vals) / (sizeof(VectorScalar)*stoch_rows) - 1) / 2;
     if (bs % 2 == 0) --bs; // Make block-size odd to reduce bank conflicts

--- a/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_SimpleTiledCrsProductTensor.hpp
+++ b/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_SimpleTiledCrsProductTensor.hpp
@@ -266,7 +266,7 @@ public:
     const dim3 dGrid( row_count , 1 , 1 );
 
     const size_type shcap =
-      Kokkos::Cuda().impl_internal_space_instance()->m_maxShmemPerBlock / 2;
+      Kokkos::Cuda().impl_internal_space_instance()->m_deviceProp.sharedMemPerBlock / 2;
     size_type bs =
       (shcap / sizeof(VectorScalar) - i_tile_size) / (4*jk_tile_size);
     if (bs % 2 == 0) --bs;
@@ -553,7 +553,7 @@ public:
     const dim3 dGrid( n_i_tile , row_count , 1 );
 
     const size_type shcap =
-      Kokkos::Cuda().impl_internal_space_instance()->m_maxShmemPerBlock / 2;
+      Kokkos::Cuda().impl_internal_space_instance()->m_deviceProp.sharedMemPerBlock / 2;
     size_type bs = ((shcap / sizeof(VectorScalar)) / tile_size) / 4;
     if (bs % 2 == 0) --bs;
     const size_type block_size_max = 31;

--- a/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_SymmetricDiagonalSpec.hpp
+++ b/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_SymmetricDiagonalSpec.hpp
@@ -67,7 +67,10 @@ public:
   {
     const int d = block.dimension();
     const int warp_size = Kokkos::Impl::CudaTraits::WarpSize;
-    const int y = ( Kokkos::Impl::cuda_internal_maximum_warp_count() * warp_size ) / d ;
+    auto const maxWarpCount = std::min<unsigned>(
+        execution_space().cuda_device_prop().maxThreadsPerBlock / warp_size,
+        warp_size);
+    const int y = ( maxWarpCount * warp_size ) / d ;
 
     if ( 0 == y ) {
       throw std::runtime_error( std::string("Stokhos::Multiply< SymmetricDiagonalSpec<Cuda> > ERROR: block too large") );

--- a/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_TiledCrsProductTensor.hpp
+++ b/packages/stokhos/src/kokkos/Cuda/Stokhos_Cuda_TiledCrsProductTensor.hpp
@@ -255,7 +255,7 @@ public:
     const size_type shmem_factor = num_tiles == 1 ? 2 : 4;
     const size_type tensor_align = num_tiles == 1 ? tensor_dimension : tile_dim;
     const size_type shcap =
-      Kokkos::Cuda().impl_internal_space_instance()->m_maxShmemPerBlock / 2;
+      Kokkos::Cuda().impl_internal_space_instance()->m_deviceProp.sharedMemPerBlock / 2;
     size_type bs = ((shcap / sizeof(VectorScalar) - dBlock.x*dBlock.y) / tensor_align - 1) / shmem_factor;
     if (bs % 2 == 0)
       --bs;

--- a/packages/stokhos/src/sacado/kokkos/vector/Kokkos_Parallel_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Kokkos_Parallel_MP_Vector.hpp
@@ -207,22 +207,26 @@ public:
     // To do:  query number of registers used by functor and adjust
     // nwarp accordingly to get maximum occupancy
 
+    auto const maxWarpCount = std::min<unsigned>(
+        m_policy.space().cuda_device_prop().maxThreadsPerBlock / CudaTraits::WarpSize,
+        CudaTraits::WarpSize);
+
     Cuda::size_type nwarp = 0;
     if (m_config.team > CudaTraits::WarpSize) {
       const Cuda::size_type warps_per_team =
         ( m_config.team + CudaTraits::WarpSize-1 ) / CudaTraits::WarpSize;
-      nwarp = cuda_internal_maximum_warp_count() / warps_per_team;
+      nwarp = maxWarpCount / warps_per_team;
     }
     else {
       const Cuda::size_type teams_per_warp =
         CudaTraits::WarpSize / m_config.team ;
-      nwarp = cuda_internal_maximum_warp_count() * teams_per_warp;
+      nwarp = maxWarpCount * teams_per_warp;
     }
     const dim3 block( m_config.team , nwarp , 1 );
 
+    const Cuda::size_type maxGridSizeX = m_policy.space().cuda_device_prop().maxGridSize[0];
     Cuda::size_type nblock =
-      std::min( (m_work + block.y - 1 ) / block.y ,
-                cuda_internal_maximum_grid_count()[0] );
+      std::min( (m_work + block.y - 1 ) / block.y , maxGridSizeX );
     const dim3 grid( nblock , 1 , 1 );
 
     const Cuda::size_type shared = m_config.shared;


### PR DESCRIPTION
Compatibility update needed for kokkos following kokkos/kokkos#6544
Address kokkos/kokkos#6561

Co-authored-by: Damien L-G <dalg24+github@gmail.com>

Thanks @dalg24 for suggested update!

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/stokhos @etphipp 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Resolve compilation errors with Cuda backend

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
**Local test (stokhos only) with sems-cuda/11.4.2**:
```
...
98% tests passed, 1 tests failed out of 66

Label Time Summary:
Stokhos    = 132.16 sec*proc (66 tests)

Total Test time (real) =  74.11 sec

The following tests FAILED:
   45 - Stokhos_TpetraCrsMatrixUQPCEUnitTest_Cuda_MPI_4 (Failed)
Errors while running CTest
```

where Stokhos_TpetraCrsMatrixUQPCEUnitTest_Cuda_MPI_4 is known failure #12427 


**Configuration**:
```
module purge
module load sems-gcc/8.5.0 sems-cuda/11.4.2 sems-cmake sems-git sems-openmpi/4.1.4 sems-ninja
export OMPI_CXX=$KOKKOS_DIR/bin/nvcc_wrapper

# Configure Trilinos
cmake \
 -GNinja \
 -DCMAKE_INSTALL_PREFIX="${PWD}/install" \
 -DCMAKE_CXX_STANDARD="17" \
 -DTPL_ENABLE_MPI:BOOL=ON \
 -DTPL_ENABLE_BLAS:BOOL=ON \
 -DTPL_ENABLE_LAPACK:BOOL=ON \
 -DTPL_ENABLE_CUSPARSE:BOOL=ON \
 -DTrilinos_ENABLE_TESTS=OFF \
 -DTrilinos_ENABLE_ALL_PACKAGES=OFF \
 -DTrilinos_ENABLE_Kokkos=ON \
 -DKokkos_ENABLE_CUDA=ON \
 -DKokkos_ENABLE_CUDA_LAMBDA=ON \
 -DKokkos_ENABLE_CUDA_UVM=OFF \
 -DTrilinos_ENABLE_Stokhos=ON \
  -DStokhos_ENABLE_TESTS=ON \
 -DKokkos_SOURCE_DIR_OVERRIDE:STRING=kokkos \
 -DKokkosKernels_SOURCE_DIR_OVERRIDE:STRING=kokkos-kernels \
$TRILINOS_DIR
```

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->