### PR TITLE
STK: Fix compiling with SYCL

### DIFF
--- a/packages/stk/stk_unit_tests/stk_expreval/UnitTestEvaluator.cpp
+++ b/packages/stk/stk_unit_tests/stk_expreval/UnitTestEvaluator.cpp
@@ -727,7 +727,7 @@ TEST(UnitTestEvaluator, testFunctionSyntax)
   EXPECT_TRUE(isInvalidFunction("gamma(1)"));
 }
 
-#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP)
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
 TEST(UnitTestEvaluator, deviceVariableMap_too_small)
 {
   stk::expreval::Eval eval("x+y+z");
@@ -1298,7 +1298,7 @@ TEST(UnitTestEvaluator, defaultVector)
 TEST(UnitTestEvaluator, Ngp_defaultVector)
 {
   EXPECT_DOUBLE_EQ(device_evaluate("x[0]",                       {}, {}),                     0);
-  #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_OPENMP)
+  #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_OPENMP)
   EXPECT_ANY_THROW(device_evaluate("x[0]+x[1]+x[2]",             {}, {}));
   #endif
 }
@@ -1338,7 +1338,7 @@ TEST(UnitTestEvaluator, Ngp_bindVector)
                             {}, {{"a", {1, 2, 3}}, {"z", {0, 1, 2}}}),                   6);
   EXPECT_DOUBLE_EQ(device_evaluate("a[0]=(1) ? 2 : 3",         {},         {{"a", {0, 0, 0}}}), 2);
 
-  #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_OPENMP)
+  #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_OPENMP)
   EXPECT_ANY_THROW(device_evaluate("a[0]+a[1]+a[3]",           {},         {{"a", {1, 2, 3}}}));
   EXPECT_ANY_THROW(device_evaluate("a[0]+a[1]+a[2]",           {},         {{"a", {1, 2, 3}}}, stk::expreval::Variable::ONE_BASED_INDEX));
   EXPECT_ANY_THROW(device_evaluate("a",                        {},         {{"a", {1, 2, 3}}}));
@@ -2761,7 +2761,7 @@ void Ngp_testRandom(const char * expression)
   checkUniformDist(results);
 }
 
-#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP)
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
 TEST(UnitTestEvaluator, Ngp_testFunction_rand)
 {
   Ngp_testRandom("rand()");
@@ -2782,7 +2782,7 @@ TEST(UnitTestEvaluator, testFunction_srand_repeatability)
   }
 }
 
-#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP)
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
 TEST(UnitTestEvaluator, Ngp_testFunction_srand_repeatability)
 {
   std::vector<double> result(10);
@@ -2803,7 +2803,7 @@ TEST(UnitTestEvaluator, testFunction_random)
   testRandom("random()");
 }
 
-#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP)
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
 TEST(UnitTestEvaluator, Ngp_testFunction_random)
 {
   Ngp_testRandom("random()");
@@ -2824,7 +2824,7 @@ TEST(UnitTestEvaluator, testFunction_random1_repeatability)
   }
 }
 
-#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP)
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
 TEST(UnitTestEvaluator, Ngp_testFunction_random1_repeatability)
 {
   std::vector<double> result(10);
@@ -2989,7 +2989,7 @@ TEST(UnitTestEvaluator, testFunction_time)
   EXPECT_NEAR(evaluate("time()"), std::time(nullptr), 1.1);
 }
 
-#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP)
+#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
 TEST(UnitTestEvaluator, Ngp_testFunction_time)
 {
   EXPECT_NEAR(device_evaluate("time()"), std::time(nullptr), 1.1);

--- a/packages/stk/stk_unit_tests/stk_ngp_test/utest_VirtualFunction.cpp
+++ b/packages/stk/stk_unit_tests/stk_ngp_test/utest_VirtualFunction.cpp
@@ -60,20 +60,20 @@ class NgpDerived : public NgpBase
 
 struct SimpleStruct {
   KOKKOS_FUNCTION
-  void print() { printf("Printing from A located at %p\n", static_cast<void*>(this)); }
+  void print() { Kokkos::printf("Printing from A located at %p\n", static_cast<void*>(this)); }
 };
 
 struct BaseStruct {
   virtual void set_i(const int) = 0;
   KOKKOS_FUNCTION
-  virtual void print() { printf("Printing from base located at %p\n", static_cast<void*>(this)); }
+  virtual void print() { Kokkos::printf("Printing from base located at %p\n", static_cast<void*>(this)); }
 };
 
 struct ChildStruct : public BaseStruct {
   int i;
   virtual void set_i(const int _i) { i = _i; }
   KOKKOS_FUNCTION
-  virtual void print() { printf("Printing from child located at %p with i %i\n", static_cast<void*>(this), i); }
+  virtual void print() { Kokkos::printf("Printing from child located at %p with i %i\n", static_cast<void*>(this), i); }
 };
 
 }  // namespace ngp

