### PR TITLE
Framework: Increase mem/core from 3 to 4 Gb

### DIFF
--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -199,7 +199,7 @@ test_cmd_options=(
     --pullrequest-gen-config-file=${GENCONFIG_CONFIG_FILE:?}
     --pullrequest-number=${PULLREQUESTNUM:?}
     --jenkins-job-number=${BUILD_NUMBER:?}
-    --req-mem-per-core=3.0
+    --req-mem-per-core=4.0
     --max-cores-allowed=${TRILINOS_MAX_CORES:=29}
     --num-concurrent-tests=4
     --test-mode=${mode}


### PR DESCRIPTION
Seeing too many OOM errors from the Intel compiler (and even the Gnu one sometimes).

@trilinos/framework 

## Motivation
Seeing repeated OOM errors in Intrepid2 ( @trilinos/intrepid2 )

## Related Issues
#12571 