### PR TITLE
Xpetra&MueLu: Fixes

### DIFF
--- a/packages/muelu/adapters/stratimikos/Xpetra_ThyraLinearOp.hpp
+++ b/packages/muelu/adapters/stratimikos/Xpetra_ThyraLinearOp.hpp
@@ -90,12 +90,12 @@ class XpetraThyraLinearOp : public Xpetra::Operator<Scalar, LocalOrdinal, Global
   //@}
 
   //! Returns the Tpetra::Map object associated with the domain of this operator.
-  Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> getDomainMap() const {
+  const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> getDomainMap() const {
     throw Exceptions::RuntimeError("Interface not supported");
   }
 
   // //! Returns the Tpetra::Map object associated with the range of this operator.
-  Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> getRangeMap() const {
+  const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> getRangeMap() const {
     throw Exceptions::RuntimeError("Interface not supported");
   }
 
@@ -171,12 +171,12 @@ class XpetraThyraLinearOp<double, LocalOrdinal, GlobalOrdinal, Node> : public Xp
   //@}
 
   //! Returns the Tpetra::Map object associated with the domain of this operator.
-  Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> getDomainMap() const {
+  const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> getDomainMap() const {
     return A_->getDomainMap();
   }
 
   // //! Returns the Tpetra::Map object associated with the range of this operator.
-  Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> getRangeMap() const {
+  const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> getRangeMap() const {
     return A_->getRangeMap();
   }
 

--- a/packages/muelu/src/Operators/MueLu_Maxwell1_decl.hpp
+++ b/packages/muelu/src/Operators/MueLu_Maxwell1_decl.hpp
@@ -196,10 +196,10 @@ class Maxwell1 : public VerboseObject, public Xpetra::Operator<Scalar, LocalOrdi
   virtual ~Maxwell1() {}
 
   //! Returns the Xpetra::Map object associated with the domain of this operator.
-  Teuchos::RCP<const Map> getDomainMap() const;
+  const Teuchos::RCP<const Map> getDomainMap() const;
 
   //! Returns the Xpetra::Map object associated with the range of this operator.
-  Teuchos::RCP<const Map> getRangeMap() const;
+  const Teuchos::RCP<const Map> getRangeMap() const;
 
   //! Returns Jacobian matrix SM
   const Teuchos::RCP<Matrix>& getJacobian() const {

--- a/packages/muelu/src/Operators/MueLu_Maxwell1_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_Maxwell1_def.hpp
@@ -79,12 +79,12 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > Maxwell1<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getDomainMap() const {
+const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > Maxwell1<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getDomainMap() const {
   return SM_Matrix_->getDomainMap();
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > Maxwell1<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getRangeMap() const {
+const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > Maxwell1<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getRangeMap() const {
   return SM_Matrix_->getRangeMap();
 }
 

--- a/packages/muelu/src/Operators/MueLu_MultiPhys_decl.hpp
+++ b/packages/muelu/src/Operators/MueLu_MultiPhys_decl.hpp
@@ -129,10 +129,10 @@ class MultiPhys : public VerboseObject, public Xpetra::Operator<Scalar, LocalOrd
   virtual ~MultiPhys() {}
 
   //! Returns the Xpetra::Map object associated with the domain of this operator.
-  Teuchos::RCP<const Map> getDomainMap() const;
+  const Teuchos::RCP<const Map> getDomainMap() const;
 
   //! Returns the Xpetra::Map object associated with the range of this operator.
-  Teuchos::RCP<const Map> getRangeMap() const;
+  const Teuchos::RCP<const Map> getRangeMap() const;
 
   //! Set parameters
   void setParameters(Teuchos::ParameterList& list);

--- a/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
@@ -78,12 +78,12 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> MultiPhys<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getDomainMap() const {
+const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> MultiPhys<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getDomainMap() const {
   return AmatMultiphysics_->getDomainMap();
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> MultiPhys<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getRangeMap() const {
+const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> MultiPhys<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getRangeMap() const {
   return AmatMultiphysics_->getRangeMap();
 }
 

--- a/packages/muelu/src/Operators/MueLu_RefMaxwell_decl.hpp
+++ b/packages/muelu/src/Operators/MueLu_RefMaxwell_decl.hpp
@@ -424,10 +424,10 @@ class RefMaxwell : public VerboseObject, public Xpetra::Operator<Scalar, LocalOr
   virtual ~RefMaxwell() {}
 
   //! Returns the Xpetra::Map object associated with the domain of this operator.
-  Teuchos::RCP<const Map> getDomainMap() const;
+  const Teuchos::RCP<const Map> getDomainMap() const;
 
   //! Returns the Xpetra::Map object associated with the range of this operator.
-  Teuchos::RCP<const Map> getRangeMap() const;
+  const Teuchos::RCP<const Map> getRangeMap() const;
 
   //! Returns Jacobian matrix SM
   const Teuchos::RCP<Matrix> &getJacobian() const {

--- a/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
@@ -122,12 +122,12 @@ Matrix2CrsMatrix(Teuchos::RCP<Xpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdi
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > RefMaxwell<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getDomainMap() const {
+const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > RefMaxwell<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getDomainMap() const {
   return SM_Matrix_->getDomainMap();
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > RefMaxwell<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getRangeMap() const {
+const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > RefMaxwell<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getRangeMap() const {
   return SM_Matrix_->getRangeMap();
 }
 

--- a/packages/muelu/src/Operators/MueLu_XpetraOperator_decl.hpp
+++ b/packages/muelu/src/Operators/MueLu_XpetraOperator_decl.hpp
@@ -79,10 +79,10 @@ class XpetraOperator : public Xpetra::Operator<Scalar, LocalOrdinal, GlobalOrdin
   //@}
 
   //! Returns the Tpetra::Map object associated with the domain of this operator.
-  Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > getDomainMap() const;
+  const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > getDomainMap() const;
 
   //! Returns the Tpetra::Map object associated with the range of this operator.
-  Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > getRangeMap() const;
+  const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > getRangeMap() const;
 
   //! Returns in Y the result of a Xpetra::Operator applied to a Xpetra::MultiVector X.
   /*!

--- a/packages/muelu/src/Operators/MueLu_XpetraOperator_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_XpetraOperator_def.hpp
@@ -51,7 +51,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >
+const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >
 XpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     getDomainMap() const {
   typedef Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> Matrix;
@@ -61,7 +61,7 @@ XpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >
+const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >
 XpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     getRangeMap() const {
   typedef Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> Matrix;

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceTransferFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceTransferFactory_def.hpp
@@ -236,7 +236,7 @@ void RebalanceTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(
 
             RCP<const Import> newImporter;
             {
-              SubFactoryMonitor(*this, "Import construction", coarseLevel);
+              SubFactoryMonitor subM2(*this, "Import construction", coarseLevel);
               newImporter = ImportFactory::Build(importer->getTargetMap(), rebalancedP->getColMap());
             }
             rebalancedP2->replaceDomainMapAndImporter(importer->getTargetMap(), newImporter);

--- a/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
@@ -830,9 +830,10 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 Scalar Ifpack2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupChebyshevEigenvalues(Level& currentLevel, const std::string& matrixName, const std::string& label, ParameterList& paramList) const {
   // Helper: This gets used for smoothers that want to set up Chebyhev
   typedef Teuchos::ScalarTraits<SC> STS;
-  SC negone                  = -STS::one();
-  RCP<const Matrix> currentA = currentLevel.Get<RCP<Matrix>>(matrixName);
-  SC lambdaMax               = negone;
+  SC negone              = -STS::one();
+  RCP<Operator> currentA = currentLevel.Get<RCP<Operator>>(matrixName);
+  RCP<Matrix> matA       = rcp_dynamic_cast<Matrix>(currentA);
+  SC lambdaMax           = negone;
 
   std::string maxEigString   = "chebyshev: max eigenvalue";
   std::string eigRatioString = "chebyshev: ratio eigenvalue";
@@ -844,12 +845,11 @@ Scalar Ifpack2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupChebyshe
     else
       lambdaMax = paramList.get<SC>(maxEigString);
     this->GetOStream(Statistics1) << label << maxEigString << " (cached with smoother parameter list) = " << lambdaMax << std::endl;
-    RCP<Matrix> matA = rcp_dynamic_cast<Matrix>(A_);
     if (!matA.is_null())
       matA->SetMaxEigenvalueEstimate(lambdaMax);
 
-  } else {
-    lambdaMax = currentA->GetMaxEigenvalueEstimate();
+  } else if (!matA.is_null()) {
+    lambdaMax = matA->GetMaxEigenvalueEstimate();
     if (lambdaMax != negone) {
       this->GetOStream(Statistics1) << label << maxEigString << " (cached with matrix) = " << lambdaMax << std::endl;
       paramList.set(maxEigString, lambdaMax);
@@ -871,11 +871,11 @@ Scalar Ifpack2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupChebyshe
     //   ratio = max(number of fine DOFs / number of coarse DOFs, defaultValue)
     //
     // NOTE: We don't need to request previous level matrix as we know for sure it was constructed
-    RCP<const Matrix> fineA = currentLevel.GetPreviousLevel()->Get<RCP<Matrix>>(matrixName);
-    size_t nRowsFine        = fineA->getGlobalNumRows();
-    size_t nRowsCoarse      = currentA->getGlobalNumRows();
+    RCP<const Operator> fineA = currentLevel.GetPreviousLevel()->Get<RCP<Operator>>(matrixName);
+    size_t nRowsFine          = fineA->getDomainMap()->getGlobalNumElements();
+    size_t nRowsCoarse        = currentA->getDomainMap()->getGlobalNumElements();
 
-    SC levelRatio = as<SC>(as<float>(nRowsFine) / nRowsCoarse);
+    SC levelRatio = as<SC>(as<double>(nRowsFine) / nRowsCoarse);
     if (STS::magnitude(levelRatio) > STS::magnitude(ratio))
       ratio = levelRatio;
   }
@@ -913,8 +913,9 @@ Scalar Ifpack2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupChebyshe
       paramList.remove(paramName);
     }
     if (doScale) {
+      TEUCHOS_ASSERT(!matA.is_null());
       const bool doReciprocal                                                       = true;
-      RCP<Vector> lumpedDiagonal                                                    = Utilities::GetLumpedMatrixDiagonal(*currentA, doReciprocal, chebyReplaceTol, chebyReplaceVal, chebyReplaceSingleEntryRowWithZero, useAverageAbsDiagVal);
+      RCP<Vector> lumpedDiagonal                                                    = Utilities::GetLumpedMatrixDiagonal(*matA, doReciprocal, chebyReplaceTol, chebyReplaceVal, chebyReplaceSingleEntryRowWithZero, useAverageAbsDiagVal);
       const Xpetra::TpetraVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& tmpVec = dynamic_cast<const Xpetra::TpetraVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&>(*lumpedDiagonal);
       paramList.set("chebyshev: operator inv diagonal", tmpVec.getTpetra_Vector());
     }

--- a/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
@@ -782,7 +782,7 @@ void Ifpack2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupHiptmair(L
   }
   if (smoother2 == "CHEBYSHEV") {
     ParameterList& list2 = paramList.sublist("hiptmair: smoother list 2");
-    SetupChebyshevEigenvalues(currentLevel, "A", "EdgeMatrix ", list2);
+    SetupChebyshevEigenvalues(currentLevel, "NodeMatrix", "NodeMatrix ", list2);
   }
 
   // FIXME: Should really add some checks to make sure the eigenvalue calcs worked like in

--- a/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
@@ -717,14 +717,14 @@ void Ifpack2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupChebyshev(
     prec_ = Ifpack2::Factory::create(type_, tA, overlap_);
     SetPrecParameters();
     {
-      SubFactoryMonitor(*this, "Preconditioner init", currentLevel);
+      SubFactoryMonitor m(*this, "Preconditioner init", currentLevel);
       prec_->initialize();
     }
   } else
     SetPrecParameters();
 
   {
-    SubFactoryMonitor(*this, "Preconditioner compute", currentLevel);
+    SubFactoryMonitor m(*this, "Preconditioner compute", currentLevel);
     prec_->compute();
   }
 

--- a/packages/muelu/src/Transfers/Matrix-Free/MueLu_MatrixFreeTentativeP_decl.hpp
+++ b/packages/muelu/src/Transfers/Matrix-Free/MueLu_MatrixFreeTentativeP_decl.hpp
@@ -105,12 +105,12 @@ class MatrixFreeTentativeP : public Xpetra::Operator<Scalar, LocalOrdinal, Globa
   void residual(const MultiVector &X, const MultiVector &B, MultiVector &R) const override;
 
   // get the range map
-  Teuchos::RCP<const Map> getRangeMap() const override {
+  const Teuchos::RCP<const Map> getRangeMap() const override {
     return fine_map_;
   }
 
   // get the domain map
-  Teuchos::RCP<const Map> getDomainMap() const override {
+  const Teuchos::RCP<const Map> getDomainMap() const override {
     return coarse_map_;
   }
 

--- a/packages/muelu/src/Utils/MueLu_Utilities_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_decl.hpp
@@ -95,6 +95,7 @@ class Epetra_Vector;
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_FEMultiVector.hpp>
+#include <Xpetra_TpetraRowMatrix.hpp>
 #include <Xpetra_TpetraCrsMatrix_fwd.hpp>
 #include <Xpetra_TpetraMultiVector_fwd.hpp>
 
@@ -512,7 +513,8 @@ class Utilities<double, int, int, Xpetra::EpetraNode> : public UtilitiesBase<dou
      (!defined(EPETRA_HAVE_OMP) && (!defined(HAVE_TPETRA_INST_SERIAL) || !defined(HAVE_TPETRA_INST_INT_INT))))
     throw Exceptions::RuntimeError("Op2TpetraRow: Tpetra has not been compiled with support for LO=GO=int.");
 #else
-    RCP<const Matrix> mat = rcp_dynamic_cast<const Matrix>(Op);
+    RCP<const Matrix> mat                                                               = rcp_dynamic_cast<const Matrix>(Op);
+    RCP<const Xpetra::TpetraRowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > rmat = rcp_dynamic_cast<const Xpetra::TpetraRowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >(Op);
     if (!mat.is_null()) {
       RCP<const CrsMatrixWrap> crsOp = rcp_dynamic_cast<const CrsMatrixWrap>(mat);
       if (crsOp == Teuchos::null)
@@ -529,6 +531,8 @@ class Utilities<double, int, int, Xpetra::EpetraNode> : public UtilitiesBase<dou
           throw Exceptions::BadCast("Cast from Xpetra::CrsMatrix to Xpetra::TpetraCrsMatrix and Xpetra::TpetraBlockCrsMatrix failed");
         return tmp_BlockCrs->getTpetra_BlockCrsMatrixNonConst();
       }
+    } else if (!rmat.is_null()) {
+      return rmat->getTpetra_RowMatrix();
     } else {
       RCP<const TpetraOperator> tpOp                                                = rcp_dynamic_cast<const TpetraOperator>(Op, true);
       RCP<const Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node> > tOp   = tpOp->getOperatorConst();
@@ -543,7 +547,8 @@ class Utilities<double, int, int, Xpetra::EpetraNode> : public UtilitiesBase<dou
      (!defined(EPETRA_HAVE_OMP) && (!defined(HAVE_TPETRA_INST_SERIAL) || !defined(HAVE_TPETRA_INST_INT_INT))))
     throw Exceptions::RuntimeError("Op2NonConstTpetraRow: Tpetra has not been compiled with support for LO=GO=int.");
 #else
-    RCP<Matrix> mat = rcp_dynamic_cast<Matrix>(Op);
+    RCP<Matrix> mat                                                               = rcp_dynamic_cast<Matrix>(Op);
+    RCP<Xpetra::TpetraRowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > rmat = rcp_dynamic_cast<Xpetra::TpetraRowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >(Op);
     if (!mat.is_null()) {
       RCP<const CrsMatrixWrap> crsOp = rcp_dynamic_cast<const CrsMatrixWrap>(mat);
       if (crsOp == Teuchos::null)
@@ -560,6 +565,8 @@ class Utilities<double, int, int, Xpetra::EpetraNode> : public UtilitiesBase<dou
           throw Exceptions::BadCast("Cast from Xpetra::CrsMatrix to Xpetra::TpetraCrsMatrix and Xpetra::TpetraBlockCrsMatrix failed");
         return tmp_BlockCrs->getTpetra_BlockCrsMatrixNonConst();
       }
+    } else if (!rmat.is_null()) {
+      return rmat->getTpetra_RowMatrixNonConst();
     } else {
       RCP<TpetraOperator> tpOp                                                = rcp_dynamic_cast<TpetraOperator>(Op, true);
       RCP<Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node> > tOp   = tpOp->getOperator();

--- a/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
@@ -48,8 +48,10 @@
 
 #include <Teuchos_DefaultComm.hpp>
 #include <Teuchos_ParameterList.hpp>
+#include <iostream>
 
 #include "MueLu_ConfigDefs.hpp"
+#include "Xpetra_TpetraRowMatrix.hpp"
 
 #ifdef HAVE_MUELU_EPETRA
 #ifdef HAVE_MPI
@@ -354,7 +356,8 @@ Tpetra::BlockCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Utilities<Sca
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RCP<const Tpetra::RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Op2TpetraRow(RCP<const Xpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> Op) {
-  RCP<const Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> mat = rcp_dynamic_cast<const Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(Op);
+  RCP<const Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> mat           = rcp_dynamic_cast<const Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(Op);
+  RCP<const Xpetra::TpetraRowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> rmat = rcp_dynamic_cast<const Xpetra::TpetraRowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(Op);
   if (!mat.is_null()) {
     RCP<const Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>> crsOp = rcp_dynamic_cast<const Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(mat);
     if (crsOp == Teuchos::null)
@@ -371,6 +374,8 @@ RCP<const Tpetra::RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> Utilitie
         throw Exceptions::BadCast("Cast from Xpetra::CrsMatrix to Xpetra::TpetraCrsMatrix and Xpetra::TpetraBlockCrsMatrix failed");
       return tmp_BlockCrs->getTpetra_BlockCrsMatrixNonConst();
     }
+  } else if (!rmat.is_null()) {
+    return rmat->getTpetra_RowMatrix();
   } else {
     RCP<const Xpetra::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> tpOp = rcp_dynamic_cast<const Xpetra::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(Op, true);
     RCP<const Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> tOp        = tpOp->getOperatorConst();
@@ -381,7 +386,8 @@ RCP<const Tpetra::RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> Utilitie
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RCP<Tpetra::RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Op2NonConstTpetraRow(RCP<Xpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> Op) {
-  RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> mat = rcp_dynamic_cast<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(Op);
+  RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> mat           = rcp_dynamic_cast<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(Op);
+  RCP<Xpetra::TpetraRowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> rmat = rcp_dynamic_cast<Xpetra::TpetraRowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(Op);
   if (!mat.is_null()) {
     RCP<const Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>> crsOp = rcp_dynamic_cast<const Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(mat);
     if (crsOp == Teuchos::null)
@@ -398,6 +404,8 @@ RCP<Tpetra::RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> Utilities<Scal
         throw Exceptions::BadCast("Cast from Xpetra::CrsMatrix to Xpetra::TpetraCrsMatrix and Xpetra::TpetraBlockCrsMatrix failed");
       return tmp_BlockCrs->getTpetra_BlockCrsMatrixNonConst();
     }
+  } else if (!rmat.is_null()) {
+    return rmat->getTpetra_RowMatrixNonConst();
   } else {
     RCP<Xpetra::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> tpOp = rcp_dynamic_cast<Xpetra::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(Op, true);
     RCP<Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> tOp        = tpOp->getOperator();

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_MultiplicativeOperator_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_MultiplicativeOperator_decl.hpp
@@ -107,9 +107,9 @@ namespace FROSch {
                            SC alpha=ScalarTraits<SC>::one(),
                            SC beta=ScalarTraits<SC>::zero()) const;
 
-        virtual ConstXMapPtr getDomainMap() const;
+        virtual const ConstXMapPtr getDomainMap() const;
 
-        virtual ConstXMapPtr getRangeMap() const;
+        virtual const ConstXMapPtr getRangeMap() const;
 
         virtual void describe(FancyOStream &out,
                               const EVerbosityLevel verbLevel=Describable::verbLevel_default) const;

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_MultiplicativeOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_MultiplicativeOperator_def.hpp
@@ -150,13 +150,13 @@ namespace FROSch {
 
 
     template <class SC,class LO,class GO,class NO>
-    typename MultiplicativeOperator<SC,LO,GO,NO>::ConstXMapPtr MultiplicativeOperator<SC,LO,GO,NO>::getDomainMap() const
+    const typename MultiplicativeOperator<SC,LO,GO,NO>::ConstXMapPtr MultiplicativeOperator<SC,LO,GO,NO>::getDomainMap() const
     {
         return OperatorVector_[0]->getDomainMap();
     }
 
     template <class SC,class LO,class GO,class NO>
-    typename MultiplicativeOperator<SC,LO,GO,NO>::ConstXMapPtr MultiplicativeOperator<SC,LO,GO,NO>::getRangeMap() const
+    const typename MultiplicativeOperator<SC,LO,GO,NO>::ConstXMapPtr MultiplicativeOperator<SC,LO,GO,NO>::getRangeMap() const
     {
         return OperatorVector_[0]->getRangeMap();
     }

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_SchwarzOperator_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_SchwarzOperator_decl.hpp
@@ -204,9 +204,9 @@ namespace FROSch {
                            SC alpha=ScalarTraits<SC>::one(),
                            SC beta=ScalarTraits<SC>::zero()) const = 0;
 
-        virtual ConstXMapPtr getDomainMap() const;
+        virtual const ConstXMapPtr getDomainMap() const;
 
-        virtual ConstXMapPtr getRangeMap() const;
+        virtual const ConstXMapPtr getRangeMap() const;
 
         virtual void describe(FancyOStream &out,
                               const EVerbosityLevel verbLevel=Describable::verbLevel_default) const = 0;

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_SchwarzOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_SchwarzOperator_def.hpp
@@ -87,13 +87,13 @@ namespace FROSch {
     }
 
     template<class SC,class LO,class GO,class NO>
-    typename SchwarzOperator<SC,LO,GO,NO>::ConstXMapPtr SchwarzOperator<SC,LO,GO,NO>::getDomainMap() const
+    const typename SchwarzOperator<SC,LO,GO,NO>::ConstXMapPtr SchwarzOperator<SC,LO,GO,NO>::getDomainMap() const
     {
         return K_->getDomainMap();
     }
 
     template<class SC,class LO,class GO,class NO>
-    typename SchwarzOperator<SC,LO,GO,NO>::ConstXMapPtr SchwarzOperator<SC,LO,GO,NO>::getRangeMap() const
+    const typename SchwarzOperator<SC,LO,GO,NO>::ConstXMapPtr SchwarzOperator<SC,LO,GO,NO>::getRangeMap() const
     {
         return K_->getRangeMap();
     }

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_SumOperator_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_SumOperator_decl.hpp
@@ -96,9 +96,9 @@ namespace FROSch {
                            SC alpha=ScalarTraits<SC>::one(),
                            SC beta=ScalarTraits<SC>::zero()) const;
 
-        virtual ConstXMapPtr getDomainMap() const;
+        virtual const ConstXMapPtr getDomainMap() const;
 
-        virtual ConstXMapPtr getRangeMap() const;
+        virtual const ConstXMapPtr getRangeMap() const;
 
         virtual void describe(FancyOStream &out,
                               const EVerbosityLevel verbLevel=Describable::verbLevel_default) const;

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_SumOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_SumOperator_def.hpp
@@ -134,13 +134,13 @@ namespace FROSch {
     }
 
     template <class SC,class LO,class GO,class NO>
-    typename SumOperator<SC,LO,GO,NO>::ConstXMapPtr SumOperator<SC,LO,GO,NO>::getDomainMap() const
+    const typename SumOperator<SC,LO,GO,NO>::ConstXMapPtr SumOperator<SC,LO,GO,NO>::getDomainMap() const
     {
         return OperatorVector_[0]->getDomainMap();
     }
 
     template <class SC,class LO,class GO,class NO>
-    typename SumOperator<SC,LO,GO,NO>::ConstXMapPtr SumOperator<SC,LO,GO,NO>::getRangeMap() const
+    const typename SumOperator<SC,LO,GO,NO>::ConstXMapPtr SumOperator<SC,LO,GO,NO>::getRangeMap() const
     {
         return OperatorVector_[0]->getRangeMap();
     }

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_AlgebraicOverlappingPreconditioner_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_AlgebraicOverlappingPreconditioner_decl.hpp
@@ -90,9 +90,9 @@ namespace FROSch {
                            SC alpha=ScalarTraits<SC>::one(),
                            SC beta=ScalarTraits<SC>::zero()) const;
 
-        virtual ConstXMapPtr getDomainMap() const;
+        virtual const ConstXMapPtr getDomainMap() const;
 
-        virtual ConstXMapPtr getRangeMap() const;
+        virtual const ConstXMapPtr getRangeMap() const;
 
         virtual void describe(FancyOStream &out,
                               const EVerbosityLevel verbLevel=Describable::verbLevel_default) const;

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_AlgebraicOverlappingPreconditioner_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_AlgebraicOverlappingPreconditioner_def.hpp
@@ -98,13 +98,13 @@ namespace FROSch {
     }
 
     template <class SC,class LO,class GO,class NO>
-    typename AlgebraicOverlappingPreconditioner<SC,LO,GO,NO>::ConstXMapPtr AlgebraicOverlappingPreconditioner<SC,LO,GO,NO>::getDomainMap() const
+    const typename AlgebraicOverlappingPreconditioner<SC,LO,GO,NO>::ConstXMapPtr AlgebraicOverlappingPreconditioner<SC,LO,GO,NO>::getDomainMap() const
     {
         return K_->getDomainMap();
     }
 
     template <class SC,class LO,class GO,class NO>
-    typename AlgebraicOverlappingPreconditioner<SC,LO,GO,NO>::ConstXMapPtr AlgebraicOverlappingPreconditioner<SC,LO,GO,NO>::getRangeMap() const
+    const typename AlgebraicOverlappingPreconditioner<SC,LO,GO,NO>::ConstXMapPtr AlgebraicOverlappingPreconditioner<SC,LO,GO,NO>::getRangeMap() const
     {
         return K_->getRangeMap();
     }

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_OneLevelPreconditioner_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_OneLevelPreconditioner_decl.hpp
@@ -95,9 +95,9 @@ namespace FROSch {
                            SC alpha=ScalarTraits<SC>::one(),
                            SC beta=ScalarTraits<SC>::zero()) const;
 
-        virtual ConstXMapPtr getDomainMap() const;
+        virtual const ConstXMapPtr getDomainMap() const;
 
-        virtual ConstXMapPtr getRangeMap() const;
+        virtual const ConstXMapPtr getRangeMap() const;
 
         virtual void describe(FancyOStream &out,
                               const EVerbosityLevel verbLevel=Describable::verbLevel_default) const;

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_OneLevelPreconditioner_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_OneLevelPreconditioner_def.hpp
@@ -142,13 +142,13 @@ namespace FROSch {
     }
 
     template <class SC,class LO,class GO,class NO>
-    typename OneLevelPreconditioner<SC,LO,GO,NO>::ConstXMapPtr OneLevelPreconditioner<SC,LO,GO,NO>::getDomainMap() const
+    const typename OneLevelPreconditioner<SC,LO,GO,NO>::ConstXMapPtr OneLevelPreconditioner<SC,LO,GO,NO>::getDomainMap() const
     {
         return K_->getDomainMap();
     }
 
     template <class SC,class LO,class GO,class NO>
-    typename OneLevelPreconditioner<SC,LO,GO,NO>::ConstXMapPtr OneLevelPreconditioner<SC,LO,GO,NO>::getRangeMap() const
+    const typename OneLevelPreconditioner<SC,LO,GO,NO>::ConstXMapPtr OneLevelPreconditioner<SC,LO,GO,NO>::getRangeMap() const
     {
         return K_->getRangeMap();
     }

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_SchwarzPreconditioner_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_SchwarzPreconditioner_decl.hpp
@@ -129,9 +129,9 @@ namespace FROSch {
                            SC alpha=ScalarTraits<SC>::one(),
                            SC beta=ScalarTraits<SC>::zero()) const = 0;
 
-        virtual ConstXMapPtr getDomainMap() const = 0;
+        virtual const ConstXMapPtr getDomainMap() const = 0;
 
-        virtual ConstXMapPtr getRangeMap() const = 0;
+        virtual const ConstXMapPtr getRangeMap() const = 0;
 
         virtual void describe(FancyOStream &out,
                               const EVerbosityLevel verbLevel=Describable::verbLevel_default) const = 0;

--- a/packages/shylu/shylu_dd/frosch/src/SolverInterfaces/FROSch_Solver_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SolverInterfaces/FROSch_Solver_decl.hpp
@@ -112,10 +112,10 @@ namespace FROSch {
                            SC beta=ScalarTraits<SC>::zero()) const = 0;
 
         //! Get domain map
-        virtual ConstXMapPtr getDomainMap() const;
+        virtual const ConstXMapPtr getDomainMap() const;
 
         //! Get range map
-        virtual ConstXMapPtr getRangeMap() const;
+        virtual const ConstXMapPtr getRangeMap() const;
 
         //! Get #IsInitialized_
         bool isInitialized() const;

--- a/packages/shylu/shylu_dd/frosch/src/SolverInterfaces/FROSch_Solver_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SolverInterfaces/FROSch_Solver_def.hpp
@@ -51,13 +51,13 @@ namespace FROSch {
     using namespace Xpetra;
 
     template<class SC,class LO,class GO,class NO>
-    typename Solver<SC,LO,GO,NO>::ConstXMapPtr Solver<SC,LO,GO,NO>::getDomainMap() const
+    const typename Solver<SC,LO,GO,NO>::ConstXMapPtr Solver<SC,LO,GO,NO>::getDomainMap() const
     {
         return K_->getDomainMap();
     }
 
     template<class SC,class LO,class GO,class NO>
-    typename Solver<SC,LO,GO,NO>::ConstXMapPtr Solver<SC,LO,GO,NO>::getRangeMap() const
+    const typename Solver<SC,LO,GO,NO>::ConstXMapPtr Solver<SC,LO,GO,NO>::getRangeMap() const
     {
         return K_->getRangeMap();
     }

--- a/packages/xpetra/src/BlockedCrsMatrix/Xpetra_BlockedCrsMatrix.hpp
+++ b/packages/xpetra/src/BlockedCrsMatrix/Xpetra_BlockedCrsMatrix.hpp
@@ -1066,7 +1066,7 @@ class BlockedCrsMatrix : public Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node
   }
 
   //! \brief Returns the Map associated with the domain of this operator.
-  RCP<const Map> getDomainMap() const {
+  const RCP<const Map> getDomainMap() const {
     XPETRA_MONITOR("XpetraBlockedCrsMatrix::getDomainMap()");
     return domainmaps_->getMap(); /*domainmaps_->getFullMap();*/
   }
@@ -1096,7 +1096,7 @@ class BlockedCrsMatrix : public Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node
   }
 
   //! Returns the Map associated with the range of this operator.
-  RCP<const Map> getRangeMap() const {
+  const RCP<const Map> getRangeMap() const {
     XPETRA_MONITOR("XpetraBlockedCrsMatrix::getRangeMap()");
     return rangemaps_->getMap(); /*rangemaps_->getFullMap();*/
   }

--- a/packages/xpetra/src/Operator/Xpetra_EpetraOperator.hpp
+++ b/packages/xpetra/src/Operator/Xpetra_EpetraOperator.hpp
@@ -71,13 +71,13 @@ class EpetraOperator : public Operator<double, int, EpetraGlobalOrdinal, Node> {
   //@{
 
   //! The Map associated with the domain of this operator, which must be compatible with X.getMap().
-  virtual Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > getDomainMap() const {
+  virtual const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > getDomainMap() const {
     XPETRA_MONITOR("EpetraOperator::getDomainMap()");
     return toXpetra<GlobalOrdinal, Node>(op_->OperatorDomainMap());
   }
 
   //! The Map associated with the range of this operator, which must be compatible with Y.getMap().
-  virtual Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > getRangeMap() const {
+  virtual const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > getRangeMap() const {
     XPETRA_MONITOR("EpetraOperator::getRangeMap()");
     return toXpetra<GlobalOrdinal, Node>(op_->OperatorRangeMap());
   }

--- a/packages/xpetra/src/Operator/Xpetra_Operator.hpp
+++ b/packages/xpetra/src/Operator/Xpetra_Operator.hpp
@@ -62,8 +62,8 @@ template <class Scalar,
           class GlobalOrdinal,
           class Node = Tpetra::KokkosClassic::DefaultNode::DefaultNodeType>
 class Operator : virtual public Teuchos::Describable {
-  typedef Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> Map;
-  typedef Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MultiVector;
+  typedef Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> map_type;
+  typedef Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> mv_type;
 
  public:
   virtual ~Operator() {}
@@ -87,10 +87,10 @@ class Operator : virtual public Teuchos::Describable {
   //@{
 
   //! The Map associated with the domain of this operator, which must be compatible with X.getMap().
-  virtual Teuchos::RCP<const Map> getDomainMap() const = 0;
+  virtual const Teuchos::RCP<const map_type> getDomainMap() const = 0;
 
   //! The Map associated with the range of this operator, which must be compatible with Y.getMap().
-  virtual Teuchos::RCP<const Map> getRangeMap() const = 0;
+  virtual const Teuchos::RCP<const map_type> getRangeMap() const = 0;
 
   //! \brief Computes the operator-multivector application.
   /*! Loosely, performs \f$Y = \alpha \cdot A^{\textrm{mode}} \cdot X + \beta \cdot Y\f$. However, the details of operation
@@ -99,7 +99,7 @@ class Operator : virtual public Teuchos::Describable {
       - if <tt>alpha == 0</tt>, apply() <b>may</b> short-circuit the operator, so that any values in \c X (including NaNs) are ignored.
    */
   virtual void
-  apply(const MultiVector& X, MultiVector& Y,
+  apply(const mv_type& X, mv_type& Y,
         Teuchos::ETransp mode = Teuchos::NO_TRANS,
         Scalar alpha          = Teuchos::ScalarTraits<Scalar>::one(),
         Scalar beta           = Teuchos::ScalarTraits<Scalar>::zero()) const = 0;
@@ -114,12 +114,12 @@ class Operator : virtual public Teuchos::Describable {
 
   //@}
 
-  virtual void removeEmptyProcessesInPlace(const RCP<const Map>& /* newMap */) {}
+  virtual void removeEmptyProcessesInPlace(const RCP<const map_type>& /* newMap */) {}
 
   //! Compute a residual R = B - (*this) * X
-  virtual void residual(const MultiVector& X,
-                        const MultiVector& B,
-                        MultiVector& R) const = 0;
+  virtual void residual(const mv_type& X,
+                        const mv_type& B,
+                        mv_type& R) const = 0;
 };
 
 }  // namespace Xpetra

--- a/packages/xpetra/src/Operator/Xpetra_TpetraOperator.hpp
+++ b/packages/xpetra/src/Operator/Xpetra_TpetraOperator.hpp
@@ -70,13 +70,13 @@ class TpetraOperator : public Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node
   //@{
 
   //! The Map associated with the domain of this operator, which must be compatible with X.getMap().
-  virtual Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > getDomainMap() const {
+  virtual const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > getDomainMap() const {
     XPETRA_MONITOR("TpetraOperator::getDomainMap()");
     return toXpetra(op_->getDomainMap());
   }
 
   //! The Map associated with the range of this operator, which must be compatible with Y.getMap().
-  virtual Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > getRangeMap() const {
+  virtual const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > getRangeMap() const {
     XPETRA_MONITOR("TpetraOperator::getRangeMap()");
     return toXpetra(op_->getRangeMap());
   }

--- a/packages/xpetra/src/RowMatrix/Xpetra_RowMatrix.hpp
+++ b/packages/xpetra/src/RowMatrix/Xpetra_RowMatrix.hpp
@@ -54,6 +54,7 @@
 #include <Tpetra_KokkosCompat_DefaultNode.hpp>
 #include "Xpetra_ConfigDefs.hpp"
 #include "Xpetra_Map.hpp"
+#include "Xpetra_Operator.hpp"
 #include "Xpetra_Vector.hpp"
 
 namespace Xpetra {
@@ -62,7 +63,7 @@ template <class Scalar,
           class LocalOrdinal,
           class GlobalOrdinal,
           class Node = Tpetra::KokkosClassic::DefaultNode::DefaultNodeType>
-class RowMatrix {
+class RowMatrix : virtual public Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node> {
  public:
   typedef Scalar scalar_type;
   typedef LocalOrdinal local_ordinal_type;

--- a/packages/xpetra/sup/Matrix/Xpetra_CrsMatrixWrap_decl.hpp
+++ b/packages/xpetra/sup/Matrix/Xpetra_CrsMatrixWrap_decl.hpp
@@ -397,11 +397,11 @@ class CrsMatrixWrap : public Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> {
 
   //! \brief Returns the Map associated with the domain of this operator.
   //! This will be <tt>null</tt> until fillComplete() is called.
-  RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > getDomainMap() const;
+  const RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > getDomainMap() const;
 
   //! Returns the Map associated with the domain of this operator.
   //! This will be <tt>null</tt> until fillComplete() is called.
-  RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > getRangeMap() const;
+  const RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > getRangeMap() const;
 
   //! \brief Returns the Map that describes the column distribution in this matrix.
   //! This might be <tt>null</tt> until fillComplete() is called.

--- a/packages/xpetra/sup/Matrix/Xpetra_CrsMatrixWrap_def.hpp
+++ b/packages/xpetra/sup/Matrix/Xpetra_CrsMatrixWrap_def.hpp
@@ -358,12 +358,12 @@ void CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>::apply(const Multi
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getDomainMap() const {
+const RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getDomainMap() const {
   return matrixData_->getDomainMap();
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getRangeMap() const {
+const RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getRangeMap() const {
   return matrixData_->getRangeMap();
 }
 


### PR DESCRIPTION
@trilinos/xpetra @trilinos/muelu 

## Motivation
- Derive `Xpetra::RowMatrix` from `Xpetra::Operator` to mirror Tpetra.
- MueLu Ifpack2: Fix an inefficiency in Hiptmair+Chebyshev.
- MueLu: Fix a couple of bad SubFactoryMonitors that were immediately deallocated.
- MueLu Ifpack2 Chebyshev: Allow use with RowMatrix.