### PR TITLE
Tempus: Utilize Teuchos Unit Test 'out'

### DIFF
--- a/packages/tempus/test/BDF2/Tempus_BDF2_ASA.cpp
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_ASA.cpp
@@ -52,10 +52,6 @@ TEUCHOS_UNIT_TEST(BDF2, SinCos_ASA)
   double order = 0.0;
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
-  Teuchos::RCP<Teuchos::FancyOStream> my_out =
-    Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-  my_out->setProcRankAndSize(comm->getRank(), comm->getSize());
-  my_out->setOutputToRootOnly(0);
   for (int n=0; n<nTimeStepSizes; n++) {
 
     // Read params from .xml file
@@ -183,17 +179,17 @@ TEUCHOS_UNIT_TEST(BDF2, SinCos_ASA)
     L2norm = std::sqrt(L2norm);
     ErrorNorm.push_back(L2norm);
 
-    //*my_out << " n = " << n << " dt = " << dt << " error = " << L2norm
-    //        << std::endl;
+    //out << " n = " << n << " dt = " << dt << " error = " << L2norm
+    //    << std::endl;
   }
 
   // Check the order and intercept
   double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-  *my_out << "  Stepper = BDF2" << std::endl;
-  *my_out << "  =========================" << std::endl;
-  *my_out << "  Expected order: " << order << std::endl;
-  *my_out << "  Observed order: " << slope << std::endl;
-  *my_out << "  =========================" << std::endl;
+  out << "  Stepper = BDF2" << std::endl;
+  out << "  =========================" << std::endl;
+  out << "  Expected order: " << order << std::endl;
+  out << "  Observed order: " << slope << std::endl;
+  out << "  =========================" << std::endl;
   TEST_FLOATING_EQUALITY( slope,          1.95006, 0.015 );
   TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.0137394, 1.0e-4 );
 

--- a/packages/tempus/test/BDF2/Tempus_BDF2_FSA.hpp
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_FSA.hpp
@@ -54,10 +54,6 @@ void test_sincos_fsa(const bool use_combined_method,
   double order = 0.0;
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
-  Teuchos::RCP<Teuchos::FancyOStream> my_out =
-    Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-  my_out->setProcRankAndSize(comm->getRank(), comm->getSize());
-  my_out->setOutputToRootOnly(0);
   for (int n=0; n<nTimeStepSizes; n++) {
 
     // Read params from .xml file
@@ -184,18 +180,18 @@ void test_sincos_fsa(const bool use_combined_method,
     L2norm = std::sqrt(L2norm);
     ErrorNorm.push_back(L2norm);
 
-    *my_out << " n = " << n << " dt = " << dt << " error = " << L2norm
-            << std::endl;
+    out << " n = " << n << " dt = " << dt << " error = " << L2norm
+        << std::endl;
 
   }
 
   // Check the order and intercept
   double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-  *my_out << "  Stepper = BDF2" << std::endl;
-  *my_out << "  =========================" << std::endl;
-  *my_out << "  Expected order: " << order << std::endl;
-  *my_out << "  Observed order: " << slope << std::endl;
-  *my_out << "  =========================" << std::endl;
+  out << "  Stepper = BDF2" << std::endl;
+  out << "  =========================" << std::endl;
+  out << "  Expected order: " << order << std::endl;
+  out << "  Observed order: " << slope << std::endl;
+  out << "  =========================" << std::endl;
   TEST_FLOATING_EQUALITY( slope,          1.94162, 0.015 );
   TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.0143743, 1.0e-4 );
 

--- a/packages/tempus/test/BDF2/Tempus_Test_BDF2_CDR.cpp
+++ b/packages/tempus/test/BDF2/Tempus_Test_BDF2_CDR.cpp
@@ -166,7 +166,8 @@ void CDR_Test(const Comm& comm, const int commSize, Teuchos::FancyOStream &out, 
     writeOrderError("Tempus_BDF2_CDR-Error.dat",
                     stepper, StepSize,
                     solutions,    xErrorNorm,    xSlope,
-                    solutionsDot, xDotErrorNorm, xDotSlope);
+                    solutionsDot, xDotErrorNorm, xDotSlope,
+                    out);
     TEST_FLOATING_EQUALITY( xSlope, order, 0.35 );
     TEST_COMPARE(xSlope, >, 0.95);
     TEST_FLOATING_EQUALITY( xDotSlope, order, 0.35 );

--- a/packages/tempus/test/BDF2/Tempus_Test_BDF2_SinCos.cpp
+++ b/packages/tempus/test/BDF2/Tempus_Test_BDF2_SinCos.cpp
@@ -159,7 +159,8 @@ TEUCHOS_UNIT_TEST(BDF2, SinCos)
     writeOrderError(err_out_file_name,
                     stepper, StepSize,
                     solutions,    xErrorNorm,    xSlope,
-                    solutionsDot, xDotErrorNorm, xDotSlope);
+                    solutionsDot, xDotErrorNorm, xDotSlope,
+                    out);
 
     TEST_FLOATING_EQUALITY( xSlope,                 order, 0.01   );
     TEST_FLOATING_EQUALITY( xDotSlope,              order, 0.01   );

