### PR TITLE
Framework: Change all `python` invocations to `python3`

### DIFF
--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """
 This file contains the base class for the Pull Request test driver.

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationInstallation.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationInstallation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """
 Custom PR Executor for Installation testing

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """
 Custom PR Executor for Standard testing

--- a/packages/framework/pr_tools/trilinosprhelpers/__init__.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 
 from .sysinfo import *

--- a/packages/framework/pr_tools/trilinosprhelpers/gitutility/GitUtility.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/gitutility/GitUtility.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """
 This class contains a set of utilities for using and querying

--- a/packages/framework/pr_tools/trilinosprhelpers/gitutility/unittests/__init__.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/gitutility/unittests/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 This file is required to enable Python to locate the package files in the parent

--- a/packages/framework/pr_tools/trilinosprhelpers/gitutility/unittests/test_GitUtility.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/gitutility/unittests/test_GitUtility.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8; mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """
 """

--- a/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/EnvvarHelper.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/EnvvarHelper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """
 """

--- a/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/JenkinsEnv.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/JenkinsEnv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 from .EnvvarHelper import EnvvarHelper
 

--- a/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/TrilinosJenkinsEnv.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/TrilinosJenkinsEnv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 from .JenkinsEnv import JenkinsEnv
 

--- a/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/__init__.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 
 from .EnvvarHelper import EnvvarHelper

--- a/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/unittests/__init__.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/unittests/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 This file is required to enable Python to locate the package files in the parent

--- a/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/unittests/test_EnvvarHelper.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/unittests/test_EnvvarHelper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8; mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """
 """

--- a/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/unittests/test_JenkinsEnv.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/unittests/test_JenkinsEnv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8; mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """
 """

--- a/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/unittests/test_TrilinosJenkinsEnv.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/jenkinsenv/unittests/test_TrilinosJenkinsEnv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8; mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """
 """

