### PR TITLE
Build documentation: remove mention of "memkind" as a Kokkos TPL

### DIFF
--- a/doc/build_ref/TrilinosBuildReferenceTemplate.rst
+++ b/doc/build_ref/TrilinosBuildReferenceTemplate.rst
@@ -142,7 +142,6 @@ Advanced options:
 * Enable dualview modify chk    ``KOKKOS_ENABLE_DUALVIEW_MODIFY_CHECK``
 Kokkos TPLs:                 
 * Use hwloc library             ``TPL_ENABLE_HWLOC``
-* Use memkind library           ``KOKKOS_ENABLE_MEMKIND``
 * Use librt                     ``KOKKOS_ENABLE_LIBRT``
 CUDA Options:                
 * Enable CUDA LDG               ``KOKKOS_ENABLE_CUDA_LDG_INTRINSIC`` (global mem load)


### PR DESCRIPTION
@ndellingwood 

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/???

## Motivation
The memkind third-party library was there to support the `Kokkos::Experimental::HBWSpace` exclusively.
It was broken for a long time and has been removed in https://github.com/kokkos/kokkos/pull/6791
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->