### PR TITLE
Ifpack2: add the option to use a point crs matrix with BTDS

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
@@ -335,6 +335,8 @@ namespace Ifpack2 {
       typedef Tpetra::Map<local_ordinal_type,global_ordinal_type,node_type> tpetra_map_type;
       typedef Tpetra::Import<local_ordinal_type,global_ordinal_type,node_type> tpetra_import_type;
       typedef Tpetra::RowMatrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type> tpetra_row_matrix_type;
+      typedef Tpetra::CrsMatrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type> tpetra_crs_matrix_type;
+      typedef Tpetra::CrsGraph<local_ordinal_type,global_ordinal_type,node_type> tpetra_crs_graph_type;
       typedef Tpetra::BlockCrsMatrix<scalar_type,local_ordinal_type,global_ordinal_type,node_type> tpetra_block_crs_matrix_type;
       typedef typename tpetra_block_crs_matrix_type::little_block_type tpetra_block_access_view_type;
       typedef Tpetra::BlockMultiVector<scalar_type,local_ordinal_type,global_ordinal_type,node_type> tpetra_block_multivector_type;
@@ -375,6 +377,7 @@ namespace Ifpack2 {
       typedef Kokkos::View<internal_vector_type***,Kokkos::LayoutRight,device_type> internal_vector_type_3d_view;
       typedef Kokkos::View<internal_vector_type****,Kokkos::LayoutRight,device_type> internal_vector_type_4d_view;
       typedef Kokkos::View<internal_vector_type*****,Kokkos::LayoutRight,device_type> internal_vector_type_5d_view;
+      typedef Kokkos::View<btdm_scalar_type**,Kokkos::LayoutRight,device_type> btdm_scalar_type_2d_view;
       typedef Kokkos::View<btdm_scalar_type***,Kokkos::LayoutRight,device_type> btdm_scalar_type_3d_view;
       typedef Kokkos::View<btdm_scalar_type****,Kokkos::LayoutRight,device_type> btdm_scalar_type_4d_view;
       typedef Kokkos::View<btdm_scalar_type*****,Kokkos::LayoutRight,device_type> btdm_scalar_type_5d_view;

--- a/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
@@ -649,7 +649,7 @@ initialize ()
         graph = A_->getGraph ();
       }
       else {
-        graph = Tpetra::getBlockCrsGraph(*Teuchos::rcp_dynamic_cast<const crs_matrix_type>(A_), block_size, false);
+        graph = Tpetra::getBlockCrsGraph(*Teuchos::rcp_dynamic_cast<const crs_matrix_type>(A_), block_size, true);
       }
       Kokkos::DefaultExecutionSpace().fence();
     }

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_decl.hpp
@@ -235,7 +235,8 @@ namespace Ifpack2 {
                          const int n_subparts_per_part = 1,
                          bool overlapCommAndComp = false, 
                          bool useSequentialMethod = false,
-                         const int block_size = -1);
+                         const int block_size = -1,
+                         const bool explicitConversion = false);
 
     //! Destructor (declared virtual for memory safety of derived classes).
     ~BlockTriDiContainer () override;
