### PR TITLE
Tempus: Split Up IMEX RK Partitioned FSA Tests

### DIFF
--- a/packages/tempus/test/IMEX_RK_Partitioned/CMakeLists.txt
+++ b/packages/tempus/test/IMEX_RK_Partitioned/CMakeLists.txt
@@ -42,6 +42,43 @@ TRIBITS_ADD_TEST(
   NUM_MPI_PROCS 1
   )
 
+
+TRIBITS_ADD_EXECUTABLE(
+  IMEX_RK_Partitioned_Combined_FSA_Tangent
+  SOURCES Tempus_IMEX_RK_Partitioned_Combined_FSA_Tangent.cpp Tempus_IMEX_RK_Partitioned_FSA.hpp
+  TESTONLYLIBS tempus_test_models
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Combined_FSA_Tangent
+  NAME "IMEX_RK_Partitioned_Combined_FSA_Tangent_Partitioned_IMEX_RK_1st_Order"
+  ARGS "--method=\"Partitioned IMEX RK 1st order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Combined_FSA_Tangent
+  NAME "IMEX_RK_Partitioned_Combined_FSA_Tangent_Partitioned_IMEX_RK_SSP2"
+  ARGS "--method=\"Partitioned IMEX RK SSP2\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Combined_FSA_Tangent
+  NAME "IMEX_RK_Partitioned_Combined_FSA_Tangent_Partitioned_IMEX_RK_ARS_233"
+  ARGS "--method=\"Partitioned IMEX RK ARS 233\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Combined_FSA_Tangent
+  NAME "IMEX_RK_Partitioned_Combined_FSA_Tangent_General_Partioned_IMEX_RK"
+  ARGS "--method=\"General Partitioned IMEX RK\""
+  NUM_MPI_PROCS 1
+  )
+
+
+
 TRIBITS_ADD_EXECUTABLE(
   IMEX_RK_Partitioned_Staggered_FSA
   SOURCES Tempus_IMEX_RK_Partitioned_Staggered_FSA.cpp Tempus_IMEX_RK_Partitioned_FSA.hpp
@@ -76,7 +113,43 @@ TRIBITS_ADD_TEST(
   NUM_MPI_PROCS 1
   )
 
+
+
+TRIBITS_ADD_EXECUTABLE(
+  IMEX_RK_Partitioned_Staggered_FSA_Tangent
+  SOURCES Tempus_IMEX_RK_Partitioned_Staggered_FSA_Tangent.cpp Tempus_IMEX_RK_Partitioned_FSA.hpp
+  TESTONLYLIBS tempus_test_models
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Staggered_FSA_Tangent
+  NAME "IMEX_RK_Partitioned_Staggered_FSA_Tangent_Partitioned_IMEX_RK_1st_Order"
+  ARGS "--method=\"Partitioned IMEX RK 1st order\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Staggered_FSA_Tangent
+  NAME "IMEX_RK_Partitioned_Staggered_FSA_Tangent_Partitioned_IMEX_RK_SSP2"
+  ARGS "--method=\"Partitioned IMEX RK SSP2\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Staggered_FSA_Tangent
+  NAME "IMEX_RK_Partitioned_Staggered_FSA_Tangent_Partitioned_IMEX_RK_ARS_233"
+  ARGS "--method=\"Partitioned IMEX RK ARS 233\""
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_TEST(
+  IMEX_RK_Partitioned_Staggered_FSA_Tangent
+  NAME "IMEX_RK_Partitioned_Staggered_FSA_Tangent_General_Partioned_IMEX_RK"
+  ARGS "--method=\"General Partitioned IMEX RK\""
+  NUM_MPI_PROCS 1
+  )
+
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Test_IMEX_RK_Partitioned_CopyFiles
   DEST_FILES Tempus_IMEX_RK_VanDerPol.xml
-  EXEDEPS IMEX_RK_Partitioned
+  EXEDEPS IMEX_RK_Partitioned IMEX_RK_Partitioned_Combined_FSA IMEX_RK_Partitioned_Combined_FSA_Tangent IMEX_RK_Partitioned_Staggered_FSA IMEX_RK_Partitioned_Staggered_FSA_Tangent
   )

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_Combined_FSA_Tangent.cpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_Combined_FSA_Tangent.cpp
@@ -16,9 +16,9 @@ std::string method_name;
 
 namespace Tempus_Test {
 
-TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol_Combined_FSA)
+TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol_Combined_FSA_Tangent)
 {
-  test_vdp_fsa(method_name, true, false, out, success);
+  test_vdp_fsa(method_name, true, true, out, success);
 }
 
 

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_Staggered_FSA.cpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_Staggered_FSA.cpp
@@ -21,10 +21,6 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol_Staggered_FSA)
   test_vdp_fsa(method_name, false, false, out, success);
 }
 
-TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol_Staggered_FSA_Tangent)
-{
-  test_vdp_fsa(method_name, false, true, out, success);
-}
 
 } // namespace Tempus_Test
 

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_Staggered_FSA_Tangent.cpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_Staggered_FSA_Tangent.cpp
@@ -16,11 +16,10 @@ std::string method_name;
 
 namespace Tempus_Test {
 
-TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol_Combined_FSA)
+TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol_Staggered_FSA_Tangent)
 {
-  test_vdp_fsa(method_name, true, false, out, success);
+  test_vdp_fsa(method_name, false, true, out, success);
 }
-
 
 } // namespace Tempus_Test
 


### PR DESCRIPTION
IMEX RK Partitioned FSA tests in debug mode were occasionally running too long, when resources were loaded.  Splitting up these tests into individual tests based on using dfdp as the tangent or not.

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

@trilinos/tempus 

## Related Issues

* Closes #12506 