### PR TITLE
Ifpack2 AdditiveSchwarz & RILUK performance improvements

### DIFF
--- a/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_def.hpp
@@ -55,6 +55,7 @@
 #ifndef IFPACK2_ADDITIVESCHWARZ_DEF_HPP
 #define IFPACK2_ADDITIVESCHWARZ_DEF_HPP
 
+#include "Ifpack2_AdditiveSchwarz_decl.hpp"
 #include "Trilinos_Details_LinearSolverFactory.hpp"
 // We need Ifpack2's implementation of LinearSolver, because we use it
 // to wrap the user-provided Ifpack2::Preconditioner in

--- a/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
@@ -953,9 +953,9 @@ void RBILUK<MatrixType>::compute ()
         "streams are not yet supported.");
 
       auto lclMtx = A_local_bcrs->getLocalMatrixDevice();
-      this->A_local_rowmap_  = lclMtx.graph.row_map;
-      this->A_local_entries_ = lclMtx.graph.entries;
-      this->A_local_values_  = lclMtx.values;
+      auto A_local_rowmap  = lclMtx.graph.row_map;
+      auto A_local_entries = lclMtx.graph.entries;
+      auto A_local_values  = lclMtx.values;
 
       // L_block_->resumeFill ();
       // U_block_->resumeFill ();
@@ -978,7 +978,7 @@ void RBILUK<MatrixType>::compute ()
       auto U_values  = lclU.values;
 
       KokkosSparse::Experimental::spiluk_numeric( KernelHandle_.getRawPtr(), this->LevelOfFill_,
-                                                  this->A_local_rowmap_, this->A_local_entries_, this->A_local_values_,
+                                                  A_local_rowmap, A_local_entries, A_local_values,
                                                   L_rowmap, L_entries, L_values, U_rowmap, U_entries, U_values );
     }
   } // Stop timing

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_decl.hpp
@@ -440,6 +440,8 @@ private:
                         const Teuchos::ETransp mode) const;
 
   void initializeState();
+
+  KokkosSparse::Experimental::SPTRSVAlgorithm kokkosKernelsAlgorithm() const;
 };
 
 } // namespace Ifpack2

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -43,6 +43,7 @@
 #ifndef IFPACK2_LOCALSPARSETRIANGULARSOLVER_DEF_HPP
 #define IFPACK2_LOCALSPARSETRIANGULARSOLVER_DEF_HPP
 
