### PR TITLE
Teko: Enable preconditioned sub-solves in block Jacobi and Gauss-Seidel

### DIFF
--- a/packages/teko/cmake/Dependencies.cmake
+++ b/packages/teko/cmake/Dependencies.cmake
@@ -1,6 +1,6 @@
 SET(LIB_REQUIRED_DEP_PACKAGES Teuchos Thyra Stratimikos Anasazi Tpetra ThyraTpetraAdapters)
 SET(LIB_OPTIONAL_DEP_PACKAGES Epetra Isorropia Ifpack2 Ifpack AztecOO Amesos Amesos2 Belos ThyraEpetraAdapters ThyraEpetraExtAdapters ML)
-SET(TEST_REQUIRED_DEP_PACKAGES Ifpack2)
+SET(TEST_REQUIRED_DEP_PACKAGES Belos Ifpack2)
 SET(TEST_OPTIONAL_DEP_PACKAGES)
 SET(LIB_REQUIRED_DEP_TPLS)
 SET(LIB_OPTIONAL_DEP_TPLS)

--- a/packages/teko/src/Teko_BlockInvDiagonalStrategy.cpp
+++ b/packages/teko/src/Teko_BlockInvDiagonalStrategy.cpp
@@ -45,6 +45,7 @@
 */
 
 #include "Teko_BlockInvDiagonalStrategy.hpp"
