### PR TITLE
Shylu: Fix compiling with SYCL

### DIFF
--- a/packages/shylu/shylu_node/tacho/src/Tacho.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho.hpp
@@ -108,6 +108,20 @@ template <typename T> struct UseThisFuture<T, Kokkos::HIP> {
   using future_type = type;
 };
 #endif
+#if defined(KOKKOS_ENABLE_SYCL)
+template <> struct UseThisDevice<Kokkos::Experimental::SYCL> {
+  using type = Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>;
+  using device_type = type;
+};
+template <> struct UseThisScheduler<Kokkos::Experimental::SYCL> {
+  using type = DummyTaskScheduler<Kokkos::Experimental::SYCL>;
+  using scheduler_type = type;
+};
+template <typename T> struct UseThisFuture<T, Kokkos::Experimental::SYCL> {
+  using type = DummyFuture<T, Kokkos::Experimental::SYCL>;
+  using future_type = type;
+};
+#endif
 #if defined(KOKKOS_ENABLE_OPENMP)
 template <> struct UseThisDevice<Kokkos::OpenMP> {
   using type = Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace>;


### PR DESCRIPTION
@trilinos/Shylu

## Motivation
This fixes compiling `Shylu` with `SYCL` enabled in `Kokkos`.

## Related Issues

* Related to #12420 and #12428

## Testing
Compiling `Trilinos` with `Shylu` and `Kokkos+SYCL`.