--- a/packages/framework/pr_tools/trilinosprhelpers/sysinfo/SysInfo.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/sysinfo/SysInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """
 System information helpers are contained in this file.

--- a/packages/framework/pr_tools/trilinosprhelpers/sysinfo/unittests/__init__.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/sysinfo/unittests/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 This file is required to enable Python to locate the package files in the parent

--- a/packages/framework/pr_tools/trilinosprhelpers/sysinfo/unittests/test_SysInfo.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/sysinfo/unittests/test_SysInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8; mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """
 """

--- a/packages/framework/pr_tools/trilinosprhelpers/sysinfo/unittests/test_gpu_utils.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/sysinfo/unittests/test_gpu_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8; mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """
 """

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/__init__.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 This file is required to enable Python to locate the package files in the parent

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8; mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """
 """

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationInstallation.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationInstallation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8; mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """
 """

--- a/packages/framework/pr_tools/unittests/__init__.py
+++ b/packages/framework/pr_tools/unittests/__init__.py
@@ -1,3 +1,3 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 

--- a/packages/panzer/adapters-stk/example/CurlLaplacianExample/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/CurlLaplacianExample/CMakeLists.txt
@@ -60,7 +60,7 @@ FOREACH( ORDER 1 2 3 4 )
       PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
       NUM_MPI_PROCS 4
       OUTPUT_FILE MPE-ConvTest-Quad-${ORDER}-32
-    TEST_4 CMND python
+    TEST_4 CMND python3
       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
            ${ORDER}
            MPE-ConvTest-Quad-${ORDER}-
@@ -92,7 +92,7 @@ FOREACH( ORDER 1 )
       PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
       NUM_MPI_PROCS 4
       OUTPUT_FILE MPE-Multiblock-ConvTest-Quad-${ORDER}-32
-    TEST_3 CMND python
+    TEST_3 CMND python3
       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
            ${ORDER}
            MPE-Multiblock-ConvTest-Quad-${ORDER}-
@@ -128,7 +128,7 @@ ENDFOREACH()
 #       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
 #       NUM_MPI_PROCS 4
 #       OUTPUT_FILE MPE-ConvTest-Tri-${ORDER}-32
-#     TEST_4 CMND python
+#     TEST_4 CMND python3
 #       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
 #            ${ORDER}
 #            MPE-ConvTest-Tri-${ORDER}-
@@ -165,7 +165,7 @@ ENDFOREACH()
 #       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
 #       NUM_MPI_PROCS 4
 #       OUTPUT_FILE MPE-ConvTest-Hex-${ORDER}-32
-#     TEST_4 CMND python
+#     TEST_4 CMND python3
 #       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
 #            ${ORDER}
 #            MPE-ConvTest-Hex-${ORDER}-

--- a/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/MixedCurlLaplacianExample/CMakeLists.txt
@@ -60,7 +60,7 @@ FOREACH( ORDER 1 2 )
       PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
       NUM_MPI_PROCS 4
       OUTPUT_FILE MPE-ConvTest-Quad-${ORDER}-32
-    TEST_4 CMND python
+    TEST_4 CMND python3
       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
            ${ORDER}
            MPE-ConvTest-Quad-${ORDER}-
@@ -92,7 +92,7 @@ FOREACH( ORDER 3 )
       PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
       NUM_MPI_PROCS 4
       OUTPUT_FILE MPE-ConvTest-Quad-${ORDER}-16
-    TEST_4 CMND python
+    TEST_4 CMND python3
       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
            ${ORDER}
            MPE-ConvTest-Quad-${ORDER}-
@@ -123,7 +123,7 @@ FOREACH( ORDER 1 )
       PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
       NUM_MPI_PROCS 4
       OUTPUT_FILE MPE-Multiblock-ConvTest-Quad-${ORDER}-32
-    TEST_3 CMND python
+    TEST_3 CMND python3
       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
            ${ORDER}
            MPE-Multiblock-ConvTest-Quad-${ORDER}-
@@ -159,7 +159,7 @@ FOREACH( ORDER 1 )
       PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
       NUM_MPI_PROCS 4
       OUTPUT_FILE MPE-ConvTest-Tri-${ORDER}-64
-    TEST_4 CMND python
+    TEST_4 CMND python3
       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
            ${ORDER}
            MPE-ConvTest-Tri-${ORDER}-
@@ -191,7 +191,7 @@ FOREACH( ORDER 2 )
       PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
       NUM_MPI_PROCS 4
       OUTPUT_FILE MPE-ConvTest-Tri-${ORDER}-16
-    TEST_3 CMND python
+    TEST_3 CMND python3
       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
            ${ORDER}
            MPE-ConvTest-Tri-${ORDER}-
@@ -227,7 +227,7 @@ ENDFOREACH()
 #       PASS_REGULAR_EXPRESSION "ALL PASSED: Epetra"
 #       NUM_MPI_PROCS 4
 #       OUTPUT_FILE MPE-ConvTest-Hex-${ORDER}-32
-#     TEST_4 CMND python
+#     TEST_4 CMND python3
 #       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
 #            ${ORDER}
 #            MPE-ConvTest-Hex-${ORDER}-

--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/CMakeLists.txt
@@ -59,7 +59,7 @@ FOREACH( ORDER 1 2 3)
       PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
       NUM_MPI_PROCS 4
       OUTPUT_FILE MPE-ConvTest-Hex-p${ORDER}-12
-    TEST_3 CMND python
+    TEST_3 CMND python3
       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
          ${ORDER}
          MPE-ConvTest-Hex-p${ORDER}-
@@ -90,7 +90,7 @@ FOREACH( ORDER 1)
       PASS_REGULAR_EXPRESSION "ALL PASSED: Tpetra"
       NUM_MPI_PROCS 4
       OUTPUT_FILE MPE-Multiblock-ConvTest-Hex-p${ORDER}-12
-    TEST_2 CMND python
+    TEST_2 CMND python3
       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
          ${ORDER}
          MPE-Multiblock-ConvTest-Hex-p${ORDER}-

--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/analyze_performance.py
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/analyze_performance.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 """
 Script for analyzing Panzer kernel performance on next-generation
@@ -12,7 +12,6 @@ __date__    = "Dec 2018"
 
 # Import python modules for command-line options, the operating system, regular
 # expressions, and system functions
-import commands
 import argparse
 import os
 import re

--- a/packages/panzer/adapters-stk/example/PoissonExample/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/PoissonExample/CMakeLists.txt
@@ -47,7 +47,7 @@ FOREACH( ORDER 1 2 3 4 )
       PASS_REGULAR_EXPRESSION "ALL PASSED"
       NUM_MPI_PROCS 4
       OUTPUT_FILE MPE-ConvTest-Quad-p${ORDER}-80
