### PR TITLE
Framework: force no fast-forward merges for pull request testing

### DIFF
--- a/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py
@@ -171,9 +171,9 @@ def merge_branch(source_url, target_branch, sourceSHA):
 
     if sha_exists_as_branch_on_remote:
         print_wrapper("REMARK: Detected ref as a remote branch, will merge as such")
-        check_call_wrapper(['git', 'merge', '--no-edit', "source_remote/" + sourceSHA])
+        check_call_wrapper(['git', 'merge', '--no-ff', '--no-edit', "source_remote/" + sourceSHA])
     else:
-        check_call_wrapper(['git', 'merge', '--no-edit', sourceSHA])
+        check_call_wrapper(['git', 'merge', '--no-ff', '--no-edit', sourceSHA])
 
     return 0
 

--- a/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverMerge.py
+++ b/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverMerge.py
@@ -169,7 +169,7 @@ class Test_mergeBranch(unittest.TestCase):
                                        mock.call(['git', 'fetch', 'origin', 'fake_develop']),
                                        mock.call(['git', 'reset', '--hard', 'HEAD']),
                                        mock.call(['git', 'checkout', '-B', 'fake_develop', 'origin/fake_develop']),
-                                       mock.call(['git', 'merge', '--no-edit', 'df324ae']),
+                                       mock.call(['git', 'merge', '--no-ff', '--no-edit', 'df324ae']),
                                        ])
         return
 
@@ -199,7 +199,7 @@ class Test_mergeBranch(unittest.TestCase):
                                        mock.call(['git', 'fetch', 'origin', 'fake_develop']),
                                        mock.call(['git', 'reset', '--hard', 'HEAD']),
                                        mock.call(['git', 'checkout', '-B', 'fake_develop', 'origin/fake_develop']),
-                                       mock.call(['git', 'merge', '--no-edit', 'df324ae']),
+                                       mock.call(['git', 'merge', '--no-ff', '--no-edit', 'df324ae']),
                                        ])
         self.assertIn("git remote exists, removing it", m_stdout.getvalue())
         return
@@ -229,7 +229,7 @@ class Test_mergeBranch(unittest.TestCase):
                                        mock.call(['git', 'fetch', 'origin', 'fake_develop']),
                                        mock.call(['git', 'reset', '--hard', 'HEAD']),
                                        mock.call(['git', 'checkout', '-B', 'fake_develop', 'origin/fake_develop']),
-                                       mock.call(['git', 'merge', '--no-edit', 'source_remote/some_ref']),
+                                       mock.call(['git', 'merge', '--no-ff', '--no-edit', 'source_remote/some_ref']),
                                        ])
         self.assertIn("git remote exists, removing it", m_stdout.getvalue())
         return


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

The current pull request testing system will perform a fast-forward merge whenever possible on the topic and target branches being merged for testing. 

The default behavior for [GitHub Actions merges](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github) is to never allow a fast-forward merge with the `--no-ff` option. This change will follow the same convention for AutoTester pull request testing.

Additional motivation is to consistently have a merge commit for the TriBITS repo version configure output for every pull request test. 
- TriBITSPub/TriBITS#597

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
[TRILFRAME-614 story comment](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-614?focusedCommentId=61803&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-61803)
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Updated tests that check the expected git commands used by https://github.com/trilinos/Trilinos/blob/471c3244b0410560fa4a5c55fa22e225358b53bf/packages/framework/pr_tools/PullRequestLinuxDriverMerge.py#L130 
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->