### PR TITLE
Framework: Add nightly cuda config

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2318,6 +2318,10 @@ use CUDA11-RUN-SERIAL-TESTS
 
 opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : OFF
 
+[rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_all]
+use rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables
+use PACKAGE-ENABLES|ALL-NO-EPETRA
+
 [rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_rdc_uvm_deprecated-on_all]
 # uses sems-v2 modules
 use rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Need this configuration to have a nightly build that replicates PR.  In this particular case, it's for adding a CUDA Kokkos+KokkosKernels develop integration line.