### PR TITLE
Nox fix doxygen

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-midnight

--- a/packages/nox/src/NOX_LineSearch_Polynomial.H
+++ b/packages/nox/src/NOX_LineSearch_Polynomial.H
@@ -161,7 +161,6 @@ namespace LineSearch {
   is used. We let \f$\lambda_1 = \frac{1}{2} \lambda_0\f$, and otherwise
 
   \f[
-
   \lambda_k = - \frac{1}{2}
   \frac{\lambda_{k-1}^2 [\phi(\lambda_{k-2}) -\phi(0)]
   - \lambda_{k-2}^2 [\phi(\lambda_{k-1}) -\phi(0)]}


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
fix doxygen for nox - an equation is broken in newer versions of doxygen

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->