--- a/packages/tempus/test/BDF2/Tempus_Test_BDF2_SinCosAdapt.cpp
+++ b/packages/tempus/test/BDF2/Tempus_Test_BDF2_SinCosAdapt.cpp
@@ -185,7 +185,8 @@ TEUCHOS_UNIT_TEST(BDF2, SinCosAdapt)
     writeOrderError("Tempus_BDF2_SinCos-Error.dat",
                     stepper, StepSize,
                     solutions,    xErrorNorm,    xSlope,
-                    solutionsDot, xDotErrorNorm, xDotSlope);
+                    solutionsDot, xDotErrorNorm, xDotSlope,
+                    out);
 
     TEST_FLOATING_EQUALITY( xSlope,                 1.932, 0.01 );
     TEST_FLOATING_EQUALITY( xDotSlope,              1.932, 0.01 );

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_ASA.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_ASA.cpp
@@ -53,10 +53,6 @@ TEUCHOS_UNIT_TEST(BackwardEuler, SinCos_ASA)
   double order = 0.0;
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
-  Teuchos::RCP<Teuchos::FancyOStream> my_out =
-    Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-  my_out->setProcRankAndSize(comm->getRank(), comm->getSize());
-  my_out->setOutputToRootOnly(0);
   for (int n=0; n<nTimeStepSizes; n++) {
 
     // Read params from .xml file
@@ -195,18 +191,18 @@ TEUCHOS_UNIT_TEST(BackwardEuler, SinCos_ASA)
     L2norm = std::sqrt(L2norm);
     ErrorNorm.push_back(L2norm);
 
-    //*my_out << " n = " << n << " dt = " << dt << " error = " << L2norm
-    //        << std::endl;
+    //out << " n = " << n << " dt = " << dt << " error = " << L2norm
+    //    << std::endl;
 
   }
 
   // Check the order and intercept
   double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-  *my_out << "  Stepper = BackwardEuler" << std::endl;
-  *my_out << "  =========================" << std::endl;
-  *my_out << "  Expected order: " << order << std::endl;
-  *my_out << "  Observed order: " << slope << std::endl;
-  *my_out << "  =========================" << std::endl;
+  out << "  Stepper = BackwardEuler" << std::endl;
+  out << "  =========================" << std::endl;
+  out << "  Expected order: " << order << std::endl;
+  out << "  Observed order: " << slope << std::endl;
+  out << "  =========================" << std::endl;
   TEST_FLOATING_EQUALITY( slope, order, 0.015 );
   TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.142525, 1.0e-4 );
 

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_FSA.hpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_FSA.hpp
@@ -56,10 +56,6 @@ void test_sincos_fsa(const bool use_combined_method,
   double order = 0.0;
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
-  Teuchos::RCP<Teuchos::FancyOStream> my_out =
-    Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-  my_out->setProcRankAndSize(comm->getRank(), comm->getSize());
-  my_out->setOutputToRootOnly(0);
   for (int n=0; n<nTimeStepSizes; n++) {
 
     // Read params from .xml file
@@ -182,18 +178,18 @@ void test_sincos_fsa(const bool use_combined_method,
     L2norm = std::sqrt(L2norm);
     ErrorNorm.push_back(L2norm);
 
-    *my_out << " n = " << n << " dt = " << dt << " error = " << L2norm
-            << std::endl;
+    out << " n = " << n << " dt = " << dt << " error = " << L2norm
+        << std::endl;
 
   }
 
   // Check the order and intercept
   double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-  *my_out << "  Stepper = BackwardEuler" << std::endl;
-  *my_out << "  =========================" << std::endl;
-  *my_out << "  Expected order: " << order << std::endl;
-  *my_out << "  Observed order: " << slope << std::endl;
-  *my_out << "  =========================" << std::endl;
+  out << "  Stepper = BackwardEuler" << std::endl;
+  out << "  =========================" << std::endl;
+  out << "  Expected order: " << order << std::endl;
+  out << "  Observed order: " << slope << std::endl;
+  out << "  =========================" << std::endl;
   TEST_FLOATING_EQUALITY( slope, order, 0.015 );
   TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.163653, 1.0e-4 );
 

--- a/packages/tempus/test/BackwardEuler/Tempus_Test_BackwardEuler_CDR.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_Test_BackwardEuler_CDR.cpp
@@ -156,7 +156,8 @@ void CDR_Test(const Comm& comm, const int commSize, Teuchos::FancyOStream &out, 
   writeOrderError("Tempus_BackwardEuler_CDR-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,            1.32213, 0.01   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.116919, 1.0e-4 );

--- a/packages/tempus/test/BackwardEuler/Tempus_Test_BackwardEuler_SinCos.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_Test_BackwardEuler_SinCos.cpp
@@ -150,7 +150,8 @@ TEUCHOS_UNIT_TEST(BackwardEuler, SinCos)
   writeOrderError("Tempus_BackwardEuler_SinCos-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,               order, 0.01   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.0486418, 1.0e-4 );

--- a/packages/tempus/test/BackwardEuler/Tempus_Test_BackwardEuler_VanDerPol.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_Test_BackwardEuler_VanDerPol.cpp
@@ -119,7 +119,8 @@ TEUCHOS_UNIT_TEST(BackwardEuler, VanDerPol)
   writeOrderError("Tempus_BackwardEuler_VanDerPol-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,            order, 0.10   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],  0.571031, 1.0e-4 );

--- a/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
@@ -186,9 +186,9 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
 
       bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
       if (!pass) {
-        std::cout << std::endl;
-        std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
-        std::cout << "defaultPL -------------- \n" << *defaultPL << std::endl;
+        out << std::endl;
+        out << "stepperPL -------------- \n" << *stepperPL << std::endl;
+        out << "defaultPL -------------- \n" << *defaultPL << std::endl;
       }
       TEST_ASSERT(pass)
     }
@@ -287,16 +287,16 @@ TEUCHOS_UNIT_TEST(DIRK, ConstructingFromDefaults)
     Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
     // Check the order and intercept
-    std::cout << "  Stepper = " << stepper->description()
-              << " with " << option << std::endl;
-    std::cout << "  =========================" << std::endl;
-    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
-                                         << get_ele(*(x_exact), 1) << std::endl;
-    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
-                                         << get_ele(*(x      ), 1) << std::endl;
-    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
-                                         << get_ele(*(xdiff  ), 1) << std::endl;
-    std::cout << "  =========================" << std::endl;
+    out << "  Stepper = " << stepper->description()
+        << " with " << option << std::endl;
+    out << "  =========================" << std::endl;
+    out << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
+                                   << get_ele(*(x_exact), 1) << std::endl;
+    out << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
+                                   << get_ele(*(x      ), 1) << std::endl;
+    out << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
+                                   << get_ele(*(xdiff  ), 1) << std::endl;
+    out << "  =========================" << std::endl;
     TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841470, 1.0e-4 );
     TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.540304, 1.0e-4 );
   }
@@ -374,16 +374,16 @@ TEUCHOS_UNIT_TEST(DIRK, useFSAL_false)
     Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
     // Check the order and intercept
-    std::cout << "  Stepper = " << stepper->description()
-              << "\n            with " << "useFSAL=false" << std::endl;
-    std::cout << "  =========================" << std::endl;
-    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
-                                         << get_ele(*(x_exact), 1) << std::endl;
-    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
-                                         << get_ele(*(x      ), 1) << std::endl;
-    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
-                                         << get_ele(*(xdiff  ), 1) << std::endl;
-    std::cout << "  =========================" << std::endl;
+    out << "  Stepper = " << stepper->description()
+        << "\n            with " << "useFSAL=false" << std::endl;
+    out << "  =========================" << std::endl;
+    out << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
+                                   << get_ele(*(x_exact), 1) << std::endl;
+    out << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
+                                   << get_ele(*(x      ), 1) << std::endl;
+    out << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
+                                   << get_ele(*(xdiff  ), 1) << std::endl;
+    out << "  =========================" << std::endl;
     if (RKMethods[m] == "EDIRK 2 Stage Theta Method") {
       TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841021, 1.0e-4 );
       TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.541002, 1.0e-4 );
