### PR TITLE
Ifpack2 Hypre: Only instantiate interface for hypre enabled options

### DIFF
--- a/packages/ifpack/utils/parseHypre.py
+++ b/packages/ifpack/utils/parseHypre.py
@@ -47,64 +47,64 @@ with open(outputFile, 'w') as out:
     m = functionInt.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, int_func> FunctionParameter::hypreMapIntFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, int_func> FunctionParameter::hypreMapIntFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionDouble.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, double_func> FunctionParameter::hypreMapDoubleFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, double_func> FunctionParameter::hypreMapDoubleFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionDoubleInt.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, double_int_func> FunctionParameter::hypreMapDoubleIntFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, double_int_func> FunctionParameter::hypreMapDoubleIntFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionIntDouble.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, int_double_func> FunctionParameter::hypreMapIntDoubleFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, int_double_func> FunctionParameter::hypreMapIntDoubleFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionIntInt.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, int_int_func> FunctionParameter::hypreMapIntIntFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, int_int_func> FunctionParameter::hypreMapIntIntFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionIntStar.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, int_star_func> FunctionParameter::hypreMapIntStarFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, int_star_func> FunctionParameter::hypreMapIntStarFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionDoubleStar.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, double_star_func> FunctionParameter::hypreMapDoubleStarFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, double_star_func> FunctionParameter::hypreMapDoubleStarFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionIntIntDoubleDouble.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, int_int_double_double_func> FunctionParameter::hypreMapIntIntDoubleDoubleFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, int_int_double_double_func> FunctionParameter::hypreMapIntIntDoubleDoubleFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionIntIntIntDoubleIntInt.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, int_int_int_double_int_int_func> FunctionParameter::hypreMapIntIntIntDoubleIntIntFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, int_int_int_double_int_int_func> FunctionParameter::hypreMapIntIntIntDoubleIntIntFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionIntStarStar.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, int_star_star_func> FunctionParameter::hypreMapIntStarStarFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, int_star_star_func> FunctionParameter::hypreMapIntStarStarFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionCharStar.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, char_star_func> FunctionParameter::hypreMapCharStarFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, char_star_func> FunctionParameter::hypreMapCharStarFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))

--- a/packages/ifpack2/src/Ifpack2_Hypre_FunctionParameters.hpp
+++ b/packages/ifpack2/src/Ifpack2_Hypre_FunctionParameters.hpp
@@ -97,15 +97,15 @@ typedef struct hypre_ParVector_struct hypre_ParVector;
 
 // The Python script that generates the ParameterMap needs to be after these typedefs
 typedef HYPRE_Int (*int_func)(HYPRE_Solver, HYPRE_Int);
-typedef HYPRE_Int (*double_func)(HYPRE_Solver, double);
-typedef HYPRE_Int (*double_int_func)(HYPRE_Solver, double, HYPRE_Int);
-typedef HYPRE_Int (*int_double_func)(HYPRE_Solver, HYPRE_Int, double);
+typedef HYPRE_Int (*double_func)(HYPRE_Solver, HYPRE_Real);
+typedef HYPRE_Int (*double_int_func)(HYPRE_Solver, HYPRE_Real, HYPRE_Int);
+typedef HYPRE_Int (*int_double_func)(HYPRE_Solver, HYPRE_Int, HYPRE_Real);
 typedef HYPRE_Int (*int_int_func)(HYPRE_Solver, HYPRE_Int, HYPRE_Int);
 typedef HYPRE_Int (*int_star_func)(HYPRE_Solver, HYPRE_Int*);
 typedef HYPRE_Int (*int_star_star_func)(HYPRE_Solver, HYPRE_Int**);
-typedef HYPRE_Int (*double_star_func)(HYPRE_Solver, double*);
-typedef HYPRE_Int (*int_int_double_double_func)(HYPRE_Solver, HYPRE_Int, HYPRE_Int, double, double);
-typedef HYPRE_Int (*int_int_int_double_int_int_func)(HYPRE_Solver, HYPRE_Int, HYPRE_Int, HYPRE_Int, double, HYPRE_Int, HYPRE_Int);
+typedef HYPRE_Int (*double_star_func)(HYPRE_Solver, HYPRE_Real*);
+typedef HYPRE_Int (*int_int_double_double_func)(HYPRE_Solver, HYPRE_Int, HYPRE_Int, HYPRE_Real, HYPRE_Real);
+typedef HYPRE_Int (*int_int_int_double_int_int_func)(HYPRE_Solver, HYPRE_Int, HYPRE_Int, HYPRE_Int, HYPRE_Real, HYPRE_Int, HYPRE_Int);
 typedef HYPRE_Int (*char_star_func)(HYPRE_Solver, char*);
 
 
