### PR TITLE
Tpetra: use non-fused residual if TPLs available

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -54,6 +54,7 @@
 #include "Teuchos_TestForException.hpp"
 #include "TpetraCore_config.h"
 #include "Tpetra_Details_Behavior.hpp"
+#include "KokkosKernels_config.h"  // for TPL enable macros
 
 /*! \file Tpetra_Details_Behavior.cpp
 
@@ -681,7 +682,13 @@ bool Behavior::skipCopyAndPermuteIfPossible() {
 }
 
 bool Behavior::fusedResidual() {
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) || \
+    defined(KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE) || \
+    defined(KOKKOSKERNELS_ENABLE_TPL_MKL)
+  constexpr bool defaultValue(false);
+#else
   constexpr bool defaultValue(true);
+#endif
 
   static bool value_ = defaultValue;
   static bool initialized_ = false;


### PR DESCRIPTION
Set behavior variable ``TPETRA_FUSED_RESIDUAL`` to OFF by default if a sparse TPL (cusparse, rocsparse, or MKL) is enabled. This improves performance of ``Tpetra::Details::residual`` compared to the Tpetra implementation of the fused residual.

The default is still ON if no TPLs are enabled.

## Related Issues
#12982 
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues
#12982 
* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Will fix major performance regression reported by Sierra
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Tested locally by building with cuSPARSE enabled, running the Ifpack2+Belos driver with Jacobi (which calls residual) and looking at the Kokkos profiling regions
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->