### PR TITLE
Panzer: Minor updates to `CartesianConn/DOFMgr`

### DIFF
--- a/packages/panzer/dof-mgr/test/cartesian_topology/CMakeLists.txt
+++ b/packages/panzer/dof-mgr/test/cartesian_topology/CMakeLists.txt
@@ -24,16 +24,16 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   COMM serial mpi
   )
 
-#TRIBITS_ADD_EXECUTABLE_AND_TEST(
-#  tCartesianTop
-#  SOURCES tCartesianTop.cpp CartesianConnManager.cpp ${UNIT_TEST_DRIVER}
-#  NUM_MPI_PROCS 4
-#  COMM serial mpi
-#  )
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  tCartesianTop
+  SOURCES tCartesianTop.cpp CartesianConnManager.cpp ${UNIT_TEST_DRIVER}
+  NUM_MPI_PROCS 4
+  COMM serial mpi
+  )
 
-#TRIBITS_ADD_EXECUTABLE_AND_TEST(
-#  tCartesianDOFMgr
-#  SOURCES tCartesianDOFMgr.cpp CartesianConnManager.cpp ${UNIT_TEST_DRIVER}
-#  NUM_MPI_PROCS 4
-#  COMM serial mpi
-#  )
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  tCartesianDOFMgr
+  SOURCES tCartesianDOFMgr.cpp CartesianConnManager.cpp ${UNIT_TEST_DRIVER}
+  NUM_MPI_PROCS 4
+  COMM serial mpi
+  )

--- a/packages/panzer/dof-mgr/test/cartesian_topology/CartesianConnManager.cpp
+++ b/packages/panzer/dof-mgr/test/cartesian_topology/CartesianConnManager.cpp
@@ -49,8 +49,7 @@ using Teuchos::rcp_dynamic_cast;
 using Teuchos::RCP;
 using Teuchos::rcpFromRef;
 