@@ -131,36 +131,36 @@ namespace Ifpack2 {
       int_func_(hypreMapIntFunc_.at(funct_name)),
       int_param1_(param1) {}
 
-    //! Single double constructor.
-    FunctionParameter(Hypre_Chooser chooser, double_func funct, double param1):
+    //! Single HYPRE_Real constructor.
+    FunctionParameter(Hypre_Chooser chooser, double_func funct, HYPRE_Real param1):
       chooser_(chooser),
       option_(1),
       double_func_(funct),
       double_param1_(param1) {}
 
-    FunctionParameter(Hypre_Chooser chooser, std::string funct_name, double param1):
+    FunctionParameter(Hypre_Chooser chooser, std::string funct_name, HYPRE_Real param1):
       chooser_(chooser),
       option_(1),
       double_func_(hypreMapDoubleFunc_.at(funct_name)),
       double_param1_(param1) {}
 
     //! Single double, single int constructor.
-    FunctionParameter(Hypre_Chooser chooser, double_int_func funct, double param1, HYPRE_Int param2):
+    FunctionParameter(Hypre_Chooser chooser, double_int_func funct, HYPRE_Real param1, HYPRE_Int param2):
       chooser_(chooser),
       option_(2),
       double_int_func_(funct),
       int_param1_(param2),
       double_param1_(param1) {}
 
-    //! Single int, single double constructor.
-    FunctionParameter(Hypre_Chooser chooser, int_double_func funct, HYPRE_Int param1, double param2):
+    //! Single int, single HYPRE_Real constructor.
+    FunctionParameter(Hypre_Chooser chooser, int_double_func funct, HYPRE_Int param1, HYPRE_Real param2):
       chooser_(chooser),
       option_(10),
       int_double_func_(funct),
       int_param1_(param1),
       double_param1_(param2) {}
 
-    FunctionParameter(Hypre_Chooser chooser, std::string funct_name, double param1, HYPRE_Int param2):
+    FunctionParameter(Hypre_Chooser chooser, std::string funct_name, HYPRE_Real param1, HYPRE_Int param2):
       chooser_(chooser),
       option_(2),
       double_int_func_(hypreMapDoubleIntFunc_.at(funct_name)),
@@ -195,7 +195,7 @@ namespace Ifpack2 {
       int_star_func_(hypreMapIntStarFunc_.at(funct_name)),
       int_star_param_(param1) {}
 
-    //! Double pointer constructor.
+    //! HYPRE_Real pointer constructor.
     FunctionParameter(Hypre_Chooser chooser, double_star_func funct, double* param1):
       chooser_(chooser),
       option_(5),
@@ -209,7 +209,7 @@ namespace Ifpack2 {
       double_star_param_(param1) {}
 
     //! Two ints, two doubles constructor.
-    FunctionParameter(Hypre_Chooser chooser, int_int_double_double_func funct, HYPRE_Int param1, HYPRE_Int param2, double param3, double param4):
+    FunctionParameter(Hypre_Chooser chooser, int_int_double_double_func funct, HYPRE_Int param1, HYPRE_Int param2, HYPRE_Real param3, HYPRE_Real param4):
       chooser_(chooser),
       option_(6),
       int_int_double_double_func_(funct),
@@ -218,7 +218,7 @@ namespace Ifpack2 {
       double_param1_(param3),
       double_param2_(param4) {}
 
-    FunctionParameter(Hypre_Chooser chooser, std::string funct_name, HYPRE_Int param1, HYPRE_Int param2, double param3, double param4):
+    FunctionParameter(Hypre_Chooser chooser, std::string funct_name, HYPRE_Int param1, HYPRE_Int param2, HYPRE_Real param3, HYPRE_Real param4):
       chooser_(chooser),
       option_(6),
       int_int_double_double_func_(hypreMapIntIntDoubleDoubleFunc_.at(funct_name)),
@@ -240,8 +240,8 @@ namespace Ifpack2 {
       int_star_star_func_(hypreMapIntStarStarFunc_.at(funct_name)),
       int_star_star_param_(param1) {}
 
-    //! Five ints, one double constructor.
-    FunctionParameter(Hypre_Chooser chooser, int_int_int_double_int_int_func funct, HYPRE_Int param1, HYPRE_Int param2, HYPRE_Int param3, double param4, HYPRE_Int param5, HYPRE_Int param6):
+    //! Five ints, one HYPRE_Real constructor.
+    FunctionParameter(Hypre_Chooser chooser, int_int_int_double_int_int_func funct, HYPRE_Int param1, HYPRE_Int param2, HYPRE_Int param3, HYPRE_Real param4, HYPRE_Int param5, HYPRE_Int param6):
       chooser_(chooser),
       option_(8),
       int_int_int_double_int_int_func_(funct),
@@ -252,7 +252,7 @@ namespace Ifpack2 {
       int_param5_(param6),
       double_param1_(param4) {}
 
-    FunctionParameter(Hypre_Chooser chooser, std::string funct_name, HYPRE_Int param1, HYPRE_Int param2, HYPRE_Int param3, double param4, HYPRE_Int param5, HYPRE_Int param6):
+    FunctionParameter(Hypre_Chooser chooser, std::string funct_name, HYPRE_Int param1, HYPRE_Int param2, HYPRE_Int param3, HYPRE_Real param4, HYPRE_Int param5, HYPRE_Int param6):
       chooser_(chooser),
       option_(8),
       int_int_int_double_int_int_func_(hypreMapIntIntIntDoubleIntIntFunc_.at(funct_name)),
@@ -369,11 +369,11 @@ namespace Ifpack2 {
     HYPRE_Int int_param3_;
     HYPRE_Int int_param4_;
     HYPRE_Int int_param5_;
-    double double_param1_;
-    double double_param2_;
+    HYPRE_Real double_param1_;
+    HYPRE_Real double_param2_;
     HYPRE_Int *int_star_param_;
     HYPRE_Int **int_star_star_param_;
-    double *double_star_param_;
+    HYPRE_Real *double_star_param_;
     char *char_star_param_;
 
     static const std::map<std::string, int_func> hypreMapIntFunc_;

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestHypre.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestHypre.cpp
@@ -66,6 +66,9 @@ using Teuchos::rcp;
 
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Ifpack2Hypre, Construct, Scalar, LocalOrdinal, GlobalOrdinal, Node)
 {
+  if (!std::is_same<HYPRE_Real, Scalar>::value || !std::is_same<HYPRE_Int, GlobalOrdinal>::value)
+    return;
+
   global_size_t num_rows_per_proc = 10;
   const RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > rowmap = tif_utest::create_tpetra_map<LocalOrdinal,GlobalOrdinal,Node>(num_rows_per_proc);
   
@@ -80,6 +83,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Ifpack2Hypre, Construct, Scalar, LocalOrdinal,
 
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Ifpack2Hypre, BoomerAMG, Scalar, LocalOrdinal, GlobalOrdinal, Node)
 {
+  if (!std::is_same<HYPRE_Real, Scalar>::value || !std::is_same<HYPRE_Int, GlobalOrdinal>::value)
+    return;
+
   const GlobalOrdinal num_rows_per_proc = 1000;
   using multivector_type = Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
   const double tol = 1e-7;
@@ -124,6 +130,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Ifpack2Hypre, BoomerAMG, Scalar, LocalOrdinal,
 
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Ifpack2Hypre, BoomerAMGNonContiguous, Scalar, LocalOrdinal, GlobalOrdinal, Node)
 {
+  if (!std::is_same<HYPRE_Real, Scalar>::value || !std::is_same<HYPRE_Int, GlobalOrdinal>::value)
+    return;
+
   const GlobalOrdinal num_rows_per_proc = 1000;
   using multivector_type = Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
   const double tol = 1e-7;
@@ -171,6 +180,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Ifpack2Hypre, BoomerAMGNonContiguous, Scalar, 
 // Tests the hypre interface's ability to work with both a preconditioner and linear
 // solver via ApplyInverse
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Ifpack2Hypre, Apply, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+  if (!std::is_same<HYPRE_Real, Scalar>::value || !std::is_same<HYPRE_Int, GlobalOrdinal>::value)
+    return;
+
   using multivector_type = Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
   const double tol = 1E-7;
 
@@ -217,6 +229,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Ifpack2Hypre, Apply, Scalar, LocalOrdinal, Glo
 
 
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Ifpack2Hypre, DiagonalMatrixInOrder, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+  if (!std::is_same<HYPRE_Real, Scalar>::value || !std::is_same<HYPRE_Int, GlobalOrdinal>::value)
+    return;
+
   using multivector_type = Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
   const double tol = 1E-7;
 
@@ -270,6 +285,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Ifpack2Hypre, DiagonalMatrixInOrder, Scalar, L
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Ifpack2Hypre, DiagonalMatrixNonContiguous, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+  if (!std::is_same<HYPRE_Real, Scalar>::value || !std::is_same<HYPRE_Int, GlobalOrdinal>::value)
+    return;
+
   using multivector_type = Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
   const double tol = 1E-7;
 
@@ -339,6 +357,6 @@ IFPACK2_ETI_MANGLING_TYPEDEFS()
 // Test all enabled combinations of Scalar (SC), LocalOrdinal (LO),
 // and GlobalOrdinal (GO) types, where Scalar is real.
 
-IFPACK2_INSTANTIATE_SLGN_REAL( UNIT_TEST_GROUP_SC_LO_GO_NO )
+IFPACK2_INSTANTIATE_SLGN( UNIT_TEST_GROUP_SC_LO_GO_NO )
 
 } // namespace (anonymous)

--- a/packages/ifpack2/utils/parseHypre.py
+++ b/packages/ifpack2/utils/parseHypre.py
@@ -47,64 +47,64 @@ with open(outputFile, 'w') as out:
     m = functionInt.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, int_func> FunctionParameter::hypreMapIntFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, int_func> FunctionParameter::hypreMapIntFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionDouble.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, double_func> FunctionParameter::hypreMapDoubleFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, double_func> FunctionParameter::hypreMapDoubleFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionDoubleInt.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, double_int_func> FunctionParameter::hypreMapDoubleIntFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, double_int_func> FunctionParameter::hypreMapDoubleIntFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionIntDouble.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, int_double_func> FunctionParameter::hypreMapIntDoubleFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, int_double_func> FunctionParameter::hypreMapIntDoubleFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionIntInt.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, int_int_func> FunctionParameter::hypreMapIntIntFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, int_int_func> FunctionParameter::hypreMapIntIntFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionIntStar.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, int_star_func> FunctionParameter::hypreMapIntStarFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, int_star_func> FunctionParameter::hypreMapIntStarFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionDoubleStar.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, double_star_func> FunctionParameter::hypreMapDoubleStarFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, double_star_func> FunctionParameter::hypreMapDoubleStarFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionIntIntDoubleDouble.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, int_int_double_double_func> FunctionParameter::hypreMapIntIntDoubleDoubleFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, int_int_double_double_func> FunctionParameter::hypreMapIntIntDoubleDoubleFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionIntIntIntDoubleIntInt.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, int_int_int_double_int_int_func> FunctionParameter::hypreMapIntIntIntDoubleIntIntFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, int_int_int_double_int_int_func> FunctionParameter::hypreMapIntIntIntDoubleIntIntFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionIntStarStar.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, int_star_star_func> FunctionParameter::hypreMapIntStarStarFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, int_star_star_func> FunctionParameter::hypreMapIntStarStarFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))
 
     out.write('\n\n')
     m = functionCharStar.findall(s)
     m = list(set(m))
     fs = ['  {{\"{func}\", &{func}}}'.format(func=func) if not func in skip else '//  {{\"{func}\", &{func}}}'.format(func=func) for func in m]
-    out.write("const std::map<std::string, char_star_func> FunctionParameter::hypreMapCharStarFunc_ = {{\n{}}};".format(',\n'.join(fs)))
+    out.write("const std::map<std::string, char_star_func> FunctionParameter::hypreMapCharStarFunc_ = {{\n{}\n}};".format(',\n'.join(fs)))


### PR DESCRIPTION
@trilinos/ifpack2 

## Motivation
Before this change, `Ifpack2::Hypre` was implemented the same no matter what template types were used. But Hypre gets compiled only for one combination of Scalar & Ordinal. This change should handle cases where we enable multiple combinations of types.

Also fixes the scripts that generate the header for the `HYPRE_*` functions. Every now and then that file was invalid C++.