### PR TITLE
Sacado: Fix compiling with SYCL

### DIFF
--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_Atomic.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_Atomic.hpp
@@ -339,6 +339,27 @@ namespace Sacado {
         }
       }
 
+#elif defined(KOKKOS_ENABLE_SYCL)
+
+      // Our implementation of Kokkos::atomic_oper_fetch() and
+      // Kokkos::atomic_fetch_oper() for Sacado types on device
+      template <typename Oper, typename DestPtrT, typename ValT, typename T>
+      typename Sacado::BaseExprType< Expr<T> >::type
+      atomic_oper_fetch_device(const Oper& op, DestPtrT dest, ValT* dest_val,
+                               const Expr<T>& x)
+      {
+        Kokkos::abort("Not implemented!");
+        return {};
+      }
+
+      template <typename Oper, typename DestPtrT, typename ValT, typename T>
+      typename Sacado::BaseExprType< Expr<T> >::type
+      atomic_fetch_oper_device(const Oper& op, DestPtrT dest, ValT* dest_val,
+                               const Expr<T>& x)
+      {
+        Kokkos::abort("Not implemented!");
+        return {};
+      }
 #endif
 
       // Overloads of Kokkos::atomic_oper_fetch/Kokkos::atomic_fetch_oper


### PR DESCRIPTION
@trilinos/Sacado

## Motivation
This fixes compiling with `Sacado` and `Kokkos+SYCL`. Clearly, it's not the best solution to just abort for unsupported functionality but at least this lets us compile.
The support for arbitrary size atomics for `Kokkos+SYCL` depends a lot on compiler versions and it's not clear to me what the best solution is as of now.

## Related Issues

* Related to #12420 and #12428

## Testing
Compiling `Trilinos` with `Sacado` and `Kokkos+SYCL`.