### PR TITLE
NOX: Reuse prec across multiple nonlinear solves

### DIFF
--- a/packages/nox/src-thyra/NOX_Observer_ReusePreconditionerFactory.cpp
+++ b/packages/nox/src-thyra/NOX_Observer_ReusePreconditionerFactory.cpp
@@ -7,6 +7,8 @@ NOX::createReusePreconditionerObserver(Teuchos::ParameterList& pl)
 {
   Teuchos::ParameterList validParams;
   validParams.set<bool>("Update prec at start of nonlinear solve",true);
+  validParams.set<int>("Update prec after this many nonlinear solves",0);
+  validParams.set<bool>("Reset nonlinear solve count on failed solve",true);
   validParams.set<int>("Update prec after this many nonlinear iterations",0);
   validParams.set<int>("Update prec after this many stalled linear solves",0);
   validParams.set<int>("Max linear iterations for stall",50);
@@ -14,6 +16,8 @@ NOX::createReusePreconditionerObserver(Teuchos::ParameterList& pl)
   pl.validateParametersAndSetDefaults(validParams);
 
   bool update_at_start = pl.get<bool>("Update prec at start of nonlinear solve");
+  int update_after_n_nonlinear_solves = pl.get<int>("Update prec after this many nonlinear solves");
+  bool reset_nonlinear_solve_count_on_failed_solve = pl.get<bool>("Reset nonlinear solve count on failed solve");
   int update_after_n_iters = pl.get<int>("Update prec after this many nonlinear iterations");
   int update_after_n_stalls = pl.get<int>("Update prec after this many stalled linear solves");
   int max_iters_for_stall = pl.get<int>("Max linear iterations for stall");
@@ -22,6 +26,11 @@ NOX::createReusePreconditionerObserver(Teuchos::ParameterList& pl)
 
   if (update_at_start)
     observer->updateAtStartOfSolve();
+
+  // Zero or negative value disables
+  if (update_after_n_nonlinear_solves > 0)
+    observer->updateAfterNNonlinearSolves(update_after_n_nonlinear_solves,
+                                          reset_nonlinear_solve_count_on_failed_solve);
 
   // Zero or negative value disables
   if (update_after_n_iters > 0)

--- a/packages/nox/test/tpetra/Tpetra_1DFEM.cpp
+++ b/packages/nox/test/tpetra/Tpetra_1DFEM.cpp
@@ -592,6 +592,7 @@ TEUCHOS_UNIT_TEST(NOX_Tpetra_1DFEM, AnalyticJacobian_UserUpdatedIfpack2Prec)
 
   // Add in Observsers. This test specifically adds in a
   // preconditioner control observer
+  Teuchos::RCP<NOX::ObserverReusePreconditioner> reuse_prec_observer;
   {
     Teuchos::ParameterList precControlPL;
     precControlPL.set("Update prec at start of nonlinear solve",true);
@@ -604,6 +605,9 @@ TEUCHOS_UNIT_TEST(NOX_Tpetra_1DFEM, AnalyticJacobian_UserUpdatedIfpack2Prec)
     observers->pushBack(pc_observer);
     observers->pushBack(print_observer);
     nl_params->sublist("Solver Options").set<Teuchos::RCP<NOX::Observer>>("Observer",observers);
+
+    // Save off observer to for unit testing
+    reuse_prec_observer = Teuchos::rcp_dynamic_cast<NOX::ObserverReusePreconditioner>(pc_observer);
   }
 
   // Set output parameters
@@ -624,6 +628,155 @@ TEUCHOS_UNIT_TEST(NOX_Tpetra_1DFEM, AnalyticJacobian_UserUpdatedIfpack2Prec)
   NOX::StatusTest::StatusType solvStatus = solver->solve();
 
   TEST_ASSERT(solvStatus == NOX::StatusTest::Converged);
+  TEST_EQUALITY(reuse_prec_observer->getNumPreconditionerUpdates(), size_t(3));
+  TEST_EQUALITY(reuse_prec_observer->getNumNonlinearSolvesCount(), size_t(1));
+
+  utils->out() << "\n";
+  Teuchos::TimeMonitor::summarize();
+}
+
+TEUCHOS_UNIT_TEST(NOX_Tpetra_1DFEM, AnalyticJacobian_UserUpdatedIfpack2PrecMultipleNonlinearSolves)
+{
+  Teuchos::TimeMonitor::zeroOutTimers();
+
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
+
+  auto utils = Teuchos::rcp(new NOX::Utils(0,comm->getRank(),0,8));
+  utils->out() << "\n\n";
+
+  // Get default Tpetra template types
+  typedef Tpetra::Vector<>::scalar_type Scalar;
+  typedef Tpetra::Vector<>::local_ordinal_type LO;
+  typedef Tpetra::Vector<>::global_ordinal_type GO;
+  typedef Tpetra::Vector<>::node_type Node;
+
+  // Create the model evaluator object
+  Scalar x00 = 0.0;
+  Scalar x01 = 1.0;
+  const Tpetra::global_size_t numGlobalElements = 100;
+  Teuchos::RCP<EvaluatorTpetra1DFEM<Scalar,LO,GO,Node> > model =
+    evaluatorTpetra1DFEM<Scalar,LO,GO,Node>(comm, numGlobalElements, x00, x01);
+
+  // Set the source term high to make the problem more difficult
+  ::Thyra::put_scalar<double>(10.0,Teuchos::rcp_const_cast<::Thyra::VectorBase<double>>(model->getNominalValues().get_p(2)).ptr());
+
+  Stratimikos::DefaultLinearSolverBuilder builder;
+
+  Teuchos::RCP<Teuchos::ParameterList> p = Teuchos::parameterList();
+  p->set("Linear Solver Type", "Belos");
+  Teuchos::ParameterList& belosList = p->sublist("Linear Solver Types").sublist("Belos");
+  belosList.set("Solver Type", "Pseudo Block GMRES");
+  belosList.sublist("Solver Types").sublist("Pseudo Block GMRES").set<int>("Maximum Iterations", 200);
+  belosList.sublist("Solver Types").sublist("Pseudo Block GMRES").set<int>("Num Blocks", 200);
+  belosList.sublist("Solver Types").sublist("Pseudo Block GMRES").set("Verbosity", 0x7f);
+  belosList.sublist("Solver Types").sublist("Pseudo Block GMRES").set("Output Frequency", 100);
+  belosList.sublist("VerboseObject").set("Verbosity Level", "none");
+  p->set("Preconditioner Type", "Ifpack2");
+  Teuchos::ParameterList& ifpackList = p->sublist("Preconditioner Types").sublist("Ifpack2");
+  ifpackList.set("Prec Type", "ILUT");
+  ifpackList.set("Overlap", 3);
+  ifpackList.sublist("Ifpack2 Settings").set("fact: ilut level-of-fill",2.0);
+
+  builder.setParameterList(p);
+
+  Teuchos::RCP<Thyra::LinearOpWithSolveFactoryBase<Scalar> >
+    lowsFactory = builder.createLinearSolveStrategy("");
+
+  model->set_W_factory(lowsFactory);
+
+  // Create the initial guess
+  Teuchos::RCP<Thyra::VectorBase<Scalar> >
+    initial_guess = model->getNominalValues().get_x()->clone_v();
+  Thyra::V_S(initial_guess.ptr(),Teuchos::ScalarTraits<Scalar>::one());
+
+  const bool updatePreconditioner = false; // User controlled updating of preconditioner
+  Teuchos::RCP<NOX::Thyra::Group> nox_group =
+    Teuchos::rcp(new NOX::Thyra::Group(*initial_guess, model, model->create_W_op(), lowsFactory, Teuchos::null, Teuchos::null, Teuchos::null, Teuchos::null, Teuchos::null, false, updatePreconditioner));
+
+  nox_group->computeF();
+
+  // Create the NOX status tests and the solver
+  // Create the convergence tests
+  Teuchos::RCP<NOX::StatusTest::NormF> absresid =
+    Teuchos::rcp(new NOX::StatusTest::NormF(1.0e-8));
+  Teuchos::RCP<NOX::StatusTest::NormWRMS> wrms =
+    Teuchos::rcp(new NOX::StatusTest::NormWRMS(1.0e-2, 1.0e-8));
+  Teuchos::RCP<NOX::StatusTest::Combo> converged =
+    Teuchos::rcp(new NOX::StatusTest::Combo(NOX::StatusTest::Combo::AND));
+  converged->addStatusTest(absresid);
+  converged->addStatusTest(wrms);
+  Teuchos::RCP<NOX::StatusTest::MaxIters> maxiters =
+    Teuchos::rcp(new NOX::StatusTest::MaxIters(20));
+  Teuchos::RCP<NOX::StatusTest::FiniteValue> fv =
+    Teuchos::rcp(new NOX::StatusTest::FiniteValue);
+  Teuchos::RCP<NOX::StatusTest::Combo> combo =
+    Teuchos::rcp(new NOX::StatusTest::Combo(NOX::StatusTest::Combo::OR));
+  combo->addStatusTest(fv);
+  combo->addStatusTest(converged);
+  combo->addStatusTest(maxiters);
+
+  // Create nox parameter list
+  Teuchos::RCP<Teuchos::ParameterList> nl_params = Teuchos::parameterList();
+  nl_params->set("Nonlinear Solver", "Line Search Based");
+  nl_params->sublist("Direction").sublist("Newton").sublist("Linear Solver").set("Tolerance", 1.0e-4);
+
+  // Add in Observsers. This test specifically adds in a
+  // preconditioner control observer
+  Teuchos::RCP<NOX::ObserverReusePreconditioner> reuse_prec_observer;
+  {
+    Teuchos::ParameterList precControlPL;
+    precControlPL.set("Update prec at start of nonlinear solve",false);
+    precControlPL.set("Update prec after this many nonlinear solves",2);
+    precControlPL.set("Reset nonlinear solve count on failed solve",true);
+    auto pc_observer = NOX::createReusePreconditionerObserver(precControlPL);
+    auto print_observer = Teuchos::rcp(new NOX::ObserverPrint(utils));
+    auto observers = Teuchos::rcp(new NOX::ObserverVector);
+    observers->pushBack(pc_observer);
+    observers->pushBack(print_observer);
+    nl_params->sublist("Solver Options").set<Teuchos::RCP<NOX::Observer>>("Observer",observers);
+
+    // Save off observer to for unit testing
+    reuse_prec_observer = Teuchos::rcp_dynamic_cast<NOX::ObserverReusePreconditioner>(pc_observer);
+  }
+
+  // Set output parameters
+  nl_params->sublist("Printing").sublist("Output Information").set("Debug",false);
+  nl_params->sublist("Printing").sublist("Output Information").set("Warning",false);
+  nl_params->sublist("Printing").sublist("Output Information").set("Error",false);
+  nl_params->sublist("Printing").sublist("Output Information").set("Test Details",false);
+  nl_params->sublist("Printing").sublist("Output Information").set("Details",false);
+  nl_params->sublist("Printing").sublist("Output Information").set("Parameters",false);
+  nl_params->sublist("Printing").sublist("Output Information").set("Linear Solver Details",false);
+  nl_params->sublist("Printing").sublist("Output Information").set("Inner Iteration",false);
+  nl_params->sublist("Printing").sublist("Output Information").set("Outer Iteration",false);
+  nl_params->sublist("Printing").sublist("Output Information").set("Outer Iteration StatusTest",false);
+
+  // Create the solver
+  Teuchos::RCP<NOX::Solver::Generic> solver =
+    NOX::Solver::buildSolver(nox_group, combo, nl_params);
+  utils->out() << "Solve #1:\n";
+  NOX::StatusTest::StatusType solvStatus = solver->solve();
+  TEST_ASSERT(solvStatus == NOX::StatusTest::Converged);
+  TEST_EQUALITY(reuse_prec_observer->getNumPreconditionerUpdates(), size_t(1));
+  TEST_EQUALITY(reuse_prec_observer->getNumNonlinearSolvesCount(), size_t(1));
+
+  utils->out() << "\nSolve #2:\n";
+  solvStatus = solver->solve();
+  TEST_ASSERT(solvStatus == NOX::StatusTest::Converged);
+  TEST_EQUALITY(reuse_prec_observer->getNumPreconditionerUpdates(), size_t(1));
+  TEST_EQUALITY(reuse_prec_observer->getNumNonlinearSolvesCount(), size_t(2));
+
+  utils->out() << "\nSolve #3:\n";
+  solvStatus = solver->solve();
+  TEST_ASSERT(solvStatus == NOX::StatusTest::Converged);
+  TEST_EQUALITY(reuse_prec_observer->getNumPreconditionerUpdates(), size_t(2));
+  TEST_EQUALITY(reuse_prec_observer->getNumNonlinearSolvesCount(), size_t(3));
+
+  utils->out() << "\nSolve #4:\n";
+  solvStatus = solver->solve();
+  TEST_ASSERT(solvStatus == NOX::StatusTest::Converged);
+  TEST_EQUALITY(reuse_prec_observer->getNumPreconditionerUpdates(), size_t(2));
+  TEST_EQUALITY(reuse_prec_observer->getNumNonlinearSolvesCount(), size_t(4));
 
   utils->out() << "\n";
   Teuchos::TimeMonitor::summarize();


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
For efficiency, one might want to reuse the preconditioner over multiple nonlinear solves. If we have multiple stages in a DIRK method, this can be useful for reusing the same preconditioner for all solves within the time step. Previous work allowed reuse within a nonlinear solve. This adds reuse across multiple nonlinear solves.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
new tests added to tpetra 1dfem

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->