### PR TITLE
SEACAS: Fix library naming

### DIFF
--- a/packages/seacas/libraries/exodus/CMakeLists.txt
+++ b/packages/seacas/libraries/exodus/CMakeLists.txt
@@ -48,7 +48,7 @@ if (SEACASExodus_ENABLE_SHARED)
       set_property(TARGET exodus_shared PROPERTY C_STANDARD 99)
       # This keeps the library out of the `all_libs` targets...
       set_target_properties(exodus_shared PROPERTIES TRIBITS_TESTONLY_LIB TRUE)
-      set_target_properties(exodus_shared PROPERTIES RUNTIME_OUTPUT_NAME exodus)
+      set_target_properties(exodus_shared PROPERTIES OUTPUT_NAME exodus)
       INSTALL(TARGETS exodus_shared DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
    endif()
 endif()


### PR DESCRIPTION
When doing a static library build, but still also building a shared exodus library, the library was being installed in a different area than what is expected by the exodus.py script that is using the shared library.  

This change seems to fix that issue and the exodus.py can correctly find the shared exodus library

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->