### PR TITLE
Tpetra: Removing copy-pasta error

### DIFF
--- a/packages/tpetra/core/test/PerformanceCGSolve/CMakeLists.txt
+++ b/packages/tpetra/core/test/PerformanceCGSolve/CMakeLists.txt
@@ -57,18 +57,7 @@ IF (Tpetra_INST_DOUBLE)
       CATEGORIES PERFORMANCE
     )
 
-    TRIBITS_ADD_TEST(
-      Performance-CGSolve
-      NAME Performance_StrongScaling_CGSolve
-      ARGS "--size=200"
-      COMM mpi
-      NUM_MPI_PROCS 25
-      STANDARD_PASS_OUTPUT
-      RUN_SERIAL
-      CATEGORIES PERFORMANCE
-    )
-
-    TRIBITS_ADD_TEST(
+  TRIBITS_ADD_TEST(
       Performance-CGSolve
       NAME Performance_StrongScaling_CGSolve
       ARGS "--size=200"


### PR DESCRIPTION
This breaks the PERFORMANCE tests, because TriBITS does _not_ like having two tests with the same name.  Needs to get fixed.

Issue: #12935 
Stakeholder feedback:  As the stakeholder, I approve
Tests: This