### PR TITLE
MueLu: Update update_params.sh to work for BSD and GNU sed

### DIFF
--- a/packages/muelu/doc/UsersGuide/update_params.sh
+++ b/packages/muelu/doc/UsersGuide/update_params.sh
@@ -173,9 +173,13 @@ echo ';
 }
 ' >> $code_file
 
-# fix quotation
-sed -i '/<Parameter/ s/\\""/\\"/g' $code_file
-sed -i '/<Parameter/ s/"\\"/\\"/g' $code_file
+# fix quotation using sed
+# GH: similar to other instances in MueLu, we need to work around the GNU/BSD sed issue
+#     the moral of the story is -i is not portable for testing!
+sed '/<Parameter/ s/\\""/\\"/g' "$code_file" > "$code_file.tmp"
+mv "$code_file.tmp" "$code_file"
+sed '/<Parameter/ s/"\\"/\\"/g' "$code_file" > "$code_file.tmp"
+mv "$code_file.tmp" "$code_file"
 
 # generate LaTeX files (MueLu options and ML compatibility)
 SECTIONS=( "general" "smoothing_and_coarse" "aggregation" "misc" "multigrid" "rebalancing" "reuse" "refmaxwell" )


### PR DESCRIPTION
@trilinos/muelu

As pointed out by @ndellingwood in #12500, invoking `sed -i` requires an extension argument immediately following `-i` on Apple machines because they use the BSD version of sed.

Really it boils down to the fact that using `-i` is not portable in testing. In fact, our checks for it in our C++ MueLu source seem fragile as well, as somebody who installs GNU sed on an Apple machine will experience different test failures. I changed this particular instance to manually create and move a `.tmp` file since that's what `sed -i` is supposed to do internally.

Closes #12500.