### PR TITLE
MueLu: Node traits and coarse solver factorization

### DIFF
--- a/packages/muelu/src/Graph/Containers/MueLu_Zoltan2GraphAdapter.hpp
+++ b/packages/muelu/src/Graph/Containers/MueLu_Zoltan2GraphAdapter.hpp
@@ -454,6 +454,6 @@ template <typename User, typename UserCoord>
 }  //namespace MueLu
 
 
-#endif// MUELU_HAVE_ZOLTAN2
+#endif// HAVE_MUELU_ZOLTAN2
   
 #endif

--- a/packages/muelu/src/Operators/MueLu_Maxwell1_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_Maxwell1_def.hpp
@@ -235,18 +235,7 @@ namespace MueLu {
 
 
     // Are we using Kokkos?
-# ifdef HAVE_MUELU_SERIAL
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosSerialWrapperNode).name())
-      useKokkos_ = false;
-# endif
-# ifdef HAVE_MUELU_OPENMP
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosOpenMPWrapperNode).name())
-      useKokkos_ = true;
-# endif
-# ifdef HAVE_MUELU_CUDA
-    if (typeid(Node).name() == typeid(Tpetra::KokkosCompat::KokkosCudaWrapperNode).name())
-      useKokkos_ = true;
-# endif
+    useKokkos_ = !Node::is_serial;
     useKokkos_ = list.get("use kokkos refactor",useKokkos_);
 
     parameterList_ = list;

--- a/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
@@ -117,23 +117,8 @@ namespace MueLu {
     }
 
     // Are we using Kokkos?
-#if !defined(HAVE_MUELU_KOKKOS_REFACTOR)
-    useKokkos_ = false;
-#else
-# ifdef HAVE_MUELU_SERIAL
-    if (typeid(Node).name() == typeid(Kokkos::Compat::KokkosSerialWrapperNode).name())
-      useKokkos_ = false;
-# endif
-# ifdef HAVE_MUELU_OPENMP
-    if (typeid(Node).name() == typeid(Kokkos::Compat::KokkosOpenMPWrapperNode).name())
-      useKokkos_ = true;
-# endif
-# ifdef HAVE_MUELU_CUDA
-    if (typeid(Node).name() == typeid(Kokkos::Compat::KokkosCudaWrapperNode).name())
-      useKokkos_ = true;
-# endif
+    useKokkos_ = !Node::is_serial;
     useKokkos_ = list.get("use kokkos refactor",useKokkos_);
-#endif
 
     paramListMultiphysics_ = Teuchos::rcpFromRef(list); 
   }

--- a/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
@@ -339,6 +339,8 @@ namespace MueLu {
     }
     prec_->setParameters(amesos2_params);
 
