### PR TITLE
Stokhos: prepare for KokkosKernels 4.3 spmv refactor

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_CrsMatrix_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_CrsMatrix_UQ_PCE.hpp
@@ -1471,6 +1471,9 @@ template <
 #if KOKKOSKERNELS_VERSION >= 40199
           typename ExecutionSpace,
 #endif
+#if KOKKOSKERNELS_VERSION >= 40299
+          typename Handle,
+#endif
           typename AlphaType,
           typename BetaType,
           typename MatrixType,
@@ -1482,9 +1485,8 @@ typename std::enable_if<
   Kokkos::is_view_uq_pce< Kokkos::View< InputType, InputP... > >::value &&
   Kokkos::is_view_uq_pce< Kokkos::View< OutputType, OutputP... > >::value
 #if KOKKOSKERNELS_VERSION >= 40299
-  // TODO what is an alternative compile-time option to determine the rank?
-  // Is rank appropriate here, or is additional checking based on specialize trait needed?
-  && (Kokkos::View< OutputType, OutputP... >().rank() == 1)
+  && KokkosSparse::is_crs_matrix_v<MatrixType>
+  && (Kokkos::View< OutputType, OutputP... >::rank() == 1)
 #endif
   >::type
 spmv(
@@ -1494,7 +1496,7 @@ spmv(
 #if KOKKOSKERNELS_VERSION < 40299
   KokkosKernels::Experimental::Controls,
 #else
-  KokkosSparse::SPMVHandle<ExecutionSpace, MatrixType,  Kokkos::View< InputType, InputP... >, Kokkos::View< OutputType, OutputP... >>* handle,
+  Handle* handle,
 #endif
   const char mode[],
   const AlphaType& a,
@@ -1507,7 +1509,6 @@ spmv(
 #endif
   )
 {
-  std::cout << "  STOKHOS UQPCE SPMV R1" << std::endl;
   typedef Kokkos::View< OutputType, OutputP... > OutputVectorType;
   typedef Kokkos::View< InputType, InputP... > InputVectorType;
   typedef Stokhos::Multiply<MatrixType, typename InputVectorType::const_type,
@@ -1545,6 +1546,9 @@ template <
 #if KOKKOSKERNELS_VERSION >= 40199
           typename ExecutionSpace,
 #endif
+#if KOKKOSKERNELS_VERSION >= 40299
+          typename Handle,
+#endif
           typename AlphaType,
           typename BetaType,
           typename MatrixType,
@@ -1556,9 +1560,8 @@ typename std::enable_if<
   Kokkos::is_view_uq_pce< Kokkos::View< InputType, InputP... > >::value &&
   Kokkos::is_view_uq_pce< Kokkos::View< OutputType, OutputP... > >::value
 #if KOKKOSKERNELS_VERSION >= 40299
-  // TODO what is an alternative compile-time option to determine the rank?
-  // Is rank appropriate here, or is additional checking based on specialize trait needed?
-  && (Kokkos::View< OutputType, OutputP... >().rank() == 2)
+  && KokkosSparse::is_crs_matrix_v<MatrixType>
+  && (Kokkos::View< OutputType, OutputP... >::rank() == 2)
 #endif
   >::type
 spmv(
@@ -1568,7 +1571,7 @@ spmv(
 #if KOKKOSKERNELS_VERSION < 40299
   KokkosKernels::Experimental::Controls,
 #else
-  KokkosSparse::SPMVHandle<ExecutionSpace, MatrixType,  Kokkos::View< InputType, InputP... >, Kokkos::View< OutputType, OutputP... >>* handle,
+  Handle* handle,
 #endif
   const char mode[],
   const AlphaType& a,
@@ -1581,7 +1584,6 @@ spmv(
 #endif
   )
 {
-  std::cout << "  STOKHOS UQPCE SPMV R2" << std::endl;
 #if KOKKOSKERNELS_VERSION >= 40199
   if(space != ExecutionSpace()) {
     Kokkos::Impl::raise_error(

--- a/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_CrsMatrix_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_CrsMatrix_UQ_PCE.hpp
@@ -1481,20 +1481,33 @@ template <
 typename std::enable_if<
   Kokkos::is_view_uq_pce< Kokkos::View< InputType, InputP... > >::value &&
   Kokkos::is_view_uq_pce< Kokkos::View< OutputType, OutputP... > >::value
+#if KOKKOSKERNELS_VERSION >= 40299
+  // TODO what is an alternative compile-time option to determine the rank?
+  // Is rank appropriate here, or is additional checking based on specialize trait needed?
+  && (Kokkos::View< OutputType, OutputP... >().rank() == 1)
+#endif
   >::type
 spmv(
 #if KOKKOSKERNELS_VERSION >= 40199
   const ExecutionSpace& space,
 #endif
+#if KOKKOSKERNELS_VERSION < 40299
   KokkosKernels::Experimental::Controls,
+#else
+  KokkosSparse::SPMVHandle<ExecutionSpace, MatrixType,  Kokkos::View< InputType, InputP... >, Kokkos::View< OutputType, OutputP... >>* handle,
+#endif
   const char mode[],
   const AlphaType& a,
   const MatrixType& A,
   const Kokkos::View< InputType, InputP... >& x,
   const BetaType& b,
-  const Kokkos::View< OutputType, OutputP... >& y,
-  const RANK_ONE)
+  const Kokkos::View< OutputType, OutputP... >& y
+#if KOKKOSKERNELS_VERSION < 40299
+  , const RANK_ONE
+#endif
+  )
 {
+  std::cout << "  STOKHOS UQPCE SPMV R1" << std::endl;
   typedef Kokkos::View< OutputType, OutputP... > OutputVectorType;
   typedef Kokkos::View< InputType, InputP... > InputVectorType;
   typedef Stokhos::Multiply<MatrixType, typename InputVectorType::const_type,
@@ -1542,20 +1555,33 @@ template <
 typename std::enable_if<
   Kokkos::is_view_uq_pce< Kokkos::View< InputType, InputP... > >::value &&
   Kokkos::is_view_uq_pce< Kokkos::View< OutputType, OutputP... > >::value
+#if KOKKOSKERNELS_VERSION >= 40299
+  // TODO what is an alternative compile-time option to determine the rank?
+  // Is rank appropriate here, or is additional checking based on specialize trait needed?
+  && (Kokkos::View< OutputType, OutputP... >().rank() == 2)
+#endif
   >::type
 spmv(
 #if KOKKOSKERNELS_VERSION >= 40199
   const ExecutionSpace& space,
 #endif
+#if KOKKOSKERNELS_VERSION < 40299
   KokkosKernels::Experimental::Controls,
+#else
+  KokkosSparse::SPMVHandle<ExecutionSpace, MatrixType,  Kokkos::View< InputType, InputP... >, Kokkos::View< OutputType, OutputP... >>* handle,
+#endif
   const char mode[],
   const AlphaType& a,
   const MatrixType& A,
   const Kokkos::View< InputType, InputP... >& x,
   const BetaType& b,
-  const Kokkos::View< OutputType, OutputP... >& y,
-  const RANK_TWO)
+  const Kokkos::View< OutputType, OutputP... >& y
+#if KOKKOSKERNELS_VERSION < 40299
+  , const RANK_TWO
+#endif
+  )
 {
+  std::cout << "  STOKHOS UQPCE SPMV R2" << std::endl;
 #if KOKKOSKERNELS_VERSION >= 40199
   if(space != ExecutionSpace()) {
     Kokkos::Impl::raise_error(
@@ -1569,7 +1595,9 @@ spmv(
   if (y.extent(1) == 1) {
     auto y_1D = subview(y, Kokkos::ALL(), 0);
     auto x_1D = subview(x, Kokkos::ALL(), 0);
-#if KOKKOSKERNELS_VERSION >= 40199
+#if KOKKOSKERNELS_VERSION >= 40299
+    spmv(space, handle, mode, a, A, x_1D, b, y_1D);
+#elif (KOKKOSKERNELS_VERSION < 40299) && (KOKKOSKERNELS_VERSION >= 40199)
     spmv(space, KokkosKernels::Experimental::Controls(), mode, a, A, x_1D, b, y_1D, RANK_ONE());
 #else
     spmv(KokkosKernels::Experimental::Controls(), mode, a, A, x_1D, b, y_1D, RANK_ONE());

--- a/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector.hpp
@@ -533,6 +533,9 @@ template <
 #if KOKKOSKERNELS_VERSION >= 40199
           typename ExecutionSpace,
 #endif
+#if KOKKOSKERNELS_VERSION >= 40299
+          typename Handle,
+#endif
           typename AlphaType,
           typename BetaType,
           typename MatrixType,
@@ -544,9 +547,8 @@ typename std::enable_if<
   Kokkos::is_view_mp_vector< Kokkos::View< InputType, InputP... > >::value &&
   Kokkos::is_view_mp_vector< Kokkos::View< OutputType, OutputP... > >::value
 #if KOKKOSKERNELS_VERSION >= 40299
-  // TODO what is an alternative compile-time option to determine the rank?
-  // Is rank appropriate here, or is additional checking based on specialize trait needed?
-  && (Kokkos::View< OutputType, OutputP... >().rank() == 1)
+  && KokkosSparse::is_crs_matrix_v<MatrixType>
+  && (Kokkos::View< OutputType, OutputP... >::rank() == 1)
 #endif
   >::type
 spmv(
@@ -556,7 +558,7 @@ spmv(
 #if KOKKOSKERNELS_VERSION < 40299
   KokkosKernels::Experimental::Controls,
 #else
-  KokkosSparse::SPMVHandle<ExecutionSpace, MatrixType,  Kokkos::View< InputType, InputP... >, Kokkos::View< OutputType, OutputP... >>* handle,
+  Handle* handle,
 #endif
   const char mode[],
   const AlphaType& a,
@@ -567,9 +569,8 @@ spmv(
 #if KOKKOSKERNELS_VERSION < 40299
   , const RANK_ONE
 #endif
-  )
+)
 {
-  std::cout << "  STOKHOS MPVEC SPMV R1" << std::endl;
   typedef Kokkos::View< OutputType, OutputP... > OutputVectorType;
   typedef Kokkos::View< InputType, InputP... > InputVectorType;
   using input_vector_type = const_type_t<InputVectorType>;
@@ -643,6 +644,9 @@ template <
 #if KOKKOSKERNELS_VERSION >= 40199
           typename ExecutionSpace,
 #endif
+#if KOKKOSKERNELS_VERSION >= 40299
+          typename Handle,
+#endif
           typename AlphaType,
           typename BetaType,
           typename MatrixType,
@@ -654,9 +658,8 @@ typename std::enable_if<
   Kokkos::is_view_mp_vector< Kokkos::View< InputType, InputP... > >::value &&
   Kokkos::is_view_mp_vector< Kokkos::View< OutputType, OutputP... > >::value
 #if KOKKOSKERNELS_VERSION >= 40299
-  // TODO what is an alternative compile-time option to determine the rank?
-  // Is rank appropriate here, or is additional checking based on specialize trait needed?
-  && (Kokkos::View< OutputType, OutputP... >().rank() == 2)
+  && KokkosSparse::is_crs_matrix_v<MatrixType>
+  && (Kokkos::View< OutputType, OutputP... >::rank() == 2)
 #endif
   >::type
 spmv(
@@ -666,7 +669,7 @@ spmv(
 #if KOKKOSKERNELS_VERSION < 40299
   KokkosKernels::Experimental::Controls,
 #else
-  KokkosSparse::SPMVHandle<ExecutionSpace, MatrixType,  Kokkos::View< InputType, InputP... >, Kokkos::View< OutputType, OutputP... >>* handle,
+  Handle* handle,
 #endif
   const char mode[],
   const AlphaType& a,
@@ -679,7 +682,6 @@ spmv(
 #endif
   )
 {
-  std::cout << "  STOKHOS MPVEC SPMV R2" << std::endl;
 #if KOKKOSKERNELS_VERSION >= 40199
   if(space != ExecutionSpace()) {
     Kokkos::Impl::raise_error(


### PR DESCRIPTION
Update the stokhos/sacado overloads of ``KokkosSparse::spmv`` in preparation for the KokkosKernels 4.3 release.
This fixes ``Stokhos_KokkosCrsMatrixUQPCEUnitTest_Cuda_MPI_1`` and ``Stokhos_KokkosCrsMatrixMPVectorUnitTest_Cuda_MPI_1`` runtime failures when building against Kokkos and KokkosKernels develop.

See discussion here: https://github.com/kokkos/kokkos-kernels/issues/2130#issuecomment-1979339518

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/stokhos 
@ndellingwood 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
KK 4.3 includes some changes to the interface of spmv (Controls is replaced by SPMVHandle). If the KK version is at least 40299 (4.3 prerelease) then make the spmv overloads for sacado types follow the new interface.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Tested on kokkos-dev2, cuda 11.4.2
- this PR as-is
- this PR built with develop branch kokkos, kokkos-kernels

There are 2 existing failures in Trilinos develop before this PR, and are not fixed in this PR:
```
Stokhos_TpetraCrsMatrixUQPCEUnitTest_Cuda_MPI_4
Stokhos_TpetraCrsMatrixMPVectorUnitTest_Cuda_MPI_4
```
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->