### PR TITLE
Framework: Remove complex from all declared non-complex configs

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1864,7 +1864,6 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 use COMMON
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none --mca btl vader,self
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL         : ON
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
 opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL         : ON
@@ -1949,7 +1948,6 @@ use USE-DEPRECATED|YES
 use COMMON_USE-MPI|NO
 
 opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -Werror=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 opt-set-cmake-var TPL_ENABLE_ParMETIS            BOOL FORCE   : OFF
 
@@ -1984,7 +1982,6 @@ use COMMON
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Werror=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
@@ -2010,7 +2007,6 @@ use COMMON
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 opt-set-cmake-var Trilinos_ENABLE_Moertel                       BOOL       : OFF
@@ -2037,7 +2033,6 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 use COMMON
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : --bind-to;none --mca btl vader,self
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL         : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL         : ON
 opt-set-cmake-var ROL_test_algorithm_TypeP_CompareTypeU_MPI_1_DISABLE BOOL         : ON
@@ -2716,7 +2711,6 @@ use USE-PT|NO
 use COMMON_SPACK_TPLS
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none --mca btl vader,self
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL         : ON
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
 opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL         : ON
@@ -2754,7 +2748,6 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 use COMMON_SPACK_TPLS
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                            STRING       : --bind-to;none --mca btl vader,self
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL         : ON
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D          BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL         : ON
 opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL         : ON
@@ -2793,7 +2786,6 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 use COMMON_SPACK_TPLS
 
 opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 opt-set-cmake-var TPL_ENABLE_ParMETIS            BOOL FORCE   : OFF
 opt-set-cmake-var TPL_ENABLE_Pnetcdf             BOOL FORCE   : OFF
@@ -2853,7 +2845,6 @@ use COMMON_SPACK_TPLS
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
@@ -2881,7 +2872,6 @@ use COMMON_SPACK_TPLS
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
 opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL       : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 opt-set-cmake-var Trilinos_ENABLE_Moertel                       BOOL       : OFF
@@ -2909,7 +2899,6 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use COMMON_SPACK_TPLS
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : --bind-to;none --mca btl vader,self
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL         : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
@@ -2945,7 +2934,6 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 use COMMON_SPACK_TPLS
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                                STRING       : --bind-to;none --mca btl vader,self
-opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                             BOOL         : ON
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D              BOOL         : ON
 opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                    BOOL         : ON
 opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE     BOOL         : ON
@@ -2954,7 +2942,7 @@ opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE                         BOO
 opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE                         BOOL         : ON
 opt-set-cmake-var CMAKE_CXX_FLAGS                                            STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
-opt-set-cmake-var TPL_ENABLE_SuperLU BOOL FORCE: OFF
+opt-set-cmake-var TPL_ENABLE_SuperLUDist BOOL FORCE: ON
 
 
 use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS


### PR DESCRIPTION
@trilinos/framework

## Motivation
Want the GenConfig spec to accurately reflect the build configuration.  If it says no-complex, complex should not be enabled.


## Related Issues
Closes #12686 
