### PR TITLE
Tpetra: matrix apply TPL improvements

### DIFF
--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp
@@ -290,7 +290,7 @@ private:
   /// - Decides whether a version of the local matrix with int-typed rowptrs can and should be used to enable spmv TPLs
   /// - Keeps SPMVHandles for both the regular local matrix, and the int-typed version
   /// - Stores the int-typed rowptrs (if they can all be represented by int)
-  mutable Details::LazyUniquePtr<ApplyHelper> applyHelper;
+  mutable std::shared_ptr<ApplyHelper> applyHelper;
 
 public:
 #endif

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -1117,7 +1117,7 @@ void BlockCrsMatrix<Scalar, LO, GO, Node>::localApplyBlockNoTrans(
   auto A_lcl = getLocalMatrixDevice();
   if(!applyHelper.get()) {
     // The apply helper does not exist, so create it
-    applyHelper.assign(new ApplyHelper(A_lcl.nnz(), A_lcl.graph.row_map));
+    applyHelper = std::make_shared<ApplyHelper>(A_lcl.nnz(), A_lcl.graph.row_map);
   }
   if(applyHelper->shouldUseIntRowptrs())
   {

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -449,6 +449,11 @@ public:
       "Invalid 'mode' argument.  Valid values are Teuchos::NO_TRANS, "
       "Teuchos::TRANS, and Teuchos::CONJ_TRANS.");
 
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      !X.isConstantStride() || !Y.isConstantStride(),
+      std::invalid_argument, "Tpetra::BlockCrsMatrix::apply: "
+      "X and Y must both be constant stride");
+
     BMV X_view;
     BMV Y_view;
     const LO blockSize = getBlockSize ();
@@ -1103,14 +1108,35 @@ void BlockCrsMatrix<Scalar, LO, GO, Node>::localApplyBlockNoTrans(
   const impl_scalar_type alpha_impl = alpha;
   const auto graph = this->graph_.getLocalGraphDevice();
 
-  auto X_mv = X.getMultiVectorView();
-  auto Y_mv = Y.getMultiVectorView();
+  mv_type X_mv = X.getMultiVectorView();
+  mv_type Y_mv = Y.getMultiVectorView();
   auto X_lcl = X_mv.getLocalViewDevice(Access::ReadOnly);
   auto Y_lcl = Y_mv.getLocalViewDevice(Access::ReadWrite);
 
+#if KOKKOSKERNELS_VERSION >= 40299
+  auto A_lcl = getLocalMatrixDevice();
+  if(!applyHelper.get()) {
+    // The apply helper does not exist, so create it
+    applyHelper.assign(new ApplyHelper(A_lcl.nnz(), A_lcl.graph.row_map));
+  }
+  if(applyHelper->shouldUseIntRowptrs())
+  {
+    auto A_lcl_int_rowptrs = applyHelper->getIntRowptrMatrix(A_lcl);
+    KokkosSparse::spmv(
+        &applyHelper->handle_int, KokkosSparse::NoTranspose,
+        alpha_impl, A_lcl_int_rowptrs, X_lcl, beta, Y_lcl);
+  }
+  else
+  {
+    KokkosSparse::spmv(
+        &applyHelper->handle, KokkosSparse::NoTranspose,
+        alpha_impl, A_lcl, X_lcl, beta, Y_lcl);
+  }
+#else
   auto A_lcl = getLocalMatrixDevice();
   KokkosSparse::spmv(KokkosSparse::NoTranspose, alpha_impl, A_lcl, X_lcl, beta,
                      Y_lcl);
+#endif
 }
 // clang-format off
 

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -4034,6 +4034,8 @@ protected:
 #if KOKKOSKERNELS_VERSION >= 40299
     // TODO: When KokkosKernels 4.4 is released, local_matrix_device_type can be permanently modified to use the default_size_type
     // of KK. This is always a type that is enabled by KK's ETI (preferring int if both or neither int and size_t are enabled).
+    //
+    // At that point the ApplyHelper can be replaced with just a SPMVHandle.
     using local_matrix_int_rowptrs_device_type =
       KokkosSparse::CrsMatrix<impl_scalar_type,
                               local_ordinal_type,
@@ -4047,12 +4049,12 @@ protected:
       local_matrix_int_rowptrs_device_type, 
       typename MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::device_view_type>;
 
