### PR TITLE
Zoltan2: Fix compiling with SYCL

### DIFF
--- a/packages/zoltan2/core/src/TpetraCrsColorer/Zoltan2_TpetraCrsColorerUtils.hpp
+++ b/packages/zoltan2/core/src/TpetraCrsColorer/Zoltan2_TpetraCrsColorerUtils.hpp
@@ -47,10 +47,10 @@ check_coloring(
             if (col != col2 && list_of_colors[col] == list_of_colors[col2])
             {
               ++lcl_conflict;
-              printf(
-		     "proc = %i : Invalid coloring!  Local row %zu"
-		     " and columns %zu, %zu have the same color %i\n",
-		     rank, row, col, col2, list_of_colors[col]);
+              Kokkos::printf(
+                "proc = %i : Invalid coloring!  Local row %zu"
+                " and columns %zu, %zu have the same color %i\n",
+                rank, row, col, col2, list_of_colors[col]);
             }
           }
         }

--- a/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -3544,11 +3544,6 @@ struct Zoltan2_MJArrayType {
 
   KOKKOS_INLINE_FUNCTION
   Zoltan2_MJArrayType(scalar_t * pSetPtr) : ptr(pSetPtr) {};
-
-  Zoltan2_MJArrayType<scalar_t>& operator=(const volatile Zoltan2_MJArrayType<scalar_t>& zmj) {
-      ptr = zmj.ptr;
-      return *this;
-  }
 };
 
 #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP)

--- a/packages/zoltan2/test/core/TpetraCrsColorer/Bug9500.cpp
+++ b/packages/zoltan2/test/core/TpetraCrsColorer/Bug9500.cpp
@@ -172,7 +172,7 @@ public:
       Kokkos::RangePolicy<execution_space_t>(0, num_local_nz),
       KOKKOS_LAMBDA(const size_t nz, int &errorcnt) {
         if (J_local_matrix.values(nz) != Jp_local_matrix.values(nz)) {
-          printf("Error in nonzero comparison %zu:  %g != %g", 
+          Kokkos::printf("Error in nonzero comparison %zu:  %g != %g",
                   nz, J_local_matrix.values(nz), Jp_local_matrix.values(nz));
           errorcnt++;
         }

--- a/packages/zoltan2/test/core/TpetraCrsColorer/TpetraCrsColorer.cpp
+++ b/packages/zoltan2/test/core/TpetraCrsColorer/TpetraCrsColorer.cpp
@@ -189,7 +189,7 @@ public:
       Kokkos::RangePolicy<execution_space_t>(0, num_local_nz),
       KOKKOS_LAMBDA(const size_t nz, int &errorcnt) {
         if (J_local_matrix.values(nz) != Jp_local_matrix.values(nz)) {
-          printf("Error in nonzero comparison %zu:  %g != %g",
+          Kokkos::printf("Error in nonzero comparison %zu:  %g != %g",
                   nz, J_local_matrix.values(nz), Jp_local_matrix.values(nz));
           errorcnt++;
         }


### PR DESCRIPTION
@trilinos/zoltan2
## Motivation
This should fix compiling `Zoltan2` and its tests using `SYCL`.

## Related Issues
* Related to #12428
