### PR TITLE
GitHub PR template: Add reminder about release notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,9 @@ Please make sure to mark:
 * Assignees
 * Labels
 
+If the changes in the PR should be considered for inclusion in the release notes,
+please apply the label "xx.y release note" where xx.y is the version of the
+upcoming release.
 Replace <teamName> below with the appropriate Trilinos package/team name.
 -->
 @trilinos/<teamName>


### PR DESCRIPTION
## Motivation
Add a reminder about adding the release notes label to the PR template.