+    prec_->numericFactorization();
+
     SmootherPrototype::IsSetup(true);
   }
 

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_def.hpp
@@ -148,9 +148,11 @@ namespace MueLu {
     // Build final prolongator
 
     // Reuse pattern if available
-    RCP<ParameterList> APparams = rcp(new ParameterList);;
+    RCP<ParameterList> APparams;
     if(pL.isSublist("matrixmatrix: kernel params"))
-      APparams->sublist("matrixmatrix: kernel params") = pL.sublist("matrixmatrix: kernel params");
+      APparams = rcp(new ParameterList(pL.sublist("matrixmatrix: kernel params")));
+    else
+      APparams = rcp(new ParameterList);
 
     if (coarseLevel.IsAvailable("AP reuse data", this)) {
       GetOStream(static_cast<MsgType>(Runtime0 | Test)) << "Reusing previous AP data" << std::endl;

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
@@ -393,6 +393,7 @@ namespace MueLu {
     validParamList->set< RCP<const FactoryBase> >("UnAmalgamationInfo", Teuchos::null, "Generating factory of UnAmalgamationInfo");
     validParamList->set< RCP<const FactoryBase> >("CoarseMap",          Teuchos::null, "Generating factory of the coarse map");
     validParamList->set< RCP<const FactoryBase> >("Coordinates",        Teuchos::null, "Generating factory of the coordinates");
+    validParamList->set< RCP<const FactoryBase> >("Node Comm",          Teuchos::null, "Generating factory of the node level communicator");
 
     // Make sure we don't recursively validate options for the matrixmatrix kernels
     ParameterList norecurse;
@@ -564,6 +565,13 @@ namespace MueLu {
     if(bTransferCoordinates_) {
       Set(coarseLevel, "Coordinates", coarseCoords);
     }
+
+    // FIXME: We should remove the NodeComm on levels past the threshold
+    if(fineLevel.IsAvailable("Node Comm")) {
+      RCP<const Teuchos::Comm<int> > nodeComm = Get<RCP<const Teuchos::Comm<int> > >(fineLevel,"Node Comm");
+      Set<RCP<const Teuchos::Comm<int> > >(coarseLevel, "Node Comm", nodeComm);
+    }
+
     Set(coarseLevel, "Nullspace", coarseNullspace);
     Set(coarseLevel, "P",         Ptentative);
 

--- a/packages/muelu/test/interface/CreateOperator.cpp
+++ b/packages/muelu/test/interface/CreateOperator.cpp
@@ -232,6 +232,9 @@ namespace MueLuExamples {
       run_sed("'s/KLU2 solver interface/<Direct> solver interface/'", baseFile);
       run_sed("'s/Basker solver interface/<Direct> solver interface/'", baseFile);
 
+      // The smoother complexity depends on the coarse solver.
+      run_sed("'s/Smoother complexity = [0-9]*.[0-9]*/Smoother complexity = <ignored>/'", baseFile);
+
       // Nuke all pointers
       run_sed("'s/0x[0-9a-f]*//g'", baseFile);
 

--- a/packages/muelu/test/interface/ParameterListInterpreter.cpp
+++ b/packages/muelu/test/interface/ParameterListInterpreter.cpp
@@ -371,6 +371,9 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         run_sed("'s/KLU2 solver interface/<Direct> solver interface/'", baseFile);
         run_sed("'s/Basker solver interface/<Direct> solver interface/'", baseFile);
 
+        // The smoother complexity depends on the coarse solver.
+        run_sed("'s/Smoother complexity = [0-9]*.[0-9]*/Smoother complexity = <ignored>/'", baseFile);
+
         // Strip template args for some classes
         std::vector<std::string> classes;
         classes.push_back("Xpetra::Matrix");

--- a/packages/muelu/test/interface/default/Output/MLaux_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLaux_tpetra.gold
@@ -70,7 +70,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 2
 Operator complexity = 1.33
-Smoother complexity = 1.33
+Smoother complexity = 1.78
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse1_tpetra.gold
@@ -131,7 +131,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.48
-Smoother complexity = 1.93
+Smoother complexity = 1.98
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/MLcoarse1b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse1b_epetra.gold
@@ -14,6 +14,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -23,7 +24,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -52,6 +55,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -61,7 +65,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -90,6 +96,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -99,7 +106,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)

--- a/packages/muelu/test/interface/default/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse2_tpetra.gold
@@ -211,7 +211,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 6
 Operator complexity = 1.50
-Smoother complexity = 1.99
+Smoother complexity = 2.00
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/MLcoarse2b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse2b_epetra.gold
@@ -14,6 +14,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -23,7 +24,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -52,6 +55,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -61,7 +65,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -90,6 +96,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -99,7 +106,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -128,6 +137,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -137,7 +147,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -166,6 +178,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -175,7 +188,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)

--- a/packages/muelu/test/interface/default/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse3_tpetra.gold
@@ -171,7 +171,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/MLcoarse3b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse3b_epetra.gold
@@ -14,6 +14,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -23,7 +24,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -52,6 +55,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -61,7 +65,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -90,6 +96,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -99,7 +106,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -128,6 +137,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -137,7 +147,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)

--- a/packages/muelu/test/interface/default/Output/MLcoarse4b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse4b_epetra.gold
@@ -14,6 +14,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -23,7 +24,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -52,6 +55,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -61,7 +65,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -90,6 +96,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -99,7 +106,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -128,6 +137,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -137,7 +147,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)

--- a/packages/muelu/test/interface/default/Output/MLemptyb_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLemptyb_epetra.gold
@@ -14,6 +14,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -23,7 +24,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -52,6 +55,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -61,7 +65,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -90,6 +96,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -99,7 +106,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -128,6 +137,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -137,7 +147,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)

--- a/packages/muelu/test/interface/default/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLpgamg1_tpetra.gold
@@ -167,7 +167,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/MLpgamg1b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLpgamg1b_epetra.gold
@@ -15,13 +15,16 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -50,13 +53,16 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -85,13 +91,16 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -120,13 +129,16 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)

--- a/packages/muelu/test/interface/default/Output/MLpgamg2b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLpgamg2b_epetra.gold
@@ -14,6 +14,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -23,7 +24,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -57,6 +60,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -66,7 +70,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -100,6 +106,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -109,7 +116,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -143,6 +152,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -152,7 +162,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning1_tpetra.gold
@@ -293,7 +293,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 6
 Operator complexity = 1.50
