### PR TITLE
Framework: Force LoadEnv to use the system found in the build name

### DIFF
--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -735,7 +735,7 @@ class TrilinosPRConfigurationBase(object):
         self.message("+" + "-"*68 + "+")
         self.message("|   E N V I R O N M E N T   S E T   U P   S T A R T")
         self.message("+" + "-"*68 + "+")
-        tr_env = LoadEnv([self.arg_pr_genconfig_job_name],
+        tr_env = LoadEnv([self.arg_pr_genconfig_job_name, "--force"],
                          load_env_ini_file=Path(self.arg_pr_env_config_file))
         tr_env.load_set_environment()
 


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Some PR machines are marked RHEL7 by `supported-systems.ini` but we want to run RHEL8 configurations on those machines without yet changing the machine's system designation. 

Solution is to force the environment load step of LoadEnv in Trilinos' PR scripts to bypass the supported-systems check. This relies trust on the user configuring PR jobs to use the correct configuration, however, with non-blocking PR tests (which is what this is targeting), those configurations should already get tested before being put in place as a production configuration.


## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

- [TRILFRAME-651](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-651)
- #13062 
- #13067 

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Manually used LoadEnv to test that this is the correct way to inject the `--force` argument when creating a `LoadEnv` object.

Furthermore, this will be tested in this PR's non-blocking CUDA builds as if this works correctly, that non-blocking build should be able to finally run
<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
