### PR TITLE
Belos: Fixes null parameter list usage with orthogonalization factory

### DIFF
--- a/packages/belos/src/BelosBlockCGSolMgr.hpp
+++ b/packages/belos/src/BelosBlockCGSolMgr.hpp
@@ -623,8 +623,9 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
   // Create orthogonalization manager if we need to.
   if (ortho_ == Teuchos::null || changedOrthoType) {
     Belos::OrthoManagerFactory<ScalarType, MV, OP> factory;
-    Teuchos::RCP<Teuchos::ParameterList> paramsOrtho;   // can be null
+    Teuchos::RCP<Teuchos::ParameterList> paramsOrtho;   
     if (orthoType_=="DGKS" && orthoKappa_ > 0) {
+      paramsOrtho = Teuchos::rcp(new Teuchos::ParameterList());
       paramsOrtho->set ("depTol", orthoKappa_ );
     }
 

--- a/packages/belos/src/BelosBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGmresSolMgr.hpp
@@ -662,8 +662,9 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuch
   // Create orthogonalization manager if we need to.
   if (ortho_ == Teuchos::null || changedOrthoType) {
     Belos::OrthoManagerFactory<ScalarType, MV, OP> factory;
-    Teuchos::RCP<Teuchos::ParameterList> paramsOrtho;   // can be null
+    Teuchos::RCP<Teuchos::ParameterList> paramsOrtho;   
     if (orthoType_=="DGKS" && orthoKappa_ > 0) {
+      paramsOrtho = Teuchos::rcp(new Teuchos::ParameterList());
       paramsOrtho->set ("depTol", orthoKappa_ );
     }
 

--- a/packages/belos/src/BelosPCPGSolMgr.hpp
+++ b/packages/belos/src/BelosPCPGSolMgr.hpp
@@ -616,6 +616,7 @@ void PCPGSolMgr<ScalarType,MV,OP,true>::setParameters( const Teuchos::RCP<Teucho
     Belos::OrthoManagerFactory<ScalarType, MV, OP> factory;
     Teuchos::RCP<Teuchos::ParameterList> paramsOrtho;   // can be null
     if (orthoType_=="DGKS" && orthoKappa_ > 0) {
+      paramsOrtho = Teuchos::rcp(new Teuchos::ParameterList());
       paramsOrtho->set ("depTol", orthoKappa_ );
     }
 

--- a/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
@@ -786,6 +786,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
     Belos::OrthoManagerFactory<ScalarType, MV, OP> factory;
     Teuchos::RCP<Teuchos::ParameterList> paramsOrtho;   // can be null
     if (orthoType_=="DGKS" && orthoKappa_ > 0) {
+      paramsOrtho = Teuchos::rcp(new Teuchos::ParameterList());
       paramsOrtho->set ("depTol", orthoKappa_ );
     }
 

--- a/packages/belos/tpetra/test/BlockGmres/CMakeLists.txt
+++ b/packages/belos/tpetra/test/BlockGmres/CMakeLists.txt
@@ -44,7 +44,10 @@ ENDIF()
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Tpetra_BlockGMRES_hb_test
   SOURCES test_bl_gmres_hb.cpp
-  ARGS "--verbose"
+  ARGS 
+    "--verbose --ortho-type=DGKS"
+    "--verbose --ortho-type=ICGS"
+    "--verbose --ortho-type=IMGS"
   COMM serial mpi
   )
 

--- a/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb.cpp
@@ -156,6 +156,8 @@ int main(int argc, char *argv[]) {
     belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
     belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
     belosList.set( "Orthogonalization", ortho );           // Orthogonalization type
+    if ( ortho == "DGKS" )
+      belosList.set( "Orthogonalization Constant",  1.41421356);
 
     int verbLevel = Belos::Errors + Belos::Warnings;
     if (debug) {


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

If the changes in the PR should be considered for inclusion in the release notes,
please apply the label "xx.y release note" where xx.y is the version of the
upcoming release.
Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Some of the solver managers, which use orthogonalization, have been modified to use the orthogonalization factory.  This modification created a bad piece of logic if the user provided the orthogonalization coefficient parameter for the DGKS orthogonalization class.  This coefficient was to be inserted into a parameter list object that was passed to the orthogonalization factory.  Unfortunately, this parameter list object was a null pointer, so providing that parameter would have caused the solver to abort.

This has been fixed for the affected solver managers and a block GMRES test has been modified to ensure that this fix adequately addresses the logic error (at least for block GMRES).

## Related Issues

* Closes #12998 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
OSX GCC13.x

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->