### PR TITLE
Intrepid2: Optimizations for pullbacks (among others)

### DIFF
--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefTensor.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefTensor.hpp
@@ -678,6 +678,8 @@ namespace Intrepid2 {
       /**/  OutputViewType     _output;
       const leftInputViewType  _leftInput;
       const rightInputViewType _rightInput;
+      
+      // TODO: make leftInputRank, rightInputRank, isTranspose template arguments -- this will allow us to eliminate all runtime branching
       const ordinal_type _outputRank;
       const ordinal_type _leftInputRank;
       const ordinal_type _rightInputRank;
@@ -875,6 +877,18 @@ namespace Intrepid2 {
                       const ordinal_type pt) const {
         const auto lpt  = (_leftInput.extent(1) == 1 ? size_type(0) : pt);
         
+        // NOTE THAT HAVING THIS "true" assumes _leftInputRank = 4, _rightInputRank = 4, _isTranspose = true.  This is ONLY for evaluating whether it's worth it to move all the branching to compile time.
+        const bool DEBUG_TEST_NON_BRANCHING_IMPLEMENTATION = true;
+        if (DEBUG_TEST_NON_BRANCHING_IMPLEMENTATION)
+        {
+          for (ordinal_type i=0;i<_iend;++i) {
+            value_type tmp(0);
+            for (ordinal_type j=0;j<_jend;++j)
+              tmp += _leftInput(cl,lpt, j,i)*_rightInput(cl,bf,pt, j);
+            _output(cl,bf,pt, i) = tmp;
+          }
+        }
+        else
         switch (_leftInputRank)
         {
           case 4:

--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefTensor.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefTensor.hpp
@@ -896,30 +896,6 @@ namespace Intrepid2 {
             {
               case 3:  apply_matvec_product_43(cl, bf, lpt, pt); break;
               default: apply_matvec_product_44(cl, bf, lpt, pt);
-//                if (_isTranspose)
-//                {
-//                  using value_type = typename OutputViewType::value_type;
-//                  ordinal_type iend = _output.extent_int(3);
-//                  ordinal_type jend = _rightInput.extent_int(3);
-//                  for (ordinal_type i=0;i<iend;++i) {
-//                    value_type tmp(0);
-//                    for (ordinal_type j=0;j<jend;++j)
-//                      tmp += _leftInput(cl,lpt, j,i)*_rightInput(cl,bf,pt, j);
-//                    _output(cl,bf,pt, i) = tmp;
-//                  }
-//                }
-//                else
-//                {
-//                  using value_type = typename OutputViewType::value_type;
-//                  ordinal_type iend = _output.extent_int(3);
-//                  ordinal_type jend = _rightInput.extent_int(3);
-//                  for (ordinal_type i=0;i<iend;++i) {
-//                    value_type tmp(0);
-//                    for (ordinal_type j=0;j<jend;++j)
-//                      tmp += _leftInput(cl,lpt, i,j)*_rightInput(cl,bf,pt, j);
-//                    _output(cl,bf,pt, i) = tmp;
-//                  }
-//                }
             }
             break;
           case 3:
@@ -937,45 +913,240 @@ namespace Intrepid2 {
             }
             break;
         }
-//        if (leftRank == 4)
-//        {
-//          // special case code for now, to see how much we gain by eliminating subviews
-//          if (rightRank == 3)
-//          {
-//            apply_matvec_product_43(_output, _leftInput, _rightInput, cl, bf, lpt, pt);
-//          }
-//          else
-//          {
-//            apply_matvec_product_44(_output, _leftInput, _rightInput, cl, bf, lpt, pt);
-//          }
-//        }
-//        else if (leftRank == 3)
-//        {
-//          if (rightRank == 3)
-//          {
-//            apply_matvec_product_43(_output, _leftInput, _rightInput, cl, bf, lpt, pt);
-//          }
-//          else
-//          {
-//            apply_matvec_product_44(_output, _leftInput, _rightInput, cl, bf, lpt, pt);
-//          }
-//        }
-//        else // leftRank == 2
-//        {
-//          std::cout << "hit subview path.\n";
-//          auto result = Kokkos::subview(_output, cl, bf, pt, Kokkos::ALL());
-//
-//          const auto left = ( leftRank == 4 ? Kokkos::subview(_leftInput, cl, lpt, Kokkos::ALL(), Kokkos::ALL()) :
-//                              leftRank == 3 ? Kokkos::subview(_leftInput, cl, lpt, Kokkos::ALL()) :
-//                                              Kokkos::subview(_leftInput, cl, lpt));
-//
-//          const auto right = ( rightRank == 3 ? Kokkos::subview(_rightInput,     bf, pt, Kokkos::ALL()) :
-//                                                Kokkos::subview(_rightInput, cl, bf, pt, Kokkos::ALL()));
-//
-//          apply_matvec_product( result, left, right, _isTranspose );
-//        }
       }
     };
+  
+  /**
+     \brief Functor for matvecProduct that avoids both subviews and branching.  This is to replace F_matvecProduct; I'm keeping F_matvecProduct around for testing and debugging.
+  */
+  template < typename OutputViewType,
+             typename leftInputViewType,
+             typename rightInputViewType,
+             ordinal_type leftInputRank,
+             ordinal_type rightInputRank,
+             bool hasField,
+             bool isTranspose>
+  struct F_matvecProduct_new {
+    /**/  OutputViewType     _output;
+    const leftInputViewType  _leftInput;
+    const rightInputViewType _rightInput;
+    
+    const ordinal_type _iend;
+    const ordinal_type _jend;
+    
+    using value_type = typename OutputViewType::value_type;
+    
+    KOKKOS_INLINE_FUNCTION
+    F_matvecProduct_new(OutputViewType     output_,
+                        leftInputViewType  leftInput_,
+                        rightInputViewType rightInput_)
+      : _output(output_), _leftInput(leftInput_), _rightInput(rightInput_),
+        _iend(output_.extent_int(output_.rank()-1)), _jend(rightInput_.extent_int(rightInputRank-1))
+    {}
+    
+    //  ****** hasField == true cases ******
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const ordinal_type cl,
+                    const ordinal_type bf,
+                    const ordinal_type pt) const
+    {
+      apply_matvec_product(cl, bf, pt);
+    }
+    
+    template <ordinal_type l=leftInputRank, ordinal_type r=rightInputRank, bool hf=hasField>
+    KOKKOS_FORCEINLINE_FUNCTION
+    typename std::enable_if_t<l==4 && r==4 && hf, void>
+    apply_matvec_product(const ordinal_type   &cl,
+                         const ordinal_type   &bf,
+                         const ordinal_type   &pt) const {
+      const auto lpt  = (_leftInput.extent(1) == 1 ? size_type(0) : pt);
+      if (isTranspose) {
+        for (ordinal_type i=0;i<_iend;++i) {
+          value_type tmp(0);
+          for (ordinal_type j=0;j<_jend;++j)
+            tmp += _leftInput(cl,lpt, j,i)*_rightInput(cl,bf,pt, j);
+          _output(cl,bf,pt, i) = tmp;
+        }
+      } else {
+        for (ordinal_type i=0;i<_iend;++i) {
+          value_type tmp(0);
+          for (ordinal_type j=0;j<_jend;++j)
+            tmp += _leftInput(cl,lpt, i,j)*_rightInput(cl,bf,pt, j);
+          _output(cl,bf,pt, i) = tmp;
+        }
+      }
+    }
+    
+    template <ordinal_type l=leftInputRank, ordinal_type r=rightInputRank, bool hf=hasField>
+    KOKKOS_FORCEINLINE_FUNCTION
+    typename std::enable_if_t<l==4 && r==3 && hf, void>
+    apply_matvec_product(const ordinal_type   &cl,
+                         const ordinal_type   &bf,
+                         const ordinal_type   &pt) const {
+      const auto lpt  = (_leftInput.extent(1) == 1 ? size_type(0) : pt);
+      if (isTranspose) {
+        for (ordinal_type i=0;i<_iend;++i) {
+          value_type tmp(0);
+          for (ordinal_type j=0;j<_jend;++j)
+            tmp += _leftInput(cl,lpt, j,i)*_rightInput(bf,pt, j);
+          _output(cl,bf,pt, i) = tmp;
+        }
+      } else {
+        for (ordinal_type i=0;i<_iend;++i) {
+          value_type tmp(0);
+          for (ordinal_type j=0;j<_jend;++j)
+            tmp += _leftInput(cl,lpt, i,j)*_rightInput(bf,pt, j);
+          _output(cl,bf,pt, i) = tmp;
+        }
+      }
+    }
+    
+    template <ordinal_type l=leftInputRank, ordinal_type r=rightInputRank, bool hf=hasField>
+    KOKKOS_FORCEINLINE_FUNCTION
+    typename std::enable_if_t<l==3 && r==4 && hf, void>
+    apply_matvec_product(const ordinal_type   &cl,
+                         const ordinal_type   &bf,
+                         const ordinal_type   &pt) const {
+      const auto lpt  = (_leftInput.extent(1) == 1 ? size_type(0) : pt);
+      for (ordinal_type i=0;i<_iend;++i)
+        _output(cl,bf,pt, i) = _leftInput(cl,lpt, i)*_rightInput(cl,bf,pt, i);
+    }
+    
+    template <ordinal_type l=leftInputRank, ordinal_type r=rightInputRank, bool hf=hasField>
+    KOKKOS_FORCEINLINE_FUNCTION
+    typename std::enable_if_t<l==3 && r==3 && hf, void>
+    apply_matvec_product(const ordinal_type   &cl,
+                         const ordinal_type   &bf,
+                         const ordinal_type   &pt) const {
+      const auto lpt  = (_leftInput.extent(1) == 1 ? size_type(0) : pt);
+      for (ordinal_type i=0;i<_iend;++i)
+        _output(cl,bf,pt, i) = _leftInput(cl,lpt, i)*_rightInput(bf,pt, i);
+    }
+    
+    template <ordinal_type l=leftInputRank, ordinal_type r=rightInputRank, bool hf=hasField>
+    KOKKOS_FORCEINLINE_FUNCTION
+    typename std::enable_if_t<l==2 && r==4 && hf, void>
+    apply_matvec_product(const ordinal_type   &cl,
+                         const ordinal_type   &bf,
+                         const ordinal_type   &pt) const {
+      const auto lpt  = (_leftInput.extent(1) == 1 ? size_type(0) : pt);
+      const value_type & val = _leftInput(cl,lpt);
+      for (ordinal_type i=0;i<_iend;++i) {
+        _output(cl,bf,pt, i) = val*_rightInput(cl,bf,pt, i);
+      }
+    }
+    
+    template <ordinal_type l=leftInputRank, ordinal_type r=rightInputRank, bool hf=hasField>
+    KOKKOS_FORCEINLINE_FUNCTION
+    typename std::enable_if_t<l==2 && r==3 && hf, void>
+    apply_matvec_product(const ordinal_type   &cl,
+                         const ordinal_type   &bf,
+                         const ordinal_type   &pt) const {
+      const auto lpt  = (_leftInput.extent(1) == 1 ? size_type(0) : pt);
+      const value_type & val = _leftInput(cl,lpt);
+      for (ordinal_type i=0;i<_iend;++i) {
+        _output(cl,bf,pt, i) = val*_rightInput(bf,pt, i);
+      }
+    }
+    
+    //  ****** hasField == false cases ******
+    KOKKOS_INLINE_FUNCTION
+    void operator()(const ordinal_type cl,
+                    const ordinal_type pt) const
+    {
+      apply_matvec_product(cl, pt);
+    }
+    
+    template <ordinal_type l=leftInputRank, ordinal_type r=rightInputRank, bool hf=hasField>
+    KOKKOS_FORCEINLINE_FUNCTION
+    typename std::enable_if_t<l==4 && r==3 && !hf, void>
+    apply_matvec_product(const ordinal_type   &cl,
+                         const ordinal_type   &pt) const {
+      const auto lpt  = (_leftInput.extent(1) == 1 ? size_type(0) : pt);
+      if (isTranspose) {
+        for (ordinal_type i=0;i<_iend;++i) {
+          value_type tmp(0);
+          for (ordinal_type j=0;j<_jend;++j)
+            tmp += _leftInput(cl,lpt, j,i)*_rightInput(cl,pt, j);
+          _output(cl,pt, i) = tmp;
+        }
+      } else {
+        for (ordinal_type i=0;i<_iend;++i) {
+          value_type tmp(0);
+          for (ordinal_type j=0;j<_jend;++j)
+            tmp += _leftInput(cl,lpt, i,j)*_rightInput(cl,pt, j);
+          _output(cl,pt, i) = tmp;
+        }
+      }
+    }
+    
+    template <ordinal_type l=leftInputRank, ordinal_type r=rightInputRank, bool hf=hasField>
+    KOKKOS_FORCEINLINE_FUNCTION
+    typename std::enable_if_t<l==4 && r==2 && !hf, void>
+    apply_matvec_product(const ordinal_type   &cl,
+                         const ordinal_type   &pt) const {
+      const auto lpt  = (_leftInput.extent(1) == 1 ? size_type(0) : pt);
+      if (isTranspose) {
+        for (ordinal_type i=0;i<_iend;++i) {
+          value_type tmp(0);
+          for (ordinal_type j=0;j<_jend;++j)
+            tmp += _leftInput(cl,lpt, j,i)*_rightInput(pt, j);
+          _output(cl,pt, i) = tmp;
+        }
+      } else {
+        for (ordinal_type i=0;i<_iend;++i) {
+          value_type tmp(0);
+          for (ordinal_type j=0;j<_jend;++j)
+            tmp += _leftInput(cl,lpt, i,j)*_rightInput(pt, j);
+          _output(cl,pt, i) = tmp;
+        }
+      }
+    }
+    
+    template <ordinal_type l=leftInputRank, ordinal_type r=rightInputRank, bool hf=hasField>
+    KOKKOS_FORCEINLINE_FUNCTION
+    typename std::enable_if_t<l==3 && r==3 && !hf, void>
+    apply_matvec_product(const ordinal_type   &cl,
+                         const ordinal_type   &pt) const {
+      const auto lpt  = (_leftInput.extent(1) == 1 ? size_type(0) : pt);
+      for (ordinal_type i=0;i<_iend;++i)
+        _output(cl,pt, i) = _leftInput(cl,lpt, i)*_rightInput(cl,pt, i);
+    }
+    
+    template <ordinal_type l=leftInputRank, ordinal_type r=rightInputRank, bool hf=hasField>
+    KOKKOS_FORCEINLINE_FUNCTION
+    typename std::enable_if_t<l==3 && r==2 && !hf, void>
+    apply_matvec_product(const ordinal_type   &cl,
+                         const ordinal_type   &pt) const {
+      const auto lpt  = (_leftInput.extent(1) == 1 ? size_type(0) : pt);
+      for (ordinal_type i=0;i<_iend;++i)
+        _output(cl,pt, i) = _leftInput(cl,lpt, i)*_rightInput(pt, i);
+    }
+    
+    template <ordinal_type l=leftInputRank, ordinal_type r=rightInputRank, bool hf=hasField>
+    KOKKOS_FORCEINLINE_FUNCTION
+    typename std::enable_if_t<l==2 && r==3 && !hf, void>
+    apply_matvec_product(const ordinal_type   &cl,
+                         const ordinal_type   &pt) const {
+      const auto lpt  = (_leftInput.extent(1) == 1 ? size_type(0) : pt);
+      const value_type & val = _leftInput(cl,lpt);
+      for (ordinal_type i=0;i<_iend;++i) {
+        _output(cl,pt, i) = val*_rightInput(cl,pt, i);
+      }
+    }
+    
+    template <ordinal_type l=leftInputRank, ordinal_type r=rightInputRank, bool hf=hasField>
+    KOKKOS_FORCEINLINE_FUNCTION
+    typename std::enable_if_t<l==2 && r==2 && !hf, void>
+    apply_matvec_product(const ordinal_type   &cl,
+                         const ordinal_type   &pt) const {
+      const auto lpt  = (_leftInput.extent(1) == 1 ? size_type(0) : pt);
+      const value_type & val = _leftInput(cl,lpt);
+      for (ordinal_type i=0;i<_iend;++i) {
+        _output(cl,pt, i) = val*_rightInput(pt, i);
+      }
+    }
+  };
   } //namespace
 
   template<typename DeviceType>
