### PR TITLE
Framework: Remove PR naming blocks

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -832,35 +832,11 @@ opt-set-cmake-var Xpetra_ENABLE_DEPRECATED_CODE  BOOL : OFF
 # PACKAGE-ENABLES
 #
 
-[PACKAGE-ENABLES|PR]
-opt-set-cmake-var Trilinos_ENABLE_MueLu BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Xpetra BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Zoltan2Core BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Zoltan2Sphynx BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Zoltan2 BOOL : ON
-# Commented out due to: "make[2]: execvp: /bin/sh: Argument list too long" when compiling packages/panzer/adapters-stk
-#    opt-set-cmake-var Trilinos_ENABLE_BUILD_STATS BOOL : ON
-
 [PACKAGE-ENABLES|ALL]
 opt-set-cmake-var Trilinos_ENABLE_ALL_PACKAGES BOOL : ON
 
-[PACKAGE-ENABLES|PR-SERIAL]
-opt-set-cmake-var Trilinos_ENABLE_NOX BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_PanzerAdaptersSTK BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_PanzerDiscFE BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_PanzerDofMgr BOOL : ON
-
 [PACKAGE-ENABLES|PR-FRAMEWORK]
 opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL : ON
-
-# Commented out due to: "make[2]: execvp: /bin/sh: Argument list too long" when compiling packages/panzer/adapters-stk
-#    opt-set-cmake-var Trilinos_ENABLE_BUILD_STATS BOOL : ON
-
-[PACKAGE-ENABLES|PR-FRAMEWORK-ATDM]
-use PACKAGE-ENABLES|PR
-use PACKAGE-ENABLES|PR-FRAMEWORK
-opt-set-cmake-var Trilinos_ENABLE_TrilinosATDMConfigTests BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats BOOL : ON
 
 [PACKAGE-ENABLES|RDC-MINIMAL]
 opt-set-cmake-var Trilinos_ENABLE_Amesos BOOL : ON
@@ -1660,18 +1636,6 @@ use USE-FPIC|YES
 use USE-MPI|YES
 use USE-PT|YES
 
-[RHEL7_SEMS_USE-ASAN|NO_USE-FPIC|NO_USE-MPI|YES_USE-PT|NO_PACKAGE-ENABLES|PR]
-use RHEL7_SEMS_USE-ASAN|NO_USE-FPIC|NO_USE-MPI|YES_USE-PT|NO
-use PACKAGE-ENABLES|PR
-
-[RHEL7_SEMS_USE-ASAN|NO_USE-FPIC|YES_USE-MPI|YES_USE-PT|NO_PACKAGE-ENABLES|PR]
-use RHEL7_SEMS_USE-ASAN|NO_USE-FPIC|YES_USE-MPI|YES_USE-PT|NO
-use PACKAGE-ENABLES|PR
-
-[RHEL7_SEMS_USE-ASAN|NO_USE-FPIC|NO_USE-MPI|YES_USE-PT|NO_PACKAGE-ENABLES|PR-SERIAL]
-use RHEL7_SEMS_USE-ASAN|NO_USE-FPIC|NO_USE-MPI|YES_USE-PT|NO
-use PACKAGE-ENABLES|PR-SERIAL
-
 [RHEL7_SEMS_USE-ASAN|NO_USE-FPIC|NO_USE-MPI|NO_USE-PT|NO]
 use RHEL7
 use USE-ASAN|NO
@@ -1966,58 +1930,6 @@ use PACKAGE-ENABLES|ALL
 #uses sems-archive modules
 use rhel7_sems-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL-NO-EPETRA