@@ -560,7 +560,8 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos)
     writeOrderError("Tempus_"+RKMethod+"_SinCos-Error.dat",
                     stepper, StepSize,
                     solutions,    xErrorNorm,    xSlope,
-                    solutionsDot, xDotErrorNorm, xDotSlope);
+                    solutionsDot, xDotErrorNorm, xDotSlope,
+                    out);
 
     TEST_FLOATING_EQUALITY( xSlope,               order, 0.01   );
     TEST_FLOATING_EQUALITY( xErrorNorm[0], RKMethodErrors[m], 5.0e-4 );
@@ -660,7 +661,8 @@ TEUCHOS_UNIT_TEST(DIRK, VanDerPol)
   writeOrderError("Tempus_"+RKMethod+"_VanDerPol-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,            order, 0.06   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0], 1.07525e-05, 1.0e-4 );
@@ -685,7 +687,7 @@ TEUCHOS_UNIT_TEST(DIRK, EmbeddedVanDerPol)
 
    for(auto integratorChoice : IntegratorList){
 
-      std::cout << "Using Integrator: " << integratorChoice << " !!!" << std::endl;
+      out << "Using Integrator: " << integratorChoice << " !!!" << std::endl;
 
       // Read params from .xml file
       RCP<ParameterList> pList =

--- a/packages/tempus/test/DIRK/Tempus_DIRK_ASA.cpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRK_ASA.cpp
@@ -71,10 +71,6 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos_ASA)
 
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
-  Teuchos::RCP<Teuchos::FancyOStream> my_out =
-    Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-  my_out->setProcRankAndSize(comm->getRank(), comm->getSize());
-  my_out->setOutputToRootOnly(0);
 
   for(std::vector<std::string>::size_type m = 0; m != RKMethods.size(); m++) {
 
@@ -228,8 +224,8 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos_ASA)
       L2norm = std::sqrt(L2norm);
       ErrorNorm.push_back(L2norm);
 
-      //*my_out << " n = " << n << " dt = " << dt << " error = " << L2norm
-      //        << std::endl;
+      //out << " n = " << n << " dt = " << dt << " error = " << L2norm
+      //    << std::endl;
     }
 
     if (comm->getRank() == 0) {
@@ -252,11 +248,11 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos_ASA)
 
     // Check the order and intercept
     double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-    *my_out << "  Stepper = " << RKMethods[m] << std::endl;
-    *my_out << "  =========================" << std::endl;
-    *my_out << "  Expected order: " << order << std::endl;
-    *my_out << "  Observed order: " << slope << std::endl;
-    *my_out << "  =========================" << std::endl;
+    out << "  Stepper = " << RKMethods[m] << std::endl;
+    out << "  =========================" << std::endl;
+    out << "  Expected order: " << order << std::endl;
+    out << "  Observed order: " << slope << std::endl;
+    out << "  =========================" << std::endl;
     TEST_FLOATING_EQUALITY( slope, order, 0.03 );
     TEST_FLOATING_EQUALITY( ErrorNorm[0], RKMethodErrors[m], 5.0e-4 );
 

