### PR TITLE
Tempus: Disable Tests That Run Too Long

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1873,6 +1873,32 @@ opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING 
 # Test failures as of 11-28-22
 opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL : ON
 
+# Under loading and debug, these Tempus run too long and timeout (fail). 2023-12-21
+opt-set-cmake-var Tempus_BackwardEuler_CDR_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_Staggered_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_VanDerPol_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BDF2_CDR_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BDF2_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_ASA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Combined_FSA_SDIRK_5_Stage_4th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Combined_FSA_SDIRK_5_Stage_5th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Staggered_FSA_SDIRK_5_Stage_4th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Staggered_FSA_SDIRK_5_Stage_5th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_ExplicitRK_ASA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_HHTAlpha_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Combined_FSA_Tangent_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Combined_FSA_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_General_Partioned_IMEX_RK_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_Tangent_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Staggered_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Staggered_FSA_Tangent_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_Newmark_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_Test_NewmarkImplicitAForm_HarmonicOscillator_Damped_FirstOrder_MPI_1_DISABLE BOOL FORCE : ON
+
 use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
 
 use RHEL7_POST
@@ -2060,6 +2086,32 @@ opt-set-cmake-var Trilinos_ENABLE_Moertel BOOL CACHE FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_Komplex BOOL CACHE FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_Rythmos BOOL CACHE FORCE : OFF
 
+# Under loading and debug, these Tempus run too long and timeout (fail). 2023-12-21
+opt-set-cmake-var Tempus_BackwardEuler_CDR_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_Staggered_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_VanDerPol_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BDF2_CDR_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BDF2_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_ASA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Combined_FSA_SDIRK_5_Stage_4th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Combined_FSA_SDIRK_5_Stage_5th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Staggered_FSA_SDIRK_5_Stage_4th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Staggered_FSA_SDIRK_5_Stage_5th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_ExplicitRK_ASA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_HHTAlpha_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Combined_FSA_Tangent_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Combined_FSA_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_General_Partioned_IMEX_RK_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_Tangent_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Staggered_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Staggered_FSA_Tangent_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_Newmark_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_Test_NewmarkImplicitAForm_HarmonicOscillator_Damped_FirstOrder_MPI_1_DISABLE BOOL FORCE : ON
+
 [rhel7_sems-clang-11.0.1-openmpi-1.10.1-openmp_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 opt-set-cmake-var Trilinos_ENABLE_OpenMP BOOL FORCE : ON
@@ -2179,19 +2231,31 @@ opt-set-cmake-var Zoltan_ch_simple_scotch_parallel_DISABLE BOOL FORCE   : ON
 opt-set-cmake-var Epetra_Directory_test_LL_MPI_1_DISABLE BOOL FORCE     : ON
 opt-set-cmake-var SEACASAprepro_lib_aprepro_lib_array_test_DISABLE BOOL FORCE     : ON
 
-# These tests time out if other stuff is running on the machine at the same time.
-#  Not a LOT of other stuff, but they seem to be more resource-intensive than one would
-#  think looking at the MPI rank count.
+# Under loading and debug, these Tempus run too long and timeout (fail). 2023-12-21
+opt-set-cmake-var Tempus_BackwardEuler_CDR_MPI_1_DISABLE BOOL FORCE : ON
 opt-set-cmake-var Tempus_BackwardEuler_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_Staggered_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_VanDerPol_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BDF2_CDR_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BDF2_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
 opt-set-cmake-var Tempus_DIRK_ASA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Combined_FSA_SDIRK_5_Stage_4th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Combined_FSA_SDIRK_5_Stage_5th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Staggered_FSA_SDIRK_5_Stage_4th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Staggered_FSA_SDIRK_5_Stage_5th_Order_MPI_1_DISABLE BOOL FORCE : ON
 opt-set-cmake-var Tempus_ExplicitRK_ASA_MPI_1_DISABLE BOOL FORCE : ON
 opt-set-cmake-var Tempus_HHTAlpha_MPI_1_DISABLE BOOL FORCE : ON
-opt-set-cmake-var Tempus_IMEX_RK_Combined_RSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Combined_FSA_Tangent_MPI_1_DISABLE BOOL FORCE : ON
 opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Combined_FSA_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
 opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_General_Partioned_IMEX_RK_MPI_1_DISABLE BOOL FORCE : ON
 opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_Tangent_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
 opt-set-cmake-var Tempus_IMEX_RK_Staggered_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Staggered_FSA_Tangent_MPI_1_DISABLE BOOL FORCE : ON
 opt-set-cmake-var Tempus_Newmark_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_Test_NewmarkImplicitAForm_HarmonicOscillator_Damped_FirstOrder_MPI_1_DISABLE BOOL FORCE : ON
 
 # This is temporarily disabled because it seems to be particularly sensitive to the spack-built
 #  MPI issue (TRILFRAME-552)
@@ -2729,6 +2793,32 @@ opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobb
 opt-set-cmake-var TPL_ENABLE_ParMETIS            BOOL FORCE   : OFF
 opt-set-cmake-var TPL_ENABLE_Pnetcdf             BOOL FORCE   : OFF
 opt-set-cmake-var TPL_Netcdf_LIBRARIES           STRING FORCE : -L${NETCDF_C_LIB|ENV};${NETCDF_C_LIB|ENV}/libnetcdf.a;${TPL_HDF5_LIBRARIES|CMAKE}
+
+# Under loading and debug, these Tempus run too long and timeout (fail). 2023-12-21
+opt-set-cmake-var Tempus_BackwardEuler_CDR_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_Staggered_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_VanDerPol_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BDF2_CDR_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BDF2_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_ASA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Combined_FSA_SDIRK_5_Stage_4th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Combined_FSA_SDIRK_5_Stage_5th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Staggered_FSA_SDIRK_5_Stage_4th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Staggered_FSA_SDIRK_5_Stage_5th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_ExplicitRK_ASA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_HHTAlpha_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Combined_FSA_Tangent_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Combined_FSA_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_General_Partioned_IMEX_RK_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_Tangent_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Staggered_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Staggered_FSA_Tangent_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_Newmark_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_Test_NewmarkImplicitAForm_HarmonicOscillator_Damped_FirstOrder_MPI_1_DISABLE BOOL FORCE : ON
 
 use RHEL7_POST
 


### PR DESCRIPTION
Several tests run too long in debug mode while the platform is loaded causing timeout failures. Disabling them. Reviewing recent runtimes, disabled tests that ran longer than about 5 minutes. These are only disabled for debug builds so still getting coverage with other builds.

@trilinos/tempus 

## Motivation
Reduce the number of random timeouts.

* Closes #12623 
* Related to #12622 