### PR TITLE
tpetra: update spadd_* api for KOKKOSKERNELS_VERSION >= 40299

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_decl.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_decl.hpp
@@ -693,7 +693,9 @@ struct AddKernels
     const row_ptrs_array_const& Browptrs,
     const col_inds_array& Bcolinds,
     const impl_scalar_type scalarB,
+#if KOKKOSKERNELS_VERSION >= 40299
     GlobalOrdinal numGlobalCols,
+#endif
     values_array& Cvals,
     row_ptrs_array& Crowptrs,
     col_inds_array& Ccolinds);

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_decl.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_decl.hpp
@@ -680,6 +680,7 @@ struct AddKernels
   /// \param Browptrs Row pointers array for B
   /// \param Bcolinds Column indices array for B
   /// \param scalarB Scaling factor for B
+  /// \param numGlobalCols The global size of the column map
   /// \param[Out] Cvals Values array for C (allocated inside function)
   /// \param[Out] Crowptrs Row pointers array for C (allocated inside function)
   /// \param[Out] Ccolinds Column indices array for C (allocated inside function)
@@ -692,6 +693,7 @@ struct AddKernels
     const row_ptrs_array_const& Browptrs,
     const col_inds_array& Bcolinds,
     const impl_scalar_type scalarB,
+    GlobalOrdinal numGlobalCols,
     values_array& Cvals,
     row_ptrs_array& Crowptrs,
     col_inds_array& Ccolinds);
@@ -728,7 +730,7 @@ struct AddKernels
   /// \param Browptrs Row pointers array for B
   /// \param Bcolinds Column indices array for B
   /// \param scalarB Scaling factor for B
-  /// \param globalNumCols The global size of the column map
+  /// \param numGlobalCols The global size of the column map
   /// \param[Out] Cvals Values array for C (allocated inside function)
   /// \param[Out] Crowptrs Row pointers array for C (allocated inside function)
   /// \param[Out] Ccolinds Column indices array for C (allocated inside function)

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -911,7 +911,11 @@ add (const Scalar& alpha,
            << "Call AddKern::addSorted(...)" << std::endl;
         std::cerr << os.str ();
       }
+#if KOKKOSKERNELS_VERSION >= 40299
       AddKern::addSorted(Avals, Arowptrs, Acolinds, alpha, Bvals, Browptrs, Bcolinds, beta, Aprime->getGlobalNumCols(), vals, rowptrs, colinds);