--- a/packages/tempus/test/DIRK/Tempus_DIRK_FSA.hpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRK_FSA.hpp
@@ -110,10 +110,6 @@ void test_sincos_fsa(const std::string& method_name,
 
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
-  Teuchos::RCP<Teuchos::FancyOStream> my_out =
-    Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-  my_out->setProcRankAndSize(comm->getRank(), comm->getSize());
-  my_out->setOutputToRootOnly(0);
 
   for(std::vector<std::string>::size_type m = 0; m != RKMethods.size(); m++) {
 
@@ -265,8 +261,8 @@ void test_sincos_fsa(const std::string& method_name,
       L2norm = std::sqrt(L2norm);
       ErrorNorm.push_back(L2norm);
 
-      //*my_out << " n = " << n << " dt = " << dt << " error = " << L2norm
-      //        << std::endl;
+      //out << " n = " << n << " dt = " << dt << " error = " << L2norm
+      //    << std::endl;
     }
 
     if (comm->getRank() == 0) {
@@ -289,11 +285,11 @@ void test_sincos_fsa(const std::string& method_name,
 
     // Check the order and intercept
     double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-    *my_out << "  Stepper = " << RKMethods[m] << std::endl;
-    *my_out << "  =========================" << std::endl;
-    *my_out << "  Expected order: " << order << std::endl;
-    *my_out << "  Observed order: " << slope << std::endl;
-    *my_out << "  =========================" << std::endl;
+    out << "  Stepper = " << RKMethods[m] << std::endl;
+    out << "  =========================" << std::endl;
+    out << "  Expected order: " << order << std::endl;
+    out << "  Observed order: " << slope << std::endl;
+    out << "  =========================" << std::endl;
 
     // Can only seem to get at most 4th order when using staggered method
     double order_expected = use_combined_method ? order : std::min(order,4.0);

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
@@ -141,9 +141,9 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ParameterList)
 
       bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
       if (!pass) {
-        std::cout << std::endl;
-        std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
-        std::cout << "defaultPL -------------- \n" << *defaultPL << std::endl;
+        out << std::endl;
+        out << "stepperPL -------------- \n" << *stepperPL << std::endl;
+        out << "defaultPL -------------- \n" << *defaultPL << std::endl;
       }
       TEST_ASSERT(pass)
     }
@@ -242,16 +242,16 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ConstructingFromDefaults)
     Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
     // Check the order and intercept
-    std::cout << "  Stepper = " << stepper->description()
-              << "\n            with " << option << std::endl;
-    std::cout << "  =========================" << std::endl;
-    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
-                                         << get_ele(*(x_exact), 1) << std::endl;
-    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
-                                         << get_ele(*(x      ), 1) << std::endl;
-    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
-                                         << get_ele(*(xdiff  ), 1) << std::endl;
-    std::cout << "  =========================" << std::endl;
+    out << "  Stepper = " << stepper->description()
+        << "\n            with " << option << std::endl;
+    out << "  =========================" << std::endl;
+    out << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
+                                   << get_ele(*(x_exact), 1) << std::endl;
+    out << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
+                                   << get_ele(*(x      ), 1) << std::endl;
+    out << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
+                                   << get_ele(*(xdiff  ), 1) << std::endl;
+    out << "  =========================" << std::endl;
     TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841470, 1.0e-4 );
     TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.540303, 1.0e-4 );
   }
@@ -329,16 +329,16 @@ TEUCHOS_UNIT_TEST(ExplicitRK, useFSAL_false)
     Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
     // Check the order and intercept
-    std::cout << "  Stepper = " << stepper->description()
-              << "\n            with " << "useFSAL=false" << std::endl;
-    std::cout << "  =========================" << std::endl;
-    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
-                                         << get_ele(*(x_exact), 1) << std::endl;
-    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
-                                         << get_ele(*(x      ), 1) << std::endl;
-    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
-                                         << get_ele(*(xdiff  ), 1) << std::endl;
-    std::cout << "  =========================" << std::endl;
+    out << "  Stepper = " << stepper->description()
+        << "\n            with " << "useFSAL=false" << std::endl;
+    out << "  =========================" << std::endl;
+    out << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
+                                   << get_ele(*(x_exact), 1) << std::endl;
+    out << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
+                                   << get_ele(*(x      ), 1) << std::endl;
+    out << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
+                                   << get_ele(*(xdiff  ), 1) << std::endl;
+    out << "  =========================" << std::endl;
     if (RKMethods[m] == "RK Forward Euler") {
       TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.882508, 1.0e-4 );
       TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.570790, 1.0e-4 );
@@ -515,7 +515,8 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
     writeOrderError("Tempus_"+RKMethod+"_SinCos-Error.dat",
                     stepper, StepSize,
                     solutions,    xErrorNorm,    xSlope,
-                    solutionsDot, xDotErrorNorm, xDotSlope);
+                    solutionsDot, xDotErrorNorm, xDotSlope,
+                    out);
 
     double order_tol = 0.01;
     if (RKMethods[m] == "Merson 4(5) Pair") order_tol = 0.04;
@@ -550,7 +551,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, EmbeddedVanDerPol)
 
   for(auto integratorChoice : IntegratorList){
 
-     std::cout << "Using Integrator: " << integratorChoice << " !!!" << std::endl;
+     out << "Using Integrator: " << integratorChoice << " !!!" << std::endl;
 
      // Read params from .xml file
      RCP<ParameterList> pList =
@@ -618,10 +619,10 @@ TEUCHOS_UNIT_TEST(ExplicitRK, EmbeddedVanDerPol)
 
         // test for number of steps
         TEST_EQUALITY(iStep, refIstep);
-        std::cout << "Tolerance = " << absTol
-           << " L2norm = "   << L2norm
-           << " iStep = "    << iStep
-           << " nFail = "    << nFail << std::endl;
+        out << "Tolerance = " << absTol
+            << " L2norm = "   << L2norm
+            << " iStep = "    << iStep
+            << " nFail = "    << nFail << std::endl;
      }
 
      // Plot sample solution and exact solution

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_ASA.cpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_ASA.cpp
@@ -71,10 +71,6 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos_ASA)
 
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
-  Teuchos::RCP<Teuchos::FancyOStream> my_out =
-    Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-  my_out->setProcRankAndSize(comm->getRank(), comm->getSize());
-  my_out->setOutputToRootOnly(0);
 
   for(std::vector<std::string>::size_type m = 0; m != RKMethods.size(); m++) {
 
@@ -232,17 +228,17 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos_ASA)
       L2norm = std::sqrt(L2norm);
       ErrorNorm.push_back(L2norm);
 
-      //*my_out << " n = " << n << " dt = " << dt << " error = " << L2norm
-      //        << std::endl;
+      //out << " n = " << n << " dt = " << dt << " error = " << L2norm
+      //    << std::endl;
     }
 
     // Check the order and intercept
     double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-    *my_out << "  Stepper = " << RKMethods[m] << std::endl;
