### PR TITLE
Panzer fix and cleanup integrators 

### DIFF
--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_BasisTimesVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_BasisTimesVector_impl.hpp
@@ -301,63 +301,36 @@ namespace panzer
       });
     }
 
-    // The following if-block is for the sake of optimization depending on the
-    // number of field multipliers.
-    if constexpr (NUM_FIELD_MULT == 0) {
-      // Loop over the quadrature points and dimensions of our vector fields,
-      // scale the integrand by the multiplier, and then perform the
-      // integration, looping over the bases.
-      for (int qp(0); qp < numQP_; ++qp) {
-        for (int dim(0); dim < numDim_; ++dim) {
+    for (int qp(0); qp < numQP_; ++qp) {
+      for (int dim(0); dim < numDim_; ++dim) {
+        if constexpr (NUM_FIELD_MULT == 0) {
           Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases), [&] (const int basis) {
             field_(cell, basis) += basis_(cell, basis, qp, dim) * multiplier_ * vector_(cell, qp, dim);
           });
-        } // end loop over the dimensions of the vector field
-      } // end loop over the quadrature points
-    }
-    else if constexpr (NUM_FIELD_MULT == 1) {
-      // Loop over the quadrature points and dimensions of our vector fields,
-      // scale the integrand by the multiplier and the single field multiplier,
-      // and then perform the actual integration, looping over the bases.
-      for (int qp(0); qp < numQP_; ++qp) {
-        for (int dim(0); dim < numDim_; ++dim) {
+        }
+        else if constexpr (NUM_FIELD_MULT == 1) {
           Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases), [&] (const int basis) {
             field_(cell, basis) += basis_(cell, basis, qp, dim) * multiplier_ * vector_(cell, qp, dim)
               * kokkosFieldMults_[0](cell, qp);
           });
-        } // end loop over the dimensions of the vector field
-      } // end loop over the quadrature points
-    }
-    else if constexpr (NUM_FIELD_MULT == 2) {
-      // Loop over the quadrature points and dimensions of our vector fields,
-      // scale the integrand by the multiplier and the single field multiplier,
-      // and then perform the actual integration, looping over the bases.
-      for (int qp(0); qp < numQP_; ++qp) {
-        for (int dim(0); dim < numDim_; ++dim) {
+        }
+        else if constexpr (NUM_FIELD_MULT == 2) {
           Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases), [&] (const int basis) {
             field_(cell, basis) += basis_(cell, basis, qp, dim) * multiplier_ * vector_(cell, qp, dim) 
               * kokkosFieldMults_[0](cell, qp) * kokkosFieldMults_[1](cell, qp);
           });
-        } // end loop over the dimensions of the vector field
-      } // end loop over the quadrature points
-    }
-    else if constexpr (NUM_FIELD_MULT == 3) {
-      // Loop over the quadrature points and dimensions of our vector fields,
-      // scale the integrand by the multiplier and the single field multiplier,
-      // and then perform the actual integration, looping over the bases.
-      for (int qp(0); qp < numQP_; ++qp) {
-        for (int dim(0); dim < numDim_; ++dim) {
+        }
+        else if constexpr (NUM_FIELD_MULT == 3) {
           Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases), [&] (const int basis) {
             field_(cell, basis) += basis_(cell, basis, qp, dim) * multiplier_ * vector_(cell, qp, dim)
               * kokkosFieldMults_[0](cell, qp) * kokkosFieldMults_[1](cell, qp) * kokkosFieldMults_[2](cell, qp);
           });
-        } // end loop over the dimensions of the vector field
-      } // end loop over the quadrature points
-    }
-    else {
-      Kokkos::abort("Panzer_Integrator_BasisTimesVector: NUM_FIELD_MULT out of range!");
-    }
-
+        }
+        else {
+          Kokkos::abort("Panzer_Integrator_BasisTimesVector: NUM_FIELD_MULT out of range!");
+        }
+      } // end loop over the dimensions of the vector field
+    } // end loop over the quadrature points
   } // end of operator()()
 
   /////////////////////////////////////////////////////////////////////////////

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisDotVector_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_Integrator_GradBasisDotVector_impl.hpp
@@ -132,7 +132,7 @@ namespace panzer
       fieldMults_[i++] = MDField<const ScalarT, Cell, IP>(name, ir.dl_scalar);
       this->addDependentField(fieldMults_[i - 1]);
     } // end loop over the field multipliers
