### PR TITLE
Ifpack2: Add support for pointwise matrices in BTDS and parallelize the crs to block conversion

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockRelaxation_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockRelaxation_decl.hpp
@@ -139,6 +139,8 @@ private:
   typedef Tpetra::Vector<scalar_type,local_ordinal_type,global_ordinal_type,node_type> vector_type;
   typedef Teuchos::ScalarTraits<scalar_type> STS;
   typedef Teuchos::ScalarTraits<magnitude_type> STM;
+  typedef Tpetra::CrsMatrix<scalar_type, local_ordinal_type,
+                                 global_ordinal_type, node_type> crs_matrix_type;
   typedef Tpetra::BlockCrsMatrix<scalar_type, local_ordinal_type,
                                  global_ordinal_type, node_type> block_crs_matrix_type;
   typedef Tpetra::Map<local_ordinal_type, global_ordinal_type, node_type> map_type;

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_decl.hpp
@@ -174,6 +174,8 @@ namespace Ifpack2 {
     //typedef Tpetra::MultiVector<local_scalar_type, local_ordinal_type, global_ordinal_type, node_type> local_mv_type;
     //typedef typename Kokkos::View<local_scalar_type**, Kokkos::HostSpace> HostViewLocal;
 
+    typedef Tpetra::CrsMatrix
+    <scalar_type,local_ordinal_type,global_ordinal_type,node_type> crs_matrix_type;
     typedef Tpetra::BlockCrsMatrix
     <scalar_type,local_ordinal_type,global_ordinal_type,node_type> block_crs_matrix_type;
 
@@ -231,7 +233,9 @@ namespace Ifpack2 {
     BlockTriDiContainer (const Teuchos::RCP<const row_matrix_type>& matrix,
                          const Teuchos::Array<Teuchos::Array<local_ordinal_type> >& partitions,
                          const int n_subparts_per_part = 1,
-                         bool overlapCommAndComp = false, bool useSequentialMethod = false);
+                         bool overlapCommAndComp = false, 
+                         bool useSequentialMethod = false,
+                         const int block_size = -1);
 
     //! Destructor (declared virtual for memory safety of derived classes).
     ~BlockTriDiContainer () override;
@@ -398,7 +402,8 @@ namespace Ifpack2 {
     void initInternal (const Teuchos::RCP<const row_matrix_type>& matrix,
                        const Teuchos::RCP<const import_type> &importer,
                        const bool overlapCommAndComp,
-                       const bool useSeqMethod);
+                       const bool useSeqMethod,
+                       const int block_size = -1);
 
     void clearInternal();
   };

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockTriDiContainer.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockTriDiContainer.cpp
@@ -279,31 +279,34 @@ static LO run_teuchos_tests (const Input& in, Teuchos::FancyOStream& out, bool& 
           for (const bool overlap_comm : {false, true}) { // temporary disabling overlap comm version
             if (seq_method && overlap_comm) continue;
             for (const bool nonuniform_lines : {false, true}) {
-              if (jacobi && nonuniform_lines) continue;
-              for (const int nvec : {1, 3}) {
-                std::stringstream ss;
-                ss << "test_BR_BTDC:"
-                   << " bs " << bs
-                   << (contiguous ? " contig" : " noncontig")
-                   << (jacobi ? " jacobi" : " tridiag")
-                   << (seq_method ? " seq_method" : "")
-                   << (overlap_comm ? " overlap_comm" : "")
-                   << (nonuniform_lines ? " nonuniform_lines" : " uniform_lines")
-                   << " nvec " << nvec;
-                const std::string details = ss.str();
-                bool threw = false;
-                try {
-                  ne = btdct::test_BR_BTDC(in.comm, sb, sbp, bs, nvec, nonuniform_lines,
-                                           different_maps, jacobi, overlap_comm, seq_method,
-                                           details);
-                  nerr += ne;
-                } catch (const std::exception& e) {
-                  threw = true;
-                }
-                if (threw)
-                  printf("Exception threw from rank %d, %s\n", in.comm->getRank(), details.c_str());
+              for (const bool pointwise : {false, true}) {
+                if (jacobi && nonuniform_lines) continue;
+                for (const int nvec : {1, 3}) {
+                  std::stringstream ss;
+                  ss << "test_BR_BTDC:"
+                    << " bs " << bs
+                    << (contiguous ? " contig" : " noncontig")
+                    << (jacobi ? " jacobi" : " tridiag")
+                    << (seq_method ? " seq_method" : "")
+                    << (overlap_comm ? " overlap_comm" : "")
+                    << (pointwise ? " point_wise" : "")
+                    << (nonuniform_lines ? " nonuniform_lines" : " uniform_lines")
+                    << " nvec " << nvec;
+                  const std::string details = ss.str();
+                  bool threw = false;
+                  try {
+                    ne = btdct::test_BR_BTDC(in.comm, sb, sbp, bs, nvec, nonuniform_lines,
+                                            different_maps, jacobi, overlap_comm, seq_method, pointwise,
+                                            details);
+                    nerr += ne;
+                  } catch (const std::exception& e) {
+                    threw = true;
+                  }
+                  if (threw)
+                    printf("Exception threw from rank %d, %s\n", in.comm->getRank(), details.c_str());
 
-                TEUCHOS_TEST(ne == 0 && ! threw, details);
+                  TEUCHOS_TEST(ne == 0 && ! threw, details);
+                }
               }
             }
           }

--- a/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
@@ -586,6 +586,12 @@ void Ifpack2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupLineSmooth
       myparamList.set("partitioner: map", TVertLineIdSmoo);
       myparamList.set("partitioner: local parts", maxPart + 1);
     } else {
+      if(myparamList.isParameter("partitioner: block size") &&
+         myparamList.get<int>("partitioner: block size") != -1) {
+        int block_size = myparamList.get<int>("partitioner: block size");
+        numLocalRows /= block_size;
+      }
+
       // we assume a constant number of DOFs per node
       size_t numDofsPerNode = numLocalRows / TVertLineIdSmoo.size();
 

--- a/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
@@ -589,6 +589,8 @@ void Ifpack2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupLineSmooth
       if (myparamList.isParameter("partitioner: block size") &&
           myparamList.get<int>("partitioner: block size") != -1) {
         int block_size = myparamList.get<int>("partitioner: block size");
+        TEUCHOS_TEST_FOR_EXCEPTION(numLocalRows % block_size != 0, Exceptions::RuntimeError,
+                                   "MueLu::Ifpack2Smoother::Setup(): the number of local nodes is incompatible with the specified block size.");
         numLocalRows /= block_size;
       }
 

--- a/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
@@ -586,8 +586,8 @@ void Ifpack2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupLineSmooth
       myparamList.set("partitioner: map", TVertLineIdSmoo);
       myparamList.set("partitioner: local parts", maxPart + 1);
     } else {
-      if(myparamList.isParameter("partitioner: block size") &&
-         myparamList.get<int>("partitioner: block size") != -1) {
+      if (myparamList.isParameter("partitioner: block size") &&
+          myparamList.get<int>("partitioner: block size") != -1) {
         int block_size = myparamList.get<int>("partitioner: block size");
         numLocalRows /= block_size;
       }

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_decl.hpp
@@ -44,6 +44,7 @@
 
 #include "Tpetra_BlockCrsMatrix_fwd.hpp"
 #include "Tpetra_CrsMatrix_fwd.hpp"
+#include "Tpetra_CrsGraph_fwd.hpp"
 #include "Tpetra_Map_fwd.hpp"
 #include "Teuchos_RCP.hpp"
 #include <string>
@@ -87,6 +88,18 @@ namespace Tpetra {
   */
   template<class Scalar, class LO, class GO, class Node>
   void writeMatrixStrip(BlockCrsMatrix<Scalar,LO,GO,Node> const &A, std::ostream &os, Teuchos::ParameterList const &params);
+
+  /// \brief Non-member constructor that creates the CrsGraph of a BlockCrsMatrix
+  /// from an existing point CrsMatrix and a block size.
+  ///
+  /// This function accepts an already constructed point version of the block matrix.
+  /// Assumptions:
+  ///   - All point entries in a logical block must be stored in the CrsMatrix, even
+  ///     if the values are zero.
+  ///   - Point rows corresponding to a particular mesh node must be stored consecutively.
+  template<class Scalar, class LO, class GO, class Node>
+  Teuchos::RCP<Tpetra::CrsGraph<LO, GO, Node>>
+  getBlockCrsGraph(const Tpetra::CrsMatrix<Scalar, LO, GO, Node>& pointMatrix, const LO &blockSize);
 
   /// \brief Non-member constructor that creates a BlockCrsMatrix from an existing point CrsMatrix.
   ///

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
@@ -292,6 +292,90 @@ namespace Tpetra {
   }
 
   template<class Scalar, class LO, class GO, class Node>
+  Teuchos::RCP<Tpetra::CrsGraph<LO, GO, Node> >
+  getBlockCrsGraph(const Tpetra::CrsMatrix<Scalar, LO, GO, Node>& pointMatrix, const LO &blockSize)
+  {
+
+      /*
+        ASSUMPTIONS:
+
+           1) In point matrix, all entries associated with a little block are present (even if they are zero).
+           2) For given mesh DOF, point DOFs appear consecutively and in ascending order in row & column maps.
+           3) Point column map and block column map are ordered consistently.
+      */
+
+      using Teuchos::Array;
+      using Teuchos::ArrayView;
+      using Teuchos::RCP;
+
+      typedef Tpetra::BlockCrsMatrix<Scalar,LO,GO,Node> block_crs_matrix_type;
+      typedef Tpetra::Map<LO,GO,Node>                   map_type;
+      typedef Tpetra::CrsGraph<LO,GO,Node>              crs_graph_type;
+      typedef Tpetra::CrsMatrix<Scalar, LO,GO,Node>     crs_matrix_type;
+
+      using local_graph_device_type  = typename crs_matrix_type::local_graph_device_type;
+      using local_matrix_device_type = typename crs_matrix_type::local_matrix_device_type;
+      using row_map_type             = typename local_graph_device_type::row_map_type::non_const_type;
+      using entries_type             = typename local_graph_device_type::entries_type::non_const_type;
+      using values_type              = typename local_matrix_device_type::values_type::non_const_type;
+
+      using offset_type              = typename row_map_type::non_const_value_type;
+
+      using execution_space = typename Node::execution_space;
+      using range_type = Kokkos::RangePolicy<execution_space, LO>;
+
+      const map_type &pointRowMap = *(pointMatrix.getRowMap());
+      RCP<const map_type> meshRowMap = createMeshMap<LO,GO,Node>(blockSize, pointRowMap);
+
+      const map_type &pointColMap = *(pointMatrix.getColMap());
+      RCP<const map_type> meshColMap = createMeshMap<LO,GO,Node>(blockSize, pointColMap);
+      if(meshColMap.is_null()) throw std::runtime_error("ERROR: Cannot create mesh colmap");
+
+      const map_type &pointDomainMap = *(pointMatrix.getDomainMap());
+      RCP<const map_type> meshDomainMap = createMeshMap<LO,GO,Node>(blockSize, pointDomainMap);
+
+      const map_type &pointRangeMap = *(pointMatrix.getRangeMap());
+      RCP<const map_type> meshRangeMap = createMeshMap<LO,GO,Node>(blockSize, pointRangeMap);
+
+      RCP<crs_graph_type> meshCrsGraph;
+
+      const offset_type bs2 = blockSize * blockSize;
+
+      {
+        auto pointLocalGraph = pointMatrix.getCrsGraph()->getLocalGraphDevice();
+        auto pointRowptr = pointLocalGraph.row_map;
+        auto pointColind = pointLocalGraph.entries;
+
+        LO block_rows = (pointRowptr.extent(0)-1)/blockSize;
+        row_map_type blockRowptr("blockRowptr", block_rows+1);
+        entries_type blockColind("blockColind", pointColind.extent(0)/(bs2));
+
+        TEUCHOS_FUNC_TIME_MONITOR("Tpetra::convertToBlockCrsMatrix::fillCrsGraph");
+        Kokkos::parallel_for("fillMesh",range_type(0,block_rows), KOKKOS_LAMBDA(const LO i) {
+
+          const LO offset_b = pointRowptr(i*blockSize)/bs2;
+          const LO offset_b_max = pointRowptr((i+1)*blockSize)/bs2;
+
+          if (i==block_rows-1)
+            blockRowptr(i+1) = offset_b_max;
+          blockRowptr(i) = offset_b;
+
+          const LO offset_p = pointRowptr(i*blockSize);
+
+          for (LO k=0; k<offset_b_max-offset_b; ++k) {
+            blockColind(offset_b + k) = pointColind(offset_p + k * blockSize)/blockSize;
+          }
+        });
+
+        meshCrsGraph = rcp(new crs_graph_type(meshRowMap, meshColMap, blockRowptr, blockColind));
+        meshCrsGraph->fillComplete(meshDomainMap,meshRangeMap);
+        Kokkos::DefaultExecutionSpace().fence();
+      }
+
+      return meshCrsGraph;
+  }
+
+  template<class Scalar, class LO, class GO, class Node>
   Teuchos::RCP<BlockCrsMatrix<Scalar, LO, GO, Node> >
   convertToBlockCrsMatrix(const Tpetra::CrsMatrix<Scalar, LO, GO, Node>& pointMatrix, const LO &blockSize)
   {
@@ -313,128 +397,53 @@ namespace Tpetra {
       typedef Tpetra::CrsGraph<LO,GO,Node>              crs_graph_type;
       typedef Tpetra::CrsMatrix<Scalar, LO,GO,Node>     crs_matrix_type;
 
-      const map_type &pointRowMap = *(pointMatrix.getRowMap());
-      RCP<const map_type> meshRowMap = createMeshMap<LO,GO,Node>(blockSize, pointRowMap);
+      using local_graph_device_type  = typename crs_matrix_type::local_graph_device_type;
+      using local_matrix_device_type = typename crs_matrix_type::local_matrix_device_type;
+      using row_map_type             = typename local_graph_device_type::row_map_type::non_const_type;
+      using values_type              = typename local_matrix_device_type::values_type::non_const_type;
 
-      const map_type &pointColMap = *(pointMatrix.getColMap());
-      RCP<const map_type> meshColMap = createMeshMap<LO,GO,Node>(blockSize, pointColMap);
-      if(meshColMap.is_null()) throw std::runtime_error("ERROR: Cannot create mesh colmap");
+      using offset_type              = typename row_map_type::non_const_value_type;
 
-      const map_type &pointDomainMap = *(pointMatrix.getDomainMap());
-      RCP<const map_type> meshDomainMap = createMeshMap<LO,GO,Node>(blockSize, pointDomainMap);
+      using execution_space = typename Node::execution_space;
+      using range_type = Kokkos::RangePolicy<execution_space, LO>;
 
-      const map_type &pointRangeMap = *(pointMatrix.getRangeMap());
-      RCP<const map_type> meshRangeMap = createMeshMap<LO,GO,Node>(blockSize, pointRangeMap);
+      RCP<block_crs_matrix_type> blockMatrix;
 
-      // Use graph ctor that provides column map and upper bound on nonzeros per row.
-      // We can use static profile because the point graph should have at least as many entries per
-      // row as the mesh graph.
-      RCP<crs_graph_type> meshCrsGraph = rcp(new crs_graph_type(meshRowMap, meshColMap,
-                                                 pointMatrix.getGlobalMaxNumRowEntries()));
-      // Fill the graph by walking through the matrix.  For each mesh row, we query the collection of point
-      // rows associated with it. The point column ids are converted to mesh column ids and put into an array.
-      // As each point row collection is finished, the mesh column ids are sorted, made unique, and inserted
-      // into the mesh graph.
-      typename crs_matrix_type::local_inds_host_view_type pointColInds;
-      typename crs_matrix_type::values_host_view_type pointVals;
-      Array<GO> meshColGids;
-      meshColGids.reserve(pointMatrix.getGlobalMaxNumRowEntries());
+      const offset_type bs2 = blockSize * blockSize;
 
-      //again, I assume that point GIDs associated with a mesh GID are consecutive.
-      //if they are not, this will break!!
-      GO indexBase = pointColMap.getIndexBase();
-      for (size_t i=0; i<pointMatrix.getLocalNumRows()/blockSize; i++) {
-        for (int j=0; j<blockSize; ++j) {
-          LO rowLid = i*blockSize+j;
-          pointMatrix.getLocalRowView(rowLid,pointColInds,pointVals); //TODO optimization: Since I don't care about values,
-                                                                      //TODO I should use the graph instead.
-          for (size_t k=0; k<pointColInds.size(); ++k) {
-            GO meshColInd = (pointColMap.getGlobalElement(pointColInds[k]) - indexBase) / blockSize + indexBase;
-            if (meshColMap->getLocalElement(meshColInd) == Teuchos::OrdinalTraits<GO>::invalid()) {
-              std::ostringstream oss;
-              oss<< "["<<i<<"] ERROR: meshColId "<< meshColInd <<" is not in the column map.  Correspnds to pointColId = "<<pointColInds[k]<<std::endl;
-              throw std::runtime_error(oss.str());
+      auto meshCrsGraph = getBlockCrsGraph(pointMatrix, blockSize);
+      {
+        auto pointLocalGraph = pointMatrix.getCrsGraph()->getLocalGraphDevice();
+        auto pointRowptr = pointLocalGraph.row_map;
+        auto pointColind = pointLocalGraph.entries;
+
+        offset_type block_rows = (pointRowptr.extent(0)-1)/blockSize;
+        TEUCHOS_FUNC_TIME_MONITOR("Tpetra::convertToBlockCrsMatrix::fillBlockCrsMatrix");
+        values_type blockValues("values",  meshCrsGraph->getLocalNumEntries()*bs2);
+        auto pointValues = pointMatrix.getLocalValuesDevice (Access::ReadOnly);
+        auto blockRowptr = meshCrsGraph->getLocalGraphDevice().row_map;
+
+        Kokkos::parallel_for("copyblockValues",range_type(0,block_rows),KOKKOS_LAMBDA(const LO i) {
+          const offset_type blkBeg    = blockRowptr[i];
+          const offset_type numBlocks = blockRowptr[i+1] - blkBeg;
+
+          // For each block in the row...
+          for (offset_type block=0; block < numBlocks; block++) {
+
+            // For each entry in the block...
+            for(LO little_row=0; little_row<blockSize; little_row++) {
+              offset_type point_row_offset = pointRowptr[i*blockSize + little_row];
+              for(LO little_col=0; little_col<blockSize; little_col++) {
+                blockValues((blkBeg+block) * bs2 + little_row * blockSize + little_col) = 
+                  pointValues[point_row_offset + block*blockSize + little_col];
+              }
             }
 
-            meshColGids.push_back(meshColInd);
           }
-        }
-        //List of mesh GIDs probably contains duplicates because we looped over all point rows in the block.
-        //Sort and make unique.
-        std::sort(meshColGids.begin(), meshColGids.end());
-        meshColGids.erase( std::unique(meshColGids.begin(), meshColGids.end()), meshColGids.end() );
-        meshCrsGraph->insertGlobalIndices(meshRowMap->getGlobalElement(i), meshColGids());
-        meshColGids.clear();
+          });
+        blockMatrix = rcp(new block_crs_matrix_type(*meshCrsGraph, blockValues, blockSize));
+        Kokkos::DefaultExecutionSpace().fence();
       }
-      meshCrsGraph->fillComplete(meshDomainMap,meshRangeMap);
-
-      //create and populate the block matrix
-      RCP<block_crs_matrix_type> blockMatrix = rcp(new block_crs_matrix_type(*meshCrsGraph, blockSize));
-
-      /// temporary pack
-      Array<Scalar> tmpBlock(blockSize*blockSize);
-
-      //preallocate the maximum number of (dense) block entries needed by any row
-      int maxBlockEntries = blockMatrix->getLocalMaxNumRowEntries();
-      Array<Array<Scalar>> blocks(maxBlockEntries);
-      for (int i=0; i<maxBlockEntries; ++i)
-        blocks[i].reserve(blockSize*blockSize);
-      std::map<int,int> bcol2bentry;             //maps block column index to dense block entries
-      std::map<int,int>::iterator iter;
-      //Fill the block matrix.  We must do this in local index space.
-      //TODO: Optimization: We assume the blocks are fully populated in the point matrix.  This means
-      //TODO: on the first point row in the block row, we know that we're hitting new block col indices.
-      //TODO: on other rows, we know the block col indices have all been seen before
-      //int offset;
-      //if (pointMatrix.getIndexBase()) offset = 0;
-      //else                     offset = 1;
-      for (size_t i=0; i<pointMatrix.getLocalNumRows()/blockSize; i++) {
-        int blkCnt=0; //how many unique block entries encountered so far in current block row
-        for (int j=0; j<blockSize; ++j) {
-          LO rowLid = i*blockSize+j;
-          pointMatrix.getLocalRowView(rowLid,pointColInds,pointVals);
-          for (size_t k=0; k<pointColInds.size(); ++k) {
-            //convert point column to block col
-            LO meshColInd = pointColInds[k] / blockSize;
-            iter = bcol2bentry.find(meshColInd);
-            if (iter == bcol2bentry.end()) {
-              //new block column
-              bcol2bentry[meshColInd] = blkCnt;
-              blocks[blkCnt].push_back(pointVals[k]);
-              blkCnt++;
-            } else {
-              //block column found previously
-              int littleBlock = iter->second;
-              blocks[littleBlock].push_back(pointVals[k]);
-            }
-          }
-        }
-        // TODO This inserts the blocks one block entry at a time.  It is probably more efficient to
-        // TODO store all the blocks in a block row contiguously so they can be inserted with a single call.
-        for (iter=bcol2bentry.begin(); iter != bcol2bentry.end(); ++iter) {
-          LO localBlockCol = iter->first;
-          Scalar *vals = (blocks[iter->second]).getRawPtr();
-          if (std::is_same<typename block_crs_matrix_type::little_block_type::array_layout,Kokkos::LayoutLeft>::value) {
-            /// col major
-            for (LO ii=0;ii<blockSize;++ii)
-              for (LO jj=0;jj<blockSize;++jj)
-                tmpBlock[ii+jj*blockSize] = vals[ii*blockSize+jj];
-            Scalar *tmp_vals = tmpBlock.getRawPtr();
-            blockMatrix->replaceLocalValues(i, &localBlockCol, tmp_vals, 1);
-          } else {
-            /// row major
-            blockMatrix->replaceLocalValues(i, &localBlockCol, vals, 1);
-          }
-        }
-
-        //Done with block row.  Zero everything out.
-        for (int j=0; j<maxBlockEntries; ++j)
-          blocks[j].clear();
-        blkCnt = 0;
-        bcol2bentry.clear();
-      }
-
-      tmpBlock.clear();
 
       return blockMatrix;
 


### PR DESCRIPTION
This PR enables the usage of the BlockTriDiagonal Solver (BTDS) for cases where the matrix is stored as a `CrsMatrix` and not a `BlockCrsMatrix`.

In that situation, the setup phase of the solver will first convert the `CrsMatrix` to a blocked one and then the usual setup of the BTDS is performed.

While the `CrsMatrix` to `BlockCrsMatrix` conversion was first relatively costly, a kokkosficiation (included in this PR) of `convertToBlockCrsMatrix` allowed to significantly improve the performance of the conversion.

The features of this PR will be used in the Matrix dependent semi-coarsening algebraic multigrid (MDSC-AMG) for Albany Land Ice  simulations.


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 
@trilinos/tpetra ( for the `convertToBlockCrsMatrix`)

The PR includes extra tests to cover the new features.