-    *my_out << "  =========================" << std::endl;
-    *my_out << "  Expected order: " << order << std::endl;
-    *my_out << "  Observed order: " << slope << std::endl;
-    *my_out << "  =========================" << std::endl;
+    out << "  Stepper = " << RKMethods[m] << std::endl;
+    out << "  =========================" << std::endl;
+    out << "  Expected order: " << order << std::endl;
+    out << "  Observed order: " << slope << std::endl;
+    out << "  =========================" << std::endl;
     TEST_FLOATING_EQUALITY( slope, order, 0.015 );
     TEST_FLOATING_EQUALITY( ErrorNorm[0], RKMethodErrors[m], 1.0e-4 );
 

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_FSA.hpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_FSA.hpp
@@ -96,10 +96,6 @@ void test_sincos_fsa(const std::string& method_name,
   }
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
-  Teuchos::RCP<Teuchos::FancyOStream> my_out =
-    Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-  my_out->setProcRankAndSize(comm->getRank(), comm->getSize());
-  my_out->setOutputToRootOnly(0);
 
   for(std::vector<std::string>::size_type m = 0; m != RKMethods.size(); m++) {
 
@@ -250,17 +246,17 @@ void test_sincos_fsa(const std::string& method_name,
       L2norm = std::sqrt(L2norm);
       ErrorNorm.push_back(L2norm);
 
-      *my_out << " n = " << n << " dt = " << dt << " error = " << L2norm
-              << std::endl;
+      out << " n = " << n << " dt = " << dt << " error = " << L2norm
+          << std::endl;
     }
 
     // Check the order and intercept
     double slope = computeLinearRegressionLogLog<double>(StepSize, ErrorNorm);
-    *my_out << "  Stepper = " << RKMethods[m] << std::endl;
-    *my_out << "  =========================" << std::endl;
-    *my_out << "  Expected order: " << order << std::endl;
-    *my_out << "  Observed order: " << slope << std::endl;
-    *my_out << "  =========================" << std::endl;
+    out << "  Stepper = " << RKMethods[m] << std::endl;
+    out << "  =========================" << std::endl;
+    out << "  Expected order: " << order << std::endl;
+    out << "  Observed order: " << slope << std::endl;
+    out << "  =========================" << std::endl;
     TEST_FLOATING_EQUALITY( slope, order, 0.04 );
     TEST_FLOATING_EQUALITY( ErrorNorm[0], RKMethodErrors[m], 1.0e-4 );
 

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
@@ -312,7 +312,8 @@ TEUCHOS_UNIT_TEST(ForwardEuler, SinCos)
   writeOrderError("Tempus_ForwardEuler_SinCos-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,               order, 0.01   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],     0.051123, 1.0e-4 );
@@ -395,7 +396,8 @@ TEUCHOS_UNIT_TEST(ForwardEuler, VanDerPol)
   writeOrderError("Tempus_ForwardEuler_VanDerPol-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,            order, 0.10   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],  0.387476, 1.0e-4 );

--- a/packages/tempus/test/HHTAlpha/Tempus_HHTAlphaTest.cpp
+++ b/packages/tempus/test/HHTAlpha/Tempus_HHTAlphaTest.cpp
@@ -332,7 +332,8 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_SecondOrder)
   writeOrderError("Tempus_HHTAlpha_SinCos_SecondOrder-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,                order, 0.02   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.00644755, 1.0e-4 );
@@ -477,7 +478,8 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_FirstOrder)
   writeOrderError("Tempus_HHTAlpha_SinCos_FirstOrder-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,           0.977568, 0.02   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.048932, 1.0e-4 );
@@ -623,7 +625,8 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_CD)
   writeOrderError("Tempus_HHTAlpha_SinCos_ExplicitCD-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,                order, 0.02   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.00451069, 1.0e-4 );

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
@@ -266,7 +266,8 @@ TEUCHOS_UNIT_TEST(IMEX_RK, VanDerPol)
     writeOrderError("Tempus_"+stepperName+"_VanDerPol-Error.dat",
                     stepper, StepSize,
                     solutions,    xErrorNorm,    xSlope,
-                    solutionsDot, xDotErrorNorm, xDotSlope);
+                    solutionsDot, xDotErrorNorm, xDotSlope,
+                    out);
 
     TEST_FLOATING_EQUALITY( xSlope,        stepperOrders[m],   0.02 );
     TEST_FLOATING_EQUALITY( xErrorNorm[0], stepperErrors[m], 1.0e-4 );

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_FSA.hpp
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_FSA.hpp
@@ -84,10 +84,6 @@ void test_vdp_fsa(const bool use_combined_method,
 
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
-  Teuchos::RCP<Teuchos::FancyOStream> my_out =
-    Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-  my_out->setProcRankAndSize(comm->getRank(), comm->getSize());
-  my_out->setOutputToRootOnly(0);
 
   std::vector<std::string>::size_type m;
   for(m = 0; m != stepperTypes.size(); m++) {
@@ -230,8 +226,8 @@ void test_vdp_fsa(const bool use_combined_method,
       StepSizeCheck.push_back(StepSize[i]);
       ErrorNorm.push_back(L2norm);
 
-      *my_out << " n = " << i << " dt = " << StepSize[i]
-              << " error = " << L2norm << std::endl;
+      out << " n = " << i << " dt = " << StepSize[i]
+          << " error = " << L2norm << std::endl;
     }
 
     // Check the order and intercept

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
@@ -264,7 +264,8 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol)
     writeOrderError("Tempus_"+stepperName+"_VanDerPol-Error.dat",
                     stepper, StepSize,
                     solutions,    xErrorNorm,    xSlope,
-                    solutionsDot, xDotErrorNorm, xDotSlope);
+                    solutionsDot, xDotErrorNorm, xDotSlope,
+                    out);
 
     TEST_FLOATING_EQUALITY( xSlope,        stepperOrders[m], 0.02 );
     TEST_FLOATING_EQUALITY( xErrorNorm[0], stepperErrors[m], 1.0e-4 );

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_FSA.hpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_FSA.hpp
@@ -118,10 +118,6 @@ void test_vdp_fsa(const std::string& method_name,
 
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
-  Teuchos::RCP<Teuchos::FancyOStream> my_out =
-    Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-  my_out->setProcRankAndSize(comm->getRank(), comm->getSize());
-  my_out->setOutputToRootOnly(0);
 
   std::vector<std::string>::size_type m;
   for(m = 0; m != stepperTypes.size(); m++) {
@@ -274,8 +270,8 @@ void test_vdp_fsa(const std::string& method_name,
       StepSizeCheck.push_back(StepSize[i]);
       ErrorNorm.push_back(L2norm);
 
-      //*my_out << " n = " << i << " dt = " << StepSize[i]
-      //        << " error = " << L2norm << std::endl;
+      //out << " n = " << i << " dt = " << StepSize[i]
+      //    << " error = " << L2norm << std::endl;
     }
 
     // Check the order and intercept

--- a/packages/tempus/test/Leapfrog/Tempus_LeapfrogTest.cpp
+++ b/packages/tempus/test/Leapfrog/Tempus_LeapfrogTest.cpp
@@ -244,7 +244,8 @@ TEUCHOS_UNIT_TEST(Leapfrog, SinCos)
   writeOrderError("Tempus_Leapfrog_SinCos-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,               order, 0.02 );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.0157928, 1.0e-4 );

--- a/packages/tempus/test/Newmark/Tempus_Test_NewmarkExplicitAForm_HarmonicOscillator_Damped.cpp
+++ b/packages/tempus/test/Newmark/Tempus_Test_NewmarkExplicitAForm_HarmonicOscillator_Damped.cpp
@@ -82,8 +82,8 @@ TEUCHOS_UNIT_TEST(NewmarkExplicitAForm, HarmonicOscillatorDamped)
 
     //Perform time-step refinement
     dt /= 2;
-    std::cout << "\n \n time step #" << n << " (out of "
-              << nTimeStepSizes-1 << "), dt = " << dt << "\n";
+    out << "\n \n time step #" << n << " (out of "
+        << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
     integrator = Tempus::createIntegratorBasic<double>(pl, model);
@@ -148,7 +148,8 @@ TEUCHOS_UNIT_TEST(NewmarkExplicitAForm, HarmonicOscillatorDamped)
   writeOrderError("Tempus_Test_NewmarkExplicitAForm_HarmonicOscillator_Damped-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,           1.060930, 0.01   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.508229, 1.0e-4 );

--- a/packages/tempus/test/Newmark/Tempus_Test_NewmarkExplicitAForm_SinCos.cpp
+++ b/packages/tempus/test/Newmark/Tempus_Test_NewmarkExplicitAForm_SinCos.cpp
@@ -148,7 +148,8 @@ TEUCHOS_UNIT_TEST(NewmarkExplicitAForm, SinCos)
   writeOrderError("Tempus_Test_NewmarkExplicitAForm_SinCos-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,              order, 0.02   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],   0.0157928, 1.0e-4 );

--- a/packages/tempus/test/Newmark/Tempus_Test_NewmarkImplicitAForm_HarmonicOscillator_Damped_FirstOrder.cpp
+++ b/packages/tempus/test/Newmark/Tempus_Test_NewmarkImplicitAForm_HarmonicOscillator_Damped_FirstOrder.cpp
@@ -80,8 +80,8 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, HarmonicOscillatorDamped_FirstOrder)
 
     //Perform time-step refinement
     dt /= 2;
-    std::cout << "\n \n time step #" << n << " (out of "
-              << nTimeStepSizes-1 << "), dt = " << dt << "\n";
+    out << "\n \n time step #" << n << " (out of "
+        << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
     integrator = Tempus::createIntegratorBasic<double>(pl, model);
@@ -146,7 +146,8 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, HarmonicOscillatorDamped_FirstOrder)
   writeOrderError("Tempus_Test_NewmarkImplicitAForm_HarmonicOscillator_Damped_FirstOrder-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,               order, 0.02   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.0224726, 1.0e-4 );

--- a/packages/tempus/test/Newmark/Tempus_Test_NewmarkImplicitAForm_HarmonicOscillator_Damped_SecondOrder.cpp
+++ b/packages/tempus/test/Newmark/Tempus_Test_NewmarkImplicitAForm_HarmonicOscillator_Damped_SecondOrder.cpp
@@ -80,8 +80,8 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, HarmonicOscillatorDamped_SecondOrder)
 
     //Perform time-step refinement
     dt /= 2;
-    std::cout << "\n \n time step #" << n << " (out of "
-              << nTimeStepSizes-1 << "), dt = " << dt << "\n";
+    out << "\n \n time step #" << n << " (out of "
+        << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
     integrator = Tempus::createIntegratorBasic<double>(pl, model);
@@ -146,7 +146,8 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, HarmonicOscillatorDamped_SecondOrder)
   writeOrderError("Tempus_Test_NewmarkImplicitAForm_HarmonicOscillator_Damped_SecondOrder_SinCos-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,               order, 0.01   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.0484483, 1.0e-4 );

--- a/packages/tempus/test/Newmark/Tempus_Test_NewmarkImplicitDForm_HarmonicOscillator_Damped_SecondOrder.cpp
+++ b/packages/tempus/test/Newmark/Tempus_Test_NewmarkImplicitDForm_HarmonicOscillator_Damped_SecondOrder.cpp
@@ -80,8 +80,8 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, HarmonicOscillatorDamped_SecondOrder)
 
     //Perform time-step refinement
     dt /= 2;
-    std::cout << "\n \n time step #" << n << " (out of "
-              << nTimeStepSizes-1 << "), dt = " << dt << "\n";
+    out << "\n \n time step #" << n << " (out of "
+        << nTimeStepSizes-1 << "), dt = " << dt << "\n";
     pl->sublist("Default Integrator")
        .sublist("Time Step Control").set("Initial Time Step", dt);
     integrator = Tempus::createIntegratorBasic<double>(pl, model);
@@ -146,7 +146,8 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, HarmonicOscillatorDamped_SecondOrder)
   writeOrderError("Tempus_Test_NewmarkImplicitDForm_HarmonicOscillator_Damped_SecondOrder_SinCos-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,               order, 0.01   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.0484483, 1.0e-4 );

--- a/packages/tempus/test/OperatorSplit/Tempus_OperatorSplitTest.cpp
+++ b/packages/tempus/test/OperatorSplit/Tempus_OperatorSplitTest.cpp
@@ -215,7 +215,8 @@ TEUCHOS_UNIT_TEST(OperatorSplit, VanDerPol)
   writeOrderError("Tempus_OperatorSplit_VanDerPol-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,            order, 0.05 );
   TEST_FLOATING_EQUALITY( xDotSlope,         order, 0.05 );//=order at small dt

--- a/packages/tempus/test/Subcycling/Tempus_SubcyclingTest.cpp
+++ b/packages/tempus/test/Subcycling/Tempus_SubcyclingTest.cpp
@@ -93,9 +93,9 @@ TEUCHOS_UNIT_TEST(Subcycling, ParameterList)
 
     bool pass = haveSameValuesSorted(*stepperPL, *defaultPL, true);
     if (!pass) {
-      std::cout << std::endl;
-      std::cout << "stepperPL -------------- \n" << *stepperPL << std::endl;
-      std::cout << "defaultPL -------------- \n" << *defaultPL << std::endl;
+      out << std::endl;
+      out << "stepperPL -------------- \n" << *stepperPL << std::endl;
+      out << "defaultPL -------------- \n" << *defaultPL << std::endl;
     }
     TEST_ASSERT(pass)
   }
@@ -197,15 +197,15 @@ TEUCHOS_UNIT_TEST(Subcycling, ConstructingFromDefaults)
   Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
   // Check the order and intercept
-  std::cout << "  Stepper = " << stepper->description() << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
-                                       << get_ele(*(x_exact), 1) << std::endl;
-  std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
-                                       << get_ele(*(x      ), 1) << std::endl;
-  std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
-                                       << get_ele(*(xdiff  ), 1) << std::endl;
-  std::cout << "  =========================" << std::endl;
+  out << "  Stepper = " << stepper->description() << std::endl;
+  out << "  =========================" << std::endl;
+  out << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
+                                 << get_ele(*(x_exact), 1) << std::endl;
+  out << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
+                                 << get_ele(*(x      ), 1) << std::endl;
+  out << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
+                                 << get_ele(*(xdiff  ), 1) << std::endl;
+  out << "  =========================" << std::endl;
   TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.882508, 1.0e-4 );
   TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.570790, 1.0e-4 );
 }
@@ -364,7 +364,8 @@ TEUCHOS_UNIT_TEST(Subcycling, SinCosAdapt)
     writeOrderError("Tempus_BDF2_SinCos-Error.dat",
                     stepper, StepSize,
                     solutions,    xErrorNorm,    xSlope,
-                    solutionsDot, xDotErrorNorm, xDotSlope);
+                    solutionsDot, xDotErrorNorm, xDotSlope,
+                    out);
 
     TEST_FLOATING_EQUALITY( xSlope,                1.00137, 0.01 );
     //TEST_FLOATING_EQUALITY( xDotSlope,            1.95089, 0.01 );
