### PR TITLE
Teuchos: Handle non-matching quotes in CLP on Mac

### DIFF
--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
@@ -62,9 +62,13 @@ inline int my_max( int a, int b ) { return a > b ? a : b; }
 
 std::string remove_quotes( const std::string& str )
 {
-  if(str[0] != '\"')
-    return str;
-  return str.substr(1,str.size()-2);
+  if (str[0] == '\"' && str[str.size()-1] == '\"')
+    return str.substr(1,str.size()-2);
+  else if (str[0] == '\"')
+    return str.substr(1,str.size()-1);
+  else if (str[str.size()-1] == '\"')
+    return str.substr(0,str.size()-2);
+  return str;
 }
 
 

--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.cpp
@@ -67,7 +67,7 @@ std::string remove_quotes( const std::string& str )
   else if (str[0] == '\"')
     return str.substr(1,str.size()-1);
   else if (str[str.size()-1] == '\"')
-    return str.substr(0,str.size()-2);
+    return str.substr(0,str.size()-1);
   return str;
 }
 

--- a/packages/teuchos/core/test/CommandLineProcessor/CMakeLists.txt
+++ b/packages/teuchos/core/test/CommandLineProcessor/CMakeLists.txt
@@ -5,3 +5,11 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   COMM serial mpi
   NUM_MPI_PROCS 1
   )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  CLP_Remove_Quotes
+  SOURCES Teuchos_CLP_Remove_Quotes.cpp
+  ARGS "--method=TEST"
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  )

--- a/packages/teuchos/core/test/CommandLineProcessor/Teuchos_CLP_Remove_Quotes.cpp
+++ b/packages/teuchos/core/test/CommandLineProcessor/Teuchos_CLP_Remove_Quotes.cpp
@@ -1,0 +1,66 @@
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_CommandLineProcessor.hpp"
+
+
+int main( int argc, char* argv[] )
+{
+  using Teuchos::CommandLineProcessor;
+
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+
+  bool verbose = true;
+  bool parse_successful = true;
+
+  std::string test_arg[4];
+  std::string test_title[4];
+  test_arg[0] = "--method=Name_of_Method";       test_title[0] = "without Quotes";
+  test_arg[1] = "--method=\"Name_of_Method\"";   test_title[1] = "with Quotes";
+  test_arg[2] = "--method=\"Name_of_Method";     test_title[2] = "with Leading Quote";
+  test_arg[3] = "--method=Name_of_Method\"";     test_title[3] = "with Trailing Quote";
+
+  for (int i=0; i<4; i++) {
+    try {
+      if (verbose)
+        std::cout << "Test "<<i<<" :  CLP - remove_quotes() " << test_title[i] << std::endl;
+
+      argv[1] = &(test_arg[i][0]);
+      CommandLineProcessor CLP(true, true);  // Recognize all options AND throw exceptions
+
+      std::string method_name = "";
+
+      CLP.setOption("method", &method_name, "Name of Method");
+      CLP.parse(argc, argv);
+
+      if (verbose)
+        std::cout << "Test "<<i<<" :  CLP - remove_quotes() " << test_title[i] << ": ";
+      if (method_name != "Name_of_Method")
+      {
+        parse_successful = false;
+        if (verbose) std::cout << "FAILED" << std::endl;
+      }
+      else
+        if (verbose) std::cout << "PASSED" << std::endl;
+    }
+    catch( CommandLineProcessor::UnrecognizedOption &excpt ) {
+      if(verbose)
+        std::cout << "*** Caught EXPECTED standard exception : " << excpt.what() << std::endl
+                  << "Test "<<i<<" :  CLP - remove_quotes() " << test_title[i] << ": PASSED" << std::endl;
+    }
+    catch( ... ) {
+      if(verbose)
+        std::cout << "*** Caught UNEXPECTED unknown exception" << std::endl
+                  << "Test "<<i<<" :  CLP - remove_quotes() " << test_title[i] << ": FAILED" << std::endl;
+      parse_successful = false;  // No exceptions should be thrown for this command line processor.
+    }
+  }
+
+  // Return whether the command line processor tests passed.
+  if (parse_successful) {
+    std::cout << "End Result: TEST PASSED" << std::endl;
+    return 0;
+  }
+  else {
+    std::cout << "End Result: TEST FAILED" << std::endl;
+    return 1;
+  }
+}


### PR DESCRIPTION
Many tests in Tempus fail due to parsing between tribits, ctest and MacOS 14 that finally leaves an argument with a single double quote, i.e.,

TRIBITS_ADD_TEST(
  ExplicitRK_Combined_FSA
  NAME "ExplicitRK_Combined_FSA_RK_Forward_Euler"
  ARGS "--method=\"RK Forward Euler\""
  NUM_MPI_PROCS 1
  )

When using ctest on a Mac, the --method arugment becomes 'RK Forward Eule' and the test fails.  The string making it to Teuchos::remove_quotes() is '"RK Forward Euler' which removes the double quote and the 'r'. Modifying Teuchos::remove_quotes() to remove a leading double quote and/or a trailing double quote fixes this issue.

Note: If the test is run directly, either

 % /opt/homebrew/bin/mpiexec "-np" "1" "/Users/ccober/myOffice/Tempus-Project/Trilinos_build/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_Combined_FSA.exe" "--method=\"RK Forward Euler\""
 or
% Tempus_ExplicitRK_Combined_FSA.exe

the test passes.


@trilinos/teuchos 


## Related Issues

* Closes #12639 