-namespace panzer {
-namespace unit_test {
+namespace panzer::unit_test {
 
 void CartesianConnManager::
 initialize(const Teuchos::MpiComm<int> & comm,GlobalOrdinal nx, GlobalOrdinal ny,
@@ -113,7 +112,7 @@ initialize(const Teuchos::MpiComm<int> & comm,GlobalOrdinal nx, GlobalOrdinal ny
   {
     totalEdges_ = totalEdges_ + totalFaces_;
     totalFaces_ *= 2;
-    totalElements_ *= totalFaces_;
+    totalElements_ *= 2;
     numSubElemsPerBrickElement_ = 2;
     numSubSidesPerBrickSide_.assign(4,1);
 
@@ -296,10 +295,12 @@ initialize(const Teuchos::MpiComm<int> & comm,GlobalOrdinal nx, GlobalOrdinal ny
 void CartesianConnManager::buildConnectivity(const panzer::FieldPattern & fp)
 {
   TEUCHOS_ASSERT(isInitialized);
-  int numIds = fp.numberIds();
+  numIds_ = fp.numberIds();
 
-  connectivity_.clear();
-  connectivity_.resize(totalElements_);
+  connectivity_ = connectivity_entries_host_view_type(
+    Kokkos::view_alloc("CartesianConnManager: connectivity - entries - host", Kokkos::WithoutInitializing),
+    totalElements_ * numIds_
+  );
 
   std::vector<std::string> elementBlockIds;
   getElementBlockIds(elementBlockIds);
@@ -311,20 +312,20 @@ void CartesianConnManager::buildConnectivity(const panzer::FieldPattern & fp)
     const std::vector<LocalOrdinal> & elmts = getElementBlock(elementBlockIds[i]);
     for(std::size_t e=0;e<elmts.size();e++) {
       LocalOrdinal element = elmts[e];
-      std::vector<GlobalOrdinal> & conn = connectivity_[element];
+      LocalOrdinal offset = 0;
 
       int ordered_dim[4] = { 0, 1, 2, 3 }; // this is the order of creation
       for(int d=0;d<4;d++) {
         int od = ordered_dim[d];
         if(dim_==2) {
           if(od!=3) // ordered dimension in 2D is incorrect
-            updateConnectivity_2d(fp,od,element,conn);
+            updateConnectivity_2d(fp,od,element,offset);
         }
         else
-          updateConnectivity_3d(fp,od,element,conn);
+          updateConnectivity_3d(fp,od,element,offset);
       }
 
-      TEUCHOS_ASSERT_EQUALITY(numIds,Teuchos::as<int>(conn.size()));
+      TEUCHOS_ASSERT_EQUALITY(offset, static_cast<LocalOrdinal>(numIds_));
     }
   }
 }
@@ -336,7 +337,7 @@ CartesianConnManager::noConnectivityClone() const
   using Teuchos::RCP;
   using Teuchos::rcp;
 
-  RCP<CartesianConnManager> clone = rcp(new CartesianConnManager);
+  auto clone = Teuchos::make_rcp<CartesianConnManager>();
 
   clone->numProc_ = numProc_;
   clone->myRank_ = myRank_;
@@ -696,7 +697,7 @@ void
 CartesianConnManager::updateConnectivity_2d(const panzer::FieldPattern & fp,
                                             int subcellDim,
                                             int localCellId,
-                                            std::vector<GlobalOrdinal> & conn) const
+                                            LocalOrdinal& offset) const
 {
   int localElementId = localCellId/numSubElemsPerBrickElement_;
   int subElementId = localCellId%numSubElemsPerBrickElement_;
@@ -716,7 +717,8 @@ CartesianConnManager::updateConnectivity_2d(const panzer::FieldPattern & fp,
       GlobalOrdinal node =  (totalBrickElements_.x+1)*index.y + index.x
                            + (n==1 || n==2) * 1                    // shift for i+1
                            + (n==3 || n==2) * (totalBrickElements_.x+1); // shift for j+1
-      conn.push_back(node);
+      connectivity_(localCellId * numIds_ + offset) = node;
+      offset++;
     }
     else if(subcellDim==1) {
       int e = subElemToBrickElementEdgesMap_[subElementId][c];
@@ -729,10 +731,13 @@ CartesianConnManager::updateConnectivity_2d(const panzer::FieldPattern & fp,
       if((elemTopology_.getKey()==shards::Triangle<3>::key) && (e == 4)) {
         edge = totalNodes_ + totalEdges_ - (totalBrickElements_.x * totalBrickElements_.y) + computeGlobalBrickElementIndex(index);
       }
-      conn.push_back(edge);
+      connectivity_(localCellId * numIds_ + offset) = edge;
+      offset++;
     }
-    else if(subcellDim==2)
-      conn.push_back(totalNodes_+totalEdges_+numSubElemsPerBrickElement_*computeGlobalBrickElementIndex(index)+subElementId);
+    else if(subcellDim==2) {
+      connectivity_(localCellId * numIds_ + offset) = totalNodes_+totalEdges_+numSubElemsPerBrickElement_*computeGlobalBrickElementIndex(index)+subElementId;
+      offset++;
+    }
 
     else {
       TEUCHOS_ASSERT(false);
@@ -744,7 +749,7 @@ void
 CartesianConnManager::updateConnectivity_3d(const panzer::FieldPattern & fp,
                                             int subcellDim,
                                             int localCellId,
-                                            std::vector<GlobalOrdinal> & conn) const
+                                            LocalOrdinal& offset) const
 {
   int localElementId = localCellId/numSubElemsPerBrickElement_;
   int subElementId = localCellId%numSubElemsPerBrickElement_;
@@ -766,7 +771,8 @@ CartesianConnManager::updateConnectivity_3d(const panzer::FieldPattern & fp,
                            + (n==3 || n==2 || n==6 || n==7) * (totalBrickElements_.x+1)                       // shift for j+1
                            + (n==4 || n==5 || n==6 || n==7) * (totalBrickElements_.y+1)*(totalBrickElements_.x+1); // shift for k+1
 
-      conn.push_back(node);
+      connectivity_(localCellId * numIds_ + offset) = node;
+      offset++;
     }
     else if(subcellDim==1) {
       int e = subElemToBrickElementEdgesMap_[subElementId][c];
@@ -827,7 +833,8 @@ CartesianConnManager::updateConnectivity_3d(const panzer::FieldPattern & fp,
         if(e == 18)
           edge = totalNodes_ +  totalEdges_ - totalBrickElements_.x * totalBrickElements_.y * totalBrickElements_.z + computeGlobalBrickElementIndex(index);
       }
-      conn.push_back(edge);
+      connectivity_(localCellId * numIds_ + offset) = edge;
+      offset++;
     }
     else if(subcellDim==2) {
       int f = subElemToBrickElementFacesMap_[subElementId][c];
@@ -880,10 +887,12 @@ CartesianConnManager::updateConnectivity_3d(const panzer::FieldPattern & fp,
           face += 6*computeGlobalBrickElementIndex(index)+(f-12);
         }
       }
-      conn.push_back(face);
+      connectivity_(localCellId * numIds_ + offset) = face;
+      offset++;
     }
     else if(subcellDim==3) {
-      conn.push_back(totalNodes_+totalEdges_+totalFaces_+numSubElemsPerBrickElement_*computeGlobalBrickElementIndex(index)+subElementId);
+      connectivity_(localCellId * numIds_ + offset) = totalNodes_+totalEdges_+totalFaces_+numSubElemsPerBrickElement_*computeGlobalBrickElementIndex(index)+subElementId;
+      offset++;
     }
     else {
       TEUCHOS_ASSERT(false);
@@ -891,5 +900,4 @@ CartesianConnManager::updateConnectivity_3d(const panzer::FieldPattern & fp,
   }
 }
 
-} // end unit test
-} // end panzer
+} // namespace panzer::unit_test

--- a/packages/panzer/dof-mgr/test/cartesian_topology/tCartesianDOFMgr_DG.cpp
+++ b/packages/panzer/dof-mgr/test/cartesian_topology/tCartesianDOFMgr_DG.cpp
@@ -85,15 +85,14 @@ namespace std {
   }
 }
 
-namespace panzer {
-namespace unit_test {
+namespace panzer::unit_test {
 
 using Triplet = CartesianConnManager::Triplet<panzer::GlobalOrdinal>;
 
-std::string getElementBlock(const Triplet & element,
-                            const CartesianConnManager & connManager)
-                                    
-{
+std::string getElementBlock(
+  const Triplet & element,
+  const CartesianConnManager & connManager
+) {
   int localElmtId = connManager.computeLocalBrickElementIndex(element);
   return connManager.getBlockId(localElmtId);
 }
@@ -116,30 +115,30 @@ TEUCHOS_UNIT_TEST(tCartesianDOFMgr_DG, basic)
 
   // build the topology
   using CCM = CartesianConnManager;
-  RCP<CCM> connManager = rcp(new CCM);
+  const auto connManager = Teuchos::make_rcp<CCM>();
   connManager->initialize(comm,nx,ny,nz,px,py,pz,bx,by,bz);
 
   // build the dof manager, and assocaite with the topology
   using DOFManager = panzer::DOFManager;
-  RCP<DOFManager> dofManager = rcp(new DOFManager);
+  const auto dofManager = Teuchos::make_rcp<DOFManager>();
   dofManager->setConnManager(connManager,*comm.getRawMpiComm());
 
   using Basis = Intrepid2::Basis<PHX::Device,double,double>;
   
-  RCP<Basis> bhgrad2 = rcp(new Intrepid2::Basis_HGRAD_HEX_Cn_FEM<PHX::Device,double,double>(2));
-  RCP<const FieldPattern> hgrad2 = rcp(new Intrepid2FieldPattern(bhgrad2));
+  RCP<Basis> bhgrad2 = Teuchos::make_rcp<Intrepid2::Basis_HGRAD_HEX_Cn_FEM<PHX::Device, double, double>>(2);
+  RCP<const FieldPattern> hgrad2 = Teuchos::make_rcp<Intrepid2FieldPattern>(bhgrad2);
   out << "HGRAD2\n" << *hgrad2 << std::endl;
 
-  RCP<Basis> bhgrad1 = rcp(new Intrepid2::Basis_HGRAD_HEX_Cn_FEM<PHX::Device,double,double>(1));
-  RCP<const FieldPattern> hgrad1 = rcp(new Intrepid2FieldPattern(bhgrad1));
+  RCP<Basis> bhgrad1 = Teuchos::make_rcp<Intrepid2::Basis_HGRAD_HEX_Cn_FEM<PHX::Device, double, double>>(1);
+  RCP<const FieldPattern> hgrad1 = Teuchos::make_rcp<Intrepid2FieldPattern>(bhgrad1);
   out << "HGRAD1\n" << *hgrad1 << std::endl;
   
-  RCP<Basis> bhcurl = rcp(new Intrepid2::Basis_HCURL_HEX_In_FEM<PHX::Device,double,double>(1));
-  RCP<const FieldPattern> hcurl = rcp(new Intrepid2FieldPattern(bhcurl));
+  RCP<Basis> bhcurl = Teuchos::make_rcp<Intrepid2::Basis_HCURL_HEX_In_FEM<PHX::Device, double, double>>(1);
+  RCP<const FieldPattern> hcurl = Teuchos::make_rcp<Intrepid2FieldPattern>(bhcurl);
   out << "HCURL2\n" << *hcurl << std::endl;
   
-  RCP<Basis> bhdiv = rcp(new Intrepid2::Basis_HDIV_HEX_In_FEM<PHX::Device,double,double>(1));
-  RCP<const FieldPattern> hdiv = rcp(new Intrepid2FieldPattern(bhdiv));
+  RCP<Basis> bhdiv = Teuchos::make_rcp<Intrepid2::Basis_HDIV_HEX_In_FEM<PHX::Device, double, double>>(1);
+  RCP<const FieldPattern> hdiv = Teuchos::make_rcp<Intrepid2FieldPattern>(bhdiv);
   out << "HDIV2\n" << *hdiv << std::endl;
 
   // Add fields. Use Hgrad2 for testing DG so that we have unknowns on
@@ -479,5 +478,4 @@ TEUCHOS_UNIT_TEST(tCartesianDOFMgr_DG, basic)
   
 }
 
-} // end unit test
-} // end panzer
+} // namespace panzer::unit test

--- a/packages/panzer/dof-mgr/test/cartesian_topology/tCartesianDOFMgr_DynRankView.cpp
+++ b/packages/panzer/dof-mgr/test/cartesian_topology/tCartesianDOFMgr_DynRankView.cpp
@@ -70,24 +70,21 @@ using Teuchos::rcp_dynamic_cast;
 using Teuchos::RCP;
 using Teuchos::rcpFromRef;
 
-namespace panzer {
-namespace unit_test {
+namespace panzer::unit_test {
 
 using Triplet = CartesianConnManager::Triplet<panzer::GlobalOrdinal>;
 
-template <typename Intrepid2Type>
-RCP<const panzer::FieldPattern> buildFieldPattern()
-{
+RCP<const panzer::FieldPattern> buildFieldPattern(
+  RCP<Intrepid2::Basis<PHX::Device, double, double>> basis
+) {
   // build a geometric pattern from a single basis
-  RCP<Intrepid2::Basis<PHX::Device,double,double> > basis = rcp(new Intrepid2Type);
-  RCP<const panzer::FieldPattern> pattern = rcp(new panzer::Intrepid2FieldPattern(basis));
-  return pattern;
+  return Teuchos::make_rcp<panzer::Intrepid2FieldPattern>(basis);
 }
 
-std::string getElementBlock(const Triplet & element,
-                            const CartesianConnManager & connManager)
-                                    
-{
+std::string getElementBlock(
+  const Triplet & element,
+  const CartesianConnManager & connManager
+) {
   int localElmtId = connManager.computeLocalBrickElementIndex(element);
   return connManager.getBlockId(localElmtId);
 }
@@ -113,18 +110,18 @@ TEUCHOS_UNIT_TEST(tCartesianDOFMgr_DynRankView, threed)
   int bx =  1, by = 2, bz = 1;
 
   // build velocity, temperature and pressure fields
-  RCP<const panzer::FieldPattern> pattern_U = buildFieldPattern<Intrepid2::Basis_HGRAD_HEX_C2_FEM<PHX::Device,double,double> >();
-  RCP<const panzer::FieldPattern> pattern_P = buildFieldPattern<Intrepid2::Basis_HGRAD_HEX_C1_FEM<PHX::Device,double,double> >();
-  RCP<const panzer::FieldPattern> pattern_T = buildFieldPattern<Intrepid2::Basis_HGRAD_HEX_C1_FEM<PHX::Device,double,double> >();
-  RCP<const panzer::FieldPattern> pattern_B = buildFieldPattern<Intrepid2::Basis_HDIV_HEX_I1_FEM<PHX::Device,double,double> >();
-  RCP<const panzer::FieldPattern> pattern_E = buildFieldPattern<Intrepid2::Basis_HCURL_HEX_I1_FEM<PHX::Device,double,double> >();
+  RCP<const panzer::FieldPattern> pattern_U = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_HEX_C2_FEM<PHX::Device, double, double>>());
+  RCP<const panzer::FieldPattern> pattern_P = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_HEX_C1_FEM<PHX::Device, double, double>>());
+  RCP<const panzer::FieldPattern> pattern_T = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_HEX_C1_FEM<PHX::Device, double, double>>());
+  RCP<const panzer::FieldPattern> pattern_B = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HDIV_HEX_I1_FEM< PHX::Device, double, double>>());
+  RCP<const panzer::FieldPattern> pattern_E = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HCURL_HEX_I1_FEM<PHX::Device, double, double>>());
 
   // build the topology
-  RCP<CCM> connManager = rcp(new CCM);
+  const auto connManager = Teuchos::make_rcp<CCM>();
   connManager->initialize(comm,nx,ny,nz,px,py,pz,bx,by,bz);
 
   // build the dof manager, and assocaite with the topology
-  RCP<DOFManager> dofManager = rcp(new DOFManager);
+  const auto dofManager = Teuchos::make_rcp<DOFManager>();
   dofManager->setConnManager(connManager,*comm.getRawMpiComm());
 
   // add TEMPERATURE field to all element blocks (MHD and solid)
@@ -170,154 +167,6 @@ TEUCHOS_UNIT_TEST(tCartesianDOFMgr_DynRankView, threed)
   out << "My Offset   = " << myOffset.x << " " << myOffset.y << " " << myOffset.z << std::endl;
   out << "My myElements = " << myElements.x << " " << myElements.y << " " << myElements.z << std::endl;
 
-  // check sharing locally on this processor
-  {
-    // choose an element in the middle of the day
-    Triplet element;
-    element.x = myOffset.x + myElements.x/2-1;
-    element.y = myOffset.y + myElements.y/2-1;
-    element.z = myOffset.z + myElements.z/2-1;
-
-    out << "Root element = " << element.x << " " << element.y << " " << element.z << std::endl;
-
-    int localElmtId    = connManager->computeLocalBrickElementIndex(element);
-    int localElmtId_px = connManager->computeLocalBrickElementIndex(Triplet(element.x+1,element.y,element.z));
-    int localElmtId_py = connManager->computeLocalBrickElementIndex(Triplet(element.x,element.y+1,element.z));
-    int localElmtId_pz = connManager->computeLocalBrickElementIndex(Triplet(element.x,element.y,element.z+1));
-
-    TEST_ASSERT(localElmtId>=0);
-    TEST_ASSERT(localElmtId_px>=0);
-    TEST_ASSERT(localElmtId_py>=0);
-    TEST_ASSERT(localElmtId_pz>=0);
-
-    std::string eblock    = getElementBlock(element,*connManager);
-    std::string eblock_px = getElementBlock(Triplet(element.x+1,element.y,element.z),*connManager);
-    std::string eblock_py = getElementBlock(Triplet(element.x,element.y+1,element.z),*connManager);
-    std::string eblock_pz = getElementBlock(Triplet(element.x,element.y,element.z+1),*connManager);
-
-    std::vector<panzer::GlobalOrdinal> gids, gids_px, gids_py, gids_pz;
-
-    dofManager->getElementGIDs(   localElmtId,   gids);
-    dofManager->getElementGIDs(localElmtId_px,gids_px);
-    dofManager->getElementGIDs(localElmtId_py,gids_py);
-    dofManager->getElementGIDs(localElmtId_pz,gids_pz);
-
-    {
-      out << "Elements " << localElmtId << " " << localElmtId_px << std::endl;
-      auto offsets   = dofManager->getGIDFieldOffsets_closure(   eblock,ux_num,2,1); // +x
-      auto offsets_n = dofManager->getGIDFieldOffsets_closure(eblock_px,ux_num,2,3); // -x
-
-      TEST_EQUALITY(offsets.first.size(),offsets_n.first.size());
-
-      std::vector<panzer::GlobalOrdinal> gid_sub, gid_sub_px;
-      for(std::size_t i=0;i<offsets.first.size();i++) {
-        gid_sub.push_back(gids[offsets.first[i]]);
-        gid_sub_px.push_back(gids_px[offsets_n.first[i]]);
-      }
-
-      std::sort(gid_sub.begin(),gid_sub.end());
-      std::sort(gid_sub_px.begin(),gid_sub_px.end());
-
-      for(std::size_t i=0;i<gid_sub.size();i++)
-        TEST_EQUALITY(gid_sub[i],gid_sub_px[i]);
-    }
-
-    {
-      out << "Elements " << localElmtId << " " << localElmtId_py << std::endl;
-      auto offsets   = dofManager->getGIDFieldOffsets_closure(   eblock,ux_num,2,2); // +y
-      auto offsets_n = dofManager->getGIDFieldOffsets_closure(eblock_py,ux_num,2,0); // -y
-
-      TEST_EQUALITY(offsets.first.size(),offsets_n.first.size());
-
-      std::vector<panzer::GlobalOrdinal> gid_sub, gid_sub_py;
-      for(std::size_t i=0;i<offsets.first.size();i++) {
-        gid_sub.push_back(gids[offsets.first[i]]);
-        gid_sub_py.push_back(gids_py[offsets_n.first[i]]);
-      }
-
-      std::sort(gid_sub.begin(),gid_sub.end());
-      std::sort(gid_sub_py.begin(),gid_sub_py.end());
-
-      for(std::size_t i=0;i<gid_sub.size();i++)
-        TEST_EQUALITY(gid_sub[i],gid_sub_py[i]);
-    }
-
-    {
-      out << "Elements " << localElmtId << " " << localElmtId_pz << std::endl;
-      auto offsets   = dofManager->getGIDFieldOffsets_closure(   eblock,ux_num,2,5); // +z
-      auto offsets_n = dofManager->getGIDFieldOffsets_closure(eblock_pz,ux_num,2,4); // -z
-
-      TEST_EQUALITY(offsets.first.size(),offsets_n.first.size());
-
-      std::vector<panzer::GlobalOrdinal> gid_sub, gid_sub_pz;
-      for(std::size_t i=0;i<offsets.first.size();i++) {
-        gid_sub.push_back(gids[offsets.first[i]]);
-        gid_sub_pz.push_back(gids_pz[offsets_n.first[i]]);
-      }
-
-      std::sort(gid_sub.begin(),gid_sub.end());
-      std::sort(gid_sub_pz.begin(),gid_sub_pz.end());
-
-      for(std::size_t i=0;i<gid_sub.size();i++)
-        TEST_EQUALITY(gid_sub[i],gid_sub_pz[i]);
-    }
-  }
-
-  // assuming a 1d partition, check shared boundaries between processors
-  {
-    Triplet element_l;
-    element_l.x = myOffset.x;
-    element_l.y = myOffset.y + myElements.y/2;
-    element_l.z = myOffset.z + myElements.z/2;
-
-    Triplet element_r;
-    element_r.x = myOffset.x + myElements.x-1;
-    element_r.y = myOffset.y + myElements.y/2;
-    element_r.z = myOffset.z + myElements.z/2;
-
-    int localElmtId_l    = connManager->computeLocalBrickElementIndex(element_l);
-    int localElmtId_r    = connManager->computeLocalBrickElementIndex(element_r);
-
-    TEST_ASSERT(localElmtId_l>=0);
-    TEST_ASSERT(localElmtId_r>=0);
-
-    std::vector<panzer::GlobalOrdinal> gids_l, gids_r;
-    dofManager->getElementGIDs(   localElmtId_l,   gids_l);
-    dofManager->getElementGIDs(   localElmtId_r,   gids_r);
-
-    std::string eblock_l = getElementBlock(element_l,*connManager);
-    std::string eblock_r = getElementBlock(element_r,*connManager);
-
-    auto offsets_l   = dofManager->getGIDFieldOffsets_closure(   eblock_l,uy_num,2,3); // -x
-    auto offsets_r   = dofManager->getGIDFieldOffsets_closure(   eblock_r,uy_num,2,1); // +x
-
-    TEST_EQUALITY(offsets_l.first.size(),offsets_r.first.size());
-
-    out << "Elements L/R " << localElmtId_l << " " << localElmtId_r << std::endl;
-    std::vector<panzer::GlobalOrdinal> gid_sub_l, gid_sub_r;
-    for(std::size_t i=0;i<offsets_l.first.size();i++) {
-      gid_sub_l.push_back(gids_l[offsets_l.first[i]]);
-      gid_sub_r.push_back(gids_r[offsets_r.first[i]]);
-    }
-
-    std::sort(gid_sub_l.begin(),gid_sub_l.end());
-    std::sort(gid_sub_r.begin(),gid_sub_r.end());
-
-    // send left
-    if(rank!=0) {
-      Teuchos::send(comm,Teuchos::as<int>(gid_sub_l.size()),&gid_sub_l[0],rank-1);
-    }
-
-    // recieve right, check 
-    if(rank!=np-1) {
-      std::vector<panzer::GlobalOrdinal> gid_remote(gid_sub_r.size(),-1);
-      Teuchos::receive(comm,rank+1,Teuchos::as<int>(gid_sub_r.size()),&gid_remote[0]);
-
-      for(std::size_t i=0;i<gid_sub_r.size();i++)
-        TEST_EQUALITY(gid_sub_r[i],gid_remote[i]);
-    }
-  }
-
   // Test the kokkos version of field offsets
   {
     const int fieldNumber = dofManager->getFieldNum("B");
@@ -340,5 +189,4 @@ TEUCHOS_UNIT_TEST(tCartesianDOFMgr_DynRankView, threed)
     
 }
 
-} // end unit test
-} // end panzer
+} // namespace panzer::unit test