@@ -397,13 +398,15 @@ namespace Ifpack2 {
     // hide details of impl using ImplObj; finally I understand why AMB did that way.
     Teuchos::RCP<BlockTriDiContainerDetails::ImplObject<MatrixType> > impl_;
     int n_subparts_per_part_;
+    int block_size_ = -1;
     
     // initialize distributed and local objects
     void initInternal (const Teuchos::RCP<const row_matrix_type>& matrix,
                        const Teuchos::RCP<const import_type> &importer,
                        const bool overlapCommAndComp,
                        const bool useSeqMethod,
-                       const int block_size = -1);
+                       const int block_size = -1,
+                       const bool explicitConversion = false);
 
     void clearInternal();
   };

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_def.hpp
@@ -83,7 +83,8 @@ namespace Ifpack2 {
                   const Teuchos::RCP<const import_type>& importer,
                   const bool overlapCommAndComp,
                   const bool useSeqMethod,
-                  const int block_size) 
+                  const int block_size,
+                  const bool explicitConversion) 
   {
     IFPACK2_BLOCKHELPER_TIMER("BlockTriDiContainer::initInternal");
 
@@ -99,15 +100,20 @@ namespace Ifpack2 {
 
     {
       IFPACK2_BLOCKHELPER_TIMER("BlockTriDiContainer::setA");
-      impl_->A = Teuchos::rcp_dynamic_cast<const block_crs_matrix_type>(matrix);
-      if (impl_->A.is_null()) {
-        TEUCHOS_TEST_FOR_EXCEPT_MSG
-          (block_size == -1, "A pointwise matrix and block_size = -1 were given as inputs.");
-        {
-          IFPACK2_BLOCKHELPER_TIMER("BlockTriDiContainer::setA::convertToBlockCrsMatrix");
-          impl_->A = Tpetra::convertToBlockCrsMatrix(*Teuchos::rcp_dynamic_cast<const crs_matrix_type>(matrix), block_size, false);
-          IFPACK2_BLOCKHELPER_TIMER_FENCE(typename BlockHelperDetails::ImplType<MatrixType>::execution_space)
+      if (explicitConversion) {
+        impl_->A = Teuchos::rcp_dynamic_cast<const block_crs_matrix_type>(matrix);
+        if (impl_->A.is_null()) {
+          TEUCHOS_TEST_FOR_EXCEPT_MSG
+            (block_size == -1, "A pointwise matrix and block_size = -1 were given as inputs.");
+          {
+            IFPACK2_BLOCKHELPER_TIMER("BlockTriDiContainer::setA::convertToBlockCrsMatrix");
+            impl_->A = Tpetra::convertToBlockCrsMatrix(*Teuchos::rcp_dynamic_cast<const crs_matrix_type>(matrix), block_size, false);
+            IFPACK2_BLOCKHELPER_TIMER_FENCE(typename BlockHelperDetails::ImplType<MatrixType>::execution_space)
+          }
         }
+      }
+      else {
+        impl_->A = matrix;
       }
       IFPACK2_BLOCKHELPER_TIMER_FENCE(typename BlockHelperDetails::ImplType<MatrixType>::execution_space)
     }
@@ -197,6 +203,7 @@ namespace Ifpack2 {
     const bool overlapCommAndComp = false;
     initInternal(matrix, importer, overlapCommAndComp, useSeqMethod);
     n_subparts_per_part_ = -1;
+    block_size_ = -1;
     IFPACK2_BLOCKHELPER_TIMER_FENCE(typename BlockHelperDetails::ImplType<MatrixType>::execution_space)
   }
 
@@ -207,12 +214,14 @@ namespace Ifpack2 {
                        const int n_subparts_per_part,
                        const bool overlapCommAndComp, 
                        const bool useSeqMethod,
-                       const int block_size)
+                       const int block_size,
+                       const bool explicitConversion)
     : Container<MatrixType>(matrix, partitions, false), partitions_(partitions)
   {
     IFPACK2_BLOCKHELPER_TIMER("BlockTriDiContainer::BlockTriDiContainer");
-    initInternal(matrix, Teuchos::null, overlapCommAndComp, useSeqMethod, block_size);
+    initInternal(matrix, Teuchos::null, overlapCommAndComp, useSeqMethod, block_size, explicitConversion);
     n_subparts_per_part_ = n_subparts_per_part;
+    block_size_ = block_size;
     IFPACK2_BLOCKHELPER_TIMER_FENCE(typename BlockHelperDetails::ImplType<MatrixType>::execution_space)
   }
 
@@ -229,6 +238,8 @@ namespace Ifpack2 {
   {
     if (List.isType<int>("partitioner: subparts per part"))
       n_subparts_per_part_ = List.get<int>("partitioner: subparts per part");
+    if (List.isType<int>("partitioner: block size"))
+      block_size_ = List.get<int>("partitioner: block size");
   }
 
   template <typename MatrixType>
@@ -239,12 +250,30 @@ namespace Ifpack2 {
     IFPACK2_BLOCKHELPER_TIMER("BlockTriDiContainer::initialize");
     this->IsInitialized_ = true;
     {
+      auto bA = Teuchos::rcp_dynamic_cast<const block_crs_matrix_type>(impl_->A);
+      if (bA.is_null()) {
+        TEUCHOS_TEST_FOR_EXCEPT_MSG
+          (block_size_ == -1, "A pointwise matrix and block_size = -1 were given as inputs.");
+        {
+          IFPACK2_BLOCKHELPER_TIMER("BlockTriDiContainer::initialize::getBlockCrsGraph");
+          auto A = Teuchos::rcp_dynamic_cast<const crs_matrix_type>(impl_->A);
+          impl_->blockGraph = Tpetra::getBlockCrsGraph(*A, block_size_, true);
+          IFPACK2_BLOCKHELPER_TIMER_FENCE(typename BlockHelperDetails::ImplType<MatrixType>::execution_space)
+        }
+      }
+      else {
+        impl_->blockGraph = Teuchos::rcpFromRef(bA->getCrsGraph());
+      }
+    }
+
+    {
       IFPACK2_BLOCKHELPER_TIMER("BlockTriDiContainer::createPartInterfaceBlockTridiagsNormManager");
-      impl_->part_interface  = BlockTriDiContainerDetails::createPartInterface<MatrixType>(impl_->A, partitions_, n_subparts_per_part_);
+      impl_->part_interface  = BlockTriDiContainerDetails::createPartInterface<MatrixType>(impl_->A, impl_->blockGraph, partitions_, n_subparts_per_part_);
       impl_->block_tridiags  = BlockTriDiContainerDetails::createBlockTridiags<MatrixType>(impl_->part_interface);
       impl_->norm_manager    = BlockHelperDetails::NormManager<MatrixType>(impl_->A->getComm());
       IFPACK2_BLOCKHELPER_TIMER_FENCE(typename BlockHelperDetails::ImplType<MatrixType>::execution_space)
     }
+
     // We assume that if you called this method, you intend to recompute
     // everything.
     this->IsComputed_ = false;
@@ -252,7 +281,9 @@ namespace Ifpack2 {
     {
       BlockTriDiContainerDetails::performSymbolicPhase<MatrixType>
         (impl_->A, 
-         impl_->part_interface, impl_->block_tridiags, 
+         impl_->blockGraph, 
+         impl_->part_interface, 
+         impl_->block_tridiags, 
          impl_->a_minus_d, 
          impl_->overlap_communication_and_computation);    
     }
@@ -270,7 +301,8 @@ namespace Ifpack2 {
       this->initialize();
     {
       BlockTriDiContainerDetails::performNumericPhase<MatrixType>
-        (impl_->A, 
+        (impl_->A,
+         impl_->blockGraph, 
          impl_->part_interface, impl_->block_tridiags, 
          Kokkos::ArithTraits<magnitude_type>::zero());
     }
@@ -303,6 +335,7 @@ namespace Ifpack2 {
 
     BlockTriDiContainerDetails::applyInverseJacobi<MatrixType>
       (impl_->A,
+       impl_->blockGraph,
        impl_->tpetra_importer, 
        impl_->async_importer, 
        impl_->overlap_communication_and_computation,
@@ -337,7 +370,8 @@ namespace Ifpack2 {
       this->initialize();
     {
       BlockTriDiContainerDetails::performNumericPhase<MatrixType>
-        (impl_->A, 
+        (impl_->A,
+         impl_->blockGraph, 
          impl_->part_interface, impl_->block_tridiags, 
          in.addRadiallyToDiagonal);
     }
@@ -366,6 +400,7 @@ namespace Ifpack2 {
     {
       r_val = BlockTriDiContainerDetails::applyInverseJacobi<MatrixType>
         (impl_->A,
+         impl_->blockGraph,
          impl_->tpetra_importer, 
          impl_->async_importer,
          impl_->overlap_communication_and_computation,

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -2866,9 +2866,6 @@ namespace Ifpack2 {
             A_values = const_cast<block_crs_matrix_type*>(A_bcrs.get())->getValuesDeviceNonConst();
           }
           else {
-#ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_PRINTF
-            printf("A->getLocalNumRows = %ld, G->getLocalNumRows = %ld, block size = %ld, blocksize= %ld \n",  A_->getLocalNumRows(), G_->getLocalNumRows(), A_->getLocalNumRows()/ G_->getLocalNumRows(), blocksize);
-#endif
             A_point_rowptr = A_crs->getCrsGraph()->getLocalGraphDevice().row_map;
             A_values = A_crs->getLocalValuesDevice (Tpetra::Access::ReadOnly);
           }
@@ -2936,18 +2933,11 @@ namespace Ifpack2 {
             else {
               const size_type pi = kps + j;
 
-#ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_PRINTF
-              printf("Extract pointwise pi = %ld, ri0 + tr = %d, kfs + j = %d\n", pi, ri0[0] + tr, kfs[0] + j);
-#endif  
               for (local_ordinal_type vi=0;vi<npacks;++vi) {
                 const size_type Aj_c = A_colindsub(kfs[vi] + j);
 
                 for (local_ordinal_type ii=0;ii<blocksize;++ii) {
                   auto point_row_offset = A_point_rowptr(lclrow(ri0[vi] + tr)*blocksize + ii);
-
-#ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_PRINTF
-                  printf("lclrow = %ld, Aj_r = %ld, Aj_c = %ld, point_row_offset = %ld, A_values.extent(0) = %ld, point_row_offset + Aj_c*blocksize = %ld\n", lclrow(ri0[vi] + tr), Aj_r, Aj_c, point_row_offset, A_values.extent(0), point_row_offset + Aj_c*blocksize);
-#endif  
 
                   for (local_ordinal_type jj=0;jj<blocksize;++jj) {
                     scalar_values(pi, ii, jj, vi) = A_values(point_row_offset + Aj_c*blocksize + jj);
@@ -3062,9 +3052,6 @@ namespace Ifpack2 {
                 for (local_ordinal_type l=lbeg;l<lend;++l,++j) {
                   const size_type Aj_c = A_colindsub(kfs + j);
                   const size_type pi = kps + j;
-#ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_PRINTF
-                  printf("Extract pi = %ld, ri0 + tr = %d, kfs + j = %d, tr = %d, lbeg = %d, lend = %d, l = %d\n", pi, ri0 + tr, kfs + j, tr, lbeg, lend, l);
-#endif
                   Kokkos::parallel_for
                     (Kokkos::TeamThreadRange(member,blocksize),
                     [&](const local_ordinal_type &ii) {

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -1035,6 +1035,7 @@ namespace Ifpack2 {
 
       auto bA = Teuchos::rcp_dynamic_cast<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_block_crs_matrix_type>(A);
 
+      TEUCHOS_ASSERT(!bA.is_null() || G->getLocalNumRows() != 0);
       const local_ordinal_type blocksize = bA.is_null() ? A->getLocalNumRows() / G->getLocalNumRows() : A->getBlockSize();
       constexpr int vector_length = impl_type::vector_length;
       constexpr int internal_vector_length = impl_type::internal_vector_length;
@@ -1869,6 +1870,7 @@ namespace Ifpack2 {
       auto A_bcrs = Teuchos::rcp_dynamic_cast<const block_crs_matrix_type>(A);
 
       bool hasBlockCrsMatrix = ! A_bcrs.is_null ();
+      TEUCHOS_ASSERT(hasBlockCrsMatrix || g->getLocalNumRows() != 0);
       const local_ordinal_type blocksize = hasBlockCrsMatrix ? A->getBlockSize() : A->getLocalNumRows()/g->getLocalNumRows();
 
       // mirroring to host
@@ -2861,7 +2863,7 @@ namespace Ifpack2 {
 
           hasBlockCrsMatrix = ! A_bcrs.is_null ();
 
-          A_block_rowptr = G_->getLocalGraphDevice().row_map; // not sure about that
+          A_block_rowptr = G_->getLocalGraphDevice().row_map;
           if (hasBlockCrsMatrix) {
             A_values = const_cast<block_crs_matrix_type*>(A_bcrs.get())->getValuesDeviceNonConst();
           }

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -193,15 +193,24 @@ namespace Ifpack2 {
     ///
     template<typename MatrixType>
     typename Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_import_type>
-    createBlockCrsTpetraImporter(const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_block_crs_matrix_type> &A) {
+    createBlockCrsTpetraImporter(const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_row_matrix_type> &A) {
       IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::CreateBlockCrsTpetraImporter");
       using impl_type = BlockHelperDetails::ImplType<MatrixType>;
       using tpetra_map_type = typename impl_type::tpetra_map_type;
       using tpetra_mv_type = typename impl_type::tpetra_block_multivector_type;
       using tpetra_import_type = typename impl_type::tpetra_import_type;
+      using crs_matrix_type = typename impl_type::tpetra_crs_matrix_type;
+      using block_crs_matrix_type = typename impl_type::tpetra_block_crs_matrix_type;
 
-      const auto g = A->getCrsGraph();  // tpetra crs graph object
-      const auto blocksize = A->getBlockSize();
+      auto A_crs = Teuchos::rcp_dynamic_cast<const crs_matrix_type>(A);
+      auto A_bcrs = Teuchos::rcp_dynamic_cast<const block_crs_matrix_type>(A);
+
+      bool hasBlockCrsMatrix = ! A_bcrs.is_null ();
+
+      // This is OK here to use the graph of the A_crs matrix and a block size of 1
+      const auto g = hasBlockCrsMatrix ? A_bcrs->getCrsGraph() : *(A_crs->getCrsGraph()); // tpetra crs graph object
+
+      const auto blocksize = hasBlockCrsMatrix ? A_bcrs->getBlockSize() : 1;
       const auto src = Teuchos::rcp(new tpetra_map_type(tpetra_mv_type::makePointMap(*g.getDomainMap(), blocksize)));
       const auto tgt = Teuchos::rcp(new tpetra_map_type(tpetra_mv_type::makePointMap(*g.getColMap()   , blocksize)));
       IFPACK2_BLOCKHELPER_TIMER_FENCE(typename BlockHelperDetails::ImplType<MatrixType>::execution_space)
@@ -883,15 +892,24 @@ namespace Ifpack2 {
     ///
     template<typename MatrixType>
     Teuchos::RCP<AsyncableImport<MatrixType> >
-    createBlockCrsAsyncImporter(const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_block_crs_matrix_type> &A) {
+    createBlockCrsAsyncImporter(const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_row_matrix_type> &A) {
       using impl_type = BlockHelperDetails::ImplType<MatrixType>;
       using tpetra_map_type = typename impl_type::tpetra_map_type;
       using local_ordinal_type = typename impl_type::local_ordinal_type;
       using global_ordinal_type = typename impl_type::global_ordinal_type;
       using local_ordinal_type_1d_view = typename impl_type::local_ordinal_type_1d_view;
+      using crs_matrix_type = typename impl_type::tpetra_crs_matrix_type;
+      using block_crs_matrix_type = typename impl_type::tpetra_block_crs_matrix_type;
 
-      const auto g = A->getCrsGraph();  // tpetra crs graph object
-      const auto blocksize = A->getBlockSize();
+      auto A_crs = Teuchos::rcp_dynamic_cast<const crs_matrix_type>(A);
+      auto A_bcrs = Teuchos::rcp_dynamic_cast<const block_crs_matrix_type>(A);
+
+      bool hasBlockCrsMatrix = ! A_bcrs.is_null ();
+
+      // This is OK here to use the graph of the A_crs matrix and a block size of 1
+      const auto g = hasBlockCrsMatrix ? A_bcrs->getCrsGraph() : *(A_crs->getCrsGraph()); // tpetra crs graph object
+
+      const auto blocksize = hasBlockCrsMatrix ? A_bcrs->getBlockSize() : 1;
       const auto domain_map = g.getDomainMap();
       const auto column_map = g.getColMap();
 
@@ -1004,7 +1022,8 @@ namespace Ifpack2 {
     ///
     template<typename MatrixType>
     BlockHelperDetails::PartInterface<MatrixType>
-    createPartInterface(const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_block_crs_matrix_type> &A,
+    createPartInterface(const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_row_matrix_type> &A,
+                        const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_crs_graph_type> &G,
                         const Teuchos::Array<Teuchos::Array<typename BlockHelperDetails::ImplType<MatrixType>::local_ordinal_type> > &partitions,
                         const typename BlockHelperDetails::ImplType<MatrixType>::local_ordinal_type n_subparts_per_part_in) {
       IFPACK2_BLOCKHELPER_TIMER("createPartInterface");
@@ -1014,7 +1033,9 @@ namespace Ifpack2 {
       using local_ordinal_type_2d_view = typename impl_type::local_ordinal_type_2d_view;
       using size_type = typename impl_type::size_type;
 
-      const auto blocksize = A->getBlockSize();
+      auto bA = Teuchos::rcp_dynamic_cast<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_block_crs_matrix_type>(A);
+
+      const local_ordinal_type blocksize = bA.is_null() ? A->getLocalNumRows() / G->getLocalNumRows() : A->getBlockSize();
       constexpr int vector_length = impl_type::vector_length;
       constexpr int internal_vector_length = impl_type::internal_vector_length;
 
@@ -1023,7 +1044,7 @@ namespace Ifpack2 {
       BlockHelperDetails::PartInterface<MatrixType> interf;
 
       const bool jacobi = partitions.size() == 0;
-      const local_ordinal_type A_n_lclrows = A->getLocalNumRows();
+      const local_ordinal_type A_n_lclrows = G->getLocalNumRows();
       const local_ordinal_type nparts = jacobi ? A_n_lclrows : partitions.size();
 
       typedef std::pair<local_ordinal_type,local_ordinal_type> size_idx_pair_type;
@@ -1817,7 +1838,8 @@ namespace Ifpack2 {
     ///
     template<typename MatrixType>
     void
-    performSymbolicPhase(const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_block_crs_matrix_type> &A,
+    performSymbolicPhase(const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_row_matrix_type> &A,
+                         const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_crs_graph_type> &g,
                          const BlockHelperDetails::PartInterface<MatrixType> &interf,
                          BlockTridiags<MatrixType> &btdm,
                          BlockHelperDetails::AmD<MatrixType> &amd,
@@ -1836,15 +1858,18 @@ namespace Ifpack2 {
       using size_type_1d_view = typename impl_type::size_type_1d_view;
       using vector_type_3d_view = typename impl_type::vector_type_3d_view;
       using vector_type_4d_view = typename impl_type::vector_type_4d_view;
+      using crs_matrix_type = typename impl_type::tpetra_crs_matrix_type;
       using block_crs_matrix_type = typename impl_type::tpetra_block_crs_matrix_type;
 
       constexpr int vector_length = impl_type::vector_length;
 
       const auto comm = A->getRowMap()->getComm();
 
-      const auto& g = A->getCrsGraph();
+      auto A_crs = Teuchos::rcp_dynamic_cast<const crs_matrix_type>(A);
+      auto A_bcrs = Teuchos::rcp_dynamic_cast<const block_crs_matrix_type>(A);
 
-      const auto blocksize = A->getBlockSize();
+      bool hasBlockCrsMatrix = ! A_bcrs.is_null ();
+      const local_ordinal_type blocksize = hasBlockCrsMatrix ? A->getBlockSize() : A->getLocalNumRows()/g->getLocalNumRows();
 
       // mirroring to host
       const auto partptr = Kokkos::create_mirror_view_and_copy     (Kokkos::HostSpace(), interf.partptr);
@@ -1861,9 +1886,9 @@ namespace Ifpack2 {
       
       Kokkos::deep_copy(col2row, Teuchos::OrdinalTraits<local_ordinal_type>::invalid());
       {
-        const auto rowmap = g.getRowMap();
-        const auto colmap = g.getColMap();
-        const auto dommap = g.getDomainMap();
+        const auto rowmap = g->getRowMap();
+        const auto colmap = g->getColMap();
+        const auto dommap = g->getDomainMap();
         TEUCHOS_ASSERT( !(rowmap.is_null() || colmap.is_null() || dommap.is_null()));
 
 #if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__) && !defined(__SYCL_DEVICE_ONLY__)
@@ -1888,7 +1913,7 @@ namespace Ifpack2 {
 
       // construct the D and R graphs in A = D + R.
       {
-        const auto local_graph = g.getLocalGraphHost();
+        const auto local_graph = g->getLocalGraphHost();
         const auto local_graph_rowptr = local_graph.row_map;
         TEUCHOS_ASSERT(local_graph_rowptr.size() == static_cast<size_t>(nrows + 1));
         const auto local_graph_colidx = local_graph.entries;
@@ -2116,8 +2141,11 @@ namespace Ifpack2 {
           }
 
           // Allocate or view values.
-          amd.tpetra_values = (const_cast<block_crs_matrix_type*>(A.get())->getValuesDeviceNonConst());
-                               
+          if (hasBlockCrsMatrix)
+            amd.tpetra_values = (const_cast<block_crs_matrix_type*>(A_bcrs.get())->getValuesDeviceNonConst());
+          else {
+            amd.tpetra_values = (const_cast<crs_matrix_type*>(A_crs.get()))->getLocalValuesDevice (Tpetra::Access::ReadWrite);
+          }
         }
 
         // Allocate view for E and initialize the values with B:
@@ -2713,7 +2741,8 @@ namespace Ifpack2 {
       using impl_scalar_type = typename impl_type::impl_scalar_type;
       using magnitude_type = typename impl_type::magnitude_type;
       /// tpetra interface
-      using block_crs_matrix_type = typename impl_type::tpetra_block_crs_matrix_type;
+      using row_matrix_type = typename impl_type::tpetra_row_matrix_type;
+      using crs_graph_type = typename impl_type::tpetra_crs_graph_type;
       /// views
       using local_ordinal_type_1d_view = typename impl_type::local_ordinal_type_1d_view;
       using local_ordinal_type_2d_view = typename impl_type::local_ordinal_type_2d_view;
@@ -2746,8 +2775,9 @@ namespace Ifpack2 {
       const local_ordinal_type max_partsz;
       // block crs matrix (it could be Kokkos::UVMSpace::size_type, which is int)
       using size_type_1d_view_tpetra = Kokkos::View<size_t*,typename impl_type::node_device_type>;
-      const ConstUnmanaged<size_type_1d_view_tpetra> A_rowptr;
-      const ConstUnmanaged<impl_scalar_type_1d_view_tpetra> A_values;
+      ConstUnmanaged<size_type_1d_view_tpetra> A_block_rowptr;
+      ConstUnmanaged<size_type_1d_view_tpetra> A_point_rowptr;
+      ConstUnmanaged<impl_scalar_type_1d_view_tpetra> A_values;
       // block tridiags
       const ConstUnmanaged<size_type_2d_view> pack_td_ptr, flat_td_ptr, pack_td_ptr_schur;
       const ConstUnmanaged<local_ordinal_type_1d_view> A_colindsub;
@@ -2762,10 +2792,13 @@ namespace Ifpack2 {
       const local_ordinal_type vector_loop_size;
       const local_ordinal_type vector_length_value;
 
+      bool hasBlockCrsMatrix;
+
     public:
       ExtractAndFactorizeTridiags(const BlockTridiags<MatrixType> &btdm_,
                                   const BlockHelperDetails::PartInterface<MatrixType> &interf_,
-                                  const Teuchos::RCP<const block_crs_matrix_type> &A_,
+                                  const Teuchos::RCP<const row_matrix_type> &A_,
+                                  const Teuchos::RCP<const crs_graph_type> &G_,
                                   const magnitude_type& tiny_) :
         // interface
         partptr(interf_.partptr),
@@ -2777,9 +2810,6 @@ namespace Ifpack2 {
         part2packrowidx0_sub(interf_.part2packrowidx0_sub),
         packindices_schur(interf_.packindices_schur),
         max_partsz(interf_.max_partsz),
-        // block crs matrix
-        A_rowptr(A_->getCrsGraph().getLocalGraphDevice().row_map),
-        A_values(const_cast<block_crs_matrix_type*>(A_.get())->getValuesDeviceNonConst()),
         // block tridiags
         pack_td_ptr(btdm_.pack_td_ptr),
         flat_td_ptr(btdm_.flat_td_ptr),
@@ -2822,7 +2852,27 @@ namespace Ifpack2 {
         // diagonal weight to avoid zero pivots
         tiny(tiny_),
         vector_loop_size(vector_length/internal_vector_length),
-        vector_length_value(vector_length) {}
+        vector_length_value(vector_length) {
+          using crs_matrix_type = typename impl_type::tpetra_crs_matrix_type;
+          using block_crs_matrix_type = typename impl_type::tpetra_block_crs_matrix_type;
+
+          auto A_crs = Teuchos::rcp_dynamic_cast<const crs_matrix_type>(A_);
+          auto A_bcrs = Teuchos::rcp_dynamic_cast<const block_crs_matrix_type>(A_);
+
+          hasBlockCrsMatrix = ! A_bcrs.is_null ();
+
+          A_block_rowptr = G_->getLocalGraphDevice().row_map; // not sure about that
+          if (hasBlockCrsMatrix) {
+            A_values = const_cast<block_crs_matrix_type*>(A_bcrs.get())->getValuesDeviceNonConst();
+          }
+          else {
+#ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_PRINTF
+            printf("A->getLocalNumRows = %ld, G->getLocalNumRows = %ld, block size = %ld, blocksize= %ld \n",  A_->getLocalNumRows(), G_->getLocalNumRows(), A_->getLocalNumRows()/ G_->getLocalNumRows(), blocksize);
+#endif
+            A_point_rowptr = A_crs->getCrsGraph()->getLocalGraphDevice().row_map;
+            A_values = A_crs->getLocalValuesDevice (Tpetra::Access::ReadOnly);
+          }
+        }
 
     private:
 
@@ -2861,25 +2911,51 @@ namespace Ifpack2 {
 #endif
         for (local_ordinal_type tr=tr_min,j=0;tr<tr_max;++tr) {
           for (local_ordinal_type e=0;e<3;++e) {
-            const impl_scalar_type* block[vector_length] = {};
-            for (local_ordinal_type vi=0;vi<npacks;++vi) {
-              const size_type Aj = A_rowptr(lclrow(ri0[vi] + tr)) + A_colindsub(kfs[vi] + j);
-              block[vi] = &A_values(Aj*blocksize_square);
-            }
-            const size_type pi = kps + j;
+            if (hasBlockCrsMatrix) {
+              const impl_scalar_type* block[vector_length] = {};
+              for (local_ordinal_type vi=0;vi<npacks;++vi) {
+                const size_type Aj = A_block_rowptr(lclrow(ri0[vi] + tr)) + A_colindsub(kfs[vi] + j);
+
+                block[vi] = &A_values(Aj*blocksize_square);
+              }
+              const size_type pi = kps + j;
 #ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_PRINTF
-            printf("Extract pi = %ld, ri0 + tr = %d, kfs + j = %d\n", pi, ri0[0] + tr, kfs[0] + j);
+              printf("Extract pi = %ld, ri0 + tr = %d, kfs + j = %d\n", pi, ri0[0] + tr, kfs[0] + j);
 #endif            
-            ++j;
-            for (local_ordinal_type ii=0;ii<blocksize;++ii) {
-              for (local_ordinal_type jj=0;jj<blocksize;++jj) {
-                const auto idx = tlb::getFlatIndex(ii, jj, blocksize);
-                auto& v = internal_vector_values(pi, ii, jj, 0);
-                for (local_ordinal_type vi=0;vi<npacks;++vi)
-                  v[vi] = static_cast<btdm_scalar_type>(block[vi][idx]);
+              ++j;            
+              for (local_ordinal_type ii=0;ii<blocksize;++ii) {
+                for (local_ordinal_type jj=0;jj<blocksize;++jj) {
+                  const auto idx = tlb::getFlatIndex(ii, jj, blocksize);
+                  auto& v = internal_vector_values(pi, ii, jj, 0);
+                  for (local_ordinal_type vi=0;vi<npacks;++vi) {
+                    v[vi] = static_cast<btdm_scalar_type>(block[vi][idx]);
+                  }
+                }
               }
             }
+            else {
+              const size_type pi = kps + j;
 
+#ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_PRINTF
+              printf("Extract pointwise pi = %ld, ri0 + tr = %d, kfs + j = %d\n", pi, ri0[0] + tr, kfs[0] + j);
+#endif  
+              for (local_ordinal_type vi=0;vi<npacks;++vi) {
+                const size_type Aj_c = A_colindsub(kfs[vi] + j);
+
+                for (local_ordinal_type ii=0;ii<blocksize;++ii) {
+                  auto point_row_offset = A_point_rowptr(lclrow(ri0[vi] + tr)*blocksize + ii);
+
+#ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_PRINTF
+                  printf("lclrow = %ld, Aj_r = %ld, Aj_c = %ld, point_row_offset = %ld, A_values.extent(0) = %ld, point_row_offset + Aj_c*blocksize = %ld\n", lclrow(ri0[vi] + tr), Aj_r, Aj_c, point_row_offset, A_values.extent(0), point_row_offset + Aj_c*blocksize);
+#endif  
+
+                  for (local_ordinal_type jj=0;jj<blocksize;++jj) {
+                    scalar_values(pi, ii, jj, vi) = A_values(point_row_offset + Aj_c*blocksize + jj);
+                  }
+                }
+              }
+              ++j;
+            }
             if (nrows[0] == 1) break;
             if (local_subpartidx % 2 == 0) {
               if (e == 1 && (tr == 0 || tr+1 == nrows[0])) break;
@@ -2965,20 +3041,39 @@ namespace Ifpack2 {
                   lend = 1;
                 }
               }
-              for (local_ordinal_type l=lbeg;l<lend;++l,++j) {
-                const size_type Aj = A_rowptr(lclrow(ri0 + tr)) + A_colindsub(kfs + j);
-                const impl_scalar_type* block = &A_values(Aj*blocksize_square);
-                const size_type pi = kps + j;
+              if (hasBlockCrsMatrix) {
+                for (local_ordinal_type l=lbeg;l<lend;++l,++j) {
+                  const size_type Aj = A_block_rowptr(lclrow(ri0 + tr)) + A_colindsub(kfs + j);
+                  const impl_scalar_type* block = &A_values(Aj*blocksize_square);
+                  const size_type pi = kps + j;
 #ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_PRINTF
-                printf("Extract pi = %ld, ri0 + tr = %d, kfs + j = %d, tr = %d, lbeg = %d, lend = %d, l = %d\n", pi, ri0 + tr, kfs + j, tr, lbeg, lend, l);
+                  printf("Extract pi = %ld, ri0 + tr = %d, kfs + j = %d, tr = %d, lbeg = %d, lend = %d, l = %d\n", pi, ri0 + tr, kfs + j, tr, lbeg, lend, l);
 #endif
-                Kokkos::parallel_for
-                  (Kokkos::TeamThreadRange(member,blocksize),
-                   [&](const local_ordinal_type &ii) {
-                    for (local_ordinal_type jj=0;jj<blocksize;++jj) {
-                      scalar_values(pi, ii, jj, v) = static_cast<btdm_scalar_type>(block[tlb::getFlatIndex(ii,jj,blocksize)]);
-                    }
-                  });
+                  Kokkos::parallel_for
+                    (Kokkos::TeamThreadRange(member,blocksize),
+                    [&](const local_ordinal_type &ii) {
+                      for (local_ordinal_type jj=0;jj<blocksize;++jj) {
+                        scalar_values(pi, ii, jj, v) = static_cast<btdm_scalar_type>(block[tlb::getFlatIndex(ii,jj,blocksize)]);
+                      }
+                    });
+                }
+              }
+              else {
+                for (local_ordinal_type l=lbeg;l<lend;++l,++j) {
+                  const size_type Aj_c = A_colindsub(kfs + j);
+                  const size_type pi = kps + j;
+#ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_PRINTF
+                  printf("Extract pi = %ld, ri0 + tr = %d, kfs + j = %d, tr = %d, lbeg = %d, lend = %d, l = %d\n", pi, ri0 + tr, kfs + j, tr, lbeg, lend, l);
+#endif
+                  Kokkos::parallel_for
+                    (Kokkos::TeamThreadRange(member,blocksize),
+                    [&](const local_ordinal_type &ii) {
+                      auto point_row_offset = A_point_rowptr(lclrow(ri0 + tr)*blocksize + ii);
+                      for (local_ordinal_type jj=0;jj<blocksize;++jj) {
+                        scalar_values(pi, ii, jj, v) = A_values(point_row_offset + Aj_c*blocksize + jj);
+                      }
+                    });
+                }
               }
             }
           }
@@ -3478,12 +3573,13 @@ namespace Ifpack2 {
     ///
     template<typename MatrixType>
     void
-    performNumericPhase(const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_block_crs_matrix_type> &A,
+    performNumericPhase(const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_row_matrix_type> &A,
+                        const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_crs_graph_type> &G,
                         const BlockHelperDetails::PartInterface<MatrixType> &interf,
                         BlockTridiags<MatrixType> &btdm,
                         const typename BlockHelperDetails::ImplType<MatrixType>::magnitude_type tiny) {
       IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NumericPhase");
-      ExtractAndFactorizeTridiags<MatrixType> function(btdm, interf, A, tiny);
+      ExtractAndFactorizeTridiags<MatrixType> function(btdm, interf, A, G, tiny);
       function.run();
       IFPACK2_BLOCKHELPER_TIMER_FENCE(typename BlockHelperDetails::ImplType<MatrixType>::execution_space)
     }
@@ -4736,7 +4832,8 @@ namespace Ifpack2 {
     template<typename MatrixType>
     int
     applyInverseJacobi(// importer
-                       const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_block_crs_matrix_type> &A,
+                       const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_row_matrix_type> &A,
+                       const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_crs_graph_type> &G,
                        const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_import_type> &tpetra_importer,
                        const Teuchos::RCP<AsyncableImport<MatrixType> > &async_importer,
                        const bool overlap_communication_and_computation,
@@ -4838,8 +4935,18 @@ namespace Ifpack2 {
                                                damping_factor, is_norm_manager_active);
 
       const local_ordinal_type_1d_view dummy_local_ordinal_type_1d_view;
+
+
+      auto A_crs = Teuchos::rcp_dynamic_cast<const typename impl_type::tpetra_crs_matrix_type>(A);
+      auto A_bcrs = Teuchos::rcp_dynamic_cast<const typename impl_type::tpetra_block_crs_matrix_type>(A);
+
+      bool hasBlockCrsMatrix = ! A_bcrs.is_null ();
+
+      // This is OK here to use the graph of the A_crs matrix and a block size of 1
+      const auto g = hasBlockCrsMatrix ? A_bcrs->getCrsGraph() : *(A_crs->getCrsGraph()); // tpetra crs graph object
+
       BlockHelperDetails::ComputeResidualVector<MatrixType>
-        compute_residual_vector(amd, A->getCrsGraph().getLocalGraphDevice(), blocksize, interf,
+        compute_residual_vector(amd, G->getLocalGraphDevice(), g.getLocalGraphDevice(), blocksize, interf,
                                 is_async_importer_active ? async_importer->dm2cm : dummy_local_ordinal_type_1d_view);
 
       // norm manager workspace resize
@@ -4923,7 +5030,8 @@ namespace Ifpack2 {
       using async_import_type = AsyncableImport<MatrixType>;
 
       // distructed objects
-      Teuchos::RCP<const typename impl_type::tpetra_block_crs_matrix_type> A;
+      Teuchos::RCP<const typename impl_type::tpetra_row_matrix_type> A;
+      Teuchos::RCP<const typename impl_type::tpetra_crs_graph_type> blockGraph;
       Teuchos::RCP<const typename impl_type::tpetra_import_type> tpetra_importer;
       Teuchos::RCP<async_import_type> async_importer;
       bool overlap_communication_and_computation;

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockTriDiContainer.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockTriDiContainer.cpp
@@ -280,32 +280,36 @@ static LO run_teuchos_tests (const Input& in, Teuchos::FancyOStream& out, bool& 
             if (seq_method && overlap_comm) continue;
             for (const bool nonuniform_lines : {false, true}) {
               for (const bool pointwise : {false, true}) {
-                if (jacobi && nonuniform_lines) continue;
-                for (const int nvec : {1, 3}) {
-                  std::stringstream ss;
-                  ss << "test_BR_BTDC:"
-                    << " bs " << bs
-                    << (contiguous ? " contig" : " noncontig")
-                    << (jacobi ? " jacobi" : " tridiag")
-                    << (seq_method ? " seq_method" : "")
-                    << (overlap_comm ? " overlap_comm" : "")
-                    << (pointwise ? " point_wise" : "")
-                    << (nonuniform_lines ? " nonuniform_lines" : " uniform_lines")
-                    << " nvec " << nvec;
-                  const std::string details = ss.str();
-                  bool threw = false;
-                  try {
-                    ne = btdct::test_BR_BTDC(in.comm, sb, sbp, bs, nvec, nonuniform_lines,
-                                            different_maps, jacobi, overlap_comm, seq_method, pointwise,
-                                            details);
-                    nerr += ne;
-                  } catch (const std::exception& e) {
-                    threw = true;
-                  }
-                  if (threw)
-                    printf("Exception threw from rank %d, %s\n", in.comm->getRank(), details.c_str());
+                for (const bool explicitConversion : {false, true}) {
+                  if (jacobi && nonuniform_lines) continue;
+                  if (!pointwise && explicitConversion) continue;
+                  for (const int nvec : {1, 3}) {
+                    std::stringstream ss;
+                    ss << "test_BR_BTDC:"
+                      << " bs " << bs
+                      << (contiguous ? " contig" : " noncontig")
+                      << (jacobi ? " jacobi" : " tridiag")
+                      << (seq_method ? " seq_method" : "")
+                      << (overlap_comm ? " overlap_comm" : "")
+                      << (pointwise ? " point_wise" : "")
+                      << (explicitConversion ? " explicit_block_conversion" : "")
+                      << (nonuniform_lines ? " nonuniform_lines" : " uniform_lines")
+                      << " nvec " << nvec;
+                    const std::string details = ss.str();
+                    bool threw = false;
+                    try {
+                      ne = btdct::test_BR_BTDC(in.comm, sb, sbp, bs, nvec, nonuniform_lines,
+                                              different_maps, jacobi, overlap_comm, seq_method, pointwise,
+                                              explicitConversion, details);
+                      nerr += ne;
+                    } catch (const std::exception& e) {
+                      threw = true;
+                    }
+                    if (threw)
+                      printf("Exception threw from rank %d, %s\n", in.comm->getRank(), details.c_str());
 
-                  TEUCHOS_TEST(ne == 0 && ! threw, details);
+                    TEUCHOS_TEST(ne == 0 && ! threw, details);
+                  }
                 }
               }
             }

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockTriDiContainerUtil.hpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockTriDiContainerUtil.hpp
@@ -159,7 +159,8 @@ struct BlockTriDiContainerTester {
                 const bool nonuniform_lines = false,
                 const bool zero_starting_soln = true,
                 const int num_sweeps = 1,
-                const bool jacobi = false) {
+                const bool jacobi = false,
+                const bool explicitConversion = false) {
     Teuchos::Array<Teuchos::ArrayRCP<LO> > parts;
     // make_parts modifies entries of A so the call to convertToCrsMatrix
     // needs to happen after make_parts
@@ -178,6 +179,7 @@ struct BlockTriDiContainerTester {
       p.set("partitioner: parts", parts);
       p.set("partitioner: subparts per part", 1);
       p.set("partitioner: block size", A->getBlockSize());
+      p.set("partitioner: explicit convert to BlockCrs", explicitConversion);
       T->setParameters(p);
     }
     return T;
@@ -207,6 +209,7 @@ struct BlockTriDiContainerTester {
       p.set("partitioner: parts", parts);
       p.set("partitioner: subparts per part", 1);
       p.set("partitioner: block size", -1);
+      p.set("partitioner: explicit convert to BlockCrs", false);
       T->setParameters(p);
     }
     return T;
@@ -219,7 +222,8 @@ struct BlockTriDiContainerTester {
   make_BTDC_PW (const StructuredBlock& sb, const StructuredBlockPart& sbp,
              const Teuchos::RCP<Tpetra_BlockCrsMatrix>& A,
              const bool overlap_comm = false, const bool nonuniform_lines = false,
-             const bool jacobi = false, const bool seq_method = false) {
+             const bool jacobi = false, const bool seq_method = false,
+             const bool explicitConversion = false) {
     Teuchos::Array<Teuchos::Array<LO> > parts;
     // make_parts modifies entries of A so the call to convertToCrsMatrix
     // needs to happen after make_parts
@@ -227,7 +231,7 @@ struct BlockTriDiContainerTester {
     auto A_pw = Tpetra::convertToCrsMatrix(*A);
 
     return Teuchos::rcp(new Ifpack2::BlockTriDiContainer<Tpetra_RowMatrix>(
-                          A_pw, parts, 1, overlap_comm, seq_method, A->getBlockSize()));
+                          A_pw, parts, 1, overlap_comm, seq_method, A->getBlockSize(), explicitConversion));
   }
 
   // Make a bare BlockTriDiContainer.
@@ -248,7 +252,8 @@ struct BlockTriDiContainerTester {
                 const StructuredBlock& sb, const StructuredBlockPart& sbp,
                 const Int bs, const Int nvec, const bool nonuniform_lines,
                 const bool different_maps, const bool jacobi, const bool overlap_comm,
-                const bool seq_method, const bool pointwise, const std::string& details) {
+                const bool seq_method, const bool pointwise, const bool explicitConversion, 
+                const std::string& details) {
 #define TEST_BR_BTDC_FAIL(msg) do {             \
       ++nerr;                                   \
       if (comm->getRank() == 0) {               \
@@ -286,13 +291,13 @@ struct BlockTriDiContainerTester {
       const Magnitude tol = 1e-3;
       const auto T_br = use_br ?
         ( pointwise ?
-          make_BR_BTDC_PW(sb, sbp, A, nonuniform_lines, zero_starting, num_sweeps, jacobi): 
+          make_BR_BTDC_PW(sb, sbp, A, nonuniform_lines, zero_starting, num_sweeps, jacobi, explicitConversion): 
           make_BR_BTDC(sb, sbp, A, nonuniform_lines, zero_starting, num_sweeps, jacobi) 
         ):
         Teuchos::null;
       const auto T_bare = use_br ? Teuchos::null :
         ( pointwise ?
-          make_BTDC_PW(sb, sbp, A, overlap_comm, nonuniform_lines, jacobi, seq_method): 
+          make_BTDC_PW(sb, sbp, A, overlap_comm, nonuniform_lines, jacobi, seq_method, explicitConversion): 
           make_BTDC(sb, sbp, A, overlap_comm, nonuniform_lines, jacobi, seq_method) 
         );
       if ( ! T_br.is_null()) {


### PR DESCRIPTION
This PR adds the option to use point crs matrices with BTDS without converting them to block ones explicitly.

This has been tried on Weaver and on Intel CPUs.