### PR TITLE
Xpetra: Add missing const qualifiers to getDomainMap and getRangeMap

### DIFF
--- a/packages/xpetra/src/Operator/Xpetra_TpetraHalfPrecisionOperator.hpp
+++ b/packages/xpetra/src/Operator/Xpetra_TpetraHalfPrecisionOperator.hpp
@@ -127,12 +127,12 @@ class TpetraHalfPrecisionOperator : public Xpetra::Operator<Scalar, LocalOrdinal
   //@}
 
   //! Returns the Tpetra::Map object associated with the domain of this TpetraOperator.
-  Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> getDomainMap() const {
+  const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> getDomainMap() const {
     return Op_->getDomainMap();
   }
 
   //! Returns the Tpetra::Map object associated with the range of this TpetraOperator.
-  Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> getRangeMap() const {
+  const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> getRangeMap() const {
     return Op_->getRangeMap();
   }
 


### PR DESCRIPTION
@xpetra
@jhux2 

https://github.com/trilinos/Trilinos/issues/12820