### PR TITLE
Framework: set KokkosKernels_sparse_cuda_MPI_1 to run serial

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1722,6 +1722,7 @@ opt-set-cmake-var Tpetra_INST_SERIAL BOOL FORCE : ON
 opt-set-cmake-var Zoltan_ENABLE_Scotch BOOL FORCE : OFF
 
 [CUDA11-RUN-SERIAL-TESTS]
+opt-set-cmake-var KokkosKernels_sparse_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
 opt-set-cmake-var KokkosKernels_batched_dla_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
 opt-set-cmake-var Intrepid2_unit-test_MonolithicExecutable_Intrepid2_Tests_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
 


### PR DESCRIPTION
Address timeout in the Kokkos Integration nightly build cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework @sebrowne @ccober6 

## Motivation
Get the nightly Kokkos Integration job to passing state https://trilinos-cdash.sandia.gov/build/1473134
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
Rebuilt the `cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static` configuration and tested `KokkosKernels_sparse_cuda_MPI_1` manually multiple times, the test completes successfully in ~62 sec when run individually

<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->