--- a/packages/panzer/dof-mgr/test/cartesian_topology/tCartesianDOFMgr_HighOrder.cpp
+++ b/packages/panzer/dof-mgr/test/cartesian_topology/tCartesianDOFMgr_HighOrder.cpp
@@ -67,30 +67,29 @@ using Teuchos::rcp_dynamic_cast;
 using Teuchos::RCP;
 using Teuchos::rcpFromRef;
 
-namespace panzer {
-namespace unit_test {
+namespace panzer::unit_test {
 
 using Triplet = CartesianConnManager::Triplet<panzer::GlobalOrdinal>;
 
-RCP<const panzer::FieldPattern> buildFieldPattern(RCP<Intrepid2::Basis<PHX::Device,double,double> > basis)
-{
+RCP<const panzer::FieldPattern> buildFieldPattern(
+  RCP<Intrepid2::Basis<PHX::Device, double, double>> basis
+) {
   // build a geometric pattern from a single basis
-  RCP<const panzer::FieldPattern> pattern = rcp(new panzer::Intrepid2FieldPattern(basis));
-  return pattern;
+  return Teuchos::make_rcp<panzer::Intrepid2FieldPattern>(basis);
 }
 
-std::string getElementBlock(const Triplet & element,
-                                    const CartesianConnManager & connManager)
-                                    
-{
+std::string getElementBlock(
+  const Triplet & element,
+  const CartesianConnManager & connManager
+) {
   int localElmtId = connManager.computeLocalBrickElementIndex(element);
   return connManager.getBlockId(localElmtId);
 }
 
 TEUCHOS_UNIT_TEST(tCartesianDOFMgr_HighOrder, ho_gid_values)
 {
-  typedef CartesianConnManager CCM;
-  typedef panzer::DOFManager DOFManager;
+  using CCM = CartesianConnManager;
+  using DOFManager = panzer::DOFManager;
 
   // build global (or serial communicator)
   #ifdef HAVE_MPI
@@ -106,19 +105,19 @@ TEUCHOS_UNIT_TEST(tCartesianDOFMgr_HighOrder, ho_gid_values)
   panzer::GlobalOrdinal nx = 8, ny = 4;//, nz = 4;
   //panzer::GlobalOrdinal nx = 4, ny = 3;//, nz = 4;
   int px = np, py = 1;//, pz = 1; // npx1 processor grids
-  int bx =  1, by = 1;//, bz = 1; // 1x2 blocks
+  int bx =  1, by = 1;//, bz = 1; // 1x1 blocks
 
   const int poly_U = 4;
   const int poly_P = 3;
-  RCP<const panzer::FieldPattern> pattern_U = buildFieldPattern( rcp(new Intrepid2::Basis_HGRAD_QUAD_Cn_FEM<PHX::Device,double,double>( poly_U )) );
-  RCP<const panzer::FieldPattern> pattern_P = buildFieldPattern( rcp(new Intrepid2::Basis_HGRAD_QUAD_Cn_FEM<PHX::Device,double,double>( poly_P )) );
+  RCP<const panzer::FieldPattern> pattern_U = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_QUAD_Cn_FEM<PHX::Device, double, double>>(poly_U));
+  RCP<const panzer::FieldPattern> pattern_P = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_QUAD_Cn_FEM<PHX::Device, double, double>>(poly_P));
 
   // build the topology
-  RCP<CCM> connManager = rcp(new CCM);
+  const auto connManager = Teuchos::make_rcp<CCM>();
   connManager->initialize(comm,nx,ny,px,py,bx,by);
 
   // build the dof manager, and assocaite with the topology
-  RCP<DOFManager> dofManager = rcp(new DOFManager);
+  const auto dofManager = Teuchos::make_rcp<DOFManager>();
   dofManager->setConnManager(connManager,*comm.getRawMpiComm());
 
   // add velocity (U) and PRESSURE fields to the MHD element block
@@ -203,14 +202,14 @@ TEUCHOS_UNIT_TEST(tCartesianDOFMgr_HighOrder, gid_values)
   // const int poly_U = 4, poly_P = 1, poly_T = 3;
   const int poly_U = 1;
 
-  RCP<const panzer::FieldPattern> pattern_U = buildFieldPattern( rcp(new Intrepid2::Basis_HGRAD_QUAD_Cn_FEM<PHX::Device,double,double>( poly_U )) );
+  RCP<const panzer::FieldPattern> pattern_U = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_QUAD_Cn_FEM<PHX::Device, double, double>>(poly_U));
 
   // build the topology
-  RCP<CCM> connManager = rcp(new CCM);
+  const auto connManager = Teuchos::make_rcp<CCM>();
   connManager->initialize(comm,nx,ny,px,py,bx,by);
 
   // build the dof manager, and assocaite with the topology
-  RCP<DOFManager> dofManager = rcp(new DOFManager);
+  const auto dofManager = Teuchos::make_rcp<DOFManager>();
   dofManager->setConnManager(connManager,*comm.getRawMpiComm());
 
   // add velocity (U) and PRESSURE fields to the MHD element block
@@ -302,16 +301,16 @@ TEUCHOS_UNIT_TEST(tCartesianDOFMgr_HighOrder, quad2d)
   // build velocity, temperature and pressure fields
   const int poly_U = 4, poly_P = 1, poly_T = 3;
 
-  RCP<const panzer::FieldPattern> pattern_U = buildFieldPattern( rcp(new Intrepid2::Basis_HGRAD_QUAD_Cn_FEM<PHX::Device,double,double>( poly_U )) );
-  RCP<const panzer::FieldPattern> pattern_P = buildFieldPattern( rcp(new Intrepid2::Basis_HGRAD_QUAD_Cn_FEM<PHX::Device,double,double>( poly_P )) );
-  RCP<const panzer::FieldPattern> pattern_T = buildFieldPattern( rcp(new Intrepid2::Basis_HGRAD_QUAD_Cn_FEM<PHX::Device,double,double>( poly_T )) );
+  RCP<const panzer::FieldPattern> pattern_U = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_QUAD_Cn_FEM<PHX::Device, double, double>>(poly_U));
+  RCP<const panzer::FieldPattern> pattern_P = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_QUAD_Cn_FEM<PHX::Device, double, double>>(poly_P));
+  RCP<const panzer::FieldPattern> pattern_T = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_QUAD_Cn_FEM<PHX::Device, double, double>>(poly_T));
   
   // build the topology