--- a/packages/stk/stk_unit_tests/stk_topology/utest_b/unit_test_quad.cpp
+++ b/packages/stk/stk_unit_tests/stk_topology/utest_b/unit_test_quad.cpp
@@ -273,7 +273,7 @@ void check_quad_6_on_device()
 
   Kokkos::parallel_for(stk::ngp::DeviceRangePolicy(0, 1), KOKKOS_LAMBDA(const int i)
   {
-    printf("Reminder: we still need to enable permutation for QUAD_6\n");
+    Kokkos::printf("Reminder: we still need to enable permutation for QUAD_6\n");
     const bool enabledPermutation = false;
     if (enabledPermutation) {
       check_permutation_node_ordinals_ngp<numNodes>(t, goldPermutationNodeOrdinals);

--- a/packages/stk/stk_unit_tests/stk_topology/utest_b/unit_test_wedge.cpp
+++ b/packages/stk/stk_unit_tests/stk_topology/utest_b/unit_test_wedge.cpp
@@ -314,7 +314,7 @@ void check_wedge_12_on_device()
 
   Kokkos::parallel_for(stk::ngp::DeviceRangePolicy(0, 1), KOKKOS_LAMBDA(const int i)
   {
-    printf("Reminder: we still need to enable permutation for wedge_12\n");
+    Kokkos::printf("Reminder: we still need to enable permutation for wedge_12\n");
     const bool enabledPermutation = false;
     if (enabledPermutation) {
       check_permutation_node_ordinals_ngp<numNodes>(t, goldPermutationNodeOrdinals);

--- a/packages/stk/stk_util/stk_util/util/ReportHandler.hpp
+++ b/packages/stk/stk_util/stk_util/util/ReportHandler.hpp
@@ -432,7 +432,7 @@ STK_INLINE_FUNCTION void ThrowErrorMsgDevice(const char * message)
 #define STK_ThrowInvalidArgIf(expr)
 #endif
 
-#if ((defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 0)) || defined(__HIP_DEVICE_COMPILE__))
+#if ((defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 0)) || defined(__HIP_DEVICE_COMPILE__) || defined(__SYCL_DEVICE_ONLY__))
 #define STK_NGP_ThrowRequireMsg(expr, message)               \
   do {                                                       \
     const bool __stk_expr_res = bool(expr);                  \
@@ -450,7 +450,7 @@ STK_INLINE_FUNCTION void ThrowErrorMsgDevice(const char * message)
   } while (false);
 #endif
 
-#if ((defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 0)) || defined(__HIP_DEVICE_COMPILE__))
+#if ((defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 0)) || defined(__HIP_DEVICE_COMPILE__) || defined(__SYCL_DEVICE_ONLY__))
 #define STK_NGP_ThrowRequire(expr)                              \
   do {                                                          \
     const bool __stk_expr_res = bool(expr);                     \
@@ -476,7 +476,7 @@ STK_INLINE_FUNCTION void ThrowErrorMsgDevice(const char * message)
 #  define STK_NGP_ThrowAssertMsg(expr,message)                                       STK_NGP_ThrowRequireMsg(expr, message)
 #endif
 
-#if ((defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 0)) || defined(__HIP_DEVICE_COMPILE__))
+#if ((defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 0)) || defined(__HIP_DEVICE_COMPILE__) || defined(__SYCL_DEVICE_ONLY__))
 #define STK_NGP_ThrowErrorMsgIf(expr, message)                                        STK_NGP_ThrowRequireMsg(!(expr), message);
 #else
 #define STK_NGP_ThrowErrorMsgIf(expr, message)                              \
@@ -488,7 +488,7 @@ STK_INLINE_FUNCTION void ThrowErrorMsgDevice(const char * message)
   } while (false);
 #endif
 
-#if ((defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 0)) || defined(__HIP_DEVICE_COMPILE__))
+#if ((defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 0)) || defined(__HIP_DEVICE_COMPILE__) || defined(__SYCL_DEVICE_ONLY__))
 #define STK_NGP_ThrowErrorIf(expr)                                     STK_NGP_ThrowRequireMsg(!(expr), "!(" #expr ")");
 #else
 #define STK_NGP_ThrowErrorIf(expr)                              \
@@ -500,7 +500,7 @@ STK_INLINE_FUNCTION void ThrowErrorMsgDevice(const char * message)
   } while (false);
 #endif
 
-#if ((defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 0)) || defined(__HIP_DEVICE_COMPILE__))
+#if ((defined(__CUDA_ARCH__) && (__CUDA_ARCH__ > 0)) || defined(__HIP_DEVICE_COMPILE__) || defined(__SYCL_DEVICE_ONLY__))
 #define STK_NGP_ThrowErrorMsg(message)                                      ThrowErrorMsgDevice(message ": " __FILE__ ":" LINE_STRING);
 #else
 #define STK_NGP_ThrowErrorMsg(message)                                      ThrowErrorMsgHost(message, STK_STR_TRACE);


### PR DESCRIPTION
@trilinos/stk
## Motivation
This should fix compiling with `SYCL` using `STK` (expect for anything related to device global variables or variadic device functions).

## Related Issues
* Related to #12428