-
-[rhel7_sems-gnu-8.3.0-openmpi-1.10.1-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_pr]
-#uses sems-archive modules
-use RHEL7_SEMS_COMPILER|GNU
-use NODE-TYPE|OPENMP-NO-SERIAL
-use BUILD-TYPE|RELEASE-DEBUG
-use RHEL7_SEMS_LIB-TYPE|STATIC
-use KOKKOS-ARCH|NO-KOKKOS-ARCH
-use RHEL7_SEMS_USE-ASAN|NO_USE-FPIC|NO_USE-MPI|YES_USE-PT|NO_PACKAGE-ENABLES|PR
-use USE-COMPLEX|NO
-use USE-RDC|NO
-use USE-UVM|NO
-use USE-DEPRECATED|YES
-
-use COMMON
-
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
-opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
-opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
-opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Werror=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
-
-use GCC_OPENMP_PACKAGE_SPECIFIC_WARNING_FLAGS
-
-use RHEL7_POST
-
-[rhel7_sems-gnu-8.3.0-openmpi-1.10.1-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-off_pr]
-#uses sems-archive modules
-use RHEL7_SEMS_COMPILER|GNU
-use NODE-TYPE|OPENMP
-use BUILD-TYPE|RELEASE-DEBUG
-use RHEL7_SEMS_LIB-TYPE|STATIC
-use KOKKOS-ARCH|NO-KOKKOS-ARCH
-use RHEL7_SEMS_USE-ASAN|NO_USE-FPIC|NO_USE-MPI|YES_USE-PT|NO_PACKAGE-ENABLES|PR
-use USE-COMPLEX|NO
-use USE-RDC|NO
-use USE-UVM|NO
-use USE-DEPRECATED|NO
-
-use COMMON
-
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
-opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
-opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
-opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
-opt-set-cmake-var Trilinos_ENABLE_Moertel                       BOOL       : OFF
-opt-set-cmake-var Trilinos_ENABLE_ShyLU_DDBDDC                  BOOL       : OFF
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -Werror=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
-
-use GCC_OPENMP_PACKAGE_SPECIFIC_WARNING_FLAGS
-
-use RHEL7_POST
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 #uses sems-archive modules
@@ -2404,16 +2316,7 @@ use SEMS_COMMON_CUDA_11
 use RHEL7_POST
 use CUDA11-RUN-SERIAL-TESTS
 
-# This is temporarily disabled because it seems to be particularly sensitive to the spack-built
-#  MPI issue (TRILFRAME-552)
-opt-set-cmake-var ROL_example_PinT_parabolic-control_AugmentedSystem_test_MPI_2_DISABLE BOOL FORCE : ON
-
-
-[rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_pr]
-use rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables
-use PACKAGE-ENABLES|PR
 opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : OFF
-
 
 [rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_rdc_uvm_deprecated-on_all]
 # uses sems-v2 modules
@@ -2832,62 +2735,6 @@ use RHEL7_POST
 # uses sems-v2 modules
 use rhel7_sems-v2-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
-
-[rhel7_sems-gnu-8.3.0-openmpi-1.10.7-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_pr]
-# uses sems-v2 modules
-use RHEL7_SEMS_COMPILER|GNU
-use NODE-TYPE|OPENMP-NO-SERIAL
-use BUILD-TYPE|RELEASE-DEBUG
-use RHEL7_SEMS_V2_LIB-TYPE|STATIC
-use KOKKOS-ARCH|NO-KOKKOS-ARCH
-use USE-ASAN|NO
-use USE-COMPLEX|NO
-use USE-FPIC|NO
-use USE-MPI|YES
-use USE-PT|NO
-use USE-RDC|NO
-use USE-UVM|NO
-use USE-DEPRECATED|YES
-use PACKAGE-ENABLES|PR
-
-use COMMON_SPACK_TPLS
-
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
-opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
-opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
-opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
-
-use RHEL7_POST
-
-[rhel7_sems-gnu-8.3.0-openmpi-1.10.7-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-off_pr]
-# uses sems-v2 modules
-use RHEL7_SEMS_COMPILER|GNU
-use NODE-TYPE|OPENMP
-use BUILD-TYPE|RELEASE-DEBUG
-use RHEL7_SEMS_V2_LIB-TYPE|STATIC
-use KOKKOS-ARCH|NO-KOKKOS-ARCH
-use USE-ASAN|NO
-use USE-COMPLEX|NO
-use USE-FPIC|NO
-use USE-MPI|YES
-use USE-PT|NO
-use USE-RDC|NO
-use USE-UVM|NO
-use USE-DEPRECATED|NO
-use PACKAGE-ENABLES|PR
-
-use COMMON_SPACK_TPLS
-
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
-opt-set-cmake-var Tpetra_INST_SERIAL                            BOOL FORCE : ON
-opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL       : OFF
-opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
-opt-set-cmake-var Trilinos_ENABLE_Moertel                       BOOL       : OFF
-opt-set-cmake-var Trilinos_ENABLE_ShyLU_DDBDDC                  BOOL       : OFF
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING     : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
-
-use RHEL7_POST
 
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.7-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 # uses sems-v2 modules


### PR DESCRIPTION
PR blocks are unused (big mistaken assumption on my part).  We use no-package-enables for PR builds.  So, change the UVM no-package-enables to disable the tests, and remove all of the pr blocks.  This will prevent PRs from trying to build tests/examples in UVM-on builds and erroring out.

@trilinos/framework 

## Motivation
Allows for using the configuration `rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables` for a new PR build.