-  RCP<CCM> connManager = rcp(new CCM);
+  const auto connManager = Teuchos::make_rcp<CCM>();
   connManager->initialize(comm,nx,ny,px,py,bx,by);
 
   // build the dof manager, and assocaite with the topology
-  RCP<DOFManager> dofManager = rcp(new DOFManager);
+  const auto dofManager = Teuchos::make_rcp<DOFManager>();
   dofManager->setConnManager(connManager,*comm.getRawMpiComm());
 
   // add TEMPERATURE field to all element blocks (MHD and solid)
@@ -520,5 +519,4 @@ TEUCHOS_UNIT_TEST(tCartesianDOFMgr_HighOrder, quad2d)
     
 }
 
-} // end unit test
-} // end panzer
+} // namespace panzer::unit_test

--- a/packages/panzer/dof-mgr/test/cartesian_topology/tCartesianTop.cpp
+++ b/packages/panzer/dof-mgr/test/cartesian_topology/tCartesianTop.cpp
@@ -46,11 +46,12 @@
 #include <Teuchos_TimeMonitor.hpp>
 #include <Teuchos_DefaultMpiComm.hpp>
 
+#include "Kokkos_DynRankView.hpp"
+
 #include "Intrepid2_HGRAD_QUAD_C1_FEM.hpp"
 #include "Intrepid2_HGRAD_QUAD_C2_FEM.hpp"
 #include "Intrepid2_HGRAD_HEX_C1_FEM.hpp"
 #include "Intrepid2_HGRAD_HEX_C2_FEM.hpp"
