### PR TITLE
Add seperator for subblock numbering for outputting Teko block matrices

### DIFF
--- a/packages/teko/src/Epetra/Teko_BlockedEpetraOperator.cpp
+++ b/packages/teko/src/Epetra/Teko_BlockedEpetraOperator.cpp
@@ -163,16 +163,12 @@ void BlockedEpetraOperator::WriteBlocks(const std::string & prefix) const
 
    for(int i=0;i<rows;i++) {
       for(int j=0;j<rows;j++) {
-         // build the file name
-         std::stringstream ss;
-         ss << prefix << "_" << i << "_" << j << ".mm";
-
          // get the row matrix object
          RCP<const Epetra_RowMatrix> mat
                = Teuchos::rcp_dynamic_cast<const Epetra_RowMatrix>(Thyra::get_Epetra_Operator(*blockOp->getBlock(i,j)));
 
          // write to file
-         EpetraExt::RowMatrixToMatrixMarketFile(ss.str().c_str(),*mat);
+         EpetraExt::RowMatrixToMatrixMarketFile(formatBlockName(prefix,i,j,rows).c_str(),*mat);
       }
    }
 }

--- a/packages/teko/src/Epetra/Teko_BlockedEpetraOperator.cpp
+++ b/packages/teko/src/Epetra/Teko_BlockedEpetraOperator.cpp
@@ -165,7 +165,7 @@ void BlockedEpetraOperator::WriteBlocks(const std::string & prefix) const
       for(int j=0;j<rows;j++) {
          // build the file name
          std::stringstream ss;
-         ss << prefix << "_" << i << j << ".mm";
+         ss << prefix << "_" << i << "_" << j << ".mm";
 
          // get the row matrix object
          RCP<const Epetra_RowMatrix> mat

--- a/packages/teko/src/Epetra/Teko_StridedEpetraOperator.cpp
+++ b/packages/teko/src/Epetra/Teko_StridedEpetraOperator.cpp
@@ -174,7 +174,7 @@ void StridedEpetraOperator::WriteBlocks(const std::string & prefix) const
       for(int j=0;j<rows;j++) {
          // build the file name
          std::stringstream ss;
-         ss << prefix << "_" << i << j << ".mm";
+         ss << prefix << "_" << i << "_" << j << ".mm";
 
          // get the row matrix object (Note: can't use "GetBlock" method b/c matrix might be reordered)
          RCP<const Epetra_RowMatrix> mat

--- a/packages/teko/src/Epetra/Teko_StridedEpetraOperator.cpp
+++ b/packages/teko/src/Epetra/Teko_StridedEpetraOperator.cpp
@@ -172,16 +172,12 @@ void StridedEpetraOperator::WriteBlocks(const std::string & prefix) const
 
    for(int i=0;i<rows;i++) {
       for(int j=0;j<rows;j++) {
-         // build the file name
-         std::stringstream ss;
-         ss << prefix << "_" << i << "_" << j << ".mm";
-
          // get the row matrix object (Note: can't use "GetBlock" method b/c matrix might be reordered)
          RCP<const Epetra_RowMatrix> mat
                = Teuchos::rcp_dynamic_cast<const Epetra_RowMatrix>(Thyra::get_Epetra_Operator(*blockOp->getBlock(i,j)));
 
          // write to file
-         EpetraExt::RowMatrixToMatrixMarketFile(ss.str().c_str(),*mat);
+         EpetraExt::RowMatrixToMatrixMarketFile(formatBlockName(prefix,i,j,rows).c_str(),*mat);
       }
    }
 }

--- a/packages/teko/src/Teko_Utilities.cpp
+++ b/packages/teko/src/Teko_Utilities.cpp
@@ -2766,5 +2766,22 @@ RCP<const Thyra::PhysicallyBlockedLinearOpBase<double> > getPhysicallyBlockedLin
     return Teuchos::null;
 }
 
+std::string formatBlockName(const std::string & prefix,int i,int j,int nrow)
+{
+  unsigned digits = 0;
+  auto blockId = nrow-1;
+  do {
+      blockId /= 10;
+      digits++;
+  } while (blockId);
+
+  std::ostringstream ss;
+  ss << prefix << "_";
+  ss << std::setfill('0') << std::setw(digits) << i;
+  ss << "_";
+  ss << std::setfill('0') << std::setw(digits) << j;
+  ss << ".mm";
+  return ss.str();
+}
 
 }

--- a/packages/teko/src/Teko_Utilities.hpp
+++ b/packages/teko/src/Teko_Utilities.hpp
@@ -915,6 +915,9 @@ bool isPhysicallyBlockedLinearOp(const LinearOp & op);
   */
 Teuchos::RCP<const Thyra::PhysicallyBlockedLinearOpBase<double> > getPhysicallyBlockedLinearOp(const LinearOp & op, ST *scalar, bool *transp);
 
+//! Construct filename string for writing blocks to matrix-market format
+std::string formatBlockName(const std::string & prefix,int i,int j,int nrow);
+
 } // end namespace Teko
 
 #ifdef _MSC_VER

