### PR TITLE
MueLu RefMaxwell: Fix issue in default parameterlist

### DIFF
--- a/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
@@ -1872,9 +1872,6 @@ namespace MueLu {
     RCP<Teuchos::TimeMonitor> tm = getTimer("vectorial nodal prolongator");
     GetOStream(Runtime0) << solverName_+"::compute(): building vectorial nodal prolongator" << std::endl;
 
-    using ATS        = Kokkos::ArithTraits<Scalar>;
-    using impl_Scalar = typename ATS::val_type;
-    using impl_ATS = Kokkos::ArithTraits<impl_Scalar>;
     using range_type = Kokkos::RangePolicy<LO, typename NO::execution_space>;
 
     typedef typename Matrix::local_matrix_type KCRS;

--- a/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
@@ -190,7 +190,7 @@ namespace MueLu {
     params->set("multigrid algorithm", "Unsmoothed");
     params->set("transpose: use implicit", MasterList::getDefault<bool>("transpose: use implicit"));
     params->set("rap: triple product", MasterList::getDefault<bool>("rap: triple product"));
-    params->set("rap: fix zero diagonals", MasterList::getDefault<bool>("rap: fix zero diagonals"));
+    params->set("rap: fix zero diagonals", true);
     params->set("rap: fix zero diagonals threshold", MasterList::getDefault<double>("rap: fix zero diagonals threshold"));
     params->set("fuse prolongation and update", MasterList::getDefault<bool>("fuse prolongation and update"));
     params->set("refmaxwell: subsolves on subcommunicators", MasterList::getDefault<bool>("refmaxwell: subsolves on subcommunicators"));

--- a/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
@@ -2525,6 +2525,8 @@ namespace MueLu {
           Dk_1 = D0;
         else if (D0.is_null())
           D0 = Dk_1;
+        if (M1_beta.is_null())
+          M1_beta = Mk_one;
       } else if (spaceNumber == 2) {
         if (Dk_2.is_null())
           Dk_2 = D0;

--- a/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
@@ -339,8 +339,6 @@ namespace MueLu {
     }
     prec_->setParameters(amesos2_params);
 
-    prec_->numericFactorization();
-
     SmootherPrototype::IsSetup(true);
   }
 


### PR DESCRIPTION
@trilinos/muelu 

- Change a parameter value in RefMaxwell's default list to match previous behavior.
- Revert change to trigger coarse solver factorization during setup. EMPIRE and Albany reported issues.
