### PR TITLE
Sacado: Remove in_parallel() use

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
@@ -939,16 +939,11 @@ struct PCEAllocation {
       m_cijk(cijk) {}
 
     inline void execute() {
-      if ( ! m_space.in_parallel() ) {
-        typedef Kokkos::RangePolicy< ExecSpace > PolicyType ;
-        const Kokkos::Impl::ParallelFor< PCEConstruct , PolicyType >
-          closure( *this , PolicyType( 0 , m_span ) );
-        closure.execute();
-        m_space.fence();
-      }
-      else {
-        for ( size_t i = 0 ; i < m_span ; ++i ) operator()(i);
-      }
+      typedef Kokkos::RangePolicy< ExecSpace > PolicyType ;
+      const Kokkos::Impl::ParallelFor< PCEConstruct , PolicyType >
+        closure( *this , PolicyType( 0 , m_span ) );
+      closure.execute();
+      m_space.fence();
     }
 
     KOKKOS_INLINE_FUNCTION

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
@@ -719,16 +719,11 @@ struct MPVectorAllocation<ValueType, false> {
       m_space(space), m_p(p), m_sp(sp), m_span(span), m_vector_size(vector_size) {}
 
     inline void execute() {
-      if ( ! m_space.in_parallel() ) {
-        typedef Kokkos::RangePolicy< ExecSpace > PolicyType ;
-        const Kokkos::Impl::ParallelFor< VectorConstruct , PolicyType >
-          closure( *this , PolicyType( 0 , m_span ) );
-        closure.execute();
-        m_space.fence();
-      }
-      else {
-        for ( size_t i = 0 ; i < m_span ; ++i ) operator()(i);
-      }
+      typedef Kokkos::RangePolicy< ExecSpace > PolicyType ;
+      const Kokkos::Impl::ParallelFor< VectorConstruct , PolicyType >
+        closure( *this , PolicyType( 0 , m_span ) );
+      closure.execute();
+      m_space.fence();
     }
 
     KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
@trilinos/Sacado

## Motivation
Checking for `in_parallel` to possibly initialize a `View` in serial (after allocating) instead of calling `parallel_for` is not portable and the respective function doesn't have a `KOKKOS_FUNCTION` annotation. We are considering deprecating `in_parallel` and it seems that it's not needed here anyway.

## Related Issues

* Related to https://github.com/kokkos/kokkos/issues/6032 and https://github.com/kokkos/kokkos/pull/6582.
