### PR TITLE
ifpack2: match size of norms* Views to MV in ILUT test

### DIFF
--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestILUT.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestILUT.cpp
@@ -106,8 +106,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2ILUT, Test0, Scalar, LocalOrdinal, Glob
 
   using STS = Teuchos::ScalarTraits<Scalar>;
   using STM = typename STS::magnitudeType;
-  Kokkos::View<STM*, Kokkos::HostSpace> norms("Initial norms", 1);
-  Kokkos::View<STM*, Kokkos::HostSpace> lastNorms("previous norms", 1);
+  Kokkos::View<STM*, Kokkos::HostSpace> norms("Initial norms", x.getNumVectors());
+  Kokkos::View<STM*, Kokkos::HostSpace> lastNorms("previous norms", x.getNumVectors());
 
   x.norm2(norms);
   std::cout << "||x_init||=" << norms[0] << std::endl;


### PR DESCRIPTION
Update to resolve potential memory corruption errors due to size mismatches between data and unmanaged Views in normImpl routine Reported in #12505

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 @jhux2 @brian-kelley 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Resolve potential memory corruption errors
See e.g. 
https://github.com/trilinos/Trilinos/pull/12505#issuecomment-1805061390
https://github.com/trilinos/Trilinos/pull/12505#issuecomment-1811197533

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
Local testing, AT
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->