### PR TITLE
Piro: correcting logic so that Beta and Gamma parameters are properly

### DIFF
--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -228,6 +228,16 @@ void Piro::TempusSolver<Scalar>::initialize(
     const bool lump_mass_matrix = tempusPL->get("Lump Mass Matrix", false);
     const bool invert_mass_matrix = tempusPL->get("Invert Mass Matrix", true);
     const bool constant_mass_matrix = tempusPL->get("Constant Mass Matrix", false);
+    if (stepperType == "Newmark Implicit a-Form" ||
+        stepperType == "Newmark Implicit d-Form") 
+    {
+      //Get Newmark Parameters.  If not specifying 'Scheme Name', make it 'User Defined'.
+      //This is needed for Newmark parameters to be properly read in / set in Tempus.
+      auto newmarkBetaParams = sublist(stepperPL,"Newmark Parameters", true);
+      if (!newmarkBetaParams->isParameter("Scheme Name")) {
+	newmarkBetaParams->set<std::string>("Scheme Name", "User Defined"); 
+      }
+    }
     if (
       stepperType == "Forward Euler" ||
       stepperType == "RK Forward Euler" ||


### PR DESCRIPTION
This PR fixes an error in the Piro/Tempus logic, which was causing the Newmark Parameters to not be read in from input file when specified.