### PR TITLE
Fix valgrind errors for ifpack2 tests

### DIFF
--- a/packages/ifpack2/src/Ifpack2_LocalFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalFilter_def.hpp
@@ -62,13 +62,13 @@ bool
 LocalFilter<MatrixType>::
 mapPairsAreFitted (const row_matrix_type& A)
 {
-  const map_type& rangeMap = * (A.getRangeMap ());
-  const map_type& rowMap = * (A.getRowMap ());
-  const bool rangeAndRowFitted = mapPairIsFitted (rowMap, rangeMap);
+  const auto rangeMap = A.getRangeMap();
+  const auto rowMap = A.getRowMap();
+  const bool rangeAndRowFitted = mapPairIsFitted (*rowMap, *rangeMap);
 
-  const map_type& domainMap = * (A.getDomainMap ());
-  const map_type& columnMap = * (A.getColMap ());
-  const bool domainAndColumnFitted = mapPairIsFitted (columnMap, domainMap);
+  const auto domainMap = A.getDomainMap();
+  const auto columnMap = A.getColMap();
+  const bool domainAndColumnFitted = mapPairIsFitted (*columnMap, *domainMap);
 
   //Note BMK 6-22: Map::isLocallyFitted is a local-only operation, not a collective.
   //This means that it can return different values on different ranks. This can cause MPI to hang,

--- a/packages/ifpack2/src/Ifpack2_MDF_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_MDF_def.hpp
@@ -155,6 +155,7 @@ auto get_local_crs_row_matrix(
 template<class MatrixType>
 MDF<MatrixType>::MDF (const Teuchos::RCP<const row_matrix_type>& Matrix_in)
   : A_ (Matrix_in),
+    Verbosity_(0),
     LevelOfFill_ (0),
     Overalloc_ (2.),
     isAllocated_ (false),
@@ -175,6 +176,7 @@ MDF<MatrixType>::MDF (const Teuchos::RCP<const row_matrix_type>& Matrix_in)
 template<class MatrixType>
 MDF<MatrixType>::MDF (const Teuchos::RCP<const crs_matrix_type>& Matrix_in)
   : A_ (Matrix_in),
+    Verbosity_(0),
     LevelOfFill_ (0),
     Overalloc_ (2.),
     isAllocated_ (false),

--- a/packages/shylu/shylu_node/fastilu/src/shylu_fastic.hpp
+++ b/packages/shylu/shylu_node/fastilu/src/shylu_fastic.hpp
@@ -1,9 +1,9 @@
 //@HEADER
 // ************************************************************************
-// 
+//
 //               ShyLU: Hybrid preconditioner package
 //                 Copyright 2012 Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
 //
@@ -34,8 +34,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Siva Rajamanickam (srajama@sandia.gov) 
-// 
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
 // ************************************************************************
 //@HEADER
 
@@ -74,9 +74,9 @@ class FastICPrec
         typedef Kokkos::View<Ordinal *, ExecSpace> OrdinalArray;
         typedef Kokkos::View<Scalar *, ExecSpace> ScalarArray;
         typedef Kokkos::View<Real *, ExecSpace> RealArray;
-        typedef Kokkos::View<Ordinal *, typename ExecSpace::array_layout, Kokkos::Serial, 
+        typedef Kokkos::View<Ordinal *, typename ExecSpace::array_layout, Kokkos::Serial,
                              Kokkos::MemoryUnmanaged> UMOrdinalArray;
-        typedef Kokkos::View<Scalar *, typename ExecSpace::array_layout, Kokkos::Serial, 
+        typedef Kokkos::View<Scalar *, typename ExecSpace::array_layout, Kokkos::Serial,
                              Kokkos::MemoryUnmanaged> UMScalarArray;
         typedef FastICPrec<Ordinal, Scalar, ExecSpace> FastPrec;
 
@@ -196,7 +196,7 @@ class FastICPrec
 
             if (level > 0)
             {
-                initGuessPrec = Teuchos::rcp(new FastPrec(aRowMapIn, aColIdxIn, aValIn, nRow_, standard_sptrsv, 3, 5, 
+                initGuessPrec = Teuchos::rcp(new FastPrec(aRowMapIn, aColIdxIn, aValIn, nRow_, standard_sptrsv, 3, 5,
                                                           level_-1, omega_, shift_, guessFlag_, blkSzIC_, blkSz_));
             }
 
@@ -221,12 +221,12 @@ class FastICPrec
             Kokkos::parallel_for(nRows, copyFunc1);
 
             //Note that the following is a temporary measure
-            //to ensure that memory resides on the device. 
+            //to ensure that memory resides on the device.
             Ordinal nnzL = lRowMap[nRows];
             Ordinal nnzA = aRowMap[nRows];
 
             MemoryPrimeFunctorNnzCoo<Ordinal, Scalar, ExecSpace> copyFunc2(aColIdx, aRowIdx, aVal);
-            MemoryPrimeFunctorNnzCsr<Ordinal, Scalar, ExecSpace> copyFunc3(lColIdx, lVal); 
+            MemoryPrimeFunctorNnzCsr<Ordinal, Scalar, ExecSpace> copyFunc3(lColIdx, lVal);
 
             ExecSpace().fence();
             Kokkos::parallel_for(nRows, copyFunc1);
@@ -263,36 +263,36 @@ class FastICPrec
             //Count the elements in each row of Lt
             auto temp = OrdinalArrayHost("temp", nRows + 1);
             auto rowPtrs = OrdinalArrayHost("rowPtrs", nRows);
-            for (Ordinal i = 0; i <= nRows; i++) 
+            for (Ordinal i = 0; i <= nRows; i++)
             {
                 temp[i] = 0;
             }
-            for (Ordinal i = 0; i < nRows; i++) 
+            for (Ordinal i = 0; i < nRows; i++)
             {
-                for (Ordinal k = lRowMap_[i]; k < lRowMap_[i+1]; k++) 
+                for (Ordinal k = lRowMap_[i]; k < lRowMap_[i+1]; k++)
                 {
                     temp[lColIdx_[k]+1]++;
 
                 }
             }
-            //Perform an add scan to get the row map for 
+            //Perform an add scan to get the row map for
             //the transpose
-            for (Ordinal i = 0; i <= nRows; i++) 
+            for (Ordinal i = 0; i <= nRows; i++)
             {
                 ltRowMap_[i] = temp[i];
             }
-            for (Ordinal i = 1; i <= nRows; i++) 
+            for (Ordinal i = 1; i <= nRows; i++)
             {
                 ltRowMap_[i] += ltRowMap_[i-1];
             }
             //Set the row pointers to their initial places;
-            for (Ordinal i = 0; i < nRows; i++) 
+            for (Ordinal i = 0; i < nRows; i++)
             {
                 rowPtrs[i] = ltRowMap_[i];
             }
             //Copy the data
             Kokkos::deep_copy(lVal_, lVal);
-            for (Ordinal i = 0; i < nRows; i++) 
+            for (Ordinal i = 0; i < nRows; i++)
             {
                 for (Ordinal k = lRowMap_[i]; k < lRowMap_[i+1]; k++)
                 {
@@ -317,23 +317,19 @@ class FastICPrec
             using std::sort;
             OrdinalArrayMirror ia = aRowMapHost;
             OrdinalArrayMirror ja = aColIdxHost;
-            int *nzu;
-            int *nzl;
-            nzu = new int[1];
-            nzl = new int[1];
             int n = nRows;
-            *nzl = aRowMapHost[nRows] * (level + 2);
-            *nzu = aRowMapHost[nRows] * (level + 2);
+            int nzl = aRowMapHost[nRows] * (level + 2);
+            int nzu = aRowMapHost[nRows] * (level + 2);
             Ordinal i;
             int levfill = level;
             vector<int> lnklst(n);
             vector<int> curlev(n);
-            vector<int> levels(*nzu);
+            vector<int> levels(nzu);
             vector<int> iwork(n);
-            vector<int> ial(*nzl);
-            vector<int> jal(*nzl);
-            vector<int> iau(*nzu);
-            vector<int> jau(*nzu);
+            vector<int> ial(nzl);
+            vector<int> jal(nzl);
+            vector<int> iau(nzu);
+            vector<int> jau(nzu);
 
             int knzl = 0;
             int knzu = 0;
@@ -423,13 +419,13 @@ class FastICPrec
                 next = first;
                 while (next < i)
                 {
-                    assert(knzl < *nzl);
+                    assert(knzl < nzl);
                     jal[knzl++] = next;
-                    if (knzl >= *nzl)
+                    if (knzl >= nzl)
                     {
                         //(*nzl)++;
-                        *nzl = *nzl + nRows;
-                        jal.resize(*nzl);
+                        nzl += nRows;
+                        jal.resize(nzl);
                     }
                     //jal.push_back(next);
                    // knzl++;
@@ -438,28 +434,17 @@ class FastICPrec
                 ial[i+1] = knzl;
                 assert(next == i);
 
-#if 0
-                if (next != i)
-                {
-                    /*
-                       assert(knzu < *nzu);
-                       levels[knzu] = 2*n;
-                       jau[knzu++] = i;
-                       */
-                }
-#endif
-
                 while (next < n)
                 {
-                    assert(knzu < *nzu);
+                    assert(knzu < nzu);
                     levels[knzu] = curlev[next];
                     jau[knzu++] = next;
-                    if (knzu >= *nzu)
+                    if (knzu >= nzu)
                     {
                         //(*nzu)++;
-                        *nzu = *nzu + nRows;
-                        jau.resize(*nzu);
-                        levels.resize(*nzu);
+                        nzu += nRows;
+                        jau.resize(nzu);
+                        levels.resize(nzu);
                     }
                     //jau.push_back(next);
                     //knzu++;
@@ -468,15 +453,14 @@ class FastICPrec
                 iau[i+1] = knzu;
             }
 
-
-            *nzl = knzl;
-            *nzu = knzu;
+            nzl = knzl;
+            nzu = knzu;
 
             #ifdef FASTIC_DEBUG_OUTPUT
             std::cout << "knzl =" << knzl;
             std::cout << "knzu =" << knzu;
             std::cout << "ILU: nnz = "<< knzl + knzu << std::endl;
-            std::cout << "Actual nnz for ILU: " << *nzl + *nzu << std::endl;
+            std::cout << "Actual nnz for ILU: " << nzl + nzu << std::endl;
             #endif
             //Initialize the A matrix that is to be used in the computation
             aRowMap = OrdinalArray("aRowMap", nRows + 1);
@@ -488,7 +472,7 @@ class FastICPrec
 
             Ordinal aRowPtr = 0;
             aRowMap_[0] = 0;
-            for (i = 0; i < nRows; i++) 
+            for (i = 0; i < nRows; i++)
             {
                 #ifdef FASTIC_DEBUG_OUTPUT
                 std::cout << "***row:" << i << std::endl;
@@ -514,7 +498,7 @@ class FastICPrec
             Kokkos::deep_copy(aColIdx, aColIdx_);
             Kokkos::deep_copy(aRowIdx, aRowIdx_);
 
-            //Now allocate memory for L and U. 
+            //Now allocate memory for L and U.
             //
             lRowMap = OrdinalArray("lRowMap", nRows + 1);
             ltRowMap = OrdinalArray("ltRowMap", nRows + 1);
@@ -545,7 +529,7 @@ class FastICPrec
                     {
                         if (col == aColIdxHost[aHostPtr])
                         {
-                            aVal_[k] = aValHost[aHostPtr]; 
+                            aVal_[k] = aValHost[aHostPtr];
                             break;
                         }
                     }
@@ -565,17 +549,17 @@ class FastICPrec
             lRowMap_ = Kokkos::create_mirror_view(lRowMap);
 
             lRowMap_[0] = 0;
-            for (Ordinal i = 0; i < nRows; i++) 
+            for (Ordinal i = 0; i < nRows; i++)
             {
                 Ordinal row_count = 0;
-                for (Ordinal k = aRowMap_[i]; k < aRowMap_[i+1]; k++) 
+                for (Ordinal k = aRowMap_[i]; k < aRowMap_[i+1]; k++)
                 {
                     Ordinal row = i;
                     Ordinal col = aColIdx_[k];
 
                     if (row >= col)
                     {
-                       row_count++; 
+                       row_count++;
                     }
                 }
                 lRowMap_[i+1] = lRowMap_[i] + row_count;
@@ -589,17 +573,17 @@ class FastICPrec
             lColIdx_ = Kokkos::create_mirror_view(lColIdx);
             diagElems_ = Kokkos::create_mirror_view(diagElems);
 
-            Ordinal lPtr = 0; 
-            for (Ordinal i = 0; i < nRows; i++) 
+            Ordinal lPtr = 0;
+            for (Ordinal i = 0; i < nRows; i++)
             {
-                for (Ordinal k = aRowMap_[i]; k < aRowMap_[i+1]; k++) 
+                for (Ordinal k = aRowMap_[i]; k < aRowMap_[i+1]; k++)
                 {
                     Ordinal row = i;
                     Ordinal col = aColIdx_[k];
 
                     if (row >= col)
                     {
-                        if (row == col) 
+                        if (row == col)
                         {
                             diagElems_[row] = aVal_[k];
                         }
@@ -629,7 +613,7 @@ class FastICPrec
                 auto lGVal_ = Kokkos::create_mirror_view(lGVal);
                 Kokkos::deep_copy(lGColIdx_, lGColIdx);
                 Kokkos::deep_copy(lGVal_, lGVal);
-                for (Ordinal i = 0; i < nRows; i++) 
+                for (Ordinal i = 0; i < nRows; i++)
                 {
                     #ifdef SHYLU_DEBUG
                     Ordinal check = lGPtr;
@@ -663,12 +647,12 @@ class FastICPrec
             //Use diag array to store scaling factors since
             //it gets set to the correct value by findFactorPattern anyway.
             auto diagFact_ = Kokkos::create_mirror_view(diagFact);
-            for (int i = 0; i < nRows; i++) 
+            for (int i = 0; i < nRows; i++)
             {
-                for(int k = aRowMap_[i]; k < aRowMap_[i+1]; k++) 
+                for(int k = aRowMap_[i]; k < aRowMap_[i+1]; k++)
                 {
                     aRowIdx_[anext++] = i;
-                    if (aColIdx_[k] == i) 
+                    if (aColIdx_[k] == i)
                     {
                         diagFact_[i] = one/RTS::sqrt(STS::abs(aVal_[k]));
                         #ifdef FASTIC_DEBUG_OUTPUT
@@ -682,9 +666,9 @@ class FastICPrec
             int row;
             int col;
             Real sc1, sc2;
-            for (int i = 0; i < nRows; i++) 
+            for (int i = 0; i < nRows; i++)
             {
-                for (int k = aRowMap_[i]; k < aRowMap_[i+1]; k++) 
+                for (int k = aRowMap_[i]; k < aRowMap_[i+1]; k++)
                 {
                     row = aRowIdx_[k];
                     col = aColIdx_[k];
@@ -701,7 +685,7 @@ class FastICPrec
         {
             const Scalar one = STS::one();
             //Scalar shift = 0.05;
-            for (Ordinal i = 0; i < nRows; i++) 
+            for (Ordinal i = 0; i < nRows; i++)
             {
                 for (Ordinal k = aRowMap_[i]; k < aRowMap_[i+1]; k++)
                 {
@@ -737,10 +721,10 @@ class FastICPrec
             Kokkos::parallel_for(nRows, parInitZero);
             ExecSpace().fence();
 #if 0
-            JacobiIterFunctor<Ordinal, Scalar, ExecSpace> jacIter(nRows, lRowMap, lColIdx, lVal, 
-                                                                  x, y, xOld, diagElems); 
-#endif 
-            BlockJacobiIterFunctorL<Ordinal, Scalar, ExecSpace> jacIter(nRows, blkSz, lRowMap, 
+            JacobiIterFunctor<Ordinal, Scalar, ExecSpace> jacIter(nRows, lRowMap, lColIdx, lVal,
+                                                                  x, y, xOld, diagElems);
+#endif
+            BlockJacobiIterFunctorL<Ordinal, Scalar, ExecSpace> jacIter(nRows, blkSz, lRowMap,
                                                                         lColIdx, lVal,
                                                                         x, y, xOld, diagElems);
             ParCopyFunctor<Ordinal, Scalar, ExecSpace> parCopy(xOld, y);
@@ -750,7 +734,7 @@ class FastICPrec
                 extent++;
             }
             ExecSpace().fence();
-            for (Ordinal i = 0; i < nTrisol; i++) 
+            for (Ordinal i = 0; i < nTrisol; i++)
             {
                 Kokkos::parallel_for(extent, jacIter);
                 ExecSpace().fence();
@@ -766,8 +750,8 @@ class FastICPrec
             Kokkos::parallel_for(nRows, parInitZero);
             ExecSpace().fence();
 #if 0
-            JacobiIterFunctor<Ordinal, Scalar, ExecSpace> jacIter(nRows, ltRowMap, ltColIdx, ltVal, 
-                                                                  x, y, xOld, diagElems); 
+            JacobiIterFunctor<Ordinal, Scalar, ExecSpace> jacIter(nRows, ltRowMap, ltColIdx, ltVal,
+                                                                  x, y, xOld, diagElems);
 #endif
             BlockJacobiIterFunctorU<Ordinal, Scalar, ExecSpace> jacIter(nRows, blkSz, ltRowMap, ltColIdx,
                                                                         ltVal, x, y, xOld, diagElems);
@@ -778,7 +762,7 @@ class FastICPrec
                 extent++;
             }
             ExecSpace().fence();
-            for (Ordinal i = 0; i < nTrisol; i++) 
+            for (Ordinal i = 0; i < nTrisol; i++)
             {
                 Kokkos::parallel_for(extent, jacIter);
                 ExecSpace().fence();
@@ -802,7 +786,7 @@ class FastICPrec
 
             ExecSpace().fence();
 
-            for (Ordinal i = 0; i < nTrisol; i++) 
+            for (Ordinal i = 0; i < nTrisol; i++)
             {
                 Kokkos::parallel_for(nRows, parInitZero1);
                 ExecSpace().fence();
@@ -844,7 +828,7 @@ class FastICPrec
                 extent++;
             }
             //Ordinal extent = aRowMap[nRows];
-            for (int i = 0; i < nFact; i++) 
+            for (int i = 0; i < nFact; i++)
             {
                 Kokkos::parallel_for(extent, icFunctor);
             }
@@ -855,7 +839,7 @@ class FastICPrec
 
             Kokkos::deep_copy(diagElems_, diagElems);
             diagElemsInv_ = Kokkos::create_mirror_view(diagElemsInv);
-            for (int i = 0; i < nRows; i++) 
+            for (int i = 0; i < nRows; i++)
             {
                 diagElemsInv_[i] = one/diagElems_[i];
             }

--- a/packages/shylu/shylu_node/fastilu/src/shylu_fastildl.hpp
+++ b/packages/shylu/shylu_node/fastilu/src/shylu_fastildl.hpp
@@ -1,9 +1,9 @@
 //@HEADER
 // ************************************************************************
-// 
+//
 //               ShyLU: Hybrid preconditioner package
 //                 Copyright 2012 Sandia Corporation
-// 
+//
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 // the U.S. Government retains certain rights in this software.
 //
@@ -34,8 +34,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Siva Rajamanickam (srajama@sandia.gov) 
-// 
+// Questions? Contact Siva Rajamanickam (srajama@sandia.gov)
+//
 // ************************************************************************
 //@HEADER
 
@@ -76,9 +76,9 @@ class FastILDLPrec
         typedef Kokkos::View<Ordinal *, ExecSpace> OrdinalArray;
         typedef Kokkos::View<Scalar *, ExecSpace> ScalarArray;
         typedef Kokkos::View<Real *, ExecSpace> RealArray;
-        typedef Kokkos::View<Ordinal *, typename ExecSpace::array_layout, Kokkos::Serial, 
+        typedef Kokkos::View<Ordinal *, typename ExecSpace::array_layout, Kokkos::Serial,
                 Kokkos::MemoryUnmanaged> UMOrdinalArray;
-        typedef Kokkos::View<Scalar *, typename ExecSpace::array_layout, Kokkos::Serial, 
+        typedef Kokkos::View<Scalar *, typename ExecSpace::array_layout, Kokkos::Serial,
                 Kokkos::MemoryUnmanaged> UMScalarArray;
         typedef FastILDLPrec<Ordinal, Scalar, ExecSpace> FastPrec;
 
@@ -198,7 +198,7 @@ class FastILDLPrec
 
             if (level > 0)
             {
-                initGuessPrec = Teuchos::rcp(new FastPrec(aRowMapIn, aColIdxIn, aValIn, nRow_, standard_sptrsv, 3, 5, 
+                initGuessPrec = Teuchos::rcp(new FastPrec(aRowMapIn, aColIdxIn, aValIn, nRow_, standard_sptrsv, 3, 5,
                                                           level_-1, omega_, shift_, guessFlag_, blkSzILDL_, blkSz_));
             }
 
@@ -224,11 +224,11 @@ class FastILDLPrec
             Kokkos::parallel_for(nRows, copyFunc1);
 
             //Note that the following is a temporary measure
-            //to ensure that memory resides on the device. 
+            //to ensure that memory resides on the device.
             Ordinal nnzL = lRowMap[nRows];
             Ordinal nnzA = aRowMap[nRows];
             MemoryPrimeFunctorNnzCoo<Ordinal, Scalar, ExecSpace> copyFunc2(aColIdx, aRowIdx, aVal);
-            MemoryPrimeFunctorNnzCsr<Ordinal, Scalar, ExecSpace> copyFunc3(lColIdx, lVal); 
+            MemoryPrimeFunctorNnzCsr<Ordinal, Scalar, ExecSpace> copyFunc3(lColIdx, lVal);
 
             ExecSpace().fence();
             Kokkos::parallel_for(nRows, copyFunc1);
@@ -242,7 +242,7 @@ class FastILDLPrec
             #endif
             initTime = t;
             return;
-            
+
         }
 
         void getL(OrdinalArray &lRowMapOut, OrdinalArray &lColIdxOut, ScalarArray &lValOut)
@@ -266,36 +266,36 @@ class FastILDLPrec
             //Count the elements in each row of Lt
             auto temp = OrdinalArrayHost("temp", nRows + 1);
             auto rowPtrs = OrdinalArrayHost("rowPtrs", nRows);
-            for (Ordinal i = 0; i <= nRows; i++) 
+            for (Ordinal i = 0; i <= nRows; i++)
             {
                 temp[i] = 0;
             }
-            for (Ordinal i = 0; i < nRows; i++) 
+            for (Ordinal i = 0; i < nRows; i++)
             {
-                for (Ordinal k = lRowMap_[i]; k < lRowMap_[i+1]; k++) 
+                for (Ordinal k = lRowMap_[i]; k < lRowMap_[i+1]; k++)
                 {
                     temp[lColIdx_[k]+1]++;
 
                 }
             }
-            //Perform an add scan to get the row map for 
+            //Perform an add scan to get the row map for
             //the transpose
-            for (Ordinal i = 0; i <= nRows; i++) 
+            for (Ordinal i = 0; i <= nRows; i++)
             {
                 ltRowMap_[i] = temp[i];
             }
-            for (Ordinal i = 1; i <= nRows; i++) 
+            for (Ordinal i = 1; i <= nRows; i++)
             {
                 ltRowMap_[i] += ltRowMap_[i-1];
             }
             //Set the row pointers to their initial places;
-            for (Ordinal i = 0; i < nRows; i++) 
+            for (Ordinal i = 0; i < nRows; i++)
             {
                 rowPtrs[i] = ltRowMap_[i];
             }
             //Copy the data
             Kokkos::deep_copy(lVal_, lVal);
-            for (Ordinal i = 0; i < nRows; i++) 
+            for (Ordinal i = 0; i < nRows; i++)
             {
                 for (Ordinal k = lRowMap_[i]; k < lRowMap_[i+1]; k++)
                 {
@@ -320,23 +320,19 @@ class FastILDLPrec
             using std::sort;
             OrdinalArrayMirror ia = aRowMapHost;
             OrdinalArrayMirror ja = aColIdxHost;
-            int *nzu;
-            int *nzl;
-            nzu = new int[1];
-            nzl = new int[1];
             int n = nRows;
-            *nzl = aRowMapHost[nRows] * (level + 2);
-            *nzu = aRowMapHost[nRows] * (level + 2);
+            int nzl = aRowMapHost[nRows] * (level + 2);
+            int nzu = aRowMapHost[nRows] * (level + 2);
             Ordinal i;
             int levfill = level;
             vector<int> lnklst(n);
             vector<int> curlev(n);
-            vector<int> levels(*nzu);
+            vector<int> levels(nzu);
             vector<int> iwork(n);
-            vector<int> ial(*nzl);
-            vector<int> jal(*nzl);
-            vector<int> iau(*nzu);
-            vector<int> jau(*nzu);
+            vector<int> ial(nzl);
+            vector<int> jal(nzl);
+            vector<int> iau(nzu);
+            vector<int> jau(nzu);
 
             int knzl = 0;
             int knzu = 0;
@@ -426,13 +422,13 @@ class FastILDLPrec
                 next = first;
                 while (next < i)
                 {
-                    assert(knzl < *nzl);
+                    assert(knzl < nzl);
                     jal[knzl++] = next;
-                    if (knzl >= *nzl)
+                    if (knzl >= nzl)
                     {
                         //(*nzl)++;
-                        *nzl = *nzl + nRows;
-                        jal.resize(*nzl);
+                        nzl += nRows;
+                        jal.resize(nzl);
                     }
                     //jal.push_back(next);
                    // knzl++;
@@ -441,28 +437,17 @@ class FastILDLPrec
                 ial[i+1] = knzl;
                 assert(next == i);
 
-#if 0
-                if (next != i)
-                {
-                    /*
-                       assert(knzu < *nzu);
-                       levels[knzu] = 2*n;
-                       jau[knzu++] = i;
-                       */
-                }
-#endif
-
                 while (next < n)
                 {
-                    assert(knzu < *nzu);
+                    assert(knzu < nzu);
                     levels[knzu] = curlev[next];
                     jau[knzu++] = next;
-                    if (knzu >= *nzu)
+                    if (knzu >= nzu)
                     {
                         //(*nzu)++;
-                        *nzu = *nzu + nRows;
-                        jau.resize(*nzu);
-                        levels.resize(*nzu);
+                        nzu += nzu + nRows;
+                        jau.resize(nzu);
+                        levels.resize(nzu);
                     }
                     //jau.push_back(next);
                     //knzu++;
@@ -476,12 +461,12 @@ class FastILDLPrec
             std::cout << "knzu =" << knzu;
             #endif
 
-            *nzl = knzl;
-            *nzu = knzu;
+            nzl = knzl;
+            nzu = knzu;
 
             #ifdef FASTILDL_DEBUG_OUTPUT
             std::cout << "ILU: nnz = "<< knzl + knzu << std::endl;
-            std::cout << "Actual nnz for ILU: " << *nzl + *nzu << std::endl;
+            std::cout << "Actual nnz for ILU: " << nzl + nzu << std::endl;
             #endif
             //Initialize the A matrix that is to be used in the computation
             aRowMap = OrdinalArray("aRowMap", nRows + 1);
@@ -493,7 +478,7 @@ class FastILDLPrec
 
             Ordinal aRowPtr = 0;
             aRowMap_[0] = 0;
-            for (i = 0; i < nRows; i++) 
+            for (i = 0; i < nRows; i++)
             {
                 #ifdef FASTILDL_DEBUG_OUTPUT
                 std::cout << "***row:" << i << std::endl;
@@ -519,7 +504,7 @@ class FastILDLPrec
             Kokkos::deep_copy(aColIdx, aColIdx_);
             Kokkos::deep_copy(aRowIdx, aRowIdx_);
 
-            //Now allocate memory for L and U. 
+            //Now allocate memory for L and U.
             //
             lRowMap = OrdinalArray("lRowMap", nRows + 1);
             ltRowMap = OrdinalArray("ltRowMap", nRows + 1);
@@ -550,7 +535,7 @@ class FastILDLPrec
                     {
                         if (col == aColIdxHost[aHostPtr])
                         {
-                            aVal_[k] = aValHost[aHostPtr]; 
+                            aVal_[k] = aValHost[aHostPtr];
                             break;
                         }
                     }
@@ -564,23 +549,23 @@ class FastILDLPrec
 
             fillL();
         }
-        
+
         void countL()
         {
             lRowMap_ = Kokkos::create_mirror_view(lRowMap);
 
             lRowMap_[0] = 0;
-            for (Ordinal i = 0; i < nRows; i++) 
+            for (Ordinal i = 0; i < nRows; i++)
             {
                 Ordinal row_count = 0;
-                for (Ordinal k = aRowMap_[i]; k < aRowMap_[i+1]; k++) 
+                for (Ordinal k = aRowMap_[i]; k < aRowMap_[i+1]; k++)
                 {
                     Ordinal row = i;
                     Ordinal col = aColIdx_[k];
 
                     if (row >= col)
                     {
-                       row_count++; 
+                       row_count++;
                     }
                 }
                 lRowMap_[i+1] = lRowMap_[i] + row_count;
@@ -594,17 +579,17 @@ class FastILDLPrec
             lColIdx_ = Kokkos::create_mirror_view(lColIdx);
             diagElems_ = Kokkos::create_mirror_view(diagElems);
 
-            Ordinal lPtr = 0; 
-            for (Ordinal i = 0; i < nRows; i++) 
+            Ordinal lPtr = 0;
+            for (Ordinal i = 0; i < nRows; i++)
             {
-                for (Ordinal k = aRowMap_[i]; k < aRowMap_[i+1]; k++) 
+                for (Ordinal k = aRowMap_[i]; k < aRowMap_[i+1]; k++)
                 {
                     Ordinal row = i;
                     Ordinal col = aColIdx_[k];
 
                     if (row >= col)
                     {
-                        if (row == col) 
+                        if (row == col)
                         {
                             diagElems_[row] = aVal_[k];
                         }
@@ -634,7 +619,7 @@ class FastILDLPrec
                 auto lGVal_ = Kokkos::create_mirror_view(lGVal);
                 Kokkos::deep_copy(lGColIdx_, lGColIdx);
                 Kokkos::deep_copy(lGVal_, lGVal);
-                for (Ordinal i = 0; i < nRows; i++) 
+                for (Ordinal i = 0; i < nRows; i++)
                 {
                     #ifdef SHYLU_DEBUG
                     Ordinal check = lGPtr;
@@ -668,12 +653,12 @@ class FastILDLPrec
             //Use diag array to store scaling factors since
             //it gets set to the correct value by findFactorPattern anyway.
             auto diagFact_ = Kokkos::create_mirror_view(diagFact);
-            for (int i = 0; i < nRows; i++) 
+            for (int i = 0; i < nRows; i++)
             {
-                for(int k = aRowMap_[i]; k < aRowMap_[i+1]; k++) 
+                for(int k = aRowMap_[i]; k < aRowMap_[i+1]; k++)
                 {
                     aRowIdx_[anext++] = i;
-                    if (aColIdx_[k] == i) 
+                    if (aColIdx_[k] == i)
                     {
                         diagFact_[i] = one/(RTS::sqrt(STS::abs(aVal_[k])));
                         #ifdef FASTILDL_DEBUG_OUTPUT
@@ -687,9 +672,9 @@ class FastILDLPrec
             int row;
             int col;
             Real sc1, sc2;
-            for (int i = 0; i < nRows; i++) 
+            for (int i = 0; i < nRows; i++)
             {
-                for (int k = aRowMap_[i]; k < aRowMap_[i+1]; k++) 
+                for (int k = aRowMap_[i]; k < aRowMap_[i+1]; k++)
                 {
                     row = aRowIdx_[k];
                     col = aColIdx_[k];
@@ -706,7 +691,7 @@ class FastILDLPrec
         {
             const Scalar one = Kokkos::ArithTraits<Scalar>::one();
             //Scalar shift = 0.05;
-            for (Ordinal i = 0; i < nRows; i++) 
+            for (Ordinal i = 0; i < nRows; i++)
             {
                 for (Ordinal k = aRowMap_[i]; k < aRowMap_[i+1]; k++)
                 {
@@ -742,8 +727,8 @@ class FastILDLPrec
             Kokkos::parallel_for(nRows, parInitZero);
             ExecSpace().fence();
 #if 0
-            JacobiIterFunctor<Ordinal, Scalar, ExecSpace> jacIter(nRows, lRowMap, lColIdx, lVal, x, y, xOld, onesVector); 
-#endif 
+            JacobiIterFunctor<Ordinal, Scalar, ExecSpace> jacIter(nRows, lRowMap, lColIdx, lVal, x, y, xOld, onesVector);
+#endif
             BlockJacobiIterFunctorL<Ordinal, Scalar, ExecSpace> jacIter(nRows, blkSz, lRowMap, lColIdx, lVal,
                                                                         x, y, xOld, onesVector);
             ParCopyFunctor<Ordinal, Scalar, ExecSpace> parCopy(xOld, y);
@@ -753,7 +738,7 @@ class FastILDLPrec
                 extent++;
             }
             ExecSpace().fence();
-            for (Ordinal i = 0; i < nTrisol; i++) 
+            for (Ordinal i = 0; i < nTrisol; i++)
             {
                 Kokkos::parallel_for(extent, jacIter);
                 ExecSpace().fence();
@@ -769,8 +754,8 @@ class FastILDLPrec
             Kokkos::parallel_for(nRows, parInitZero);
             ExecSpace().fence();
 #if 0
-            JacobiIterFunctor<Ordinal, Scalar, ExecSpace> jacIter(nRows, ltRowMap, ltColIdx, ltVal, x, y, xOld, onesVector); 
-#endif 
+            JacobiIterFunctor<Ordinal, Scalar, ExecSpace> jacIter(nRows, ltRowMap, ltColIdx, ltVal, x, y, xOld, onesVector);
+#endif
             BlockJacobiIterFunctorU<Ordinal, Scalar, ExecSpace> jacIter(nRows, blkSz, ltRowMap, ltColIdx, ltVal,
                                                                         x, y, xOld, onesVector);
             ParCopyFunctor<Ordinal, Scalar, ExecSpace> parCopy(xOld, y);
@@ -781,7 +766,7 @@ class FastILDLPrec
             }
             ExecSpace().fence();
 
-            for (Ordinal i = 0; i < nTrisol; i++) 
+            for (Ordinal i = 0; i < nTrisol; i++)
             {
                 Kokkos::parallel_for(extent, jacIter);
                 ExecSpace().fence();
@@ -822,7 +807,7 @@ class FastILDLPrec
                 extent++;
             }
             //Ordinal extent = aRowMap[nRows];
-            for (int i = 0; i < nFact; i++) 
+            for (int i = 0; i < nFact; i++)
             {
                 Kokkos::parallel_for(extent, ildltFunctor);
             }
@@ -833,7 +818,7 @@ class FastILDLPrec
 
             Kokkos::deep_copy(diagElems_, diagElems);
             diagElemsInv_ = Kokkos::create_mirror_view(diagElemsInv);
-            for (int i = 0; i < nRows; i++) 
+            for (int i = 0; i < nRows; i++)
             {
                 diagElemsInv_[i] = one/diagElems_[i];
             }
@@ -994,7 +979,7 @@ class FastILDLFunctor
                 _Ap(Ap), _Ai(Ai), _Aj(Aj),  _Lp(Lp), _Li(Li), _Ax(Ax), _Lx(Lx), _diag(diag), _omega(omega)
     {
     }
-        
+
         KOKKOS_INLINE_FUNCTION
             void operator()(const Ordinal blk_index) const
             {
@@ -1021,7 +1006,7 @@ class FastILDLFunctor
                     Ordinal lptr = _Lp[i];
                     Ordinal ltptr = _Lp[j];
                     Ordinal endpt = j;
-                    if (i >= j) { 
+                    if (i >= j) {
 
                         for ( ; _Li[lptr] < endpt && _Li[ltptr] < endpt; )
                         {
@@ -1035,12 +1020,12 @@ class FastILDLFunctor
                             {
                                 lptr++;
                             }
-                            else 
+                            else
                             {
                                 ltptr++;
                             }
                         }
-                        if (i > j) 
+                        if (i > j)
                         {
                             val = (val-acc_val) / _diag[j];
                             for ( ; _Li[lptr] < j ; lptr++) ; // dummy loop


### PR DESCRIPTION
Fix valgrind errors coming from ifpack2. Also remove trailing whitespaces from a couple shylu headers.

@trilinos/shylu 
@trilinos/ifpack2 

## Motivation

Valgrind errors were showing up on the dashboard after some ifpack2 tests were promoted to nightly.

## Related Issues

Fixes #12379

## Testing

Ran a few tests with valgrind to confirm valgrind errors are fixed.
