### PR TITLE
Ifpack2: add reordering sublist to valid parameters

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Parameters.cpp
+++ b/packages/ifpack2/src/Ifpack2_Parameters.cpp
@@ -159,6 +159,10 @@ void getValidParameters(Teuchos::ParameterList& params)
   Teuchos::ParameterList dummyListSubdomain;
   params.set("subdomain solver parameters",dummyListSubdomain);
   params.sublist("subdomain solver parameters").disableRecursiveValidation();
+  Teuchos::ParameterList dummyListReordering;
+  params.set("schwarz: reordering list",dummyListReordering);
+  // Ifpack2 doesn't attempt to validate options for Zoltan2
+  params.sublist("schwarz: reordering list").disableRecursiveValidation();
 
   // Ifpack2_BlockRelaxation.hpp
   // params.set("relaxation: type", "Jacobi"); // already set


### PR DESCRIPTION
Add "schwarz: reordering list" as a valid Ifpack2 parameter. This fixes #12658.

@trilinos/ifpack2 