### PR TITLE
Panzer improve mass matrix assembly

### DIFF
--- a/packages/panzer/adapters-stk/src/Panzer_STK_LocalMeshUtilities.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_LocalMeshUtilities.cpp
@@ -454,6 +454,8 @@ setupLocalMeshSidesetInfo(const panzer_stk::STK_Interface & mesh,
 Teuchos::RCP<panzer::LocalMeshInfo>
 generateLocalMeshInfo(const panzer_stk::STK_Interface & mesh)
 {
+  TEUCHOS_FUNC_TIME_MONITOR_DIFF("panzer_stk::generateLocalMeshInfo",GenerateLocalMeshInfo);
+
   using Teuchos::RCP;
   using Teuchos::rcp;
 
@@ -473,8 +475,6 @@ generateLocalMeshInfo(const panzer_stk::STK_Interface & mesh)
   TEUCHOS_ASSERT(typeid(panzer::LocalOrdinal) == typeid(int));
 
   Teuchos::RCP<const Teuchos::Comm<int> > comm = mesh.getComm();
-
-  TEUCHOS_FUNC_TIME_MONITOR_DIFF("panzer_stk::generateLocalMeshInfo",GenerateLocalMeshInfo);
 
   // This horrible line of code is required since the connection manager only takes rcps of a mesh
   RCP<const panzer_stk::STK_Interface> mesh_rcp = Teuchos::rcpFromRef(mesh);

--- a/packages/panzer/disc-fe/src/Panzer_BasisDescriptor.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_BasisDescriptor.cpp
@@ -134,6 +134,13 @@ getPointDescriptor() const
   return pd;
 }
 
+bool operator==(const panzer::BasisDescriptor& left,
+                const panzer::BasisDescriptor& right)
+{
+  return ( (left.getType() == right.getType()) &&
+           (left.getOrder() == right.getOrder()) );
+}
+
 } // end namespace panzer
 
 std::size_t

--- a/packages/panzer/disc-fe/src/Panzer_BasisDescriptor.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BasisDescriptor.hpp
@@ -108,6 +108,9 @@ protected:
   std::size_t _key;
 };
 
