### PR TITLE
Tpetra: skip test that spmv_mv used cusparse

### DIFF
--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ApplyUsesTPLs.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ApplyUsesTPLs.cpp
@@ -284,8 +284,17 @@ namespace {
       Tpetra::Details::KokkosRegionCounter::stop();
 
 #if defined(HAVE_TPETRA_CUDA) || defined(HAVE_TPETRACORE_CUDA)
+
+      // We don't use cuSPARSE SpMM for all versions.
+      // Below is the exact condition used to enable cuSPARSE for spmv_mv in KokkosKernels.
+      // (see KokkosSparse_spmv_mv_tpl_spec_avail.hpp for more details)
+      //
+      // - 10300 and below produced incorrect results and failed KK tests
+      // - 11702 also produced incorrect results for very small inputs, causing a Tpetra test to fail
+#if defined(CUSPARSE_VERSION) && (10301 <= CUSPARSE_VERSION) && (CUSPARSE_VERSION != 11702)
       if constexpr (std::is_same_v<typename Node::execution_space, Kokkos::Cuda>)
         TEST_COMPARE(Tpetra::Details::KokkosRegionCounter::get_count_region_contains("spmv[TPL_"), ==, 1);
+#endif
 #endif
 #if defined(HAVE_TPETRA_HIP) || defined(HAVE_TPETRACORE_HIP)
       // The multivector case is not yet hooked up in Kokkos Kernels.


### PR DESCRIPTION
For some versions of cusparse, KokkosKernels spmv_mv doesn't use cusparseSpMM because it gives incorrect results. For these versions, skip the check that a TPL was used in Tpetra. This only applies to cusparse and the multiple vectors case.

For reference, the versions of cuSPARSE that are never used are:
- CUSPARSE_VERSION < 10301
- CUSPARSE_VERSION == 11702
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Just a change to a test. My workstation happens to have CUDA 11.6 with ``CUSPARSE_VERSION == 11702`` installed, so this test was failing for me but this PR skips the failing check.
<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