-    /// The apply helper is lazily created in apply(), and reset (destructed) when resumeFill is called.
+    /// The apply helper is lazily created in apply(), and reset when resumeFill is called.
     /// It performs 3 functions:
     /// - Decides whether a version of the local matrix with int-typed rowptrs can and should be used to enable spmv TPLs
     /// - Keeps SPMVHandles for both the regular local matrix, and the int-typed version
     /// - Stores the int-typed rowptrs (if they can all be represented by int)
-    mutable Details::LazyUniquePtr<ApplyHelper> applyHelper;
+    mutable std::shared_ptr<ApplyHelper> applyHelper;
 #endif
 
   public:

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -45,7 +45,13 @@
 /// \brief Declaration of the Tpetra::CrsMatrix class
 
 #include "Tpetra_CrsMatrix_fwd.hpp"
+#include "KokkosSparse_Utils.hpp"
+#include "KokkosSparse_CrsMatrix.hpp"
+#if KOKKOSKERNELS_VERSION >= 40299
+#include "Tpetra_Details_MatrixApplyHelper.hpp"
+#else
 #include "Tpetra_LocalCrsMatrixOperator.hpp"
+#endif
 #include "Tpetra_RowMatrix_decl.hpp"
 #include "Tpetra_Exceptions.hpp"
 #include "Tpetra_DistObject.hpp"
@@ -53,8 +59,6 @@
 #include "Tpetra_Vector.hpp"
 #include "Tpetra_Details_PackTraits.hpp" // unused here, could delete
 #include "Tpetra_Details_ExecutionSpacesUser.hpp"
-#include "KokkosSparse_Utils.hpp"
-#include "KokkosSparse_CrsMatrix.hpp"
 #include "Teuchos_DataAccess.hpp"
 
 #include <memory> // std::shared_ptr
@@ -506,12 +510,13 @@ private:
     using local_matrix_host_type = 
           typename local_matrix_device_type::HostMirror;
 
-
+#if KOKKOSKERNELS_VERSION < 40299
     /// \brief The type of the local matrix-vector operator (a wrapper of \c KokkosSparse::CrsMatrix )
     using local_multiply_op_type =
       LocalCrsMatrixOperator<scalar_type,
                              scalar_type,
                              device_type>;
+#endif
 
     using row_ptrs_device_view_type = 
           typename row_matrix_type::row_ptrs_device_view_type;
@@ -2323,12 +2328,14 @@ private:
     local_matrix_device_type getLocalMatrixDevice () const;
     local_matrix_host_type getLocalMatrixHost () const;
 
+#if KOKKOSKERNELS_VERSION < 40299
     /// \brief The local sparse matrix operator 
     ///   (a wrapper of \c getLocalMatrixDevice()
     ///   that supports local matrix-vector multiply)
     ///
     /// \warning It is only valid to call this method if this->isFillComplete().
     std::shared_ptr<local_multiply_op_type> getLocalMultiplyOperator () const;
+#endif
 
     /// \brief Number of global elements in the row map of this matrix.
     ///
@@ -2546,6 +2553,7 @@ protected:
     values_wdv_type valuesUnpacked_wdv;
     mutable values_wdv_type valuesPacked_wdv;
 
+#if KOKKOSKERNELS_VERSION < 40299
     using ordinal_rowptrs_type = typename local_multiply_op_type::ordinal_view_type;
     /// \brief local_ordinal typed version of local matrix's rowptrs.
     ///   This allows the LocalCrsMatrixOperator to have rowptrs and entries be the same type,
@@ -2555,6 +2563,7 @@ protected:
     ///     - the cuSPARSE TPL is enabled
     ///     - local_ordinal_type can represent getLocalNumEntries()
     mutable ordinal_rowptrs_type ordinalRowptrs;
+#endif
 
 public:
 
@@ -4020,6 +4029,31 @@ protected:
     ///   to their owning processes.
     std::map<GlobalOrdinal, std::pair<Teuchos::Array<GlobalOrdinal>,
                                       Teuchos::Array<Scalar> > > nonlocals_;
