### PR TITLE
Framework: Display image used for AT2 run

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -69,7 +69,7 @@ jobs:
           # should print unknown if $AT2_IMAGE env. variable cannot be found
           echo "image: ${AT2_IMAGE:-unknown}"
 
-          python ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
+          python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
             --source-repo-url ${GITHUB_WORKSPACE} \
             --target-repo-url ${GITHUB_WORKSPACE} \
             --target-branch-name ${{ github.event.pull_request.base.ref }} \
@@ -140,7 +140,7 @@ jobs:
           # should print unknown if $AT2_IMAGE env. variable cannot be found
           echo "image: ${AT2_IMAGE:-unknown}"
 
-          python ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
+          python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
             --source-repo-url ${GITHUB_WORKSPACE} \
             --target-repo-url ${GITHUB_WORKSPACE} \
             --target-branch-name ${{ github.event.pull_request.base.ref }} \

--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -66,7 +66,6 @@ jobs:
           sed -i "/\[rhel8\]/a `cat /etc/hostname`" /home/runner/_work/Trilinos/Trilinos/packages/framework/ini-files/supported-systems.ini
           printf "\n\n\n"
 
-          # should print unknown if $AT2_IMAGE env. variable cannot be found
           echo "image: ${AT2_IMAGE:-unknown}"
 
           python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
@@ -137,7 +136,6 @@ jobs:
           sed -i "/\[rhel8\]/a `cat /etc/hostname`" /home/runner/_work/Trilinos/Trilinos/packages/framework/ini-files/supported-systems.ini
           printf "\n\n\n"
 
-          # should print unknown if $AT2_IMAGE env. variable cannot be found
           echo "image: ${AT2_IMAGE:-unknown}"
 
           python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \

--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -66,6 +66,9 @@ jobs:
           sed -i "/\[rhel8\]/a `cat /etc/hostname`" /home/runner/_work/Trilinos/Trilinos/packages/framework/ini-files/supported-systems.ini
           printf "\n\n\n"
 
+          # should print unknown if $AT2_IMAGE env. variable cannot be found
+          echo "image: ${AT2_IMAGE:-unknown}"
+
           python ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
             --source-repo-url ${GITHUB_WORKSPACE} \
             --target-repo-url ${GITHUB_WORKSPACE} \
@@ -133,6 +136,9 @@ jobs:
 
           sed -i "/\[rhel8\]/a `cat /etc/hostname`" /home/runner/_work/Trilinos/Trilinos/packages/framework/ini-files/supported-systems.ini
           printf "\n\n\n"
+
+          # should print unknown if $AT2_IMAGE env. variable cannot be found
+          echo "image: ${AT2_IMAGE:-unknown}"
 
           python ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
             --source-repo-url ${GITHUB_WORKSPACE} \


### PR DESCRIPTION
@trilinos/framework 

## Motivation
As a Trilinos developer, I want to easily replicate AT2 builds.  This requires me to know what image was used for an AT2 run.  I want that information displayed in a way that is easy for me to find.

