### PR TITLE
tpetra: test: look for Kokkos Kernels 4.3.1 TPL region labels

### DIFF
--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ApplyUsesTPLs.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ApplyUsesTPLs.cpp
@@ -292,15 +292,24 @@ namespace {
       // - 10300 and below produced incorrect results and failed KK tests
       // - 11702 also produced incorrect results for very small inputs, causing a Tpetra test to fail
 #if defined(CUSPARSE_VERSION) && (10301 <= CUSPARSE_VERSION) && (CUSPARSE_VERSION != 11702)
-      if constexpr (std::is_same_v<typename Node::execution_space, Kokkos::Cuda>)
-        TEST_COMPARE(Tpetra::Details::KokkosRegionCounter::get_count_region_contains("spmv[TPL_"), ==, 1);
-#endif
-#endif
+      if constexpr (std::is_same_v<typename Node::execution_space, Kokkos::Cuda>) {
+        const size_t numTplCalls =
+          Tpetra::Details::KokkosRegionCounter::get_count_region_contains("spmv[TPL_") +
+          Tpetra::Details::KokkosRegionCounter::get_count_region_contains("spmv_mv[TPL_"); // added in Kernels 4.3.1, okay to look for before
+        TEST_COMPARE(numTplCalls, ==, 1);
+      }
+#endif // Specific cuSparse versions work
+#endif // CUDA
+
 #if defined(HAVE_TPETRA_HIP) || defined(HAVE_TPETRACORE_HIP)
       // The multivector case is not yet hooked up in Kokkos Kernels.
-      if constexpr (std::is_same_v<typename Node::execution_space, Kokkos::HIP>)
-        TEST_COMPARE(Tpetra::Details::KokkosRegionCounter::get_count_region_contains("spmv[TPL_"), ==, 0);
-#endif
+      if constexpr (std::is_same_v<typename Node::execution_space, Kokkos::HIP>) {
+        const size_t numTplCalls =
+          Tpetra::Details::KokkosRegionCounter::get_count_region_contains("spmv[TPL_") +
+          Tpetra::Details::KokkosRegionCounter::get_count_region_contains("spmv_mv[TPL_"); // added in Kernels 4.3.1, okay to look for before
+        TEST_COMPARE(numTplCalls, ==, 0);
+      }
+#endif // HIP
     }
 
     using Teuchos::outArg;

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ApplyUsesTPLs.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ApplyUsesTPLs.cpp
@@ -307,7 +307,13 @@ namespace {
         const size_t numTplCalls =
           Tpetra::Details::KokkosRegionCounter::get_count_region_contains("spmv[TPL_") +
           Tpetra::Details::KokkosRegionCounter::get_count_region_contains("spmv_mv[TPL_"); // added in Kernels 4.3.1, okay to look for before
+#if (KOKKOSKERNELS_VERSION >= 40399)
+        // rocSparse spmv_mv has been added to KokkosKernels develop
+        // Delete the #else branch at the next release 
+        TEST_COMPARE(numTplCalls, ==, 1);
+#else
         TEST_COMPARE(numTplCalls, ==, 0);
+#endif
       }
 #endif // HIP
     }


### PR DESCRIPTION
Kokkos Kernels 4.3.1 updated the profiling region labels for SpMV TPL usage.