### PR TITLE
Ifpack2: Fix a floating point exception error when num_teams=0

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -1050,7 +1050,7 @@ namespace Ifpack2 {
           SolveTridiagsDefaultModeAndAlgo<typename execution_space::memory_space>::
           recommended_team_size(blocksize, vector_length, internal_vector_length);
 
-        const local_ordinal_type num_teams = execution_space().concurrency() / (team_size * vector_length);
+        const local_ordinal_type num_teams = std::max(1, execution_space().concurrency() / (team_size * vector_length));
 
         n_subparts_per_part = getAutomaticNSubparts(nparts, num_teams, line_length, blocksize);
 


### PR DESCRIPTION
When `num_teams == 0`, a floating point exception error is faced in `costSolveSchur`.