-#include "Kokkos_DynRankView.hpp"
 
 #include "PanzerCore_config.hpp"
 
@@ -64,24 +65,20 @@ using Teuchos::rcp_dynamic_cast;
 using Teuchos::RCP;
 using Teuchos::rcpFromRef;
 
-namespace panzer {
-namespace unit_test {
+namespace panzer::unit_test {
 
-typedef Kokkos::DynRankView<double,PHX::Device> FieldContainer;
-template <typename Intrepid2Type>
-RCP<const panzer::FieldPattern> buildFieldPattern()
-{
+RCP<const panzer::FieldPattern> buildFieldPattern(
+  RCP<Intrepid2::Basis<PHX::Device, double, double>> basis
+) {
   // build a geometric pattern from a single basis
-  RCP<Intrepid2::Basis<double,FieldContainer> > basis = rcp(new Intrepid2Type);
-  RCP<const panzer::FieldPattern> pattern = rcp(new panzer::Intrepid2FieldPattern(basis));
-  return pattern;
+  return Teuchos::make_rcp<panzer::Intrepid2FieldPattern>(basis);
 }
 
 // test that you can correctly compute a rank index from a global processor id
 TEUCHOS_UNIT_TEST(tCartesianTop, computeMyRankTriplet)
 {
-  typedef CartesianConnManager<int,panzer::GlobalOrdinal> CCM;
-  typedef CCM::Triplet<int> Triplet;
+  using CCM = CartesianConnManager;
+  using Triplet = typename CCM::Triplet<int>;
 
   // test 2D
   {
@@ -107,16 +104,16 @@ TEUCHOS_UNIT_TEST(tCartesianTop, computeMyRankTriplet)
 }
 
 // test that you can correctly compute a rank index from a grobal processor id
-TEUCHOS_UNIT_TEST(tCartesianTop, computeLocalElementGlobalTriplet)
+TEUCHOS_UNIT_TEST(tCartesianTop, computeLocalBrickElementGlobalTriplet)
 {
-  typedef CartesianConnManager<int,panzer::GlobalOrdinal> CCM;
-  typedef CCM::Triplet<panzer::GlobalOrdinal> Triplet;
+  using CCM = CartesianConnManager;
+  using Triplet = typename CCM::Triplet<panzer::GlobalOrdinal>;
 
   // test 2D
   {
-    auto t0 = CCM::computeLocalElementGlobalTriplet( 1,Triplet(4,3,1),Triplet(7,2,0));
-    auto t1 = CCM::computeLocalElementGlobalTriplet( 4,Triplet(4,3,1),Triplet(7,2,0));
-    auto t2 = CCM::computeLocalElementGlobalTriplet(11,Triplet(4,3,1),Triplet(7,2,0));
+    auto t0 = CCM::computeLocalBrickElementGlobalTriplet( 1,Triplet(4,3,1),Triplet(7,2,0));
+    auto t1 = CCM::computeLocalBrickElementGlobalTriplet( 4,Triplet(4,3,1),Triplet(7,2,0));
+    auto t2 = CCM::computeLocalBrickElementGlobalTriplet(11,Triplet(4,3,1),Triplet(7,2,0));
 
     TEST_EQUALITY(t0.x,1+7); TEST_EQUALITY(t0.y,0+2); TEST_EQUALITY(t0.z,0);
     TEST_EQUALITY(t1.x,0+7); TEST_EQUALITY(t1.y,1+2); TEST_EQUALITY(t1.z,0);
@@ -125,9 +122,9 @@ TEUCHOS_UNIT_TEST(tCartesianTop, computeLocalElementGlobalTriplet)
 
   // test 3D
   {
-    auto t0 = CCM::computeLocalElementGlobalTriplet( 1+2*12,Triplet(4,3,5),Triplet(7,2,3));
-    auto t1 = CCM::computeLocalElementGlobalTriplet( 4+1*12,Triplet(4,3,5),Triplet(7,2,3));
-    auto t2 = CCM::computeLocalElementGlobalTriplet(11+4*12,Triplet(4,3,5),Triplet(7,2,3));
+    auto t0 = CCM::computeLocalBrickElementGlobalTriplet( 1+2*12,Triplet(4,3,5),Triplet(7,2,3));
+    auto t1 = CCM::computeLocalBrickElementGlobalTriplet( 4+1*12,Triplet(4,3,5),Triplet(7,2,3));
+    auto t2 = CCM::computeLocalBrickElementGlobalTriplet(11+4*12,Triplet(4,3,5),Triplet(7,2,3));
 
     TEST_EQUALITY(t0.x,1+7); TEST_EQUALITY(t0.y,0+2); TEST_EQUALITY(t0.z,2+3);
     TEST_EQUALITY(t1.x,0+7); TEST_EQUALITY(t1.y,1+2); TEST_EQUALITY(t1.z,1+3);
@@ -135,43 +132,43 @@ TEUCHOS_UNIT_TEST(tCartesianTop, computeLocalElementGlobalTriplet)
   }
 }
 
-TEUCHOS_UNIT_TEST(tCartesianTop, computeLocalElementIndex)
+TEUCHOS_UNIT_TEST(tCartesianTop, computeLocalBrickElementIndex)
 {
-  typedef CartesianConnManager<int,panzer::GlobalOrdinal> CCM;
-  typedef CCM::Triplet<panzer::GlobalOrdinal> Triplet;
+  using CCM = CartesianConnManager;
+  using Triplet = typename CCM::Triplet<panzer::GlobalOrdinal>;
 
   // test 2D
   {
-    auto t0 = CCM::computeLocalElementGlobalTriplet( 1,Triplet(4,3,1),Triplet(7,2,0));
-    auto t1 = CCM::computeLocalElementGlobalTriplet( 4,Triplet(4,3,1),Triplet(7,2,0));
-    auto t2 = CCM::computeLocalElementGlobalTriplet(11,Triplet(4,3,1),Triplet(7,2,0));
+    auto t0 = CCM::computeLocalBrickElementGlobalTriplet( 1,Triplet(4,3,1),Triplet(7,2,0));
+    auto t1 = CCM::computeLocalBrickElementGlobalTriplet( 4,Triplet(4,3,1),Triplet(7,2,0));
+    auto t2 = CCM::computeLocalBrickElementGlobalTriplet(11,Triplet(4,3,1),Triplet(7,2,0));
 
-    TEST_EQUALITY(CCM::computeLocalElementIndex(t0,Triplet(4,3,1),Triplet(7,2,0)), 1);
-    TEST_EQUALITY(CCM::computeLocalElementIndex(t1,Triplet(4,3,1),Triplet(7,2,0)), 4);
-    TEST_EQUALITY(CCM::computeLocalElementIndex(t2,Triplet(4,3,1),Triplet(7,2,0)),11);
+    TEST_EQUALITY(CCM::computeLocalBrickElementIndex(t0,Triplet(4,3,1),Triplet(7,2,0)), 1);
+    TEST_EQUALITY(CCM::computeLocalBrickElementIndex(t1,Triplet(4,3,1),Triplet(7,2,0)), 4);
+    TEST_EQUALITY(CCM::computeLocalBrickElementIndex(t2,Triplet(4,3,1),Triplet(7,2,0)),11);
   }
 
   // test 3D
   {
-    auto t0 = CCM::computeLocalElementGlobalTriplet( 1+2*12,Triplet(4,3,5),Triplet(7,2,3));
-    auto t1 = CCM::computeLocalElementGlobalTriplet( 4+1*12,Triplet(4,3,5),Triplet(7,2,3));
-    auto t2 = CCM::computeLocalElementGlobalTriplet(11+4*12,Triplet(4,3,5),Triplet(7,2,3));
+    auto t0 = CCM::computeLocalBrickElementGlobalTriplet( 1+2*12,Triplet(4,3,5),Triplet(7,2,3));
+    auto t1 = CCM::computeLocalBrickElementGlobalTriplet( 4+1*12,Triplet(4,3,5),Triplet(7,2,3));
+    auto t2 = CCM::computeLocalBrickElementGlobalTriplet(11+4*12,Triplet(4,3,5),Triplet(7,2,3));
 
-    TEST_EQUALITY(CCM::computeLocalElementIndex(t0,Triplet(4,3,5),Triplet(7,2,3)), 1+2*12);
-    TEST_EQUALITY(CCM::computeLocalElementIndex(t1,Triplet(4,3,5),Triplet(7,2,3)), 4+1*12);
-    TEST_EQUALITY(CCM::computeLocalElementIndex(t2,Triplet(4,3,5),Triplet(7,2,3)),11+4*12);
+    TEST_EQUALITY(CCM::computeLocalBrickElementIndex(t0,Triplet(4,3,5),Triplet(7,2,3)), 1+2*12);
+    TEST_EQUALITY(CCM::computeLocalBrickElementIndex(t1,Triplet(4,3,5),Triplet(7,2,3)), 4+1*12);
+    TEST_EQUALITY(CCM::computeLocalBrickElementIndex(t2,Triplet(4,3,5),Triplet(7,2,3)),11+4*12);
   }
 }
 
-TEUCHOS_UNIT_TEST(tCartesianTop, computeGlobalElementIndex)
+TEUCHOS_UNIT_TEST(tCartesianTop, computeGlobalBrickElementIndex)
 {
-  typedef CartesianConnManager<int,panzer::GlobalOrdinal> CCM;
-  typedef CCM::Triplet<panzer::GlobalOrdinal> Triplet;
+  using CCM = CartesianConnManager;
+  using Triplet = typename CCM::Triplet<panzer::GlobalOrdinal>;
 
   // test 2D
   {
-    panzer::GlobalOrdinal t0 = CCM::computeGlobalElementIndex(Triplet(1,1,0),Triplet(4,3,1));
-    panzer::GlobalOrdinal t1 = CCM::computeGlobalElementIndex(Triplet(3,2,0),Triplet(4,3,1));
+    panzer::GlobalOrdinal t0 = CCM::computeGlobalBrickElementIndex(Triplet(1,1,0),Triplet(4,3,1));
+    panzer::GlobalOrdinal t1 = CCM::computeGlobalBrickElementIndex(Triplet(3,2,0),Triplet(4,3,1));
 
     TEST_EQUALITY(t0, 5);
     TEST_EQUALITY(t1,11);
@@ -179,8 +176,8 @@ TEUCHOS_UNIT_TEST(tCartesianTop, computeGlobalElementIndex)
 
   // test 3D
   {
-    panzer::GlobalOrdinal t0 = CCM::computeGlobalElementIndex(Triplet( 1,1,3),Triplet(4,3,6));
-    panzer::GlobalOrdinal t1 = CCM::computeGlobalElementIndex(Triplet( 3,2,5),Triplet(4,3,6));
+    panzer::GlobalOrdinal t0 = CCM::computeGlobalBrickElementIndex(Triplet( 1,1,3),Triplet(4,3,6));
+    panzer::GlobalOrdinal t1 = CCM::computeGlobalBrickElementIndex(Triplet( 3,2,5),Triplet(4,3,6));
 
     TEST_EQUALITY(t0, 5+3*12);
     TEST_EQUALITY(t1,11+5*12);
@@ -190,8 +187,8 @@ TEUCHOS_UNIT_TEST(tCartesianTop, computeGlobalElementIndex)
 // This test checks functions used to generate the topology are correct
 TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_2d_1dpart_helpers)
 {
-  typedef CartesianConnManager<int,panzer::GlobalOrdinal> CCM;
-  typedef CCM::Triplet<panzer::GlobalOrdinal> TripletGO;
+  using CCM = CartesianConnManager;
+  using Triplet = typename CCM::Triplet<panzer::GlobalOrdinal>;
 
   // build global (or serial communicator)
   #ifdef HAVE_MPI
@@ -204,15 +201,14 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_2d_1dpart_helpers)
   int rank = comm.getRank();
 
   // field pattern for basis required
-  RCP<const panzer::FieldPattern> fp
-        = buildFieldPattern<Intrepid2::Basis_HGRAD_QUAD_C2_FEM<double,FieldContainer> >();
-
+  RCP<const panzer::FieldPattern> fp = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_QUAD_C2_FEM<PHX::Device, double, double>>());
+  
   // mesh description
   panzer::GlobalOrdinal nx = 10, ny = 7;
   int px = np, py = 1;
   int bx =  1, by = 2;
 
-  RCP<CartesianConnManager<int,panzer::GlobalOrdinal> > connManager = rcp(new CartesianConnManager<int,panzer::GlobalOrdinal>);
+  const auto connManager = Teuchos::make_rcp<CCM>();
   connManager->initialize(comm,nx,ny,px,py,bx,by);
 
   // test element blocks are computed properly and sized appropriately
@@ -230,8 +226,8 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_2d_1dpart_helpers)
 
   // test that owned and offset elements are correct
   { 
-    auto myElements = connManager->getMyElementsTriplet();
-    auto myOffset = connManager->getMyOffsetTriplet();
+    auto myElements = connManager->getMyBrickElementsTriplet();
+    auto myOffset = connManager->getMyBrickOffsetTriplet();
 
     panzer::GlobalOrdinal n = nx / px;
     panzer::GlobalOrdinal r = nx - n * px;
@@ -249,15 +245,15 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_2d_1dpart_helpers)
   // test that the elements are in the right blocks
   {
     panzer::GlobalOrdinal blk0[4],blk1[4];
-    blk0[0] = connManager->computeLocalElementIndex(TripletGO(2,2,0));
-    blk0[1] = connManager->computeLocalElementIndex(TripletGO(5,2,0));
-    blk0[2] = connManager->computeLocalElementIndex(TripletGO(7,2,0));
-    blk0[3] = connManager->computeLocalElementIndex(TripletGO(9,2,0));
+    blk0[0] = connManager->computeLocalBrickElementIndex(Triplet(2,2,0));
+    blk0[1] = connManager->computeLocalBrickElementIndex(Triplet(5,2,0));
+    blk0[2] = connManager->computeLocalBrickElementIndex(Triplet(7,2,0));
+    blk0[3] = connManager->computeLocalBrickElementIndex(Triplet(9,2,0));
 
-    blk1[0] = connManager->computeLocalElementIndex(TripletGO(2,12,0));
-    blk1[1] = connManager->computeLocalElementIndex(TripletGO(5,12,0));
-    blk1[2] = connManager->computeLocalElementIndex(TripletGO(7,12,0));
-    blk1[3] = connManager->computeLocalElementIndex(TripletGO(9,12,0));
+    blk1[0] = connManager->computeLocalBrickElementIndex(Triplet(2,12,0));
+    blk1[1] = connManager->computeLocalBrickElementIndex(Triplet(5,12,0));
+    blk1[2] = connManager->computeLocalBrickElementIndex(Triplet(7,12,0));
+    blk1[3] = connManager->computeLocalBrickElementIndex(Triplet(9,12,0));
 
     bool found = false;
     for(int i=0;i<4;i++) {
@@ -307,7 +303,7 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_2d_1dpart_helpers)
 
 TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_2d_1dpart)
 {
-  typedef CartesianConnManager<int,panzer::GlobalOrdinal> CCM;
+  using CCM = CartesianConnManager;
 
   // build global (or serial communicator)
   #ifdef HAVE_MPI
@@ -327,10 +323,10 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_2d_1dpart)
   // test 2D nodal discretization
   {
     // field pattern for basis required
-    RCP<const panzer::FieldPattern> fp = buildFieldPattern<Intrepid2::Basis_HGRAD_QUAD_C1_FEM<double,FieldContainer> >();
-
+    RCP<const panzer::FieldPattern> fp = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_QUAD_C1_FEM<PHX::Device, double, double>>());
+  
     // build the topology
-    RCP<CartesianConnManager<int,panzer::GlobalOrdinal> > connManager = rcp(new CartesianConnManager<int,panzer::GlobalOrdinal>);
+    const auto connManager = Teuchos::make_rcp<CCM>();
     connManager->initialize(comm,nx,ny,px,py,bx,by);
     connManager->buildConnectivity(*fp);
 
@@ -342,8 +338,8 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_2d_1dpart)
       for(std::size_t i=0;i<elmts0.size();i++) {
         TEST_EQUALITY(connManager->getConnectivitySize(elmts0[i]),4);
   
-        auto global = CCM::computeLocalElementGlobalTriplet(elmts0[i],connManager->getMyElementsTriplet(),
-                                                                      connManager->getMyOffsetTriplet());
+        auto global = CCM::computeLocalBrickElementGlobalTriplet(elmts0[i],connManager->getMyBrickElementsTriplet(),
+                                                                           connManager->getMyBrickOffsetTriplet());
         auto * conn = connManager->getConnectivity(elmts0[i]);
         TEST_ASSERT(conn!=0);
   
@@ -361,10 +357,10 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_2d_1dpart)
     panzer::GlobalOrdinal totalEdges = (bx*nx+1)*(by*ny)+(bx*nx)*(by*ny+1);
 
     // field pattern for basis required
-    RCP<const panzer::FieldPattern> fp = buildFieldPattern<Intrepid2::Basis_HGRAD_QUAD_C2_FEM<double,FieldContainer> >();
+    RCP<const panzer::FieldPattern> fp = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_QUAD_C2_FEM<PHX::Device, double, double>>());
 
     // build the topology
-    RCP<CartesianConnManager<int,panzer::GlobalOrdinal> > connManager = rcp(new CartesianConnManager<int,panzer::GlobalOrdinal>);
+    const auto connManager = Teuchos::make_rcp<CCM>();
     connManager->initialize(comm,nx,ny,px,py,bx,by);
     connManager->buildConnectivity(*fp);
 
@@ -376,8 +372,8 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_2d_1dpart)
       for(std::size_t i=0;i<elmts0.size();i++) {
         TEST_EQUALITY(connManager->getConnectivitySize(elmts0[i]),9);
   
-        auto global = CCM::computeLocalElementGlobalTriplet(elmts0[i],connManager->getMyElementsTriplet(),
-                                                                      connManager->getMyOffsetTriplet());
+        auto global = CCM::computeLocalBrickElementGlobalTriplet(elmts0[i],connManager->getMyBrickElementsTriplet(),
+                                                                           connManager->getMyBrickOffsetTriplet());
         auto * conn = connManager->getConnectivity(elmts0[i]);
         TEST_ASSERT(conn!=0);
   
@@ -403,8 +399,8 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_2d_1dpart)
 // This test checks functions used to generate the topology are correct
 TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_3d_1dpart_helpers)
 {
-  typedef CartesianConnManager<int,panzer::GlobalOrdinal> CCM;
-  typedef CCM::Triplet<panzer::GlobalOrdinal> TripletGO;
+  using CCM = CartesianConnManager;
+  using Triplet = typename CCM::Triplet<panzer::GlobalOrdinal>;
 
   // build global (or serial communicator)
   #ifdef HAVE_MPI
@@ -417,15 +413,14 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_3d_1dpart_helpers)
   int rank = comm.getRank();
 
   // field pattern for basis required
-  RCP<const panzer::FieldPattern> fp
-        = buildFieldPattern<Intrepid2::Basis_HGRAD_HEX_C2_FEM<double,FieldContainer> >();
+  RCP<const panzer::FieldPattern> fp = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_HEX_C2_FEM<PHX::Device, double, double>>());
 
   // mesh description
   panzer::GlobalOrdinal nx = 10, ny = 7, nz = 4;
   int px = np, py = 1, pz = 1;
   int bx =  1, by = 2, bz = 1;
 
-  RCP<CartesianConnManager<int,panzer::GlobalOrdinal> > connManager = rcp(new CartesianConnManager<int,panzer::GlobalOrdinal>);
+  const auto connManager = Teuchos::make_rcp<CCM>();
   connManager->initialize(comm,nx,ny,nz,px,py,pz,bx,by,bz);
 
   // test element blocks are computed properly and sized appropriately
@@ -443,8 +438,8 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_3d_1dpart_helpers)
 
   // test that owned and offset elements are correct
   { 
-    auto myElements = connManager->getMyElementsTriplet();
-    auto myOffset = connManager->getMyOffsetTriplet();
+    auto myElements = connManager->getMyBrickElementsTriplet();
+    auto myOffset = connManager->getMyBrickOffsetTriplet();
 
     panzer::GlobalOrdinal n = nx / px;
     panzer::GlobalOrdinal r = nx - n * px;
@@ -462,15 +457,15 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_3d_1dpart_helpers)
   // test that the elements are in the right blocks
   {
     panzer::GlobalOrdinal blk0[4],blk1[4];
-    blk0[0] = connManager->computeLocalElementIndex(TripletGO(2,2,3));
-    blk0[1] = connManager->computeLocalElementIndex(TripletGO(5,2,3));
-    blk0[2] = connManager->computeLocalElementIndex(TripletGO(7,2,3));
-    blk0[3] = connManager->computeLocalElementIndex(TripletGO(9,2,3));
+    blk0[0] = connManager->computeLocalBrickElementIndex(Triplet(2,2,3));
+    blk0[1] = connManager->computeLocalBrickElementIndex(Triplet(5,2,3));
+    blk0[2] = connManager->computeLocalBrickElementIndex(Triplet(7,2,3));
+    blk0[3] = connManager->computeLocalBrickElementIndex(Triplet(9,2,3));
 
-    blk1[0] = connManager->computeLocalElementIndex(TripletGO(2,12,1));
-    blk1[1] = connManager->computeLocalElementIndex(TripletGO(5,12,1));
-    blk1[2] = connManager->computeLocalElementIndex(TripletGO(7,12,1));
-    blk1[3] = connManager->computeLocalElementIndex(TripletGO(9,12,1));
+    blk1[0] = connManager->computeLocalBrickElementIndex(Triplet(2,12,1));
+    blk1[1] = connManager->computeLocalBrickElementIndex(Triplet(5,12,1));
+    blk1[2] = connManager->computeLocalBrickElementIndex(Triplet(7,12,1));
+    blk1[3] = connManager->computeLocalBrickElementIndex(Triplet(9,12,1));
 
     bool found = false;
     for(int i=0;i<4;i++) {
@@ -520,7 +515,7 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_3d_1dpart_helpers)
 
 TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_3d_1dpart)
 {
-  typedef CartesianConnManager<int,panzer::GlobalOrdinal> CCM;
+  using CCM = CartesianConnManager;
 
   // build global (or serial communicator)
   #ifdef HAVE_MPI
@@ -545,10 +540,10 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_3d_1dpart)
   // test 3D nodal discretization
   {
     // field pattern for basis required
-    RCP<const panzer::FieldPattern> fp = buildFieldPattern<Intrepid2::Basis_HGRAD_HEX_C1_FEM<double,FieldContainer> >();
+    RCP<const panzer::FieldPattern> fp = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_HEX_C1_FEM<PHX::Device, double, double>>());
 
     // build the topology
