### PR TITLE
Belos-Thyra adapter: Eliminate a deepcopy from MvTransMv

### DIFF
--- a/packages/stratimikos/adapters/belos/src/BelosThyraAdapter.hpp
+++ b/packages/stratimikos/adapters/belos/src/BelosThyraAdapter.hpp
@@ -360,7 +360,8 @@ namespace Belos {
           RTOpPack::SubMultiVectorView<ScalarType>(
             0, m, 0, n,
             arcpFromArrayView(arrayView(&B(0,0), B.stride()*B.numCols())), B.stride()
-            )
+            ),
+          false
           );
       Thyra::apply<ScalarType>(A, Thyra::CONJTRANS, mv, B_thyra.ptr(), alpha);
     }

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraVectorSpace_decl.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraVectorSpace_decl.hpp
@@ -121,7 +121,7 @@ protected:
 public:
 
   RCP<MultiVectorBase<Scalar> >
-  createCachedMembersView( const RTOpPack::SubMultiVectorView<Scalar> &raw_mv ) const;
+  createCachedMembersView( const RTOpPack::SubMultiVectorView<Scalar> &raw_mv, bool initialize = true) const;
 
   RCP<const MultiVectorBase<Scalar> >
   createCachedMembersView( const RTOpPack::ConstSubMultiVectorView<Scalar> &raw_mv ) const;

--- a/packages/thyra/core/src/interfaces/operator_vector/fundamental/Thyra_VectorSpaceBase_decl.hpp
+++ b/packages/thyra/core/src/interfaces/operator_vector/fundamental/Thyra_VectorSpaceBase_decl.hpp
@@ -745,7 +745,7 @@ protected:
    * <tt>MultiVectorBase</tt> object using explicit vector access.
    */
   virtual RCP<MultiVectorBase<Scalar> >
-  createCachedMembersView( const RTOpPack::SubMultiVectorView<Scalar> &raw_mv ) const { return this->createMembersView(raw_mv); };
+  createCachedMembersView( const RTOpPack::SubMultiVectorView<Scalar> &raw_mv, bool initialize = true) const { return this->createMembersView(raw_mv); };
 
   /** \brief Create a (possibly) cached multi-vector member that is a <tt>const</tt> view of raw
    * multi-vector data. The caching mechanism must be implemented by child classes, by default


### PR DESCRIPTION
@trilinos/belos @trilinos/thyra 

## Motivation
The Thyra adapter for Belos does the following in `MvTransMv`:
- "alias" the SerialDenseMatrix $c$ for the result to a cached MV $C$, copying the contents of $c$ to $C$,
- computing $C:=\alpha A^T B$,
- copying $C$ to $c$.

The deepcopy in the first step is not required.