### PR TITLE
Ifpack2: Use assumeMpiIsGPUAware in BTDS

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -558,7 +558,8 @@ namespace Ifpack2 {
                   &reqs.recv[i]);
           }
           else {
-            const auto buffer_recv_host = Kokkos::create_mirror_view(buffer.recv);
+            const auto buffer_recv_host = Kokkos::create_mirror_view(
+              Kokkos::view_alloc(Kokkos::WithoutInitializing), buffer.recv);
             irecv(comm,
                   reinterpret_cast<char*>(buffer_recv_host.data() + offset_host.recv[i]*mv_blocksize),
                   (offset_host.recv[i+1] - offset_host.recv[i])*mv_blocksize*sizeof(impl_scalar_type),
@@ -597,7 +598,8 @@ namespace Ifpack2 {
                   &reqs.send[i]);
           }
           else {
-            const auto buffer_send_host = Kokkos::create_mirror_view(buffer.send);
+            const auto buffer_send_host = Kokkos::create_mirror_view(
+              Kokkos::view_alloc(Kokkos::WithoutInitializing), buffer.send);
             Kokkos::deep_copy(buffer_send_host, buffer.send);
             isend(comm,
                   reinterpret_cast<const char*>(buffer_send_host.data() + offset_host.send[i]*mv_blocksize),
@@ -729,7 +731,8 @@ namespace Ifpack2 {
                   &reqs.recv[i]);
           }
           else {
-            const auto buffer_recv_host = Kokkos::create_mirror_view(buffer.recv);
+            const auto buffer_recv_host = Kokkos::create_mirror_view(
+              Kokkos::view_alloc(Kokkos::WithoutInitializing), buffer.recv);
             irecv(comm,
                   reinterpret_cast<char*>(buffer_recv_host.data() + offset_host.recv[i]*mv_blocksize),
                   (offset_host.recv[i+1] - offset_host.recv[i])*mv_blocksize*sizeof(impl_scalar_type),
@@ -754,7 +757,8 @@ namespace Ifpack2 {
                   &reqs.send[i]);
           }
           else {
-            const auto buffer_send_host = Kokkos::create_mirror_view(buffer.send);
+            const auto buffer_send_host = Kokkos::create_mirror_view(
+              Kokkos::view_alloc(Kokkos::WithoutInitializing), buffer.send);
             Kokkos::deep_copy(buffer_send_host, buffer.send);
             isend(comm,
                   reinterpret_cast<const char*>(buffer_send_host.data() + offset_host.send[i]*mv_blocksize),


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 
@jjellio 

This PR fixes #12132 by using `assumeMpiIsGPUAware()` to deduce if GPU Aware MPI can be used or if the data needs to be copied to host before/after sending/receiving respectively.

The branch has been tested on V100 using:
```
TPETRA_ASSUME_GPU_AWARE_MPI=0 \
mpirun -np 4 Ifpack2_BlockTriDiagonalSolver.exe  \
--withoutOverlapCommAndComp  --matrixType=Laplace3D  \
--blockSize=11  --nx=64  --ny=32  --nz=64  \
--sublinesPerLine=1  --tol=0  --numIters=2  --withStackedTimer
```
and
```
TPETRA_ASSUME_GPU_AWARE_MPI=1 \
mpirun -np 4 Ifpack2_BlockTriDiagonalSolver.exe  \
--withoutOverlapCommAndComp  --matrixType=Laplace3D  \
--blockSize=11  --nx=64  --ny=32  --nz=64  \
--sublinesPerLine=1  --tol=0  --numIters=2  --withStackedTimer
```

Before this fix, the run with `TPETRA_ASSUME_GPU_AWARE_MPI=0` failed.

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->