### PR TITLE
Belos CGSingleRedIter: Reorder memory so that MvTransMv arguments have constant stride

### DIFF
--- a/packages/belos/src/BelosCGSingleRedIter.hpp
+++ b/packages/belos/src/BelosCGSingleRedIter.hpp
@@ -332,30 +332,30 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
 	  TEUCHOS_TEST_FOR_EXCEPTION(tmp == Teuchos::null,std::invalid_argument,
 			     "Belos::CGSingleRedIter::setStateSize(): linear problem does not specify multivectors to clone from.");
 
-          // W_ = (R_, AZ_, Z_)
+          // W_ = (AZ_, R_, Z_)
           W_ = MVT::Clone( *tmp, 3 );
           std::vector<int> index2(2,0);
           std::vector<int> index(1,0);
 
-          // S_ = (R_, AZ_)
+          // S_ = (AZ_, R_)
           index2[0] = 0;
           index2[1] = 1;
           S_ = MVT::CloneViewNonConst( *W_, index2 );
 
           // U_ = (AZ_, Z_)
-          index2[0] = 1;
+          index2[0] = 0;
           index2[1] = 2;
           U_ = MVT::CloneViewNonConst( *W_, index2 );
 
-          index[0] = 0;
-          R_ = MVT::CloneViewNonConst( *W_, index );
           index[0] = 1;
+          R_ = MVT::CloneViewNonConst( *W_, index );
+          index[0] = 0;
           AZ_ = MVT::CloneViewNonConst( *W_, index );
           index[0] = 2;
           Z_ = MVT::CloneViewNonConst( *W_, index );
 
           // T_ = (R_, Z_)
-          index2[0] = 0;
+          index2[0] = 1;
           index2[1] = 2;
           T_ = MVT::CloneViewNonConst( *W_, index2 );
 
@@ -487,14 +487,14 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
     if (foldConvergenceDetectionIntoAllreduce_ && convTest_->getResNormType() == Belos::TwoNorm) {
       // Compute first <S_,T_> a.k.a. <R_,Z_>, <AZ_,Z_> and <R_,R_> combined (also computes unneeded <AZ_,R_>)
       MVT::MvTransMv( one, *S_, *T_, sHt );
-      rHz_ = sHt(0,1);
-      delta = sHt(1,1);
-      rHr_ = sHt(0,0);
+      rHz_ = sHt(1,1);
+      delta = sHt(0,1);
+      rHr_ = sHt(1,0);
     } else {
       // Compute first <s,z> a.k.a. <r,z> and <Az,z> combined
       MVT::MvTransMv( one, *S_, *Z_, sHz );
-      rHz_ = sHz(0,0);
-      delta = sHz(1,0);
+      rHz_ = sHz(1,0);
+      delta = sHz(0,0);
     }
     if ((Teuchos::ScalarTraits<ScalarType>::magnitude(delta) < Teuchos::ScalarTraits<ScalarType>::eps()) &&
         (stest_->checkStatus(this) == Passed))
@@ -546,9 +546,9 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
         //
         // Update scalars.
         rHz_old = rHz_;
-        rHz_ = sHt(0,1);
-        delta = sHt(1,1);
-        rHr_ = sHt(0,0);
+        rHz_ = sHt(1,1);
+        delta = sHt(0,1);
+        rHr_ = sHt(1,0);
 
         // Increment the iteration
         iter_++;
@@ -621,8 +621,8 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
         //
         // Update scalars.
         rHz_old = rHz_;
-        rHz_ = sHz(0,0);
-        delta = sHz(1,0);
+        rHz_ = sHz(1,0);
+        delta = sHz(0,0);
         //
         beta = rHz_ / rHz_old;
         alpha = rHz_ / (delta - (beta*rHz_ / alpha));


### PR DESCRIPTION
@trilinos/belos 

## Motivation
The single reduce CG uses two MVs to hold its vector data. Different operations act on single vectors or sub-MVs. In particular, there is a call to `MvTransMv` for MVs $S=[W_0, W_1]$ and $T=[W_0,W_2]$ where $W$ is a MV with 3 columns. This call was slow on GPUs because it ran on a MV with non-constant stride. By reordering $W$ we now have $S=[W_0, W_1]$ and $T=[W_1,W_2]$ instead.