### PR TITLE
Framework: Disable debug symbols

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -314,7 +314,6 @@ opt-set-cmake-var Trilinos_ENABLE_CONFIGURE_TIMING BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES BOOL : ON
 
 # Options from cmake/std/MpiReleaseDebugSharedPtSettings.cmake
-opt-set-cmake-var Trilinos_ENABLE_DEBUG_SYMBOLS BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_EXPLICIT_INSTANTIATION BOOL : ON
 opt-set-cmake-var Teuchos_ENABLE_DEFAULT_STACKTRACE BOOL : OFF
 
@@ -1050,7 +1049,6 @@ opt-set-cmake-var NOX_ENABLE_KOKKOS_SOLVER_STACK BOOL FORCE : ON
 
 opt-set-cmake-var MPI_EXEC_NUMPROCS_FLAG STRING : -p
 opt-set-cmake-var MPI_EXEC_POST_NUMPROCS_FLAGS STRING : --rs_per_socket;4
-opt-set-cmake-var Trilinos_ENABLE_DEBUG_SYMBOLS BOOL FORCE : OFF
 
 opt-set-cmake-var Kokkos_ENABLE_CXX11_DISPATCH_LAMBDA BOOL FORCE : ON
 opt-set-cmake-var MueLu_ENABLE_EXPLICIT_INSTANTIATION BOOL FORCE : ON


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Build directories were jumping in size massively.  Previously, this setting seemed to have no effect, but after the merge of https://github.com/trilinos/Trilinos/pull/12707, the `-g` flag started showing up on compile lines (correctly).  Remove that setting from `configs-specs.ini` to get builds back to where they were before.


## Related Issues

* Closes #12732 


## Testing
I ran the configuration `rhel7_sems-gnu-8.3.0-openmpi-1.10.1-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-off_all` with and without the change.  Without the change (at version https://github.com/trilinos/Trilinos/commit/9f40ed4121e6ebcd7df6b6510b9942c2106bae54) the build directory was over 600GB before the build was even completed.  With this change, the completed build was 75GB.