+
+  private:
+#if KOKKOSKERNELS_VERSION >= 40299
+    // TODO: When KokkosKernels 4.4 is released, local_matrix_device_type can be permanently modified to use the default_size_type
+    // of KK. This is always a type that is enabled by KK's ETI (preferring int if both or neither int and size_t are enabled).
+    using local_matrix_int_rowptrs_device_type =
+      KokkosSparse::CrsMatrix<impl_scalar_type,
+                              local_ordinal_type,
+                              device_type,
+                              void,
+                              int>;
+
+    /// The specialization of Details::MatrixApplyHelper used by this class in apply().
+    using ApplyHelper = Details::MatrixApplyHelper<
+      local_matrix_device_type,
+      local_matrix_int_rowptrs_device_type, 
+      typename MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::device_view_type>;
+
+    /// The apply helper is lazily created in apply(), and reset (destructed) when resumeFill is called.
+    /// It performs 3 functions:
+    /// - Decides whether a version of the local matrix with int-typed rowptrs can and should be used to enable spmv TPLs
+    /// - Keeps SPMVHandles for both the regular local matrix, and the int-typed version
+    /// - Stores the int-typed rowptrs (if they can all be represented by int)
+    mutable Details::LazyUniquePtr<ApplyHelper> applyHelper;
+#endif
 
   public:
     // FIXME (mfh 24 Feb 2014) Is it _really_ necessary to make this a

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -64,7 +64,6 @@
 #include "Tpetra_Details_Profiling.hpp"
 #include "Tpetra_Details_rightScaleLocalCrsMatrix.hpp"
 #include "Tpetra_Details_ScalarViewTraits.hpp"
-#include "KokkosSparse_getDiagCopy.hpp"
 #include "Tpetra_Details_copyConvert.hpp"
 #include "Tpetra_Details_iallreduce.hpp"
 #include "Tpetra_Details_getEntryOnHost.hpp"
@@ -75,7 +74,9 @@
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_DataAccess.hpp"
 #include "Teuchos_SerialDenseMatrix.hpp" // unused here, could delete
-#include "KokkosBlas.hpp"
+#include "KokkosBlas1_scal.hpp"
+#include "KokkosSparse_getDiagCopy.hpp"
+#include "KokkosSparse_spmv.hpp"
 
 #include <memory>
 #include <sstream>
@@ -1028,6 +1029,7 @@ namespace Tpetra {
                                 staticGraph_->getLocalGraphHost());
   }
 
+#if KOKKOSKERNELS_VERSION < 40299
 // KDDKDD NOT SURE WHY THIS MUST RETURN A SHARED_PTR
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   std::shared_ptr<typename CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::local_multiply_op_type>
@@ -1035,10 +1037,8 @@ namespace Tpetra {
   getLocalMultiplyOperator () const
   {
     auto localMatrix = getLocalMatrixDevice();
-#ifdef HAVE_TPETRACORE_CUDA
-#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
-    if(this->getLocalNumEntries() <= size_t(Teuchos::OrdinalTraits<LocalOrdinal>::max()) &&
-       std::is_same<Node, Tpetra::KokkosCompat::KokkosCudaWrapperNode>::value)
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) || defined(KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE) || defined(KOKKOSKERNELS_ENABLE_TPL_MKL)
+    if(this->getLocalNumEntries() <= size_t(Teuchos::OrdinalTraits<LocalOrdinal>::max()))
     {
       if(this->ordinalRowptrs.data() == nullptr)
       {
@@ -1060,11 +1060,11 @@ namespace Tpetra {
           std::make_shared<local_matrix_device_type>(localMatrix), this->ordinalRowptrs);
     }
 #endif
-#endif
 // KDDKDD NOT SURE WHY THIS MUST RETURN A SHARED_PTR
     return std::make_shared<local_multiply_op_type>(
                            std::make_shared<local_matrix_device_type>(localMatrix));
   }
+#endif
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   bool
@@ -4307,6 +4307,10 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     if (! isStaticGraph ()) { // Don't resume fill of a nonowned graph.
       myGraph_->resumeFill (params);
     }
+#if KOKKOSKERNELS_VERSION >= 40299
+    // Delete the apply helper (if it exists)
+    applyHelper.reset();
+#endif
     fillComplete_ = false;
   }
 
@@ -4899,6 +4903,14 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       }
       return;
     }
+    else if (beta == ZERO) {
+      //Thyra was implicitly assuming that Y gets set to zero / or is overwritten
+      //when bets==0. This was not the case with transpose in a multithreaded
+      //environment where a multiplication with subsequent atomic_adds is used
+      //since 0 is effectively not special cased. Doing the explicit set to zero here
+      //This catches cases where Y is nan or inf.
+      Y_in.putScalar (ZERO);
+    }
 
     const size_t numVectors = X_in.getNumVectors ();
 
