### PR TITLE
Belos: Avoid duplicate doxygen anchors. Add missing closing \f$.

### DIFF
--- a/packages/belos/doc/index.doc
+++ b/packages/belos/doc/index.doc
@@ -57,7 +57,7 @@ via the following included solvers:
    <li>Flexible variants:  Flexible GMRES
    </ul>
 
-   \section contributors Belos Contributors
+   \section Belos_contributors Belos Contributors
 
    The following people have contributed to the development of %Belos:
 

--- a/packages/belos/src/BelosRCGSolMgr.hpp
+++ b/packages/belos/src/BelosRCGSolMgr.hpp
@@ -69,7 +69,7 @@
 \ingroup belos_solver_framework
 \author Michael Parks and Heidi Thornquist
 
-\section Belos_GCRODR_summary Summary
+\section Belos_RCGSol_summary Summary
 
 This class implements the GCRODR (Recycling GMRES) iterative linear
 solver.  This solver is suited for solving sequences of related linear

--- a/packages/belos/src/BelosStatusTestGenResSubNorm.hpp
+++ b/packages/belos/src/BelosStatusTestGenResSubNorm.hpp
@@ -87,7 +87,7 @@ class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP> {
     of the initial residual.  The least costly form of the 2-norm depends on the chosen iterative
     method.
 
-    @param Tolerance: Specifies tolerance \f$\tau\f
+    @param Tolerance: Specifies tolerance \f$\tau\f$
     @param subIdx: index of block row in the n x n block system we want to check the residual of
     @param quorum: Number of residual (sub-)vectors which are needed to be within the tolerance before check is considered to be passed
     @param showMaxResNormOnly: for output only


### PR DESCRIPTION
@hkthorn

@trilinos/belos

## Motivation

Minor fixes to Doxygen comments:

- Seeks to solve two "duplicate anchor" warnings (causes problems when importing the tag file when using "warn as error").
- Add missing closing \f$ (to avoid that Doxygen considers everything that follows as a LaTeX comment). 

Joined work with @romintomasetti.

