### PR TITLE
Attempt to fix clang-format workflow

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -16,7 +16,7 @@ jobs:
         clangFormatVersion: 14
         inplace: true
     - run: git diff HEAD > format_patch.txt
-    - run: if [ "$(cat format_patch.txt)" == "" ] ; then rm format_patch.txt ; fi
+    - run: if [ "$(cat format_patch.txt)" == "" ] ; then rm format_patch.txt ; else cat format_patch.txt; fi
 
     - uses: actions/upload-artifact@v4
       id: upload-artf
@@ -24,21 +24,22 @@ jobs:
       with:
         name: clang format patch
         path: format_patch.txt
-        
+
     - name: Artifact ID test
       run: |
         echo "Artifact ID is ${{ steps.upload-artf.outputs.artifact-id }}"
-        echo "Link: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts/${{ steps.upload-artf.outputs.artifact-id }}"
-        
+        echo "Link: ${{ steps.upload-artf.outputs.artifact-url }}"
+
+    # This does not work for PRs from forks.
     - name: Post artifact in issue comment
       uses: mshick/add-pr-comment@v2.8.1
-      if: ${{ hashFiles('format_patch.txt') != '' }}          
+      if: ${{ (hashFiles('format_patch.txt') != '') && (github.event.pull_request.head.repo.full_name == github.repository) }}
       with:
         message: |
-          Your PR updated files that did not respect package clang formatting settings.  Please apply the patch found [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload-artf.outputs.artifact-id }})
-        
+          Your PR updated files that did not respect package clang formatting settings.  Please apply the patch found [here](${{ steps.upload-artf.outputs.artifact-url }})
+
     - uses: actions/github-script@v3
       if: ${{ hashFiles('format_patch.txt') != '' }}
       with:
         script: |
-          core.setFailed('Please download and apply the formatting patch! It is located at the bottom of the summary tab for this workflow.')
+          core.setFailed('Your PR updated files that did not respect package clang formatting settings. Please download and apply the formatting patch! It is located at the bottom of the summary tab for this workflow and at this link: ${{ steps.upload-artf.outputs.artifact-url }}')


### PR DESCRIPTION
## Motivation
The clang-format action did not work correctly for PRs from forks. This change appears to fix that.