-    RCP<CartesianConnManager<int,panzer::GlobalOrdinal> > connManager = rcp(new CartesianConnManager<int,panzer::GlobalOrdinal>);
+    const auto connManager = Teuchos::make_rcp<CCM>();
     connManager->initialize(comm,nx,ny,nz,px,py,pz,bx,by,bz);
     connManager->buildConnectivity(*fp);
 
@@ -560,8 +555,8 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_3d_1dpart)
       for(std::size_t i=0;i<elmts0.size();i++) {
         TEST_EQUALITY(connManager->getConnectivitySize(elmts0[i]),8);
   
-        auto global = CCM::computeLocalElementGlobalTriplet(elmts0[i],connManager->getMyElementsTriplet(),
-                                                                      connManager->getMyOffsetTriplet());
+        auto global = CCM::computeLocalBrickElementGlobalTriplet(elmts0[i],connManager->getMyBrickElementsTriplet(),
+                                                                           connManager->getMyBrickOffsetTriplet());
         auto * conn = connManager->getConnectivity(elmts0[i]);
         TEST_ASSERT(conn!=0);
   
@@ -585,10 +580,10 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_3d_1dpart)
     panzer::GlobalOrdinal totalFaces = (bx*nx+1)*(by*ny)*(bz*nz)+(bx*nx)*(by*ny+1)*(bz*nz)+(bx*nx)*(by*ny)*(bz*nz+1);
 
     // field pattern for basis required
