### PR TITLE
Tpetra: Fix #12898, Teuchos: absolute float array compare

### DIFF
--- a/packages/teuchos/core/src/Teuchos_LocalTestingHelpers.hpp
+++ b/packages/teuchos/core/src/Teuchos_LocalTestingHelpers.hpp
@@ -189,6 +189,19 @@
     if (!result) success = false; \
   }
 
+/** \brief Assert that a1.size()==a2.size() and |a[i]-b[i]| <= tol, i=0....
+ *
+ * Works for any object types that support a1[i], a1.size(), a2[j], and
+ * a2.size(), but the element types of a1 and a2 must be the same and Teuchos::ScalarTraits
+ * must have a specialization for this element type.
+ *
+ * \ingroup Teuchos_UnitTestAssertMacros_grp
+ */
+#define TEST_ABSOLUTE_COMPARE_FLOATING_ARRAYS( a1, a2, tol ) \
+  { \
+    const bool result = compareFloatingArraysAbsolute(a1,#a1,a2,#a2,tol,out); \
+    if (!result) success = false; \
+  }
 
 /** \brief Assert that the statement 'code' throws the exception 'ExceptType'
  * (otherwise the test fails).

--- a/packages/teuchos/core/src/Teuchos_LocalTestingHelpers.hpp
+++ b/packages/teuchos/core/src/Teuchos_LocalTestingHelpers.hpp
@@ -164,7 +164,7 @@
 
 /** \brief Assert that a1.size()==a2.size() and a[i]==b[i], i=0....
  *
- * Works for any object types that support a1[i], a1.size(), a2[j], and
+ * Works for all object types that support a1[i], a1.size(), a2[j], and
  * a2.size() and types a1 and a2 can be different types!
  *
  * \ingroup Teuchos_UnitTestAssertMacros_grp
@@ -178,7 +178,7 @@
 
 /** \brief Assert that a1.size()==a2.size() and rel_error(a[i],b[i]) <= tol, i=0....
  *
- * Works for any object types that support a1[i], a1.size(), a2[j], and
+ * Works for all object types that support a1[i], a1.size(), a2[j], and
  * a2.size() and types a1 and a2 can be different types!
  *
  * \ingroup Teuchos_UnitTestAssertMacros_grp
@@ -191,7 +191,7 @@
 
 /** \brief Assert that a1.size()==a2.size() and |a[i]-b[i]| <= tol, i=0....
  *
- * Works for any object types that support a1[i], a1.size(), a2[j], and
+ * Works for all object types that support a1[i], a1.size(), a2[j], and
  * a2.size(), but the element types of a1 and a2 must be the same and Teuchos::ScalarTraits
  * must have a specialization for this element type.
  *

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
@@ -50,6 +50,7 @@
 #include "Tpetra_Details_scaleBlockDiagonal.hpp"
 #include "Tpetra_Apply_Helpers.hpp"
 #include "TpetraUtils_MatrixGenerator.hpp"
+#include "KokkosBlas1_nrm2.hpp"
 #include <type_traits> // std::is_same
 
 
@@ -1060,17 +1061,27 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     auto lclMtx1 = A1->getLocalMatrixDevice();
     values_type A1_values = lclMtx1.values;
     values_type A2_values("values",A1_values.extent(0));
+    values_type A2_abs_values("absolute values",A1_values.extent(0));
     Kokkos::parallel_for( range_policy(0,A1_values.extent(0)),KOKKOS_LAMBDA(const int i){
         A2_values[i] = A1_values[i] + A1_values[i];
+        A2_abs_values[i] = Kokkos::abs(A2_values[i]);
       });
 
     RCP<MAT> A2 = rcp(new MAT(map,A1->getColMap(),lclMtx1.graph.row_map,lclMtx1.graph.entries,A2_values));
     A2->expertStaticFillComplete(A1->getDomainMap(),A1->getRangeMap(),A1->getGraph()->getImporter(),A1->getGraph()->getExporter());
+    // Entrywise absolute value of A2, used for choosing a tolerance
+    RCP<MAT> A2_abs = rcp(new MAT(map,A1->getColMap(),lclMtx1.graph.row_map,lclMtx1.graph.entries,A2_abs_values));
+    A2_abs->expertStaticFillComplete(A1->getDomainMap(),A1->getRangeMap(),A1->getGraph()->getImporter(),A1->getGraph()->getExporter());
 
     /* Allocate multivectors */
     MV X(map,2), Y1a(map,2), Y1b(map,2), Y2a(map,2), Y2b(map,2), compare(map,2);
+    MV Y_abs(map,2);
     Array<Mag> norm(2), exact(2,MT_ZERO);
     X.putScalar(ONE);
+
+    A2_abs->apply(X, Y_abs);
+    // both columns of X are filled with 1, so just use the first column here
+    Mag absNorm = Y_abs.getVector(0)->norm1();
 
     // Do a std::vector version 
     {
@@ -1090,13 +1101,14 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
       // Compare
       compare.update(ONE,Y1a,-ONE,Y1b,ZERO);
       compare.norm1(norm());
+
       if (ST::isOrdinal) {TEST_COMPARE_ARRAYS(exact,norm);}
-      else{TEST_COMPARE_FLOATING_ARRAYS(exact,norm,2.0*testingTol<Mag>());}
+      else{TEST_ABSOLUTE_COMPARE_FLOATING_ARRAYS(exact,norm,absNorm*testingTol<Mag>());}
 
       compare.update(ONE,Y2a,-ONE,Y2b,ZERO);
       compare.norm1(norm());
       if (ST::isOrdinal) {TEST_COMPARE_ARRAYS(exact,norm);}
-      else {TEST_COMPARE_FLOATING_ARRAYS(exact,norm,2.0*testingTol<Mag>());}
+      else {TEST_ABSOLUTE_COMPARE_FLOATING_ARRAYS(exact,norm,absNorm*testingTol<Mag>());}
     }
 
     // Do a std::vector version w/ a nice combination of options
@@ -1127,12 +1139,12 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
         compare.update(ONE,Y1a,-ONE,Y1b,ZERO);
         compare.norm1(norm());
         if (ST::isOrdinal) {TEST_COMPARE_ARRAYS(exact,norm);}
-        else{TEST_COMPARE_FLOATING_ARRAYS(exact,norm,2.0*testingTol<Mag>());}
+        else{TEST_ABSOLUTE_COMPARE_FLOATING_ARRAYS(exact,norm,absNorm*testingTol<Mag>());}
         
         compare.update(ONE,Y2a,-ONE,Y2b,ZERO);
         compare.norm1(norm());
         if (ST::isOrdinal) {TEST_COMPARE_ARRAYS(exact,norm);}
-        else {TEST_COMPARE_FLOATING_ARRAYS(exact,norm,2.0*testingTol<Mag>());}
+        else {TEST_ABSOLUTE_COMPARE_FLOATING_ARRAYS(exact,norm,absNorm*testingTol<Mag>());}
       }
     }
 