-    
+
     // Set the name of this object.
     string n("Integrator_GradBasisDotVector (");
     if (evalStyle_ == EvaluatorStyle::CONTRIBUTES)
@@ -237,60 +237,36 @@ namespace panzer
         field_(cell, basis) = 0.0;
       });
 
-    // The following if-block is for the sake of optimization depending on the
-    // number of field multipliers.
-    if (NUM_FIELD_MULT == 0)
-    {
-      // Loop over the quadrature points and dimensions of our vector fields,
-      // scale the integrand by the multiplier, and then perform the
-      // integration, looping over the bases.
-      for (int qp(0); qp < numQP; ++qp)
-      {
-        for (int dim(0); dim < numDim; ++dim)
-        {
+    for (int qp(0); qp < numQP; ++qp) {
+      for (int dim(0); dim < numDim; ++dim) {
+        if constexpr (NUM_FIELD_MULT == 0) {
 	  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases), [&] (const int basis) {
 	    field_(cell, basis) += basis_(cell, basis, qp, dim) * multiplier_ * vector_(cell, qp, dim);
 	  });
-        } // end loop over the dimensions of the vector field
-      } // end loop over the quadrature points
-    }
-    else if (NUM_FIELD_MULT == 1)
-    {
-      // Loop over the quadrature points and dimensions of our vector fields,
-      // scale the integrand by the multiplier and the single field multiplier,
-      // and then perform the actual integration, looping over the bases.
-      for (int qp(0); qp < numQP; ++qp)
-      {
-        for (int dim(0); dim < numDim; ++dim)
-        {
+        }
+        else if constexpr (NUM_FIELD_MULT == 1) {
 	  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases), [&] (const int basis) {
-	    field_(cell, basis) += basis_(cell, basis, qp, dim) * multiplier_ * vector_(cell, qp, dim) * kokkosFieldMults_(0)(cell, qp);
+	    field_(cell, basis) += basis_(cell, basis, qp, dim) * multiplier_ * vector_(cell, qp, dim)
+              * kokkosFieldMults_(0)(cell, qp);
 	  });
-        } // end loop over the dimensions of the vector field
-      } // end loop over the quadrature points
-    }
-    else
-    {
-      // Loop over the quadrature points and pre-multiply all the field
-      // multipliers together.  Then loop over the dimensions of our vector
-      // fields, scale the integrand by the multiplier and the combination of
-      // the field multipliers, and then perform the actual integration,
-      // looping over the bases.
-      const int numFieldMults(kokkosFieldMults_.extent(0));
-      for (int qp(0); qp < numQP; ++qp)
-      {
-	team.team_barrier();
-	tmp_(cell) = 1.0;
-        for (int fm(0); fm < numFieldMults; ++fm)
-          tmp_(cell) *= kokkosFieldMults_(fm)(cell, qp);
-        for (int dim(0); dim < numDim; ++dim)
-        {
+        }
+        else if constexpr (NUM_FIELD_MULT == 2) {
 	  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases), [&] (const int basis) {
-	    field_(cell, basis) += basis_(cell, basis, qp, dim) *  multiplier_ * vector_(cell, qp, dim) * tmp_(cell);
+	    field_(cell, basis) += basis_(cell, basis, qp, dim) * multiplier_ * vector_(cell, qp, dim)
+              * kokkosFieldMults_(0)(cell, qp) * kokkosFieldMults_(1)(cell, qp);
 	  });
-        } // end loop over the dimensions of the vector field
-      } // end loop over the quadrature points
-    } // end if (NUM_FIELD_MULT == something)
+        }
+        else if constexpr (NUM_FIELD_MULT == 3) {
+	  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases), [&] (const int basis) {
+	    field_(cell, basis) += basis_(cell, basis, qp, dim) * multiplier_ * vector_(cell, qp, dim)
+              * kokkosFieldMults_(0)(cell, qp) * kokkosFieldMults_(1)(cell, qp) * kokkosFieldMults_(2)(cell, qp);
+	  });
+        }
+        else {
+          Kokkos::abort("Panzer_Integrator_GradBasisDotVector: NUM_FIELD_MULT out of range!");
+        }
+      } // end dim loop
+    } // end qp loop
   } // end of operator()()
 
   /////////////////////////////////////////////////////////////////////////////
