### PR TITLE
Tpetra/KokkosKernels: fix apply/spmv performance regressions

### DIFF
--- a/packages/kokkos-kernels/sparse/impl/KokkosSparse_spmv_spec.hpp
+++ b/packages/kokkos-kernels/sparse/impl/KokkosSparse_spmv_spec.hpp
@@ -203,7 +203,8 @@ struct SPMV_MV<ExecutionSpace, Handle, AMatrix, XVector, YVector, false, false,
                KOKKOSKERNELS_IMPL_COMPILE_LIBRARY> {
   typedef typename YVector::non_const_value_type coefficient_type;
 
-  static void spmv_mv(const ExecutionSpace& space, Handle* handle,
+  // TODO: pass handle through to implementation and use tuning parameters
+  static void spmv_mv(const ExecutionSpace& space, Handle* /* handle */,
                       const char mode[], const coefficient_type& alpha,
                       const AMatrix& A, const XVector& x,
                       const coefficient_type& beta, const YVector& y) {

--- a/packages/kokkos-kernels/sparse/impl/KokkosSparse_spmv_spec.hpp
+++ b/packages/kokkos-kernels/sparse/impl/KokkosSparse_spmv_spec.hpp
@@ -208,49 +208,18 @@ struct SPMV_MV<ExecutionSpace, Handle, AMatrix, XVector, YVector, false, false,
                       const AMatrix& A, const XVector& x,
                       const coefficient_type& beta, const YVector& y) {
     typedef Kokkos::ArithTraits<coefficient_type> KAT;
-    // Intercept special case: if x/y have only 1 column and both are
-    // contiguous, use the more efficient single-vector impl.
-    //
-    // We cannot do this if x or y is noncontiguous, because the column subview
-    // must be LayoutStride which is not ETI'd.
-    //
-    // Do not use a TPL even if one is available for the types:
-    // we don't want the same handle being used in both TPL and non-TPL versions
-    if (x.extent(1) == size_t(1) && x.span_is_contiguous() &&
-        y.span_is_contiguous()) {
-      Kokkos::View<typename XVector::const_value_type*, default_layout,
-                   typename XVector::device_type>
-          x0(x.data(), x.extent(0));
-      Kokkos::View<typename YVector::non_const_value_type*, default_layout,
-                   typename YVector::device_type>
-          y0(y.data(), y.extent(0));
-      if (beta == KAT::zero()) {
-        spmv_beta<ExecutionSpace, Handle, AMatrix, decltype(x0), decltype(y0),
-                  0>(space, handle, mode, alpha, A, x0, beta, y0);
-      } else if (beta == KAT::one()) {
-        spmv_beta<ExecutionSpace, Handle, AMatrix, decltype(x0), decltype(y0),
-                  1>(space, handle, mode, alpha, A, x0, beta, y0);
-      } else if (beta == -KAT::one()) {
-        spmv_beta<ExecutionSpace, Handle, AMatrix, decltype(x0), decltype(y0),
-                  -1>(space, handle, mode, alpha, A, x0, beta, y0);
-      } else {
-        spmv_beta<ExecutionSpace, Handle, AMatrix, decltype(x0), decltype(y0),
-                  2>(space, handle, mode, alpha, A, x0, beta, y0);
-      }
+    if (alpha == KAT::zero()) {
+      spmv_alpha_mv<ExecutionSpace, AMatrix, XVector, YVector, 0>(
+          space, mode, alpha, A, x, beta, y);
+    } else if (alpha == KAT::one()) {
+      spmv_alpha_mv<ExecutionSpace, AMatrix, XVector, YVector, 1>(
+          space, mode, alpha, A, x, beta, y);
+    } else if (alpha == -KAT::one()) {
+      spmv_alpha_mv<ExecutionSpace, AMatrix, XVector, YVector, -1>(
+          space, mode, alpha, A, x, beta, y);
     } else {
-      if (alpha == KAT::zero()) {
-        spmv_alpha_mv<ExecutionSpace, AMatrix, XVector, YVector, 0>(
-            space, mode, alpha, A, x, beta, y);
-      } else if (alpha == KAT::one()) {
-        spmv_alpha_mv<ExecutionSpace, AMatrix, XVector, YVector, 1>(
-            space, mode, alpha, A, x, beta, y);
-      } else if (alpha == -KAT::one()) {
-        spmv_alpha_mv<ExecutionSpace, AMatrix, XVector, YVector, -1>(
-            space, mode, alpha, A, x, beta, y);
-      } else {
-        spmv_alpha_mv<ExecutionSpace, AMatrix, XVector, YVector, 2>(
-            space, mode, alpha, A, x, beta, y);
-      }
+      spmv_alpha_mv<ExecutionSpace, AMatrix, XVector, YVector, 2>(
+          space, mode, alpha, A, x, beta, y);
     }
   }
 };

--- a/packages/kokkos-kernels/sparse/src/KokkosSparse_spmv.hpp
+++ b/packages/kokkos-kernels/sparse/src/KokkosSparse_spmv.hpp
@@ -40,31 +40,6 @@ struct RANK_ONE {};
 struct RANK_TWO {};
 }  // namespace
 
-namespace Impl {
-template <typename ExecutionSpace, typename Handle, typename AMatrix,
-          typename XVector, class YVector>
-inline constexpr bool spmv_general_tpl_avail() {
-  constexpr bool isBSR = ::KokkosSparse::Experimental::is_bsr_matrix_v<AMatrix>;
-  if constexpr (!isBSR) {
-    // CRS
-    if constexpr (XVector::rank() == 1)
-      return spmv_tpl_spec_avail<ExecutionSpace, Handle, AMatrix, XVector,
-                                 YVector>::value;
-    else
-      return spmv_mv_tpl_spec_avail<ExecutionSpace, Handle, AMatrix, XVector,
-                                    YVector>::value;
-  } else {
-    // BSR
-    if constexpr (XVector::rank() == 1)
-      return spmv_bsrmatrix_tpl_spec_avail<ExecutionSpace, Handle, AMatrix,
-                                           XVector, YVector>::value;
-    else
-      return spmv_mv_bsrmatrix_tpl_spec_avail<ExecutionSpace, Handle, AMatrix,
-                                              XVector, YVector>::value;
-  }
-}
-}  // namespace Impl
-
 // clang-format off
 /// \brief Kokkos sparse matrix-vector multiply.
 /// Computes y := alpha*Op(A)*x + beta*y, where Op(A) is
@@ -247,8 +222,8 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[],
       typename YVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
   // Special case: XVector/YVector are rank-2 but x,y both have one column and
-  // are contiguous. If a TPL is available for rank-1 vectors but not rank-2,
-  // take rank-1 subviews of x,y and call the rank-1 version.
+  // are contiguous. In this case take rank-1 subviews of x,y and call the
+  // rank-1 version.
   if constexpr (XVector::rank() == 2) {
     using XVector_SubInternal = Kokkos::View<
         typename XVector::const_value_type*,
@@ -259,19 +234,12 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[],
         typename YVector::non_const_value_type*,
         typename KokkosKernels::Impl::GetUnifiedLayout<YVector>::array_layout,
         typename YVector::device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-    if constexpr (!Impl::spmv_general_tpl_avail<
-                      ExecutionSpace, HandleImpl, AMatrix_Internal,
-                      XVector_Internal, YVector_Internal>() &&
-                  Impl::spmv_general_tpl_avail<
-                      ExecutionSpace, HandleImpl, AMatrix_Internal,
-                      XVector_SubInternal, YVector_SubInternal>()) {
-      if (x.extent(1) == size_t(1) && x.span_is_contiguous() &&
-          y.span_is_contiguous()) {
-        XVector_SubInternal xsub(x.data(), x.extent(0));
-        YVector_SubInternal ysub(y.data(), y.extent(0));
-        spmv(space, handle->get_impl(), mode, alpha, A, xsub, beta, ysub);
-        return;
-      }
+    if (x.extent(1) == size_t(1) && x.span_is_contiguous() &&
+        y.span_is_contiguous()) {
+      XVector_SubInternal xsub(x.data(), x.extent(0));
+      YVector_SubInternal ysub(y.data(), y.extent(0));
+      spmv(space, handle->get_impl(), mode, alpha, A, xsub, beta, ysub);
+      return;
     }
   }
 

--- a/packages/kokkos-kernels/sparse/src/KokkosSparse_spmv_handle.hpp
+++ b/packages/kokkos-kernels/sparse/src/KokkosSparse_spmv_handle.hpp
@@ -235,7 +235,8 @@ struct SPMVHandleImpl {
                 "SPMVHandleImpl: Ordinal must not be a const type");
   SPMVHandleImpl(SPMVAlgorithm algo_) : algo(algo_) {}
   ~SPMVHandleImpl() {
-    if (tpl) delete tpl;
+    if (tpl_rank1) delete tpl_rank1;
+    if (tpl_rank2) delete tpl_rank2;
   }
 
   ImplType* get_impl() { return this; }
@@ -243,9 +244,9 @@ struct SPMVHandleImpl {
   /// Get the SPMVAlgorithm used by this handle
   SPMVAlgorithm get_algorithm() const { return this->algo; }
 
-  bool is_set_up                     = false;
-  const SPMVAlgorithm algo           = SPMV_DEFAULT;
-  TPL_SpMV_Data<ExecutionSpace>* tpl = nullptr;
+  const SPMVAlgorithm algo                 = SPMV_DEFAULT;
+  TPL_SpMV_Data<ExecutionSpace>* tpl_rank1 = nullptr;
+  TPL_SpMV_Data<ExecutionSpace>* tpl_rank2 = nullptr;
   // Expert tuning parameters for native SpMV
   // TODO: expose a proper Experimental interface to set these. Currently they
   // can be assigned directly in the SPMVHandle as they are public members.

--- a/packages/kokkos-kernels/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp
@@ -186,16 +186,16 @@ void spmv_mv_cusparse(const Kokkos::Cuda &exec, Handle *handle,
   }
 
   KokkosSparse::Impl::CuSparse10_SpMV_Data *subhandle;
-  if (handle->is_set_up) {
-    subhandle =
-        dynamic_cast<KokkosSparse::Impl::CuSparse10_SpMV_Data *>(handle->tpl);
+  if (handle->tpl_rank2) {
+    subhandle = dynamic_cast<KokkosSparse::Impl::CuSparse10_SpMV_Data *>(
+        handle->tpl_rank2);
     if (!subhandle)
       throw std::runtime_error(
           "KokkosSparse::spmv: subhandle is not set up for cusparse");
     subhandle->set_exec_space(exec);
   } else {
-    subhandle   = new KokkosSparse::Impl::CuSparse10_SpMV_Data(exec);
-    handle->tpl = subhandle;
+    subhandle         = new KokkosSparse::Impl::CuSparse10_SpMV_Data(exec);
+    handle->tpl_rank2 = subhandle;
     /* create matrix */
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseCreateCsr(
         &subhandle->mat, A.numRows(), A.numCols(), A.nnz(),
@@ -209,8 +209,6 @@ void spmv_mv_cusparse(const Kokkos::Cuda &exec, Handle *handle,
 
     KOKKOS_IMPL_CUDA_SAFE_CALL(
         cudaMalloc(&subhandle->buffer, subhandle->bufferSize));
-
-    handle->is_set_up = true;
   }
 
   KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpMM(cusparseHandle, opA, opB, &alpha,


### PR DESCRIPTION
@trilinos/tpetra 
@trilinos/kokkos-kernels 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Fix ``Tpetra::CrsMatrix::apply`` performance regressions caused by https://github.com/kokkos/kokkos-kernels/pull/2126 and #12852. Calls cusparse spmv ALG2 for imbalanced matrices in CUDA versions <= 11.2.1.

KokkosKernels changes are the same as https://github.com/kokkos/kokkos-kernels/pull/2204 but this shouldn't wait for the next release.

## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
apply is well tested for correctness.

For performance, here is a before/after for 1000-iteration CG run with an SierraTF abnormal energy problem, on Vortex. This matrix triggers the imbalanced row condition in Tpetra. The total solve time for develop branch was 3.48s, but with this PR is 1.73s.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->