@@ -1156,12 +1168,12 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
       compare.update(ONE,Y1a,-ONE,Y1b,ZERO);
       compare.norm1(norm());
       if (ST::isOrdinal) {TEST_COMPARE_ARRAYS(exact,norm);}
-      else{TEST_COMPARE_FLOATING_ARRAYS(exact,norm,2.0*testingTol<Mag>());}
+      else{TEST_ABSOLUTE_COMPARE_FLOATING_ARRAYS(exact,norm,absNorm*testingTol<Mag>());}
 
       compare.update(ONE,Y2a,-ONE,Y2b,ZERO);
       compare.norm1(norm());
       if (ST::isOrdinal) {TEST_COMPARE_ARRAYS(exact,norm);}
-      else {TEST_COMPARE_FLOATING_ARRAYS(exact,norm,2.0*testingTol<Mag>());}
+      else {TEST_ABSOLUTE_COMPARE_FLOATING_ARRAYS(exact,norm,absNorm*testingTol<Mag>());}
     }
 
   }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 
@trilinos/teuchos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes #12898 , and adds a testing macro ``TEST_ABSOLUTE_COMPARE_FLOATING_ARRAYS( a1, a2, tol )``
to Teuchos that might be useful in other contexts.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Tested by first enabling the nondeterministic cuSPARSE SpMV algorithm, making `` TpetraCore_CrsMatrix_UnitTests4_MPI_4`` fail just like in #12898. Then applied these changes and checked that the test now passes.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->