-    TEST_5 CMND python
+    TEST_5 CMND python3
       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
          ${ORDER}
          MPE-ConvTest-Quad-p${ORDER}-
@@ -91,7 +91,7 @@ FOREACH( ORDER 1 2 3 4 )
       PASS_REGULAR_EXPRESSION "ALL PASSED"
       NUM_MPI_PROCS 4
       OUTPUT_FILE MPE-ConvTest-Tri-p${ORDER}-80
-    TEST_5 CMND python
+    TEST_5 CMND python3
       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
          ${ORDER}
          MPE-ConvTest-Tri-p${ORDER}-
@@ -119,7 +119,7 @@ TRIBITS_ADD_ADVANCED_TEST(
     NUM_MPI_PROCS 2
     OUTPUT_FILE PoissonExampleCurvilinear_3_Q1.out
   COMM mpi
-  TEST_2 CMND python
+  TEST_2 CMND python3
   ARGS   ${CMAKE_CURRENT_SOURCE_DIR}/compareWithGold_Curvilinear.py
          ${CMAKE_CURRENT_SOURCE_DIR}/PoissonExampleCurvilinear_3_Q2.gold
          ${CMAKE_CURRENT_SOURCE_DIR}/PoissonExampleCurvilinear_3_Q1.gold

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceExample/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceExample/CMakeLists.txt
@@ -61,7 +61,7 @@ TRIBITS_ADD_ADVANCED_TEST(
     PASS_REGULAR_EXPRESSION "PASS BASICS"
     NUM_MPI_PROCS 4
     OUTPUT_FILE PIE-ConvTest-20
-  TEST_2 CMND python
+  TEST_2 CMND python3
     ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
          PIE-ConvTest-
          10
@@ -82,7 +82,7 @@ TRIBITS_ADD_ADVANCED_TEST(
     PASS_REGULAR_EXPRESSION "PASS BASICS"
     NUM_MPI_PROCS 4
     OUTPUT_FILE PIE-ConvTest-8
-  TEST_2 CMND python
+  TEST_2 CMND python3
     ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
          PIE-ConvTest-
          4

--- a/packages/panzer/adapters-stk/example/PoissonInterfaceTpetra/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/PoissonInterfaceTpetra/CMakeLists.txt
@@ -61,7 +61,7 @@ TRIBITS_ADD_ADVANCED_TEST(
     PASS_REGULAR_EXPRESSION "PASS BASICS"
     NUM_MPI_PROCS 4
     OUTPUT_FILE PIE-ConvTest-20
-  TEST_2 CMND python
+  TEST_2 CMND python3
     ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
          PIE-ConvTest-
          10
@@ -82,7 +82,7 @@ TRIBITS_ADD_ADVANCED_TEST(
     PASS_REGULAR_EXPRESSION "PASS BASICS"
     NUM_MPI_PROCS 4
     OUTPUT_FILE PIE-ConvTest-8
-  TEST_2 CMND python
+  TEST_2 CMND python3
     ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
          PIE-ConvTest-
          4

--- a/packages/panzer/maintenance/replacePanzerEvaluatorMacros.py
+++ b/packages/panzer/maintenance/replacePanzerEvaluatorMacros.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This script will read a file and replace any Panzer Evaluator macros it
 # finds with their contents.


### PR DESCRIPTION
`python2` has been deprecated for a very long time, and we expect `python3`, though we currently access it through `python` in many places.  According to https://peps.python.org/pep-0394/, this is implementation/deployment-specific, and not best practice.

I left any snapshotted packages (e.g. kokkos, compadre) alone, as well as any deprecated packages (e.g. pytrilinos).

I also left the stuff in `cmake` alone, because it appeared to be system-specific, and we (Framework) don't manage those systems.  Tagging @trilinos/muelu since some of those crontabs appear to be theirs.


**This is a potentially-breaking change for backwards-compatibility (though I doubt that will actually manifest).**


@trilinos/framework 

## Motivation
With the transition of many of our test machines to RHEL8+, `python` is no longer installed by default and we do not want to patch the OS to fix this.
