### PR TITLE
Panzer MiniEM: Use truncated MG hierarchies on GPU

### DIFF
--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuCuda.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuCuda.xml
@@ -20,6 +20,15 @@
                   <Parameter name="repartition: target rows per thread" type="int" value="95000"/>
                   <Parameter name="repartition: min rows per thread" type="int" value="10000"/>
 
+                  <!-- make this a one-level method -->
+                  <Parameter name="max levels" type="int" value="1"/>
+                  <Parameter        name="coarse: type"                       type="string"   value="CHEBYSHEV"/>
+                  <ParameterList    name="coarse: params">
+                    <Parameter      name="chebyshev: degree"                    type="int"      value="6"/>
+                    <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="5.4"/>
+                    <Parameter      name="chebyshev: eigenvalue max iterations" type="int" value="100"/>
+                  </ParameterList>
+
                 </ParameterList>
 
                 <ParameterList name="refmaxwell: 22list">
@@ -28,6 +37,15 @@
 
                   <Parameter name="repartition: target rows per thread" type="int" value="180000"/>
                   <Parameter name="repartition: min rows per thread" type="int" value="10000"/>
+
+                  <!-- make this a one-level method -->
+                  <Parameter name="max levels" type="int" value="1"/>
+                  <Parameter        name="coarse: type"                       type="string"   value="CHEBYSHEV"/>
+                  <ParameterList    name="coarse: params">
+                    <Parameter      name="chebyshev: degree"                    type="int"      value="6"/>>
+                    <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="7"/>
+                    <Parameter      name="chebyshev: eigenvalue max iterations" type="int" value="100"/>
+                  </ParameterList>
 
                 </ParameterList>
 


### PR DESCRIPTION
@trilinos/panzer 

## Motivation
Less robust than using a full multigrid hierarchy, but faster on out test problems.