### PR TITLE
Framework: Use PR-format build name based on group

### DIFF
--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -482,7 +482,7 @@ class TrilinosPRConfigurationBase(object):
 
         PR-<PR Number>-test-<Jenkins Job Name>-<Job Number">
         """
-        if self.arg_pullrequest_cdash_track == "Pull Request":
+        if "Pull Request" in self.arg_pullrequest_cdash_track:
             output = "PR-{}-test-{}-{}".format(self.arg_pullrequest_number, self.arg_pr_genconfig_job_name, self.arg_jenkins_job_number)
         elif self.arg_dashboard_build_name != "__UNKNOWN__":
             output = self.arg_dashboard_build_name

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -348,6 +348,15 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         expected_build_name = "PR-{}-test-{}-{}".format(args.pullrequest_number, args.genconfig_build_name, args.jenkins_job_number)
         self.assertEqual(build_name, expected_build_name)
 
+    def test_TrilinosPRConfigurationBaseBuildNameContainsPullRequest(self):
+        """Test that a group containing 'Pull Request' causes the build name to reflect a PR build."""
+        args = self.dummy_args_gcc_720()
+        args.pullrequest_cdash_track = "Pull Request (Non-blocking)"
+        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
+        build_name = pr_config.pullrequest_build_name
+        print("--- build_name = {}".format(build_name))
+        expected_build_name = "PR-{}-test-{}-{}".format(args.pullrequest_number, args.genconfig_build_name, args.jenkins_job_number)
+        self.assertEqual(build_name, expected_build_name)
 
     def test_TrilinosPRConfigurationBaseBuildNameNonPRTrack(self):
         args = self.dummy_args_non_pr_track()


### PR DESCRIPTION
@trilinos/framework

## Motivation
If the track name contains "Pull Request", we want the build name formatted with the PR "style".  Now we can have multiple Pull Request groups (for example, a non-blocking one that allows us to preview new configurations)!

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-625