### PR TITLE
KokkosKernels: disable cuBLAS dot wrapper

### DIFF
--- a/packages/kokkos-kernels/blas/tpls/KokkosBlas1_dot_tpl_spec_avail.hpp
+++ b/packages/kokkos-kernels/blas/tpls/KokkosBlas1_dot_tpl_spec_avail.hpp
@@ -89,8 +89,14 @@ KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL_BLAS(Kokkos::complex<float>, Kokkos::LayoutLeft,
   KOKKOSBLAS1_DOT_TPL_SPEC(Kokkos::complex<double>, LAYOUT, EXECSPACE, MEMSPACE)
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
+// Note BMK: CUBLAS dot is consistently slower than our native dot
+// (measured 11.2, 11.8, 12.0 using perf test, and all are similar)
+// If a future version improves performance, re-enable it here and
+// in the tpl_spec_decl file.
+#if 0
 KOKKOSBLAS1_DOT_TPL_SPEC_AVAIL(Kokkos::LayoutLeft, Kokkos::Cuda,
                                Kokkos::CudaSpace)
+#endif
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCBLAS

--- a/packages/kokkos-kernels/blas/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/blas/tpls/KokkosBlas1_dot_tpl_spec_decl.hpp
@@ -101,6 +101,9 @@ KOKKOSBLAS1_DOT_TPL_SPEC_DECL_BLAS_EXT(false)
 
 // cuBLAS
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
+// Disabled because native has better performance.
+// See tpl_spec_avail file for more details
+#if 0
 #include <KokkosBlas_tpl_spec.hpp>
 
 namespace KokkosBlas {
@@ -173,6 +176,7 @@ KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS_EXT(true)
 KOKKOSBLAS1_DOT_TPL_SPEC_DECL_CUBLAS_EXT(false)
 }  // namespace Impl
 }  // namespace KokkosBlas
+#endif
 #endif
 
 // rocBLAS


### PR DESCRIPTION
It performs worse than our native impl.
See https://github.com/kokkos/kokkos-kernels/pull/2206 for details (this PR applies exactly the same changes)

@ndellingwood Heads up about another patch (this one probably shouldn't wait for the next release either)
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation
Changes in KokkosKernels 4.3.0 enabled TPLs for ``KokkosBlas::dot`` in more cases. This was good for HIP/rocBLAS, but it turned out to be bad for CUDA/cuBLAS. This showed up on the performance dashboard for PerformanceCGSolve. I separately used the KK dot perftest to check CUDA versions 11.2, 11.8 and 12.0 and for all of them, cuBLAS dot was slower than KK native.

## Related Issues
Fixes #12982. Turns out axpby was fine - the axpby time just appeared to increase because of kernels being async. But loading the Kokkos simple kernel timer showed that the regression was really just in dot.
