### PR TITLE
Framework: Correct list/string joining

### DIFF
--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
@@ -75,7 +75,7 @@ class TrilinosPRConfigurationStandard(TrilinosPRConfigurationBase):
              ]
 
         if self.arg_extra_configure_args:
-            cmd.append(f"-DEXTRA_CONFIGURE_ARGS:STRING={';'.join(self.arg_extra_configure_args)}")
+            cmd.append(f"-DEXTRA_CONFIGURE_ARGS:STRING={self.arg_extra_configure_args}")
 
         self.message( "--- ctest version:")
         if not self.args.dry_run:


### PR DESCRIPTION
No need to ; join something that's already passed as a ;-joined string.
@trilinos/framework 