### PR TITLE
Tpetra: test that CrsMatrix::apply overwrites NaNs

### DIFF
--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -370,9 +370,13 @@ namespace { // (anonymous)
     //Input vector: elements are all 1s
     MV w(domainMap, numVecs, false);
     w.putScalar(ST::one());
-    //Output vector: zero initially
-    //note: rowMap is non-overlapping so this is OK
-    MV v(rowMap, numVecs, true);
+    //Output vector: if Scalar is real or complex, fill with NaN to test that NaNs are correctly overwritten with beta=0.
+    //If Scalar is an integer, fill with ones instead to at least test that the output vector is zeroed.
+    MV v(rowMap, numVecs, false);
+    if constexpr(Kokkos::ArithTraits<Scalar>::is_integer)
+      v.putScalar(Kokkos::ArithTraits<Scalar>::one());
+    else
+      v.putScalar(Kokkos::ArithTraits<Scalar>::nan());
     //Do the apply. If cuSPARSE is enabled, the merge path algorithm will be used. Otherwise, this tests the fallback.
     imba.apply(w, v);
     Teuchos::Array<Scalar> vvals(numLocalRows * numVecs);
@@ -393,7 +397,10 @@ namespace { // (anonymous)
       //Now run again, but on single vectors only (rank-1)
       auto wcol = w.getVector(0);
       auto vcol = v.getVectorNonConst(0);
-      vcol->putScalar(ST::zero());
+      if constexpr(Kokkos::ArithTraits<Scalar>::is_integer)
+        vcol->putScalar(Kokkos::ArithTraits<Scalar>::one());
+      else
+        vcol->putScalar(Kokkos::ArithTraits<Scalar>::nan());
       imba.apply(*wcol, *vcol);
       vcol->get1dCopy(vvals(), numLocalRows);
       for(size_t i = 0; i < numLocalRows - 1; i++)
@@ -414,6 +421,57 @@ namespace { // (anonymous)
     }
   }
 
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, ApplyOverwriteNan, LO, GO, Scalar, Node )
+  {
+    typedef Teuchos::ScalarTraits<Scalar> ST;
+    // NaN is only representable for floating-point real and complex types
+    if constexpr(!ST::isOrdinal) {
+      typedef Tpetra::CrsMatrix<Scalar,LO,GO,Node> MAT;
+      typedef Tpetra::MultiVector<Scalar,LO,GO,Node> MV;
+      typedef Tpetra::Vector<Scalar,LO,GO,Node> V;
+      typedef typename ST::magnitudeType Mag;
+      typedef Teuchos::ScalarTraits<Mag> MT;
+      const GST INVALID = Teuchos::OrdinalTraits<GST>::invalid();
+      // get a comm
+      RCP<const Comm<int> > comm = getDefaultComm();
+      const size_t myImageID = comm->getRank();
+      // create a Map
+      const size_t numLocal = 10;
+      const size_t numVecs  = 5;
+      RCP<const Tpetra::Map<LO,GO,Node> > map =
+        createContigMapWithNode<LO,GO,Node>(INVALID,numLocal,comm);
+      // create the identity matrix
+      GO base = numLocal*myImageID;
+      RCP<Tpetra::RowMatrix<Scalar,LO,GO,Node> > eye;
+      {
+        RCP<MAT> eye_crs = rcp(new MAT(map,numLocal));
+        for (size_t i=0; i<numLocal; ++i) {
+          eye_crs->insertGlobalValues(base+i,tuple<GO>(base+i),tuple<Scalar>(ST::one()));
+        }
+        eye_crs->fillComplete();
+        eye = eye_crs;
+      }
+      MV mvrand(map,numVecs,false), mvres(map,numVecs,false);
+      mvrand.randomize();
+      // because beta=0 (default argument), the NaN values in mvres should be overwritten
+      mvres.putScalar(Kokkos::ArithTraits<Scalar>::nan());
+      eye->apply(mvrand, mvres);
+      mvres.update(-ST::one(), mvrand, ST::one());
+      Array<Mag> norms(numVecs), zeros(numVecs, MT::zero());
+      mvres.norm1(norms());
+      TEST_COMPARE_FLOATING_ARRAYS(norms, zeros, MT::zero());
+      // Test with a single column as well
+      auto mvrand_col0 = mvrand.getVectorNonConst(0);
+      auto mvres_col0 = mvres.getVectorNonConst(0);
+      mvrand_col0->randomize();
+      mvres_col0->putScalar(Kokkos::ArithTraits<Scalar>::nan());
+      eye->apply(*mvrand_col0, *mvres_col0);
+      mvres_col0->update(-ST::one(), *mvrand_col0, ST::one());
+      Array<Mag> norm_col0(1), zeros_col0(1, MT::zero());
+      mvres_col0->norm1(norm_col0());
+      TEST_COMPARE_FLOATING_ARRAYS(norm_col0, zeros_col0, MT::zero());
+    }
+  }
 
   TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, InsertLocalValuesCombineModes, LO, GO, Scalar, Node )
   {
@@ -507,6 +565,7 @@ namespace { // (anonymous)
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, TheEyeOfTruth,  LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, ZeroMatrix,     LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, ImbalancedRowMatrix, LO, GO, SCALAR, NODE ) \
+      TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, ApplyOverwriteNan, LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, BadCalls,       LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, SimpleEigTest,  LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, InsertLocalValuesCombineModes,  LO, GO, SCALAR, NODE )


### PR DESCRIPTION
In ``CrsMatrix::apply``, if beta==0 and y contains NaNs or Infs, these should be overwritten with the value alpha*A*x (not just multipled by 0, which would result in more NaNs in the final result).

Test this for both the normal and imbalanced row paths, with single and multiple columns.
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

Panzer MiniEM and other applications like Aria depend on this behavior but it wasn't sufficiently tested. See #13089 for more info

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
This is mostly a change to tests. The one change in code is to never use merge path unless the matrix's node is Cuda and cuSPARSE is enabled (before, the node==Cuda check was missing). This change is tested by the new tests.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
