### PR TITLE
Framework: Explicitly disable tcp for PR testing with openmpi 

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1849,6 +1849,7 @@ use RHEL7_POST
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 #uses sems-archive modules
+opt-set-cmake-var CMAKE_CXX_FLAGS STRING FORCE : ""
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|DEBUG
@@ -1863,7 +1864,7 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use COMMON
 
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL         : ON
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
@@ -1956,7 +1957,7 @@ use USE-DEPRECATED|YES
 
 use COMMON
 
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
@@ -1982,7 +1983,7 @@ use USE-DEPRECATED|NO
 
 use COMMON
 
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
@@ -2010,7 +2011,7 @@ use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 use COMMON
 
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : --bind-to;none
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL         : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL         : ON
@@ -2042,7 +2043,7 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use COMMON
 
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 
 use RHEL7_TEST_DISABLES|CLANG
@@ -2090,7 +2091,7 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use COMMON_SPACK_TPLS
 
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 
 use RHEL7_TEST_DISABLES|CLANG
@@ -2164,7 +2165,7 @@ use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 use COMMON_SPACK_TPLS
 
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
 
 opt-set-cmake-var TPL_Netcdf_LIBRARIES STRING FORCE : -L${NETCDF_C_LIB|ENV}/lib;${NETCDF_C_LIB|ENV}/libnetcdf.so;${PARALLEL_NETCDF_LIB|ENV}/libpnetcdf.a
 opt-set-cmake-var TPL_HDF5_LIBRARIES STRING FORCE : ${HDF5_LIB|ENV}/libhdf5_hl.so;${HDF5_LIB|ENV}/libhdf5.a;${ZLIB_LIB|ENV}/libz.a;-ldl
@@ -2646,7 +2647,7 @@ use USE-MPI|YES
 use USE-PT|NO
 use COMMON_SPACK_TPLS
 
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL         : ON
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
@@ -2684,7 +2685,7 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use COMMON_SPACK_TPLS
 
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL         : ON
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
@@ -2756,7 +2757,7 @@ use PACKAGE-ENABLES|PR
 
 use COMMON_SPACK_TPLS
 
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
@@ -2784,7 +2785,7 @@ use PACKAGE-ENABLES|PR
 
 use COMMON_SPACK_TPLS
 
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
@@ -2813,7 +2814,7 @@ use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use COMMON_SPACK_TPLS
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : --bind-to;none
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL         : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL         : ON
@@ -2849,7 +2850,7 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use COMMON_SPACK_TPLS
 
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                                STRING       : --bind-to;none
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                                STRING       : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                             BOOL         : ON
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D              BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                    BOOL         : ON

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1849,7 +1849,6 @@ use RHEL7_POST
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 #uses sems-archive modules
-opt-set-cmake-var CMAKE_CXX_FLAGS STRING FORCE : ""
 use RHEL7_SEMS_COMPILER|GNU
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|DEBUG
@@ -1869,7 +1868,7 @@ opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL   
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
 opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 # Test failures as of 11-28-22
 opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL : ON


### PR DESCRIPTION
@trilinos/framework 

## Motivation
This is in response to #12391 and will set `--mca btl vader,self` for builds with openmpi 
## Related Issues
#12391 

## Testing
After building and running `ctest -VV` I see:
```
Test command: /projects/sems/install/rhel7-x86_64/sems/compiler/gcc/8.3.0/openmpi/1.10.1/bin/mpirun "--bind-to" "none --mca btl vader,self" "-np" "1" "/scratch/jfrye/build/TRILFRAME-608-disable-tcp/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_Combined_FSA_Tangent.exe"
```