### PR TITLE
Xpetra&MueLu: Fix for diagonal extraction

### DIFF
--- a/packages/xpetra/src/CrsGraph/Xpetra_CrsGraph.hpp
+++ b/packages/xpetra/src/CrsGraph/Xpetra_CrsGraph.hpp
@@ -242,6 +242,9 @@ class CrsGraph
   virtual typename local_graph_type::HostMirror getLocalGraphHost() const = 0;
   virtual local_graph_type getLocalGraphDevice() const                    = 0;
 
+  //! Get offsets of the diagonal entries in the matrix.
+  virtual void getLocalDiagOffsets(const Kokkos::View<size_t *, device_type, Kokkos::MemoryUnmanaged> &offsets) const = 0;
+
 #else
 #ifdef __GNUC__
 #warning "Xpetra Kokkos interface for CrsMatrix is enabled (HAVE_XPETRA_KOKKOS_REFACTOR) but Tpetra is disabled. The Kokkos interface needs Tpetra to be enabled, too."

--- a/packages/xpetra/src/CrsGraph/Xpetra_EpetraCrsGraph.hpp
+++ b/packages/xpetra/src/CrsGraph/Xpetra_EpetraCrsGraph.hpp
@@ -309,6 +309,11 @@ class EpetraCrsGraphT
                                "Xpetra::EpetraCrsGraph only available for GO=int or GO=long long with EpetraNode (Serial or OpenMP depending on configuration)");
     TEUCHOS_UNREACHABLE_RETURN((local_graph_type()));
   }
+
+  void getLocalDiagOffsets(const Kokkos::View<size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> &offsets) const {
+    TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
+                               "Epetra does not support getLocalDiagOffsets!");
+  }
 #else
 #ifdef __GNUC__
 #warning "Xpetra Kokkos interface for CrsGraph is enabled (HAVE_XPETRA_KOKKOS_REFACTOR) but Tpetra is disabled. The Kokkos interface needs Tpetra to be enabled, too."
@@ -838,6 +843,10 @@ class EpetraCrsGraphT<int, EpetraNode>
     return localGraph;
   }
 
+  void getLocalDiagOffsets(const Kokkos::View<size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> &offsets) const {
+    TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
+                               "Epetra does not support getLocalDiagOffsets!");
+  }
 #else
 #ifdef __GNUC__
 #warning "Xpetra Kokkos interface for CrsGraph is enabled (HAVE_XPETRA_KOKKOS_REFACTOR) but Tpetra is disabled. The Kokkos interface needs Tpetra to be enabled, too."
@@ -1397,6 +1406,11 @@ class EpetraCrsGraphT<long long, EpetraNode>
     local_graph_type localGraph = local_graph_type(kokkosColind, kokkosRowPtr);
 
     return localGraph;
+  }
+
+  void getLocalDiagOffsets(const Kokkos::View<size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> &offsets) const {
+    TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
+                               "Epetra does not support getLocalDiagOffsets!");
   }
 #else
 #ifdef __GNUC__

--- a/packages/xpetra/src/CrsGraph/Xpetra_TpetraCrsGraph_decl.hpp
+++ b/packages/xpetra/src/CrsGraph/Xpetra_TpetraCrsGraph_decl.hpp
@@ -323,6 +323,9 @@ class TpetraCrsGraph
   /// \brief Access the local KokkosSparse::StaticCrsGraph data for device use
   local_graph_type getLocalGraphDevice() const;
 
+  //! Get offsets of the diagonal entries in the matrix.
+  void getLocalDiagOffsets(const Kokkos::View<size_t*, typename Node::device_type, Kokkos::MemoryUnmanaged>& offsets) const;
+
   //! Force the computation of global constants if we don't have them
   void computeGlobalConstants();
 

--- a/packages/xpetra/src/CrsGraph/Xpetra_TpetraCrsGraph_def.hpp
+++ b/packages/xpetra/src/CrsGraph/Xpetra_TpetraCrsGraph_def.hpp
@@ -383,6 +383,11 @@ typename Xpetra::CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::local_graph_type T
 }
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
+void TpetraCrsGraph<LocalOrdinal, GlobalOrdinal, Node>::getLocalDiagOffsets(const Kokkos::View<size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> &offsets) const {
+  getTpetra_CrsGraph()->getLocalDiagOffsets(offsets);
+}
+
+template <class LocalOrdinal, class GlobalOrdinal, class Node>
 void TpetraCrsGraph<LocalOrdinal, GlobalOrdinal, Node>::computeGlobalConstants() {
   // mfh 07 May 2018: See GitHub Issue #2565.
   graph_->computeGlobalConstants();
@@ -1095,6 +1100,11 @@ class TpetraCrsGraph<int, long long, EpetraNode>
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
                                "Epetra does not support Kokkos::StaticCrsGraph!");
     TEUCHOS_UNREACHABLE_RETURN((local_graph_type()));
+  }
+
+  void getLocalDiagOffsets(const Kokkos::View<size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> &offsets) const {
+    TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
+                               "Epetra does not support getLocalDiagOffsets!");
   }
 
   typename local_graph_type::HostMirror getLocalGraphHost() const {

--- a/packages/xpetra/src/CrsMatrix/Xpetra_CrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_CrsMatrix.hpp
@@ -227,6 +227,9 @@ class CrsMatrix
   //! Get a copy of the diagonal entries owned by this node, with local row indices, using row offsets.
   virtual void getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag, const Teuchos::ArrayView<const size_t> &offsets) const = 0;
 
+  //! Get a copy of the diagonal entries owned by this node, with local row indices, using row offsets.
+  virtual void getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag, const Kokkos::View<const size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> &offsets) const = 0;
+
   //! Replace the diagonal entries of the matrix
   virtual void replaceDiag(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag) = 0;
 

