### PR TITLE
Framework: Rename nightly builds with custom dashboard name

### DIFF
--- a/cmake/SimpleTesting/cmake/ctest-cdash-setup.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-cdash-setup.cmake
@@ -65,14 +65,14 @@ endif()
 
 # Optionally upload the config files
 # TODO: Note how this works / what it's doing in CMake-land.
-message(">>> Write `configure_command_file`:")
+message(">>> Write `configure_command_file` and `genconfig_build_name_file`:")
 if(skip_upload_config_files)
     message(">>> - SKIPPED")
 else()
     message(">>> - WRITTEN")
-    #message(">>> - configure_command_file : ${configure_command_file}")
-    #message(">>> - CTEST_CONFIGURE_COMMAND: ${CTEST_CONFIGURE_COMMAND}")
     file(WRITE ${configure_command_file} ${CTEST_CONFIGURE_COMMAND})
+    file(WRITE ${genconfig_build_name_file} $ENV{GENCONFIG_BUILD_NAME})
+
 endif()
 message(">>>")
 

--- a/cmake/SimpleTesting/cmake/ctest-common.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-common.cmake
@@ -158,6 +158,7 @@ set(CTEST_BUILD_FLAGS "-j${PARALLEL_LEVEL} -k 0")
 # * REQUIRES `CTEST_BINARY_DIRECTORY` to be set.
 if(NOT skip_upload_config_files)
     set(configure_command_file ${CTEST_BINARY_DIRECTORY}/configure_command.txt)
+    set(genconfig_build_name_file ${CTEST_BINARY_DIRECTORY}/genconfig_build_name.txt)
 endif()
 
 

--- a/cmake/SimpleTesting/cmake/ctest-functions.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-functions.cmake
@@ -82,8 +82,14 @@ macro(submit_upload_config_files)
         if( NOT (skip_single_submit AND skip_by_parts_submit) )
             message(">>> ctest_upload(FILES ${configure_command_file}")
             message("                 ${configure_file}")
-            message("                 ${package_enables_file} )")
-            ctest_upload(FILES ${configure_command_file} ${configure_file} ${package_enables_file})
+            message("                 ${package_enables_file}")
+            message("                 ${genconfig_build_name_file})")
+
+            ctest_upload(FILES ${configure_command_file}
+                               ${configure_file}
+                               ${package_enables_file}
+                               ${genconfig_build_name_file})
+
             message(">>> ctest_submit(PARTS upload")
             message("                 RETRY_COUNT  ${ctest_submit_retry_count}")
             message("                 RETRY_DELAY  ${ctest_submit_retry_delay}")
@@ -127,6 +133,7 @@ macro(print_options_list)
     message(">>> subproject_count         = ${subproject_count}")
     message(">>> dashboard_model          = ${dashboard_model}")
     message(">>> dashboard_track          = ${dashboard_track}")
+    message(">>> genconfig_build_name_file= ${genconfig_build_name_file}")
     message(">>> configure_command_file   = ${configure_command_file}")
     message(">>> configure_file           = ${configure_file}")
     message(">>> build_root               = ${build_root}")

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -210,6 +210,7 @@ test_cmd_options=(
     --build-dir=${TRILINOS_BUILD_DIR:?}
     --ctest-driver=${WORKSPACE:?}/Trilinos/cmake/SimpleTesting/cmake/ctest-driver.cmake
     --ctest-drop-site=${TRILINOS_CTEST_DROP_SITE:?}
+    --dashboard-build-name=${DASHBOARD_BUILD_NAME}
 )
 
 if [[ ${on_kokkos_develop} == "1" ]]

--- a/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
@@ -109,6 +109,13 @@ def parse_args():
                           help='The Jenkins build number',
                           required=True)
 
