### PR TITLE
Teuchos: add option to Kokkos::fence in timers

### DIFF
--- a/packages/teuchos/CMakeLists.txt
+++ b/packages/teuchos/CMakeLists.txt
@@ -433,9 +433,7 @@ IF(TPL_ENABLE_Valgrind)
   ENDIF()
 ENDIF()
 
-# Enabling Kokkos profiling hooks in Teuchos timers requires that the
-# Kokkos package be enabled
-
+#Option Teuchos_KOKKOS_PROFILING
 IF(DEFINED ${PROJECT_NAME}_ENABLE_Kokkos AND ${PROJECT_NAME}_ENABLE_Kokkos)
   SET(${PACKAGE_NAME}_KOKKOS_PROFILING_DEFAULT ON)
 ELSE()
@@ -448,9 +446,28 @@ TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_KOKKOS_PROFILING
   "Wrap every Teuchos timer with a Kokkos profiling region."
   "${${PACKAGE_NAME}_KOKKOS_PROFILING_DEFAULT}")
 IF (${PACKAGE_NAME}_KOKKOS_PROFILING)
+  # Enabling Kokkos profiling hooks in Teuchos timers requires that the
+  # Kokkos package be enabled
+  IF(NOT(DEFINED ${PROJECT_NAME}_ENABLE_Kokkos AND ${PROJECT_NAME}_ENABLE_Kokkos))
+    MESSAGE(FATAL_ERROR "Setting Teuchos_KOKKOS_PROFILING=ON requires that the Kokkos package is enabled.")
+  ENDIF()
   MESSAGE(STATUS "Wrapping every Teuchos timer with a Kokkos profiling region.")
 ENDIF()
 
+#Option Teuchos_TIMER_KOKKOS_FENCE
+SET(Teuchos_TIMER_KOKKOS_FENCE_DEFAULT OFF)
+TRIBITS_ADD_OPTION_AND_DEFINE(
+  Teuchos_TIMER_KOKKOS_FENCE
+  HAVE_TEUCHOS_TIMER_KOKKOS_FENCE
+  "Call Kokkos::fence() whenever a Teuchos timer starts or stops."
+  "${Teuchos_KOKKOS_PROFILING_DEFAULT}")
+IF (Teuchos_TIMER_KOKKOS_FENCE)
+  # Enabling Kokkos::fence() in Teuchos timers requires that the Kokkos package be enabled
+  IF(NOT(DEFINED ${PROJECT_NAME}_ENABLE_Kokkos AND ${PROJECT_NAME}_ENABLE_Kokkos))
+    MESSAGE(FATAL_ERROR "Setting Teuchos_TIMER_KOKKOS_FENCE=ON requires that the Kokkos package is enabled.")
+  ENDIF()
+  MESSAGE(STATUS "Will call Kokkos::fence() when a Teuchos timer starts or stops.")
+ENDIF()
 
 #
 # D) Process the subpackages for Teuchos

--- a/packages/teuchos/comm/test/Time/TimeMonitor_UnitTests.cpp
+++ b/packages/teuchos/comm/test/Time/TimeMonitor_UnitTests.cpp
@@ -1123,7 +1123,6 @@ namespace Teuchos {
       TimeMonitor monitor (*timer);
       // Timer has started; record current fence count
       fenceCountAfterStart = KokkosFenceCounter::numFences;
-      sleep(1);
     }
     // Timer has stopped; record again
     fenceCountAfterStop = KokkosFenceCounter::numFences;

--- a/packages/teuchos/comm/test/Time/TimeMonitor_UnitTests.cpp
+++ b/packages/teuchos/comm/test/Time/TimeMonitor_UnitTests.cpp
@@ -67,6 +67,10 @@ void sleep(int sec)
 }
 #endif
 
