### PR TITLE
Phalanx: temporary disable of failing test

### DIFF
--- a/packages/phalanx/test/ViewOfViews/tPhalanxViewOfViews.cpp
+++ b/packages/phalanx/test/ViewOfViews/tPhalanxViewOfViews.cpp
@@ -418,6 +418,10 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_UserStreamInitialize) {
       }
 }
 
+/* Temporarily disable:
+   https://github.com/kokkos/kokkos-tools/issues/224
+   https://github.com/trilinos/Trilinos/pull/11391
+
 TEUCHOS_UNIT_TEST(PhalanxViewOfViews,KokkosToolsDefaultStreamCheck) {
   PHX::set_enforce_no_default_stream_use();
   // Checks are only active for CUDA and HIP backends
@@ -426,6 +430,8 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,KokkosToolsDefaultStreamCheck) {
 #endif
   PHX::unset_enforce_no_default_stream_use();
 }
+
+*/
 
 // Make sure that an uninitialized ViewOviews3 can be default
 // constructed and destoryed. Happens in application unit tests.


### PR DESCRIPTION

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fencing stream check not working if gpu device id is not equal to 0. Temporarily disabling.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->