@@ -5018,7 +5030,6 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
     auto X_lcl = X.getLocalViewDevice(Access::ReadOnly);
     auto Y_lcl = Y.getLocalViewDevice(Access::ReadWrite);
-    auto matrix_lcl = getLocalMultiplyOperator();
 
     const bool debug = ::Tpetra::Details::Behavior::debug ();
     if (debug) {
@@ -5079,10 +5090,51 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     if(nrows != 0)
       maxRowImbalance = getLocalMaxNumRowEntries() - (getLocalNumEntries() / nrows);
 
+#if KOKKOSKERNELS_VERSION >= 40299
+    auto A_lcl = getLocalMatrixDevice();
+    if(!applyHelper.get()) {
+      // The apply helper does not exist, so create it.
+      // This is when we can choose the spmv algorithm.
+      bool exceedsImbalanceThreshold = size_t(maxRowImbalance) >= Tpetra::Details::Behavior::rowImbalanceThreshold();
+      KokkosSparse::SPMVAlgorithm algo =
+        exceedsImbalanceThreshold ? KokkosSparse::SPMV_MERGE_PATH : KokkosSparse::SPMV_DEFAULT;
+      applyHelper.assign(new ApplyHelper(A_lcl.nnz(), A_lcl.graph.row_map, algo));
+    }
+
+    // Translate mode (Teuchos enum) to KokkosKernels (1-character string)
+    const char* modeKK = nullptr;
+    switch(mode)
+    {
+      case Teuchos::NO_TRANS:
+        modeKK = KokkosSparse::NoTranspose;        break;
+      case Teuchos::TRANS:
+        modeKK = KokkosSparse::Transpose;          break;
+      case Teuchos::CONJ_TRANS:
+        modeKK = KokkosSparse::ConjugateTranspose; break;
+      default:
+        throw std::invalid_argument("Tpetra::CrsMatrix::localApply: invalid mode");
+    }
+
+    if(applyHelper->shouldUseIntRowptrs())
+    {
+      auto A_lcl_int_rowptrs = applyHelper->getIntRowptrMatrix(A_lcl);
+      KokkosSparse::spmv(
+          &applyHelper->handle_int, modeKK,
+          impl_scalar_type(alpha), A_lcl_int_rowptrs, X_lcl, impl_scalar_type(beta), Y_lcl);
+    }
+    else
+    {
+      KokkosSparse::spmv(
+          &applyHelper->handle, modeKK,
+          impl_scalar_type(alpha), A_lcl, X_lcl, impl_scalar_type(beta), Y_lcl);
+    }
+#else
+    auto matrix_lcl = getLocalMultiplyOperator();
     if(size_t(maxRowImbalance) >= Tpetra::Details::Behavior::rowImbalanceThreshold())
       matrix_lcl->applyImbalancedRows (X_lcl, Y_lcl, mode, alpha, beta);
     else
       matrix_lcl->apply (X_lcl, Y_lcl, mode, alpha, beta);
+#endif
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -5108,16 +5160,6 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     }
     else {
       ProfilingRegion regionTranspose ("Tpetra::CrsMatrix::apply (transpose)");
-
-      //Thyra was implicitly assuming that Y gets set to zero / or is overwritten
-      //when bets==0. This was not the case with transpose in a multithreaded
-      //environment where a multiplication with subsequent atomic_adds is used
-      //since 0 is effectively not special cased. Doing the explicit set to zero here
-      //This catches cases where Y is nan or inf.
-      const Scalar ZERO = Teuchos::ScalarTraits<Scalar>::zero ();
-      if (beta == ZERO) {
-        Y.putScalar (ZERO);
-      }
       this->applyTranspose (X, Y, mode, alpha, beta);
     }
   }

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -5098,7 +5098,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       bool exceedsImbalanceThreshold = size_t(maxRowImbalance) >= Tpetra::Details::Behavior::rowImbalanceThreshold();
       KokkosSparse::SPMVAlgorithm algo =
         exceedsImbalanceThreshold ? KokkosSparse::SPMV_MERGE_PATH : KokkosSparse::SPMV_DEFAULT;
-      applyHelper.assign(new ApplyHelper(A_lcl.nnz(), A_lcl.graph.row_map, algo));
+      applyHelper = std::make_shared<ApplyHelper>(A_lcl.nnz(), A_lcl.graph.row_map, algo);
     }
 
     // Translate mode (Teuchos enum) to KokkosKernels (1-character string)

