### PR TITLE
Amesos2 : remove "Disabling Amesos2_ENABLE_ShyLU_NodeTacho because CUDA or HIP is enabled in Kokkos"

### DIFF
--- a/packages/amesos2/CMakeLists.txt
+++ b/packages/amesos2/CMakeLists.txt
@@ -67,10 +67,6 @@ TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_ENABLE_KLU2
   ON
 )
 
-IF (Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP)
-  tribits_disable_optional_dependency(ShyLU_NodeTacho "NOTE: Disabling ${PACKAGE_NAME}_ENABLE_ShyLU_NodeTacho because CUDA or HIP is enabled in Kokkos")
-ENDIF()
-
 TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_ENABLE_Basker
    HAVE_AMESOS2_BASKER
    "Enable Basker in Amesos2"


### PR DESCRIPTION

@trilinos/amesos2 

## Motivation

We want to allow enabling Amesos2's Tacho interface when CUDA/HIP is enabled.

## Testing



## Additional Information
With
````
    -D Trilinos_ENABLE_ShyLU_NodeTacho:BOOL=ON \
    -D Trilinos_ENABLE_Amesos2:BOOL=ON \
````
or with
````
    -D Trilinos_ENABLE_ShyLU_NodeTacho:BOOL=ON \
    -D Trilinos_ENABLE_Amesos2:BOOL=ON \
    -D   Amesos2_ENABLE_ShyLU_NodeTacho:BOOL=ON \
````
we get
````
-- NOTE: Disabling Amesos2_ENABLE_ShyLU_NodeTacho because CUDA or HIP is enabled in Kokkos
````

[PR 12291](https://github.com/trilinos/Trilinos/pull/12291) replaced:
````
IF (Trilinos_ENABLE_ShyLU_NodeTacho AND NOT Kokkos_ENABLE_CUDA AND NOT Kokkos_ENABLE_HIP)
  SET(Amesos2_HAVE_TACHO ON)
ELSE()
  SET(Amesos2_HAVE_TACHO OFF)
ENDIF()
````
with
````
IF (Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP)
  tribits_disable_optional_dependency(ShyLU_NodeTacho "NOTE: Disabling ${PACKAGE_NAME}_ENABLE_ShyLU_NodeTacho because CUDA or HIP is enabled in Kokkos")
ENDIF()
````