### PR TITLE
Fix mistake in #13058: cmake option default

### DIFF
--- a/packages/teuchos/CMakeLists.txt
+++ b/packages/teuchos/CMakeLists.txt
@@ -460,7 +460,7 @@ TRIBITS_ADD_OPTION_AND_DEFINE(
   Teuchos_TIMER_KOKKOS_FENCE
   HAVE_TEUCHOS_TIMER_KOKKOS_FENCE
   "Call Kokkos::fence() whenever a Teuchos timer starts or stops."
-  "${Teuchos_KOKKOS_PROFILING_DEFAULT}")
+  "${Teuchos_TIMER_KOKKOS_FENCE_DEFAULT}")
 IF (Teuchos_TIMER_KOKKOS_FENCE)
   # Enabling Kokkos::fence() in Teuchos timers requires that the Kokkos package be enabled
   IF(NOT(DEFINED ${PROJECT_NAME}_ENABLE_Kokkos AND ${PROJECT_NAME}_ENABLE_Kokkos))


### PR DESCRIPTION
Fix default for option to fence in Teuchos timers (copy-paste mistake)

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->
<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
