### PR TITLE
Framework: Add gcc-serial container config

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2871,6 +2871,9 @@ opt-set-cmake-var TPL_Netcdf_LIBRARIES      STRING FORCE : ""
 opt-set-cmake-var TPL_ENABLE_ParMETIS       BOOL FORCE   : OFF
 opt-set-cmake-var TPL_ENABLE_Pnetcdf        BOOL FORCE   : OFF
 
+opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats     BOOL FORCE : OFF
+
 use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
 use RHEL8_POST
 
@@ -2925,8 +2928,6 @@ opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats BOOL FORCE : OFF
 [rhel8_gcc-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel8_gcc-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
-opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats     BOOL FORCE : OFF
 
 [rhel8_aue-gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel8_aue-gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2915,6 +2915,12 @@ use PACKAGE-ENABLES|ALL
 opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats BOOL FORCE : OFF
 
+[rhel8_gcc-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+use rhel8_gcc-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use PACKAGE-ENABLES|ALL
+opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats     BOOL FORCE : OFF
+
 [rhel8_aue-gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel8_aue-gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2866,6 +2866,8 @@ opt-set-cmake-var TPL_BLAS_LIBRARIES        STRING FORCE : ${OPENBLAS_ROOT|ENV}/
 opt-set-cmake-var TPL_LAPACK_LIBRARY_DIRS   STRING FORCE : ${OPENBLAS_ROOT|ENV}/lib
 opt-set-cmake-var TPL_LAPACK_LIBRARIES      STRING FORCE : ${OPENBLAS_ROOT|ENV}/lib/libopenblas.a;-L${OPENBLAS_ROOT|ENV}/lib;-lgfortran;-lgomp;-lm
 
+opt-set-cmake-var TPL_Netcdf_LIBRARIES      STRING FORCE : ""
+
 opt-set-cmake-var TPL_ENABLE_ParMETIS       BOOL FORCE   : OFF
 opt-set-cmake-var TPL_ENABLE_Pnetcdf        BOOL FORCE   : OFF
 

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2861,11 +2861,8 @@ use COMMON_SPACK_TPLS
 
 opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
-opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
 opt-set-cmake-var TPL_ENABLE_ParMETIS            BOOL FORCE   : OFF
 opt-set-cmake-var TPL_ENABLE_Pnetcdf             BOOL FORCE   : OFF
-
-opt-set-cmake-var TPL_Netcdf_LIBRARIES           STRING FORCE : -L${NETCDF_C_LIB|ENV};${NETCDF_C_LIB|ENV}/libnetcdf.a;${TPL_HDF5_LIBRARIES|CMAKE}
 
 use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
 use RHEL8_POST

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2838,6 +2838,38 @@ opt-set-cmake-var Stratimikos_Galeri_xpetra_complex_double_Jacobi_MPI_4_DISABLE 
 use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
 use RHEL8_POST
 
+[rhel8_gcc-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# gcc-serial containerized environment
+use COMPILER|GNU
+use NODE-TYPE|SERIAL
+use BUILD-TYPE|RELEASE-DEBUG
+
+use RHEL8_LIB-TYPE|SHARED
+use KOKKOS-ARCH|NO-KOKKOS-ARCH
+
+use USE-ASAN|NO
+use USE-COMPLEX|NO
+use USE-FPIC|NO
+use USE-MPI|NO
+use USE-PT|NO
+use USE-RDC|NO
+use USE-UVM|NO
+use USE-DEPRECATED|YES
+use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
+
+use COMMON_SPACK_TPLS
+
+opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+
+opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
+opt-set-cmake-var TPL_ENABLE_ParMETIS            BOOL FORCE   : OFF
+opt-set-cmake-var TPL_ENABLE_Pnetcdf             BOOL FORCE   : OFF
+
+opt-set-cmake-var TPL_Netcdf_LIBRARIES           STRING FORCE : -L${NETCDF_C_LIB|ENV};${NETCDF_C_LIB|ENV}/libnetcdf.a;${TPL_HDF5_LIBRARIES|CMAKE}
+
+use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
+use RHEL8_POST
+
 [rhel8_aue-gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use COMPILER|GNU
 use NODE-TYPE|SERIAL

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2861,8 +2861,13 @@ use COMMON_SPACK_TPLS
 
 opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
-opt-set-cmake-var TPL_ENABLE_ParMETIS            BOOL FORCE   : OFF
-opt-set-cmake-var TPL_ENABLE_Pnetcdf             BOOL FORCE   : OFF
+opt-set-cmake-var TPL_BLAS_LIBRARY_DIRS     STRING FORCE : ${OPENBLAS_ROOT|ENV}/lib
+opt-set-cmake-var TPL_BLAS_LIBRARIES        STRING FORCE : ${OPENBLAS_ROOT|ENV}/lib/libopenblas.a;-L${OPENBLAS_ROOT|ENV}/lib;-lgfortran;-lgomp;-lm
+opt-set-cmake-var TPL_LAPACK_LIBRARY_DIRS   STRING FORCE : ${OPENBLAS_ROOT|ENV}/lib
+opt-set-cmake-var TPL_LAPACK_LIBRARIES      STRING FORCE : ${OPENBLAS_ROOT|ENV}/lib/libopenblas.a;-L${OPENBLAS_ROOT|ENV}/lib;-lgfortran;-lgomp;-lm
+
+opt-set-cmake-var TPL_ENABLE_ParMETIS       BOOL FORCE   : OFF
+opt-set-cmake-var TPL_ENABLE_Pnetcdf        BOOL FORCE   : OFF
 
 use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
 use RHEL8_POST

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2874,6 +2874,9 @@ opt-set-cmake-var TPL_ENABLE_Pnetcdf        BOOL FORCE   : OFF
 opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats     BOOL FORCE : OFF
 
+# Turned off to bypass: ML CONFIGURATION ERROR:  SuperLU_5.0 detected - only SuperLU version < 5.0 currently supported for this package.
+opt-set-cmake-var ML_ENABLE_SuperLU BOOL FORCE : OFF
+
 use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
 use RHEL8_POST
 

--- a/packages/framework/ini-files/environment-specs.ini
+++ b/packages/framework/ini-files/environment-specs.ini
@@ -158,6 +158,8 @@ envvar-find-in-path MPIF90 : mpif90
 
 [rhel8_gcc-openmpi]
 
+[rhel8_gcc-serial]
+
 [rhel8_aue-gcc-openmpi]
 
 [rhel8_oneapi-intelmpi]

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -174,6 +174,7 @@ gnu
 [rhel8]
 oneapi-intelmpi
 gcc-openmpi
+gcc-serial
 aue-gcc-openmpi
 sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.1.4
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Add a configuration entry to GenConfig that is meant for a general gcc-serial container configuration. This config will be used with a gcc-serial container to mimic the existing `Trilinos_PR_gcc-8.3.0-serial` PR test, but using the new AutoTester2 system and GitHub Actions.

This configuration is based on this existing configuration `rhel7_sems-v2-gnu-8.3.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables`.




## Stakeholder Feedback

- [TRILFRAME-629](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-629)

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
- Configured, built, and tested this configuration with an prototype gcc-serial container with no issues.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->