-Smoother complexity = 1.99
+Smoother complexity = 2.00
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning2_tpetra.gold
@@ -236,7 +236,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning3_tpetra.gold
@@ -236,7 +236,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother1_tpetra.gold
@@ -171,7 +171,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/MLsmoother1b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother1b_epetra.gold
@@ -14,6 +14,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -23,7 +24,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -52,6 +55,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -61,7 +65,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -90,6 +96,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -99,7 +106,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -128,6 +137,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -137,7 +147,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)

--- a/packages/muelu/test/interface/default/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother2_tpetra.gold
@@ -171,7 +171,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/MLsmoother2b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother2b_epetra.gold
@@ -14,6 +14,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -23,7 +24,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -52,6 +55,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -61,7 +65,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -90,6 +96,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -99,7 +106,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -128,6 +137,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -137,7 +147,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)

--- a/packages/muelu/test/interface/default/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother3_tpetra.gold
@@ -171,7 +171,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 0.00
+Smoother complexity = 0.02
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/MLsmoother3b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother3b_epetra.gold
@@ -14,6 +14,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -23,7 +24,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -52,6 +55,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -61,7 +65,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -90,6 +96,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -99,7 +106,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -128,6 +137,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -137,7 +147,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)

--- a/packages/muelu/test/interface/default/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother4_tpetra.gold
@@ -171,7 +171,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/MLsmoother4b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother4b_epetra.gold
@@ -14,6 +14,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -23,7 +24,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -52,6 +55,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -61,7 +65,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -90,6 +96,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -99,7 +106,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -128,6 +137,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -137,7 +147,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)

--- a/packages/muelu/test/interface/default/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLunsmoothed1_tpetra.gold
@@ -155,7 +155,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/MLunsmoothed1b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLunsmoothed1b_epetra.gold
@@ -14,6 +14,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -23,7 +24,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -52,6 +55,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -61,7 +65,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -90,6 +96,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -99,7 +106,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)
@@ -128,6 +137,7 @@ Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 algorithm = "classical" classical algorithm = "default": threshold = 0, blocksize = 1
+aggregation: use ml scaling of drop tol = 1
 lightweight wrap = 1
 Filtered matrix is not being constructed as no filtering is being done
 Build (MueLu::TentativePFactory)
