### PR TITLE
KokkosKernels: patch in #2240

### DIFF
--- a/packages/kokkos-kernels/sparse/impl/KokkosSparse_spmv_impl.hpp
+++ b/packages/kokkos-kernels/sparse/impl/KokkosSparse_spmv_impl.hpp
@@ -32,8 +32,6 @@
 namespace KokkosSparse {
 namespace Impl {
 
-constexpr const char* KOKKOSSPARSE_ALG_NATIVE_MERGE = "native-merge";
-
 // This TransposeFunctor is functional, but not necessarily performant.
 template <class execution_space, class AMatrix, class XVector, class YVector,
           bool conjugate>
@@ -603,7 +601,8 @@ static void spmv_beta(const execution_space& exec, Handle* handle,
                       typename YVector::const_value_type& beta,
                       const YVector& y) {
   if (mode[0] == NoTranspose[0]) {
-    if (handle->algo == SPMV_MERGE_PATH) {
+    if (handle->algo == SPMV_MERGE_PATH ||
+        handle->algo == SPMV_NATIVE_MERGE_PATH) {
       SpmvMergeHierarchical<execution_space, AMatrix, XVector, YVector>::spmv(
           exec, mode, alpha, A, x, beta, y);
     } else {
@@ -611,7 +610,8 @@ static void spmv_beta(const execution_space& exec, Handle* handle,
                              dobeta, false>(exec, handle, alpha, A, x, beta, y);
     }
   } else if (mode[0] == Conjugate[0]) {
-    if (handle->algo == SPMV_MERGE_PATH) {
+    if (handle->algo == SPMV_MERGE_PATH ||
+        handle->algo == SPMV_NATIVE_MERGE_PATH) {
       SpmvMergeHierarchical<execution_space, AMatrix, XVector, YVector>::spmv(
           exec, mode, alpha, A, x, beta, y);
     } else {

--- a/packages/kokkos-kernels/sparse/unit_test/Test_Sparse_spmv.hpp
+++ b/packages/kokkos-kernels/sparse/unit_test/Test_Sparse_spmv.hpp
@@ -493,7 +493,11 @@ template <typename scalar_t, typename lno_t, typename size_type,
 void test_spmv_algorithms(lno_t numRows, size_type nnz, lno_t bandwidth,
                           lno_t row_size_variance, bool heavy) {
   using namespace KokkosSparse;
-  for (SPMVAlgorithm algo : {SPMV_DEFAULT, SPMV_NATIVE, SPMV_MERGE_PATH}) {
+  // Here, SPMV_MERGE_PATH will test a TPL's algorithm for imbalanced matrices
+  // if available (like cuSPARSE ALG2). SPMV_NATIVE_MERGE_PATH will always call
+  // the KokkosKernels implmentation of merge path.
+  for (SPMVAlgorithm algo :
+       {SPMV_DEFAULT, SPMV_NATIVE, SPMV_MERGE_PATH, SPMV_NATIVE_MERGE_PATH}) {
     test_spmv<scalar_t, lno_t, size_type, Device>(algo, numRows, nnz, bandwidth,
                                                   row_size_variance, heavy);
   }


### PR DESCRIPTION
Fix logic around merge path with TPLs

``SPMV_MERGE_PATH`` is not always a native algorithm, but it was incorrectly taking the native/fallback codepath. Add ``SPMV_NATIVE_MERGE_PATH`` to cover that case specifically. Test this new option in the spmv unit tests.

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

* Fixes issue reported directly from Aria, where the nan overwriting behavior was not happening because the cuSPARSE should have been taken, but the native merge path was running instead 
@vbrunini 

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
This PR adds testing for the new algorithm option ``SPMV_NATIVE_MERGE_PATH`` in KokkosKernels.
#13090 will add testing in Tpetra also.
<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