@@ -529,7 +530,8 @@ TEUCHOS_UNIT_TEST(Subcycling, VanDerPolOperatorSplit)
   writeOrderError("Tempus_Subcycling_VanDerPol-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,           1.25708, 0.05 );
   TEST_FLOATING_EQUALITY( xDotSlope,        1.20230, 0.05 );

--- a/packages/tempus/test/TestUtils/Tempus_ConvergenceTestUtils.hpp
+++ b/packages/tempus/test/TestUtils/Tempus_ConvergenceTestUtils.hpp
@@ -198,10 +198,11 @@ void writeOrderError(
   Scalar & xDotSlope,
   std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar>>> & solutionsDotDot,
   std::vector<Scalar> & xDotDotErrorNorm,
-  Scalar & xDotDotSlope)
+  Scalar & xDotDotSlope,
+  Teuchos::FancyOStream &out)
 {
   if ( solutions.empty() ) {
-    std::cout << "No solutions to write out!\n" << std::endl;
+    out << "No solutions to write out!\n" << std::endl;
     return;
   }
   std::size_t lastElem = solutions.size()-1;  // Last element is the ref soln.
@@ -240,15 +241,15 @@ void writeOrderError(
   }
 
   Scalar order = stepper->getOrder();
-  std::cout << "  Stepper = " << stepper->description() << std::endl;
-  std::cout << "  =================================" << std::endl;
-  std::cout << "  Expected Order = " << order        << std::endl;
-  std::cout << "  x        Order = " << xSlope       << std::endl;
+  out << "  Stepper = " << stepper->description() << std::endl;
+  out << "  =================================" << std::endl;
+  out << "  Expected Order = " << order        << std::endl;
+  out << "  x        Order = " << xSlope       << std::endl;
   if (!solutionsDot.empty())
-    std::cout<<"  xDot     Order = " << xDotSlope    << std::endl;
+    out<<"  xDot     Order = " << xDotSlope    << std::endl;
   if (!solutionsDotDot.empty())
-    std::cout<<"  xDotDot  Order = " << xDotDotSlope << std::endl;
-  std::cout << "  =================================" << std::endl;
+    out<<"  xDotDot  Order = " << xDotDotSlope << std::endl;
+  out << "  =================================" << std::endl;
 
   std::ofstream ftmp(filename);
   Scalar factor = 0.0;
@@ -275,7 +276,8 @@ void writeOrderError(
   Scalar & xSlope,
   std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar>>> & solutionsDot,
   std::vector<Scalar> & xDotErrorNorm,
-  Scalar & xDotSlope)
+  Scalar & xDotSlope,
+  Teuchos::FancyOStream &out)
 {
   std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar>>> solutionsDotDot;
   std::vector<Scalar> xDotDotErrorNorm;
@@ -283,7 +285,7 @@ void writeOrderError(
   writeOrderError(filename, stepper, StepSize,
                   solutions,       xErrorNorm,       xSlope,
                   solutionsDot,    xDotErrorNorm,    xDotSlope,
-                  solutionsDotDot, xDotDotErrorNorm, xDotDotSlope);
+                  solutionsDotDot, xDotDotErrorNorm, xDotDotSlope, out);
 }
 
 template<class Scalar>