@@ -137,7 +147,9 @@ BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
 BuildAggregates (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
+aggregation: match ML phase1 = 1   [unused]
 aggregation: match ML phase2a = 1   [unused]
+aggregation: match ML phase2b = 1   [unused]
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
 Build (MueLu::CoarseMapFactory)

--- a/packages/muelu/test/interface/default/Output/aggregatequalities_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregatequalities_tpetra.gold
@@ -104,7 +104,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation1_tpetra.gold
@@ -84,7 +84,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation3_tpetra.gold
@@ -90,7 +90,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation4_tpetra.gold
@@ -96,7 +96,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/aggregation5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation5_np4_tpetra.gold
@@ -80,7 +80,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/aggregation5_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation5_tpetra.gold
@@ -80,7 +80,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/coarse1_tpetra.gold
@@ -120,7 +120,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.48
-Smoother complexity = 1.93
+Smoother complexity = 1.98
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_e3d_tpetra.gold
@@ -82,7 +82,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 2.11
-Smoother complexity = 2.22
+Smoother complexity = 2.59
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_p2d_tpetra.gold
@@ -82,7 +82,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_p3d_tpetra.gold
@@ -82,7 +82,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_pg_np4_tpetra.gold
@@ -76,7 +76,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_pg_tpetra.gold
@@ -76,7 +76,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
@@ -68,7 +68,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.48
-Smoother complexity = 1.93
+Smoother complexity = 1.98
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
@@ -192,7 +192,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.48
-Smoother complexity = 1.93
+Smoother complexity = 1.98
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
@@ -70,7 +70,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.48
-Smoother complexity = 1.93
+Smoother complexity = 1.98
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
@@ -198,7 +198,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.48
-Smoother complexity = 1.93
+Smoother complexity = 1.98
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin1_tpetra.gold
@@ -90,7 +90,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin2_tpetra.gold
@@ -94,7 +94,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin3_tpetra.gold
@@ -94,7 +94,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/empty_tpetra.gold
@@ -84,7 +84,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/notay_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/notay_tpetra.gold
@@ -68,7 +68,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 2
 Operator complexity = 1.00
-Smoother complexity = 1.33
+Smoother complexity = 1.34
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_1_np1_tpetra.gold
@@ -120,7 +120,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.34
-Smoother complexity = 1.57
+Smoother complexity = 1.58
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_1_np4_tpetra.gold
@@ -120,7 +120,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.36
-Smoother complexity = 1.59
+Smoother complexity = 1.60
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np1_tpetra.gold
@@ -93,7 +93,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.34
-Smoother complexity = 1.57
+Smoother complexity = 1.58
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np4_tpetra.gold
@@ -93,7 +93,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.36
-Smoother complexity = 1.59
+Smoother complexity = 1.60
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np1_tpetra.gold
@@ -98,7 +98,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.34
-Smoother complexity = 1.57
+Smoother complexity = 1.58
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np4_tpetra.gold
@@ -98,7 +98,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.36
-Smoother complexity = 1.59
+Smoother complexity = 1.60
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np1_tpetra.gold
@@ -23,7 +23,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 2
 Operator complexity = 1.30
-Smoother complexity = 1.20
+Smoother complexity = 2.94
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np4_tpetra.gold
@@ -23,7 +23,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 2
 Operator complexity = 1.31
-Smoother complexity = 1.20
+Smoother complexity = 2.94
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/pg1_tpetra.gold
@@ -80,7 +80,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/pg2_tpetra.gold
@@ -80,7 +80,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_np4_tpetra.gold
@@ -110,7 +110,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_tpetra.gold
@@ -114,7 +114,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_np4_tpetra.gold
@@ -117,7 +117,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_tpetra.gold
@@ -116,7 +116,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_np4_tpetra.gold
@@ -124,7 +124,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_tpetra.gold
@@ -124,7 +124,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_tpetra.gold
@@ -114,7 +114,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -149,7 +149,7 @@ Level 2
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_tpetra.gold
@@ -121,7 +121,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -156,7 +156,7 @@ Level 2
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_tpetra.gold
@@ -104,7 +104,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -139,7 +139,7 @@ Level 2
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_tpetra.gold
@@ -109,7 +109,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -144,7 +144,7 @@ Level 2
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_tpetra.gold
@@ -104,7 +104,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -177,7 +177,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_tpetra.gold
@@ -109,7 +109,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -186,7 +186,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_np4_tpetra.gold
@@ -114,7 +114,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -245,7 +245,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_tpetra.gold
@@ -121,7 +121,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -258,7 +258,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_np4_tpetra.gold
@@ -114,7 +114,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -142,7 +142,7 @@ Level 2
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_tpetra.gold
@@ -121,7 +121,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -149,7 +149,7 @@ Level 2
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_np4_tpetra.gold
@@ -110,7 +110,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -237,7 +237,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_tpetra.gold
@@ -114,7 +114,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -244,7 +244,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_tpetra.gold
@@ -116,7 +116,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -223,7 +223,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_tpetra.gold
@@ -121,7 +121,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -232,7 +232,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_tpetra.gold
@@ -119,7 +119,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -239,7 +239,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_tpetra.gold
@@ -123,7 +123,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -246,7 +246,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_tpetra.gold
@@ -115,7 +115,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -234,7 +234,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
@@ -119,7 +119,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -241,7 +241,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother10_tpetra.gold
@@ -80,7 +80,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother11_tpetra.gold
@@ -88,7 +88,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother12_tpetra.gold
@@ -187,7 +187,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 6
 Operator complexity = 1.50
-Smoother complexity = 1.99
+Smoother complexity = 2.00
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother13_tpetra.gold
@@ -88,7 +88,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother1_tpetra.gold
@@ -84,7 +84,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother2_tpetra.gold
@@ -84,7 +84,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother3_tpetra.gold
@@ -84,7 +84,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 0.00
+Smoother complexity = 0.15
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother4_tpetra.gold
@@ -72,7 +72,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 0.00
+Smoother complexity = 0.15
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother5_tpetra.gold
@@ -82,7 +82,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother6_tpetra.gold
@@ -78,7 +78,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 2.67
+Smoother complexity = 2.81
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother9_tpetra.gold
@@ -88,7 +88,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/sync1_tpetra.gold
@@ -84,7 +84,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose1_tpetra.gold
@@ -80,7 +80,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_np4_tpetra.gold
@@ -100,7 +100,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_tpetra.gold
@@ -104,7 +104,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_np4_tpetra.gold
@@ -102,7 +102,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_tpetra.gold
@@ -106,7 +106,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/default/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/unsmoothed1_tpetra.gold
@@ -76,7 +76,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
@@ -71,7 +71,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 2
 Operator complexity = 1.33
-Smoother complexity = 1.33
+Smoother complexity = 1.78
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse1_tpetra.gold
@@ -131,7 +131,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.48
-Smoother complexity = 1.93
+Smoother complexity = 1.98
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse2_tpetra.gold
@@ -211,7 +211,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 6
 Operator complexity = 1.50
-Smoother complexity = 1.99
+Smoother complexity = 2.00
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse3_tpetra.gold
@@ -171,7 +171,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg1_tpetra.gold
@@ -167,7 +167,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
@@ -293,7 +293,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 6
 Operator complexity = 1.50
-Smoother complexity = 1.99
+Smoother complexity = 2.00
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
@@ -236,7 +236,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
@@ -236,7 +236,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother1_tpetra.gold
@@ -171,7 +171,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother2_tpetra.gold
@@ -171,7 +171,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother3_tpetra.gold
@@ -171,7 +171,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 0.00
+Smoother complexity = 0.02
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
@@ -171,7 +171,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_tpetra.gold
@@ -155,7 +155,7 @@ smoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 5
 Operator complexity = 1.49
-Smoother complexity = 1.98
+Smoother complexity = 1.99
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
@@ -78,7 +78,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation3_tpetra.gold
@@ -84,7 +84,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation4_tpetra.gold
@@ -90,7 +90,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse1_tpetra.gold
@@ -111,7 +111,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.48
-Smoother complexity = 1.93
+Smoother complexity = 1.98
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
@@ -76,7 +76,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 2.11
-Smoother complexity = 2.22
+Smoother complexity = 2.59
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
@@ -76,7 +76,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
@@ -76,7 +76,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_np4_tpetra.gold
@@ -74,7 +74,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_tpetra.gold
@@ -74,7 +74,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
@@ -65,7 +65,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.48
-Smoother complexity = 1.93
+Smoother complexity = 1.98
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
@@ -183,7 +183,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.48
-Smoother complexity = 1.93
+Smoother complexity = 1.98
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
@@ -67,7 +67,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.48
-Smoother complexity = 1.93
+Smoother complexity = 1.98
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
@@ -189,7 +189,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.48
-Smoother complexity = 1.93
+Smoother complexity = 1.98
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
@@ -84,7 +84,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin2_tpetra.gold
@@ -88,7 +88,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
@@ -88,7 +88,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/empty_tpetra.gold
@@ -78,7 +78,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_tpetra.gold
@@ -114,7 +114,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.34
-Smoother complexity = 1.57
+Smoother complexity = 1.58
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_tpetra.gold
@@ -114,7 +114,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.36
-Smoother complexity = 1.59
+Smoother complexity = 1.61
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
@@ -89,7 +89,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.34
-Smoother complexity = 1.57
+Smoother complexity = 1.58
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
@@ -89,7 +89,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.36
-Smoother complexity = 1.59
+Smoother complexity = 1.61
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
@@ -94,7 +94,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.34
-Smoother complexity = 1.57
+Smoother complexity = 1.58
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
@@ -94,7 +94,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 4
 Operator complexity = 1.36
-Smoother complexity = 1.59
+Smoother complexity = 1.61
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_tpetra.gold
@@ -23,7 +23,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 2
 Operator complexity = 1.30
-Smoother complexity = 1.20
+Smoother complexity = 2.94
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_tpetra.gold
@@ -23,7 +23,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 2
 Operator complexity = 1.31
-Smoother complexity = 1.20
+Smoother complexity = 2.91
 Cycle type          = V
 
 level  rows   nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg1_tpetra.gold
@@ -78,7 +78,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg2_tpetra.gold
@@ -78,7 +78,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
@@ -104,7 +104,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
@@ -108,7 +108,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
@@ -111,7 +111,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
@@ -110,7 +110,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
@@ -118,7 +118,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
@@ -118,7 +118,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
@@ -108,7 +108,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -143,7 +143,7 @@ Level 2
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
@@ -115,7 +115,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -150,7 +150,7 @@ Level 2
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
@@ -98,7 +98,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -133,7 +133,7 @@ Level 2
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
@@ -103,7 +103,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -138,7 +138,7 @@ Level 2
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
@@ -98,7 +98,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -171,7 +171,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
@@ -103,7 +103,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -180,7 +180,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
@@ -108,7 +108,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -233,7 +233,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
@@ -115,7 +115,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -246,7 +246,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
@@ -108,7 +108,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -136,7 +136,7 @@ Level 2
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
@@ -115,7 +115,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -143,7 +143,7 @@ Level 2
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
@@ -104,7 +104,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -225,7 +225,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
@@ -108,7 +108,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -232,7 +232,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
@@ -110,7 +110,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -209,7 +209,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
@@ -115,7 +115,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -218,7 +218,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
@@ -113,7 +113,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -227,7 +227,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
@@ -117,7 +117,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -234,7 +234,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
@@ -109,7 +109,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -221,7 +221,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
@@ -113,7 +113,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
@@ -228,7 +228,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother10_tpetra.gold
@@ -74,7 +74,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother11_tpetra.gold
@@ -82,7 +82,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
@@ -172,7 +172,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 6
 Operator complexity = 1.50
-Smoother complexity = 1.99
+Smoother complexity = 2.00
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
@@ -82,7 +82,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother1_tpetra.gold
@@ -78,7 +78,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother2_tpetra.gold
@@ -78,7 +78,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother3_tpetra.gold
@@ -78,7 +78,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 0.00
+Smoother complexity = 0.15
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother4_tpetra.gold
@@ -66,7 +66,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 0.00
+Smoother complexity = 0.15
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
@@ -76,7 +76,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother6_tpetra.gold
@@ -72,7 +72,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 2.67
+Smoother complexity = 2.81
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
@@ -82,7 +82,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/sync1_tpetra.gold
@@ -78,7 +78,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose1_tpetra.gold
@@ -74,7 +74,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
@@ -94,7 +94,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
@@ -98,7 +98,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
@@ -96,7 +96,7 @@ Replacing maps with a subcommunicator
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.45
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
@@ -100,7 +100,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
@@ -74,7 +74,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
@@ -76,7 +76,7 @@ presmoother ->
 --------------------------------------------------------------------------------
 Number of levels    = 3
 Operator complexity = 1.44
-Smoother complexity = 1.78
+Smoother complexity = 1.93
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs

--- a/packages/muelu/test/maxwell/ReitzingerPFactory.cpp
+++ b/packages/muelu/test/maxwell/ReitzingerPFactory.cpp
@@ -230,6 +230,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup2Level_Unsmoothed, Sc
     RCP<TentativePFactory>        PnodalFact = rcp(new TentativePFactory());
     PnodalFact->SetParameterList(tp_list);
     M1.SetFactory("P",PnodalFact);
+    M1.SetFactory("CoarseSolver", Teuchos::null);
 
 
     bool r;
@@ -272,6 +273,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup2Level_Unsmoothed, Sc
     M1.SetKokkosRefactor(false);
     RCP<ReitzingerPFactory> PedgeFact  = rcp(new ReitzingerPFactory());
     M1.SetFactory("P",PedgeFact);
+    M1.SetFactory("CoarseSolver", Teuchos::null);
 
     // Do the setup
     bool r;
@@ -340,6 +342,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup2Level_AlphaSmoothed,
     RCP<TentativePFactory>        PnodalFact = rcp(new TentativePFactory());
     PnodalFact->SetParameterList(tp_list);
     M1.SetFactory("P",PnodalFact);
+    M1.SetFactory("CoarseSolver", Teuchos::null);
 
 
     bool r;
@@ -385,6 +388,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup2Level_AlphaSmoothed,
     PFact->SetFactory("P",PedgeFact);
     M1.SetFactory("Ptent",PedgeFact);
     M1.SetFactory("P",PFact);
+    M1.SetFactory("CoarseSolver", Teuchos::null);
 
 
     // Do the setup
@@ -463,6 +467,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_AlphaSmoothed,
       RCP<TentativePFactory>        PnodalFact = rcp(new TentativePFactory());
       PnodalFact->SetParameterList(tp_list);
       M2.SetFactory("P",PnodalFact);
+      M2.SetFactory("CoarseSolver", Teuchos::null);
     }
 
     bool r;
