### PR TITLE
Tpetra: remove FE assembly 1 rank test

### DIFF
--- a/packages/tpetra/core/example/Finite-Element-Assembly/CMakeLists.txt
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/CMakeLists.txt
@@ -50,17 +50,6 @@ TRIBITS_ADD_TEST(
   NAME Performance_StrongScaling_FEMAssembly_InsertGlobalIndicesFESPKokkos
   ARGS "--with-insert-global-indices-fe --num-elements-x=8192 --num-elements-y=8192 --kokkos"
   COMM mpi
-  NUM_MPI_PROCS 1
-  STANDARD_PASS_OUTPUT
-  RUN_SERIAL
-  CATEGORIES PERFORMANCE
-)
-
-TRIBITS_ADD_TEST(
-  FEMAssembly
-  NAME Performance_StrongScaling_FEMAssembly_InsertGlobalIndicesFESPKokkos
-  ARGS "--with-insert-global-indices-fe --num-elements-x=8192 --num-elements-y=8192 --kokkos"
-  COMM mpi
   NUM_MPI_PROCS 4
   STANDARD_PASS_OUTPUT
   RUN_SERIAL


### PR DESCRIPTION
FE perf tests use an 8192^2 quad mesh (9-pt stencil). When running on one vortex rank (V100 16GB), memory allocations fail reliably.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This is the only nightly performance test that fails reliably. Right now, the perf test builds are running "ctest || true" so that failures won't kill the whole Jenkins job. But after removing this, the "ctest" command can be expected to be successful 100% of the time. This way, if the Jenkins job fails, we can tell at a glance if any tests are failing.   
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->