### PR TITLE
Tpetra: assume gpu-aware mpi

### DIFF
--- a/packages/tpetra/CMakeCuda.txt
+++ b/packages/tpetra/CMakeCuda.txt
@@ -25,7 +25,9 @@ ENDIF ()
 
 # Checks that only matter if building with CUDA enabled.
 IF (Tpetra_ENABLE_CUDA) 
-  message("CUDA_VERSION=${CUDA_VERSION}")
+  IF (DEFINED CUDA_VERSION)
+    message(STATUS "CUDA_VERSION=${CUDA_VERSION}")
+  ENDIF ()
   IF (NOT DEFINED Kokkos_ENABLE_CUDA_LAMBDA OR NOT Kokkos_ENABLE_CUDA_LAMBDA)
     MESSAGE (FATAL_ERROR "If building with CUDA, Tpetra and downstream packages require that you set the CMake option Kokkos_ENABLE_CUDA_LAMBDA:BOOL=ON (this is the default behavior).")
   ENDIF ()

--- a/packages/tpetra/CMakeLists.txt
+++ b/packages/tpetra/CMakeLists.txt
@@ -368,7 +368,7 @@ ENDIF () # Tpetra_INST_SYCL
 # safe, but possibly less performant assumption that MPI is not CUDA
 # aware.
 
-SET (Tpetra_ASSUME_GPU_AWARE_MPI_DEFAULT OFF)
+SET (Tpetra_ASSUME_GPU_AWARE_MPI_DEFAULT ON)
 
 ASSERT_DEFINED (TPL_ENABLE_MPI)
 MESSAGE (STATUS "Determine whether Tpetra will assume that MPI is GPU aware:")
@@ -511,7 +511,8 @@ ELSE ()
         MESSAGE (STATUS "  - While I found the \"ompi_info\" executable, it would not run.  Thus, I will make the sane assumption that your MPI implementation is NOT GPU aware. You can change this at configure time with the option Tpetra_ASSUME_GPU_AWARE_MPI=ON, and override the configure-time setting at runtime with the environment variable TPETRA_ASSUME_GPU_AWARE_MPI=ON or OFF.")
       ENDIF ()
     ELSE ()
-      MESSAGE (STATUS "  - Tpetra did not find the \"ompi_info\" executable.  This may not be bad; for example, if your MPI implementation is not OpenMPI, then you won't have this executable.  Tpetra will conservatively assume that your MPI implementation is NOT GPU aware.  If you would like to change this, please set the CMake variable Tpetra_ASSUME_GPU_AWARE_MPI:BOOL=ON explicitly at configure time.  You can also override this at runtime with the environment variable TPETRA_ASSUME_GPU_AWARE_MPI=ON or OFF.")
+      MESSAGE (STATUS "  - Search for \"ompi_info\" failed, unable to automatically detect whether MPI is GPU-aware.")
+      MESSAGE (STATUS "  - Whether MPI is GPU-aware may be specified at runtime with the environment variable TPETRA_ASSUME_GPU_AWARE_MPI=ON or OFF.")
     ENDIF () # Tpetra_FOUND_OMPI_INFO_EXECUTABLE
   ENDIF () # Whether we are cross compiling
 ENDIF () # Whether we have CUDA and MPI
@@ -542,6 +543,7 @@ TRIBITS_ADD_OPTION_AND_DEFINE(
   ${Tpetra_ASSUME_CUDA_AWARE_MPI})
 
 
+MESSAGE(STATUS "Tpetra: defaulting to Tpetra_ASSUME_GPU_AWARE_MPI: ${Tpetra_ASSUME_GPU_AWARE_MPI}")
 
 #
 # Check that users did not attempt to enable both the OpenMP and
@@ -586,6 +588,7 @@ MESSAGE(STATUS "  - OpenMP:  ${HAVE_TPETRA_OPENMP}")
 MESSAGE(STATUS "  - Cuda:    ${HAVE_TPETRA_CUDA}")
 MESSAGE(STATUS "  - HIP:     ${HAVE_TPETRA_HIP}")
 MESSAGE(STATUS "  - SYCL:    ${HAVE_TPETRA_SYCL}")
+
 
 # Fix Github Issue #190 by making sure that users enabled at least one
 # Node type.


### PR DESCRIPTION
Tpetra will now set Tpetra_ASSUME_GPU_AWARE_MPI to true unless automatic detection or the user indicates otherwise. Previously, the default value was false.

Addresses #12468.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/<teamName>

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Most HPC platforms have GPU-aware MPI.  The existing logic (which I didn't really change) is fragile and assumes an OpenMPI-based variant.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Discussions with @csiefer2.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested with local cmake configuring.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->