### PR TITLE
Muelu: Add Thyra style submaps to subblock factory

### DIFF
--- a/packages/muelu/src/Transfers/BlockedTransfers/MueLu_SubBlockAFactory_def.hpp
+++ b/packages/muelu/src/Transfers/BlockedTransfers/MueLu_SubBlockAFactory_def.hpp
@@ -155,8 +155,10 @@ void SubBlockAFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level& c
   RCP<const MapExtractor> rangeMapExtractor  = A->getRangeMapExtractor();
   RCP<const MapExtractor> domainMapExtractor = A->getDomainMapExtractor();
 
-  RCP<const Map> rangeMap  = rangeMapExtractor->getMap(row);
-  RCP<const Map> domainMap = domainMapExtractor->getMap(col);
+  bool thyraMode = rangeMapExtractor->getThyraMode();
+
+  RCP<const Map> rangeMap  = rangeMapExtractor->getMap(row, thyraMode);
+  RCP<const Map> domainMap = domainMapExtractor->getMap(col, thyraMode);
 
   // use user-specified striding information if available. Otherwise try to use internal striding information from the submaps!
   if (bRangeUserSpecified)


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Currently only Xpetra style maps are retrieved from the map extractor inside the subblock factory. If Thyra style maps are used, the GID numbering is wrong (e.g. not starting at 0 and wrong offset). 

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Related to #12665

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Additional Information
<!--- 
  Anything else we need to know in evaluating this merge request?
-->
Relevant for fully monolithic multigrid for multi-physics problems.
@mayrmt 