### PR TITLE
Framework: Force genconfig system for DetermineSystem

### DIFF
--- a/packages/framework/pr_tools/LaunchDriver.py
+++ b/packages/framework/pr_tools/LaunchDriver.py
@@ -91,7 +91,7 @@ def main(argv):
 
   print("LaunchDriver> INFO: TRILINOS_DIR=\"" + os.environ["TRILINOS_DIR"] + "\"", flush=True)
 
-  ds = DetermineSystem(args.build_name, args.supported_systems)
+  ds = DetermineSystem(args.build_name, args.supported_systems, force_build_name=True)
 
   launch_env = get_launch_env(ds.system_name)
   launch_cmd = get_launch_cmd(ds.system_name)


### PR DESCRIPTION
@trilinos/framework 

## Motivation
We have our GPU systems marked as RHEL7 even though they are RHEL8 because we want to use the RHEL7 stack (until we have all of the new configurations working).  This prevents the newer machines from being recognized as RHEL8, and running configurations only for RHEL8.

As a solution, trust the user who specified the configuration to know what they are doing on a specific machine.  This follows what is already done with the GenConfig call (we use --force there).

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-646

## Testing
I did not test this manually, but I did look at the signature for `DetermineSystem` and used the keyword argument specified by its docstring.