### PR TITLE
Ignore commits with changes from clang format

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# first run of clang-format over MueLu
+1b1b032cf67a001d7c7595e3ccea653d5bcd1277
+27387a814f72487f5a3fbb634cd5d1b298dfe4c5


### PR DESCRIPTION
## Motivation
@trilinos/muelu applied clang-format to `packages/muelu`, but we don't want to see these changes listed in `git blame`.
The new file has the two commits that should be ignored.
In order to use it, do a 
```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```