### PR TITLE
Intrepid2: Fix enums for SYCL

### DIFF
--- a/packages/intrepid/src/Shared/Intrepid_Types.hpp
+++ b/packages/intrepid/src/Shared/Intrepid_Types.hpp
@@ -203,7 +203,7 @@ namespace Intrepid {
               reconstructed functions or basis functions. Pairs of primitive operators are used to 
               specify what kind of local weak operator should be constructed.
   */
-  enum EOperator{
+  enum EOperator : int {
     OPERATOR_VALUE = 0,
     OPERATOR_GRAD,      // 1
     OPERATOR_CURL,      // 2

--- a/packages/intrepid2/src/Shared/Intrepid2_TensorViewIterator.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TensorViewIterator.hpp
@@ -74,7 +74,7 @@ namespace Intrepid2
   class TensorViewIterator
   {
   public:
-    enum RankCombinationType
+    enum RankCombinationType : int
     {
       DIMENSION_MATCH,
       TENSOR_PRODUCT,

--- a/packages/intrepid2/src/Shared/Intrepid2_Types.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Types.hpp
@@ -272,7 +272,7 @@ namespace Intrepid2 {
       reconstructed functions or basis functions. Pairs of primitive operators are used to
       specify what kind of local weak operator should be constructed.
   */
-  enum EOperator{
+  enum EOperator : int {
     OPERATOR_VALUE = 0,
     OPERATOR_GRAD,      // 1
     OPERATOR_CURL,      // 2


### PR DESCRIPTION
@trilinos/intrepid2

## Motivation
This should fix compiling all the `Intrepid*` tests using `SYCL`. Note that `SYCL` requires explicitly specifying the underlying type for all enums used in device code.

# Related Issues
* Related to #12428