@@ -314,14 +290,11 @@ namespace panzer
     const int numBases = basis_.extent(1);
     const int fadSize = Kokkos::dimension_scalar(field_.get_view());
 
-    scratch_view tmp;
     scratch_view tmp_field;
     if (Sacado::IsADType<ScalarT>::value) {
-      tmp = scratch_view(team.team_shmem(),1,fadSize);
       tmp_field = scratch_view(team.team_shmem(),numBases,fadSize);
     }
     else {
-      tmp = scratch_view(team.team_shmem(),1);
       tmp_field = scratch_view(team.team_shmem(),numBases);
     }
 
@@ -332,59 +305,36 @@ namespace panzer
 
     // The following if-block is for the sake of optimization depending on the
     // number of field multipliers.
-    if (NUM_FIELD_MULT == 0)
-    {
-      // Loop over the quadrature points and dimensions of our vector fields,
-      // scale the integrand by the multiplier, and then perform the
-      // integration, looping over the bases.
-      for (int qp(0); qp < numQP; ++qp)
-      {
-        for (int dim(0); dim < numDim; ++dim)
-        {
+    for (int qp(0); qp < numQP; ++qp) {
+      for (int dim(0); dim < numDim; ++dim) {
+        if constexpr (NUM_FIELD_MULT == 0) {
 	  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases), [&] (const int basis) {
 	    tmp_field(basis) += basis_(cell, basis, qp, dim) * multiplier_ * vector_(cell, qp, dim);
 	  });
-        } // end loop over the dimensions of the vector field
-      } // end loop over the quadrature points
-    }
-    else if (NUM_FIELD_MULT == 1)
-    {
-      // Loop over the quadrature points and dimensions of our vector fields,
-      // scale the integrand by the multiplier and the single field multiplier,
-      // and then perform the actual integration, looping over the bases.
-      for (int qp(0); qp < numQP; ++qp)
-      {
-        for (int dim(0); dim < numDim; ++dim)
-        {
+        }
+        else if constexpr (NUM_FIELD_MULT == 1) {
 	  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases), [&] (const int basis) {
-	    tmp_field(basis) += basis_(cell, basis, qp, dim) * multiplier_ * vector_(cell, qp, dim) * kokkosFieldMults_(0)(cell, qp);
+	    tmp_field(basis) += basis_(cell, basis, qp, dim) * multiplier_ * vector_(cell, qp, dim)
+              * kokkosFieldMults_(0)(cell, qp);
 	  });
-        } // end loop over the dimensions of the vector field
-      } // end loop over the quadrature points
-    }
-    else
-    {
-      // Loop over the quadrature points and pre-multiply all the field
-      // multipliers together.  Then loop over the dimensions of our vector
-      // fields, scale the integrand by the multiplier and the combination of
-      // the field multipliers, and then perform the actual integration,
-      // looping over the bases.
-      const int numFieldMults(kokkosFieldMults_.extent(0));
-      for (int qp(0); qp < numQP; ++qp)
-      {
-        ScalarT fieldMultsTotal(1); // need shared mem here
-        for (int fm(0); fm < numFieldMults; ++fm)
-          fieldMultsTotal *= kokkosFieldMults_(fm)(cell, qp);
-        for (int dim(0); dim < numDim; ++dim)
-        {
-	  team.team_barrier();
-          tmp(0) = multiplier_ * vector_(cell, qp, dim) * fieldMultsTotal;
+        }
+        else if constexpr (NUM_FIELD_MULT == 2) {
 	  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases), [&] (const int basis) {
-	    tmp_field(basis) += basis_(cell, basis, qp, dim) * tmp(0);
+	    tmp_field(basis) += basis_(cell, basis, qp, dim) * multiplier_ * vector_(cell, qp, dim)
+              * kokkosFieldMults_(0)(cell, qp) * kokkosFieldMults_(1)(cell, qp);
 	  });
-        } // end loop over the dimensions of the vector field
-      } // end loop over the quadrature points
-    } // end if (NUM_FIELD_MULT == something)
+        }
+        else if constexpr (NUM_FIELD_MULT == 3) {
+	  Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,numBases), [&] (const int basis) {
+	    tmp_field(basis) += basis_(cell, basis, qp, dim) * multiplier_ * vector_(cell, qp, dim)
+              * kokkosFieldMults_(0)(cell, qp) * kokkosFieldMults_(1)(cell, qp) * kokkosFieldMults_(2)(cell, qp);
+	  });
+        }
+        else {
+          Kokkos::abort("Panzer_Integrator_GradBasisDotVector: NUM_FIELD_MULT out of range!");
+        }
+      } // end loop over the dimensions of the vector field
+    } // end loop over the quadrature points
 
     // Put final values into target field
     if (evalStyle_ == EvaluatorStyle::EVALUATES) {
@@ -422,10 +372,10 @@ namespace panzer
       int bytes;
       if (Sacado::IsADType<ScalarT>::value) {
 	const int fadSize = Kokkos::dimension_scalar(field_.get_view());
-	bytes = scratch_view::shmem_size(1,fadSize) + scratch_view::shmem_size(basis_.extent(1),fadSize);
+	bytes = scratch_view::shmem_size(basis_.extent(1),fadSize);
       }
       else
-	bytes = scratch_view::shmem_size(1) + scratch_view::shmem_size(basis_.extent(1));
+	bytes = scratch_view::shmem_size(basis_.extent(1));
 
       // The following if-block is for the sake of optimization depending on the
       // number of field multipliers.  The parallel_fors will loop over the cells
@@ -436,9 +386,16 @@ namespace panzer
       } else if (fieldMults_.size() == 1) {
 	auto policy = panzer::HP::inst().teamPolicy<ScalarT,SharedFieldMultTag<1>,PHX::Device>(workset.num_cells).set_scratch_size(0,Kokkos::PerTeam(bytes));
         parallel_for(this->getName(), policy, *this);
-      } else {
-	auto policy = panzer::HP::inst().teamPolicy<ScalarT,SharedFieldMultTag<-1>,PHX::Device>(workset.num_cells).set_scratch_size(0,Kokkos::PerTeam(bytes));
+      } else if (fieldMults_.size() == 2) {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,SharedFieldMultTag<2>,PHX::Device>(workset.num_cells).set_scratch_size(0,Kokkos::PerTeam(bytes));
         parallel_for(this->getName(), policy, *this);
+      } else if (fieldMults_.size() == 3) {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,SharedFieldMultTag<3>,PHX::Device>(workset.num_cells).set_scratch_size(0,Kokkos::PerTeam(bytes));
+        parallel_for(this->getName(), policy, *this);
+      } else {
+        TEUCHOS_TEST_FOR_EXCEPTION(fieldMults_.size() > 3,std::runtime_error,
+                                   "ERROR: Panzer_Integrator_GradBasisDotVector supports up to three field multipliers! User requested "
+                                   << fieldMults_.size() << "!");
       }
     }
     else {
@@ -451,9 +408,16 @@ namespace panzer
       } else if (fieldMults_.size() == 1) {
 	auto policy = panzer::HP::inst().teamPolicy<ScalarT,FieldMultTag<1>,PHX::Device>(workset.num_cells);
         parallel_for(this->getName(), policy, *this);
-      } else {
-	auto policy = panzer::HP::inst().teamPolicy<ScalarT,FieldMultTag<-1>,PHX::Device>(workset.num_cells);
+      } else if (fieldMults_.size() == 2) {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,FieldMultTag<2>,PHX::Device>(workset.num_cells);
         parallel_for(this->getName(), policy, *this);
+      } else if (fieldMults_.size() == 3) {
+	auto policy = panzer::HP::inst().teamPolicy<ScalarT,FieldMultTag<3>,PHX::Device>(workset.num_cells);
+        parallel_for(this->getName(), policy, *this);
+      } else {
+        TEUCHOS_TEST_FOR_EXCEPTION(fieldMults_.size() > 3,std::runtime_error,
+                                   "ERROR: Panzer_Integrator_GradBasisDotVector supports up to three field multipliers! User requested "
+                                   << fieldMults_.size() << "!");
       }
     }
   } // end of evaluateFields()

