### PR TITLE
Framework: Rename Kokkos nightly integration builds with custom dashboard name

### DIFF
--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -481,11 +481,11 @@ class TrilinosPRConfigurationBase(object):
         Generate the build name string to report back to CDash.
 
         PR-<PR Number>-test-<Jenkins Job Name>-<Job Number">
+
         """
         if self.arg_pullrequest_cdash_track == "Pull Request":
             output = "PR-{}-test-{}-{}".format(self.arg_pullrequest_number, self.arg_pr_genconfig_job_name, self.arg_jenkins_job_number)
-        elif self.arg_pullrequest_cdash_track == "Nightly" or \
-             self.arg_pullrequest_cdash_track == "Kokkos Integration":
+        elif self.arg_dashboard_build_name != "__UNKNOWN__":
             output = self.arg_dashboard_build_name
         else:
             output = self.arg_pr_genconfig_job_name            

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -481,7 +481,6 @@ class TrilinosPRConfigurationBase(object):
         Generate the build name string to report back to CDash.
 
         PR-<PR Number>-test-<Jenkins Job Name>-<Job Number">
-
         """
         if self.arg_pullrequest_cdash_track == "Pull Request":
             output = "PR-{}-test-{}-{}".format(self.arg_pullrequest_number, self.arg_pr_genconfig_job_name, self.arg_jenkins_job_number)

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -484,7 +484,8 @@ class TrilinosPRConfigurationBase(object):
         """
         if self.arg_pullrequest_cdash_track == "Pull Request":
             output = "PR-{}-test-{}-{}".format(self.arg_pullrequest_number, self.arg_pr_genconfig_job_name, self.arg_jenkins_job_number)
-        elif self.arg_pullrequest_cdash_track == "Nightly":
+        elif self.arg_pullrequest_cdash_track == "Nightly" or \
+             self.arg_pullrequest_cdash_track == "Kokkos Integration":
             output = self.arg_dashboard_build_name
         else:
             output = self.arg_pr_genconfig_job_name            

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -273,6 +273,12 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         return args
 
 
+    def dummy_args_kokkos_track(self):
+        args = copy.deepcopy(self.dummy_args())
+        args.pullrequest_cdash_track = "Kokkos Integration"
+        return args
+
+
     def dummy_args_master_pass(self):
         """
         Modify arguments to test a develop->master with a valid
@@ -366,6 +372,14 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
 
     def test_TrilinosPRConfigurationBaseBuildNameNightlyTrack(self):
         args = self.dummy_args_nightly_track()
+        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
+        build_name = pr_config.pullrequest_build_name
+        expected_build_name = args.dashboard_build_name
+        self.assertEqual(build_name, expected_build_name)
+
+
+    def test_TrilinosPRConfigurationBaseBuildNameKokkosTrack(self):
+        args = self.dummy_args_kokkos_track()
         pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
         build_name = pr_config.pullrequest_build_name
         expected_build_name = args.dashboard_build_name

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -363,11 +363,27 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
 
     def test_TrilinosPRConfigurationBaseBuildNameNonPRTrack(self):
         args = self.dummy_args_non_pr_track()
+
         pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
+
         build_name = pr_config.pullrequest_build_name
-        print("--- build_name = {}".format(build_name))
-        expected_build_name = args.genconfig_build_name
+        expected_build_name = args.dashboard_build_name
         self.assertEqual(build_name, expected_build_name)
+
+
+    def test_TrilinosPRConfigurationBaseBuildNameDefaultDashboardName(self):
+        """
+        Test the build name output when dashboard_build_name contains
+        the default Jenkins parameter value, '__UNKNOWN__'.
+        """
+        args = self.dummy_args_non_pr_track()
+        args.dashboard_build_name = "__UNKNOWN__"
+
+        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
+
+        result_build_name = pr_config.pullrequest_build_name
+        expected_build_name = args.genconfig_build_name
+        self.assertEqual(expected_build_name, result_build_name)
 
 
     def test_TrilinosPRConfigurationBaseBuildNameNightlyTrack(self):

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -267,18 +267,6 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         return args
 
 
-    def dummy_args_nightly_track(self):
-        args = copy.deepcopy(self.dummy_args())
-        args.pullrequest_cdash_track = "Nightly"
-        return args
-
-
-    def dummy_args_kokkos_track(self):
-        args = copy.deepcopy(self.dummy_args())
-        args.pullrequest_cdash_track = "Kokkos Integration"
-        return args
-
-
     def dummy_args_master_pass(self):
         """
         Modify arguments to test a develop->master with a valid
@@ -384,22 +372,6 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         result_build_name = pr_config.pullrequest_build_name
         expected_build_name = args.genconfig_build_name
         self.assertEqual(expected_build_name, result_build_name)
-
-
-    def test_TrilinosPRConfigurationBaseBuildNameNightlyTrack(self):
-        args = self.dummy_args_nightly_track()
-        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
-        build_name = pr_config.pullrequest_build_name
-        expected_build_name = args.dashboard_build_name
-        self.assertEqual(build_name, expected_build_name)
-
-
-    def test_TrilinosPRConfigurationBaseBuildNameKokkosTrack(self):
-        args = self.dummy_args_kokkos_track()
-        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
-        build_name = pr_config.pullrequest_build_name
-        expected_build_name = args.dashboard_build_name
-        self.assertEqual(build_name, expected_build_name)
 
 
     def test_TrilinosPRConfigurationBaseDashboardModelPRTrack(self):


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Recently renamed dashboard build names for the Nightly track by using a custom string set with `DASHBOARD_BUILD_NAME` environment variable inside Nightly Jenkins jobs. Nightly Kokkos Integration build names should follow this as well.


## Related Issues

- #12760 

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
- [TRILFRAME-620](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-620)
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

`test_TrilinosPRConfigurationBaseBuildNameKokkosTrack`
`TrilinosFrameworkTests` testing all related Trilinos PR scripts touched by these changes

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->