### PR TITLE
Intrepid2: Continue work to allow space instance to be passed to getValues

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEM.hpp
@@ -128,7 +128,8 @@ namespace Intrepid2 {
                typename outputValueValueType, class ...outputValueProperties,
                typename inputPointValueType,  class ...inputPointProperties>
       static void
-      getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+      getValues( const typename DeviceType::execution_space& space,
+                       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
                  const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
                  const EOperator operatorType);
 
@@ -178,25 +179,29 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HCURL_TET_I1_FEM : public Basis<DeviceType,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisBase = Basis<DeviceType,outputValueType,pointValueType>;
+    using typename BasisBase::ExecutionSpace;
+
+    using typename BasisBase::OrdinalTypeArray1DHost;
+    using typename BasisBase::OrdinalTypeArray2DHost;
+    using typename BasisBase::OrdinalTypeArray3DHost;
+
+    using typename BasisBase::OutputViewType;
+    using typename BasisBase::PointViewType ;
+    using typename BasisBase::ScalarViewType;
 
     /** \brief  Constructor.
      */
     Basis_HCURL_TET_I1_FEM();
 
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
+    using BasisBase::getValues;
 
     virtual
     void
-    getValues(       OutputViewType outputValues,
-               const PointViewType  inputPoints,
-               const EOperator operatorType = OPERATOR_VALUE ) const override {
+    getValues( const ExecutionSpace& space,
+                     OutputViewType  outputValues,
+               const PointViewType   inputPoints,
+               const EOperator       operatorType = OPERATOR_VALUE ) const override {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
       Intrepid2::getValues_HCURL_Args(outputValues,
@@ -206,9 +211,10 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HCURL_TET_I1_FEM::
-        getValues<DeviceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<DeviceType>(space, 
+                              outputValues,
+                              inputPoints,
+                              operatorType);
     }
 
     virtual
@@ -227,8 +233,8 @@ namespace Intrepid2 {
 #endif
       Kokkos::deep_copy(dofCoords, this->dofCoords_);
     }
-    
-      
+
+
   virtual
   void
   getDofCoeffs( ScalarViewType dofCoeffs ) const override {
@@ -284,8 +290,8 @@ namespace Intrepid2 {
     BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
     getHostBasis() const override{
       return Teuchos::rcp(new Basis_HCURL_TET_I1_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>());
-    }                                                                                                                                                                                                                                         
-    
+    }
+
 
   };
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEM.hpp
@@ -120,7 +120,8 @@ namespace Intrepid2 {
                typename outputValueValueType, class ...outputValueProperties,
                typename inputPointValueType,  class ...inputPointProperties>
       static void
-      getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+      getValues( const typename DeviceType::execution_space& space,
+                       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
                  const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
                  const EOperator operatorType);
 
@@ -181,23 +182,27 @@ namespace Intrepid2 {
             typename pointValueType = double >
   class Basis_HCURL_TRI_I1_FEM : public Basis<DeviceType, outputValueType, pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisBase = Basis<DeviceType,outputValueType,pointValueType>;
+    using typename BasisBase::ExecutionSpace;
+
+    using typename BasisBase::OrdinalTypeArray1DHost;
+    using typename BasisBase::OrdinalTypeArray2DHost;
+    using typename BasisBase::OrdinalTypeArray3DHost;
+
+    using typename BasisBase::OutputViewType;
+    using typename BasisBase::PointViewType ;
+    using typename BasisBase::ScalarViewType;
 
     /** \brief  Constructor.
      */
     Basis_HCURL_TRI_I1_FEM();
 
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
+    using BasisBase::getValues;
 
     virtual
     void
-    getValues(       OutputViewType outputValues,
+    getValues( const ExecutionSpace& space,
+                     OutputViewType outputValues,
                const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const override {
 #ifdef HAVE_INTREPID2_DEBUG
@@ -209,9 +214,10 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HCURL_TRI_I1_FEM::
-        getValues<DeviceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<DeviceType>(space,
+                              outputValues,
+                              inputPoints,
+                              operatorType);
     }
 
     virtual
@@ -230,7 +236,7 @@ namespace Intrepid2 {
 #endif
       Kokkos::deep_copy(dofCoords, this->dofCoords_);
     }
-    
+
   virtual
   void
   getDofCoeffs( ScalarViewType dofCoeffs ) const override {
@@ -246,8 +252,8 @@ namespace Intrepid2 {
         ">>> ERROR: (Intrepid2::Basis_HCURL_TRI_I1_FEM::getDofCoeffs) incorrect reference cell (1st) dimension in dofCoeffs array");
 #endif
     Kokkos::deep_copy(dofCoeffs, this->dofCoeffs_);
-  }    
-    
+  }
+
 
     virtual
     const char*

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEMDef.hpp
@@ -99,7 +99,8 @@ namespace Intrepid2 {
               typename inputPointValueType,  class ...inputPointProperties>
     void 
     Basis_HCURL_TRI_I1_FEM::
-    getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+    getValues( const typename DT::execution_space& space,
+                     Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
                const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
                const EOperator operatorType ) {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
@@ -108,7 +109,7 @@ namespace Intrepid2 {
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);
-      Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
+      Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(space, 0, loopSize);
   
       switch (operatorType) {
       case OPERATOR_VALUE: {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
@@ -85,7 +85,7 @@ namespace Intrepid2 {
           break;
         }
       }
-      
+
       typedef typename Kokkos::DynRankView<typename workViewType::value_type, typename workViewType::memory_space> viewType;
       auto vcprop = Kokkos::common_view_alloc_prop(work);
       auto ptr = work.data();
@@ -210,7 +210,7 @@ namespace Intrepid2 {
     // Note: the only reason why equispaced can't support higher order than Parameters::MaxOrder appears to be the fact that the tags below get stored into a fixed-length array.
     // TODO: relax the maximum order requirement by setting up tags in a different container, perhaps directly into an OrdinalTypeArray1DHost (tagView, below).  (As of this writing (1/25/22), looks like other nodal bases do this in a similar way -- those should be fixed at the same time; maybe search for Parameters::MaxOrder.)
     INTREPID2_TEST_FOR_EXCEPTION( order > Parameters::MaxOrder, std::invalid_argument, "polynomial order exceeds the max supported by this class");
-    
+
     // Basis-dependent initializations
     constexpr ordinal_type tagSize  = 4;        // size of DoF tag, i.e., number of fields in the tag
     constexpr ordinal_type maxCard = CardinalityHCurlTri(Parameters::MaxOrder);
@@ -257,7 +257,11 @@ namespace Intrepid2 {
 
     // tabulate the scalar orthonormal basis at cubature points
     Kokkos::DynRankView<scalarType,typename DT::execution_space::array_layout,Kokkos::HostSpace> phisAtCubPoints("Hcurl::Tri::In::phisAtCubPoints", cardPn , myCub.getNumPoints() );
-    Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(phisAtCubPoints, cubPoints, order, OPERATOR_VALUE);
+    Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(typename Kokkos::HostSpace::execution_space{},
+                                                                                                                       phisAtCubPoints,
+                                                                                                                       cubPoints,
+                                                                                                                       order,
+                                                                                                                       OPERATOR_VALUE);
 
     // now do the integration
     for (ordinal_type i=0;i<order;i++) {
@@ -315,7 +319,11 @@ namespace Intrepid2 {
                                                                             edge ,
                                                                             this->basisCellTopology_ );
 
-      Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(phisAtEdgePoints , edgePts, order, OPERATOR_VALUE);
+      Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(typename Kokkos::HostSpace::execution_space{},
+                                                                                                                         phisAtEdgePoints,
+                                                                                                                         edgePts,
+                                                                                                                         order,
+                                                                                                                         OPERATOR_VALUE);
 
       // loop over points (rows of V2)
       for (ordinal_type j=0;j<numPtsPerEdge;j++) {
@@ -365,7 +373,11 @@ namespace Intrepid2 {
 
       Kokkos::DynRankView<scalarType,typename DT::execution_space::array_layout,Kokkos::HostSpace>
         phisAtInternalPoints("Hcurl::Tri::In::phisAtInternalPoints", cardPn , numPtsPerCell );
-      Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>( phisAtInternalPoints , internalPoints , order, OPERATOR_VALUE );
+      Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(typename Kokkos::HostSpace::execution_space{},
+                                                                                                                         phisAtInternalPoints,
+                                                                                                                         internalPoints,
+                                                                                                                         order,
+                                                                                                                         OPERATOR_VALUE);
 
       // copy values into right positions of V2
       for (ordinal_type j=0;j<numPtsPerCell;j++) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
@@ -258,7 +258,11 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
 
   // tabulate the scalar orthonormal basis at cubature points
   Kokkos::DynRankView<scalarType,typename DT::execution_space::array_layout,Kokkos::HostSpace> phisAtCubPoints("Hdiv::Tet::In::phisAtCubPoints", cardPn , myCub.getNumPoints() );
-  Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(phisAtCubPoints, cubPoints, order, OPERATOR_VALUE);
+  Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(typename Kokkos::HostSpace::execution_space{},
+                                                                                                                     phisAtCubPoints,
+                                                                                                                     cubPoints,
+                                                                                                                     order,
+                                                                                                                     OPERATOR_VALUE);
 
   // now do the integration
   for (ordinal_type i=0;i<dim_PkH;i++) {
@@ -317,7 +321,11 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
         this->basisCellTopology_ );
 
     // get phi values at face points
-    Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(phisAtFacePoints, facePts, order, OPERATOR_VALUE);
+    Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(typename Kokkos::HostSpace::execution_space{},
+                                                                                                                       phisAtFacePoints,
+                                                                                                                       facePts,
+                                                                                                                       order,
+                                                                                                                       OPERATOR_VALUE);
 
     // loop over points (rows of V2)
     for (ordinal_type j=0;j<numPtsPerFace;j++) {
@@ -364,7 +372,11 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
 
     Kokkos::DynRankView<scalarType,typename DT::execution_space::array_layout,Kokkos::HostSpace>
     phisAtInternalPoints("Hdiv::Tet::In::phisAtInternalPoints", cardPn , numPtsPerCell );
-    Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>( phisAtInternalPoints , internalPoints , order, OPERATOR_VALUE );
+    Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(typename Kokkos::HostSpace::execution_space{},
+                                                                                                                       phisAtInternalPoints,
+                                                                                                                       internalPoints,
+                                                                                                                       order,
+                                                                                                                       OPERATOR_VALUE );
 
     // copy values into right positions of V2
     for (ordinal_type j=0;j<numPtsPerCell;j++) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
@@ -84,7 +84,7 @@ getValues( /* */ OutputViewType output,
       break;
     }
   }
-  
+
   typedef typename Kokkos::DynRankView<typename workViewType::value_type, typename workViewType::memory_space> viewType;
   auto vcprop = Kokkos::common_view_alloc_prop(work);
   auto ptr = work.data();
@@ -254,7 +254,11 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
 
   // tabulate the scalar orthonormal basis at cubature points
   Kokkos::DynRankView<scalarType,typename DT::execution_space::array_layout,Kokkos::HostSpace> phisAtCubPoints("Hdiv::Tri::In::phisAtCubPoints", cardPn , myCub.getNumPoints() );
-  Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(phisAtCubPoints, cubPoints, order, OPERATOR_VALUE);
+  Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(typename Kokkos::HostSpace::execution_space{},
+                                                                                                                     phisAtCubPoints,
+                                                                                                                     cubPoints,
+                                                                                                                     order,
+                                                                                                                     OPERATOR_VALUE);
 
   // now do the integration
   for (ordinal_type i=0;i<order;i++) {
@@ -310,7 +314,11 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
         edge ,
         this->basisCellTopology_ );
 
-    Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(phisAtEdgePoints , edgePts, order, OPERATOR_VALUE);
+    Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(typename Kokkos::HostSpace::execution_space{},
+                                                                                                                       phisAtEdgePoints,
+                                                                                                                       edgePts,
+                                                                                                                       order,
+                                                                                                                       OPERATOR_VALUE);
 
     // loop over points (rows of V2)
     for (ordinal_type j=0;j<numPtsPerEdge;j++) {
@@ -362,7 +370,11 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
 
     Kokkos::DynRankView<scalarType,typename DT::execution_space::array_layout,Kokkos::HostSpace>
     phisAtInternalPoints("Hdiv::Tri::In::phisAtInternalPoints", cardPn , numPtsPerCell );
-    Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>( phisAtInternalPoints , internalPoints , order, OPERATOR_VALUE );
+    Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(typename Kokkos::HostSpace::execution_space{},
+                                                                                                                       phisAtInternalPoints,
+                                                                                                                       internalPoints,
+                                                                                                                       order,
+                                                                                                                       OPERATOR_VALUE);
 
     // copy values into right positions of V2
     for (ordinal_type j=0;j<numPtsPerCell;j++) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEM.hpp
@@ -115,7 +115,8 @@ namespace Intrepid2 {
                typename outputValueValueType, class ...outputValueProperties,
                typename inputPointValueType,  class ...inputPointProperties>
       static void
-      getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+      getValues( const typename DeviceType::execution_space& space,
+                       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
                  const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
                  const EOperator operatorType);
 
@@ -171,37 +172,42 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HGRAD_HEX_C1_FEM : public Basis<DeviceType,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisBase = Basis<DeviceType,outputValueType,pointValueType>;
+    using typename BasisBase::ExecutionSpace;
+
+    using typename BasisBase::OrdinalTypeArray1DHost;
+    using typename BasisBase::OrdinalTypeArray2DHost;
+    using typename BasisBase::OrdinalTypeArray3DHost;
+
+    using typename BasisBase::OutputViewType;
+    using typename BasisBase::PointViewType ;
+    using typename BasisBase::ScalarViewType;
 
     /** \brief  Constructor.
      */
     Basis_HGRAD_HEX_C1_FEM();
 
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
-
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
+    using BasisBase::getValues;
 
     virtual
     void
-    getValues(       OutputViewType outputValues,
-               const PointViewType  inputPoints,
-               const EOperator operatorType = OPERATOR_VALUE ) const override {
+    getValues( const ExecutionSpace& space,
+                     OutputViewType  outputValues,
+               const PointViewType   inputPoints,
+               const EOperator       operatorType = OPERATOR_VALUE ) const override {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
       Intrepid2::getValues_HGRAD_Args(outputValues,
                                       inputPoints,
                                       operatorType,
                                       this->getBaseCellTopology(),
-                                      this->getCardinality() );
+                                      this->getCardinality());
 #endif
       Impl::Basis_HGRAD_HEX_C1_FEM::
-        getValues<DeviceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<DeviceType>(space,
+                              outputValues,
+                              inputPoints,
+                              operatorType);
     }
 
     virtual

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEMDef.hpp
@@ -310,7 +310,8 @@ namespace Intrepid2 {
              typename inputPointValueType,  class ...inputPointProperties>
     void
     Basis_HGRAD_HEX_C1_FEM::
-    getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+    getValues( const typename DT::execution_space& space,
+                     Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
                const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
                const EOperator operatorType ) {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
@@ -319,7 +320,7 @@ namespace Intrepid2 {
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);
-      Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
+      Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(space, 0, loopSize);
 
       switch (operatorType) {
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEMDef.hpp
@@ -1481,7 +1481,8 @@ namespace Intrepid2 {
              typename inputPointValueType,  class ...inputPointProperties>
     void
     Basis_HGRAD_HEX_DEG2_FEM<serendipity>::
-    getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+    getValues( const typename DT::execution_space& space,
+                     Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
                const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
                const EOperator operatorType ) {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
@@ -1490,7 +1491,7 @@ namespace Intrepid2 {
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);
-      Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
+      Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(space, 0, loopSize);
 
       switch (operatorType) {
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEM.hpp
@@ -84,7 +84,8 @@ namespace Intrepid2 {
                typename inputPointValueType,  class ...inputPointProperties,
                typename vinvValueType,        class ...vinvProperties>
       static void
-      getValues(        Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+      getValues(  const typename DeviceType::execution_space& space,
+                        Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
                   const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
                   const Kokkos::DynRankView<vinvValueType,       vinvProperties...>        vinv,
                   const EOperator operatorType );
@@ -111,9 +112,9 @@ namespace Intrepid2 {
                        vinvViewType        vinv_,
                        workViewType        work_,
                  const ordinal_type        opDn_ = 0 )
-          : _outputValues(outputValues_), _inputPoints(inputPoints_), 
+          : _outputValues(outputValues_), _inputPoints(inputPoints_),
             _vinv(vinv_), _work(work_), _opDn(opDn_) {}
-        
+
         KOKKOS_INLINE_FUNCTION
         void operator()(const size_type iter) const {
           const auto ptBegin = Util<ordinal_type>::min(iter*numPtsEval,    _inputPoints.extent(0));
@@ -149,16 +150,16 @@ namespace Intrepid2 {
       };
     };
   }
-  
+
   /** \class  Intrepid2::Basis_HGRAD_HEX_Cn_FEM
-      \brief  Implementation of the default H(grad)-compatible FEM basis of degree 2 on Hexahedron cell 
-      
+      \brief  Implementation of the default H(grad)-compatible FEM basis of degree 2 on Hexahedron cell
+
       Implements Lagrangian basis of degree n on the reference Hexahedron cell. The basis has
-      cardinality (n+1)^3 and spans a COMPLETE polynomial space. Basis functions are dual 
+      cardinality (n+1)^3 and spans a COMPLETE polynomial space. Basis functions are dual
       to a unisolvent set of degrees-of-freedom (DoF) defined lexicographically on an
       array of input points.
-      
-      \endverbatim      
+
+      \endverbatim
   */
 
   template<typename DeviceType = void,
@@ -167,13 +168,16 @@ namespace Intrepid2 {
   class Basis_HGRAD_HEX_Cn_FEM
     : public Basis<DeviceType,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisBase = Basis<DeviceType,outputValueType,pointValueType>;
+    using typename BasisBase::ExecutionSpace;
 
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
+    using typename BasisBase::OrdinalTypeArray1DHost;
+    using typename BasisBase::OrdinalTypeArray2DHost;
+    using typename BasisBase::OrdinalTypeArray3DHost;
+
+    using typename BasisBase::OutputViewType;
+    using typename BasisBase::PointViewType ;
+    using typename BasisBase::ScalarViewType;
 
   private:
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
@@ -189,13 +193,14 @@ namespace Intrepid2 {
     Basis_HGRAD_HEX_Cn_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);
 
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
+    using BasisBase::getValues;
 
     virtual
     void
-    getValues(       OutputViewType outputValues,
-               const PointViewType  inputPoints,
-               const EOperator operatorType = OPERATOR_VALUE ) const override {
+    getValues( const ExecutionSpace& space,
+                     OutputViewType  outputValues,
+               const PointViewType   inputPoints,
+               const EOperator       operatorType = OPERATOR_VALUE ) const override {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HGRAD_Args(outputValues,
                                       inputPoints,
@@ -205,10 +210,11 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
       Impl::Basis_HGRAD_HEX_Cn_FEM::
-        getValues<DeviceType,numPtsPerEval>( outputValues,
-                                                inputPoints,
-                                                this->vinv_,
-                                                operatorType );
+        getValues<DeviceType,numPtsPerEval>(space,
+                                            outputValues,
+                                            inputPoints,
+                                            this->vinv_,
+                                            operatorType);
     }
 
 
@@ -262,7 +268,7 @@ namespace Intrepid2 {
 
     ordinal_type
     getWorkSizePerPoint(const EOperator operatorType) {
-      return 4*getPnCardinality<1>(this->basisDegree_); 
+      return 4*getPnCardinality<1>(this->basisDegree_);
     }
 
     /** \brief returns the basis associated to a subCell.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEMDef.hpp
@@ -198,7 +198,8 @@ namespace Intrepid2 {
              typename vinvValueType,        class ...vinvProperties>
     void
     Basis_HGRAD_HEX_Cn_FEM::
-    getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+    getValues( const typename DT::execution_space& space,
+                     Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
                const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
                const Kokkos::DynRankView<vinvValueType,       vinvProperties...>        vinv,
                const EOperator operatorType ) {
@@ -211,7 +212,7 @@ namespace Intrepid2 {
       const auto loopSizeTmp1 = (inputPoints.extent(0)/numPtsPerEval);
       const auto loopSizeTmp2 = (inputPoints.extent(0)%numPtsPerEval != 0);
       const auto loopSize = loopSizeTmp1 + loopSizeTmp2;
-      Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
+      Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(space, 0, loopSize);
 
       typedef typename inputPointViewType::value_type inputPointType;
 
@@ -221,7 +222,7 @@ namespace Intrepid2 {
 
       auto vcprop = Kokkos::common_view_alloc_prop(inputPoints);
       typedef typename Kokkos::DynRankView< inputPointType, typename inputPointViewType::memory_space> workViewType;
-      workViewType  work(Kokkos::view_alloc("Basis_HGRAD_HEX_Cn_FEM::getValues::work", vcprop), workSize, inputPoints.extent(0));
+      workViewType  work(Kokkos::view_alloc(space, "Basis_HGRAD_HEX_Cn_FEM::getValues::work", vcprop), workSize, inputPoints.extent(0));
 
       switch (operatorType) {
       case OPERATOR_VALUE: {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
@@ -249,7 +249,7 @@ namespace Intrepid2 {
     const double alpha = 0.0, beta = 0.0;
     Impl::Basis_HGRAD_LINE_Cn_FEM_JACOBI::
       getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>
-      (vmat, dofCoords, order, alpha, beta, OPERATOR_VALUE);
+      (typename Kokkos::HostSpace::execution_space{}, vmat, dofCoords, order, alpha, beta, OPERATOR_VALUE);
 
     ordinal_type info = 0;
     Teuchos::LAPACK<ordinal_type,typename ScalarViewType::value_type> lapack;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBI.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBI.hpp
@@ -153,11 +153,12 @@ namespace Intrepid2 {
                    const ordinal_type   opDn = 0 );
       };
       
-      template<typename ExecSpaceType, ordinal_type numPtsPerEval,
+      template<typename DeviceType, ordinal_type numPtsPerEval,
                typename outputValueValueType, class ...outputValueProperties,
                typename inputPointValueType,  class ...inputPointProperties>
       static void
-      getValues(        Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+      getValues(  const typename DeviceType::execution_space& space,
+                        Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
                   const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
                   const ordinal_type order,
                   const double alpha,
@@ -232,27 +233,32 @@ namespace Intrepid2 {
     : public Basis<DeviceType,outputValueType,pointValueType> {
   public:
     typedef double value_type;
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    using BasisBase = Basis<DeviceType,outputValueType,pointValueType>;
+    using typename BasisBase::ExecutionSpace;
+
+    using typename BasisBase::OrdinalTypeArray1DHost;
+    using typename BasisBase::OrdinalTypeArray2DHost;
+    using typename BasisBase::OrdinalTypeArray3DHost;
+
+    using typename BasisBase::OutputViewType;
+    using typename BasisBase::PointViewType ;
+    using typename BasisBase::ScalarViewType;
     
     /** \brief  Constructor.
      */
     Basis_HGRAD_LINE_Cn_FEM_JACOBI( const ordinal_type order, 
                                     const double alpha = 0, 
-                                    const double beta = 0 );  
-
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
+                                    const double beta = 0 );
    
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
+    using BasisBase::getValues;
  
     virtual
     void
-    getValues(       OutputViewType outputValues,
-               const PointViewType  inputPoints,
-               const EOperator operatorType = OPERATOR_VALUE ) const override {
+    getValues( const ExecutionSpace& space,
+                     OutputViewType  outputValues,
+               const PointViewType   inputPoints,
+               const EOperator       operatorType = OPERATOR_VALUE ) const override {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HGRAD_Args(outputValues,
                                       inputPoints,
@@ -262,12 +268,13 @@ namespace Intrepid2 {
 #endif
       constexpr ordinal_type numPtsPerEval = 1;
       Impl::Basis_HGRAD_LINE_Cn_FEM_JACOBI::
-        getValues<DeviceType,numPtsPerEval>( outputValues, 
-                                                inputPoints, 
-                                                this->getDegree(),
-                                                this->alpha_, 
-                                                this->beta_,
-                                                operatorType );
+        getValues<DeviceType,numPtsPerEval>(space,
+                                            outputValues, 
+                                            inputPoints, 
+                                            this->getDegree(),
+                                            this->alpha_, 
+                                            this->beta_,
+                                            operatorType);
     }
     
   private:

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBIDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBIDef.hpp
@@ -54,7 +54,7 @@ namespace Intrepid2 {
   // -------------------------------------------------------------------------------------
 
   namespace Impl {
-    
+
     // output (N,P,D)
     // input  (P,D) - assumes that it has a set of points to amortize the function call cost for jacobi polynomial.
     template<EOperator opType>
@@ -86,11 +86,11 @@ namespace Intrepid2 {
         }
         break;
       }
-      case OPERATOR_GRAD: 
+      case OPERATOR_GRAD:
       case OPERATOR_D1: {
         for (ordinal_type p=0;p<card;++p) {
           auto polyd = Kokkos::subview( output, p, Kokkos::ALL(), 0 );
-          Polylib::Serial::JacobiPolynomialDerivative(np, pts, polyd, p, alpha, beta);      
+          Polylib::Serial::JacobiPolynomialDerivative(np, pts, polyd, p, alpha, beta);
         }
         break;
       }
@@ -109,7 +109,7 @@ namespace Intrepid2 {
           const ordinal_type pend = output.extent(0);
           const ordinal_type iend = output.extent(1);
           const ordinal_type jend = output.extent(2);
-          
+
           for (ordinal_type p=0;p<pend;++p)
             for (ordinal_type i=0;i<iend;++i)
               for (ordinal_type j=0;j<jend;++j)
@@ -121,12 +121,12 @@ namespace Intrepid2 {
 
           for (ordinal_type p=opDn;p<card;++p) {
             double scaleFactor = 1.0;
-            for (ordinal_type i=1;i<=opDn;++i) 
+            for (ordinal_type i=1;i<=opDn;++i)
               scaleFactor *= 0.5*(p + alpha + beta + i);
-            
-            const auto poly = Kokkos::subview( output, p, Kokkos::ALL(), 0 );        
+
+            const auto poly = Kokkos::subview( output, p, Kokkos::ALL(), 0 );
             Polylib::Serial::JacobiPolynomial(np, pts, poly, null, p-opDn, alpha+opDn, beta+opDn);
-            for (ordinal_type i=0;i<np;++i) 
+            for (ordinal_type i=0;i<np;++i)
               poly(i) = scaleFactor*poly(i);
           }
         }
@@ -138,15 +138,16 @@ namespace Intrepid2 {
       }
       }
     }
-    
+
     // -------------------------------------------------------------------------------------
-    
+
     template<typename DT, ordinal_type numPtsPerEval,
              typename outputValueValueType, class ...outputValueProperties,
              typename inputPointValueType,  class ...inputPointProperties>
-    void 
+    void
     Basis_HGRAD_LINE_Cn_FEM_JACOBI::
-    getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+    getValues( const typename DT::execution_space& space,
+                     Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
                const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
                const ordinal_type order,
                const double alpha,
@@ -160,19 +161,19 @@ namespace Intrepid2 {
       const auto loopSizeTmp1 = (inputPoints.extent(0)/numPtsPerEval);
       const auto loopSizeTmp2 = (inputPoints.extent(0)%numPtsPerEval != 0);
       const auto loopSize = loopSizeTmp1 + loopSizeTmp2;
-      Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
-      
+      Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(space, 0, loopSize);
+
       switch (operatorType) {
       case OPERATOR_VALUE: {
         typedef Functor<outputValueViewType,inputPointViewType,OPERATOR_VALUE,numPtsPerEval> FunctorType;
-        Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, 
+        Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints,
                                                   order, alpha, beta) );
         break;
       }
       case OPERATOR_GRAD:
       case OPERATOR_D1: {
         typedef Functor<outputValueViewType,inputPointViewType,OPERATOR_GRAD,numPtsPerEval> FunctorType;
-        Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, 
+        Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints,
                                                   order, alpha, beta) );
         break;
       }
@@ -186,7 +187,7 @@ namespace Intrepid2 {
       case OPERATOR_D9:
       case OPERATOR_D10: {
         typedef Functor<outputValueViewType,inputPointViewType,OPERATOR_Dn,numPtsPerEval> FunctorType;
-        Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, 
+        Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints,
                                                   order, alpha, beta,
                                                   getOperatorOrder(operatorType)) );
         break;
@@ -210,19 +211,19 @@ namespace Intrepid2 {
 
   template<typename DT, typename OT, typename PT>
   Basis_HGRAD_LINE_Cn_FEM_JACOBI<DT,OT,PT>::
-  Basis_HGRAD_LINE_Cn_FEM_JACOBI( const ordinal_type order, 
-                                  const double alpha, 
+  Basis_HGRAD_LINE_Cn_FEM_JACOBI( const ordinal_type order,
+                                  const double alpha,
                                   const double beta ) {
     this->basisCardinality_  = order+1;
-    this->basisDegree_       = order;    
+    this->basisDegree_       = order;
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Line<> >() );
     this->basisType_         = BASIS_FEM_HIERARCHICAL;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
     this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
-    // jacobi 
-    this->alpha_ = alpha;    
-    this->beta_  = beta;    
+    // jacobi
+    this->alpha_ = alpha;
+    this->beta_  = beta;
 
     // initialize tags
     {
@@ -231,20 +232,20 @@ namespace Intrepid2 {
       const ordinal_type posScDim = 0;        // position in the tag, counting from 0, of the subcell dim
       const ordinal_type posScOrd = 1;        // position in the tag, counting from 0, of the subcell ordinal
       const ordinal_type posDfOrd = 2;        // position in the tag, counting from 0, of DoF ordinal relative to the subcell
-      
+
       ordinal_type tags[Parameters::MaxOrder+1][4];
       const ordinal_type card = this->basisCardinality_;
       for (ordinal_type i=0;i<card;++i) {
         tags[i][0] = 1;     // these are all "internal" i.e. "volume" DoFs
         tags[i][1] = 0;     // there is only one line
-        tags[i][2] = i;     // local DoF id 
-        tags[i][3] = card;  // total number of DoFs 
+        tags[i][2] = i;     // local DoF id
+        tags[i][3] = card;  // total number of DoFs
       }
-     
+
       OrdinalTypeArray1DHost tagView(&tags[0][0], card*4);
- 
+
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
-      // tags are constructed on host 
+      // tags are constructed on host
       this->setOrdinalTagData(this->tagToOrdinal_,
                               this->ordinalToTag_,
                               tagView,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEM.hpp
@@ -52,12 +52,12 @@
 #include "Intrepid2_Basis.hpp"
 
 namespace Intrepid2 {
-  
+
   /** \class  Intrepid2::Basis_HGRAD_TET_COMP12_FEM
       \brief  Implementation of the default H(grad)-compatible FEM basis of degree 2 on Tetrahedron cell
-  
+
       Implements Lagrangian basis of degree 2 on the reference Tetrahedron cell. The basis has
-      cardinality 10 and spans a COMPLETE quadratic polynomial space. Basis functions are dual 
+      cardinality 10 and spans a COMPLETE quadratic polynomial space. Basis functions are dual
       to a unisolvent set of degrees-of-freedom (DoF) defined and enumerated as follows:
 
       \verbatim
@@ -90,8 +90,8 @@ namespace Intrepid2 {
       |   MAX   |  maxScDim=0  |  maxScOrd=3  |  maxDfOrd=0  |     -       |                           |
       |=========|==============|==============|==============|=============|===========================|
       \endverbatim
-  
-      \remark   Ordering of DoFs follows the node order in Tetrahedron<10> topology. Note that node order 
+
+      \remark   Ordering of DoFs follows the node order in Tetrahedron<10> topology. Note that node order
       in this topology follows the natural order of k-subcells where the nodes are located, i.e.,
       L_0 to L_3 correspond to 0-subcells (vertices) 0 to 3 and L_4 to L_9 correspond to
       1-subcells (edges) 0 to 5.
@@ -115,7 +115,7 @@ namespace Intrepid2 {
       getLocalSubTet( const pointValueType x,
                       const pointValueType y,
                       const pointValueType z );
-      
+
       /**
         \brief See Intrepid2::Basis_HGRAD_TET_COMP12_FEM
       */
@@ -127,17 +127,18 @@ namespace Intrepid2 {
         static void
         getValues(       outputValueViewType outputValues,
                    const inputPointViewType  inputPoints );
-        
+
       };
-      
-      template<typename DeviceType, 
+
+      template<typename DeviceType,
                typename outputValueValueType, class ...outputValueProperties,
                typename inputPointValueType,  class ...inputPointProperties>
       static void
-      getValues(        Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+      getValues(  const typename DeviceType::execution_space& space,
+                        Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
                   const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
                   const EOperator operatorType );
-      
+
       /**
         \brief See Intrepid2::Basis_HGRAD_TET_COMP12_FEM
       */
@@ -147,12 +148,12 @@ namespace Intrepid2 {
       struct Functor {
               outputValueViewType _outputValues;
         const inputPointViewType  _inputPoints;
-        
+
         KOKKOS_INLINE_FUNCTION
         Functor(      outputValueViewType outputValues_,
                       inputPointViewType  inputPoints_ )
           : _outputValues(outputValues_), _inputPoints(inputPoints_) {}
-        
+
         KOKKOS_INLINE_FUNCTION
         void operator()(const ordinal_type pt) const {
           switch (opType) {
@@ -186,37 +187,41 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HGRAD_TET_COMP12_FEM : public Basis<DeviceType,outputValueType,pointValueType> {
   public:
-    using OrdinalTypeArray1DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
-    using OrdinalTypeArray2DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
-    using OrdinalTypeArray3DHost = typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    using BasisBase = Basis<DeviceType,outputValueType,pointValueType>;
+    using typename BasisBase::ExecutionSpace;
+
+    using typename BasisBase::OrdinalTypeArray1DHost;
+    using typename BasisBase::OrdinalTypeArray2DHost;
+    using typename BasisBase::OrdinalTypeArray3DHost;
+
+    using typename BasisBase::OutputViewType;
+    using typename BasisBase::PointViewType ;
+    using typename BasisBase::ScalarViewType;
 
     /** \brief  Constructor.
      */
     Basis_HGRAD_TET_COMP12_FEM();
-    
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
 
-    using Basis<DeviceType,outputValueType,pointValueType>::getValues;
+    using BasisBase::getValues;
 
-    /** \brief  FEM basis evaluation on a <strong>reference Tetrahedron</strong> cell. 
-    
+    /** \brief  FEM basis evaluation on a <strong>reference Tetrahedron</strong> cell.
+
         Returns values of <var>operatorType</var> acting on FEM basis functions for a set of
-        points in the <strong>reference Tetrahedron</strong> cell. For rank and dimensions of 
+        points in the <strong>reference Tetrahedron</strong> cell. For rank and dimensions of
         I/O array arguments see Section \ref basis_md_array_sec .
-  
+
         \param  outputValues      [out] - rank-2 or 3 array with the computed basis values
-        \param  inputPoints       [in]  - rank-2 array with dimensions (P,D) containing reference points  
-        \param  operatorType      [in]  - operator applied to basis functions    
-        
+        \param  inputPoints       [in]  - rank-2 array with dimensions (P,D) containing reference points
+        \param  operatorType      [in]  - operator applied to basis functions
+
         For rank and dimension specifications of <var>ArrayScalar</var> arguments see \ref basis_array_specs
     */
     virtual
     void
-    getValues(       OutputViewType outputValues,
-               const PointViewType  inputPoints,
-               const EOperator operatorType = OPERATOR_VALUE ) const override {
+    getValues( const ExecutionSpace& space,
+                     OutputViewType  outputValues,
+               const PointViewType   inputPoints,
+               const EOperator       operatorType = OPERATOR_VALUE ) const override {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HGRAD_Args(outputValues,
                                       inputPoints,
@@ -225,9 +230,10 @@ namespace Intrepid2 {
                                       this->getCardinality() );
 #endif
       Impl::Basis_HGRAD_TET_COMP12_FEM::
-        getValues<DeviceType>( outputValues,
-                                  inputPoints,
-                                  operatorType );
+        getValues<DeviceType>(space,
+                              outputValues,
+                              inputPoints,
+                              operatorType);
     }
 
     /** \brief  Returns spatial locations (coordinates) of degrees of freedom on a

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEMDef.hpp
@@ -321,7 +321,8 @@ namespace Intrepid2 {
              typename inputPointValueType,  class ...inputPointProperties>
     void
     Basis_HGRAD_TET_COMP12_FEM::
-    getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+    getValues( const typename DT::execution_space& space,
+                     Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
                const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
                const EOperator operatorType ) {
       typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
@@ -330,7 +331,7 @@ namespace Intrepid2 {
 
       // Number of evaluation points = dim 0 of inputPoints
       const auto loopSize = inputPoints.extent(0);
-      Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
+      Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(space, 0, loopSize);
 
       switch (operatorType) {
         

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEMDef.hpp
@@ -246,7 +246,7 @@ Basis_HGRAD_TET_Cn_FEM( const ordinal_type order,
   // Note: the only reason why equispaced can't support higher order than Parameters::MaxOrder appears to be the fact that the tags below get stored into a fixed-length array.
   // TODO: relax the maximum order requirement by setting up tags in a different container, perhaps directly into an OrdinalTypeArray1DHost (tagView, below).  (As of this writing (1/25/22), looks like other nodal bases do this in a similar way -- those should be fixed at the same time; maybe search for Parameters::MaxOrder.)
   INTREPID2_TEST_FOR_EXCEPTION( order > Parameters::MaxOrder, std::invalid_argument, "polynomial order exceeds the max supported by this class");
-  
+
   // Basis-dependent initializations
   constexpr ordinal_type tagSize  = 4;        // size of DoF tag, i.e., number of fields in the tag
   constexpr ordinal_type maxCard = Intrepid2::getPnCardinality<spaceDim, Parameters::MaxOrder>();
@@ -403,7 +403,11 @@ Basis_HGRAD_TET_Cn_FEM( const ordinal_type order,
   work("Hgrad::Tet::Cn::work", lwork),
   ipiv("Hgrad::Tet::Cn::ipiv", card);
 
-  Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::device_type,Parameters::MaxNumPtsPerBasisEval>(vmat, dofCoords, order, OPERATOR_VALUE);
+  Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(typename Kokkos::HostSpace::execution_space{},
+                                                                                                                     vmat,
+                                                                                                                     dofCoords,
+                                                                                                                     order,
+                                                                                                                     OPERATOR_VALUE);
 
   ordinal_type info = 0;
   Teuchos::LAPACK<ordinal_type,scalarType> lapack;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTH.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTH.hpp
@@ -135,7 +135,8 @@ public:
   typename outputValueValueType, class ...outputValueProperties,
   typename inputPointValueType,  class ...inputPointProperties>
   static void
-  getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+  getValues( const typename DeviceType::execution_space& space,
+                   Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
              const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
              const ordinal_type order,
              const EOperator operatorType );
@@ -217,25 +218,30 @@ class Basis_HGRAD_TET_Cn_FEM_ORTH
     : public Basis<DeviceType,outputValueType,pointValueType> {
     public:
   typedef double value_type;
-  typedef typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost OrdinalTypeArray1DHost;
-  typedef typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost OrdinalTypeArray2DHost;
-  typedef typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost OrdinalTypeArray3DHost;
+
+  using BasisBase = Basis<DeviceType,outputValueType,pointValueType>;
+  using typename BasisBase::ExecutionSpace;
+
+  using typename BasisBase::OrdinalTypeArray1DHost;
+  using typename BasisBase::OrdinalTypeArray2DHost;
+  using typename BasisBase::OrdinalTypeArray3DHost;
+
+  using typename BasisBase::OutputViewType;
+  using typename BasisBase::PointViewType ;
+  using typename BasisBase::ScalarViewType;
 
   /** \brief  Constructor.
    */
   Basis_HGRAD_TET_Cn_FEM_ORTH( const ordinal_type order );
-
-  using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-  using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-  using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
   
-  using Basis<DeviceType,outputValueType,pointValueType>::getValues;
+  using BasisBase::getValues;
 
   virtual
   void
-  getValues(       OutputViewType outputValues,
-             const PointViewType  inputPoints,
-             const EOperator operatorType = OPERATOR_VALUE ) const override {
+  getValues( const ExecutionSpace& space,
+                   OutputViewType  outputValues,
+             const PointViewType   inputPoints,
+             const EOperator       operatorType = OPERATOR_VALUE ) const override {
     #ifdef HAVE_INTREPID2_DEBUG
           Intrepid2::getValues_HGRAD_Args(outputValues,
                                           inputPoints,
@@ -245,10 +251,11 @@ class Basis_HGRAD_TET_Cn_FEM_ORTH
     #endif
     constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
     Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::
-    getValues<DeviceType,numPtsPerEval>( outputValues,
-        inputPoints,
-        this->getDegree(),
-        operatorType );
+    getValues<DeviceType,numPtsPerEval>(space, 
+                                        outputValues,
+                                        inputPoints,
+                                        this->getDegree(),
+                                        operatorType);
   }
 };
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTHDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTHDef.hpp
@@ -415,7 +415,9 @@ typename outputValueValueType, class ...outputValueProperties,
 typename inputPointValueType,  class ...inputPointProperties>
 void
 Basis_HGRAD_TET_Cn_FEM_ORTH::
-getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+getValues( 
+    const typename DT::execution_space& space,
+          Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
     const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
     const ordinal_type order,
     const EOperator operatorType ) {
@@ -427,7 +429,7 @@ getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties.
   const auto loopSizeTmp1 = (inputPoints.extent(0)/numPtsPerEval);
   const auto loopSizeTmp2 = (inputPoints.extent(0)%numPtsPerEval != 0);
   const auto loopSize = loopSizeTmp1 + loopSizeTmp2;
-  Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
+  Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(space, 0, loopSize);
 
   typedef typename inputPointViewType::value_type inputPointType;
   const ordinal_type cardinality = outputValues.extent(0);
@@ -445,7 +447,7 @@ getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties.
   }
   case OPERATOR_GRAD:
   case OPERATOR_D1: {
-    workViewType  work(Kokkos::view_alloc("Basis_HGRAD_TET_In_FEM_ORTH::getValues::work", vcprop), cardinality, inputPoints.extent(0), spaceDim+1);
+    workViewType  work(Kokkos::view_alloc(space, "Basis_HGRAD_TET_In_FEM_ORTH::getValues::work", vcprop), cardinality, inputPoints.extent(0), spaceDim+1);
     typedef Functor<outputValueViewType,inputPointViewType,workViewType,OPERATOR_D1,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, work, order) );
     break;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
@@ -287,7 +287,11 @@ Basis_HGRAD_TRI_Cn_FEM( const ordinal_type order,
   work("Hgrad::Tri::Cn::work", lwork),
   ipiv("Hgrad::Tri::Cn::ipiv", card);
 
-  Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(vmat, dofCoords, order, OPERATOR_VALUE);
+  Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(typename Kokkos::HostSpace::execution_space{},
+                                                                                                                     vmat,
+                                                                                                                     dofCoords,
+                                                                                                                     order,
+                                                                                                                     OPERATOR_VALUE);
 
   ordinal_type info = 0;
   Teuchos::LAPACK<ordinal_type,scalarType> lapack;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTH.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTH.hpp
@@ -138,7 +138,8 @@ public:
   typename outputValueValueType, class ...outputValueProperties,
   typename inputPointValueType,  class ...inputPointProperties>
   static void
-  getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+  getValues( const typename DeviceType::execution_space& space,
+                   Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
              const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
              const ordinal_type order,
              const EOperator operatorType );
@@ -220,25 +221,30 @@ class Basis_HGRAD_TRI_Cn_FEM_ORTH
     : public Basis<DeviceType,outputValueType,pointValueType> {
     public:
   typedef double value_type;
-  typedef typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost OrdinalTypeArray1DHost;
-  typedef typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost OrdinalTypeArray2DHost;
-  typedef typename Basis<DeviceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost OrdinalTypeArray3DHost;
+
+  using BasisBase = Basis<DeviceType,outputValueType,pointValueType>;
+  using typename BasisBase::ExecutionSpace;
+
+  using typename BasisBase::OrdinalTypeArray1DHost;
+  using typename BasisBase::OrdinalTypeArray2DHost;
+  using typename BasisBase::OrdinalTypeArray3DHost;
+
+  using typename BasisBase::OutputViewType;
+  using typename BasisBase::PointViewType ;
+  using typename BasisBase::ScalarViewType;
 
   /** \brief  Constructor.
    */
   Basis_HGRAD_TRI_Cn_FEM_ORTH( const ordinal_type order );
 
-    using OutputViewType = typename Basis<DeviceType,outputValueType,pointValueType>::OutputViewType;
-    using PointViewType  = typename Basis<DeviceType,outputValueType,pointValueType>::PointViewType;
-    using ScalarViewType = typename Basis<DeviceType,outputValueType,pointValueType>::ScalarViewType;
-
-  using Basis<DeviceType,outputValueType,pointValueType>::getValues;
+  using BasisBase::getValues;
 
   virtual
   void
-  getValues(       OutputViewType outputValues,
-             const PointViewType  inputPoints,
-             const EOperator operatorType = OPERATOR_VALUE ) const override {
+  getValues( const ExecutionSpace& space,
+                   OutputViewType  outputValues,
+             const PointViewType   inputPoints,
+             const EOperator       operatorType = OPERATOR_VALUE ) const override {
     #ifdef HAVE_INTREPID2_DEBUG
           Intrepid2::getValues_HGRAD_Args(outputValues,
                                           inputPoints,
@@ -248,10 +254,11 @@ class Basis_HGRAD_TRI_Cn_FEM_ORTH
     #endif
     constexpr ordinal_type numPtsPerEval = Parameters::MaxNumPtsPerBasisEval;
     Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::
-    getValues<DeviceType,numPtsPerEval>( outputValues,
-        inputPoints,
-        this->getDegree(),
-        operatorType );
+    getValues<DeviceType,numPtsPerEval>(space,
+                                        outputValues,
+                                        inputPoints,
+                                        this->getDegree(),
+                                        operatorType);
   }
 };
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTHDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTHDef.hpp
@@ -335,7 +335,9 @@ typename outputValueValueType, class ...outputValueProperties,
 typename inputPointValueType,  class ...inputPointProperties>
 void
 Basis_HGRAD_TRI_Cn_FEM_ORTH::
-getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+getValues(
+    const typename DT::execution_space& space,
+          Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
     const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
     const ordinal_type order,
     const EOperator operatorType ) {
@@ -347,7 +349,7 @@ getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties.
   const auto loopSizeTmp1 = (inputPoints.extent(0)/numPtsPerEval);
   const auto loopSizeTmp2 = (inputPoints.extent(0)%numPtsPerEval != 0);
   const auto loopSize = loopSizeTmp1 + loopSizeTmp2;
-  Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
+  Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(space, 0, loopSize);
 
   typedef typename inputPointViewType::value_type inputPointType;
   const ordinal_type cardinality = outputValues.extent(0);
@@ -365,7 +367,7 @@ getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties.
   }
   case OPERATOR_GRAD:
   case OPERATOR_D1: {
-    workViewType  work(Kokkos::view_alloc("Basis_HGRAD_TRI_In_FEM_ORTH::getValues::work", vcprop), cardinality, inputPoints.extent(0), spaceDim+1);
+    workViewType  work(Kokkos::view_alloc(space, "Basis_HGRAD_TRI_In_FEM_ORTH::getValues::work", vcprop), cardinality, inputPoints.extent(0), spaceDim+1);
     typedef Functor<outputValueViewType,inputPointViewType,workViewType,OPERATOR_D1,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, work, order) );
     break;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEMDef.hpp
@@ -254,7 +254,7 @@ namespace Intrepid2 {
     const double alpha = 0.0, beta = 0.0;
     Impl::Basis_HGRAD_LINE_Cn_FEM_JACOBI::
       getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>
-      (vmat, dofCoords, order, alpha, beta, OPERATOR_VALUE);
+      (typename Kokkos::HostSpace::execution_space{}, vmat, dofCoords, order, alpha, beta, OPERATOR_VALUE);
 
     ordinal_type info = 0;
     Teuchos::LAPACK<ordinal_type,typename ScalarViewType::value_type> lapack;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEMDef.hpp
@@ -258,7 +258,11 @@ Basis_HVOL_TRI_Cn_FEM( const ordinal_type order,
   work("HVOL::Tri::Cn::work", lwork),
   ipiv("HVOL::Tri::Cn::ipiv", card);
 
-  Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(vmat, dofCoords, order, OPERATOR_VALUE);
+  Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::getValues<Kokkos::HostSpace::execution_space,Parameters::MaxNumPtsPerBasisEval>(typename Kokkos::HostSpace::execution_space{},
+                                                                                                                     vmat,
+                                                                                                                     dofCoords,
+                                                                                                                     order,
+                                                                                                                     OPERATOR_VALUE);
 
   ordinal_type info = 0;
   Teuchos::LAPACK<ordinal_type,scalarType> lapack;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TET_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TET_I1_FEM/test_01.hpp
@@ -58,49 +58,29 @@
 #include "Teuchos_RCP.hpp"
 
 #include "packages/intrepid2/unit-test/Discretization/Basis/Macros.hpp"
+#include "packages/intrepid2/unit-test/Discretization/Basis/Setup.hpp"
 
 namespace Intrepid2 {
 
   namespace Test {
 
+    using HostSpaceType = Kokkos::DefaultHostExecutionSpace;
+
     template<typename ValueType, typename DeviceType>
     int HCURL_TET_I1_FEM_Test01(const bool verbose) {
-      
-      Teuchos::RCP<std::ostream> outStream;
-      Teuchos::oblackholestream bhs; // outputs nothing
 
-      if (verbose)
-        outStream = Teuchos::rcp(&std::cout, false);
-      else
-        outStream = Teuchos::rcp(&bhs, false);
-      
+      //! Create an execution space instance.
+      const auto space = Kokkos::Experimental::partition_space(typename DeviceType::execution_space {}, 1)[0];
+
+      //! Setup test output stream.
+      Teuchos::RCP<std::ostream> outStream = setup_output_stream<DeviceType>(
+        verbose, "Basis_HCURL_TET_I1_FEM", {
+          "1) Conversion of Dof tags into Dof ordinals and back",
+          "2) Basis values for VALUE and CURL operators"
+      });
+
       Teuchos::oblackholestream oldFormatState;
       oldFormatState.copyfmt(std::cout);
-
-      using DeviceSpaceType = typename DeviceType::execution_space;       
-      typedef typename
-        Kokkos::DefaultHostExecutionSpace HostSpaceType ;
-      
-      *outStream << "DeviceSpace::  "; DeviceSpaceType().print_configuration(*outStream, false);
-      *outStream << "HostSpace::    ";   HostSpaceType().print_configuration(*outStream, false);
-
-  *outStream
-    << "===============================================================================\n"
-    << "|                                                                             |\n"
-    << "|                 Unit Test (Basis_HCURL_TET_I1_FEM)                          |\n"
-    << "|                                                                             |\n"
-    << "|     1) Conversion of Dof tags into Dof ordinals and back                    |\n"
-    << "|     2) Basis values for VALUE and CURL operators                            |\n"
-    << "|                                                                             |\n"
-    << "|  Questions? Contact  Pavel Bochev (pbboche@sandia.gov) or                   |\n"
-    << "|                      Denis Ridzal (dridzal@sandia.gov).                     |\n"
-    << "|                      Kara Peterson (kjpeter@sandia.gov).                    |\n"
-    << "|                      Kyungjoo Kim  (kyukim@sandia.gov).                     |\n"
-    << "|                                                                             |\n"
-    << "|  Intrepid's website: http://trilinos.sandia.gov/packages/intrepid           |\n"
-    << "|  Trilinos website:   http://trilinos.sandia.gov                             |\n"
-    << "|                                                                             |\n"
-    << "===============================================================================\n";
 
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType> DynRankViewHost;
@@ -122,7 +102,7 @@ namespace Intrepid2 {
 
   try{
     ordinal_type nthrow = 0, ncatch = 0;
-#ifdef HAVE_INTREPID2_DEBUG  
+#ifdef HAVE_INTREPID2_DEBUG
 
     DynRankView ConstructWithLabel( tetNodes, 10, 3 );
 
@@ -134,7 +114,7 @@ namespace Intrepid2 {
     vals = DynRankView("vals", cardinality, numPoints);
 
     {
-    // exception #1: GRAD cannot be applied to HCURL functions 
+    // exception #1: GRAD cannot be applied to HCURL functions
     // resize vals to rank-3 container with dimensions (num. basis functions, num. points, arbitrary)
       INTREPID2_TEST_ERROR_EXPECTED(  tetBasis.getValues(vals, tetNodes, OPERATOR_GRAD) );
     }
@@ -143,8 +123,8 @@ namespace Intrepid2 {
     // resize vals to rank-2 container with dimensions (num. basis functions, num. points)
       INTREPID2_TEST_ERROR_EXPECTED(  tetBasis.getValues(vals, tetNodes, OPERATOR_DIV) );
     }
-    {     
-    // Exceptions 3-7: all bf tags/bf Ids below are wrong and should cause getDofOrdinal() and 
+    {
+    // Exceptions 3-7: all bf tags/bf Ids below are wrong and should cause getDofOrdinal() and
     // getDofTag() to access invalid array elements thereby causing bounds check exception
     // exception #3
       INTREPID2_TEST_ERROR_EXPECTED( tetBasis.getDofOrdinal(3,0,0) );
@@ -175,12 +155,12 @@ namespace Intrepid2 {
     // exception #11 output values must be of rank-3 for OPERATOR_CURL
       INTREPID2_TEST_ERROR_EXPECTED( tetBasis.getValues(badVals1,tetNodes,OPERATOR_CURL) );
     }
-    { 
+    {
     // exception #12 incorrect 0th dimension of output array (must equal number of basis functions)
       DynRankView ConstructWithLabel(badVals2, cardinality+1, numPoints, 3);
       INTREPID2_TEST_ERROR_EXPECTED( tetBasis.getValues(badVals2,tetNodes,OPERATOR_VALUE) );
     }
-    { 
+    {
     // exception #13 incorrect 1st dimension of output array (must equal number of points)
       DynRankView ConstructWithLabel(badVals3, cardinality, numPoints+1, 3);
       INTREPID2_TEST_ERROR_EXPECTED( tetBasis.getValues(badVals3,tetNodes,OPERATOR_VALUE) );
@@ -205,22 +185,22 @@ namespace Intrepid2 {
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
     errorFlag = -1000;
   };
-  
+
   *outStream
     << "\n"
     << "===============================================================================\n"
     << "| TEST 2: correctness of tag to enum and enum to tag lookups                  |\n"
     << "===============================================================================\n";
-  
+
   // all tags are on host space
   try{
     const auto allTags = tetBasis.getAllDofTags();
-    
+
     // Loop over all tags, lookup the associated dof enumeration and then lookup the tag again
     const ordinal_type dofTagSize = allTags.extent(0);
     for (ordinal_type i = 0; i < dofTagSize; ++i) {
       auto bfOrd  = tetBasis.getDofOrdinal(allTags(i,0), allTags(i,1), allTags(i,2));
-      
+
       const auto myTag = tetBasis.getDofTag(bfOrd);
        if( !( (myTag(0) == allTags(i,0)) &&
               (myTag(1) == allTags(i,1)) &&
@@ -228,19 +208,19 @@ namespace Intrepid2 {
               (myTag(3) == allTags(i,3)) ) ) {
         errorFlag++;
         *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-        *outStream << " getDofOrdinal( {" 
-          << allTags(i,0) << ", " 
-          << allTags(i,1) << ", " 
-          << allTags(i,2) << ", " 
-          << allTags(i,3) << "}) = " << bfOrd <<" but \n";   
+        *outStream << " getDofOrdinal( {"
+          << allTags(i,0) << ", "
+          << allTags(i,1) << ", "
+          << allTags(i,2) << ", "
+          << allTags(i,3) << "}) = " << bfOrd <<" but \n";
         *outStream << " getDofTag(" << bfOrd << ") = { "
-          << myTag(0) << ", " 
-          << myTag(1) << ", " 
-          << myTag(2) << ", " 
-          << myTag(3) << "}\n";        
+          << myTag(0) << ", "
+          << myTag(1) << ", "
+          << myTag(2) << ", "
+          << myTag(3) << "}\n";
       }
     }
-    
+
     // Now do the same but loop over basis functions
     for( ordinal_type bfOrd = 0; bfOrd < tetBasis.getCardinality(); bfOrd++) {
       const auto myTag = tetBasis.getDofTag(bfOrd);
@@ -249,13 +229,13 @@ namespace Intrepid2 {
         errorFlag++;
         *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
         *outStream << " getDofTag(" << bfOrd << ") = { "
-          << myTag(0) << ", " 
-          << myTag(1) << ", " 
-          << myTag(2) << ", " 
-          << myTag(3) << "} but getDofOrdinal({" 
-          << myTag(0) << ", " 
-          << myTag(1) << ", " 
-          << myTag(2) << ", " 
+          << myTag(0) << ", "
+          << myTag(1) << ", "
+          << myTag(2) << ", "
+          << myTag(3) << "} but getDofOrdinal({"
+          << myTag(0) << ", "
+          << myTag(1) << ", "
+          << myTag(2) << ", "
           << myTag(3) << "} ) = " << myBfOrd << "\n";
       }
     }
@@ -264,15 +244,15 @@ namespace Intrepid2 {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
-  
+
   *outStream
     << "\n"
     << "===============================================================================\n"
     << "| TEST 3: correctness of basis function values                                |\n"
     << "===============================================================================\n";
-  
+
   outStream -> precision(20);
-  
+
   // VALUE: Each row pair gives the 6x3 correct basis set values at an evaluation point: (P,F,D) layout
   const ValueType basisValues[] = {
     // 4 vertices
@@ -297,7 +277,7 @@ namespace Intrepid2 {
 
      1.0,0.,0.,  -1.0,0.,0.,  -1.0,-2.0,-1.0,
      0.,0.,1.0,  0.,0.,0.,  0.,0.,1.0,
- 
+
      1.0,0.,0.,  0.,0.,0.,  0.,-1.0,0.,  1.0,1.0,2.0,
      -1.0,0.,0.,  0.,-1.0,0.,
 
@@ -307,9 +287,9 @@ namespace Intrepid2 {
      0.,0.,0.,  -1.0,0.,0.,  -1.0,-1.0,-1.0,  1.0,1.0,1.0,
     -1.0,0.,0.,  0.,-1.0,1.0
   };
-  
+
   // CURL: each row pair gives the 3x12 correct values of the curls of the 12 basis functions: (P,F,D) layout
-  const ValueType basisCurls[] = {   
+  const ValueType basisCurls[] = {
     // 4 vertices
      0.,-4.0,4.0,  0.,0.,4.0,  -4.0,0.,4.0,  -4.0,4.0,0.,
      0.,-4.0,0.,  4.0,0.,0.,
@@ -342,7 +322,7 @@ namespace Intrepid2 {
      0.,-4.0,4.0,  0.,0.,4.0,  -4.0,0.,4.0,  -4.0,4.0,0.,
      0.,-4.0,0.,  4.0,0.,0.,
   };
-  
+
   try{
     // Define array containing the 4 vertices of the reference TET and its 6 edge centers.
     DynRankViewHost ConstructWithLabel(tetNodesHost, 10, 3);
@@ -360,22 +340,22 @@ namespace Intrepid2 {
 
     auto tetNodes = Kokkos::create_mirror_view(typename DeviceType::memory_space(), tetNodesHost);
     Kokkos::deep_copy(tetNodes, tetNodesHost);
-        
+
     // Dimensions for the output arrays:
     const ordinal_type cardinality = tetBasis.getCardinality();
     const ordinal_type numPoints = tetNodes.extent(0);
     const ordinal_type spaceDim  = tetBasis.getBaseCellTopology().getDimension();
-    
-    { 
+
+    {
     // Check VALUE of basis functions: resize vals to rank-3 container:
     DynRankView ConstructWithLabel(vals, cardinality, numPoints, spaceDim);
-    tetBasis.getValues(vals, tetNodes, OPERATOR_VALUE);
+    tetBasis.getValues(space, vals, tetNodes, OPERATOR_VALUE);
     auto vals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), vals);
     Kokkos::deep_copy(vals_host, vals);
     for (ordinal_type i = 0; i < cardinality; ++i) {
       for (ordinal_type j = 0; j < numPoints; ++j) {
         for (ordinal_type k = 0; k < spaceDim; ++k) {
-          
+
           // compute offset for (P,F,D) data layout: indices are P->j, F->i, D->k
            const ordinal_type l = k + i * spaceDim + j * spaceDim * cardinality;
            if (std::abs(vals_host(i,j,k) - basisValues[l]) > tol ) {
@@ -392,16 +372,16 @@ namespace Intrepid2 {
       }
     }
     }
-    { 
+    {
     // Check CURL of basis function: resize vals to rank-3 container
     DynRankView ConstructWithLabel(vals, cardinality, numPoints, spaceDim);
-    tetBasis.getValues(vals, tetNodes, OPERATOR_CURL);
+    tetBasis.getValues(space, vals, tetNodes, OPERATOR_CURL);
     auto vals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), vals);
     Kokkos::deep_copy(vals_host, vals);
     for (ordinal_type i = 0; i < cardinality; ++i) {
       for (ordinal_type j = 0; j < numPoints; ++j) {
         for (ordinal_type k = 0; k < spaceDim; ++k) {
-          
+
           // compute offset for (P,F,D) data layout: indices are P->j, F->i, D->k
            const ordinal_type l = k + i * spaceDim + j * spaceDim * cardinality;
            if (std::abs(vals_host(i,j,k) - basisCurls[l]) > tol ) {
@@ -419,14 +399,14 @@ namespace Intrepid2 {
     }
     }
 
-   }    
-  
+   }
+
   // Catch unexpected errors
   catch (std::logic_error &err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
- 
+
   *outStream
     << "\n"
     << "===============================================================================\n"
@@ -466,7 +446,7 @@ namespace Intrepid2 {
     DynRankView ConstructWithLabel(dofCoeffs, cardinality, spaceDim);
     tetBasis.getDofCoords(cvals);
     tetBasis.getDofCoeffs(dofCoeffs);
-    tetBasis.getValues(bvals, cvals, OPERATOR_VALUE);
+    tetBasis.getValues(space, bvals, cvals, OPERATOR_VALUE);
 
     auto cvals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), cvals);
     Kokkos::deep_copy(cvals_host, cvals);
@@ -507,14 +487,14 @@ namespace Intrepid2 {
   << "===============================================================================\n"
   << "| TEST 5: Function Space is Correct                                           |\n"
   << "===============================================================================\n";
-  
+
   try {
     const EFunctionSpace fs = tetBasis.getFunctionSpace();
-    
+
     if (fs != FUNCTION_SPACE_HCURL)
     {
       *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
-      
+
       // Output the multi-index of the value where the error is:
       *outStream << " Expected a function space of FUNCTION_SPACE_HCURL (enum value " << FUNCTION_SPACE_HCURL << "),";
       *outStream << " but got " << fs << "\n";
@@ -530,12 +510,12 @@ namespace Intrepid2 {
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
     errorFlag = -1000;
   }
-      
+
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";
   else
     std::cout << "End Result: TEST PASSED\n";
-  
+
   // reset format state of std::cout
   std::cout.copyfmt(oldFormatState);
   return errorFlag;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TRI_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TRI_I1_FEM/test_01.hpp
@@ -59,48 +59,29 @@
 #include "Teuchos_RCP.hpp"
 
 #include "packages/intrepid2/unit-test/Discretization/Basis/Macros.hpp"
+#include "packages/intrepid2/unit-test/Discretization/Basis/Setup.hpp"
 
 namespace Intrepid2 {
 
   namespace Test {
 
+    using HostSpaceType = Kokkos::DefaultHostExecutionSpace;
+
     template<typename ValueType, typename DeviceType>
     int HCURL_TRI_I1_FEM_Test01(const bool verbose) {
-      
-      Teuchos::RCP<std::ostream> outStream;
-      Teuchos::oblackholestream bhs; // outputs nothing
 
-      if (verbose)
-        outStream = Teuchos::rcp(&std::cout, false);
-      else
-        outStream = Teuchos::rcp(&bhs, false);
-      
+      //! Create an execution space instance.
+      const auto space = Kokkos::Experimental::partition_space(typename DeviceType::execution_space {}, 1)[0];
+
+      //! Setup test output stream.
+      Teuchos::RCP<std::ostream> outStream = setup_output_stream<DeviceType>(
+        verbose, "Basis_HCURL_TRI_I1_FEM", {
+          "1) Conversion of Dof tags into Dof ordinals and back",
+          "2) Basis values for VALUE and CURL operators"
+      });
+
       Teuchos::oblackholestream oldFormatState;
       oldFormatState.copyfmt(std::cout);
-      using DeviceSpaceType = typename DeviceType::execution_space;       
-      typedef typename
-        Kokkos::DefaultHostExecutionSpace HostSpaceType ;
-      
-      *outStream << "DeviceSpace::  "; DeviceSpaceType().print_configuration(*outStream, false);
-      *outStream << "HostSpace::    ";   HostSpaceType().print_configuration(*outStream, false);
-  
-  *outStream 
-    << "===============================================================================\n" 
-    << "|                                                                             |\n" 
-    << "|                 Unit Test (Basis_HCURL_TRI_I1_FEM)                          |\n" 
-    << "|                                                                             |\n" 
-    << "|     1) Conversion of Dof tags into Dof ordinals and back                    |\n" 
-    << "|     2) Basis values for VALUE and CURL operators                            |\n" 
-    << "|                                                                             |\n" 
-    << "|  Questions? Contact  Pavel Bochev  (pbboche@sandia.gov),                    |\n" 
-    << "|                      Denis Ridzal  (dridzal@sandia.gov),                    |\n" 
-    << "|                      Kara Peterson (kjpeter@sandia.gov).                    |\n" 
-    << "|                      Kyungjoo Kim  (kyukim@sandia.gov).                     |\n"
-    << "|                                                                             |\n" 
-    << "|  Intrepid's website: http://trilinos.sandia.gov/packages/intrepid           |\n" 
-    << "|  Trilinos website:   http://trilinos.sandia.gov                             |\n" 
-    << "|                                                                             |\n" 
-    << "===============================================================================\n";
 
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType> DynRankViewHost;
@@ -135,14 +116,14 @@ namespace Intrepid2 {
     vals = DynRankView("vals", cardinality, numPoints);
 
     {
-    // exception #1: GRAD cannot be applied to HCURL functions 
+    // exception #1: GRAD cannot be applied to HCURL functions
       INTREPID2_TEST_ERROR_EXPECTED( triBasis.getValues(vals, triNodes, OPERATOR_GRAD) );
     }
     {
     // exception #2: DIV cannot be applied to HCURL functions
       INTREPID2_TEST_ERROR_EXPECTED( triBasis.getValues(vals, triNodes, OPERATOR_DIV) );
     }
-    // Exceptions 3-7: all bf tags/bf Ids below are wrong and should cause getDofOrdinal() and 
+    // Exceptions 3-7: all bf tags/bf Ids below are wrong and should cause getDofOrdinal() and
     // getDofTag() to access invalid array elements thereby causing bounds check exception
     {
     // exception #3
@@ -165,17 +146,17 @@ namespace Intrepid2 {
     // exception #9 dimension 1 in the input point array must equal space dimension of the cell
     {
       DynRankView ConstructWithLabel(badPoints2, 4, triBasis.getBaseCellTopology().getDimension() + 1);
-      INTREPID2_TEST_ERROR_EXPECTED( triBasis.getValues(vals, badPoints2, OPERATOR_VALUE) ); 
+      INTREPID2_TEST_ERROR_EXPECTED( triBasis.getValues(vals, badPoints2, OPERATOR_VALUE) );
     }
     {
     // exception #10 output values must be of rank-3 for OPERATOR_VALUE in 2D
       DynRankView ConstructWithLabel(badVals1, 4, 3);
-      INTREPID2_TEST_ERROR_EXPECTED( triBasis.getValues(badVals1, triNodes, OPERATOR_VALUE) ); 
+      INTREPID2_TEST_ERROR_EXPECTED( triBasis.getValues(badVals1, triNodes, OPERATOR_VALUE) );
     }
     {
     // exception #11 output values must be of rank-2 for OPERATOR_CURL
       DynRankView ConstructWithLabel(badCurls1,4,3,2);
-      INTREPID2_TEST_ERROR_EXPECTED( triBasis.getValues(badCurls1, triNodes, OPERATOR_CURL) ); 
+      INTREPID2_TEST_ERROR_EXPECTED( triBasis.getValues(badCurls1, triNodes, OPERATOR_CURL) );
     }
     {
     // exception #12 incorrect 0th dimension of output array (must equal number of basis functions)
@@ -191,13 +172,13 @@ namespace Intrepid2 {
     // exception #14: incorrect 2nd dimension of output array for VALUE (must equal the space dimension)
       DynRankView ConstructWithLabel(badVals4, triBasis.getCardinality(), triNodes.extent(0), triBasis.getBaseCellTopology().getDimension() - 1);
       INTREPID2_TEST_ERROR_EXPECTED( triBasis.getValues(badVals4, triNodes, OPERATOR_VALUE) ) ;
-    } 
-    // exception #15: D2 cannot be applied to HCURL functions 
+    }
+    // exception #15: D2 cannot be applied to HCURL functions
     // resize vals to rank-3 container with dimensions (num. basis functions, num. points, arbitrary)
-//    vals.resize(triBasis.getCardinality(), 
-//                triNodes.extent(0),  
+//    vals.resize(triBasis.getCardinality(),
+//                triNodes.extent(0),
 //                Intrepid2::getDkCardinality(OPERATOR_D2, triBasis.getBaseCellTopology().getDimension()));
-//    INTREPID2_TEST_ERROR_EXPECTED( triBasis.getValues(vals, triNodes, OPERATOR_D2) ); 
+//    INTREPID2_TEST_ERROR_EXPECTED( triBasis.getValues(vals, triNodes, OPERATOR_D2) );
 #endif
   // Check if number of thrown exceptions matches the one we expect
     if (nthrow != ncatch) {
@@ -211,22 +192,22 @@ namespace Intrepid2 {
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
     errorFlag = -1000;
   }
-  
+
   *outStream
     << "\n"
     << "===============================================================================\n"
     << "| TEST 2: correctness of tag to enum and enum to tag lookups                  |\n"
     << "===============================================================================\n";
-  
+
   // all tags are on host space
   try{
     const auto allTags = triBasis.getAllDofTags();
-    
+
     // Loop over all tags, lookup the associated dof enumeration and then lookup the tag again
     const ordinal_type dofTagSize = allTags.extent(0);
     for (ordinal_type i = 0; i < dofTagSize; ++i) {
       const auto bfOrd  = triBasis.getDofOrdinal(allTags(i,0), allTags(i,1), allTags(i,2));
-      
+
       const auto myTag = triBasis.getDofTag(bfOrd);
        if( !( (myTag(0) == allTags(i,0)) &&
               (myTag(1) == allTags(i,1)) &&
@@ -234,19 +215,19 @@ namespace Intrepid2 {
               (myTag(3) == allTags(i,3)) ) ) {
         errorFlag++;
         *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-        *outStream << " getDofOrdinal( {" 
-          << allTags(i,0) << ", " 
-          << allTags(i,1) << ", " 
-          << allTags(i,2) << ", " 
-          << allTags(i,3) << "}) = " << bfOrd <<" but \n";   
+        *outStream << " getDofOrdinal( {"
+          << allTags(i,0) << ", "
+          << allTags(i,1) << ", "
+          << allTags(i,2) << ", "
+          << allTags(i,3) << "}) = " << bfOrd <<" but \n";
         *outStream << " getDofTag(" << bfOrd << ") = { "
-          << myTag(0) << ", " 
-          << myTag(1) << ", " 
-          << myTag(2) << ", " 
-          << myTag(3) << "}\n";        
+          << myTag(0) << ", "
+          << myTag(1) << ", "
+          << myTag(2) << ", "
+          << myTag(3) << "}\n";
       }
     }
-    
+
     // Now do the same but loop over basis functions
     for( ordinal_type bfOrd = 0; bfOrd < triBasis.getCardinality(); bfOrd++) {
       const auto myTag  = triBasis.getDofTag(bfOrd);
@@ -255,13 +236,13 @@ namespace Intrepid2 {
         errorFlag++;
         *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
         *outStream << " getDofTag(" << bfOrd << ") = { "
-          << myTag(0) << ", " 
-          << myTag(1) << ", " 
-          << myTag(2) << ", " 
-          << myTag(3) << "} but getDofOrdinal({" 
-          << myTag(0) << ", " 
-          << myTag(1) << ", " 
-          << myTag(2) << ", " 
+          << myTag(0) << ", "
+          << myTag(1) << ", "
+          << myTag(2) << ", "
+          << myTag(3) << "} but getDofOrdinal({"
+          << myTag(0) << ", "
+          << myTag(1) << ", "
+          << myTag(2) << ", "
           << myTag(3) << "} ) = " << myBfOrd << "\n";
       }
     }
@@ -270,15 +251,15 @@ namespace Intrepid2 {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
-  
+
   *outStream
     << "\n"
     << "===============================================================================\n"
     << "| TEST 3: correctness of basis function values                                |\n"
     << "===============================================================================\n";
-  
+
   outStream -> precision(20);
-  
+
   // VALUE: correct values in (P,F,D) layout
   const ValueType basisValues[] = {
     2.0, 0, 0, 0, 0, -2.0, 2.0, 2.0, 0, 2.0, 0, 0, 0, 0, \
@@ -286,9 +267,9 @@ namespace Intrepid2 {
     1.0, 1.0, -1.0, 1.0, -1.0, -1.0, 1.0, 0, \
     -1.0, 0, -1.0, -2.0, 1.5, 0.5, -0.5, 0.5, \
     -0.5, -1.5};
-  
+
   // CURL: correct values in (P,F) layout
-  const ValueType basisCurls[] = {   
+  const ValueType basisCurls[] = {
     4.0,  4.0,  4.0,
     4.0,  4.0,  4.0,
     4.0,  4.0,  4.0,
@@ -297,18 +278,18 @@ namespace Intrepid2 {
     4.0,  4.0,  4.0,
     4.0,  4.0,  4.0
   };
-  
+
   try{
     DynRankViewHost ConstructWithLabel(triNodesHost, 7, 2);
-    triNodesHost(0,0) =  0.0;  triNodesHost(0,1) =  0.0;  
-    triNodesHost(1,0) =  1.0;  triNodesHost(1,1) =  0.0;  
-    triNodesHost(2,0) =  0.0;  triNodesHost(2,1) =  1.0;  
+    triNodesHost(0,0) =  0.0;  triNodesHost(0,1) =  0.0;
+    triNodesHost(1,0) =  1.0;  triNodesHost(1,1) =  0.0;
+    triNodesHost(2,0) =  0.0;  triNodesHost(2,1) =  1.0;
     // edge midpoints
-    triNodesHost(3,0) =  0.5;  triNodesHost(3,1) =  0.0;  
-    triNodesHost(4,0) =  0.5;  triNodesHost(4,1) =  0.5;  
-    triNodesHost(5,0) =  0.0;  triNodesHost(5,1) =  0.5;  
+    triNodesHost(3,0) =  0.5;  triNodesHost(3,1) =  0.0;
+    triNodesHost(4,0) =  0.5;  triNodesHost(4,1) =  0.5;
+    triNodesHost(5,0) =  0.0;  triNodesHost(5,1) =  0.5;
     // Inside Triangle
-    triNodesHost(6,0) =  0.25; triNodesHost(6,1) =  0.25;  
+    triNodesHost(6,0) =  0.25; triNodesHost(6,1) =  0.25;
 
     auto triNodes = Kokkos::create_mirror_view(typename DeviceType::memory_space(), triNodesHost);
     Kokkos::deep_copy(triNodes, triNodesHost);
@@ -317,17 +298,17 @@ namespace Intrepid2 {
     const ordinal_type cardinality = triBasis.getCardinality();
     const ordinal_type numPoints = triNodes.extent(0);
     const ordinal_type spaceDim  = triBasis.getBaseCellTopology().getDimension();
-    
+
     {
     // Check VALUE of basis functions: resize vals to rank-3 container:
     DynRankView ConstructWithLabel(vals, cardinality, numPoints, spaceDim);
-    triBasis.getValues(vals, triNodes, OPERATOR_VALUE);
+    triBasis.getValues(space, vals, triNodes, OPERATOR_VALUE);
     auto vals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), vals);
     Kokkos::deep_copy(vals_host, vals);
     for (ordinal_type i = 0; i < cardinality; ++i) {
       for (ordinal_type j = 0; j < numPoints; ++j) {
         for (ordinal_type k = 0; k < spaceDim; ++k) {
-          
+
           // compute offset for (P,F,D) data layout: indices are P->j, F->i, D->k
            ordinal_type l = k + i * spaceDim + j * spaceDim * cardinality;
            if (std::abs(vals_host(i,j,k) - basisValues[l]) > tol) {
@@ -343,12 +324,12 @@ namespace Intrepid2 {
          }
       }
     }
-    } 
-    
+    }
+
     {
     // Check CURL of basis function: resize vals to rank-2 container
     DynRankView ConstructWithLabel(vals, cardinality, numPoints);
-    triBasis.getValues(vals, triNodes, OPERATOR_CURL);
+    triBasis.getValues(space, vals, triNodes, OPERATOR_CURL);
     auto vals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), vals);
     Kokkos::deep_copy(vals_host, vals);
     for (ordinal_type i = 0; i < cardinality; ++i) {
@@ -357,7 +338,7 @@ namespace Intrepid2 {
         if (std::abs(vals_host(i,j) - basisCurls[l]) > tol) {
           errorFlag++;
           *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-          
+
           // Output the multi-index of the value where the error is:
           *outStream << " At multi-index { ";
           *outStream << i << " ";*outStream << j << " ";
@@ -365,17 +346,17 @@ namespace Intrepid2 {
             << " but reference curl component: " << basisCurls[l] << "\n";
         }
       }
-    }  
+    }
     }
   } //end try
-   
+
   // Catch unexpected errors
   catch (std::logic_error &err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
- 
-  *outStream 
+
+  *outStream
     << "\n"
     << "===============================================================================\n"
     << "| TEST 4: correctness of DoF locations                                        |\n"
@@ -414,7 +395,7 @@ namespace Intrepid2 {
     DynRankView ConstructWithLabel(dofCoeffs, cardinality, spaceDim);
     triBasis.getDofCoeffs(dofCoeffs);
     triBasis.getDofCoords(cvals);
-    triBasis.getValues(bvals, cvals, OPERATOR_VALUE);
+    triBasis.getValues(space, bvals, cvals, OPERATOR_VALUE);
 
     auto cvals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), cvals);
     Kokkos::deep_copy(cvals_host, cvals);
@@ -455,14 +436,14 @@ namespace Intrepid2 {
   << "===============================================================================\n"
   << "| TEST 5: Function Space is Correct                                           |\n"
   << "===============================================================================\n";
-  
+
   try {
     const EFunctionSpace fs = triBasis.getFunctionSpace();
-    
+
     if (fs != FUNCTION_SPACE_HCURL)
     {
       *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
-      
+
       // Output the multi-index of the value where the error is:
       *outStream << " Expected a function space of FUNCTION_SPACE_HCURL (enum value " << FUNCTION_SPACE_HCURL << "),";
       *outStream << " but got " << fs << "\n";
@@ -478,12 +459,12 @@ namespace Intrepid2 {
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
     errorFlag = -1000;
   }
-      
+
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";
   else
     std::cout << "End Result: TEST PASSED\n";
- 
+
   // reset format state of std::cout
   std::cout.copyfmt(oldFormatState);
   return errorFlag;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C2_FEM/test_01.hpp
@@ -56,49 +56,29 @@
 #include "Teuchos_RCP.hpp"
 
 #include "packages/intrepid2/unit-test/Discretization/Basis/Macros.hpp"
+#include "packages/intrepid2/unit-test/Discretization/Basis/Setup.hpp"
 
 namespace Intrepid2 {
 
   namespace Test {
 
+    using HostSpaceType = Kokkos::DefaultHostExecutionSpace;
+
     template<bool serendipity, typename ValueType, typename DeviceType>
     int HGRAD_HEX_DEG2_FEM_Test01(const bool verbose) {
 
-      Teuchos::RCP<std::ostream> outStream;
-      Teuchos::oblackholestream bhs; // outputs nothing
+      //! Create an execution space instance.
+      const auto space = Kokkos::Experimental::partition_space(typename DeviceType::execution_space {}, 1)[0];
 
-      if (verbose)
-        outStream = Teuchos::rcp(&std::cout, false);
-      else
-        outStream = Teuchos::rcp(&bhs,       false);
+      //! Setup test output stream.
+      Teuchos::RCP<std::ostream> outStream = setup_output_stream<DeviceType>(
+        verbose, (serendipity) ? "Basis_HGRAD_HEX_I2_Serendipity FEM" : "Basis_HGRAD_HEX_C2_FEM", {
+          "1) Conversion of Dof tags into Dof ordinals and back",
+          "2) Basis values for VALUE, GRAD, and Dk operators"
+      });
 
       Teuchos::oblackholestream oldFormatState;
       oldFormatState.copyfmt(std::cout);
-
-      using DeviceSpaceType = typename DeviceType::execution_space;
-      typedef typename
-        Kokkos::DefaultHostExecutionSpace HostSpaceType ;
-
-      *outStream << "DeviceSpace::  "; DeviceSpaceType().print_configuration(*outStream, false);
-      *outStream << "HostSpace::    ";   HostSpaceType().print_configuration(*outStream, false);
-
-      *outStream
-        << "\n"
-        << "===============================================================================\n"
-        << "|                                                                             |\n";
-      
-      if constexpr (serendipity) 
-        *outStream
-        << "|            Unit Test (Basis_HGRAD_HEX_I2_Serendipity FEM)                   |\n";
-      else 
-        *outStream
-        << "|                 Unit Test (Basis_HGRAD_HEX_C2_FEM)                          |\n";
-      *outStream  
-        << "|                                                                             |\n"
-        << "|     1) Conversion of Dof tags into Dof ordinals and back                    |\n"
-        << "|     2) Basis values for VALUE, GRAD, and Dk operators                       |\n"
-        << "|                                                                             |\n"
-        << "===============================================================================\n";
 
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
@@ -110,7 +90,7 @@ namespace Intrepid2 {
       typedef ValueType outputValueType;
       typedef ValueType pointValueType;
       BasisPtr<DeviceType,outputValueType,pointValueType> hexBasis;
-      if constexpr (serendipity) 
+      if constexpr (serendipity)
         hexBasis = Teuchos::rcp(new Basis_HGRAD_HEX_I2_FEM<DeviceType,outputValueType,pointValueType>());
       else
         hexBasis = Teuchos::rcp(new Basis_HGRAD_HEX_C2_FEM<DeviceType,outputValueType,pointValueType>());
@@ -443,12 +423,12 @@ namespace Intrepid2 {
           // Generic array for values, grads, curls, etc. that will be properly sized before each call
           DynRankView ConstructWithLabel(vals, numFields, numPoints);
           // Check VALUE of basis functions: resize vals to rank-2 container:
-          hexBasis->getValues(vals, hexNodes, OPERATOR_VALUE);
+          hexBasis->getValues(space, vals, hexNodes, OPERATOR_VALUE);
           auto vals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), vals);
           Kokkos::deep_copy(vals_host, vals);
           for (ordinal_type i = 0; i < numFields; ++i) {
             for (ordinal_type j = 0; j < numPoints; ++j) {
-              ValueType basisVal = (i==j) ? 1.0 : 0.0;  //Kronecher property 
+              ValueType basisVal = (i==j) ? 1.0 : 0.0;  //Kronecher property
               if (std::abs(vals_host(i,j) - basisVal) > tol ) {
                 errorFlag++;
                 *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
@@ -466,7 +446,7 @@ namespace Intrepid2 {
         {
           DynRankView ConstructWithLabel(vals, numFields, numPoints, spaceDim);
           // Check GRAD of basis function: resize vals to rank-3 container
-          hexBasis->getValues(vals, hexNodes, OPERATOR_GRAD);
+          hexBasis->getValues(space, vals, hexNodes, OPERATOR_GRAD);
           auto vals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), vals);
           Kokkos::deep_copy(vals_host, vals);
           for (ordinal_type i = 0; i < numFields; ++i) {
@@ -490,7 +470,7 @@ namespace Intrepid2 {
           }
 
           // Check D1 of basis function (do not resize vals because it has the correct size: D1 = GRAD)
-          hexBasis->getValues(vals, hexNodes, OPERATOR_D1);
+          hexBasis->getValues(space, vals, hexNodes, OPERATOR_D1);
           Kokkos::deep_copy(vals_host, vals);
           for (ordinal_type i = 0; i < numFields; ++i) {
             for (ordinal_type j = 0; j < numPoints; ++j) {
@@ -516,7 +496,7 @@ namespace Intrepid2 {
         {
           // Check D2 of basis function
           DynRankView ConstructWithLabel(vals, numFields, numPoints, D2Cardin);
-          hexBasis->getValues(vals, hexNodes, OPERATOR_D2);
+          hexBasis->getValues(space, vals, hexNodes, OPERATOR_D2);
           auto vals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), vals);
           Kokkos::deep_copy(vals_host, vals);
           for (ordinal_type i = 0; i < numFields; ++i) {
@@ -543,7 +523,7 @@ namespace Intrepid2 {
         {
           // Check D3 of basis function
           DynRankView ConstructWithLabel(vals, numFields, numPoints, D3Cardin);
-          hexBasis->getValues(vals, hexNodes, OPERATOR_D3);
+          hexBasis->getValues(space, vals, hexNodes, OPERATOR_D3);
           auto vals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), vals);
           Kokkos::deep_copy(vals_host, vals);
           for (ordinal_type i = 0; i < numFields; ++i) {
@@ -571,7 +551,7 @@ namespace Intrepid2 {
           // Check D4 of basis function
           if(!serendipity) { //don't have tabulated values for D4 for serendipity elements
             DynRankView ConstructWithLabel(vals, numFields, numPoints, D4Cardin);
-            hexBasis->getValues(vals, hexNodes, OPERATOR_D4);
+            hexBasis->getValues(space, vals, hexNodes, OPERATOR_D4);
             auto vals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), vals);
             Kokkos::deep_copy(vals_host, vals);
             for (ordinal_type i = 0; i < numFields; i++) {
@@ -609,7 +589,7 @@ namespace Intrepid2 {
             // The last dimension is the number of kth derivatives and needs to be resized for every Dk
             const ordinal_type DkCardin  = getDkCardinality(op, spaceDim);
             DynRankView ConstructWithLabel(vals, numFields, numPoints, DkCardin);
-            hexBasis->getValues(vals, hexNodes, op);
+            hexBasis->getValues(space, vals, hexNodes, op);
             auto vals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), vals);
             Kokkos::deep_copy(vals_host, vals);
 
@@ -672,7 +652,7 @@ namespace Intrepid2 {
 
         // Check mathematical correctness.
         hexBasis->getDofCoords(cvals);
-        hexBasis->getValues(bvals, cvals, OPERATOR_VALUE);
+        hexBasis->getValues(space, bvals, cvals, OPERATOR_VALUE);
         auto cvals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), cvals);
         Kokkos::deep_copy(cvals_host, cvals);
         auto bvals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), bvals);
@@ -704,14 +684,14 @@ namespace Intrepid2 {
       << "===============================================================================\n"
       << "| TEST 5: Function Space is Correct                                           |\n"
       << "===============================================================================\n";
-      
+
       try {
         const EFunctionSpace fs = hexBasis->getFunctionSpace();
-        
+
         if (fs != FUNCTION_SPACE_HGRAD)
         {
           *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
-          
+
           // Output the multi-index of the value where the error is:
           *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
           *outStream << " but got " << fs << "\n";
@@ -727,7 +707,7 @@ namespace Intrepid2 {
         *outStream << "-------------------------------------------------------------------------------" << "\n\n";
         errorFlag = -1000;
       }
-      
+
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";
       else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_Cn_FEM/test_01.hpp
@@ -61,57 +61,35 @@
 #include "Teuchos_RCP.hpp"
 
 #include "packages/intrepid2/unit-test/Discretization/Basis/Macros.hpp"
+#include "packages/intrepid2/unit-test/Discretization/Basis/Setup.hpp"
 
 namespace Intrepid2 {
 
 namespace Test {
 
+using HostSpaceType = Kokkos::DefaultHostExecutionSpace;
+
 template<typename OutValueType, typename PointValueType, typename DeviceType>
 int HGRAD_HEX_Cn_FEM_Test01(const bool verbose) {
 
-  Teuchos::RCP<std::ostream> outStream;
-  Teuchos::oblackholestream bhs; // outputs nothing
+  //! Create an execution space instance.
+  const auto space = Kokkos::Experimental::partition_space(typename DeviceType::execution_space {}, 1)[0];
 
-  if (verbose)
-    outStream = Teuchos::rcp(&std::cout, false);
-  else
-    outStream = Teuchos::rcp(&bhs,       false);
+  //! Setup test output stream.
+  Teuchos::RCP<std::ostream> outStream = setup_output_stream<DeviceType>(
+    verbose, "Basis_HGRAD_HEX_Cn_FEM FEM", {
+      "1) Conversion of Dof tags into Dof ordinals and back",
+      "2) Basis values for VALUE, GRAD, and Dk operators"
+  });
 
   Teuchos::oblackholestream oldFormatState;
   oldFormatState.copyfmt(std::cout);
 
-  using DeviceSpaceType = typename DeviceType::execution_space;
-  typedef typename
-      Kokkos::DefaultHostExecutionSpace HostSpaceType ;
-
-  *outStream << "DeviceSpace::  "; DeviceSpaceType().print_configuration(*outStream, false);
-  *outStream << "HostSpace::    ";   HostSpaceType().print_configuration(*outStream, false);
-
-  *outStream
-  << "===============================================================================\n"
-  << "|                                                                             |\n"
-  << "|                 Unit Test (Basis_HGRAD_HEX_Cn_FEM)                          |\n"
-  << "|                                                                             |\n"
-  << "|     1) Conversion of Dof tags into Dof ordinals and back                    |\n"
-  << "|     2) Basis values for VALUE, GRAD, and Dk operators                       |\n"
-  << "|                                                                             |\n"
-  << "|  Questions? Contact  Pavel Bochev  (pbboche@sandia.gov),                    |\n"
-  << "|                      Robert Kirby  (robert.c.kirby@ttu.edu),                |\n"
-  << "|                      Denis Ridzal  (dridzal@sandia.gov),                    |\n"
-  << "|                      Kara Peterson (kjpeter@sandia.gov),                    |\n"
-  << "|                      Kyungjoo Kim  (kyukim@sandia.gov),                     |\n"
-  << "|                      Mauro Perego  (mperego@sandia.gov).                    |\n"
-  << "|                                                                             |\n"
-  << "|  Intrepid's website: http://trilinos.sandia.gov/packages/intrepid           |\n"
-  << "|  Trilinos website:   http://trilinos.sandia.gov                             |\n"
-  << "|                                                                             |\n"
-  << "===============================================================================\n";
-
   typedef Kokkos::DynRankView<PointValueType,DeviceType> DynRankViewPointValueType;
   typedef Kokkos::DynRankView<OutValueType,DeviceType> DynRankViewOutValueType;
   typedef typename ScalarTraits<OutValueType>::scalar_type scalar_type;
-  typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;      
-  typedef Kokkos::DynRankView<scalar_type, HostSpaceType> DynRankViewHostScalarValueType;      
+  typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
+  typedef Kokkos::DynRankView<scalar_type, HostSpaceType> DynRankViewHostScalarValueType;
 
   const scalar_type tol = tolerence();
   int errorFlag = 0;
@@ -315,7 +293,7 @@ int HGRAD_HEX_Cn_FEM_Test01(const bool verbose) {
     auto lattice_host = Kokkos::create_mirror_view(lattice);
 
     DynRankViewOutValueType ConstructWithLabelOutView(basisAtLattice, basisCardinality, basisCardinality);
-    hexBasis.getValues(basisAtLattice, lattice, OPERATOR_VALUE);
+    hexBasis.getValues(space, basisAtLattice, lattice, OPERATOR_VALUE);
 
     auto h_basisAtLattice = Kokkos::create_mirror_view(basisAtLattice);
     Kokkos::deep_copy(h_basisAtLattice, basisAtLattice);
@@ -496,7 +474,7 @@ int HGRAD_HEX_Cn_FEM_Test01(const bool verbose) {
 
       DynRankViewHostScalarValueType ConstructWithLabel(hexNodesHost, 27, 3);
       DynRankViewPointValueType ConstructWithLabelPointView(hexNodes, 27, 3);
-      
+
 
       // do it lexicographically as a lattice
       hexNodesHost(0, 0) = -1.0;   hexNodesHost(0, 1) = -1.0;  hexNodesHost(0, 2) = -1.0;
@@ -529,7 +507,7 @@ int HGRAD_HEX_Cn_FEM_Test01(const bool verbose) {
 
       auto hexNodes_scalar = Kokkos::create_mirror_view(typename DeviceType::memory_space(), hexNodesHost);
       Kokkos::deep_copy(hexNodes_scalar, hexNodesHost);
-      
+
       RealSpaceTools<DeviceType>::clone(hexNodes, hexNodes_scalar);
 
       // Dimensions for the output arrays:
@@ -544,7 +522,7 @@ int HGRAD_HEX_Cn_FEM_Test01(const bool verbose) {
       {
         // Check VALUE of basis functions: resize vals to rank-2 container:
         DynRankViewOutValueType ConstructWithLabelOutView(vals, numFields, numPoints);
-        hexBasis.getValues(vals, hexNodes, OPERATOR_VALUE);
+        hexBasis.getValues(space, vals, hexNodes, OPERATOR_VALUE);
         auto vals_host = Kokkos::create_mirror_view(vals);
         Kokkos::deep_copy(vals_host, vals);
         for (ordinal_type i = 0; i < numFields; ++i) {
@@ -570,7 +548,7 @@ int HGRAD_HEX_Cn_FEM_Test01(const bool verbose) {
       {
         // Check GRAD of basis function: resize vals to rank-3 container
         DynRankViewOutValueType ConstructWithLabelOutView(vals, numFields, numPoints, spaceDim);
-        hexBasis.getValues(vals, hexNodes, OPERATOR_GRAD);
+        hexBasis.getValues(space, vals, hexNodes, OPERATOR_GRAD);
         auto vals_host = Kokkos::create_mirror_view(vals);
         Kokkos::deep_copy(vals_host, vals);
         for (ordinal_type i = 0; i < numFields; ++i) {
@@ -598,7 +576,7 @@ int HGRAD_HEX_Cn_FEM_Test01(const bool verbose) {
       {
         // Check GRAD of basis function: resize vals to rank-3 container
         DynRankViewOutValueType ConstructWithLabelOutView(vals, numFields, numPoints, spaceDim);
-        hexBasis.getValues(vals, hexNodes, OPERATOR_D1);
+        hexBasis.getValues(space, vals, hexNodes, OPERATOR_D1);
         auto vals_host = Kokkos::create_mirror_view(vals);
         Kokkos::deep_copy(vals_host, vals);
         for (ordinal_type i = 0; i < numFields; ++i) {
@@ -626,7 +604,7 @@ int HGRAD_HEX_Cn_FEM_Test01(const bool verbose) {
       {
         // Check GRAD of basis function: resize vals to rank-3 container
         DynRankViewOutValueType ConstructWithLabelOutView(vals, numFields, numPoints, D2Cardin);
-        hexBasis.getValues(vals, hexNodes, OPERATOR_D2);
+        hexBasis.getValues(space, vals, hexNodes, OPERATOR_D2);
         auto vals_host = Kokkos::create_mirror_view(vals);
         Kokkos::deep_copy(vals_host, vals);
         for (ordinal_type i = 0; i < numFields; ++i) {
@@ -654,7 +632,7 @@ int HGRAD_HEX_Cn_FEM_Test01(const bool verbose) {
       {
         // Check GRAD of basis function: resize vals to rank-3 container
         DynRankViewOutValueType ConstructWithLabelOutView(vals, numFields, numPoints, D3Cardin);
-        hexBasis.getValues(vals, hexNodes, OPERATOR_D3);
+        hexBasis.getValues(space, vals, hexNodes, OPERATOR_D3);
         auto vals_host = Kokkos::create_mirror_view(vals);
         Kokkos::deep_copy(vals_host, vals);
         for (ordinal_type i = 0; i < numFields; ++i) {
@@ -682,7 +660,7 @@ int HGRAD_HEX_Cn_FEM_Test01(const bool verbose) {
       {
         // Check GRAD of basis function: resize vals to rank-3 container
         DynRankViewOutValueType ConstructWithLabelOutView(vals, numFields, numPoints, D4Cardin);
-        hexBasis.getValues(vals, hexNodes, OPERATOR_D4);
+        hexBasis.getValues(space, vals, hexNodes, OPERATOR_D4);
         auto vals_host = Kokkos::create_mirror_view(vals);
         Kokkos::deep_copy(vals_host, vals);
         for (ordinal_type i = 0; i < numFields; ++i) {
@@ -718,7 +696,7 @@ int HGRAD_HEX_Cn_FEM_Test01(const bool verbose) {
         const ordinal_type DkCardin = Intrepid2::getDkCardinality(op, spaceDim);
 
         DynRankViewOutValueType ConstructWithLabelOutView(vals, numFields, numPoints, DkCardin);
-        hexBasis.getValues(vals, hexNodes, op);
+        hexBasis.getValues(space, vals, hexNodes, op);
         auto vals_host = Kokkos::create_mirror_view(vals);
         Kokkos::deep_copy(vals_host, vals);
         for (ordinal_type i = 0; i < numFields; ++i) {
@@ -744,23 +722,23 @@ int HGRAD_HEX_Cn_FEM_Test01(const bool verbose) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
-  
+
   *outStream
   << "\n"
   << "===============================================================================\n"
   << "| TEST 5: Function Space is Correct                                           |\n"
   << "===============================================================================\n";
-  
+
   try {
     constexpr ordinal_type order = 2;
     HexBasisType hexBasis(order);
-    
+
     const EFunctionSpace fs = hexBasis.getFunctionSpace();
-    
+
     if (fs != FUNCTION_SPACE_HGRAD)
     {
       *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
-      
+
       // Output the multi-index of the value where the error is:
       *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
       *outStream << " but got " << fs << "\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_Cn_FEM_JACOBI/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_Cn_FEM_JACOBI/test_01.hpp
@@ -65,8 +65,13 @@ namespace Intrepid2 {
 
   namespace Test {
 
+    using HostSpaceType = Kokkos::DefaultHostExecutionSpace;
+
     template<typename ValueType, typename DeviceType>
     int HGRAD_LINE_Cn_FEM_JACOBI_Test01(const bool verbose) {
+
+      //! Create an execution space instance.
+      const auto space = Kokkos::Experimental::partition_space(typename DeviceType::execution_space {}, 1)[0];
 
       Teuchos::RCP<std::ostream> outStream = setup_output_stream<DeviceType>(
         verbose, "Basis_HGRAD_LINE_Cn_FEM_JACOBI", {
@@ -322,7 +327,7 @@ namespace Intrepid2 {
         {
           *outStream << " -- Comparing OPERATOR_VALUE -- \n\n"; 
           DynRankView ConstructWithLabel(vals, numFields, numPoints);
-          lineBasis.getValues(vals, lineNodes, OPERATOR_VALUE);
+          lineBasis.getValues(space, vals, lineNodes, OPERATOR_VALUE);
 
           // host mirror for comparison
           auto valsHost = Kokkos::create_mirror_view(vals);
@@ -352,7 +357,7 @@ namespace Intrepid2 {
         {
           *outStream << " -- Comparing OPERATOR_D1 -- \n\n"; 
           DynRankView ConstructWithLabel(vals, numFields, numPoints, spaceDim);
-          lineBasis.getValues(vals, lineNodes, OPERATOR_D1);
+          lineBasis.getValues(space, vals, lineNodes, OPERATOR_D1);
 
           // host mirror for comparison
           auto valsHost = Kokkos::create_mirror_view(vals);
@@ -382,7 +387,7 @@ namespace Intrepid2 {
         {
           *outStream << " -- Comparing OPERATOR_D2 -- \n\n"; 
           DynRankView ConstructWithLabel(vals, numFields, numPoints, spaceDim);
-          lineBasis.getValues(vals, lineNodes, OPERATOR_D2);
+          lineBasis.getValues(space, vals, lineNodes, OPERATOR_D2);
 
           // host mirror for comparison
           auto valsHost = Kokkos::create_mirror_view(vals);
@@ -412,7 +417,7 @@ namespace Intrepid2 {
         {
           *outStream << " -- Comparing OPERATOR_D3 -- \n\n"; 
           DynRankView ConstructWithLabel(vals, numFields, numPoints, spaceDim);
-          lineBasis.getValues(vals, lineNodes, OPERATOR_D3);
+          lineBasis.getValues(space, vals, lineNodes, OPERATOR_D3);
 
           // host mirror for comparison
           auto valsHost = Kokkos::create_mirror_view(vals);

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_COMP12_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_COMP12_FEM/test_01.hpp
@@ -71,6 +71,9 @@ namespace Intrepid2 {
     template<typename ValueType, typename DeviceType>
     int HGRAD_TET_COMP12_FEM_Test01(const bool verbose) {
       
+      //! Create an execution space instance.
+      const auto space = Kokkos::Experimental::partition_space(typename DeviceType::execution_space {}, 1)[0];
+      
       Teuchos::RCP<std::ostream> outStream = setup_output_stream<DeviceType>(
         verbose, "Basis_HGRAD_TET_COMP12_FEM", {
           "1) Evaluation of Basis Function Values"
@@ -302,7 +305,7 @@ namespace Intrepid2 {
         {
           *outStream << " check VALUE of basis functions at nodes\n";
           DynRankView vals = DynRankView("vals", numFields, numNodes);
-          tetBasis.getValues(vals, tetNodes, OPERATOR_VALUE);
+          tetBasis.getValues(space, vals, tetNodes, OPERATOR_VALUE);
           auto vals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), vals);
           Kokkos::deep_copy(vals_host, vals);
 
@@ -329,7 +332,7 @@ namespace Intrepid2 {
         {
           *outStream << " check VALUE of basis functions at points\n";
           DynRankView vals = DynRankView("vals", numFields, numPoints);
-          tetBasis.getValues(vals, tetPoints, OPERATOR_VALUE);
+          tetBasis.getValues(space, vals, tetPoints, OPERATOR_VALUE);
           auto vals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), vals);
           Kokkos::deep_copy(vals_host, vals);
 
@@ -380,7 +383,7 @@ namespace Intrepid2 {
 
           DynRankView vals = DynRankView("vals", numFields, numRandomPoints);
         
-          tetBasis.getValues(vals, tetRandomPoints, OPERATOR_VALUE);
+          tetBasis.getValues(space, vals, tetRandomPoints, OPERATOR_VALUE);
           auto vals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), vals);
           Kokkos::deep_copy(vals_host, vals);
         
@@ -405,7 +408,7 @@ namespace Intrepid2 {
         // Check GRAD of basis functions at points: resize vals to rank-3 container:\n";
         {
           DynRankView vals = DynRankView("vals", numFields, numPoints, spaceDim);
-          tetBasis.getValues(vals, tetPoints, OPERATOR_GRAD);
+          tetBasis.getValues(space, vals, tetPoints, OPERATOR_GRAD);
           auto vals_host = Kokkos::create_mirror_view(typename HostSpaceType::memory_space(), vals);
           Kokkos::deep_copy(vals_host, vals);
           for (ordinal_type i=0;i<numFields;++i) {

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_Cn_FEM_ORTH/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_Cn_FEM_ORTH/test_01.hpp
@@ -60,6 +60,7 @@
 #include "Intrepid2_CubatureDirectTriDefault.hpp"
 
 #include "packages/intrepid2/unit-test/Discretization/Basis/Macros.hpp"
+#include "packages/intrepid2/unit-test/Discretization/Basis/Setup.hpp"
 
 namespace Intrepid2 {
 
@@ -68,34 +69,16 @@ namespace Test {
 template<typename ValueType, typename DeviceType>
 int HGRAD_TRI_Cn_FEM_ORTH_Test01(const bool verbose) {
 
-  Teuchos::RCP<std::ostream> outStream;
-  Teuchos::oblackholestream bhs; // outputs nothing
+  //! Create an execution space instance.
+  const auto space = Kokkos::Experimental::partition_space(typename DeviceType::execution_space {}, 1)[0];
 
-  if (verbose)
-    outStream = Teuchos::rcp(&std::cout, false);
-  else
-    outStream = Teuchos::rcp(&bhs, false);
+  Teuchos::RCP<std::ostream> outStream = setup_output_stream<DeviceType>(
+    verbose, "OrthogonalBases", {
+        "1) Tests orthogonality of triangular orthogonal basis"
+  });
 
   Teuchos::oblackholestream oldFormatState;
   oldFormatState.copyfmt(std::cout);
-
-  *outStream
-  << "===============================================================================\n"
-  << "|                                                                             |\n"
-  << "|                           Unit Test OrthogonalBases                         |\n"
-  << "|                                                                             |\n"
-  << "|     1) Tests orthogonality of triangular orthogonal basis                   |\n"
-  << "|                                                                             |\n"
-  << "|  Questions? Contact  Pavel Bochev (pbboche@sandia.gov),                     |\n"
-  << "|                      Denis Ridzal (dridzal@sandia.gov),                     |\n"
-  << "|                      Robert Kirby (robert.c.kirby@ttu.edu),                 |\n"
-  << "|                      Mauro Perego (mperego@sandia.gov),                     |\n"
-  << "|                      Kyungjoo Kim (kyukim@sandia.gov)                       |\n"
-  << "|                                                                             |\n"
-  << "|  Intrepid's website: http://trilinos.sandia.gov/packages/intrepid           |\n"
-  << "|  Trilinos website:   http://trilinos.sandia.gov                             |\n"
-  << "|                                                                             |\n"
-  << "===============================================================================\n";
 
   typedef Kokkos::DynRankView<ValueType, DeviceType> DynRankView;
 
@@ -138,7 +121,7 @@ int HGRAD_TRI_Cn_FEM_ORTH_Test01(const bool verbose) {
     // Tabulate the basis functions at the cubature points
     DynRankView ConstructWithLabel(basisAtCubPts, polydim, npts);
 
-    triBasis.getValues(basisAtCubPts, cubPoints, OPERATOR_VALUE);
+    triBasis.getValues(space, basisAtCubPts, cubPoints, OPERATOR_VALUE);
     auto h_basisAtCubPts = Kokkos::create_mirror_view(basisAtCubPts);
     Kokkos::deep_copy(h_basisAtCubPts, basisAtCubPts);
 
@@ -181,7 +164,7 @@ int HGRAD_TRI_Cn_FEM_ORTH_Test01(const bool verbose) {
       PointTools::getLattice(lattice, tri_3, order, 0, POINTTYPE_EQUISPACED);
 
       DynRankView ConstructWithLabel(dBasisAtLattice, polydim , np_lattice , dim);
-      triBasis.getValues(dBasisAtLattice, lattice, OPERATOR_D1);
+      triBasis.getValues(space, dBasisAtLattice, lattice, OPERATOR_D1);
 
       auto h_dBasisAtLattice = Kokkos::create_mirror_view(dBasisAtLattice);
       Kokkos::deep_copy(h_dBasisAtLattice, dBasisAtLattice);
@@ -334,7 +317,7 @@ int HGRAD_TRI_Cn_FEM_ORTH_Test01(const bool verbose) {
       PointTools::getLattice(lattice, tri_3, order, 0, POINTTYPE_EQUISPACED);
 
       DynRankView ConstructWithLabel(dBasisAtLattice, polydim , np_lattice , 3);
-      triBasis.getValues(dBasisAtLattice, lattice, OPERATOR_D2);
+      triBasis.getValues(space, dBasisAtLattice, lattice, OPERATOR_D2);
 
       auto h_dBasisAtLattice = Kokkos::create_mirror_view(dBasisAtLattice);
       Kokkos::deep_copy(h_dBasisAtLattice, dBasisAtLattice);


### PR DESCRIPTION
@CamelliaDPG @mperego 

@trilinos/intrepid2

This PR is a follow up of:
- https://github.com/trilinos/Trilinos/pull/12366

The PR #12366 had started allowing an execution space instance to be passed to`getValues`. In PR #12366, this had been done for some, but not all, of the bases the Intrepid2 supports.

In this PR, the work of PR #12366 is continued to a few more, but still not all, bases. The same changes as in PR #12366 are now also made for
- `HCURL TET I1 In`
- `HCURL TRI I1`
- `HGRAD HEX C1 C2 Cn`
- `HGRAD LINE Cn_JACOBI`
- `HGRAD TET COMP12 Cn_FEM_ORTH`
- `HGRAD TRI Cn_FEM_ORTH`