+#else
+      AddKern::addSorted(Avals, Arowptrs, Acolinds, alpha, Bvals, Browptrs, Bcolinds, beta, vals, rowptrs, colinds);
+#endif
     }
     else
     {

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -3711,8 +3711,6 @@ addSorted(
   const typename MMdetails::AddKernels<SC, LO, GO, NO>::impl_scalar_type scalarB,
 #if KOKKOSKERNELS_VERSION >= 40299
   GO numGlobalCols,
-#else
-  GO /* numGlobalCols */,
 #endif
   typename MMdetails::AddKernels<SC, LO, GO, NO>::values_array& Cvals,
   typename MMdetails::AddKernels<SC, LO, GO, NO>::row_ptrs_array& Crowptrs,

--- a/packages/tpetra/core/src/Tpetra_CrsGraphTransposer_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraphTransposer_def.hpp
@@ -271,6 +271,7 @@ namespace Tpetra {
     auto nrows = rowptrs.extent(0) - 1;
     auto rowptrsSym = row_ptrs_array(Kokkos::ViewAllocateWithoutInitializing("row ptrs sym"), nrows + 1);
 
+    auto ncols = graph->getGlobalNumCols();
     col_inds_array colindsSym;
 
     if(!matchingColMaps) {
@@ -294,7 +295,11 @@ namespace Tpetra {
       global_col_inds_array globalColindsSym;
 
       KokkosSparse::Experimental::spadd_symbolic
-        (&handle, rowptrs, colindsConverted, rowptrsT, colindsTConverted, rowptrsSym);
+        (&handle,
+#if KOKKOSKERNELS_VERSION >= 40299
+         nrows, graph->getGlobalNumCols(),
+#endif
+         rowptrs, colindsConverted, rowptrsT, colindsTConverted, rowptrsSym);
       globalColindsSym = global_col_inds_array(Kokkos::ViewAllocateWithoutInitializing("global colinds sym"), addHandle->get_c_nnz());
 
       UnsortedNumericIndicesOnlyFunctor<
@@ -325,7 +330,11 @@ namespace Tpetra {
       auto addHandle = handle.get_spadd_handle();
 
       KokkosSparse::Experimental::spadd_symbolic
-        (&handle, rowptrs, colinds, rowptrsT, colindsT, rowptrsSym);
+        (&handle,
+#if KOKKOSKERNELS_VERSION >= 40299
+         nrows, graph->getGlobalNumCols(),
+#endif
+         rowptrs, colinds, rowptrsT, colindsT, rowptrsSym);
       colindsSym = col_inds_array(Kokkos::ViewAllocateWithoutInitializing("C colinds"), addHandle->get_c_nnz());
 
       if (sorted) {

--- a/packages/tpetra/core/src/Tpetra_CrsGraphTransposer_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraphTransposer_def.hpp
@@ -271,7 +271,6 @@ namespace Tpetra {
     auto nrows = rowptrs.extent(0) - 1;
     auto rowptrsSym = row_ptrs_array(Kokkos::ViewAllocateWithoutInitializing("row ptrs sym"), nrows + 1);
 
-    auto ncols = graph->getGlobalNumCols();
     col_inds_array colindsSym;
 
     if(!matchingColMaps) {

--- a/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
@@ -2154,6 +2154,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, threaded_add_sorted, SC, LO, GO
   Tpetra::MMdetails::AddKernels<SC, LO, GO, NT>::addSorted(
                                 valsCRS[0], rowptrsCRS[0], colindsCRS[0], one, 
                                 valsCRS[1], rowptrsCRS[1], colindsCRS[1], one, 
+#if KOKKOSKERNELS_VERSION >= 40299
+                                nrows, // assumes square matrices
+#endif
                                 valsCRS[2], rowptrsCRS[2], colindsCRS[2]);
 
   ExecSpace().fence();


### PR DESCRIPTION
PR kokkos/kokkos-kernels#1962 introduced API updates to the spadd_* routines This is allowed as spadd resides in the Experimental namespace, but requires propagating backward-compatibility breaking changes to Trilinos

Resolve kokkos/kokkos-kernels#2089

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra @brian-kelley @csiefer2



## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fix compilation errors with kokkos-kernels@develop branch

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing

Locally tested Tpetra in a Cuda build on Weaver (rhel8 queue) with this configuration:
```bash
export ATDM_CONFIG_REGISTER_CUSTOM_CONFIG_DIR=${TRILINOS_DIR}/cmake/std/atdm/contributed/weaver
source ${TRILINOS_DIR}/cmake/std/atdm/load-env.sh weaver-cuda-11.2-opt
export OMPI_CXX="$KOKKOS_PATH/bin/nvcc_wrapper"


cmake \
      -D CMAKE_CXX_FLAGS='-g' \
      -D CMAKE_CXX_STANDARD="17" \
      -D CMAKE_INSTALL_PREFIX=$PWD/install \
      -D Trilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
      -D Trilinos_ASSERT_DEFINED_DEPENDENCIES=IGNORE \
      -D TPL_ENABLE_CUSOLVER:BOOL=OFF \
      -D TPL_ENABLE_CUBLAS:BOOL=OFF \
      -DTrilinos_ENABLE_TESTS=ON \
      -DTrilinos_ENABLE_ALL_PACKAGES=OFF \
      -DTrilinos_ENABLE_COMPLEX_DOUBLE=ON \
      \
      -D Trilinos_ENABLE_Kokkos=ON \
      -D Kokkos_ARCH_VOLTA70=ON \
      -D Kokkos_ARCH_POWER9=ON \
      -D Kokkos_ENABLE_CUDA=ON \
      -D Kokkos_ENABLE_CUDA_LAMBDA=ON \
      -D Kokkos_ENABLE_CUDA_UVM=OFF \
      -D Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=OFF \
      -D KokkosKernels_ENABLE_TPL_CUSOLVER=OFF \
      -DTrilinos_ENABLE_Tpetra=ON \
      -D Tpetra_ENABLE_TESTS=ON \
      \
      -DKokkos_SOURCE_DIR_OVERRIDE:STRING=kokkos \
      -DKokkosKernels_SOURCE_DIR_OVERRIDE:STRING=kokkos-kernels \
$TRILINOS_DIR
```

<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->