+bool operator==(const panzer::BasisDescriptor& left,
+                const panzer::BasisDescriptor& right);
+
 } // namespace panzer
 
 namespace std {

--- a/packages/panzer/disc-fe/src/Panzer_BasisDescriptor.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BasisDescriptor.hpp
@@ -66,8 +66,8 @@ public:
 
   /** \brief Constructor for basis description
    *
-   * \param[in] basis_order Basis order (e.g. 1 could be piecewise linear)
-   * \param[in] basis_type Basis type (e.g. HGrad, HDiv, HCurl, ...)
+   * \param[in] basis_order Basis order as defined by Intrepid2 (e.g. 1 could be piecewise linear)
+   * \param[in] basis_type Basis type (a string: "HGrad", "HDiv", "HCurl", or "HVol")
    */
   BasisDescriptor(const int basis_order, const std::string & basis_type);
 
@@ -90,7 +90,6 @@ public:
    */
   std::size_t getKey() const {return _key;}
 
-
   /** \brief Build a point descriptor that builds reference points for
    *  the DOF locations. This method throws if no points exist for this
    *  basis.
@@ -98,9 +97,8 @@ public:
   PointDescriptor getPointDescriptor() const;
 
 protected:
-
  
-  /// Basis type (HGrad, HDiv, HCurl,...)
+  /// Basis type (HGrad, HDiv, HCurl, HVol)
   std::string _basis_type;
 
   // Basis order (>0)
@@ -108,20 +106,16 @@ protected:
 
   // Unique key associated with basis.
   std::size_t _key;
-
 };
 
-}
-
+} // namespace panzer
 
 namespace std {
-
-template <>
-struct hash<panzer::BasisDescriptor>
-{
-  std::size_t operator()(const panzer::BasisDescriptor& desc) const;
-};
-
+  template <>
+  struct hash<panzer::BasisDescriptor>
+  {
+    std::size_t operator()(const panzer::BasisDescriptor& desc) const;
+  };
 }
 
 

--- a/packages/panzer/disc-fe/src/Panzer_BasisValues2.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BasisValues2.hpp
@@ -384,6 +384,9 @@ namespace panzer {
     hasUniformReferenceSpace() const
     {return is_uniform_;}
 
+    /// Return the basis descriptor
+    panzer::BasisDescriptor getBasisDescriptor() const;
+
     /// Get the extended dimensions used by sacado AD allocations
     const std::vector<PHX::index_size_type> &
     getExtendedDimensions() const

--- a/packages/panzer/disc-fe/src/Panzer_BasisValues2_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BasisValues2_impl.hpp
@@ -127,6 +127,7 @@ BasisValues2(const std::string & pre,
     , num_cells_(0)
     , num_evaluate_cells_(0)
     , is_uniform_(false)
+    , num_orientations_cells_(0)
 
 {
   // Default all lazy evaluated components to not-evaluated
@@ -687,6 +688,13 @@ setCellNodeCoordinates(PHX::MDField<Scalar,Cell,NODE,Dim> node_coordinates)
 }
 
 template <typename Scalar>
+panzer::BasisDescriptor BasisValues2<Scalar>::getBasisDescriptor() const
+{
+  auto pure_basis = basis_layout->getBasis();
+  return {pure_basis->order(),pure_basis->type()};
+}
+
+template <typename Scalar>
 void
 BasisValues2<Scalar>::
 resetArrays()
@@ -1201,7 +1209,6 @@ getBasisValues(const bool weighted,
     // should only be reached if non-weighted. This is a by-product of
     // the two construction paths in panzer. Unification should help
     // fix the logic.
-
     if(orientations_.size() > 0)
       applyOrientationsImpl<Scalar>(num_orientations_cells_, tmp_basis_scalar.get_view(), orientations_, *intrepid_basis);
 

--- a/packages/panzer/disc-fe/src/Panzer_BasisValues2_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BasisValues2_impl.hpp
@@ -160,6 +160,7 @@ evaluateValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,
                const PHX::MDField<Scalar,Cell,IP,Dim,Dim> & jac_inv,
                const int in_num_cells)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::evaluateValues(5 arg)",bv_ev_5);
 
   build_weighted = false;
 
@@ -225,6 +226,7 @@ evaluateValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,
                bool use_node_coordinates,
                const int in_num_cells)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::evaluateValues(8 arg, uniform cub pts)",bv_ev_8u);
 
   // This is the base call that will add all the non-weighted versions
   evaluateValues(cub_points, jac, jac_det, jac_inv, in_num_cells);
@@ -278,6 +280,7 @@ evaluateValues(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
                bool use_node_coordinates,
                const int in_num_cells)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::evaluateValues(8 arg,nonuniform cub pts)",bv_ev_8nu);
 
   cell_node_coordinates_ = node_coordinates;
 
@@ -335,11 +338,11 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
                  const PHX::MDField<Scalar,Cell,IP> & jac_det,
                  const PHX::MDField<Scalar,Cell,IP,Dim,Dim> & jac_inv)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::evaluateValuesCV(5 arg)",bv_ev_cv_5);
 
   PHX::MDField<Scalar,Cell,IP> weighted_measure;
   PHX::MDField<Scalar,Cell,NODE,Dim> node_coordinates;
   evaluateValues(cub_points,jac,jac_det,jac_inv,weighted_measure,node_coordinates,false,jac.extent(0));
-
 }
 
 template <typename Scalar>
@@ -352,6 +355,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
                  bool use_node_coordinates,
                  const int in_num_cells)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::evaluateValuesCV(7 arg)",bv_ev_cv_7);
   PHX::MDField<Scalar,Cell,IP> weighted_measure;
   evaluateValues(cell_cub_points,jac,jac_det,jac_inv,weighted_measure,node_coordinates,use_node_coordinates,in_num_cells);
 }
@@ -375,6 +379,8 @@ applyOrientations(const std::vector<Intrepid2::Orientation> & orientations,
 {
   if (!intrepid_basis->requireOrientation())
     return;
+
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::applyOrientations()",bv_ev_app_orts);
 
   // We only allow the orientations to be applied once
   TEUCHOS_ASSERT(not orientations_applied_);
@@ -622,7 +628,6 @@ setup(const Teuchos::RCP<const panzer::BasisIRLayout> & basis,
 
   // Reset internal data
   resetArrays();
-
 }
 
 template <typename Scalar>
@@ -650,7 +655,6 @@ setupUniform(const Teuchos::RCP<const panzer::BasisIRLayout> &  basis,
 
   // Reset internal data
   resetArrays();
-
 }
 
 template <typename Scalar>
@@ -771,6 +775,8 @@ getBasisCoordinatesRef(const bool cache,
   if(basis_coordinates_ref_evaluated_ and not force)
     return basis_coordinates_ref;
 
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::getBasisCoordinatesRef()",bv_get_bc_ref);
+
   MDFieldArrayFactory af(prefix,getExtendedDimensions(),true);
 
   const int num_card  = basis_layout->cardinality();
@@ -796,6 +802,8 @@ getBasisValuesRef(const bool cache,
   // Check if array already exists
   if(basis_ref_scalar_evaluated_ and not force)
     return basis_ref_scalar;
+
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::getBasisValuesRef()",bv_get_bV_ref);
 
   // Reference quantities only exist for a uniform reference space
   TEUCHOS_ASSERT(hasUniformReferenceSpace());
@@ -830,6 +838,8 @@ getVectorBasisValuesRef(const bool cache,
   // Check if array already exists
   if(basis_ref_vector_evaluated_ and not force)
     return basis_ref_vector;
+
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::getVectorBasisValuesRef()",bv_get_vec_bv_ref);
 
   // Reference quantities only exist for a uniform reference space
   TEUCHOS_ASSERT(hasUniformReferenceSpace());
@@ -866,6 +876,8 @@ getGradBasisValuesRef(const bool cache,
   if(grad_basis_ref_evaluated_ and not force)
     return grad_basis_ref;
 
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::getGradBasisValuesRef()",bv_get_grad_bv_ref);
+
   // Reference quantities only exist for a uniform reference space
   TEUCHOS_ASSERT(hasUniformReferenceSpace());
 
@@ -901,6 +913,8 @@ getCurl2DVectorBasisRef(const bool cache,
   if(curl_basis_ref_scalar_evaluated_ and not force)
     return curl_basis_ref_scalar;
 
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::getCurl2DVectorBasisRef()",bv_get_curl2_bv_ref);
+
   // Reference quantities only exist for a uniform reference space
   TEUCHOS_ASSERT(hasUniformReferenceSpace());
   TEUCHOS_ASSERT(basis_layout->dimension() == 2);
@@ -935,6 +949,8 @@ getCurlVectorBasisRef(const bool cache,
   // Check if array already exists
   if(curl_basis_ref_vector_evaluated_ and not force)
     return curl_basis_ref_vector;
+
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::getCurlVectorBasisRef()",bv_get_curl_vec_bv_ref);
 
   // Reference quantities only exist for a uniform reference space
   TEUCHOS_ASSERT(hasUniformReferenceSpace());
@@ -972,6 +988,8 @@ getDivVectorBasisRef(const bool cache,
   if(div_basis_ref_evaluated_ and not force)
     return div_basis_ref;
 
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::getDivVectorBasisRef()",bv_get_div_vec_bv_ref);
+
   // Reference quantities only exist for a uniform reference space
   TEUCHOS_ASSERT(hasUniformReferenceSpace());
 
@@ -1002,6 +1020,8 @@ BasisValues2<Scalar>::
 getBasisCoordinates(const bool cache,
                     const bool force) const
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::getBasisCoordinates()",bv_get_bc);
+
   // Check if array already exists
   if(basis_coordinates_evaluated_ and not force)
     return basis_coordinates;
@@ -1046,6 +1066,8 @@ getBasisValues(const bool weighted,
   } else
     if(basis_scalar_evaluated_ and not force)
       return basis_scalar;
+
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::getBasisValues()",bv_get_bv);
 
   MDFieldArrayFactory af(prefix,getExtendedDimensions(),true);
 
@@ -1205,6 +1227,8 @@ getVectorBasisValues(const bool weighted,
   } else
     if(basis_vector_evaluated_ and not force)
       return basis_vector;
+
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::getVectorBasisValues()",bv_get_vec_bv);
 
   MDFieldArrayFactory af(prefix,getExtendedDimensions(),true);
 
@@ -1389,6 +1413,8 @@ getGradBasisValues(const bool weighted,
     if(grad_basis_evaluated_ and not force)
       return grad_basis;
 
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::getGradBasisValues()",bv_get_grad_bv);
+
   MDFieldArrayFactory af(prefix,getExtendedDimensions(),true);
 
   const int num_cells  = num_cells_;
@@ -1536,6 +1562,8 @@ getCurl2DVectorBasis(const bool weighted,
     if(curl_basis_scalar_evaluated_ and not force)
       return curl_basis_scalar;
 
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::getCurl2DVectorBasis()",bv_get_curl2d_vec_bv);
+
   MDFieldArrayFactory af(prefix,getExtendedDimensions(),true);
 
   const int num_cells  = num_cells_;
@@ -1680,6 +1708,8 @@ getCurlVectorBasis(const bool weighted,
   } else
     if(curl_basis_vector_evaluated_ and not force)
       return curl_basis_vector;
+
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::getCurlVectorBasis()",bv_get_curl_vec_bv);
 
   MDFieldArrayFactory af(prefix,getExtendedDimensions(),true);
 
@@ -1828,6 +1858,8 @@ getDivVectorBasis(const bool weighted,
   } else
     if(div_basis_evaluated_ and not force)
       return div_basis;
+
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::basisValues2::getDevVectorBasis()",bv_get_div_vec_bv);
 
   MDFieldArrayFactory af(prefix,getExtendedDimensions(),true);
 

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
@@ -102,6 +102,7 @@ correctVirtualNormals(PHX::MDField<Scalar,Cell,IP,Dim> normals,
                       const shards::CellTopology & cell_topology,
                       const SubcellConnectivity & face_connectivity)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::correctVirtualNormals()",corr_virt_norms);
 
   // What we want is for the adjoining face of the virtual cell to have normals that are the negated real cell's normals.
   // we correct the normals here:
@@ -169,6 +170,7 @@ correctVirtualRotationMatrices(PHX::MDField<Scalar,Cell,IP,Dim,Dim> rotation_mat
                                const shards::CellTopology & cell_topology,
                                const SubcellConnectivity & face_connectivity)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::correctVirtualRotationMatrices()",corr_virt_rotmat);
 
   // What we want is for the adjoining face of the virtual cell to have normals that are the negated real cell's normals.
   // we correct the normals here:
@@ -216,6 +218,7 @@ void
 applyBasePermutation(PHX::MDField<Scalar,IP> field,
                      PHX::MDField<const int,Cell,IP> permutations)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::applyBasePermutation(rank 1)",app_base_perm_r1);
   MDFieldArrayFactory af("",true);
 
   const int num_ip = field.extent(0);
@@ -235,6 +238,7 @@ void
 applyBasePermutation(PHX::MDField<Scalar,IP,Dim> field,
                      PHX::MDField<const int,Cell,IP> permutations)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::applyBasePermutation(rank 2)",app_base_perm_r2);
   MDFieldArrayFactory af("",true);
 
   const int num_ip = field.extent(0);
@@ -256,6 +260,7 @@ void
 applyPermutation(PHX::MDField<Scalar,Cell,IP> field,
                  PHX::MDField<const int,Cell,IP> permutations)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::applyPermutation(rank 2)",app_perm_r2);
   MDFieldArrayFactory af("",true);
 
   const int num_cells = field.extent(0);
@@ -276,6 +281,7 @@ void
 applyPermutation(PHX::MDField<Scalar,Cell,IP,Dim> field,
                  PHX::MDField<const int,Cell,IP> permutations)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::applyPermutation(rank 3)",app_perm_r3);
   MDFieldArrayFactory af("",true);
 
   const int num_cells = field.extent(0);
@@ -298,6 +304,7 @@ void
 applyPermutation(PHX::MDField<Scalar,Cell,IP,Dim,Dim> field,
                  PHX::MDField<const int,Cell,IP> permutations)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::applyPermutation(rank 4)",app_perm_r4);
   MDFieldArrayFactory af("",true);
 
   const int num_cells = field.extent(0);
@@ -327,6 +334,8 @@ generatePermutations(const int num_cells,
                      PHX::MDField<const Scalar,Cell,IP,Dim> coords,
                      PHX::MDField<const Scalar,Cell,IP,Dim> other_coords)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::generatePermutations()",gen_perms);
+
   const int num_ip = coords.extent(1);
   const int num_dim = coords.extent(2);
 
@@ -380,6 +389,7 @@ generateSurfacePermutations(const int num_cells,
                             PHX::MDField<const Scalar,Cell,IP,Dim,Dim> surface_rotation_matrices)
 
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::generateSurfacePermutations()",gen_surf_perms);
 
   // The challenge for this call is handling wedge-based periodic boundaries
   // We need to make sure that we can align points along faces that are rotated with respect to one another.
@@ -565,10 +575,9 @@ generateSurfacePermutations(const int num_cells,
 #undef PANZER_CROSS
 
   return permutation;
-
 }
 
-}
+} // end anonymous namespace
 
 //template<typename DataType>
 //using UnmanagedDynRankView = Kokkos::DynRankView<DataType,typename PHX::DevLayout<DataType>::type,PHX::Device,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
@@ -617,6 +626,8 @@ template <typename Scalar>
 void IntegrationValues2<Scalar>::
 setupArrays(const Teuchos::RCP<const panzer::IntegrationRule>& ir)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::setupArrays()",setup_arrays);
+
   MDFieldArrayFactory af(prefix_,alloc_arrays_);
 
   typedef panzer::IntegrationDescriptor ID;
@@ -668,7 +679,6 @@ setupArrays(const Teuchos::RCP<const panzer::IntegrationRule>& ir)
   surface_normals = af.template buildStaticArray<Scalar,Cell,IP,Dim>("surface_normals",num_cells, num_ip,num_space_dim);
 
   surface_rotation_matrices = af.template buildStaticArray<Scalar,Cell,IP,Dim,Dim>("surface_rotation_matrices",num_cells, num_ip,3,3);
-
 }
 
 
@@ -682,6 +692,7 @@ evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates,
                const Teuchos::RCP<const SubcellConnectivity> & face_connectivity,
                const int num_virtual_cells)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::evaluateValues(with virtual cells)",eval_vals_with_virts);
 
   setup(int_rule, in_node_coordinates, in_num_cells);
 
@@ -692,7 +703,6 @@ evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim> & in_node_coordinates,
 
   // Evaluate everything once permutations are generated
   evaluateEverything();
-
 }
 
 template <typename Scalar>
@@ -702,6 +712,7 @@ evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
                const PHX::MDField<Scalar,Cell,IP,Dim>& other_ip_coordinates,
                const int in_num_cells)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::evaluateValues(no virtual cells)",eval_vals_no_virts);
 
   setup(int_rule, in_node_coordinates, in_num_cells);
 
@@ -710,7 +721,6 @@ evaluateValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_coordinates,
 
   // Evaluate everything once permutations are generated
   evaluateEverything();
-
 }
 
 template <typename Scalar>
@@ -719,6 +729,8 @@ IntegrationValues2<Scalar>::
 setupPermutations(const Teuchos::RCP<const SubcellConnectivity> & face_connectivity,
                   const int num_virtual_cells)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::setupPermutations(connectivity)",setup_perms_conn);
+
   TEUCHOS_ASSERT(not int_rule->isSide());
   TEUCHOS_ASSERT(face_connectivity != Teuchos::null);
   TEUCHOS_TEST_FOR_EXCEPT_MSG(int_rule->getType() != panzer::IntegrationDescriptor::SURFACE,
@@ -738,6 +750,7 @@ void
 IntegrationValues2<Scalar>::
 setupPermutations(const PHX::MDField<Scalar,Cell,IP,Dim> & other_ip_coordinates)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::setupPermutations(other_coords)",setup_perms_coords);
   resetArrays();
   requires_permutation_ = false;
   permutations_ = generatePermutations<Scalar>(num_evaluate_cells_, getCubaturePoints(false,true), other_ip_coordinates);
@@ -752,6 +765,7 @@ setup(const Teuchos::RCP<const panzer::IntegrationRule>& ir,
       const PHX::MDField<Scalar,Cell,NODE,Dim> & cell_node_coordinates,
       const int num_cells)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::setup()",setup);
 
   // Clear arrays just in case we are rebuilding this object
   resetArrays();
@@ -789,9 +803,11 @@ getUniformCubaturePointsRef(const bool cache,
                             const bool force,
                             const bool apply_permutation) const
 {
-
   if(cub_points_evaluated_ and not force)
     return cub_points;
+
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getUniformCubaturePointsRef()",get_uniform_cub_pts_ref);
 
   Intrepid2::CellTools<PHX::Device::execution_space> cell_tools;
   MDFieldArrayFactory af(prefix_,true);
@@ -845,9 +861,11 @@ getUniformSideCubaturePointsRef(const bool cache,
                                 const bool force,
                                 const bool apply_permutation) const
 {
-
   if(side_cub_points_evaluated_ and not force)
     return side_cub_points;
+
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getUniformSideCubaturePointsRef()",get_uniform_side_cub_pts_ref);
 
   MDFieldArrayFactory af(prefix_,true);
 
@@ -895,9 +913,11 @@ getUniformCubatureWeightsRef(const bool cache,
                              const bool force,
                              const bool apply_permutation) const
 {
-
   if(cub_weights_evaluated_ and not force)
     return cub_weights;
+
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getUniformCubatureWeightRef()",get_uniform_cub_weights_ref);
 
   MDFieldArrayFactory af(prefix_,true);
 
@@ -953,6 +973,9 @@ getJacobian(const bool cache,
   if(jac_evaluated_ and not force)
     return jac;
 
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getJacobian()",get_jacobian);
+
   Intrepid2::CellTools<PHX::Device::execution_space> cell_tools;
   MDFieldArrayFactory af(prefix_,true);
 
@@ -980,7 +1003,6 @@ getJacobian(const bool cache,
   }
 
   return aux;
-
 }
 
 template <typename Scalar>
@@ -989,9 +1011,11 @@ IntegrationValues2<Scalar>::
 getJacobianInverse(const bool cache,
                    const bool force) const
 {
-
   if(jac_inv_evaluated_ and not force)
     return jac_inv;
+
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getJacobianInverse()",get_jacobian_inv);
 
   Intrepid2::CellTools<PHX::Device::execution_space> cell_tools;
   MDFieldArrayFactory af(prefix_,true);
@@ -1016,7 +1040,6 @@ getJacobianInverse(const bool cache,
   }
 
   return aux;
-
 }
 
 template <typename Scalar>
@@ -1025,9 +1048,11 @@ IntegrationValues2<Scalar>::
 getJacobianDeterminant(const bool cache,
                        const bool force) const
 {
-
   if(jac_det_evaluated_ and not force)
     return jac_det;
+
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getJacobianDeterminant()",get_jacobian_det);
 
   Intrepid2::CellTools<PHX::Device::execution_space> cell_tools;
   MDFieldArrayFactory af(prefix_,true);
@@ -1051,7 +1076,6 @@ getJacobianDeterminant(const bool cache,
   }
 
   return aux;
-
 }
 
 template <typename Scalar>
@@ -1060,9 +1084,11 @@ IntegrationValues2<Scalar>::
 getWeightedMeasure(const bool cache,
                    const bool force) const
 {
-
   if(weighted_measure_evaluated_ and not force)
     return weighted_measure;
+
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getWeightedMeasure()",get_wt_meas);
 
   MDFieldArrayFactory af(prefix_,true);
 
@@ -1218,7 +1244,6 @@ getWeightedMeasure(const bool cache,
   }
 
   return aux;
-
 }
 
 template <typename Scalar>
@@ -1227,9 +1252,11 @@ IntegrationValues2<Scalar>::
 getWeightedNormals(const bool cache,
                    const bool force) const
 {
-
   if(weighted_normals_evaluated_ and not force)
     return weighted_normals;
+
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getWeightedNormals()",get_wt_normals);
 
   MDFieldArrayFactory af(prefix_,true);
 
@@ -1264,7 +1291,6 @@ getWeightedNormals(const bool cache,
   }
 
   return aux;
-
 }
 
 template <typename Scalar>
@@ -1273,9 +1299,11 @@ IntegrationValues2<Scalar>::
 getSurfaceNormals(const bool cache,
                   const bool force) const
 {
-
   if(surface_normals_evaluated_ and not force)
     return surface_normals;
+
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getSurfaceNormals()",get_surf_normals);
 
   TEUCHOS_TEST_FOR_EXCEPT_MSG(int_rule->isSide(),
                               "IntegrationValues2::getSurfaceNormals : This call doesn't work with sides (only surfaces).");
@@ -1389,9 +1417,11 @@ IntegrationValues2<Scalar>::
 getSurfaceRotationMatrices(const bool cache,
                            const bool force) const
 {
-
   if(surface_rotation_matrices_evaluated_ and not force)
     return surface_rotation_matrices;
+
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getSurfaceRotationMatrices()",get_surf_rot_mat);
 
   MDFieldArrayFactory af(prefix_,true);
 
@@ -1448,9 +1478,11 @@ IntegrationValues2<Scalar>::
 getCovarientMatrix(const bool cache,
                    const bool force) const
 {
-
   if(covarient_evaluated_ and not force)
     return covarient;
+
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getCovariantMatrix()",get_cov_mat);
 
   MDFieldArrayFactory af(prefix_,true);
 
@@ -1480,7 +1512,6 @@ getCovarientMatrix(const bool cache,
   }
 
   return aux;
-
 }
 
 template <typename Scalar>
@@ -1489,9 +1520,11 @@ IntegrationValues2<Scalar>::
 getContravarientMatrix(const bool cache,
                        const bool force) const
 {
-
   if(contravarient_evaluated_ and not force)
     return contravarient;
+
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getContravarientMatrix()",get_contra_mat);
 
   MDFieldArrayFactory af(prefix_,true);
 
@@ -1514,7 +1547,6 @@ getContravarientMatrix(const bool cache,
   }
 
   return aux;
-
 }
 
 template <typename Scalar>
@@ -1523,9 +1555,11 @@ IntegrationValues2<Scalar>::
 getNormContravarientMatrix(const bool cache,
                            const bool force) const
 {
-
   if(norm_contravarient_evaluated_ and not force)
     return norm_contravarient;
+
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getNormContravarientMatrix()",get_norm_contr_mat);
 
   MDFieldArrayFactory af(prefix_,true);
 
@@ -1554,7 +1588,6 @@ getNormContravarientMatrix(const bool cache,
   }
 
   return aux;
-
 }
 
 template <typename Scalar>
@@ -1563,9 +1596,11 @@ IntegrationValues2<Scalar>::
 getCubaturePoints(const bool cache,
                   const bool force) const
 {
-
   if(ip_coordinates_evaluated_ and not force)
     return ip_coordinates;
+
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getCubaturePoints()",get_cub_pts);
 
   MDFieldArrayFactory af(prefix_,true);
 
@@ -1621,7 +1656,6 @@ getCubaturePoints(const bool cache,
   }
 
   return aux;
-
 }
 
 
@@ -1631,9 +1665,11 @@ IntegrationValues2<Scalar>::
 getCubaturePointsRef(const bool cache,
                      const bool force) const
 {
-
   if(ref_ip_coordinates_evaluated_)
     return ref_ip_coordinates;
+
+  // Only log time if values computed (i.e. don't log if values are already cached)
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::getCubaturePointsRef()",get_cub_pts_ref);
 
   using ID=panzer::IntegrationDescriptor;
   const bool is_surface = int_rule->getType() == ID::SURFACE;
@@ -1743,7 +1779,6 @@ getCubaturePointsRef(const bool cache,
   }
 
   return aux;
-
 }
 
 template <typename Scalar>
@@ -1751,6 +1786,7 @@ void
 IntegrationValues2<Scalar>::
 evaluateEverything()
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::integrationValues2::evaluateEverything()",eval_everything);
 
   using ID=panzer::IntegrationDescriptor;
   const bool is_surface = int_rule->getType() == ID::SURFACE;
@@ -1795,7 +1831,6 @@ evaluateEverything()
     getCovarientMatrix(true,true);
     getNormContravarientMatrix(true,true);
   }
-
 }
 
 #define INTEGRATION_VALUES2_INSTANTIATION(SCALAR) \

--- a/packages/panzer/disc-fe/src/Panzer_IntrepidOrientation.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntrepidOrientation.cpp
@@ -130,4 +130,55 @@ namespace panzer {
                                "panzer::buildIntrepidOrientation: Could not cast GlobalIndexer");
   }
 
+  void buildIntrepidOrientations(const std::vector<std::string>& eBlockNames,
+                                 const panzer::ConnManager & connMgrInput,
+                                 std::map<std::string,std::vector<Intrepid2::Orientation>> & orientations)
+  {
+    using Teuchos::rcp_dynamic_cast;
+    using Teuchos::RCP;
+    using Teuchos::rcp;
+
+    auto connMgrPtr = connMgrInput.noConnectivityClone();
+    auto& connMgr = *connMgrPtr;
+
+    // Map element block name to topology
+    std::map<std::string,shards::CellTopology> eb_name_to_topo;
+    {
+      std::vector<std::string> elementBlockIds;
+      connMgr.getElementBlockIds(elementBlockIds);
+
+      std::vector<shards::CellTopology> elementBlockTopologies;
+      connMgr.getElementBlockTopologies(elementBlockTopologies);
+
+      for (size_t i=0; i < elementBlockIds.size(); ++i) {
+        eb_name_to_topo[elementBlockIds[i]] = elementBlockTopologies[i];
+      }
+    }
+
+    // Currently panzer supports only one element topology for whole mesh (use the first cell topology)
+    const auto cellTopo = eb_name_to_topo[eBlockNames[0]];
+    const int numVerticesPerCell = cellTopo.getVertexCount();
+
+    const auto fp = NodalFieldPattern(cellTopo);
+    connMgr.buildConnectivity(fp);
+
+    // Loop over requested element blocks
+    for (size_t i=0;i<eBlockNames.size();++i) {
+
+      const auto &lids = connMgr.getElementBlock(eBlockNames[i]);
+      const size_t num_elems = lids.size();
+      auto& orts = orientations[eBlockNames[i]];
+      orts.resize(num_elems);
+
+      for (int c=0;c<num_elems;++c) {
+        const int lid = lids[c];
+        Kokkos::View<const panzer::GlobalOrdinal*,Kokkos::HostSpace> 
+          vertices(connMgr.getConnectivity(lid),numVerticesPerCell);
+
+        // This function call expects a view for the vertices, not the nodes
+        orts[lid] = Intrepid2::Orientation::getOrientation(cellTopo, vertices);
+      }
+    }
+  }
+
 } // end namespace panzer

--- a/packages/panzer/disc-fe/src/Panzer_IntrepidOrientation.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntrepidOrientation.cpp
@@ -170,7 +170,7 @@ namespace panzer {
       auto& orts = orientations[eBlockNames[i]];
       orts.resize(num_elems);
 
-      for (int c=0;c<num_elems;++c) {
+      for (size_t c=0;c<num_elems;++c) {
         const int lid = lids[c];
         Kokkos::View<const panzer::GlobalOrdinal*,Kokkos::HostSpace> 
           vertices(connMgr.getConnectivity(lid),numVerticesPerCell);

--- a/packages/panzer/disc-fe/src/Panzer_IntrepidOrientation.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntrepidOrientation.hpp
@@ -52,10 +52,33 @@
 
 namespace panzer {
 
+  /** \brief Builds the element orientations for all element blocks.
+      
+      @param orientation [out] A vector that will be resized to the number of elements in the mesh and contain the orientaitons.
+      @param connMgr [in] Element connectivity interface. A no-connectivity clone will be created internally to generate vertex information.
+   */
   void
   buildIntrepidOrientation(std::vector<Intrepid2::Orientation> & orientation,  
                            panzer::ConnManager & connMgr);
 
+  /** \brief Builds the element orientations for the specified element blocks.
+      
+      @param eBlockNames [in] element block names to create orientations for.
+      @param connMgr [in] Element connectivity interface. A no-connectivity clone will be created internally to generate vertex information.
+      @param orientation [out] A map of Kokkos Views containing the orientations. The key is the element block name from the connMgr. Any previous views will be reallocated internally.
+
+      @note: This is for L2 projections that operate on an element block basis.
+   */
+  // template<typename... Props>
+  // void
+  // buildIntrepidOrientations(const std::vector<std::string>& eBlockNames,
+  //                           const panzer::ConnManager & connMgr,
+  //                           std::map<std::string,Kokkos::View<Intrepid2::Orientation*, Props...>> & orientations);
+  void
+  buildIntrepidOrientations(const std::vector<std::string>& eBlockNames,
+                            const panzer::ConnManager & connMgr,
+                            std::map<std::string,std::vector<Intrepid2::Orientation>> & orientations);
+  
   /** Build an orientation container from a global indexer and a field.
    * Underneath this does several dynamic casts to determine the type of GlobalIndexer
    * object that has been passed in.

--- a/packages/panzer/disc-fe/src/Panzer_L2Projection.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_L2Projection.hpp
@@ -28,6 +28,7 @@ namespace panzer {
   class DOFManager;
   class GlobalIndexer;
   class WorksetContainer;
+  template<typename T> class BasisValues2;
 
   /** \brief Unified set of tools for building objects for lumped and
       consistent L2 projects between bases.
@@ -42,6 +43,8 @@ namespace panzer {
     mutable Teuchos::RCP<panzer::WorksetContainer> worksetContainer_;
     bool setupCalled_;
     Teuchos::RCP<panzer::DOFManager> targetGlobalIndexer_;
+    bool useUserSuppliedBasisValues_;
+    std::map<std::string,Teuchos::RCP<panzer::BasisValues2<double>>> basisValues_;
 
   public:
 
@@ -63,6 +66,16 @@ namespace panzer {
                const Teuchos::RCP<const panzer::ConnManager>& connManager,
                const std::vector<std::string>& elementBlockNames,
                const Teuchos::RCP<panzer::WorksetContainer> worksetContainer = Teuchos::null);
+
+    /** \brief Override using the panzer::WorksetContainer and instead use the registered BasisValues object.
+
+        \param[in] bv BasisValues object setup in lazy evalaution mode with registered orientations if required.
+
+        The intention of this function is to minimize memory use and
+        redundant evaluations by avoiding workset construction and
+        enforcing lazy evaluation in basis values.
+     */
+    void useBasisValues(const std::map<std::string,Teuchos::RCP<panzer::BasisValues2<double>>>& map_eblock_to_bv);
 
     /// Returns the target global indexer. Will be null if setup() has not been called.
     Teuchos::RCP<panzer::GlobalIndexer> getTargetGlobalIndexer() const;

--- a/packages/panzer/disc-fe/src/Panzer_PureBasis.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_PureBasis.hpp
@@ -64,14 +64,14 @@ namespace panzer {
     typedef enum { HGRAD=0, HCURL=1, HDIV=2, HVOL=3, CONST=4 } EElementSpace;
     
     /** Build a basis given a type, order and CellData object
-      \param[in] basis_type String name that describes the type of basis
+      \param[in] basis_type String name that describes the type of basis ("HGrad", "HDiv", "HCurl", or "HVol")
       \param[in] basis_order Order of the basis
       \param[in] cell_data Description of the basis
     */
     PureBasis(const std::string & basis_type,const int basis_order,const CellData & cell_data);
 
     /** Build a basis given a type, order, number of cells (for data layouts) and shards topology
-      \param[in] basis_type String name that describes the type of basis
+      \param[in] basis_type String name that describes the type of basis ("HGrad", "HDiv", "HCurl", or "HVol")
       \param[in] basis_order Order of the basis
       \param[in] num_cells Number of cells used in the data layouts for this basis
       \param[in] cell_topo A shards topology description

--- a/packages/panzer/disc-fe/src/Panzer_WorksetContainer.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_WorksetContainer.cpp
@@ -113,6 +113,8 @@ const WorksetNeeds & WorksetContainer::lookupNeeds(const std::string & eBlock) c
 Teuchos::RCP<std::vector<Workset> >
 WorksetContainer::getWorksets(const WorksetDescriptor & wd)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::WorksetContainer::getWorksets()",pwkst_con_get_worksets);
+
    Teuchos::RCP<std::vector<Workset> > worksetVector;
    WorksetMap::iterator itr = worksets_.find(wd);
    if(itr==worksets_.end()) {
@@ -143,6 +145,8 @@ WorksetContainer::getWorksets(const WorksetDescriptor & wd)
 Teuchos::RCP<std::map<unsigned,Workset> >
 WorksetContainer::getSideWorksets(const WorksetDescriptor & desc)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::WorksetContainer::getSideWorksets()",pwkst_con_get_side_worksets);
+
    Teuchos::RCP<std::map<unsigned,Workset> > worksetMap;
 
    // this is the key for the workset map
@@ -205,6 +209,8 @@ addBasis(const std::string & type,int order,const std::string & rep_field)
 void WorksetContainer::
 applyOrientations(const Teuchos::RCP<const panzer::GlobalIndexer> & ugi)
 {
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::WorksetContainer::applyOrientations(ugi)",pwkst_con_apply_orts);
+
   // this gurantees orientations won't accidently be applied twice.
   TEUCHOS_ASSERT(globalIndexer_==Teuchos::null);
 
@@ -256,6 +262,8 @@ void WorksetContainer::
 applyOrientations(const std::string & eBlock, std::vector<Workset> & worksets) const
 {
   using Teuchos::RCP;
+
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::WorksetContainer::applyOrientations(eBlock,worksets)",pwkst_con_apply_orts_eb_w);
 
   /////////////////////////////////
   // this is for volume worksets //
@@ -377,6 +385,8 @@ applyOrientations(const WorksetDescriptor & desc,std::map<unsigned,Workset> & wo
 {
   using Teuchos::RCP;
   
+  PANZER_FUNC_TIME_MONITOR_DIFF("panzer::WorksetContainer::applyOrientations(wd,worksets)",pwkst_con_apply_orts_wd_wksts);
+
   /////////////////////////////////
   // this is for side worksets //
   /////////////////////////////////

--- a/packages/panzer/mini-em/src/solvers/MiniEM_Interpolation.hpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_Interpolation.hpp
@@ -11,7 +11,6 @@
 #endif
 
 #include "Panzer_LOCPair_GlobalEvaluationData.hpp"
-#include "Panzer_IntrepidOrientation.hpp"
 #include "Panzer_IntrepidBasisFactory.hpp"
 #include "Intrepid2_OrientationTools.hpp"
 #include "Intrepid2_LagrangianInterpolation.hpp"

--- a/packages/panzer/mini-em/src/solvers/MiniEM_MatrixFreeInterpolationOp.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_MatrixFreeInterpolationOp.cpp
@@ -1,7 +1,6 @@
 #include "MiniEM_MatrixFreeInterpolationOp.hpp"
 #include <Tpetra_Operator.hpp>
 #include "Panzer_LOCPair_GlobalEvaluationData.hpp"
-#include "Panzer_IntrepidOrientation.hpp"
 #include "Panzer_IntrepidBasisFactory.hpp"
 #include "Panzer_IntrepidFieldPattern.hpp"
 #include "Panzer_BlockedTpetraLinearObjFactory.hpp"


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Improve multiple mass matrix assembly by reusing workset information where possible and moving to lazy evalaution in workset construction.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
projection test modified to test the lazy construction path
<!--- 
