### PR TITLE
Framework: Add Clang RHEL8 configuration

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2059,6 +2059,9 @@ use RHEL7_TEST_DISABLES|CLANG
 opt-set-cmake-var SuperLU_LIBRARY_NAMES STRING : superlu;m
 opt-set-cmake-var ML_ENABLE_SuperLU BOOL FORCE : OFF
 
+opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE BOOL : ON
+opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE BOOL : ON
+
 use RHEL7_POST
 
 [rhel8_sems-clang-11.0.1-openmpi-4.0.5-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2035,7 +2035,7 @@ use PACKAGE-ENABLES|ALL
 use rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
-[rhel7_sems-clang-11.0.1-openmpi-1.10.7-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+[rhel8_sems-clang-11.0.1-openmpi-4.0.5-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 # uses sems-v2 modules
 use RHEL7_SEMS_COMPILER|CLANG
 use NODE-TYPE|SERIAL
@@ -2056,11 +2056,14 @@ opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL       : ON
 
 use RHEL7_TEST_DISABLES|CLANG
 
+opt-set-cmake-var SuperLU_LIBRARY_NAMES STRING : superlu;m
+opt-set-cmake-var ML_ENABLE_SuperLU BOOL FORCE : OFF
+
 use RHEL7_POST
 
-[rhel7_sems-clang-11.0.1-openmpi-1.10.7-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+[rhel8_sems-clang-11.0.1-openmpi-4.0.5-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 # uses sems-v2 modules
-use rhel7_sems-clang-11.0.1-openmpi-1.10.7-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use rhel8_sems-clang-11.0.1-openmpi-4.0.5-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel7_sems-intel-19.0.5-mpich-3.2-serial_release-debug_static_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -175,6 +175,7 @@ gnu
 oneapi-intelmpi
 gcc-openmpi
 sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.1.4
+sems-clang-11.0.1-openmpi-4.0.5-serial
 
 [ats2]
 cuda-11.2.152-gnu-8.3.1-spmpi-rolling


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Need to support all PR configurations on RHEL8 as machines transition.

## Testing
I ran a build + test on one of the new RHEL8 machines, and two Pliris random vector tests fail.  Everything else passes.  Those same two tests fail with CUDA, ATS2, and our GCC + OpenMPI container, so I've disabled them here as well.