--- a/packages/tpetra/core/src/Tpetra_Details_MatrixApplyHelper.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_MatrixApplyHelper.hpp
@@ -1,0 +1,155 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_MATRIX_APPLY_HELPER_HPP
+#define TPETRA_MATRIX_APPLY_HELPER_HPP
+
+#include "Kokkos_Core.hpp"
+#include "KokkosSparse_spmv_handle.hpp"
+
+#if KOKKOSKERNELS_VERSION < 40299
+#error "Tpetra::Details::MatrixApplyHelper can only be included with KokkosKernels 4.3+"
+#endif
+
+namespace Tpetra {
+namespace Details {
+
+// Class that works pretty much like std::unique_ptr, except it has
+// operator= and copy-constructor that leave the new object null.
+//
+// unique_ptr would force CrsMatrix and BlockCrsMatrix to have deleted operator=,
+// but this version doesn't.
+template<typename T>
+struct LazyUniquePtr
+{
+  LazyUniquePtr() : ptr(nullptr) {}
+  LazyUniquePtr(T* ptr_) : ptr(ptr_) {}
+  LazyUniquePtr(const LazyUniquePtr<T>&) {ptr = nullptr;}
+  void operator=(const LazyUniquePtr<T>&) {ptr = nullptr;}
+  ~LazyUniquePtr() {if(ptr) delete ptr;}
+  T* operator->(){return ptr;}
+  T* get() {return ptr;}
+  void assign(T* ptr_)
+  {
+    reset();
+    ptr = ptr_;
+  }
+  void reset()
+  {
+    if(ptr)
+      delete ptr;
+    ptr = nullptr;
+  }
+  T* ptr;
+};
+
+/// Helper for CrsMatrix::apply and BlockCrsMatrix::apply. Converts rowptrs
+/// of the local matrix to int if it's not already int-valued, and overflow won't occur.
+/// This enables TPLs to be used in KokkosSparse::spmv.
+///
+/// This functionality is temporary. When KokkosKernels 4.4 is released, the default offset (rowptrs element type)
+/// in KK's ETI will switch to int, and Tpetra's matrix types will also switch to int. This will make the int rowptrs handling
+/// here unnecessary, and CrsMatrix/BlockCrsMatrix can simply store the SPMVHandle themselves.
+template<typename LocalMatrix, typename IntLocalMatrix, typename MultiVectorLocalView>
+struct MatrixApplyHelper
+{
+  using Rowptrs = typename LocalMatrix::row_map_type;
+  using IntRowptrs = typename IntLocalMatrix::row_map_type;
+  using XVectorType = typename MultiVectorLocalView::const_type;
+  using YVectorType = MultiVectorLocalView;
+  using SPMVHandle = KokkosSparse::SPMVHandle<typename LocalMatrix::device_type, LocalMatrix, XVectorType, YVectorType>;
+  using SPMVHandleInt = KokkosSparse::SPMVHandle<typename LocalMatrix::device_type, IntLocalMatrix, XVectorType, YVectorType>;
+
+  MatrixApplyHelper(size_t nnz_, const typename LocalMatrix::row_map_type& rowptrs, KokkosSparse::SPMVAlgorithm algo = KokkosSparse::SPMV_DEFAULT)
+    : nnz(nnz_), handle(algo), handle_int(algo)
+  {
+    if(shouldUseIntRowptrs())
+      fillRowptrsInt(rowptrs);
+    // otherwise, leave rowptrs_int empty
+  }
+
+  bool shouldUseIntRowptrs() const
+  {
+    // Use int-valued rowptrs if:
+    // - number of entries doesn't overflow int
+    // - LocalMatrix's rowptrs is not already int-typed
+    return nnz <= size_t(INT_MAX) && !std::is_same_v<int, typename Rowptrs::non_const_value_type>;
+  }
+
+  // Given the local matrix, return a version with int-typed rowptrs
+  IntLocalMatrix getIntRowptrMatrix(const LocalMatrix& A)
+  {
+    if constexpr(KokkosSparse::is_crs_matrix_v<LocalMatrix>)
+    {
+      return IntLocalMatrix("", A.numRows(), A.numCols(), A.nnz(),
+          A.values, rowptrs_int, A.graph.entries);
+    }
+    else
+    {
+      return IntLocalMatrix("", A.numRows(), A.numCols(), A.nnz(),
+          A.values, rowptrs_int, A.graph.entries, A.blockDim());
+    }
+  }
+
+  void fillRowptrsInt(const Rowptrs& rowptrs)
+  {
+    // Populate rowptrs_int as a deep copy of rowptrs, converted to int.
+    // This needs to be in its own public function because KOKKOS_LAMBDA cannot be used inside constructor or protected/private
+    typename IntRowptrs::non_const_type rowptrs_temp(
+        Kokkos::view_alloc(Kokkos::WithoutInitializing, "rowptrs_int"), rowptrs.extent(0));
+    Kokkos::parallel_for(Kokkos::RangePolicy<typename LocalMatrix::execution_space>(0, rowptrs.extent(0)),
+      KOKKOS_LAMBDA(int i)
+      {
+        rowptrs_temp(i) = int(rowptrs(i));
+      });
+    rowptrs_int = rowptrs_temp;
+  }
+
+  size_t nnz;
+  // SPMVHandles are lazily initialized by actual spmv calls.
+  // We declare both here because we don't know until runtime (based on nnz) which should be used.
+  SPMVHandle handle;
+  SPMVHandleInt handle_int;
+  IntRowptrs rowptrs_int;
+};
+}
+}
+
+#endif // TPETRA_MATRIX_APPLY_HELPER_HPP
+