+#include "Ifpack2_LocalSparseTriangularSolver_decl.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_Core.hpp"
 #include "Teuchos_StandardParameterEntryValidators.hpp"

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -683,8 +683,8 @@ compute ()
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && (CUDA_VERSION >= 11030)
   if constexpr ( std::is_same_v<typename crs_matrix_type::execution_space, Kokkos::Cuda> )
   {
-    if (Teuchos::nonnull(kh_) && this->isKokkosKernelsSptrsv_) {
-      if (!isKokkosKernelsStream_) {
+    if (this->isKokkosKernelsSptrsv_) {
+      if (Teuchos::nonnull(kh_) && !isKokkosKernelsStream_) {
         auto A_crs = Teuchos::rcp_dynamic_cast<const crs_matrix_type> (A_crs_, true);
         auto Alocal = A_crs->getLocalMatrixDevice();
         auto val    = Alocal.values;
@@ -700,7 +700,7 @@ compute ()
         auto ind    = Alocal.graph.entries;
         KokkosSparse::Experimental::sptrsv_symbolic(kh_.getRawPtr(), ptr, ind, val);
   #endif
-      } else {
+      } else if (kh_v_nonnull_) {
         for (int i = 0; i < num_streams_; i++) {
           auto A_crs_i = Teuchos::rcp_dynamic_cast<const crs_matrix_type> (A_crs_v_[i], true);
           auto Alocal_i = A_crs_i->getLocalMatrixDevice();

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -586,7 +586,7 @@ initialize ()
   #if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && defined(KOKKOS_ENABLE_CUDA)
       // CuSparse only supports int type ordinals 
       // and scalar types of float, double, float complex and double complex
-      if (std::is_same<Kokkos::Cuda, HandleExecSpace>::value &&
+      if constexpr (std::is_same<Kokkos::Cuda, HandleExecSpace>::value &&
           std::is_same<int, local_ordinal_type>::value &&
         (std::is_same<scalar_type, float>::value ||
           std::is_same<scalar_type, double>::value ||
@@ -617,7 +617,7 @@ initialize ()
   #if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && defined(KOKKOS_ENABLE_CUDA)
         // CuSparse only supports int type ordinals 
         // and scalar types of float, double, float complex and double complex
-        if (std::is_same<Kokkos::Cuda, HandleExecSpace>::value &&
+        if constexpr (std::is_same<Kokkos::Cuda, HandleExecSpace>::value &&
             std::is_same<int, local_ordinal_type>::value &&
           (std::is_same<scalar_type, float>::value ||
             std::is_same<scalar_type, double>::value ||

--- a/packages/ifpack2/src/Ifpack2_OverlappingRowMatrix_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_OverlappingRowMatrix_def.hpp
@@ -190,6 +190,7 @@ OverlappingRowMatrix (const Teuchos::RCP<const row_matrix_type>& A,
       ExtMatrixDynGraph->getDomainMap(),
       ExtMatrixDynGraph->getRangeMap()));
     ExtMatrix_ = rcp (new crs_matrix_type(ExtMatrixStaticGraph, ExtLclMatrix.values));
+    ExtMatrix_->fillComplete ();
   }
 
   // fix indices for overlapping matrix

--- a/packages/ifpack2/src/Ifpack2_OverlappingRowMatrix_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_OverlappingRowMatrix_def.hpp
@@ -45,6 +45,7 @@
 
 #include <sstream>
 
+#include <Ifpack2_OverlappingRowMatrix_decl.hpp>
 #include <Ifpack2_Details_OverlappingRowGraph.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_Import.hpp>
@@ -179,9 +180,16 @@ OverlappingRowMatrix (const Teuchos::RCP<const row_matrix_type>& A,
   ExtImporter_ = rcp (new import_type (A_->getRowMap (), ExtMap_));
 
   {
-    ExtMatrix_ = rcp (new crs_matrix_type (ExtMap_, ColMap_, 0));
-    ExtMatrix_->doImport (*A_, *ExtImporter_, Tpetra::INSERT);
-    ExtMatrix_->fillComplete (A_->getDomainMap (), RowMap_);
+    auto ExtMatrixDynGraph = rcp (new crs_matrix_type (ExtMap_, ColMap_, 0));
+    ExtMatrixDynGraph->doImport (*A_, *ExtImporter_, Tpetra::INSERT);
+    ExtMatrixDynGraph->fillComplete (A_->getDomainMap (), RowMap_);
+    auto ExtLclMatrix = ExtMatrixDynGraph->getLocalMatrixDevice();
+    auto ExtMatrixStaticGraph = rcp (new crs_graph_type(ExtLclMatrix.graph,
+      ExtMap_,
+      ColMap_,
+      ExtMatrixDynGraph->getDomainMap(),
+      ExtMatrixDynGraph->getRangeMap()));
+    ExtMatrix_ = rcp (new crs_matrix_type(ExtMatrixStaticGraph, ExtLclMatrix.values));
   }
 
   // fix indices for overlapping matrix
@@ -846,11 +854,8 @@ OverlappingRowMatrix<MatrixType>::getExtHaloStartsHost() const
 template<class MatrixType>
 void OverlappingRowMatrix<MatrixType>::doExtImport()
 {
-  //TODO: CrsMatrix can't doImport after resumeFill (see #9720). Ideally, this import could
-  //happen using combine mode REPLACE without reconstructing the matrix.
-  //Maybe even without another fillComplete since this doesn't change structure - see #9655.
-  ExtMatrix_ = rcp (new crs_matrix_type (ExtMap_, ColMap_, 0));
-  ExtMatrix_->doImport (*A_, *ExtImporter_, Tpetra::INSERT);
+  ExtMatrix_->resumeFill();
+  ExtMatrix_->doImport (*A_, *ExtImporter_, Tpetra::REPLACE);
   ExtMatrix_->fillComplete (A_->getDomainMap (), RowMap_);
 }
 

--- a/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
@@ -578,6 +578,10 @@ private:
   static void checkOrderingConsistency (const row_matrix_type& A);
   void initAllValues (const row_matrix_type& A);
 
+  void compute_serial();
+  void compute_kkspiluk();
+  void compute_kkspiluk_stream();
+
   /// \brief Return A, wrapped in a LocalFilter, if necessary.
   ///
   /// "If necessary" means that if A is already a LocalFilter, or if
@@ -599,6 +603,8 @@ protected:
   /// may be computed using a crs_matrix_type that initialize() constructs
   /// temporarily.
   Teuchos::RCP<const row_matrix_type> A_local_;
+  Teuchos::RCP<const crs_matrix_type> A_local_crs_;
+  Teuchos::RCP<crs_matrix_type> A_local_crs_nc_;
   lno_row_view_t A_local_rowmap_;
   lno_nonzero_view_t A_local_entries_;
   scalar_nonzero_view_t A_local_values_;

--- a/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
@@ -580,7 +580,14 @@ private:
 
   void compute_serial();
   void compute_kkspiluk();
+// Workaround Cuda limitation of KOKKOS_LAMBDA in private/protected member functions
+#ifdef KOKKOS_ENABLE_CUDA
+public:
+#endif KOKKOS_ENABLE_CUDA
   void compute_kkspiluk_stream();
+#ifdef KOKKOS_ENABLE_CUDA
+private:
+#endif
 
   /// \brief Return A, wrapped in a LocalFilter, if necessary.
   ///

--- a/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
@@ -652,6 +652,7 @@ protected:
   std::vector<execution_space> exec_space_instances_;
   bool hasStreamReordered_;
   std::vector<typename lno_nonzero_view_t::non_const_type> perm_v_;
+  std::vector<typename lno_nonzero_view_t::non_const_type> reverse_perm_v_;
 };
 
 // NOTE (mfh 11 Feb 2015) This used to exist in order to deal with

--- a/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
@@ -605,9 +605,6 @@ protected:
   Teuchos::RCP<const row_matrix_type> A_local_;
   Teuchos::RCP<const crs_matrix_type> A_local_crs_;
   Teuchos::RCP<crs_matrix_type> A_local_crs_nc_;
-  lno_row_view_t A_local_rowmap_;
-  lno_nonzero_view_t A_local_entries_;
-  scalar_nonzero_view_t A_local_values_;
   std::vector<local_matrix_device_type> A_local_diagblks;
   std::vector< lno_row_view_t > A_local_diagblks_rowmap_v_;
   std::vector< lno_nonzero_view_t > A_local_diagblks_entries_v_;

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -877,7 +877,7 @@ void RILUK<MatrixType>::compute_serial ()
   Teuchos::Array<local_ordinal_type> InI(MaxNumEntries); // Allocate temp space
   Teuchos::Array<scalar_type> InV(MaxNumEntries);
   size_t num_cols = U_->getColMap()->getLocalNumElements();
-  Teuchos::Array<int> colflag(num_cols);
+  Teuchos::Array<int> colflag(num_cols, -1);
 
   auto DV = Kokkos::subview(D_->getLocalViewHost(Tpetra::Access::ReadWrite), Kokkos::ALL(), 0);
 

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -883,9 +883,6 @@ void RILUK<MatrixType>::compute_serial ()
 
   // Now start the factorization.
 
-  for (size_t j = 0; j < num_cols; ++j) {
-    colflag[j] = -1;
-  }
   using IST = typename row_matrix_type::impl_scalar_type;
   for (size_t i = 0; i < L_->getLocalNumRows (); ++i) {
     local_ordinal_type local_row = i;

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -998,11 +998,6 @@ void RILUK<MatrixType>::compute_serial ()
 template<class MatrixType>
 void RILUK<MatrixType>::compute_kkspiluk()
 {
-  auto lclMtx = A_local_crs_->getLocalMatrixDevice();
-  A_local_rowmap_  = lclMtx.graph.row_map;
-  A_local_entries_ = lclMtx.graph.entries;
-  A_local_values_  = lclMtx.values;
-
   L_->resumeFill ();
   U_->resumeFill ();
 
@@ -1024,8 +1019,9 @@ void RILUK<MatrixType>::compute_kkspiluk()
   auto U_entries = lclU.graph.entries;
   auto U_values  = lclU.values;
 
+  auto lclMtx = A_local_crs_->getLocalMatrixDevice();
   KokkosSparse::Experimental::spiluk_numeric( KernelHandle_.getRawPtr(), LevelOfFill_,
-                                              A_local_rowmap_, A_local_entries_, A_local_values_,
+                                              lclMtx.graph.row_map, lclMtx.graph.entries, lclMtx.values,
                                               L_rowmap, L_entries, L_values, U_rowmap, U_entries, U_values );
 
   L_->fillComplete (L_->getColMap (), A_local_->getRangeMap ());

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -1223,8 +1223,10 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
     "fixed.  There is a FIXME in this file about this very issue.");
 #ifdef HAVE_IFPACK2_DEBUG
   {
-    const magnitude_type D_nrm1 = D_->norm1 ();
-    TEUCHOS_TEST_FOR_EXCEPTION( STM::isnaninf (D_nrm1), std::runtime_error, "Ifpack2::RILUK::apply: The 1-norm of the stored diagonal is NaN or Inf.");
+    if (!isKokkosKernelsStream_) {
+      const magnitude_type D_nrm1 = D_->norm1 ();
+      TEUCHOS_TEST_FOR_EXCEPTION( STM::isnaninf (D_nrm1), std::runtime_error, "Ifpack2::RILUK::apply: The 1-norm of the stored diagonal is NaN or Inf.");
+    }
     Teuchos::Array<magnitude_type> norms (X.getNumVectors ());
     X.norm1 (norms ());
     bool good = true;

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -426,6 +426,11 @@ setParameters (const Teuchos::ParameterList& params)
 
   LevelOfFill_ = fillLevel;
   Overalloc_ = overalloc;
+#ifdef KOKKOS_ENABLE_OPENMP
+  if constexpr (std::is_same_v<execution_space, Kokkos::OpenMP>) {
+    nstreams = std::min(nstreams, execution_space{}.concurrency());
+  }
+#endif
   num_streams_ = nstreams;
 
   if (num_streams_ >= 1) {

--- a/packages/ifpack2/test/belos/CMakeLists.txt
+++ b/packages/ifpack2/test/belos/CMakeLists.txt
@@ -381,78 +381,76 @@ ENDIF()
 
 
 
-IF(Kokkos_ENABLE_CUDA)
-  TRIBITS_ADD_TEST(
-    tif_belos
-    NAME RILUK_2streams_hb_belos
-    ARGS "--xml_file=test_2_RILUK_2streams_nos1_hb.xml"
-    COMM serial mpi
-    NUM_MPI_PROCS 2
-    STANDARD_PASS_OUTPUT
-  )
+TRIBITS_ADD_TEST(
+  tif_belos
+  NAME RILUK_2streams_hb_belos
+  ARGS "--xml_file=test_2_RILUK_2streams_nos1_hb.xml"
+  COMM serial mpi
+  NUM_MPI_PROCS 2
+  STANDARD_PASS_OUTPUT
+)
 
-  TRIBITS_ADD_TEST(
-    tif_belos
-    NAME RILUK_4streams_hb_belos
-    ARGS "--xml_file=test_2_RILUK_4streams_nos1_hb.xml"
-    COMM serial mpi
-    NUM_MPI_PROCS 2
-    STANDARD_PASS_OUTPUT
-  )
+TRIBITS_ADD_TEST(
+  tif_belos
+  NAME RILUK_4streams_hb_belos
+  ARGS "--xml_file=test_2_RILUK_4streams_nos1_hb.xml"
+  COMM serial mpi
+  NUM_MPI_PROCS 2
+  STANDARD_PASS_OUTPUT
+)
 
-  TRIBITS_ADD_TEST(
-    tif_belos
-    NAME RILUK_2streams_hb_belos
-    ARGS "--xml_file=test_4_RILUK_2streams_nos1_hb.xml"
-    COMM serial mpi
-    NUM_MPI_PROCS 4
-    STANDARD_PASS_OUTPUT
-  )
+TRIBITS_ADD_TEST(
+  tif_belos
+  NAME RILUK_2streams_hb_belos
+  ARGS "--xml_file=test_4_RILUK_2streams_nos1_hb.xml"
+  COMM serial mpi
+  NUM_MPI_PROCS 4
+  STANDARD_PASS_OUTPUT
+)
 
-  TRIBITS_ADD_TEST(
-    tif_belos
-    NAME RILUK_4streams_hb_belos
-    ARGS "--xml_file=test_4_RILUK_4streams_nos1_hb.xml"
-    COMM serial mpi
-    NUM_MPI_PROCS 4
-    STANDARD_PASS_OUTPUT
-  )
-  TRIBITS_ADD_TEST(
-    tif_belos
-    NAME RILUK_2streams_rcm_hb_belos
-    ARGS "--xml_file=test_2_RILUK_2streams_rcm_nos1_hb.xml"
-    COMM serial mpi
-    NUM_MPI_PROCS 2
-    STANDARD_PASS_OUTPUT
-  )
+TRIBITS_ADD_TEST(
+  tif_belos
+  NAME RILUK_4streams_hb_belos
+  ARGS "--xml_file=test_4_RILUK_4streams_nos1_hb.xml"
+  COMM serial mpi
+  NUM_MPI_PROCS 4
+  STANDARD_PASS_OUTPUT
+)
+TRIBITS_ADD_TEST(
+  tif_belos
+  NAME RILUK_2streams_rcm_hb_belos
+  ARGS "--xml_file=test_2_RILUK_2streams_rcm_nos1_hb.xml"
+  COMM serial mpi
+  NUM_MPI_PROCS 2
+  STANDARD_PASS_OUTPUT
+)
 
-  TRIBITS_ADD_TEST(
-    tif_belos
-    NAME RILUK_4streams_rcm_hb_belos
-    ARGS "--xml_file=test_2_RILUK_4streams_rcm_nos1_hb.xml"
-    COMM serial mpi
-    NUM_MPI_PROCS 2
-    STANDARD_PASS_OUTPUT
-  )
+TRIBITS_ADD_TEST(
+  tif_belos
+  NAME RILUK_4streams_rcm_hb_belos
+  ARGS "--xml_file=test_2_RILUK_4streams_rcm_nos1_hb.xml"
+  COMM serial mpi
+  NUM_MPI_PROCS 2
+  STANDARD_PASS_OUTPUT
+)
 
-  TRIBITS_ADD_TEST(
-    tif_belos
-    NAME RILUK_2streams_rcm_hb_belos
-    ARGS "--xml_file=test_4_RILUK_2streams_rcm_nos1_hb.xml"
-    COMM serial mpi
-    NUM_MPI_PROCS 4
-    STANDARD_PASS_OUTPUT
-  )
+TRIBITS_ADD_TEST(
+  tif_belos
+  NAME RILUK_2streams_rcm_hb_belos
+  ARGS "--xml_file=test_4_RILUK_2streams_rcm_nos1_hb.xml"
+  COMM serial mpi
+  NUM_MPI_PROCS 4
+  STANDARD_PASS_OUTPUT
+)
 
-  TRIBITS_ADD_TEST(
-    tif_belos
-    NAME RILUK_4streams_rcm_hb_belos
-    ARGS "--xml_file=test_4_RILUK_4streams_rcm_nos1_hb.xml"
-    COMM serial mpi
-    NUM_MPI_PROCS 4
-    STANDARD_PASS_OUTPUT
-  )
-ENDIF()
+TRIBITS_ADD_TEST(
+  tif_belos
+  NAME RILUK_4streams_rcm_hb_belos
+  ARGS "--xml_file=test_4_RILUK_4streams_rcm_nos1_hb.xml"
+  COMM serial mpi
+  NUM_MPI_PROCS 4
+  STANDARD_PASS_OUTPUT
+)
 ENDIF()
 
 


### PR DESCRIPTION
@trilinos/ifpack2 @jhux2 @vqd8a @brian-kelley 

## Motivation
Improved stream ILU performance for Sierra. Starting to look at some new problems on H100, these changes in total give a ~6x speedup in preconditioner compute for a particular problem using AdditiveSchwarz with overlap 1 and RILUK with fill level 1 and 20 streams.

## Related Issues
#9720

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
