### PR TITLE
STK: Implement Reporter without virtual

### DIFF
--- a/packages/stk/stk_ngp_test/stk_ngp_test/GlobalReporter.hpp
+++ b/packages/stk/stk_ngp_test/stk_ngp_test/GlobalReporter.hpp
@@ -5,13 +5,18 @@
 
 namespace ngp_testing {
 
-class ReporterBase;
+template <typename DeviceType>
+class Reporter;
+
+using DeviceReporter = Reporter<Kokkos::DefaultExecutionSpace::device_type>;
+using HostReporter = Reporter<Kokkos::DefaultHostExecutionSpace::device_type>;
 
 void initialize_reporters();
 void finalize_reporters();
 
-NGP_TEST_FUNCTION ReporterBase* get_reporter();
-ReporterBase* get_device_reporter();
+NGP_TEST_FUNCTION HostReporter*  get_host_reporter();
+NGP_TEST_FUNCTION DeviceReporter* get_device_reporter();
+DeviceReporter* get_device_reporter_on_host();
 
 }
 

--- a/packages/stk/stk_ngp_test/stk_ngp_test/Reporter.hpp
+++ b/packages/stk/stk_ngp_test/stk_ngp_test/Reporter.hpp
@@ -43,28 +43,15 @@ inline std::ostream& operator<<(std::ostream& out, const Report& r) {
   return out;
 }
 
-class ReporterBase {
- public:
-  virtual ~ReporterBase() = default;
-  virtual void clear() = 0;
-  virtual void resize(int n) = 0;
-  virtual int get_capacity() const = 0;
-  virtual int report_failures(std::ostream& out = std::cout) = 0;
-
-  NGP_TEST_FUNCTION
-  virtual void add_failure(const char* condition,
-                           const char* location) const = 0;
-};
-
 template<class Device>
-class Reporter : public ReporterBase {
+class Reporter {
  public:
   Reporter(int numReports) : reporter(numReports) {}
-  void clear() override { reporter.clear(); }
-  void resize(int n) override { reporter.resize(n); }
-  int get_capacity() const override { return reporter.getCapacity(); }
+  void clear() { reporter.clear(); }
+  void resize(int n) { reporter.resize(n); }
+  int get_capacity() const { return reporter.getCapacity(); }
 
-  int report_failures(std::ostream& out = std::cout) override {
+  int report_failures(std::ostream& out = std::cout) {
     int numAttemptedReports = reporter.getNumReportAttempts();
     int numReports = reporter.getNumReports();
 
@@ -87,7 +74,7 @@ class Reporter : public ReporterBase {
 
   NGP_TEST_INLINE
   void add_failure(const char* condition,
-                   const char* location) const override {
+                   const char* location) const {
     static const int dummyWorkIndex = -1;
     reporter.add_report(dummyWorkIndex, ReportT(condition, location));
   }

--- a/packages/stk/stk_ngp_test/stk_ngp_test/ngp_test.cpp
+++ b/packages/stk/stk_ngp_test/stk_ngp_test/ngp_test.cpp
@@ -48,13 +48,13 @@ void Test::TearDown() {
 
 inline
 int get_max_failure_reports_per_test() {
-  return get_reporter()->get_capacity();
+  return get_host_reporter()->get_capacity();
 }
 
 inline
 void set_max_failure_reports_per_test(const int n) {
-  get_reporter()->resize(n);
-  get_device_reporter()->resize(n);
+  get_host_reporter()->resize(n);
+  get_device_reporter_on_host()->resize(n);
 }
 
 
@@ -62,20 +62,21 @@ namespace internal {
 
 NGP_TEST_INLINE
 void add_failure(const char* condition, const char* location) {
-  get_reporter()->add_failure(condition, location);
+  KOKKOS_IF_ON_HOST((get_host_reporter()->add_failure(condition, location);))
+  KOKKOS_IF_ON_DEVICE((get_device_reporter()->add_failure(condition, location);))
 }
 
 inline
 int report_failures() {
-  int numFailures = get_reporter()->report_failures();
-  numFailures += get_device_reporter()->report_failures();
+  int numFailures = get_host_reporter()->report_failures();
+  numFailures += get_device_reporter_on_host()->report_failures();
   return numFailures;
 }
 
 inline
 void clear_failures() {
-  get_reporter()->clear();
-  get_device_reporter()->clear();
+  get_host_reporter()->clear();
+  get_device_reporter_on_host()->clear();
 }
 
 }


### PR DESCRIPTION
@trilinos/stk

## Motivation
This should fix compiling and running all the `STK` tests using `SYCL`. Note that the `SYCL` doesn't support virtual device functions (yet).

# Related Issues
* Related to #12428