--- a/packages/tpetra/core/src/Tpetra_Details_MatrixApplyHelper.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_MatrixApplyHelper.hpp
@@ -50,35 +50,6 @@
 namespace Tpetra {
 namespace Details {
 
-// Class that works pretty much like std::unique_ptr, except it has
-// operator= and copy-constructor that leave the new object null.
-//
-// unique_ptr would force CrsMatrix and BlockCrsMatrix to have deleted operator=,
-// but this version doesn't.
-template<typename T>
-struct LazyUniquePtr
-{
-  LazyUniquePtr() : ptr(nullptr) {}
-  LazyUniquePtr(T* ptr_) : ptr(ptr_) {}
-  LazyUniquePtr(const LazyUniquePtr<T>&) {ptr = nullptr;}
-  void operator=(const LazyUniquePtr<T>&) {ptr = nullptr;}
-  ~LazyUniquePtr() {if(ptr) delete ptr;}
-  T* operator->(){return ptr;}
-  T* get() {return ptr;}
-  void assign(T* ptr_)
-  {
-    reset();
-    ptr = ptr_;
-  }
-  void reset()
-  {
-    if(ptr)
-      delete ptr;
-    ptr = nullptr;
-  }
-  T* ptr;
-};
-
 /// Helper for CrsMatrix::apply and BlockCrsMatrix::apply. Converts rowptrs
 /// of the local matrix to int if it's not already int-valued, and overflow won't occur.
 /// This enables TPLs to be used in KokkosSparse::spmv.

--- a/packages/tpetra/core/src/Tpetra_Details_residual.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_residual.hpp
@@ -339,9 +339,10 @@ void localResidual(const CrsMatrix<SC,LO,GO,NO> &  A,
        std::runtime_error, "X, Y and R may not alias one another.");
   }
       
-  SC one = Teuchos::ScalarTraits<SC>::one();
 #ifdef TPETRA_DETAILS_USE_REFERENCE_RESIDUAL
-  SC negone = -one, zero = Teuchos::ScalarTraits<SC>::zero();    
+  SC one = Teuchos::ScalarTraits<SC>::one();
+  SC negone = -one;
+  SC zero = Teuchos::ScalarTraits<SC>::zero();
   // This is currently a "reference implementation" waiting until Kokkos Kernels provides
   // a residual kernel.
   A.localApply(X_colmap,R,Teuchos::NO_TRANS, one, zero);


### PR DESCRIPTION
- Integrate SPMVHandle (for KokkosKernels 4.3+), enabling reuse of matrix analysis
- Rework how int-typed rowptrs are handled. Now works for BlockCrsMatrix too, and rocsparse can be used (not just cusparse)

This adds a new helper struct ``Tpetra::Details::MatrixApplyHelper`` which deals with the rowptrs and SPMVHandles (one for the int-rowptr typed matrix and one for the standard local device matrix). This is temporary - in KokkosKernels 4.4, int will become the default rowptr type so we can get rid of the helper and replace it with a simple SPMVHandle.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
- Performance improvements for ``CrsMatrix::apply`` and ``BlockCrsMatrix::apply``.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->