+    optional.add_argument('--dashboard-build-name',
+                          dest="dashboard_build_name",
+                          action='store',
+                          default="UNKNOWN",
+                          help='The build name posted by ctest to a dashboard',
+                          required=False)
+
     optional.add_argument('--source-dir',
                           dest="source_dir",
                           action='store',
@@ -280,6 +287,7 @@ def parse_args():
     print("| - [O] test-mode                   : {test_mode}".format(**vars(arguments)))
     print("| - [O] workspace-dir               : {workspace_dir}".format(**vars(arguments)))
     print("| - [O] extra_configure_args        : {extra_configure_args}".format(**vars(arguments)))
+    print("| - [O] dashboard_build_name        : {dashboard_build_name}".format(**vars(arguments)))
     #print("| - [O] : {}".format(**vars(arguments)))
     print("+" + "="*78 + "+")
 

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -46,6 +46,8 @@ class TrilinosPRConfigurationBase(object):
         arg_pr_config_file: The config.ini file that specifies the configuration to load.
         arg_pr_jenkins_job_name: The Jenkins Job Name.
         arg_ccache_enable: Enable ccache.
+        arg_dashboard_build_name: A shortened genconfig build name
+                                  for posting to a testing dashboard.
         filename_subprojects: The subprojects file.
         working_directory_ctest: Gen. working dir where TFW_testing_single_configure_prototype
             is executed from.
@@ -299,6 +301,14 @@ class TrilinosPRConfigurationBase(object):
         """
         return self.args.genconfig_build_name
 
+    @property
+    def arg_dashboard_build_name(self):
+        """
+        The simplified genconfig build name containing only the
+        special attributes of the full build name.
+        Default is to use the value in args.dashboard_build_name.
+        """
+        return self.args.dashboard_build_name
 
     @property
     def arg_filename_subprojects(self):
@@ -474,6 +484,8 @@ class TrilinosPRConfigurationBase(object):
         """
         if self.arg_pullrequest_cdash_track == "Pull Request":
             output = "PR-{}-test-{}-{}".format(self.arg_pullrequest_number, self.arg_pr_genconfig_job_name, self.arg_jenkins_job_number)
+        elif self.arg_pullrequest_cdash_track == "Nightly":
+            output = self.arg_dashboard_build_name
         else:
             output = self.arg_pr_genconfig_job_name            
         return output
@@ -698,6 +710,7 @@ class TrilinosPRConfigurationBase(object):
         self.message("--- arg_pr_gen_config_file      = {}".format(self.arg_pr_gen_config_file))
         self.message("--- arg_pr_jenkins_job_name     = {}".format(self.arg_pr_jenkins_job_name))
         self.message("--- arg_pr_genconfig_job_name   = {}".format(self.arg_pr_genconfig_job_name))
+        self.message("--- arg_dashboard_build_name    = {}".format(self.arg_dashboard_build_name))
         self.message("--- arg_pullrequest_number      = {}".format(self.arg_pullrequest_number))
         self.message("--- arg_pullrequest_cdash_track = {}".format(self.arg_pullrequest_cdash_track))
         self.message("--- arg_req_mem_per_core        = {}".format(self.arg_req_mem_per_core))

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -212,6 +212,7 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
             target_branch_name="develop",
             pullrequest_build_name="Trilinos-pullrequest-gcc-7.2.0",
             genconfig_build_name="rhel7_sems-gnu-7.2.0-openmpi-1.10.1-openmp_release_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-package-enables",
+            dashboard_build_name="gnu-7.2.0-openmpi-1.10.1_release_static_openmp",
             jenkins_job_number=99,
             pullrequest_number='0000',
             pullrequest_cdash_track="Pull Request",
@@ -263,6 +264,12 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
     def dummy_args_non_pr_track(self):
         args = copy.deepcopy(self.dummy_args())
         args.pullrequest_cdash_track = "some_random_track"
+        return args
+
+
+    def dummy_args_nightly_track(self):
+        args = copy.deepcopy(self.dummy_args())
+        args.pullrequest_cdash_track = "Nightly"
         return args
 
 
@@ -354,6 +361,15 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         build_name = pr_config.pullrequest_build_name
         print("--- build_name = {}".format(build_name))
         expected_build_name = args.genconfig_build_name
+        self.assertEqual(build_name, expected_build_name)
+
+
+    def test_TrilinosPRConfigurationBaseBuildNameNightlyTrack(self):
+        args = self.dummy_args_nightly_track()
+        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
+        build_name = pr_config.pullrequest_build_name
+        print("--- build_name = {}".format(build_name))
+        expected_build_name = args.dashboard_build_name
         self.assertEqual(build_name, expected_build_name)
 
 

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -368,7 +368,6 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         args = self.dummy_args_nightly_track()
         pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
         build_name = pr_config.pullrequest_build_name
-        print("--- build_name = {}".format(build_name))
         expected_build_name = args.dashboard_build_name
         self.assertEqual(build_name, expected_build_name)
 

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationInstallation.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationInstallation.py
@@ -155,6 +155,7 @@ class TrilinosPRConfigurationInstallationTest(TestCase):
             target_branch_name="develop",
             pullrequest_build_name="Trilinos-pullrequest-gcc-8.3.0-installation-testing",
             genconfig_build_name="rhel7_sems-gnu-8.3.0-openmpi-1.10.1-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_trilinos-pr",
+            dashboard_build_name="gnu-7.2.0-openmpi-1.10.1_release-debug_shared_openmp",
             pullrequest_cdash_track="Pull Request",
             jenkins_job_number=99,
             pullrequest_number='0000',

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationStandard.py
@@ -152,6 +152,7 @@ class TrilinosPRConfigurationStandardTest(TestCase):
             target_branch_name="develop",
             pullrequest_build_name="Trilinos-pullrequest-gcc-7.2.0",
             genconfig_build_name="rhel7_sems-gnu-7.2.0-openmpi-1.10.1-openmp_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_trilinos-pr",
+            dashboard_build_name="gnu-7.2.0-openmpi-1.10.1_release-debug_shared_openmp",
             pullrequest_cdash_track="Pull Request",
             jenkins_job_number=99,
             pullrequest_number='0000',

--- a/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
@@ -67,6 +67,7 @@ class Test_parse_args(unittest.TestCase):
                                          target_branch_name='real_trash',
                                          pullrequest_build_name='Some_odd_compiler',
                                          genconfig_build_name='Some_odd_compiler_and_options',
+                                         dashboard_build_name='UNKNOWN',
                                          pullrequest_number='4242',
                                          jenkins_job_number='2424',
                                          source_dir='UNKNOWN',
@@ -121,6 +122,7 @@ class Test_parse_args(unittest.TestCase):
                                    --genconfig-build-name GENCONFIG_BUILD_NAME
                                    --pullrequest-number PULLREQUEST_NUMBER
                                    --jenkins-job-number JENKINS_JOB_NUMBER
+                                   [--dashboard-build-name DASHBOARD_BUILD_NAME]
                                    [--source-dir SOURCE_DIR] [--build-dir BUILD_DIR]
                                    [--use-explicit-cachefile] [--ctest-driver CTEST_DRIVER]
                                    [--ctest-drop-site CTEST_DROP_SITE]
@@ -159,6 +161,8 @@ class Test_parse_args(unittest.TestCase):
                                         The Jenkins build number
 
                 Optional Arguments:
+                  --dashboard-build-name DASHBOARD_BUILD_NAME
+                                        The build name posted by ctest to a dashboard
                   --source-dir SOURCE_DIR
                                         Directory containing the source code to compile/test.
                   --build-dir BUILD_DIR
@@ -227,6 +231,7 @@ class Test_parse_args(unittest.TestCase):
                                    --genconfig-build-name GENCONFIG_BUILD_NAME
                                    --pullrequest-number PULLREQUEST_NUMBER
                                    --jenkins-job-number JENKINS_JOB_NUMBER
+                                   [--dashboard-build-name DASHBOARD_BUILD_NAME]
                                    [--source-dir SOURCE_DIR] [--build-dir BUILD_DIR]
                                    [--use-explicit-cachefile] [--ctest-driver CTEST_DRIVER]
                                    [--ctest-drop-site CTEST_DROP_SITE]


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework

## Motivation
Current build names posted to CDash use GenConfig build name strings which are unreadable at a glance when trying to differentiate between build lines. The build names should only include "special" attributes of the GenConfig strings to be more easily readable. 

This will be trialed with the nightly builds first.

## Proposed Solution
- Jenkins nightly jobs have new env variable `DASHBOARD_BUILD_NAME`
- This env variable is read by the PR scripts somewhere and uses this value when posting to the CDash track `Nightly`


<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
- [TRILFRAME-620](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-620)

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
- `test_TrilinosPRConfigurationBaseBuildNameNightlyTrack`
- `TrilinosFrameworkTests` testing all related Trilinos PR scripts touched by these changes
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->