### PR TITLE
Krino: Do not process krino tests if testing is disabled

### DIFF
--- a/packages/krino/krino/CMakeLists.txt
+++ b/packages/krino/krino/CMakeLists.txt
@@ -11,7 +11,7 @@ add_subdirectory(krino_lib)
 add_subdirectory(region)
 add_subdirectory(rebalance_utils)
 add_subdirectory(parser)
-add_subdirectory(unit_tests)
+TRIBITS_ADD_TEST_DIRECTORIES(unit_tests)
 
 SET(SOURCES_MAIN Apps_krino.cpp)
 


### PR DESCRIPTION
Setting `-DTrilinos_ENABLE_Krino=ON` `-DTrilinos_ENABLE_TESTS=OFF` `-DTrilinos_ENABLE_Gtest=OFF` yielded build errors finding gtest headers, which showed that Krino tests were still being built. Disable them conditionally with the
`TRIBITS_ADD_TEST_DIRECTORIES()` macro (note that this is the correct thing do to as per
https://tribits.org/doc/TribitsUsersGuide.html#tribits-add-executable-and-test)

## Motivation
Want to be able to disable the build of test executables in Krino with `-DTrilinos_ENABLE_TESTS=OFF`.  I need to do this to add a build-only PR line.

## Testing
Tested my local build with this change and the test executable did not get built (which was the expected behavior).
