### PR TITLE
SEACAS: Fix build with embedded/non-installed fmt library

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_Region.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Region.h
@@ -22,9 +22,7 @@
 #include "Ioss_Utils.h"
 #include "Ioss_VariableType.h"
 #include "ioss_export.h"
-#if !defined BUILT_IN_SIERRA
-#include <fmt/ostream.h>
-#endif
+
 #include <functional> // for less
 #include <iosfwd>     // for ostream
 #include <map>        // for map, map<>::value_compare
@@ -435,17 +433,9 @@ namespace Ioss {
 
         if (found && field.get_role() != role) {
           std::ostringstream errmsg;
-#if defined BUILT_IN_SIERRA
           errmsg << "ERROR: Field " << field.get_name() << " with role " << field.role_string()
                  << " on entity " << entity->name() << " does not match previously found role "
                  << Ioss::Field::role_string(role) << ".\n",
-#else
-          fmt::print(errmsg,
-                     "ERROR: Field {} with role {} on entity {} does not match previously found "
-                     "role {}.\n",
-                     field.get_name(), field.role_string(), entity->name(),
-                     Ioss::Field::role_string(role));
-#endif
               IOSS_ERROR(errmsg);
         }
 

--- a/packages/seacas/libraries/ioss/src/Ioss_StructuredBlock.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_StructuredBlock.h
@@ -14,8 +14,6 @@
 #include "Ioss_ZoneConnectivity.h"
 #include <array>
 #include <cassert>
-#include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <iosfwd>
 #include <stddef.h>
 #include <stdint.h>
@@ -370,10 +368,3 @@ namespace Ioss {
   };
 } // namespace Ioss
 
-#if FMT_VERSION >= 90000
-namespace fmt {
-  template <> struct formatter<Ioss::BoundaryCondition> : ostream_formatter
-  {
-  };
-} // namespace fmt
-#endif

--- a/packages/seacas/libraries/ioss/src/Ioss_ZoneConnectivity.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_ZoneConnectivity.h
@@ -10,8 +10,6 @@
 #include <array>
 #include <cassert>
 #include <cmath>
-#include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <iosfwd>
 #include <stdlib.h>
 #include <string>
@@ -154,10 +152,3 @@ namespace Ioss {
   IOSS_EXPORT std::ostream &operator<<(std::ostream &os, const ZoneConnectivity &zgc);
 } // namespace Ioss
 
-#if FMT_VERSION >= 90000
-namespace fmt {
-  template <> struct formatter<Ioss::ZoneConnectivity> : ostream_formatter
-  {
-  };
-} // namespace fmt
-#endif


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Trilinos does not require the TPL fmt and instead there is an embedded copy of the fmt library in the seacas ioss source code.  However, this embedded version is not installed, so is not available for applications using a Trilinos installation and therefore, there can be no includes of `fmt/{anything}.h` in the installed seacas ioss include files.  This removes the include that is causing problems.  
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->