### PR TITLE
NOX: add tests, fix NOX::Epetra::MatrixFree for backward difference (12715)

### DIFF
--- a/packages/nox/src-epetra/NOX_Epetra_MatrixFree.C
+++ b/packages/nox/src-epetra/NOX_Epetra_MatrixFree.C
@@ -190,8 +190,7 @@ int MatrixFree::Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
   // Compute the perturbed RHS
   perturbX = currentX;
   Y = X;
-  Y.Scale(eta);
-  perturbX.update(scaleFactor,nevY,1.0);
+  perturbX.update(eta*scaleFactor,nevY,1.0);
 
   if (!useGroupForComputeF)
       interface->computeF(perturbX.getEpetraVector(), fp.getEpetraVector(),
@@ -204,8 +203,7 @@ int MatrixFree::Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
   }
 
   if ( diffType == Centered ) {
-    Y.Scale(-2.0);
-    perturbX.update(scaleFactor,nevY,1.0);
+    perturbX.update(-2.0*eta*scaleFactor,nevY,1.0);
     if (!useGroupForComputeF)
       interface->computeF(perturbX.getEpetraVector(), fmPtr->getEpetraVector(),
               NOX::Epetra::Interface::Required::MF_Res);

--- a/packages/nox/src-epetra/NOX_Epetra_MatrixFree.C
+++ b/packages/nox/src-epetra/NOX_Epetra_MatrixFree.C
@@ -193,7 +193,7 @@ int MatrixFree::Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
   perturbX = currentX;
   Y = X;
   Y.Scale(eta);
-  perturbX.update(1.0,nevY,1.0);
+  perturbX.update(scaleFactor,nevY,1.0);
 
   if (!useGroupForComputeF)
       interface->computeF(perturbX.getEpetraVector(), fp.getEpetraVector(),

--- a/packages/nox/src-epetra/NOX_Epetra_MatrixFree.C
+++ b/packages/nox/src-epetra/NOX_Epetra_MatrixFree.C
@@ -220,7 +220,7 @@ int MatrixFree::Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
   }
   else {
     nevY.update(1.0, fp, -1.0, *fmPtr, 0.0);
-    nevY.scale( 1.0/(2.0 * eta) );
+    nevY.scale( 1.0/(2.0 * eta * scaleFactor) );
   }
 
   return 0;

--- a/packages/nox/src-epetra/NOX_Epetra_MatrixFree.C
+++ b/packages/nox/src-epetra/NOX_Epetra_MatrixFree.C
@@ -170,9 +170,7 @@ int MatrixFree::Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
     if ( Teuchos::is_null(fmPtr) )
       fmPtr = Teuchos::rcp(new NOX::Epetra::Vector(fo));
 
-  double scaleFactor = 1.0;
-  if ( diffType == Backward )
-  scaleFactor = -1.0;
+  const double scaleFactor = (diffType == Backward ? -1.0 : 1.0);
 
   if (computeEta) {
     if (useNewPerturbation) {

--- a/packages/nox/src-epetra/NOX_Epetra_MatrixFree.C
+++ b/packages/nox/src-epetra/NOX_Epetra_MatrixFree.C
@@ -188,8 +188,7 @@ int MatrixFree::Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
     eta = userEta;
 
   // Compute the perturbed RHS
-  perturbX = currentX;
-  perturbX.update(eta*scaleFactor,nevX,1.0);
+  perturbX.update(1.0,currentX,eta*scaleFactor,nevX,0.0);
 
   if (!useGroupForComputeF)
       interface->computeF(perturbX.getEpetraVector(), fp.getEpetraVector(),

--- a/packages/nox/src-epetra/NOX_Epetra_MatrixFree.C
+++ b/packages/nox/src-epetra/NOX_Epetra_MatrixFree.C
@@ -189,8 +189,7 @@ int MatrixFree::Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
 
   // Compute the perturbed RHS
   perturbX = currentX;
-  Y = X;
-  perturbX.update(eta*scaleFactor,nevY,1.0);
+  perturbX.update(eta*scaleFactor,nevX,1.0);
 
   if (!useGroupForComputeF)
       interface->computeF(perturbX.getEpetraVector(), fp.getEpetraVector(),
@@ -203,7 +202,7 @@ int MatrixFree::Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
   }
 
   if ( diffType == Centered ) {
-    perturbX.update(-2.0*eta*scaleFactor,nevY,1.0);
+    perturbX.update(-2.0*eta*scaleFactor,nevX,1.0);
     if (!useGroupForComputeF)
       interface->computeF(perturbX.getEpetraVector(), fmPtr->getEpetraVector(),
               NOX::Epetra::Interface::Required::MF_Res);


### PR DESCRIPTION
@rppawlo

## Motivation

This PR fixes issue #12715 , and adds a couple of tests to exercise the `Backward` and `Centered` difference modes for `NOX::Epetra:MatrixFree`.

## Related Issues

* Closes issue #12715 

## Testing

In the very first commit 77495f1, this PR adds checks to trigger the issue, then resolves the issue in the next commit 57041c3.

## Additional Information

All commits after the first two of the PR are just very small tidying up of the code to make it easier to follow and avoid similar issues; please feel free to review and accept/reject those commits as needed as they are not essential to the PR.

Some of these commits might improve performance by making use of a single `update()` call and reducing intermediate copies or passes over the vectors.

I just want to draw your attention to the fact that I've assumed that a sequence like this:

```c++
perturbX = currentX;
Y = X;
Y.Scale(eta);
perturbX.update(scaleFactor,nevY,1.0);
```

may safely be coalesced into:

```c++
perturbX.update(1.0, currentX, eta*scaleFactor, nevX, 0.0);
```

The risk I can see is that in the case where the entries of `perturbX` are uninitialized (and might e.g. contain NaNs), then the behaviour depends on how `NOX::Epetra::Vector::update()` is implemented internally when the last argument `gamma` is 0.0.

If `x.update(..., gamma)` internally performs `x[i] <- ... + gamma*x[i]` then this will propagate NaNs in `x` into the result, even when `gamma == 0.0`.

From a cursory look at `Epetra_MultiVector`, it seems that `v.Update(..., scalarThis=0.0)` tests for `scalarThis == 0.0`, in which case it performs a direct assignment into `v`, and the previous entries of `v` are never used. But I don't know whether this is accidental, or a part of the contract that `Epetra_MultiVector::Update()` and `NOX::Epetra::Vector::update()` promises to their callers.