### PR TITLE
Teko: explicitAdd reuse existing operator if possible

### DIFF
--- a/packages/teko/src/Teko_Utilities.cpp
+++ b/packages/teko/src/Teko_Utilities.cpp
@@ -2066,7 +2066,10 @@ const ModifiableLinearOp explicitAdd(const LinearOp & opl_in,const LinearOp & op
          }
          catch (std::exception & e) {
            RCP<Teuchos::FancyOStream> out = Teuchos::VerboseObjectBase::getDefaultOStream();
-           *out << "Teko: explicitAdd unable to reuse existing operator. Creating new operator." << std::endl;
+           *out << "*** THROWN EXCEPTION ***\n";
+           *out << e.what() << std::endl;
+           *out << "************************\n";
+           *out << "Teko: explicitAdd unable to reuse existing operator. Creating new operator.\n" << std::endl;
            explicitCrsOp = Tpetra::MatrixMatrix::add<ST,LO,GO,NT>(scalarl,transpl,*tCrsOpl,scalarr,transpr,*tCrsOpr);
          }
       }else{

--- a/packages/teko/src/Teko_Utilities.cpp
+++ b/packages/teko/src/Teko_Utilities.cpp
@@ -2064,7 +2064,7 @@ const ModifiableLinearOp explicitAdd(const LinearOp & opl_in,const LinearOp & op
            explicitCrsOp = rcp_dynamic_cast<Tpetra::CrsMatrix<ST,LO,GO,NT> >(tOp->getTpetraOperator(),true);
            Tpetra::MatrixMatrix::Add<ST,LO,GO,NT>(*tCrsOpl,transpl,scalarl,*tCrsOpr,transpr,scalarr,explicitCrsOp);
          }
-         catch (std::exception & e) {
+         catch (std::logic_error & e) {
            RCP<Teuchos::FancyOStream> out = Teuchos::VerboseObjectBase::getDefaultOStream();
            *out << "*** THROWN EXCEPTION ***\n";
            *out << e.what() << std::endl;

--- a/packages/teko/src/Teko_Utilities.cpp
+++ b/packages/teko/src/Teko_Utilities.cpp
@@ -1977,20 +1977,19 @@ const LinearOp explicitAdd(const LinearOp & opl_in,const LinearOp & opr_in)
   *
   * \returns Matrix sum with a Epetra_CrsMatrix implementation
   */
-const ModifiableLinearOp explicitAdd(const LinearOp & opl,const LinearOp & opr,
+const ModifiableLinearOp explicitAdd(const LinearOp & opl_in,const LinearOp & opr_in,
                                      const ModifiableLinearOp & destOp)
 {
    // if blocked, add block by block
-   if(isPhysicallyBlockedLinearOp(opl)){
-     TEUCHOS_ASSERT(isPhysicallyBlockedLinearOp(opr));
+   if(isPhysicallyBlockedLinearOp(opl_in) && isPhysicallyBlockedLinearOp(opr_in)){
 
      double scalarl = 0.0;
      bool transpl = false;
-     RCP<const Thyra::PhysicallyBlockedLinearOpBase<double> > blocked_opl = getPhysicallyBlockedLinearOp(opl, &scalarl, &transpl);
+     RCP<const Thyra::PhysicallyBlockedLinearOpBase<double> > blocked_opl = getPhysicallyBlockedLinearOp(opl_in, &scalarl, &transpl);
 
      double scalarr = 0.0;
      bool transpr = false;
-     RCP<const Thyra::PhysicallyBlockedLinearOpBase<double> > blocked_opr = getPhysicallyBlockedLinearOp(opr, &scalarr, &transpr);
+     RCP<const Thyra::PhysicallyBlockedLinearOpBase<double> > blocked_opr = getPhysicallyBlockedLinearOp(opr_in, &scalarr, &transpr);
 
      int numRows = blocked_opl->productRange()->numBlocks();
      int numCols = blocked_opl->productDomain()->numBlocks();
@@ -2022,6 +2021,26 @@ const ModifiableLinearOp explicitAdd(const LinearOp & opl,const LinearOp & opr,
      return blocked_sum;
    }
 
+   LinearOp opl = opl_in;
+   LinearOp opr = opr_in;
+   // if only one is blocked, it must be 1x1
+   if(isPhysicallyBlockedLinearOp(opl)){
+     double scalarl = 0.0;
+     bool transpl = false;
+     RCP<const Thyra::PhysicallyBlockedLinearOpBase<double> > blocked_opl = getPhysicallyBlockedLinearOp(opl, &scalarl, &transpl);
+     TEUCHOS_ASSERT(blocked_opl->productRange()->numBlocks() == 1);
+     TEUCHOS_ASSERT(blocked_opl->productDomain()->numBlocks() == 1);
+     opl = Thyra::scale(scalarl,blocked_opl->getBlock(0,0));
+   }
+   if(isPhysicallyBlockedLinearOp(opr)){
+     double scalarr = 0.0;
+     bool transpr = false;
+     RCP<const Thyra::PhysicallyBlockedLinearOpBase<double> > blocked_opr = getPhysicallyBlockedLinearOp(opr, &scalarr, &transpr);
+     TEUCHOS_ASSERT(blocked_opr->productRange()->numBlocks() == 1);
+     TEUCHOS_ASSERT(blocked_opr->productDomain()->numBlocks() == 1);
+     opr = Thyra::scale(scalarr,blocked_opr->getBlock(0,0));
+   }
+
    bool isTpetral = Teko::TpetraHelpers::isTpetraLinearOp(opl);
    bool isTpetrar = Teko::TpetraHelpers::isTpetraLinearOp(opr);
 
@@ -2037,14 +2056,26 @@ const ModifiableLinearOp explicitAdd(const LinearOp & opl,const LinearOp & opr,
 
       // Build output operator
       RCP<Thyra::LinearOpBase<ST> > explicitOp;
-      if(destOp!=Teuchos::null)
+      RCP<Tpetra::CrsMatrix<ST,LO,GO,NT> > explicitCrsOp;
+      if(destOp!=Teuchos::null){
          explicitOp = destOp;
-      else
+         try {// try to reuse matrix sparsity with Add. If it fails, build new operator with add
+           RCP<Thyra::TpetraLinearOp<ST,LO,GO,NT> > tOp = rcp_dynamic_cast<Thyra::TpetraLinearOp<ST,LO,GO,NT> >(destOp);
+           explicitCrsOp = rcp_dynamic_cast<Tpetra::CrsMatrix<ST,LO,GO,NT> >(tOp->getTpetraOperator(),true);
+           Tpetra::MatrixMatrix::Add<ST,LO,GO,NT>(*tCrsOpl,transpl,scalarl,*tCrsOpr,transpr,scalarr,explicitCrsOp);
+         }
+         catch (std::exception & e) {
+           RCP<Teuchos::FancyOStream> out = Teuchos::VerboseObjectBase::getDefaultOStream();
+           *out << "Teko: explicitAdd unable to reuse existing operator. Creating new operator." << std::endl;
+           explicitCrsOp = Tpetra::MatrixMatrix::add<ST,LO,GO,NT>(scalarl,transpl,*tCrsOpl,scalarr,transpr,*tCrsOpr);
+         }
+      }else{
          explicitOp = rcp(new Thyra::TpetraLinearOp<ST,LO,GO,NT>());
+         explicitCrsOp = Tpetra::MatrixMatrix::add<ST,LO,GO,NT>(scalarl,transpl,*tCrsOpl,scalarr,transpr,*tCrsOpr);
+      }
       RCP<Thyra::TpetraLinearOp<ST,LO,GO,NT> > tExplicitOp = rcp_dynamic_cast<Thyra::TpetraLinearOp<ST,LO,GO,NT> >(explicitOp);
 
       // Do explicit matrix-matrix add
-      RCP<Tpetra::CrsMatrix<ST,LO,GO,NT> > explicitCrsOp = Tpetra::MatrixMatrix::add<ST,LO,GO,NT>(scalarl,transpl,*tCrsOpl,scalarr,transpr,*tCrsOpr);
       tExplicitOp->initialize(Thyra::tpetraVectorSpace<ST,LO,GO,NT>(explicitCrsOp->getRangeMap()),Thyra::tpetraVectorSpace<ST,LO,GO,NT>(explicitCrsOp->getDomainMap()),explicitCrsOp);
       return tExplicitOp;
 

--- a/packages/teko/tests/src/tExplicitOps_tpetra.hpp
+++ b/packages/teko/tests/src/tExplicitOps_tpetra.hpp
@@ -86,6 +86,7 @@ protected:
    // matrix to invert
    Teko::ModifiableLinearOp F_;
    Teko::ModifiableLinearOp G_;
+   Teko::ModifiableLinearOp H_;
    Teko::LinearOp D_;
 };
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teko 

## Motivation
Have the explicitAdd in Teko reuse the existing operator pointer if possible (when the sparsity pattern is unchanged).
The goal is to reuse the setups of Ifpack2 smoothers when using reuse options in MueLu.
Reuse of Ifpack2 smoothers, such as additive schwarz, rely on the underlying operator pointer being the same
(see: https://github.com/trilinos/Trilinos/blob/9665b8ef28ce53e3a47ad2243fdcb33b73ff49f4/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_def.hpp#L1754).

(Note: MueLu does not check this and will happily report that it is reusing the smoother setup while ifpack2 is actually rebuilding the smoother from scratch.)

This fix allows MueLu and Ifpack2 to reuse the smoother setup.
It also contains some updates to the block detecting logic for the explicitAdd.

<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->