### PR TITLE
Stokhos: Initialize Kokkos from cml args in unit tests in stokhos

### DIFF
--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosArrayKernelsUnitTest_OpenMP.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosArrayKernelsUnitTest_OpenMP.cpp
@@ -81,19 +81,11 @@ TEUCHOS_UNIT_TEST( Kokkos_SG_SpMv, double_OpenMP_CrsMatrixFree_MKL ) {
 #endif
 
 int main( int argc, char* argv[] ) {
+  // Setup the MPI session
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
-  const size_t team_count =
-  Kokkos::hwloc::get_available_numa_count() *
-    Kokkos::hwloc::get_available_cores_per_numa();
-  const size_t threads_per_team =
-    Kokkos::hwloc::get_available_threads_per_core();
-
-  // Initialize openmp
-  Kokkos::InitializationSettings init_args;
-  init_args.set_num_threads(team_count*threads_per_team);
-  Kokkos::initialize( init_args );
-  //Kokkos::print_configuration( std::cout );
+  // Initialize Kokkos
+  Kokkos::initialize(argc, argv);
 
   // Setup (has to happen after initialization)
   setup.setup();

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosCrsMatrixMPVectorUnitTest_OpenMP.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosCrsMatrixMPVectorUnitTest_OpenMP.cpp
@@ -114,19 +114,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL(
 CRS_MATRIX_MP_VECTOR_MULTIPLY_TESTS_ORDINAL_SCALAR_DEVICE(int, double, OpenMP)
 
 int main( int argc, char* argv[] ) {
+  // Setup the MPI session
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
-  // Initialize threads
-  num_cores =
-    Kokkos::hwloc::get_available_numa_count() *
-    Kokkos::hwloc::get_available_cores_per_numa();
-  num_hyper_threads =
-    Kokkos::hwloc::get_available_threads_per_core();
-
-  Kokkos::InitializationSettings init_args;
-  init_args.set_num_threads(num_cores*num_hyper_threads);
-  Kokkos::initialize( init_args );
-  //Kokkos::print_configuration(std::cout);
+  // Initialize Kokkos
+  Kokkos::initialize(argc, argv);
 
   // Run tests
   int ret = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosCrsMatrixUQPCEUnitTest_OpenMP.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosCrsMatrixUQPCEUnitTest_OpenMP.cpp
@@ -52,19 +52,11 @@ using Kokkos::OpenMP;
 CRSMATRIX_UQ_PCE_TESTS_DEVICE( OpenMP )
 
 int main( int argc, char* argv[] ) {
+  // Setup the MPI session
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
-  // Initialize threads
-  const size_t num_cores =
-    Kokkos::hwloc::get_available_numa_count() *
-    Kokkos::hwloc::get_available_cores_per_numa();
-  const size_t num_hyper_threads =
-    Kokkos::hwloc::get_available_threads_per_core();
-
-  Kokkos::InitializationSettings init_args;
-  init_args.set_num_threads(num_cores*num_hyper_threads);
-  Kokkos::initialize( init_args );
-  Kokkos::print_configuration(std::cout);
+  // Initialize Kokkos
+  Kokkos::initialize(argc, argv);
 
   // Run tests
   int ret = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosViewFadMPVectorUnitTest_OpenMP.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosViewFadMPVectorUnitTest_OpenMP.cpp
@@ -52,19 +52,11 @@ using Kokkos::OpenMP;
 VIEW_FAD_MP_VECTOR_TESTS_DEVICE( OpenMP )
 
 int main( int argc, char* argv[] ) {
+// Setup the MPI session
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
-  // Initialize threads
-  size_t num_cores =
-    Kokkos::hwloc::get_available_numa_count() *
-    Kokkos::hwloc::get_available_cores_per_numa();
-  size_t num_hyper_threads =
-    Kokkos::hwloc::get_available_threads_per_core();
-
-  Kokkos::InitializationSettings init_args;
-  init_args.set_num_threads(num_cores*num_hyper_threads);
-  Kokkos::initialize( init_args );
-  //Kokkos::print_configuration(std::cout);
+  // Initialize Kokkos
+  Kokkos::initialize(argc, argv);
 
   // Run tests
   int ret = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosViewMPVectorUnitTest_OpenMP.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosViewMPVectorUnitTest_OpenMP.cpp
@@ -52,19 +52,11 @@ using Kokkos::OpenMP;
 VIEW_MP_VECTOR_TESTS_DEVICE( OpenMP )
 
 int main( int argc, char* argv[] ) {
+  // Setup the MPI session
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
-  // Initialize threads
-  size_t num_cores =
-    Kokkos::hwloc::get_available_numa_count() *
-    Kokkos::hwloc::get_available_cores_per_numa();
-  size_t num_hyper_threads =
-    Kokkos::hwloc::get_available_threads_per_core();
-
-  Kokkos::InitializationSettings init_args;
-  init_args.set_num_threads(num_cores*num_hyper_threads);
-  Kokkos::initialize( init_args );
-  //Kokkos::print_configuration(std::cout);
+  // Initialize Kokkos
+  Kokkos::initialize(argc, argv);
 
   // Run tests
   int ret = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosViewUQPCEUnitTest_OpenMP.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosViewUQPCEUnitTest_OpenMP.cpp
@@ -52,21 +52,11 @@ using Kokkos::OpenMP;
 VIEW_UQ_PCE_TESTS_DEVICE( OpenMP )
 
 int main( int argc, char* argv[] ) {
+// Setup the MPI session
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
-  // Initialize threads
-  const size_t num_cores =
-    Kokkos::hwloc::get_available_numa_count() *
-    Kokkos::hwloc::get_available_cores_per_numa();
-  const size_t num_hyper_threads =
-    Kokkos::hwloc::get_available_threads_per_core();
-  // const size_t num_cores = 1;
-  // const size_t num_hyper_threads = 1;
-
-  Kokkos::InitializationSettings init_args;
-  init_args.set_num_threads(num_cores*num_hyper_threads);
-  Kokkos::initialize( init_args );
-  //Kokkos::print_configuration(std::cout);
+  // Initialize Kokkos
+  Kokkos::initialize(argc, argv);
 
   // Run tests
   int ret = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);

--- a/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest_OpenMP.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest_OpenMP.cpp
@@ -53,22 +53,13 @@ typedef Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::OpenMP> OpenMPWrap
 CRSMATRIX_MP_VECTOR_TESTS_N( OpenMPWrapperNode )
 
 int main( int argc, char* argv[] ) {
+  // Setup the MPI session
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
   Kokkos::global_sacado_mp_vector_size = VectorSize;
 
-  // Initialize threads
-  const size_t num_cores =
-    Kokkos::hwloc::get_available_numa_count() *
-    Kokkos::hwloc::get_available_cores_per_numa();
-  const size_t num_hyper_threads =
-    Kokkos::hwloc::get_available_threads_per_core();
-  // const size_t num_cores = 1;
-  // const size_t num_hyper_threads = 1;
-  Kokkos::InitializationSettings init_args;
-  init_args.set_num_threads(num_cores*num_hyper_threads);
-  Kokkos::initialize( init_args );
-  //Kokkos::print_configuration(std::cout);
+  // Initialize Kokkos
+  Kokkos::initialize(argc, argv);
 
   // Run tests
   Teuchos::UnitTestRepository::setGloballyReduceTestResult(true);

--- a/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixUQPCEUnitTest_OpenMP.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixUQPCEUnitTest_OpenMP.cpp
@@ -53,20 +53,11 @@ typedef Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::OpenMP> OpenMPWrap
 CRSMATRIX_UQ_PCE_TESTS_N( OpenMPWrapperNode )
 
 int main( int argc, char* argv[] ) {
+// Setup the MPI session
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
 
-  // Initialize threads
-  const size_t num_cores =
-    Kokkos::hwloc::get_available_numa_count() *
-    Kokkos::hwloc::get_available_cores_per_numa();
-  const size_t num_hyper_threads =
-    Kokkos::hwloc::get_available_threads_per_core();
-  // const size_t num_cores = 1;
-  // const size_t num_hyper_threads = 1;
-  Kokkos::InitializationSettings init_args;
-  init_args.set_num_threads(num_cores*num_hyper_threads);
-  Kokkos::initialize( init_args );
-  //Kokkos::print_configuration(std::cout);
+  // Initialize Kokkos
+  Kokkos::initialize(argc, argv);
 
   // Run tests
   Teuchos::UnitTestRepository::setGloballyReduceTestResult(true);


### PR DESCRIPTION
@trilinos/stokhos
@etphipp 

Several `OpenMP` versions of `Stokhos`'s unit tests override the flags that are passed to `Kokkos::initialize`. They hardcode a number of OpenMP threads that they deduce from calls to `get_available_numa_count()` and `get_available_threads_per_core()`. Many of these unit tests use MPI, e.g. 4 MPI ranks. An issue is then that when these unit tests run on a single CPU, and all the MPI ranks are thus on this CPU, we have oversubscription.

For example, in our group, we run the trilinos tests on a workstation with a single cpu (16 cores/32 threads). We see these Stokhos tests asking for 4 * 32 threads. This has never caused a noticeable issue until recently. We updated our OpenMPI and one of these unit tests slowed down very significantly. The issue went away when we modified the test to avoid oversubscription.

This PR modifies these unit tests so that it's the arguments passed on the command line that are passed to Kokkos.

@etphipp, was there any reason that you coded the tests with an internally hardcoded number of threads? Do you agree with the proposed fix, or do you have another suggestion?

Joint work with @romintomasetti. 