--- a/packages/teko/src/Tpetra/Teko_BlockedTpetraOperator.cpp
+++ b/packages/teko/src/Tpetra/Teko_BlockedTpetraOperator.cpp
@@ -162,17 +162,13 @@ void BlockedTpetraOperator::WriteBlocks(const std::string & prefix) const
 
    for(int i=0;i<rows;i++) {
       for(int j=0;j<rows;j++) {
-         // build the file name
-         std::stringstream ss;
-         ss << prefix << "_" << i << "_" << j << ".mm";
-
          // get the row matrix object
          RCP<const Thyra::TpetraLinearOp<ST,LO,GO,NT> > tOp = rcp_dynamic_cast<const Thyra::TpetraLinearOp<ST,LO,GO,NT> >(blockOp->getBlock(i,j));
          RCP<const Tpetra::CrsMatrix<ST,LO,GO,NT> > mat
                = Teuchos::rcp_dynamic_cast<const Tpetra::CrsMatrix<ST,LO,GO,NT> >(tOp->getConstTpetraOperator());
 
          // write to file
-         Tpetra::MatrixMarket::Writer<Tpetra::CrsMatrix<ST,LO,GO,NT> >::writeSparseFile(ss.str().c_str(),mat);
+         Tpetra::MatrixMarket::Writer<Tpetra::CrsMatrix<ST,LO,GO,NT> >::writeSparseFile(formatBlockName(prefix,i,j,rows).c_str(),mat);
       }
    }
 }

--- a/packages/teko/src/Tpetra/Teko_BlockedTpetraOperator.cpp
+++ b/packages/teko/src/Tpetra/Teko_BlockedTpetraOperator.cpp
@@ -164,7 +164,7 @@ void BlockedTpetraOperator::WriteBlocks(const std::string & prefix) const
       for(int j=0;j<rows;j++) {
          // build the file name
          std::stringstream ss;
-         ss << prefix << "_" << i << j << ".mm";
+         ss << prefix << "_" << i << "_" << j << ".mm";
 
          // get the row matrix object
          RCP<const Thyra::TpetraLinearOp<ST,LO,GO,NT> > tOp = rcp_dynamic_cast<const Thyra::TpetraLinearOp<ST,LO,GO,NT> >(blockOp->getBlock(i,j));

--- a/packages/teko/src/Tpetra/Teko_StridedTpetraOperator.cpp
+++ b/packages/teko/src/Tpetra/Teko_StridedTpetraOperator.cpp
@@ -173,7 +173,7 @@ void StridedTpetraOperator::WriteBlocks(const std::string & prefix) const
       for(int j=0;j<rows;j++) {
          // build the file name
          std::stringstream ss;
-         ss << prefix << "_" << i << j << ".mm";
+         ss << prefix << "_" << i << "_" << j << ".mm";
 
          // get the row matrix object (Note: can't use "GetBlock" method b/c matrix might be reordered)
          RCP<const Thyra::TpetraLinearOp<ST,LO,GO,NT> > tOp = rcp_dynamic_cast<const Thyra::TpetraLinearOp<ST,LO,GO,NT> >(blockOp->getBlock(i,j));

--- a/packages/teko/src/Tpetra/Teko_StridedTpetraOperator.cpp
+++ b/packages/teko/src/Tpetra/Teko_StridedTpetraOperator.cpp
@@ -171,17 +171,13 @@ void StridedTpetraOperator::WriteBlocks(const std::string & prefix) const
 
    for(int i=0;i<rows;i++) {
       for(int j=0;j<rows;j++) {
-         // build the file name
-         std::stringstream ss;
-         ss << prefix << "_" << i << "_" << j << ".mm";
-
          // get the row matrix object (Note: can't use "GetBlock" method b/c matrix might be reordered)
          RCP<const Thyra::TpetraLinearOp<ST,LO,GO,NT> > tOp = rcp_dynamic_cast<const Thyra::TpetraLinearOp<ST,LO,GO,NT> >(blockOp->getBlock(i,j));
          RCP<const Tpetra::CrsMatrix<ST,LO,GO,NT> > mat
                = Teuchos::rcp_dynamic_cast<const Tpetra::CrsMatrix<ST,LO,GO,NT> >(tOp->getConstTpetraOperator());
 
          // write to file
-         Tpetra::MatrixMarket::Writer<Tpetra::CrsMatrix<ST,LO,GO,NT> >::writeSparseFile(ss.str().c_str(),mat);
+         Tpetra::MatrixMarket::Writer<Tpetra::CrsMatrix<ST,LO,GO,NT> >::writeSparseFile(formatBlockName(prefix,i,j,rows).c_str(),mat);
       }
    }
 }


### PR DESCRIPTION
When > 10 subblocks are present, there's no way to disambiguate between the output for $A_{11,1}$ and $A_{1,11}$. This PR adds a trivial `_` character to seperate the entries in the various `*::WriteBlocks` functions.

@trilinos/Teko
@cgcgcg 
