### PR TITLE
Tpetra: fix a couple of deprecated warnings

### DIFF
--- a/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_def.hpp
@@ -112,12 +112,9 @@ apply (Kokkos::View<const mv_scalar_type**, array_layout,
   const auto op = transpose ?
     (conjugate ? KokkosSparse::ConjugateTranspose :
      KokkosSparse::Transpose) : KokkosSparse::NoTranspose;
-  //Currently KK has no cusparse wrapper for rank-2 (SpMM)
-  //TODO: whent that is supported, use A_cusparse for that case also
-  if(X.extent(1) == size_t(1) && have_A_cusparse)
+  if(have_A_cusparse)
   {
-    KokkosSparse::spmv (op, alpha, A_cusparse, Kokkos::subview(X, Kokkos::ALL(), 0),
-                            beta, Kokkos::subview(Y, Kokkos::ALL(), 0));
+    KokkosSparse::spmv (op, alpha, A_cusparse, X, beta, Y);
   }
   else
   {
@@ -139,47 +136,7 @@ applyImbalancedRows (
        const mv_scalar_type alpha,
        const mv_scalar_type beta) const
 {
-  const bool conjugate = (mode == Teuchos::CONJ_TRANS);
-  const bool transpose = (mode != Teuchos::NO_TRANS);
-
-#ifdef HAVE_TPETRA_DEBUG
-  const char tfecfFuncName[] = "applyLoadBalanced: ";
-
-  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-    (X.extent (1) != Y.extent (1), std::runtime_error,
-     "X.extent(1) = " << X.extent (1) << " != Y.extent(1) = "
-     << Y.extent (1) << ".");
-  // If the two pointers are NULL, then they don't alias one
-  // another, even though they are equal.
-  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-    (X.data () == Y.data () && X.data () != nullptr,
-     std::runtime_error, "X and Y may not alias one another.");
-#endif // HAVE_TPETRA_DEBUG
-
-  const auto op = transpose ?
-    (conjugate ? KokkosSparse::ConjugateTranspose :
-     KokkosSparse::Transpose) : KokkosSparse::NoTranspose;
-  //Select the merge path algorithm (used if available, otherwise has no effect)
-  //TODO BMK: If/when KokkosKernels gets its own SPMV implementation for imbalanced rows,
-  //call that here or select it using Controls.
-  //Ideally it supports multivectors from the beginning.
-  if((Details::Behavior::useMergePathMultiVector() || X.extent(1) == size_t(1)) && have_A_cusparse)
-  {
-    KokkosKernels::Experimental::Controls controls;
-    controls.setParameter("algorithm", "merge");
-    //Apply on one column at a time (must be rank-1)
-    for(size_t vec = 0; vec < X.extent(1); vec++)
-    {
-      KokkosSparse::spmv (controls, op,
-          alpha, A_cusparse, Kokkos::subview(X, Kokkos::ALL(), vec),
-          beta, Kokkos::subview(Y, Kokkos::ALL(), vec));
-    }
-  }
-  else
-  {
-    //Just run multivector version of spmv (no controls, and no cusparse support)
-    KokkosSparse::spmv (op, alpha, *A_, X, beta, Y);
-  }
+  apply(X, Y, mode, alpha, beta);
 }
 
 template<class MultiVectorScalar, class MatrixScalar, class Device>

--- a/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
@@ -805,7 +805,7 @@ bool findZero (const OneDViewType& x)
   using functor_type = FindZero<view_type, size_type>;
 
   Kokkos::RangePolicy<execution_space, size_type> range (0, x.extent (0));
-  range.set (Kokkos::ChunkSize (500)); // adjust as needed
+  range.set_chunk_size (500); // adjust as needed
 
   int foundZero = 0;
   Kokkos::parallel_reduce ("findZero", range, functor_type (x), foundZero);

--- a/packages/tpetra/core/test/PerformanceCGSolve/cg_solve_file.cpp
+++ b/packages/tpetra/core/test/PerformanceCGSolve/cg_solve_file.cpp
@@ -303,7 +303,6 @@ int main(int argc, char *argv[]) {
   const char* rawKokkosNumDevices = std::getenv("KOKKOS_NUM_DEVICES");
   if(rawKokkosNumDevices)
     numgpus = std::atoi(rawKokkosNumDevices);
-  int skipgpu = 999;
 
   bool useSYCL = false;
   bool useHIP = false;
@@ -316,7 +315,6 @@ int main(int argc, char *argv[]) {
   cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
   cmdp.setOption("numthreads",&numthreads,"Number of threads per thread team.");
   cmdp.setOption("numgpus",&numgpus,"Number of GPUs.");
-  cmdp.setOption("skipgpu",&skipgpu,"Do not use this GPU.");
   cmdp.setOption("hostname",&hostname,"Override of hostname for PerfTest entry.");
   cmdp.setOption("testarchive",&testarchive,"Set filename for Performance Test archive.");
   cmdp.setOption("filename",&filename,"Filename for test matrix.");
@@ -405,7 +403,6 @@ int main(int argc, char *argv[]) {
   Kokkos::InitializationSettings kokkosArgs;
   kokkosArgs.set_num_threads(numthreads);
   kokkosArgs.set_device_id(myRank % numgpus);
-  kokkosArgs.set_skip_device(skipgpu);
   kokkosArgs.set_disable_warnings(!verbose);
 
   Kokkos::initialize (kokkosArgs);


### PR DESCRIPTION
And make ``LocalCrsMatrixOperator::applyImbalancedRows`` just call the default spmv algorithm for now.
A merge path implementation exists in KokkosKernels but currently has an issue preventing it from being used (NaNs are not handled correctly).

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Avoid warnings from using functions now deprecated in Kokkos/KokkosKernels 4.3.0.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->