--- a/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
@@ -199,6 +199,7 @@ class EpetraCrsMatrixT
   void getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag) const {}
   void getLocalDiagOffsets(Teuchos::ArrayRCP<size_t> &offsets) const {}
   void getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag, const Teuchos::ArrayView<const size_t> &offsets) const {}
+  void getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag, const Kokkos::View<const size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> &offsets) const {}
   void replaceDiag(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag) {}
   void leftScale(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &x){};
   void rightScale(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &x){};
@@ -938,6 +939,11 @@ class EpetraCrsMatrixT<int, EpetraNode>
 
   //! Get a copy of the diagonal entries owned by this node, with local row indices, using row offsets.
   void getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> & /* diag */, const Teuchos::ArrayView<const size_t> & /* offsets */) const {
+    TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraCrsMatrixT.getLocalDiagCopy using offsets is not implemented or supported.");
+  }
+
+  //! Get a copy of the diagonal entries owned by this node, with local row indices, using row offsets.
+  void getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> & /* diag */, const Kokkos::View<const size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> & /* offsets */) const {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraCrsMatrixT.getLocalDiagCopy using offsets is not implemented or supported.");
   }
 
@@ -2040,6 +2046,11 @@ class EpetraCrsMatrixT<long long, EpetraNode>
 
   //! Get a copy of the diagonal entries owned by this node, with local row indices, using row offsets.
   void getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> & /* diag */, const Teuchos::ArrayView<const size_t> & /* offsets */) const {
+    TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraCrsMatrixT.getLocalDiagCopy using offsets is not implemented or supported.");
+  }
+
+  //! Get a copy of the diagonal entries owned by this node, with local row indices, using row offsets.
+  void getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> & /* diag */, const Kokkos::View<const size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> & /* offsets */) const {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraCrsMatrixT.getLocalDiagCopy using offsets is not implemented or supported.");
   }
 

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix_decl.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix_decl.hpp
@@ -323,6 +323,9 @@ class TpetraBlockCrsMatrix
   //! Get offsets of the diagonal entries in the matrix.
   void getLocalDiagOffsets(Teuchos::ArrayRCP<size_t> &offsets) const;
 
+  //! Get a copy of the diagonal entries owned by this node, with local row indices, using row offsets.
+  void getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag, const Kokkos::View<const size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> &offsets) const;
+
   void replaceDiag(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag);
 
   //! Left scale operator with given vector values

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix_def.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix_def.hpp
@@ -581,6 +581,14 @@ void TpetraBlockCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   throw std::runtime_error("Xpetra::TpetraBlockCrsMatrix function not implemented in " + std::string(__FILE__) + ":" + std::to_string(__LINE__));
 }
 
+//! Get a copy of the diagonal entries owned by this node, with local row indices.
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void TpetraBlockCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+    getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag,
+                     const Kokkos::View<const size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> &offsets) const {
+  throw std::runtime_error("Xpetra::TpetraBlockCrsMatrix function not implemented in " + std::string(__FILE__) + ":" + std::to_string(__LINE__));
+}
+
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void TpetraBlockCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     getLocalDiagOffsets(Teuchos::ArrayRCP<size_t> &offsets) const {
@@ -992,6 +1000,9 @@ class TpetraBlockCrsMatrix<Scalar, int, int, EpetraNode>
   //! Get a copy of the diagonal entries owned by this node, with local row indices.
   void getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag, const Teuchos::ArrayView<const size_t> &offsets) const {}
 
+  //! Get a copy of the diagonal entries owned by this node, with local row indices.
+  void getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag, const Kokkos::View<const size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> &offsets) const {}
+
   void replaceDiag(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag) {}
 
   void leftScale(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &x) {}
@@ -1288,6 +1299,9 @@ class TpetraBlockCrsMatrix<Scalar, int, long long, EpetraNode>
 
   //! Get a copy of the diagonal entries owned by this node, with local row indices.
   void getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag, const Teuchos::ArrayView<const size_t> &offsets) const {}
+
+  //! Get a copy of the diagonal entries owned by this node, with local row indices.
+  void getLocalDiagCopy(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag, const Kokkos::View<const size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> &offsets) const {}
 
   void replaceDiag(Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag) const {}
 

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix_decl.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix_decl.hpp
@@ -377,6 +377,9 @@ class TpetraCrsMatrix
   //! Get a copy of the diagonal entries owned by this node, with local row indices.
   void getLocalDiagCopy(Vector &diag, const Teuchos::ArrayView<const size_t> &offsets) const;
 
+  //! Get a copy of the diagonal entries owned by this node, with local row indices, using row offsets.
+  void getLocalDiagCopy(Vector &diag, const Kokkos::View<const size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> &offsets) const;
+
   //! Replace the diagonal entries of the matrix
   void replaceDiag(const Vector &diag);
 

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix_def.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix_def.hpp
@@ -557,6 +557,12 @@ void TpetraCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getLocalDiagCop
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void TpetraCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getLocalDiagCopy(Vector &diag, const Kokkos::View<const size_t *, typename Node::device_type, Kokkos::MemoryUnmanaged> &offsets) const {
+  XPETRA_MONITOR("TpetraCrsMatrix::getLocalDiagCopy");
+  mtx_->getLocalDiagCopy(*(toTpetra(diag)), offsets);
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void TpetraCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::replaceDiag(const Vector &diag) {
   XPETRA_MONITOR("TpetraCrsMatrix::replaceDiag");
   Tpetra::replaceDiagonalCrsMatrix(*mtx_, *(toTpetra(diag)));


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
- Xpetra: Expose getLocalDiagOffsets and getLocalDiagCopy with Kokkos views
- MueLu: Fix #12736 and use Kokkos views in GetMatrixDiagonal