### PR TITLE
Fix ROL_Constraint_Partitioned_Def.hpp bound check

### DIFF
--- a/packages/rol/src/function/constraint/ROL_Constraint_Partitioned_Def.hpp
+++ b/packages/rol/src/function/constraint/ROL_Constraint_Partitioned_Def.hpp
@@ -66,7 +66,7 @@ int Constraint_Partitioned<Real>::getNumberConstraintEvaluations(void) const {
 
 template<typename Real>
 Ptr<Constraint<Real>> Constraint_Partitioned<Real>::get(int ind) const {
-  if (ind < 0 || ind > static_cast<int>(cvec_.size())) {
+  if (ind < 0 || ind >= static_cast<int>(cvec_.size())) {
     throw Exception::NotImplemented(">>> Constraint_Partitioned::get : Index out of bounds!");
   }
   return cvec_[ind];


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/rol

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Constraint_Partitioned::get will currently accept an index of size cvec_.size().

Since `  int  ncval_; // Number of constraint evaluations` is a private member variable, its interface can't be used by external calling functions. 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

N/A

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->