### PR TITLE
Panzer MiniEM: Make truncating MueLu hierarchies optional

### DIFF
--- a/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
+++ b/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
@@ -23,7 +23,7 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyBlockPrecFiles
   darcyTetAnalytic.xml darcyHexAnalytic.xml
   solverCG.xml solverGMRES.xml
   solverMueLu.xml solverMueLu2D.xml solverMueLuEpetra.xml
-  solverMueLuOpenMP.xml solverMueLuCuda.xml
+  solverMueLuOpenMP.xml solverMueLuCuda.xml solverMueLuTruncated.xml
   solverMueLuHO.xml solverMueLuHOCuda.xml
   solverAugmentationUseILU.xml
   solverML.xml
@@ -94,6 +94,7 @@ TRIBITS_ADD_TEST(
    # POSTFIX_AND_ARGS_ "order3,2_matrixFree" --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-pthOrder.xml --basis-order=3 --pCoarsenSchedule="2,1" --matrixFree
    POSTFIX_AND_ARGS_4 "2D"                  --solver=MueLu --numTimeSteps=1 --linAlgebra=Tpetra --inputFile=maxwell2D.xml
    POSTFIX_AND_ARGS_5 "order1_analytic"     --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-analyticSolution.xml
+   POSTFIX_AND_ARGS_6 "order1_truncated"    --solver=MueLu --numTimeSteps=1 --linAlgebra=Tpetra --truncateMueLuHierarchy
    NUM_MPI_PROCS 4
    )
 

--- a/packages/panzer/mini-em/example/BlockPrec/MiniEM_helpers.cpp
+++ b/packages/panzer/mini-em/example/BlockPrec/MiniEM_helpers.cpp
@@ -94,14 +94,13 @@ namespace mini_em {
   }
 
 
