### PR TITLE
Framework: Add '-fp-model=precise' when using OneAPI compiler

### DIFF
--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -1,5 +1,10 @@
 tribits_get_package_enable_status(Kokkos  KokkosEnable "")
 
+IF (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+  MESSAGE("-- " "Adding '-fp-model=precise' to C++ compiler flags because Trilinos needs it when using the Intel OneAPI C++ compiler.")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fp-model=precise")
+ENDIF()
+
 IF (KokkosEnable)
   MESSAGE("-- " "Skip adding flags for OpenMP because Kokkos flags does that ...")
   SET(OpenMP_CXX_FLAGS_OVERRIDE " ")

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2924,8 +2924,6 @@ use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|ALL
 
-opt-set-cmake-var CMAKE_CXX_FLAGS STRING FORCE : "-fp-model=precise"
-
 opt-set-cmake-var TPL_BLAS_LIBRARIES   STRING : -qmkl=sequential
 opt-set-cmake-var TPL_LAPACK_LIBRARIES STRING : -qmkl=sequential
 


### PR DESCRIPTION
Always use `-fp-model=precise` when building with Intel OneAPI C++ compiler.  We need it, or else tests fail.  Also multiple downstream customers have discovered this when using the newer Intel compiler.

@trilinos/framework 

## Motivation
Users should not have to know magic flags to use when building Trilinos.

## Related Issues
https://github.com/trilinos/Trilinos/issues/12470


## Testing
I tested this with the old (classic) Intel compiler and a OneAPI (nextgen) one.  Behavior was as expected.