+#ifdef HAVE_TEUCHOS_TIMER_KOKKOS_FENCE
+#include "Kokkos_Core.hpp"
+#endif
+
 namespace {
 
   void func_time_monitor1()
@@ -1077,5 +1081,58 @@ namespace Teuchos {
     // This sets up for the next unit test (if there is one).
     TimeMonitor::clearCounters ();
   }
+
+  //
+  // Test that Time::start() and Time::stop() call Kokkos::fence(),
+  // if the option to do that is enabled.
+  //
+  #ifdef HAVE_TEUCHOS_TIMER_KOKKOS_FENCE
+  namespace KokkosFenceCounter
+  {
+    static int numFences;
+
+    void reset()
+    {
+      numFences = 0;
+    }
+
+    void begin_fence_callback(const char*, const uint32_t deviceId, uint64_t*) {
+      using namespace Kokkos::Tools::Experimental;
+      // Only count global device fences on the default space. Otherwise fences
+      // could be counted multiple times, depending on how many backends are enabled.
+      DeviceType fenceDevice = identifier_from_devid(deviceId).type;
+      DeviceType defaultDevice = DeviceTypeTraits<Kokkos::DefaultExecutionSpace>::id;
+      if(fenceDevice == defaultDevice)
+        numFences++;
+    }
+  }
+
+  TEUCHOS_UNIT_TEST( TimeMonitor, CheckTimerKokkosFences )
+  {
+    // This test doesn't care about the comm size or rank because Kokkos
+    // fences and profiling is purely local to each rank.
+    //
+    // Set up the fence counter (reset count to 0 and set the callback)
+    KokkosFenceCounter::reset();
+    Kokkos::Tools::Experimental::set_begin_fence_callback(KokkosFenceCounter::begin_fence_callback);
+    int fenceCountAfterStart = 0;
+    int fenceCountAfterStop = 0;
+
+    {
+      RCP<Time> timer = TimeMonitor::getNewCounter ("Timer XYZ");
+      TimeMonitor monitor (*timer);
+      // Timer has started; record current fence count
+      fenceCountAfterStart = KokkosFenceCounter::numFences;
+      sleep(1);
+    }
+    // Timer has stopped; record again
+    fenceCountAfterStop = KokkosFenceCounter::numFences;
+    TEST_EQUALITY(fenceCountAfterStart, 1);
+    TEST_EQUALITY(fenceCountAfterStop, 2);
+
+    // This sets up for the next unit test (if there is one).
+    TimeMonitor::clearCounters ();
+  }
+  #endif
 
 } // namespace Teuchos

--- a/packages/teuchos/core/cmake/Teuchos_config.h.in
+++ b/packages/teuchos/core/cmake/Teuchos_config.h.in
@@ -154,6 +154,8 @@
 
 #cmakedefine HAVE_TEUCHOS_KOKKOS_PROFILING
 
+#cmakedefine HAVE_TEUCHOS_TIMER_KOKKOS_FENCE
+
 /* template qualifier required for calling template methods from non-template
    code */
 #define INVALID_TEMPLATE_QUALIFIER @INVALID_TEMPLATE_QUALIFIER@

--- a/packages/teuchos/core/src/Teuchos_Time.cpp
+++ b/packages/teuchos/core/src/Teuchos_Time.cpp
@@ -87,6 +87,10 @@ extern void popRegion ();
 } // namespace Kokkos
 #endif
 
+#ifdef HAVE_TEUCHOS_TIMER_KOKKOS_FENCE
+#include "Kokkos_Core.hpp"
+#endif
+
 namespace Teuchos {
 
 #ifdef HAVE_TEUCHOS_TIME_MASSIF_SNAPSHOTS
@@ -125,6 +129,9 @@ void Time::start(bool reset_in)
     }
 #endif
     startTime_ = wallTime();
+#ifdef HAVE_TEUCHOS_TIMER_KOKKOS_FENCE
+    Kokkos::fence();
+#endif
 #if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOS)
     ::Kokkos::Profiling::pushRegion (name_);
 #endif
@@ -147,6 +154,9 @@ double Time::stop()
         VALGRIND_MONITOR_COMMAND(cmd.data());
         numCallsMassifSnapshots_++;
       }
+#endif
+#ifdef HAVE_TEUCHOS_TIMER_KOKKOS_FENCE
+      Kokkos::fence();
 #endif
 #if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOS)
       ::Kokkos::Profiling::popRegion ();


### PR DESCRIPTION
If ``Teuchos_TIMER_KOKKOS_FENCE=ON``, then call ``Kokkos::fence()`` in Timer start() and stop() methods.

- This option is off by default as it could hurt performance, especially for an application using multiple concurrent exec space instances
- Turning it on requires Kokkos be enabled

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

Neither Teuchos timers nor Kokkos profiling regions fenced before, so non-blocking kernels might be launched while one timer is active but spend most of their actual execution time in another. #13048 fixed an example of this by adding fences directly: in PerformanceCGSolve, time spent in spmv kernels was showing up in the dot subtimer.

This option could be enabled in the Trilinos nightly performance builds so that we measure kernel times more accurately (at the expense of a slight slowdown from kernel launch overhead).

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

No related issue, but this feature was agreed upon in the comments of PR #13048.

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
In local builds checked that:
- enabling this without Kokkos enabled errors at configure time
- the fences get called when this is enabled
<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