-  Teuchos::RCP<Teuchos::ParameterList> getSolverParameters(linearAlgebraType linAlgebra,
-                                                           physicsType physics,
-                                                           solverType solver,
-                                                           int dim,
-                                                           Teuchos::RCP<const Teuchos::MpiComm<int> > &comm,
-                                                           Teuchos::RCP<Teuchos::FancyOStream> &out,
-                                                           std::string &xml,
-                                                           int basis_order) {
+  Teuchos::RCP<Teuchos::ParameterList>
+  getSolverParameters(linearAlgebraType linAlgebra, physicsType physics,
+                      solverType solver, int dim,
+                      Teuchos::RCP<const Teuchos::MpiComm<int>> &comm,
+                      Teuchos::RCP<Teuchos::FancyOStream> &out,
+                      std::string &xml, int basis_order,
+                      const bool truncateMueLuHierarchy) {
     using Teuchos::RCP;
     using Teuchos::rcp;
 
@@ -161,6 +160,8 @@ namespace mini_em {
             if (dim == 2)
               updateParams("solverMueLu2D.xml", lin_solver_pl, comm, out);
           }
+          if (truncateMueLuHierarchy)
+          updateParams("solverMueLuTruncated.xml", lin_solver_pl, comm, out);
           if (basis_order > 1) {
             RCP<Teuchos::ParameterList> lin_solver_pl_lo = lin_solver_pl;
             lin_solver_pl = rcp(new Teuchos::ParameterList("Linear Solver"));

--- a/packages/panzer/mini-em/example/BlockPrec/MiniEM_helpers.hpp
+++ b/packages/panzer/mini-em/example/BlockPrec/MiniEM_helpers.hpp
@@ -58,7 +58,8 @@ namespace mini_em {
                                                            Teuchos::RCP<const Teuchos::MpiComm<int> > &comm,
                                                            Teuchos::RCP<Teuchos::FancyOStream> &out,
                                                            std::string &xml,
-                                                           int basis_order);
+                                                           int basis_order,
+                                                           const bool truncateMueLuHierarchy = false);
 
   void setClosureParameters(physicsType physics,
                             Teuchos::ParameterList &physicsEqSet,

--- a/packages/panzer/mini-em/example/BlockPrec/main.cpp
+++ b/packages/panzer/mini-em/example/BlockPrec/main.cpp
@@ -120,6 +120,7 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
     std::string xml = "";
     solverType solverValues[5] = {AUGMENTATION, MUELU, ML, CG, GMRES};
     const char * solverNames[5] = {"Augmentation", "MueLu", "ML", "CG", "GMRES"};
+    bool truncateMueLuHierarchy = false;
     solverType solver = MUELU;
     int numTimeSteps = 1;
     double finalTime = -1.;
@@ -146,6 +147,7 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
     clp.setOption("inputFile",&input_file,"XML file with the problem definitions");
     clp.setOption("solverFile",&xml,"XML file with the solver params");
     clp.setOption<solverType>("solver",&solver,5,solverValues,solverNames,"Solver that is used");
+    clp.setOption("truncateMueLuHierarchy", "no-truncateMueLuHierarchy", &truncateMueLuHierarchy, "Truncate the MueLu hierarchy");
     clp.setOption("numTimeSteps",&numTimeSteps);
     clp.setOption("finalTime",&finalTime);
     clp.setOption("matrixFree","no-matrixFree",&matrixFree,"matrix-free operators");
@@ -290,7 +292,7 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
         throw;
     }
 
-    RCP<Teuchos::ParameterList> lin_solver_pl = mini_em::getSolverParameters(linAlgebra, physics, solver, dim, comm, out, xml, basis_order);
+    RCP<Teuchos::ParameterList> lin_solver_pl = mini_em::getSolverParameters(linAlgebra, physics, solver, dim, comm, out, xml, basis_order, truncateMueLuHierarchy);
 
     if (lin_solver_pl->sublist("Preconditioner Types").isSublist("Teko") &&
         lin_solver_pl->sublist("Preconditioner Types").sublist("Teko").isSublist("Inverse Factory Library")) {

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuCuda.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuCuda.xml
@@ -20,15 +20,6 @@
                   <Parameter name="repartition: target rows per thread" type="int" value="95000"/>
                   <Parameter name="repartition: min rows per thread" type="int" value="10000"/>
 
-                  <!-- make this a one-level method -->
-                  <Parameter name="max levels" type="int" value="1"/>
-                  <Parameter        name="coarse: type"                       type="string"   value="CHEBYSHEV"/>
-                  <ParameterList    name="coarse: params">
-                    <Parameter      name="chebyshev: degree"                    type="int"      value="6"/>
-                    <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="5.4"/>
-                    <Parameter      name="chebyshev: eigenvalue max iterations" type="int" value="100"/>
-                  </ParameterList>
-
                 </ParameterList>
 
                 <ParameterList name="refmaxwell: 22list">
@@ -37,15 +28,6 @@
 
                   <Parameter name="repartition: target rows per thread" type="int" value="180000"/>
                   <Parameter name="repartition: min rows per thread" type="int" value="10000"/>
-
-                  <!-- make this a one-level method -->
-                  <Parameter name="max levels" type="int" value="1"/>
-                  <Parameter        name="coarse: type"                       type="string"   value="CHEBYSHEV"/>
-                  <ParameterList    name="coarse: params">
-                    <Parameter      name="chebyshev: degree"                    type="int"      value="6"/>>
-                    <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="7"/>
-                    <Parameter      name="chebyshev: eigenvalue max iterations" type="int" value="100"/>
-                  </ParameterList>
 
                 </ParameterList>
 

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLuTruncated.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLuTruncated.xml
@@ -1,0 +1,46 @@
+<ParameterList name="Linear Solver">
+
+  <ParameterList name="Preconditioner Types">
+    <ParameterList name="Teko">
+      <ParameterList name="Inverse Factory Library">
+        <ParameterList name="Maxwell">
+
+          <ParameterList name="S_E Preconditioner">
+            <ParameterList name="Preconditioner Types">
+              <ParameterList name="MueLuRefMaxwell">
+
+                <ParameterList name="refmaxwell: 11list">
+
+                  <!-- make this a one-level method -->
+                  <Parameter name="max levels" type="int" value="1"/>
+                  <Parameter        name="coarse: type"                       type="string"   value="CHEBYSHEV"/>
+                  <ParameterList    name="coarse: params">
+                    <Parameter      name="chebyshev: degree"                    type="int"      value="6"/>
+                    <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="5.4"/>
+                    <Parameter      name="chebyshev: eigenvalue max iterations" type="int" value="100"/>
+                  </ParameterList>
+
+                </ParameterList>
+
+                <ParameterList name="refmaxwell: 22list">
+
+                  <!-- make this a one-level method -->
+                  <Parameter name="max levels" type="int" value="1"/>
+                  <Parameter        name="coarse: type"                       type="string"   value="CHEBYSHEV"/>
+                  <ParameterList    name="coarse: params">
+                    <Parameter      name="chebyshev: degree"                    type="int"      value="6"/>>
+                    <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="7"/>
+                    <Parameter      name="chebyshev: eigenvalue max iterations" type="int" value="100"/>
+                  </ParameterList>
+
+                </ParameterList>
+
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>


### PR DESCRIPTION
@trilinos/panzer 

## Motivation
Allows to select whether the multigrid preconditioner should be set up with truncated hierarchies.
The option is disabled by default, meaning that a full hierarchy will be set up.