### PR TITLE
Disable secondary submit to testing-dev.sandia.gov

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -20,9 +20,9 @@ IF (CTEST_DROP_METHOD STREQUAL "http" OR CTEST_DROP_METHOD STREQUAL "https")
   SET_DEFAULT_AND_FROM_ENV(CTEST_DROP_LOCATION "/cdash/submit.php?project=Trilinos")
   SET_DEFAULT_AND_FROM_ENV(CTEST_TRIGGER_SITE "")
   SET_DEFAULT_AND_FROM_ENV(CTEST_DROP_SITE_CDASH TRUE)
-  # Secondary submit to development CDash site
-  SET_DEFAULT_AND_FROM_ENV(TRIBITS_2ND_CTEST_DROP_SITE
-    "testing-dev.sandia.gov")
-  SET_DEFAULT_AND_FROM_ENV(TRIBITS_2ND_CTEST_DROP_LOCATION
-    "/cdash/submit.php?project=Trilinos")
+#  # Secondary submit to development CDash site
+#  SET_DEFAULT_AND_FROM_ENV(TRIBITS_2ND_CTEST_DROP_SITE
+#    "testing-dev.sandia.gov")
+#  SET_DEFAULT_AND_FROM_ENV(TRIBITS_2ND_CTEST_DROP_LOCATION
+#    "/cdash/submit.php?project=Trilinos")
 ENDIF()


### PR DESCRIPTION
The submits to testing-dev.sandia.gov/cdash don't work from some machines at SNL. Therefore, we will disable for now until this can be fixed.  (See commit message).