@@ -525,6 +530,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_AlphaSmoothed,
       M2.SetFactory("Ptent",PedgeFact2);
       M2.SetFactory("D0",PedgeFact2);
       M2.SetFactory("P",PFact);
+      M2.SetFactory("CoarseSolver", Teuchos::null);
     }
     
     // Do the setup
@@ -608,6 +614,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_Unsmoothed, Sc
       RCP<TentativePFactory>        PnodalFact = rcp(new TentativePFactory());
       PnodalFact->SetParameterList(tp_list);
       M2.SetFactory("P",PnodalFact);
+      M2.SetFactory("CoarseSolver", Teuchos::null);
     }
 
     bool r;
@@ -666,7 +673,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(ReitzingerPFactory, Setup3Level_Unsmoothed, Sc
       M2.SetFactory("Ptent",PFact);
       M2.SetFactory("D0",PFact);
       M2.SetFactory("P",PFact);
-     
+      M2.SetFactory("CoarseSolver", Teuchos::null);
     }
     
     // Do the setup

--- a/packages/muelu/test/unit_tests/GenericRFactory.cpp
+++ b/packages/muelu/test/unit_tests/GenericRFactory.cpp
@@ -89,10 +89,10 @@ namespace MueLuTests {
     #include <MueLu_UseShortNames.hpp>
     MUELU_TESTING_SET_OSTREAM;
     MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
-#   if !defined(MUELU_HAVE_IFPACK)
+#   if !defined(HAVE_MUELU_IFPACK)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseEpetra, "Ifpack");
 #   endif
-#   if !defined(MUELU_HAVE_IFPACK2)
+#   if !defined(HAVE_MUELU_IFPACK2)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseTpetra, "Ifpack2");
 #   endif
     out << "version: " << MueLu::Version() << std::endl;
@@ -134,7 +134,10 @@ namespace MueLuTests {
     UncoupledAggFact->SetMaxNeighAlreadySelected(0);
     UncoupledAggFact->SetOrdering("natural");
 
+    Teuchos::ParameterList sapParamList;
+    sapParamList.sublist("matrixmatrix: kernel params").set("compute global constants", true);
     RCP<SaPFactory>         Pfact = rcp( new SaPFactory());
+    Pfact->SetParameterList(sapParamList);
     RCP<Factory>           Rfact = rcp( new GenericRFactory() );
     H->SetMaxCoarseSize(1);
 
@@ -150,6 +153,7 @@ namespace MueLuTests {
     RCP<SmootherFactory> coarseSolveFact = rcp(new SmootherFactory(smooProto, Teuchos::null));
 
     FactoryManager M;
+    M.SetKokkosRefactor(false);
     M.SetFactory("P", Pfact);
     M.SetFactory("R", Rfact);
     M.SetFactory("Aggregates", UncoupledAggFact);
@@ -224,10 +228,10 @@ namespace MueLuTests {
     #include <MueLu_UseShortNames.hpp>
     MUELU_TESTING_SET_OSTREAM;
     MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
-#   if !defined(MUELU_HAVE_IFPACK)
+#   if !defined(HAVE_MUELU_IFPACK)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseEpetra, "Ifpack");
 #   endif
-#   if !defined(MUELU_HAVE_IFPACK2)
+#   if !defined(HAVE_MUELU_IFPACK2)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseTpetra, "Ifpack2");
 #   endif
     out << "version: " << MueLu::Version() << std::endl;

--- a/packages/muelu/test/unit_tests/Repartition.cpp
+++ b/packages/muelu/test/unit_tests/Repartition.cpp
@@ -906,10 +906,10 @@ namespace MueLuTests {
 #   include <MueLu_UseShortNames.hpp>
     MUELU_TESTING_SET_OSTREAM;
     MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
-#   if !defined(MUELU_HAVE_AMESOS) || !defined(MUELU_HAVE_IFPACK)
+#   if !defined(HAVE_MUELU_AMESOS) || !defined(HAVE_MUELU_IFPACK)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseEpetra, "Amesos, Ifpack");
 #   endif
-#   if !defined(MUELU_HAVE_AMESOS2) || !defined(MUELU_HAVE_IFPACK2)
+#   if !defined(HAVE_MUELU_AMESOS2) || !defined(HAVE_MUELU_IFPACK2)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseTpetra, "Amesos2, Ifpack2");
 #   endif
 
@@ -1019,10 +1019,10 @@ namespace MueLuTests {
     MUELU_TESTING_SET_OSTREAM;
 
     MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
-#   if !defined(MUELU_HAVE_AMESOS) || !defined(MUELU_HAVE_IFPACK)
+#   if !defined(HAVE_MUELU_AMESOS) || !defined(HAVE_MUELU_IFPACK)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseEpetra, "Amesos, Ifpack");
 #   endif
-#   if !defined(MUELU_HAVE_AMESOS2) || !defined(MUELU_HAVE_IFPACK2)
+#   if !defined(HAVE_MUELU_AMESOS2) || !defined(HAVE_MUELU_IFPACK2)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseTpetra, "Amesos2, Ifpack2");
 #   endif
    

--- a/packages/muelu/test/unit_tests/Smoothers/BlockedSmoother.cpp
+++ b/packages/muelu/test/unit_tests/Smoothers/BlockedSmoother.cpp
@@ -927,8 +927,7 @@ namespace MueLuTests {
       TEST_EQUALITY(n00[0], Teuchos::as<Scalar>(v00->getGlobalLength() * 0.25));
       TEST_EQUALITY(n11[0], Teuchos::as<Scalar>(v01->getGlobalLength() * 1.0));
       TEST_EQUALITY(n22[0], Teuchos::as<Scalar>(v10->getGlobalLength() * 0.5));
-      TEUCHOS_TEST_COMPARE(n33[0], <, v11->getGlobalLength() * 0.33333334, out, success);
-      TEUCHOS_TEST_COMPARE(n33[0], >, v11->getGlobalLength() * 0.33333333, out, success);
+      TEST_FLOATING_EQUALITY(n33[0], v11->getGlobalLength() / 3.0, Teuchos::ScalarTraits<magnitude_type>::eps());
 
     } // end UseTpetra
   }
@@ -1696,8 +1695,7 @@ namespace MueLuTests {
       TEST_EQUALITY(n00[0], Teuchos::as<Scalar>(v00->getGlobalLength() * 0.25));
       TEST_EQUALITY(n11[0], Teuchos::as<Scalar>(v01->getGlobalLength() * 1.0));
       TEST_EQUALITY(n22[0], Teuchos::as<Scalar>(v10->getGlobalLength() * 0.5));
-      TEUCHOS_TEST_COMPARE(n33[0], <, v11->getGlobalLength() * 0.33333334, out, success);
-      TEUCHOS_TEST_COMPARE(n33[0], >, v11->getGlobalLength() * 0.33333333, out, success);
+      TEST_FLOATING_EQUALITY(n33[0], v11->getGlobalLength() / 3.0, Teuchos::ScalarTraits<magnitude_type>::eps());
     } // end UseTpetra
   }
 

--- a/packages/muelu/test/unit_tests/TentativePFactory.cpp
+++ b/packages/muelu/test/unit_tests/TentativePFactory.cpp
@@ -538,10 +538,10 @@ namespace MueLuTests {
 #   include "MueLu_UseShortNames.hpp"
     MUELU_TESTING_SET_OSTREAM;
     MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
-#   if !defined(MUELU_HAVE_IFPACK)
+#   if !defined(HAVE_MUELU_IFPACK)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseEpetra, "Ifpack");
 #   endif
-#   if !defined(MUELU_HAVE_IFPACK2)
+#   if !defined(HAVE_MUELU_IFPACK2)
     MUELU_TESTING_DO_NOT_TEST(Xpetra::UseTpetra, "Ifpack2");
 #   endif
 

--- a/packages/muelu/test/unit_tests/testCoordinates.xml
+++ b/packages/muelu/test/unit_tests/testCoordinates.xml
@@ -11,6 +11,7 @@
   <!-- ===========  AGGREGATION  =========== -->
   <Parameter        name="aggregation: type"                    type="string"   value="uncoupled"/>
   <Parameter        name="aggregation: drop scheme"             type="string"   value="classical"/>
+  <Parameter        name="aggregation: deterministic"           type="bool"     value="true"/>
   <!-- <Parameter        name="aggregation: drop tol"                type="double"   value="0.1"/> -->
 
   <!-- ===========  SMOOTHING  =========== -->


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
- Use new `Node` traits in two more spots.
- Call `numericFactorization` in MueLu's coarse solver setup.
- Interface test: rebase gold files and ignore smoother complexity because it depends on the type of coarse solver that's chosen. Before we triggered factorization in setup the coarse solver was simply ignored in the complexity computation.
- ReitzingerP test: skip construction of coarse solvers as the matrices can be singular.
- Change assert in block smoother test so that it passes with other scalar types.
- Replace "MUELU_HAVE_*" with "HAVE_MUELU_*". Closes #11843
- Fix PL bug in SaPFactory
- Add missing propagation of "Node Comm" to TentativeP_kokkos.

@ndellingwood : Before this change, we only called `setParameters` during the multigrid setup and `solve` during multigrid solve. We were seeing that the Amesos2 solver was constructed during our first solve. Can you confirm that with this change we should not be seeing factorization during the first `solve` call?