-    RCP<const panzer::FieldPattern> fp = buildFieldPattern<Intrepid2::Basis_HGRAD_HEX_C2_FEM<double,FieldContainer> >();
+    RCP<const panzer::FieldPattern> fp = buildFieldPattern(Teuchos::make_rcp<Intrepid2::Basis_HGRAD_HEX_C2_FEM<PHX::Device, double, double>>());
 
     // build the topology
-    RCP<CartesianConnManager<int,panzer::GlobalOrdinal> > connManager = rcp(new CartesianConnManager<int,panzer::GlobalOrdinal>);
+    const auto connManager = Teuchos::make_rcp<CCM>();
     connManager->initialize(comm,nx,ny,nz,px,py,pz,bx,by,bz);
     connManager->buildConnectivity(*fp);
 
@@ -600,8 +595,8 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_3d_1dpart)
       for(std::size_t i=0;i<elmts0.size();i++) {
         TEST_EQUALITY(connManager->getConnectivitySize(elmts0[i]),27);
   
-        auto global = CCM::computeLocalElementGlobalTriplet(elmts0[i],connManager->getMyElementsTriplet(),
-                                                                      connManager->getMyOffsetTriplet());
+        auto global = CCM::computeLocalBrickElementGlobalTriplet(elmts0[i],connManager->getMyBrickElementsTriplet(),
+                                                                           connManager->getMyBrickOffsetTriplet());
         out << "Element Triplet: " << global.x << ", " << global.y << ", " << global.z << std::endl;
         auto * conn = connManager->getConnectivity(elmts0[i]);
         TEST_ASSERT(conn!=0);
@@ -658,6 +653,4 @@ TEUCHOS_UNIT_TEST(tCartesianTop, connmanager_3d_1dpart)
   }
 }
 
-} // end unit test
-} // end panzer
-
+} // namespace panzer::unit test


### PR DESCRIPTION
@trilinos/panzer
@rppawlo 

This PR makes minor updates to the `CartesianConnMgr` and `CartesianDOFMgr`:
- use of nested namespaces
- use of new functions such as `Teaches::make_rcp`
- re-enable tests `tCartesianTop` and `tCartesianDOFMgr` after updates such as eliminating use of `FieldContainer`
- replace `std::vector` storage with host view storage in `CartesianConnMgr`
- delete overlap between `tCartesianDOFMgr` and `tCartesianDOFMgr_DynRankView`
- use of `Brick` in various names in `tCartesianTop` 

This PR is preparatory work to prepare for using these tests for device `Conn` and `DOF` managers.