### PR TITLE
Tpetra: fix SYCL mem space name in test

### DIFF
--- a/packages/tpetra/core/test/Comm/gpuAwareMpi.cpp
+++ b/packages/tpetra/core/test/Comm/gpuAwareMpi.cpp
@@ -81,7 +81,7 @@ namespace { // (anonymous)
   typedef Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace> test_device_type;
   typedef Tpetra::KokkosCompat::KokkosHIPWrapperNode test_node_type;
 #elif defined(KOKKOS_ENABLE_SYCL)
-  typedef Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLSpace> test_device_type;
+  typedef Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace> test_device_type;
   typedef Tpetra::KokkosCompat::KokkosSYCLWrapperNode test_node_type;
 #endif
   typedef Tpetra::Map<>::local_ordinal_type LO;


### PR DESCRIPTION
No such thing as SYCLSpace :)
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Fix build with SYCL backend enabled.  Improves compilation and testing on Sunspot/Aurora at ALCF for Office of Science FASTMath/OASYS project.

## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
