### PR TITLE
SEACAS Iocgns: add missing cgnsconfig.h include

### DIFF
--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_Utils.C
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_Utils.C
@@ -44,6 +44,7 @@
 #endif
 #include "cgns/Iocgns_StructuredZoneData.h"
 #include "cgns/Iocgns_Utils.h"
+#include <cgnsconfig.h>
 #include <cgnstypes.h>
 #include <cmath>
 #include <cstring>


### PR DESCRIPTION
The file Iocgns_Utils.C needs macros defined in cgnsconfig.h but was not including it directly. Adding this include fixes the nightly performance build on Stria.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes this build error on Stria with cgns/3.4.0 loaded and enabled as TPL:
```
.../Trilinos/packages/seacas/libraries/ioss/src/cgns/Iocgns_Utils.C:3038:2: error: "Not defined..."
#error "Not defined..."
 ^
```
The context for this error is:
```
3032 #if CG_BUILD_HDF5
3033   unsigned major;
3034   unsigned minor;
3035   unsigned release;
3036   H5get_libversion(&major, &minor, &release);
3037   fmt::print(config, "\t\tHDF5 enabled ({}.{}.{})\n", major, minor, release);
3038 #else
3039 #error "Not defined..."
3040 #endif
```
cgnsconfig.h is the file that contains ``#define CG_BUILD_HDF5 1``. I checked that the include guard macro ``CGNSCONFIG_H`` was also not defined at this point, so it was definitely a case of a missing include.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->