@@ -293,7 +295,8 @@ void writeOrderError(
   std::vector<Scalar> & StepSize,
   std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar>>> & solutions,
   std::vector<Scalar> & xErrorNorm,
-  Scalar & xSlope)
+  Scalar & xSlope,
+  Teuchos::FancyOStream &out)
 {
   std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar>>> solutionsDot;
   std::vector<Scalar> xDotErrorNorm;
@@ -304,7 +307,7 @@ void writeOrderError(
   writeOrderError(filename, stepper, StepSize,
                   solutions,       xErrorNorm,       xSlope,
                   solutionsDot,    xDotErrorNorm,    xDotSlope,
-                  solutionsDotDot, xDotDotErrorNorm, xDotDotSlope);
+                  solutionsDotDot, xDotDotErrorNorm, xDotDotSlope, out);
 }
 
 template<class Scalar>

--- a/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
+++ b/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
@@ -318,7 +318,8 @@ TEUCHOS_UNIT_TEST(Trapezoidal, SinCos)
   writeOrderError("Tempus_Trapezoidal_SinCos-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,                 order, 0.01   );
   TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.000832086, 1.0e-4 );
@@ -400,7 +401,8 @@ TEUCHOS_UNIT_TEST(Trapezoidal, VanDerPol)
   writeOrderError("Tempus_Trapezoidal_VanDerPol-Error.dat",
                   stepper, StepSize,
                   solutions,    xErrorNorm,    xSlope,
-                  solutionsDot, xDotErrorNorm, xDotSlope);
+                  solutionsDot, xDotErrorNorm, xDotSlope,
+                  out);
 
   TEST_FLOATING_EQUALITY( xSlope,            order, 0.10 );
   TEST_FLOATING_EQUALITY( xDotSlope,         order, 0.10 );//=order at samll dt

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitAForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitAForm.cpp
@@ -195,13 +195,13 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, ConstructingFromDefaults)
     Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
     // Check the order and intercept
