### PR TITLE
Zoltan: fix crashes in phg and hierarchical partitioning

### DIFF
--- a/packages/zoltan/src/hier/hier.c
+++ b/packages/zoltan/src/hier/hier.c
@@ -1746,6 +1746,7 @@ int Zoltan_Hier(
       ZOLTAN_FREE(&hpp.adjproc);
       ZOLTAN_FREE(&hpp.geom_vec);
       MPI_Comm_free(&hpp.hier_comm);
+      hpp.hier_comm = MPI_COMM_NULL;
     }
 
     ierr = Zoltan_LB_Free_Part(&hier_import_gids, &hier_import_lids,

--- a/packages/zoltan/src/phg/phg_build_calls.c
+++ b/packages/zoltan/src/phg/phg_build_calls.c
@@ -651,7 +651,7 @@ phg_GID_lookup       *lookup_myHshVtxs = NULL;
         ew_lids = ZOLTAN_MALLOC_LID_ARRAY(zz, myEWs.size);
         myEWs.wgt = (float *)ZOLTAN_MALLOC(myEWs.size * cnt);
 
-        if (!myEWs.edgeGID || !ew_lids || !myEWs.wgt){
+        if (!myEWs.edgeGID || !myEWs.wgt){
           MEMORY_ERROR;
         }
 


### PR DESCRIPTION
@trilinos/zoltan

## Motivation
Addresses issues #12729 and #12730.

## Testing
The fix to #12729 is likely not exercised by tests, as I can't seem to find any that set `NUM_LID_ENTRIES` to zero.

The fix to #12730 should be exercised by existing hierarchical partitioning tests.