### PR TITLE
ifpack2 : reorganize symbolic/numeric setup of SparseContainer 

### DIFF
--- a/packages/ifpack2/src/Ifpack2_SparseContainer_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_SparseContainer_decl.hpp
@@ -172,7 +172,7 @@ private:
   using inverse_mv_type = Tpetra::MultiVector<InverseScalar, InverseLocalOrdinal, InverseGlobalOrdinal, InverseNode>;
   using InverseCrs = Tpetra::CrsMatrix<InverseScalar, InverseLocalOrdinal, InverseGlobalOrdinal, InverseNode>;
   using InverseMap = typename Tpetra::Map<InverseLocalOrdinal, InverseGlobalOrdinal, InverseNode>;
-
+  using InverseGraph = typename InverseCrs::crs_graph_type;
   using typename Container<MatrixType>::HostView;
   using typename Container<MatrixType>::ConstHostView;
   using HostViewInverse = typename inverse_mv_type::dual_view_type::t_host;
@@ -287,6 +287,8 @@ private:
 
   //! Extract the submatrices identified by the local indices set by the constructor.
   void extract ();
+  void extractGraph ();
+  void extractValues ();
 
   /// \brief Post-permutation, post-view version of apply().
   ///

--- a/packages/ifpack2/src/Ifpack2_SparseContainer_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_SparseContainer_def.hpp
@@ -90,6 +90,9 @@ void SparseContainer<MatrixType,InverseType>::initialize ()
   // objects.  We do this first to save memory.  (In an RCP
   // assignment, the right-hand side and left-hand side coexist before
   // the left-hand side's reference count gets updated.)
+  Teuchos::RCP<Teuchos::Time> timer =
+    Teuchos::TimeMonitor::getNewCounter ("Ifpack2::SparseContainer::initialize");
+  Teuchos::TimeMonitor timeMon (*timer);
 
   //Will create the diagonal blocks and their inverses
   //in extract()
@@ -114,6 +117,10 @@ void SparseContainer<MatrixType,InverseType>::initialize ()
 template<class MatrixType, class InverseType>
 void SparseContainer<MatrixType,InverseType>::compute ()
 {
+  Teuchos::RCP<Teuchos::Time> timer =
+    Teuchos::TimeMonitor::getNewCounter ("Ifpack2::SparseContainer::compute");
+  Teuchos::TimeMonitor timeMon (*timer);
+
   this->IsComputed_ = false;
   if (!this->isInitialized ()) {
     this->initialize ();
@@ -188,6 +195,10 @@ apply (ConstHostView X,
   // to convert X and Y to the Tpetra::MultiVector specialization that
   // InverseType wants.  This class' X_ and Y_ internal fields are of
   // the right type for InverseType, so we can use those as targets.
+  Teuchos::RCP<Teuchos::Time> timer =
+    Teuchos::TimeMonitor::getNewCounter ("Ifpack2::SparseContainer::apply");
+  Teuchos::TimeMonitor timeMon (*timer);
+
 
   // Tpetra::MultiVector specialization corresponding to InverseType.
   Details::MultiVectorLocalGatherScatter<mv_type, inverse_mv_type> mvgs;
@@ -664,6 +675,10 @@ extractGraph ()
   //offset - blockOffsets_[b]: gives the column within block b.
   //
   //This provides the block and col within a block in O(1).
+  Teuchos::RCP<Teuchos::Time> timer =
+    Teuchos::TimeMonitor::getNewCounter ("Ifpack2::SparseContainer::extractGraph");
+  Teuchos::TimeMonitor timeMon (*timer);
+
   Teuchos::Array<InverseGlobalOrdinal> indicesToInsert;
   if(this->scalarsPerRow_ > 1)
   {
@@ -818,6 +833,10 @@ extractValues ()
   //offset - blockOffsets_[b]: gives the column within block b.
   //
   //This provides the block and col within a block in O(1).
+  Teuchos::RCP<Teuchos::Time> timer =
+    Teuchos::TimeMonitor::getNewCounter ("Ifpack2::SparseContainer::extractValues");
+  Teuchos::TimeMonitor timeMon (*timer);
+
   Teuchos::Array<InverseGlobalOrdinal> indicesToInsert;
   Teuchos::Array<InverseScalar> valuesToInsert;
   if(this->scalarsPerRow_ > 1)

--- a/packages/ifpack2/test/belos/CMakeLists.txt
+++ b/packages/ifpack2/test/belos/CMakeLists.txt
@@ -46,6 +46,7 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(Ifpack2BelosCopyFiles
   test_ILUT_calore1_mm.xml 
   test_Jacobi_calore1_mm.xml 
   test_Jacobi_calore1_mm_constGraph.xml 
+  test_BlockRelaxationAmesos2_calore1_mm.xml
   test_BlockRelaxationZoltan2_calore1_mm.xml
   test_GS_calore1_mm.xml
   test_MTGS_calore1_mm.xml
@@ -946,6 +947,17 @@ TRIBITS_ADD_TEST(
   tif_belos
   NAME BlockRelaxation_Zoltan2_belos
   ARGS "--xml_file=test_BlockRelaxationZoltan2_calore1_mm.xml"
+  COMM serial mpi
+  NUM_MPI_PROCS 2
+  STANDARD_PASS_OUTPUT
+)
+ENDIF()
+
+IF(${PACKAGE_NAME}_ENABLE_Amesos2)
+TRIBITS_ADD_TEST(
+  tif_belos
+  NAME BlockRelaxation_Amesos2_belos
+  ARGS "--xml_file=test_BlockRelaxationAmesos2_calore1_mm.xml"
   COMM serial mpi
   NUM_MPI_PROCS 2
   STANDARD_PASS_OUTPUT

--- a/packages/ifpack2/test/belos/test_BlockRelaxationAmesos2_calore1_mm.xml
+++ b/packages/ifpack2/test/belos/test_BlockRelaxationAmesos2_calore1_mm.xml
@@ -1,0 +1,29 @@
+<ParameterList name="test_params">
+  <Parameter name="mm_file"     type="string" value="calore1.mtx"/>
+  <Parameter name="rhs_mm_file" type="string" value="calore1_rhs.mtx"/>
+
+  <Parameter name="solver_type" type="string" value="Block Gmres"/>
+  <ParameterList name="Belos">
+    <!-- "Num Blocks" is the krylov subspace size, or iters-per-restart. -->
+    <Parameter name="Num Blocks" type="int" value="50"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+  </ParameterList>
+
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="SCHWARZ"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="schwarz: overlap level" type="int"    value="1"/>
+    <Parameter name="schwarz: combine mode"  type="string" value="ZERO"/>
+    <Parameter name="subdomain solver name"  type="string" value="BLOCK_RELAXATION"/>
+    <ParameterList name="subdomain solver parameters">
+      <Parameter name="partitioner: local parts" type="int"      value="2"/>
+      <Parameter name="partitioner: overlap"     type="int"      value="1"/>
+      <Parameter name="relaxation: container"    type="string"   value="SparseAmesos2"/>
+      <ParameterList name="Amesos2">
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="11"/>
+</ParameterList>


### PR DESCRIPTION
@trilinos/ifpack2 

## Motivation

Attempt to reorganize the symbolic/numerical setup of SparseContainer.

## Testing

## Additional Information

 It is still on host, but this lets us call initialize on each block during symbolic setup (for BlockRelaxation) and addresses [Issue#12789](https://github.com/trilinos/Trilinos/issues/12789).