@@ -989,58 +1160,121 @@ namespace Intrepid2 {
                  const Kokkos::DynRankView<rightInputValueType,rightInputProperties...>  rightInput,
                  const bool hasField,
                  const bool isTranspose ) {
+    
+    using Output = Kokkos::DynRankView<outputValueType,    outputProperties...>;
+    using Left   = const Kokkos::DynRankView<leftInputValueType, leftInputProperties...>;
+    using Right  = const Kokkos::DynRankView<rightInputValueType,rightInputProperties...>;
+    
+    // FTNMAB: FunctorType with left rank N, right rank M, hasField = (A==T), isTranspose = (B==T)
+    
+    // hasField == true
+    using FT44TT = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,4,4,  true,  true>;
+    using FT43TT = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,4,3,  true,  true>;
+    using FT44TF = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,4,4,  true, false>;
+    using FT43TF = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,4,3,  true, false>;
+    
+    // for left rank 3, 2, isTranspose does not matter
+    using FT34TF = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,3,4,  true, false>;
+    using FT33TF = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,3,3,  true, false>;
+    using FT24TF = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,2,4,  true, false>;
+    using FT23TF = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,2,3,  true, false>;
+    
+    // hasField == false
+    using FT43FT = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,4,3, false,  true>;
+    using FT42FT = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,4,2, false,  true>;
+    using FT43FF = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,4,3, false, false>;
+    using FT42FF = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,4,2, false, false>;
+    
+    // for left rank 3, 2, isTranspose does not matter
+    using FT33FF = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,3,3, false, false>;
+    using FT32FF = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,3,2, false, false>;
+    using FT23FF = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,2,3, false, false>;
+    using FT22FF = FunctorArrayTools::F_matvecProduct_new<Output,Left,Right,2,2, false, false>;
 
     typedef       Kokkos::DynRankView<outputValueType,    outputProperties...>      OutputViewType;
     typedef const Kokkos::DynRankView<leftInputValueType, leftInputProperties...>   leftInputViewType;
     typedef const Kokkos::DynRankView<rightInputValueType,rightInputProperties...>  rightInputViewType;
-    typedef FunctorArrayTools::F_matvecProduct<OutputViewType, leftInputViewType, rightInputViewType> FunctorType;
-
-    FunctorType functor(output, leftInput, rightInput, isTranspose);
     
-    // TODO: consider checking to see if we are running in serial on host.  If so, use for loops instead of parallel_for.
-    const bool TRY_SERIAL_FOR = false;
+    const ordinal_type l = leftInput.rank();
+    const ordinal_type r = rightInput.rank();
     
-    if (TRY_SERIAL_FOR)
+    using range_policy2 = Kokkos::MDRangePolicy< ExecSpaceType, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
+    range_policy2 policy2( { 0, 0 }, { output.extent(0), output.extent(1) } );
+    
+    using range_policy3 = Kokkos::MDRangePolicy< ExecSpaceType, Kokkos::Rank<3>, Kokkos::IndexType<ordinal_type> >;
+    range_policy3 policy3( { 0, 0, 0 }, { output.extent(0), output.extent(1), output.extent(2) } );
+    
+    // just to make the below a little easier to read, we pack l and r together:
+    const ordinal_type lr = l * 10 + r;
+    const auto &ov = output;
+    const auto &lv = leftInput;
+    const auto &rv = rightInput;
+    
+    if (hasField) // this means we want policy3
     {
-      const int iend = output.extent_int(0);
-      const int jend = output.extent_int(1);
-      if (hasField)
+      if (l == 4)
       {
-        const int kend = output.extent_int(2);
-        for (ordinal_type i=0; i<iend; i++)
+        // isTranspose matters
+        if (isTranspose)
         {
-          for (ordinal_type j=0; j<jend; j++)
+          switch (r)
           {
-            for (ordinal_type k=0; k<kend; k++)
-            {
-              functor(i,j,k);
-            }
+            case 4:  { FT44TT f(ov,lv,rv); Kokkos::parallel_for( policy3, f ); } break;
+            default: { FT43TT f(ov,lv,rv); Kokkos::parallel_for( policy3, f ); }
+          }
+        }
+        else
+        {
+          switch (r)
+          {
+            case 4:  { FT44TF f(ov,lv,rv); Kokkos::parallel_for( policy3, f ); } break;
+            default: { FT43TF f(ov,lv,rv); Kokkos::parallel_for( policy3, f ); }
           }
         }
       }
-      else
+      else // l == 3 or 2; isTranspose does not matter
       {
-        for (ordinal_type i=0; i<iend; i++)
+        switch (lr)
         {
-          for (ordinal_type j=0; j<jend; j++)
-          {
-            functor(i,j);
-          }
+          case 34: { FT34TF f(ov,lv,rv); Kokkos::parallel_for( policy3, f ); } break;
+          case 33: { FT33TF f(ov,lv,rv); Kokkos::parallel_for( policy3, f ); } break;
+          case 24: { FT24TF f(ov,lv,rv); Kokkos::parallel_for( policy3, f ); } break;
+          default: { FT23TF f(ov,lv,rv); Kokkos::parallel_for( policy3, f ); } // 23
         }
       }
     }
-    else if (hasField) {
-      using range_policy_type = Kokkos::MDRangePolicy
-        < ExecSpaceType, Kokkos::Rank<3>, Kokkos::IndexType<ordinal_type> >;
-      range_policy_type policy( { 0, 0, 0 },
-                                { output.extent(0), output.extent(1), output.extent(2) } );
-      Kokkos::parallel_for( policy, functor );
-    } else {
-      using range_policy_type = Kokkos::MDRangePolicy
-        < ExecSpaceType, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
-      range_policy_type policy( { 0, 0 },
-                                { output.extent(0), output.extent(1) } );
-      Kokkos::parallel_for( policy, functor );
+    else // hasField is false; use policy2
+    {
+      if (l == 4)
+      {
+        // isTranspose matters
+        if (isTranspose)
+        {
+          switch (r)
+          {
+            case 3:  { FT43FT f(ov,lv,rv); Kokkos::parallel_for( policy2, f ); } break;
+            default: { FT42FT f(ov,lv,rv); Kokkos::parallel_for( policy2, f ); } // 2
+          }
+        }
+        else
+        {
+          switch (r)
+          {
+            case 3:  { FT43FF f(ov,lv,rv); Kokkos::parallel_for( policy2, f ); } break;
+            default: { FT42FF f(ov,lv,rv); Kokkos::parallel_for( policy2, f ); } // 2
+          }
+        }
+      }
+      else // l == 3 or 2; isTranspose does not matter
+      {
+        switch (lr)
+        {
+          case 33: { FT33FF f(ov,lv,rv); Kokkos::parallel_for( policy2, f ); } break;
+          case 32: { FT32FF f(ov,lv,rv); Kokkos::parallel_for( policy2, f ); } break;
+          case 23: { FT23FF f(ov,lv,rv); Kokkos::parallel_for( policy2, f ); } break;
+          default: { FT22FF f(ov,lv,rv); Kokkos::parallel_for( policy2, f ); } // 22
+        }
+      }
     }
   }
 

--- a/packages/intrepid2/unit-test/Discretization/Integration/test_util.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Integration/test_util.hpp
@@ -55,6 +55,8 @@
 #include "Intrepid2_Utils.hpp"
 #include "Intrepid2_OrientationTools.hpp"
 
+#include <cmath>
+
 namespace Intrepid2 {
 
   namespace Test {
@@ -165,8 +167,18 @@ namespace Intrepid2 {
       return value/++k;
     }
 
+    // beta implemented here because apparently Apple clang does not define it.
+    template<typename ArithmeticType>
+    double beta(const ArithmeticType &x, const ArithmeticType &y)
+    {
+      auto Gamma_x   = std::tgamma(x);
+      auto Gamma_y   = std::tgamma(y);
+      auto Gamma_xpy = std::tgamma(x+y);
+      return Gamma_x * Gamma_y / Gamma_xpy;
+    }
+  
     /* 
-      Integral of monomial over unit pyramid from initial implemetation by John Burkardt
+      Integral of monomial over unit pyramid from initial implementation by John Burkardt
         Integral ( over unit pyramid ) x^m y^n z^p dx dy dz
     */
     template<typename ValueType>
@@ -176,7 +188,7 @@ namespace Intrepid2 {
         int degCoeff = 2 + xDeg + yDeg;
         ValueType sign = 1.0;
         for (int i=0; i <= degCoeff; ++i) {
-          auto comb = std::round(sign / ((degCoeff+1) * std::beta(degCoeff-i+1,i+1)));   // sign * nCr(degCoeff,i)
+          auto comb = std::round(sign / ((degCoeff+1) * beta(degCoeff-i+1,i+1)));   // sign * nCr(degCoeff,i)
           value += comb / ( i + zDeg + 1.0 );
           sign = -sign;
         }


### PR DESCRIPTION
@trilinos/intrepid2

## Motivation
When moving from Intrepid to Intrepid2, Sierra noticed substantial performance degradation in one of their performance tests.  The most egregious offender was `HGRADtransformGRAD`, which ultimately calls `ArrayTools::Internal::matvecProduct()`.  The functor called by the latter involved Kokkos subviews and a fair amount of run-time branching.

This PR reimplements that functor to eliminate both the use of subviews and the run-time branching, in favor of compile-time template specializations of the functor, combined with logic that selects the appropriate specialization prior to the launch of the parallel kernel.  In our testing with parameters intended to reproduce Sierra's performance tests, this results in a roughly 3x speedup, with performance that outperforms the Intrepid implementation on a serial CPU by about 10%.  (On parallel runs, we can expect increasing performance gains, since Intrepid is a purely serial implementation.)

`matvecProduct()`, which is optimized here, is called by a many methods in Intrepid2, including most of the pullbacks.  We have not studied the performance of pullbacks beyond `HGRADtransformGRAD()` (which is an alias for `HCURLtransformVALUE()` ), but given the nature of the optimizations, we do expect that all these will see substantially improved performance.

## Testing
These changes are tested by the ArrayTools tests, and nearly anything that calls pullbacks.