+#include "Teko_InverseFactory.hpp"
 
 namespace Teko {
 
@@ -65,6 +66,21 @@ InvFactoryDiagStrategy::InvFactoryDiagStrategy(
     defaultInvFact_ = defaultFact;
 }
 
+InvFactoryDiagStrategy::InvFactoryDiagStrategy(
+    const std::vector<Teuchos::RCP<InverseFactory> >& inverseFactories,
+    const std::vector<Teuchos::RCP<InverseFactory> >& preconditionerFactories,
+    const Teuchos::RCP<InverseFactory>& defaultInverseFact,
+    const Teuchos::RCP<InverseFactory>& defaultPreconditionerFact) {
+  invDiagFact_  = inverseFactories;
+  precDiagFact_ = preconditionerFactories;
+
+  if (defaultInverseFact == Teuchos::null)
+    defaultInvFact_ = invDiagFact_[0];
+  else
+    defaultInvFact_ = defaultInverseFact;
+  defaultPrecFact_ = defaultPreconditionerFact;
+}
+
 /** returns an (approximate) inverse of the diagonal blocks of A
  * where A is closely related to the original source for invD0 and invD1
  */
@@ -73,35 +89,51 @@ void InvFactoryDiagStrategy::getInvD(const BlockedLinearOp& A, BlockPrecondition
   Teko_DEBUG_SCOPE("InvFactoryDiagStrategy::getInvD", 10);
 
   // loop over diagonals, build an inverse operator for each
-  int diagCnt = A->productRange()->numBlocks();
-  int invCnt  = invDiagFact_.size();
+  size_t diagCnt = A->productRange()->numBlocks();
 
-  Teko_DEBUG_MSG("# diags = " << diagCnt << ", # inverses = " << invCnt, 6);
+  Teko_DEBUG_MSG("# diags = " << diagCnt << ", # inverses = " << invDiagFact_.size(), 6);
 
   const std::string opPrefix = "JacobiDiagOp";
-  if (diagCnt <= invCnt) {
-    for (int i = 0; i < diagCnt; i++)
-      invDiag.push_back(buildInverse(*invDiagFact_[i], getBlock(i, i, A), state, opPrefix, i));
-  } else {
-    for (int i = 0; i < invCnt; i++)
-      invDiag.push_back(buildInverse(*invDiagFact_[i], getBlock(i, i, A), state, opPrefix, i));
-
-    for (int i = invCnt; i < diagCnt; i++)
-      invDiag.push_back(buildInverse(*defaultInvFact_, getBlock(i, i, A), state, opPrefix, i));
+  for (size_t i = 0; i < diagCnt; i++) {
+    auto precFact = ((i < precDiagFact_.size()) && (!precDiagFact_[i].is_null()))
+                        ? precDiagFact_[i]
+                        : defaultPrecFact_;
+    auto invFact  = (i < invDiagFact_.size()) ? invDiagFact_[i] : defaultInvFact_;
+    invDiag.push_back(buildInverse(*invFact, precFact, getBlock(i, i, A), state, opPrefix, i));
   }
 }
 
-LinearOp InvFactoryDiagStrategy::buildInverse(const InverseFactory& invFact, const LinearOp& matrix,
+LinearOp InvFactoryDiagStrategy::buildInverse(const InverseFactory& invFact,
+                                              Teuchos::RCP<InverseFactory>& precFact,
+                                              const LinearOp& matrix,
                                               BlockPreconditionerState& state,
                                               const std::string& opPrefix, int i) const {
   std::stringstream ss;
   ss << opPrefix << "_" << i;
 
-  ModifiableLinearOp& invOp = state.getModifiableOp(ss.str());
+  ModifiableLinearOp& invOp  = state.getModifiableOp(ss.str());
+  ModifiableLinearOp& precOp = state.getModifiableOp("prec_" + ss.str());
+
+  if (precFact != Teuchos::null) {
+    if (precOp == Teuchos::null) {
+      precOp = precFact->buildInverse(matrix);
+      state.addModifiableOp("prec_" + ss.str(), precOp);
+    } else {
+      Teko::rebuildInverse(*precFact, matrix, precOp);
+    }
+  }
+
   if (invOp == Teuchos::null)
-    invOp = Teko::buildInverse(invFact, matrix);
-  else
-    rebuildInverse(invFact, matrix, invOp);
+    if (precOp.is_null())
+      invOp = Teko::buildInverse(invFact, matrix);
+    else
+      invOp = Teko::buildInverse(invFact, matrix, precOp);
+  else {
+    if (precOp.is_null())
+      Teko::rebuildInverse(invFact, matrix, invOp);
+    else
+      Teko::rebuildInverse(invFact, matrix, precOp, invOp);
+  }
 
   return invOp;
 }

--- a/packages/teko/src/Teko_BlockInvDiagonalStrategy.hpp
+++ b/packages/teko/src/Teko_BlockInvDiagonalStrategy.hpp
@@ -139,6 +139,12 @@ class InvFactoryDiagStrategy : public BlockInvDiagonalStrategy {
   InvFactoryDiagStrategy(const std::vector<Teuchos::RCP<InverseFactory> > &factories,
                          const Teuchos::RCP<InverseFactory> &defaultFact = Teuchos::null);
 
+  InvFactoryDiagStrategy(
+      const std::vector<Teuchos::RCP<InverseFactory> > &inverseFactories,
+      const std::vector<Teuchos::RCP<InverseFactory> > &preconditionerFactories,
+      const Teuchos::RCP<InverseFactory> &defaultInverseFact        = Teuchos::null,
+      const Teuchos::RCP<InverseFactory> &defaultPreconditionerFact = Teuchos::null);
+
   virtual ~InvFactoryDiagStrategy() {}
 
   /** returns an (approximate) inverse of the diagonal blocks of A
@@ -157,11 +163,14 @@ class InvFactoryDiagStrategy : public BlockInvDiagonalStrategy {
  protected:
   // stored inverse operators
   std::vector<Teuchos::RCP<InverseFactory> > invDiagFact_;
+  std::vector<Teuchos::RCP<InverseFactory> > precDiagFact_;
   Teuchos::RCP<InverseFactory> defaultInvFact_;
+  Teuchos::RCP<InverseFactory> defaultPrecFact_;
 
   //! Conveinence function for building inverse operators
-  LinearOp buildInverse(const InverseFactory &invFact, const LinearOp &matrix,
-                        BlockPreconditionerState &state, const std::string &opPrefix, int i) const;
+  LinearOp buildInverse(const InverseFactory &invFact, Teuchos::RCP<InverseFactory> &precFact,
+                        const LinearOp &matrix, BlockPreconditionerState &state,
+                        const std::string &opPrefix, int i) const;
 
  private:
   InvFactoryDiagStrategy();

--- a/packages/teko/src/Teko_GaussSeidelPreconditionerFactory.cpp
+++ b/packages/teko/src/Teko_GaussSeidelPreconditionerFactory.cpp
@@ -102,19 +102,25 @@ void GaussSeidelPreconditionerFactory::initializeFromParameterList(
   pl.print(DEBUG_STREAM);
   Teko_DEBUG_MSG_END();
 
-  const std::string inverse_type = "Inverse Type";
+  const std::string inverse_type        = "Inverse Type";
+  const std::string preconditioner_type = "Preconditioner Type";
   std::vector<RCP<InverseFactory> > inverses;
+  std::vector<RCP<InverseFactory> > preconditioners;
 
   RCP<const InverseLibrary> invLib = getInverseLibrary();
 
   // get string specifying default inverse
-  std::string invStr = "Amesos";
+  std::string invStr  = "Amesos";
+  std::string precStr = "None";
   if (pl.isParameter(inverse_type)) invStr = pl.get<std::string>(inverse_type);
+  if (pl.isParameter(preconditioner_type)) precStr = pl.get<std::string>(preconditioner_type);
   if (pl.isParameter("Use Upper Triangle"))
     solveType_ = pl.get<bool>("Use Upper Triangle") ? GS_UseUpperTriangle : GS_UseLowerTriangle;
 
   Teko_DEBUG_MSG("GSPrecFact: Building default inverse \"" << invStr << "\"", 5);
   RCP<InverseFactory> defaultInverse = invLib->getInverseFactory(invStr);
+  RCP<InverseFactory> defaultPrec;
+  if (precStr != "None") defaultPrec = invLib->getInverseFactory(precStr);
 
   // now check individual solvers
   Teuchos::ParameterList::ConstIterator itr;
@@ -144,6 +150,29 @@ void GaussSeidelPreconditionerFactory::initializeFromParameterList(
         inverses[position - 1] = invLib->getInverseFactory(invStr2);
       } else
         inverses[position - 1] = invLib->getInverseFactory(invStr2);
+    } else if (fieldName.compare(0, preconditioner_type.length(), preconditioner_type) == 0 &&
+               fieldName != preconditioner_type) {
+      int position = -1;
+      std::string preconditioner, type;
+
+      // figure out position
+      std::stringstream ss(fieldName);
+      ss >> preconditioner >> type >> position;
+
+      if (position <= 0) {
+        Teko_DEBUG_MSG("Gauss-Seidel \"Preconditioner Type\" must be a (strictly) positive integer",
+                       1);
+      }
+
+      // inserting preconditioner factory into vector
+      std::string precStr2 = pl.get<std::string>(fieldName);
+      Teko_DEBUG_MSG(
+          "GSPrecFact: Building preconditioner " << position << " \"" << precStr2 << "\"", 5);
+      if (position > (int)preconditioners.size()) {
+        preconditioners.resize(position, defaultPrec);
+        preconditioners[position - 1] = invLib->getInverseFactory(precStr2);
+      } else
+        preconditioners[position - 1] = invLib->getInverseFactory(precStr2);
     }
   }
 
@@ -151,7 +180,8 @@ void GaussSeidelPreconditionerFactory::initializeFromParameterList(
   if (inverses.size() == 0) inverses.push_back(defaultInverse);
 
   // based on parameter type build a strategy
-  invOpsStrategy_ = rcp(new InvFactoryDiagStrategy(inverses, defaultInverse));
+  invOpsStrategy_ =
+      rcp(new InvFactoryDiagStrategy(inverses, preconditioners, defaultInverse, defaultPrec));
 }
 
 }  // namespace Teko

--- a/packages/teko/tests/src/tBlockJacobiPreconditionerFactory_tpetra.hpp
+++ b/packages/teko/tests/src/tBlockJacobiPreconditionerFactory_tpetra.hpp
@@ -73,6 +73,7 @@ class tBlockJacobiPreconditionerFactory_tpetra : public UnitTest {
   bool test_initializePrec(int verbosity, std::ostream& os);
   bool test_uninitializePrec(int verbosity, std::ostream& os);
   bool test_isCompatible(int verbosity, std::ostream& os);
+  bool test_iterativeSolves(int verbosity, std::ostream& os);
 
  protected:
   double tolerance_;


### PR DESCRIPTION
@trilinos/teko

## Motivation
These changes allow to use preconditioned iterative solvers for the diagonal blocks of block Jacobi and Gauss-Seidel.

For example:
```xml
<ParameterList name="BGS">
  <Parameter name="Type" type="string" value="Block Gauss-Seidel"/>
  <Parameter name="Use Upper Triangle" type="bool" value="true"/>
  <Parameter name="Inverse Type 1"  type="string" value="Amesos2"/>
  <Parameter name="Inverse Type 2"  type="string" value="itSolver"/>
  <Parameter name="Preconditioner Type 2"  type="string" value="prec"/>
</ParameterList>

<ParameterList name="itSolver">
  <Parameter name="Type" type="string" value="Belos"/>
  <Parameter name="Solver Type" type="string" value="Pseudo Block GMRES"/>
</ParameterList>

<ParameterList name="prec">
  <Parameter name="Type" type="string" value="Ifpack2"/>
  <Parameter name="Prec Type" type="string" value="relaxation"/>
  <ParameterList name="Ifpack2 Settings">
    <Parameter name="relaxation: type" type="string" value="Jacobi"/>
  </ParameterList>
</ParameterList>
```

Closes #12674. Should be merged after #12671.