### PR TITLE
Tpetra: Reject unrecognized `TPETRA_`-prefixed environment variables

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -38,23 +38,104 @@
 // ************************************************************************
 // @HEADER
 */
-#include "Tpetra_Details_Behavior.hpp"
-#include "TpetraCore_config.h"
+// clang-format on
 #include <algorithm> // std::transform
-#include <cstdlib> // std::getenv
-#include <cctype> // std::toupper
-#include <string>
-#include <map>
-#include <vector>
+#include <cctype>    // std::toupper
+#include <cstdlib>   // std::getenv
 #include <functional>
-#include "Teuchos_TestForException.hpp"
-#include "Teuchos_OrdinalTraits.hpp"
+#include <map>
 #include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "Teuchos_OrdinalTraits.hpp"
+#include "Teuchos_TestForException.hpp"
+#include "TpetraCore_config.h"
+#include "Tpetra_Details_Behavior.hpp"
+
+/*! \file Tpetra_Details_Behavior.cpp
+
+This file is primarily concerned with providing programmatic access to certain
+environment variables. The variable is evaluated on first access, and the data
+is cached to provide the same result on future accesses even if the underlying
+environment has changed.
+
+There are boolean variables:
+
+  TPETRA_ENV_VAR=1|ON|YES|TRUE     <lower or upper case>
+  TPETRA_ENV_VAR=0|OFF|NO|FALSE    <lower or upper case>
+
+There are size_t variables (negative values are max size_t)
+
+  TPETRA_ENV_VAR=XXXXX  <XXXX is parsed as a long long, then cast to size_t>
+
+There are "named" boolean variables, where multiple names are associated with
+the variable.
+
+  TPETRA_ENV_VAR=name1:name2:....
+
+If a name is queried for a variable, and it was provided, the result is true.
+Else false.
+
+There are also two special cases:
+
+  `CUDA_LAUNCH_BLOCKING` is not prefixed with "TPETRA_" but is otherwise a
+boolean variable
+
+  `MM_TAFC_OptimizationCoreCount` is not prefixed with "TPETRA_",
+and is parsed as an int instead of a long long
+
+*/
 
 namespace Tpetra {
 namespace Details {
 
 namespace BehaviorDetails {
+
+constexpr const std::string_view RESERVED_PREFIX = "TPETRA_";
+constexpr const std::string_view ASSUME_GPU_AWARE_MPI =
+    "TPETRA_ASSUME_GPU_AWARE_MPI";
+constexpr const std::string_view CUDA_LAUNCH_BLOCKING = "CUDA_LAUNCH_BLOCKING";
+constexpr const std::string_view MM_TAFC_OptimizationCoreCount =
+    "MM_TAFC_OptimizationCoreCount";
+constexpr const std::string_view VERBOSE_PRINT_COUNT_THRESHOLD =
+    "TPETRA_VERBOSE_PRINT_COUNT_THRESHOLD";
+constexpr const std::string_view ROW_IMBALANCE_THRESHOLD =
+    "TPETRA_ROW_IMBALANCE_THRESHOLD";
+constexpr const std::string_view MULTIVECTOR_USE_MERGE_PATH =
+    "TPETRA_MULTIVECTOR_USE_MERGE_PATH";
+constexpr const std::string_view VECTOR_DEVICE_THRESHOLD =
+    "TPETRA_VECTOR_DEVICE_THRESHOLD";
+constexpr const std::string_view HIERARCHICAL_UNPACK_BATCH_SIZE =
+    "TPETRA_HIERARCHICAL_UNPACK_BATCH_SIZE";
+constexpr const std::string_view HIERARCHICAL_UNPACK_TEAM_SIZE =
+    "TPETRA_HIERARCHICAL_UNPACK_TEAM_SIZE";
+constexpr const std::string_view USE_TEUCHOS_TIMERS =
+    "TPETRA_USE_TEUCHOS_TIMERS";
+constexpr const std::string_view USE_KOKKOS_PROFILING =
+    "TPETRA_USE_KOKKOS_PROFILING";
+constexpr const std::string_view DEBUG = "TPETRA_DEBUG";
+constexpr const std::string_view VERBOSE = "TPETRA_VERBOSE";
+constexpr const std::string_view TIMING = "TPETRA_TIMING";
+constexpr const std::string_view HIERARCHICAL_UNPACK =
+    "TPETRA_HIERARCHICAL_UNPACK";
+constexpr const std::string_view SKIP_COPY_AND_PERMUTE =
+    "TPETRA_SKIP_COPY_AND_PERMUTE";
+constexpr const std::string_view OVERLAP = "TPETRA_OVERLAP";
+constexpr const std::string_view SPACES_ID_WARN_LIMIT =
+    "TPETRA_SPACES_ID_WARN_LIMIT";
+constexpr const std::string_view TIME_KOKKOS_DEEP_COPY =
+    "TPETRA_TIME_KOKKOS_DEEP_COPY";
+constexpr const std::string_view TIME_KOKKOS_DEEP_COPY_VERBOSE1 =
+    "TPETRA_TIME_KOKKOS_DEEP_COPY_VERBOSE1";
+constexpr const std::string_view TIME_KOKKOS_DEEP_COPY_VERBOSE2 =
+    "TPETRA_TIME_KOKKOS_DEEP_COPY_VERBOSE2";
+constexpr const std::string_view TIME_KOKKOS_FENCE = "TPETRA_TIME_KOKKOS_FENCE";
+constexpr const std::string_view TIME_KOKKOS_FUNCTIONS =
+    "TPETRA_TIME_KOKKOS_FUNCTIONS";
+
+// clang-format off
 std::map<std::string, std::map<std::string, bool> > namedVariableMap_;
 bool verboseDisabled_ = false;
 bool timingDisabled_ = false;
@@ -163,74 +244,6 @@ namespace { // (anonymous)
   }
 
   bool
-  getEnvironmentVariableAsBool (const char environmentVariableName[],
-                                const bool defaultValue)
-  {
-    const char* varVal = std::getenv (environmentVariableName);
-
-    bool retVal = defaultValue;
-    if (varVal != nullptr) {
-      auto state = environmentVariableState(std::string(varVal));
-      if (state == EnvironmentVariableIsSet_ON) retVal = true;
-      else if (state == EnvironmentVariableIsSet_OFF) retVal = false;
-    }
-    return retVal;
-  }
-
-  size_t
-  getEnvironmentVariableAsSize(const char environmentVariableName[],
-                               const size_t defaultValue)
-  {
-    const char prefix[] = "Tpetra::Details::Behavior: ";
-
-    const char* varVal = std::getenv(environmentVariableName);
-    if (varVal == nullptr) {
-      return defaultValue;
-    }
-    else {
-      // This could throw invalid_argument or out_of_range.
-      // Go ahead and let it do so.
-      long long val = std::stoll(stringToUpper(varVal));
-      if (val < static_cast<long long>(0)) {
-        // If negative - user has requested threshold be lifted
-        return std::numeric_limits<size_t>::max();
-      }
-//      TEUCHOS_TEST_FOR_EXCEPTION
-//        (val < static_cast<long long>(0), std::out_of_range,
-//         prefix << "Environment variable \""
-//         << environmentVariableName << "\" is supposed to be a size, "
-//         "but it has a negative integer value " << val << ".");
-      if (sizeof(long long) > sizeof(size_t)) {
-        // It's hard to test this code, but I want to try writing it
-        // at least, in case we ever have to run on 32-bit machines or
-        // machines with sizeof(long long)=16 and sizeof(size_t)=8.
-        constexpr long long maxSizeT =
-          static_cast<long long>(std::numeric_limits<size_t>::max());
-        TEUCHOS_TEST_FOR_EXCEPTION
-          (val > maxSizeT, std::out_of_range, prefix << "Environment "
-           "variable \"" << environmentVariableName << "\" has a "
-           "value " << val << " larger than the largest size_t value "
-           << maxSizeT << ".");
-      }
-      return static_cast<size_t>(val);
-    }
-  }
-
-  bool
-  idempotentlyGetEnvironmentVariableAsBool (bool& value,
-                                            bool& initialized,
-                                            const char environmentVariableName[],
-                                            const bool defaultValue)
-  {
-    if (! initialized) {
-      value = getEnvironmentVariableAsBool (environmentVariableName,
-                                            defaultValue);
-      initialized = true;
-    }
-    return value;
-  }
-
-  bool
   idempotentlyGetNamedEnvironmentVariableAsBool (const char name[],
                                                  bool& initialized,
                                                  const char environmentVariableName[],
@@ -249,22 +262,103 @@ namespace { // (anonymous)
       return thisEnvironmentVariable->second;
     return thisEnvironmentVariableMap["DEFAULT"];
   }
+// clang-format on
 
-  size_t
-  idempotentlyGetEnvironmentVariableAsSize
-    (size_t& value,
-     bool& initialized,
-     const char environmentVariableName[],
-     const size_t defaultValue)
-  {
-    if (! initialized) {
-      value = getEnvironmentVariableAsSize(environmentVariableName,
-                                           defaultValue);
-      initialized = true;
-    }
-    return value;
+template <typename T>
+T getEnvironmentVariable(const std::string_view environmentVariableName,
+                         const T defaultValue) {
+  const char prefix[] = "Tpetra::Details::Behavior: ";
+
+  const char *varVal = std::getenv(environmentVariableName.data());
+  if (varVal == nullptr) {
+    return defaultValue;
+  } else {
+    std::stringstream ss(varVal);
+    T parsed;
+    ss >> parsed;
+
+    TEUCHOS_TEST_FOR_EXCEPTION(!ss, std::out_of_range,
+                               prefix << "Environment "
+                                         "variable \""
+                                      << environmentVariableName
+                                      << "\" has a "
+                                         "value "
+                                      << varVal
+                                      << " that cannot be parsed as a "
+                                      << typeid(T).name() << ".");
+
+    return parsed;
   }
+}
 
+// full specialization of bool to preserve historical Tpetra parsing behavior
+template <>
+bool getEnvironmentVariable<bool>(
+    const std::string_view environmentVariableName, const bool defaultValue) {
+  const char *varVal = std::getenv(environmentVariableName.data());
+  bool retVal = defaultValue;
+  if (varVal != nullptr) {
+    auto state = environmentVariableState(std::string(varVal));
+    if (state == EnvironmentVariableIsSet_ON)
+      retVal = true;
+    else if (state == EnvironmentVariableIsSet_OFF)
+      retVal = false;
+  }
+  return retVal;
+}
+
+/*! full specialization of size_t to preserve historical Tpetra parsing behavior
+
+Parse it as a long long. If negative, return max size_t.
+Else, return cast to size_t
+*/
+template <>
+size_t
+getEnvironmentVariable<size_t>(const std::string_view environmentVariableName,
+                               const size_t defaultValue) {
+  const char prefix[] = "Tpetra::Details::Behavior: ";
+
+  const char *varVal = std::getenv(environmentVariableName.data());
+  if (varVal == nullptr) {
+    return defaultValue;
+  } else {
+    long long val = std::stoll(stringToUpper(varVal));
+    if (val < static_cast<long long>(0)) {
+      // If negative - user has requested threshold be lifted
+      return std::numeric_limits<size_t>::max();
+    }
+    if (sizeof(long long) > sizeof(size_t)) {
+      // It's hard to test this code, but I want to try writing it
+      // at least, in case we ever have to run on 32-bit machines or
+      // machines with sizeof(long long)=16 and sizeof(size_t)=8.
+      constexpr long long maxSizeT =
+          static_cast<long long>(std::numeric_limits<size_t>::max());
+      TEUCHOS_TEST_FOR_EXCEPTION(
+          val > maxSizeT, std::out_of_range,
+          prefix << "Environment "
+                    "variable \""
+                 << environmentVariableName
+                 << "\" has a "
+                    "value "
+                 << val << " larger than the largest size_t value " << maxSizeT
+                 << ".");
+    }
+    return static_cast<size_t>(val);
+  }
+}
+
+template <typename T>
+T idempotentlyGetEnvironmentVariable(
+    T &value, bool &initialized, const std::string_view environmentVariableName,
+    const T defaultValue) {
+  if (!initialized) {
+    value = getEnvironmentVariable<T>(environmentVariableName, defaultValue);
+    initialized = true;
+  }
+  return value;
+}
+
+// clang-format off
   constexpr bool debugDefault () {
 #ifdef HAVE_TPETRA_DEBUG
     return true;
@@ -298,350 +392,286 @@ namespace { // (anonymous)
   }
 
 } // namespace (anonymous)
+// clang-format on
 
-bool Behavior::debug ()
-{
-  constexpr char envVarName[] = "TPETRA_DEBUG";
-  constexpr bool defaultValue = debugDefault ();
-
-  static bool value_ = defaultValue;
-  static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool (value_,
-                                                   initialized_,
-                                                   envVarName,
-                                                   defaultValue);
-}
-
-bool Behavior::verbose ()
-{
-  if (BehaviorDetails::verboseDisabled_) return false;
-
-  constexpr char envVarName[] = "TPETRA_VERBOSE";
-  constexpr bool defaultValue = verboseDefault ();
+bool Behavior::debug() {
+  constexpr bool defaultValue = debugDefault();
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool (value_,
-                                                   initialized_,
-                                                   envVarName,
-                                                   defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::DEBUG, defaultValue);
 }
 
-bool Behavior::timing ()
-{
-  if (BehaviorDetails::timingDisabled_) return false;
+bool Behavior::verbose() {
+  if (BehaviorDetails::verboseDisabled_)
+    return false;
 
-  constexpr char envVarName[] = "TPETRA_TIMING";
-  constexpr bool defaultValue = timingDefault ();
+  constexpr bool defaultValue = verboseDefault();
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool (value_,
-                                                   initialized_,
-                                                   envVarName,
-                                                   defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::VERBOSE, defaultValue);
 }
 
-bool Behavior::assumeMpiIsGPUAware ()
-{
-  constexpr char envVarName[] = "TPETRA_ASSUME_GPU_AWARE_MPI";
-  constexpr bool defaultValue = assumeMpiIsGPUAwareDefault ();
+bool Behavior::timing() {
+  if (BehaviorDetails::timingDisabled_)
+    return false;
+
+  constexpr bool defaultValue = timingDefault();
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool (value_,
-                                                   initialized_,
-                                                   envVarName,
-                                                   defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::TIMING, defaultValue);
 }
 
-bool Behavior::cudaLaunchBlocking ()
-{
-  constexpr char envVarName[] = "CUDA_LAUNCH_BLOCKING";
-  constexpr bool defaultValue = cudaLaunchBlockingDefault ();
+bool Behavior::assumeMpiIsGPUAware() {
+  constexpr bool defaultValue = assumeMpiIsGPUAwareDefault();
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool (value_,
-                                                   initialized_,
-                                                   envVarName,
-                                                   defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::ASSUME_GPU_AWARE_MPI,
+      defaultValue);
 }
 
-int Behavior::TAFC_OptimizationCoreCount ()
-{
-    // only call getenv once, save the value.
-    static int savedval=-1;
-    if(savedval!=-1) return savedval;
-    const char* varVal = std::getenv ("MM_TAFC_OptimizationCoreCount");
-    if (varVal == nullptr) {
-        savedval = 3000;
-        return savedval;
-    }
-    savedval = std::stoi(std::string(varVal));
-    return savedval;
+bool Behavior::cudaLaunchBlocking() {
+  constexpr bool defaultValue = cudaLaunchBlockingDefault();
+
+  static bool value_ = defaultValue;
+  static bool initialized_ = false;
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::CUDA_LAUNCH_BLOCKING,
+      defaultValue);
 }
 
-size_t Behavior::verbosePrintCountThreshold ()
-{
-  constexpr char envVarName[] = "TPETRA_VERBOSE_PRINT_COUNT_THRESHOLD";
-  constexpr size_t defaultValue (200);
+int Behavior::TAFC_OptimizationCoreCount() {
+  constexpr int _default = 3000;
+  static int value_ = _default;
+  static bool initialized_ = false;
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::MM_TAFC_OptimizationCoreCount,
+      _default);
+}
+
+size_t Behavior::verbosePrintCountThreshold() {
+  constexpr size_t defaultValue(200);
 
   static size_t value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsSize
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::VERBOSE_PRINT_COUNT_THRESHOLD,
+      defaultValue);
 }
 
-size_t Behavior::rowImbalanceThreshold ()
-{
-  constexpr char envVarName[] = "TPETRA_ROW_IMBALANCE_THRESHOLD";
-  constexpr size_t defaultValue (256);
+size_t Behavior::rowImbalanceThreshold() {
+  constexpr size_t defaultValue(256);
 
   static size_t value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsSize
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::ROW_IMBALANCE_THRESHOLD,
+      defaultValue);
 }
 
-bool Behavior::useMergePathMultiVector()
-{
-  constexpr char envVarName[] = "TPETRA_MULTIVECTOR_USE_MERGE_PATH";
+bool Behavior::useMergePathMultiVector() {
   constexpr bool defaultValue = false;
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::MULTIVECTOR_USE_MERGE_PATH,
+      defaultValue);
 }
 
-  size_t Behavior::multivectorKernelLocationThreshold ()
-{
-  constexpr char envVarName[] = "TPETRA_VECTOR_DEVICE_THRESHOLD";
-  constexpr size_t defaultValue (22000);
+size_t Behavior::multivectorKernelLocationThreshold() {
+  constexpr size_t defaultValue(22000);
 
   static size_t value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsSize
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::VECTOR_DEVICE_THRESHOLD,
+      defaultValue);
 }
 
-size_t Behavior::hierarchicalUnpackBatchSize ()
-{
-  constexpr char envVarName[] = "TPETRA_HIERARCHICAL_UNPACK_BATCH_SIZE";
+size_t Behavior::hierarchicalUnpackBatchSize() {
 
 #ifdef HAVE_TPETRA_INST_CUDA
-  constexpr size_t defaultValue (16);
+  constexpr size_t defaultValue(16);
 #else
-  constexpr size_t defaultValue (256);
+  constexpr size_t defaultValue(256);
 #endif
 
   static size_t value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsSize
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::HIERARCHICAL_UNPACK_BATCH_SIZE,
+      defaultValue);
 }
 
-size_t Behavior::hierarchicalUnpackTeamSize ()
-{
-  constexpr char envVarName[] = "TPETRA_HIERARCHICAL_UNPACK_TEAM_SIZE";
+size_t Behavior::hierarchicalUnpackTeamSize() {
 #ifdef HAVE_TPETRA_INST_CUDA
-  const size_t defaultValue (16);
+  const size_t defaultValue(16);
 #else
-  const size_t defaultValue (Teuchos::OrdinalTraits<size_t>::invalid ());
+  const size_t defaultValue(Teuchos::OrdinalTraits<size_t>::invalid());
 #endif
 
   static size_t value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsSize
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::HIERARCHICAL_UNPACK_TEAM_SIZE,
+      defaultValue);
 }
 
-bool Behavior::profilingRegionUseTeuchosTimers ()
-{
-  constexpr char envVarName[] = "TPETRA_USE_TEUCHOS_TIMERS";
+bool Behavior::profilingRegionUseTeuchosTimers() {
   constexpr bool defaultValue(false);
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::USE_TEUCHOS_TIMERS, defaultValue);
 }
 
-bool Behavior::profilingRegionUseKokkosProfiling ()
-{
-  constexpr char envVarName[] = "TPETRA_USE_KOKKOS_PROFILING";
+bool Behavior::profilingRegionUseKokkosProfiling() {
   constexpr bool defaultValue(false);
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::USE_KOKKOS_PROFILING,
+      defaultValue);
 }
 
-
-bool Behavior::debug (const char name[])
-{
-  constexpr char envVarName[] = "TPETRA_DEBUG";
+bool Behavior::debug(const char name[]) {
   constexpr bool defaultValue = false;
 
   static bool initialized_ = false;
-  return idempotentlyGetNamedEnvironmentVariableAsBool (name,
-                                                        initialized_,
-                                                        envVarName,
-                                                        defaultValue);
+  return idempotentlyGetNamedEnvironmentVariableAsBool(
+      name, initialized_, BehaviorDetails::DEBUG.data(), defaultValue);
 }
 
-bool Behavior::verbose (const char name[])
-{
-  if (BehaviorDetails::verboseDisabled_) return false;
+bool Behavior::verbose(const char name[]) {
+  if (BehaviorDetails::verboseDisabled_)
+    return false;
 
-  constexpr char envVarName[] = "TPETRA_VERBOSE";
   constexpr bool defaultValue = false;
 
   static bool initialized_ = false;
-  return idempotentlyGetNamedEnvironmentVariableAsBool (name,
-                                                        initialized_,
-                                                        envVarName,
-                                                        defaultValue);
+  return idempotentlyGetNamedEnvironmentVariableAsBool(
+      name, initialized_, BehaviorDetails::VERBOSE.data(), defaultValue);
 }
 
-void Behavior::enable_verbose_behavior () {
+void Behavior::enable_verbose_behavior() {
   BehaviorDetails::verboseDisabled_ = false;
 }
 
-void Behavior::disable_verbose_behavior () {
+void Behavior::disable_verbose_behavior() {
   BehaviorDetails::verboseDisabled_ = true;
 }
 
-bool Behavior::timing (const char name[])
-{
-  if (BehaviorDetails::timingDisabled_) return false;
+bool Behavior::timing(const char name[]) {
+  if (BehaviorDetails::timingDisabled_)
+    return false;
 
-  constexpr char envVarName[] = "TPETRA_TIMING";
   constexpr bool defaultValue = false;
 
   static bool initialized_ = false;
-  return idempotentlyGetNamedEnvironmentVariableAsBool (name,
-                                                        initialized_,
-                                                        envVarName,
-                                                        defaultValue);
+  return idempotentlyGetNamedEnvironmentVariableAsBool(
+      name, initialized_, BehaviorDetails::TIMING.data(), defaultValue);
 }
 
-void Behavior::enable_timing() {
-  BehaviorDetails::timingDisabled_ = false;
-}
+void Behavior::enable_timing() { BehaviorDetails::timingDisabled_ = false; }
 
-void Behavior::disable_timing() {
-  BehaviorDetails::timingDisabled_ = true;
-}
+void Behavior::disable_timing() { BehaviorDetails::timingDisabled_ = true; }
 
-bool Behavior::hierarchicalUnpack ()
-{
-  constexpr char envVarName[] = "TPETRA_HIERARCHICAL_UNPACK";
+bool Behavior::hierarchicalUnpack() {
   constexpr bool defaultValue = hierarchicalUnpackDefault();
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool (value_,
-                                                   initialized_,
-                                                   envVarName,
-                                                   defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::HIERARCHICAL_UNPACK, defaultValue);
 }
 
-bool Behavior::skipCopyAndPermuteIfPossible ()
-{
-  constexpr char envVarName[] = "TPETRA_SKIP_COPY_AND_PERMUTE";
+bool Behavior::skipCopyAndPermuteIfPossible() {
   constexpr bool defaultValue(false);
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::SKIP_COPY_AND_PERMUTE,
+      defaultValue);
 }
 
-bool Behavior::overlapCommunicationAndComputation ()
-{
-  constexpr char envVarName[] = "TPETRA_OVERLAP";
+bool Behavior::overlapCommunicationAndComputation() {
   constexpr bool defaultValue(false);
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::OVERLAP, defaultValue);
 }
 
-size_t Behavior::spacesIdWarnLimit ()
-{
-  constexpr char envVarName[] = "TPETRA_SPACES_ID_WARN_LIMIT";
+size_t Behavior::spacesIdWarnLimit() {
   constexpr size_t defaultValue(16);
 
   static size_t value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsSize
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::SPACES_ID_WARN_LIMIT,
+      defaultValue);
 }
 
-bool Behavior::timeKokkosDeepCopy() 
-{
-  constexpr char envVarName[] = "TPETRA_TIME_KOKKOS_DEEP_COPY";
+bool Behavior::timeKokkosDeepCopy() {
   constexpr bool defaultValue(false);
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::TIME_KOKKOS_DEEP_COPY,
+      defaultValue);
+}
 
-}    
-
-bool Behavior::timeKokkosDeepCopyVerbose1() 
-{
-  constexpr char envVarName[] = "TPETRA_TIME_KOKKOS_DEEP_COPY_VERBOSE1";
+bool Behavior::timeKokkosDeepCopyVerbose1() {
   constexpr bool defaultValue(false);
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::TIME_KOKKOS_DEEP_COPY_VERBOSE1,
+      defaultValue);
+}
 
-}    
-
-bool Behavior::timeKokkosDeepCopyVerbose2() 
-{
-  constexpr char envVarName[] = "TPETRA_TIME_KOKKOS_DEEP_COPY_VERBOSE2";
+bool Behavior::timeKokkosDeepCopyVerbose2() {
   constexpr bool defaultValue(false);
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::TIME_KOKKOS_DEEP_COPY_VERBOSE2,
+      defaultValue);
+}
 
-}    
-
-bool Behavior::timeKokkosFence() 
-{
-  constexpr char envVarName[] = "TPETRA_TIME_KOKKOS_FENCE";
+bool Behavior::timeKokkosFence() {
   constexpr bool defaultValue(false);
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool
-    (value_, initialized_, envVarName, defaultValue);
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::TIME_KOKKOS_FENCE, defaultValue);
+}
 
-}  
-
-bool Behavior::timeKokkosFunctions() 
-{
-  constexpr char envVarName[] = "TPETRA_TIME_KOKKOS_FUNCTIONS";
+bool Behavior::timeKokkosFunctions() {
   constexpr bool defaultValue(false);
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool
-    (value_, initialized_, envVarName, defaultValue);
-
-}  
-
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::TIME_KOKKOS_FUNCTIONS,
+      defaultValue);
+}
 
 } // namespace Details
 } // namespace Tpetra


### PR DESCRIPTION
Tpetra "behaviors" are controlled by certain environment variables. If such an environment variable is not present, the default behavior is used.

This can lead to three kinds of problems 
1) a user continues to use a formerly-valid variable after it has been removed (e.g. `TPETRA_ASSUME_CUDA_AWARE_MPI` rather than `TPETRA_ASSUME_GPU_AWARE_MPI`
2) A user typos an environment variable, e.g. `TPETRA_SPACES_ID_WARN_LIMT`
3) Tpetra developers typo an environment variable: https://github.com/trilinos/Trilinos/issues/12648

In all cases, the intended user behavior is silently not respected, since Tpetra is happy to use the defaults without comment.

Ameliorate this problem by searching the environment for any unexpected `TPETRA_`-prefixed variables, and erroring out if they are present.

closes #12651 