### PR TITLE
Fix 12648

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -573,7 +573,7 @@ bool Behavior::overlapCommunicationAndComputation ()
 
 size_t Behavior::spacesIdWarnLimit ()
 {
-  constexpr char envVarName[] = "TPETRA_SPACES_ID_WARN_LIMT";
+  constexpr char envVarName[] = "TPETRA_SPACES_ID_WARN_LIMIT";
   constexpr size_t defaultValue(16);
 
   static size_t value_ = defaultValue;
@@ -645,4 +645,3 @@ bool Behavior::timeKokkosFunctions()
 
 } // namespace Details
 } // namespace Tpetra
-

--- a/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.hpp
@@ -231,7 +231,7 @@ public:
       TPETRA_DETAILS_SPACES_THROW(
           "requested instance id "
           << i << " (>= " << Tpetra::Details::Behavior::spacesIdWarnLimit()
-          << ") set by TPETRA_SPACES_ID_WARN_LIMT");
+          << ") set by TPETRA_SPACES_ID_WARN_LIMIT");
     }
 
     // make sure we can store an exec space at index i for priority


### PR DESCRIPTION
fix spelling error in environment variable name.

closes: #12648
