### PR TITLE
Tpetra,MueLu: GPU fixes

### DIFF
--- a/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
+++ b/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
@@ -283,6 +283,7 @@ class HierarchyManager : public HierarchyFactory<Scalar, LocalOrdinal, GlobalOrd
     // This is cached, but involves and MPI_Allreduce.
     H.description();
     H.describe(H.GetOStream(Runtime0), verbosity_);
+    H.CheckForEmptySmoothersAndCoarseSolve();
 
     // When we reuse hierarchy, it is necessary that we don't
     // change the number of levels. We also cannot make requests

--- a/packages/muelu/src/Misc/MueLu_RAPFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_RAPFactory_def.hpp
@@ -164,7 +164,7 @@ void RAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level& fineLev
       // Reuse pattern if available (multiple solve)
       RCP<ParameterList> APparams = rcp(new ParameterList);
       if (pL.isSublist("matrixmatrix: kernel params"))
-        APparams->sublist("matrixmatrix: kernel params") = pL.sublist("matrixmatrix: kernel params");
+        APparams = rcp(new ParameterList(pL.sublist("matrixmatrix: kernel params")));
 
       // By default, we don't need global constants for A*P
       APparams->set("compute global constants: temporaries", APparams->get("compute global constants: temporaries", false));
@@ -189,7 +189,7 @@ void RAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level& fineLev
       // Reuse coarse matrix memory if available (multiple solve)
       RCP<ParameterList> RAPparams = rcp(new ParameterList);
       if (pL.isSublist("matrixmatrix: kernel params"))
-        RAPparams->sublist("matrixmatrix: kernel params") = pL.sublist("matrixmatrix: kernel params");
+        RAPparams = rcp(new ParameterList(pL.sublist("matrixmatrix: kernel params")));
 
       if (coarseLevel.IsAvailable("RAP reuse data", this)) {
         GetOStream(static_cast<MsgType>(Runtime0 | Test)) << "Reusing previous RAP data" << std::endl;

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_decl.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_decl.hpp
@@ -247,6 +247,8 @@ class Hierarchy : public BaseClass {
 
   void SetupRe();
 
+  void CheckForEmptySmoothersAndCoarseSolve();
+
   //! Clear impermanent data from previous setup
   void Clear(int startLevel = 0);
   void ExpertClear();

--- a/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
@@ -333,7 +333,7 @@ void Amesos2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Setup(Level& cu
   amesos2_params->setName("Amesos2");
   if ((rowMap->getGlobalNumElements() != as<size_t>((rowMap->getMaxAllGlobalIndex() - rowMap->getMinAllGlobalIndex()) + 1)) ||
       (!rowMap->isContiguous() && (rowMap->getComm()->getSize() == 1))) {
-    if (!(amesos2_params->sublist(prec_->name()).template isType<bool>("IsContiguous")))
+    if ((type_ != "Cusolver") && !(amesos2_params->sublist(prec_->name()).template isType<bool>("IsContiguous")))
       amesos2_params->sublist(prec_->name()).set("IsContiguous", false, "Are GIDs Contiguous");
   }
   prec_->setParameters(amesos2_params);

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -129,6 +129,8 @@ constexpr const std::string_view HIERARCHICAL_UNPACK =
     "TPETRA_HIERARCHICAL_UNPACK";
 constexpr const std::string_view SKIP_COPY_AND_PERMUTE =
     "TPETRA_SKIP_COPY_AND_PERMUTE";
+constexpr const std::string_view FUSED_RESIDUAL =
+    "TPETRA_FUSED_RESIDUAL";
 constexpr const std::string_view OVERLAP = "TPETRA_OVERLAP";
 constexpr const std::string_view SPACES_ID_WARN_LIMIT =
     "TPETRA_SPACES_ID_WARN_LIMIT";
@@ -156,7 +158,8 @@ constexpr const auto RECOGNIZED_VARS = make_array(
     MULTIVECTOR_USE_MERGE_PATH, VECTOR_DEVICE_THRESHOLD,
     HIERARCHICAL_UNPACK_BATCH_SIZE, HIERARCHICAL_UNPACK_TEAM_SIZE,
     USE_TEUCHOS_TIMERS, USE_KOKKOS_PROFILING, DEBUG, VERBOSE, TIMING,
-    HIERARCHICAL_UNPACK, SKIP_COPY_AND_PERMUTE, OVERLAP, SPACES_ID_WARN_LIMIT,
+    HIERARCHICAL_UNPACK, SKIP_COPY_AND_PERMUTE, FUSED_RESIDUAL,
+    OVERLAP, SPACES_ID_WARN_LIMIT,
     TIME_KOKKOS_DEEP_COPY, TIME_KOKKOS_DEEP_COPY_VERBOSE1,
     TIME_KOKKOS_DEEP_COPY_VERBOSE2, TIME_KOKKOS_FENCE, TIME_KOKKOS_FUNCTIONS);
 
@@ -669,6 +672,16 @@ bool Behavior::skipCopyAndPermuteIfPossible() {
   static bool initialized_ = false;
   return idempotentlyGetEnvironmentVariable(
       value_, initialized_, BehaviorDetails::SKIP_COPY_AND_PERMUTE,
+      defaultValue);
+}
+
+bool Behavior::fusedResidual() {
+  constexpr bool defaultValue(true);
+
+  static bool value_ = defaultValue;
+  static bool initialized_ = false;
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::FUSED_RESIDUAL,
       defaultValue);
 }
 

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
@@ -259,9 +259,16 @@ public:
   /// \brief Use Kokkos::Profiling in Tpetra::ProfilingRegion
   ///
   /// This is enabled by default if KOKKOS_ENABLE_PROFILING is defined.
-  /// You mau control this at run time via the <tt>TPETRA_USE_KOKKOS_PROFILING</tt>
+  /// You may control this at run time via the <tt>TPETRA_USE_KOKKOS_PROFILING</tt>
   /// environment variable.
   static bool profilingRegionUseKokkosProfiling();
+
+  /// \brief Fusing SpMV and update in residual instead of using 2 kernel launches.
+  /// Fusing kernels implies that no TPLs (CUSPARSE, ROCSPARSE, ...) will be used for the residual.
+  ///
+  /// This is enabled by default.  You may control this at run time via the
+  /// <tt>TPETRA_FUSED_RESIDUAL</tt> environment variable.
+  static bool fusedResidual();
 
   /// \brief Skip copyAndPermute if possible
   ///


### PR DESCRIPTION
@trilinos/tpetra @trilinos/muelu 

## Motivation
GPU related changes:
- Tpetra: Make use of TPL provided spmv in `Tpetra::residual` a runtime option
- MueLu: Don't set `Klu` options for non-Klu solvers (e.g.CuSOLVER)
- MueLu: Fix bad PL with Tpetra matrixmatrix options
- MueLu: Only warn in setup about levels without smoother/coarse solver. Fixes #8955