-    std::cout << "  Stepper = " << stepper->description()
-              << "\n            with " << option << std::endl;
-    std::cout << "  =========================" << std::endl;
-    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << std::endl;
-    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << std::endl;
-    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << std::endl;
-    std::cout << "  =========================" << std::endl;
+    out << "  Stepper = " << stepper->description()
+        << "\n            with " << option << std::endl;
+    out << "  =========================" << std::endl;
+    out << "  Exact solution   : " << get_ele(*(x_exact), 0) << std::endl;
+    out << "  Computed solution: " << get_ele(*(x      ), 0) << std::endl;
+    out << "  Difference       : " << get_ele(*(xdiff  ), 0) << std::endl;
+    out << "  =========================" << std::endl;
     TEST_FLOATING_EQUALITY(get_ele(*(x), 0), -0.222222, 1.0e-4 );
   }
 }

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitDForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitDForm.cpp
@@ -119,12 +119,12 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, Constructing_From_Defaults)
   Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
   // Check the order and intercept
-  std::cout << "  Stepper = " << stepper->description() << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << std::endl;
-  std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << std::endl;
-  std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << std::endl;
-  std::cout << "  =========================" << std::endl;
+  out << "  Stepper = " << stepper->description() << std::endl;
+  out << "  =========================" << std::endl;
+  out << "  Exact solution   : " << get_ele(*(x_exact), 0) << std::endl;
+  out << "  Computed solution: " << get_ele(*(x      ), 0) << std::endl;
+  out << "  Difference       : " << get_ele(*(xdiff  ), 0) << std::endl;
+  out << "  =========================" << std::endl;
   TEST_FLOATING_EQUALITY(get_ele(*(x), 0), -0.222222, 1.0e-4 );
 }
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControl.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControl.cpp
@@ -322,14 +322,14 @@ TEUCHOS_UNIT_TEST(TimeStepControl, setOutputTimes)
   auto times_out = tsc->getOutputTimes();
   double maxDiff = 0.0;
 
-  //std::cout << "\n  times_in, times_out = " << std::endl;
+  //out << "\n  times_in, times_out = " << std::endl;
   for (size_t i=0; i < times_in.size(); ++i) {
-    //std::cout << std::setw(25) << std::setprecision(16) << times_in[i] << ","
-    //          << std::setw(25) << std::setprecision(16) << times_out[i]
-    //          << std::endl;
+    //out << std::setw(25) << std::setprecision(16) << times_in[i] << ","
+    //    << std::setw(25) << std::setprecision(16) << times_out[i]
+    //    << std::endl;
     maxDiff = std::max(std::fabs(times_in[i] - times_out[i]), maxDiff);
   }
-  //std::cout << "  maxDiff = " << maxDiff << std::endl;
+  //out << "  maxDiff = " << maxDiff << std::endl;
 
   TEST_COMPARE(maxDiff, <, 1.0e-25);
 
@@ -352,14 +352,14 @@ TEUCHOS_UNIT_TEST(TimeStepControl, setOutputTimes)
   times_out = tsc->getOutputTimes();
   maxDiff = 0.0;
 
-  //std::cout << "\n  times_in, times_out = " << std::endl;
+  //out << "\n  times_in, times_out = " << std::endl;
   for (size_t i=0; i < times_in.size(); ++i) {
-    //std::cout << std::setw(30) << std::setprecision(20) << times_in[i] << ","
-    //          << std::setw(30) << std::setprecision(20) << times_out[i]
-    //          << std::endl;
+    //out << std::setw(30) << std::setprecision(20) << times_in[i] << ","
+    //    << std::setw(30) << std::setprecision(20) << times_out[i]
+    //    << std::endl;
     maxDiff = std::max(std::fabs(times_in[i] - times_out[i]), maxDiff);
   }
-  //std::cout << "  maxDiff = " << maxDiff << std::endl;
+  //out << "  maxDiff = " << maxDiff << std::endl;
 
   TEST_COMPARE(maxDiff, <, 1.0e-25);
 }


### PR DESCRIPTION
Replace std::cout and other streams with the Teuchos 'out' (Teuchos::fancyOStream).

@trilinos/tempus 

## Related Issues

* Closes #12655