### PR TITLE
Framework: Add specs for nightly container build

### DIFF
--- a/packages/framework/ini-files/environment-specs.ini
+++ b/packages/framework/ini-files/environment-specs.ini
@@ -151,4 +151,18 @@
 # Common environment options not specific to a particular system.
 #------------------------------------------------------------------------------
 
+[MPI-COMPILER-VARS]
+envvar-find-in-path MPICC  : mpicc
+envvar-find-in-path MPICXX : mpicxx
+envvar-find-in-path MPIF90 : mpif90
+
 [rhel8_gcc-openmpi]
+
+[rhel8_oneapi-intelmpi]
+use MPI-COMPILER-VARS
+envvar-find-in-path I_MPI_CXX : icpx
+envvar-find-in-path I_MPI_CC  : icx
+envvar-find-in-path I_MPI_F90  : ifx
+envvar-set I_MPI_PIN : 0
+envvar-set MPIR_CVAR_CH4_OFI_TAG_BITS : 31
+envvar-set MPIR_CVAR_CH4_OFI_RANK_BITS : 8


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Now that we have open environment specs checked in, add the ones for the nightly GenConfig-based OneAPI build.