--- a/packages/phalanx/src/Phalanx_KokkosViewOfViews.hpp
+++ b/packages/phalanx/src/Phalanx_KokkosViewOfViews.hpp
@@ -323,9 +323,9 @@ namespace PHX {
     /// execution space instance, the function does not internally
     /// fence. Be sure to manually fence as needed.
     template<typename ExecSpace,typename... Extents>
-    ViewOfViews3(const ExecSpace& exec_space,const std::string name,Extents... extents)
+    ViewOfViews3(const ExecSpace& e_space,const std::string name,Extents... extents)
       : view_host_(Kokkos::view_alloc(typename OuterViewType::HostMirror::execution_space(),name),extents...),
-        view_device_(Kokkos::view_alloc(exec_space,name),extents...),
+        view_device_(Kokkos::view_alloc(e_space,name),extents...),
         device_view_is_synced_(false),
         is_initialized_(true),
         use_count_(0),
@@ -388,10 +388,10 @@ namespace PHX {
     /// instance, the function does not internally fence. Be sure to
     /// manually fence as needed.
     template<typename ExecSpace,typename... Extents>
-    void initialize(const ExecSpace& exec_space,const std::string name,Extents... extents)
+    void initialize(const ExecSpace& e_space,const std::string name,Extents... extents)
     {
       view_host_ = typename OuterViewType::HostMirror(Kokkos::view_alloc(typename OuterViewType::HostMirror::execution_space(),name),extents...);
-      view_device_ = OuterViewType(Kokkos::view_alloc(exec_space,name),extents...);
+      view_device_ = OuterViewType(Kokkos::view_alloc(e_space,name),extents...);
       view_host_unmanaged_ = Kokkos::create_mirror_view(Kokkos::view_alloc(typename OuterViewType::HostMirror::execution_space()),view_device_);
       device_view_is_synced_ = false;
       is_initialized_ = true;
@@ -450,10 +450,10 @@ namespace PHX {
     /// supplies the execution space instance, the function does not
     /// internally fence. Be sure to manually fence as needed.
     template<typename ExecSpace>
-    void syncHostToDevice(const ExecSpace& exec_space)
+    void syncHostToDevice(const ExecSpace& e_space)
     {
       TEUCHOS_ASSERT(is_initialized_);
-      Kokkos::deep_copy(exec_space,view_device_,view_host_unmanaged_);
+      Kokkos::deep_copy(e_space,view_device_,view_host_unmanaged_);
       device_view_is_synced_ = true;
     }
 


### PR DESCRIPTION
## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
@cgcgcg found an issue with the Integrator_GradBasisDotVector when using two multipliers. This has been fixed. Also simplified the code with c++17. Cleaned up another integrator as well. Temoved some shadow warnings from ViewOfViews object in phalanx.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
N/A

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
