### PR TITLE
Tpetra: get accurate timing in CG perf test

### DIFF
--- a/packages/tpetra/core/test/PerformanceCGSolve/cg_solve_file.cpp
+++ b/packages/tpetra/core/test/PerformanceCGSolve/cg_solve_file.cpp
@@ -89,21 +89,26 @@ bool cg_solve (Teuchos::RCP<CrsMatrix> A, Teuchos::RCP<Vector> b, Teuchos::RCP<V
   LO print_freq = max_iter/10;
   print_freq = std::min(print_freq, 50);
   print_freq = std::max(print_freq, 1);
+  Kokkos::fence();
   {
     TimeMonitor t(*TimeMonitor::getNewTimer(addTimerName));
     p->update(1.0,*x,0.0,*x,0.0);
+    Kokkos::fence();
   }
   {
     TimeMonitor t(*TimeMonitor::getNewTimer(matvecTimerName));
     A->apply(*p, *Ap);
+    Kokkos::fence();
   }
   {
     TimeMonitor t(*TimeMonitor::getNewTimer(addTimerName));
     r->update(1.0,*b,-1.0,*Ap,0.0);
+    Kokkos::fence();
   }
   {
     TimeMonitor t(*TimeMonitor::getNewTimer(dotTimerName));
     rtrans = r->dot(*r);
+    Kokkos::fence();
   }
 
   normr = std::sqrt(rtrans);
@@ -118,17 +123,20 @@ bool cg_solve (Teuchos::RCP<CrsMatrix> A, Teuchos::RCP<Vector> b, Teuchos::RCP<V
     if (k == 1) {
         TimeMonitor t(*TimeMonitor::getNewTimer(addTimerName));
         p->update(1.0,*r,0.0);
+        Kokkos::fence();
     }
     else {
       oldrtrans = rtrans;
       {
         TimeMonitor t(*TimeMonitor::getNewTimer(dotTimerName));
         rtrans = r->dot(*r);
+        Kokkos::fence();
       }
       {
         TimeMonitor t(*TimeMonitor::getNewTimer(addTimerName));
         magnitude_type beta = rtrans/oldrtrans;
         p->update(1.0,*r,beta);
+        Kokkos::fence();
       }
     }
     normr = std::sqrt(rtrans);
@@ -141,10 +149,12 @@ bool cg_solve (Teuchos::RCP<CrsMatrix> A, Teuchos::RCP<Vector> b, Teuchos::RCP<V
     {
       TimeMonitor t(*TimeMonitor::getNewTimer(matvecTimerName));
       A->apply(*p, *Ap);
+      Kokkos::fence();
     }
     {
       TimeMonitor t(*TimeMonitor::getNewTimer(dotTimerName));
       p_ap_dot = Ap->dot(*p);
+      Kokkos::fence();
     }
     {
       TimeMonitor t(*TimeMonitor::getNewTimer(addTimerName));
@@ -158,11 +168,14 @@ bool cg_solve (Teuchos::RCP<CrsMatrix> A, Teuchos::RCP<Vector> b, Teuchos::RCP<V
       alpha = rtrans / p_ap_dot;
       x->update(alpha,*p,1.0);
       r->update(-alpha,*Ap,1.0);
+      Kokkos::fence();
     }
   }
   {
+    Kokkos::fence();
     TimeMonitor t(*TimeMonitor::getNewTimer(dotTimerName));
     rtrans = r->dot(*r);
+    Kokkos::fence();
   }
 
   normr = std::sqrt(rtrans);
@@ -266,6 +279,11 @@ int run()
   // The vector x on input is the initial guess for the CG solve.
   // On output, it is the approximate solution.
   RCP<vec_type> x (new vec_type (A->getDomainMap ()));
+
+  // Untimed warm-up apply
+  A->apply(*b, *x);
+  // Zero out x again
+  x->putScalar(0);
 
   // Solve the linear system Ax=b using CG.
   RCP<StackedTimer> timer = rcp(new StackedTimer("CG: global"));


### PR DESCRIPTION
In PerformanceCGSolve:
- Add untimed warmup apply (explained below)
- Add fences between kernels so that all time is attributed to the correct sub-timer

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

- Without a fence in between, time spent in the spmv kernel would spill over into the dot timer.
- Without a warmup apply, the very high cost of the initial rocSPARSE spmv means that the spmv time increased overall for the number of calls done by this test (76).

**In the long run rocSPARSE is 32% faster per call, but with the 1-rank CG matrix it will only break even after 228 apply calls.** It's impossible to know how many applies will be done ahead of time without the user telling us through the spmv handle. There are already options related to this:
- ``SPMV_FAST_SETUP`` calls native instead of rocsparse
- ``SPMV_DEFAULT`` is used by Tpetra CrsMatrix. It ignores setup cost and optimizes for all later calls, so it does call rocsparse

When KokkosKernels 4.3.1 was released and rocSPARSE started getting used, it appeared as a slowdown in the performance dashboard for all the AMD GPU machines.

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->

## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
**Should Teuchos TimeMonitor constructor/destructor do a ``Kokkos::fence`` to fix this problem everywhere?** I used to think Kokkos profiling regions (which are created by Teuchos timers) did this for us but they don't.