### PR TITLE
Framework: Finalize RHEL8 Clang build (disable failing test)

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -445,6 +445,11 @@ opt-set-cmake-var TPL_METIS_LIBRARIES STRING FORCE : ${METIS_LIB|ENV}/libmetis.s
 opt-set-cmake-var Zlib_INCLUDE_DIRS PATH FORCE : ${ZLIB_INC|ENV}
 opt-set-cmake-var Zlib_LIBRARY_DIRS PATH FORCE : ${ZLIB_LIB|ENV}
 
+# This is temporarily disabled because it seems to be particularly sensitive to the spack-built
+#  MPI issue (TRILFRAME-552)
+opt-set-cmake-var ROL_example_PinT_parabolic-control_AugmentedSystem_test_MPI_2_DISABLE BOOL FORCE : ON
+
+
 [COMMON_AUE_SPACK]
 use COMMON_SPACK_TPLS
 
@@ -2183,11 +2188,6 @@ opt-set-cmake-var Tempus_IMEX_RK_Staggered_FSA_Tangent_MPI_1_DISABLE BOOL FORCE 
 opt-set-cmake-var Tempus_Newmark_MPI_1_DISABLE BOOL FORCE : ON
 opt-set-cmake-var Tempus_Test_NewmarkImplicitAForm_HarmonicOscillator_Damped_FirstOrder_MPI_1_DISABLE BOOL FORCE : ON
 
-# This is temporarily disabled because it seems to be particularly sensitive to the spack-built
-#  MPI issue (TRILFRAME-552)
-opt-set-cmake-var ROL_example_PinT_parabolic-control_AugmentedSystem_test_MPI_2_DISABLE BOOL FORCE : ON
-
-
 [rhel7_sems-intel-2021.3-sems-openmpi-4.0.5_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 # uses sems-v2 modules
 use rhel7_sems-intel-2021.3-sems-openmpi-4.0.5_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
@@ -2291,10 +2291,6 @@ opt-set-cmake-var STKUnit_tests_stk_mesh_unit_tests_MPI_4_DISABLE BOOL : ON
 # This was failing fairly reliably and Nate said it should be okay to disable (https://github.com/trilinos/Trilinos/issues/11678)
 opt-set-cmake-var Kokkos_CoreUnitTest_CudaTimingBased_MPI_1_DISABLE BOOL : ON
 
-# This is temporarily disabled because it seems to be particularly sensitive to the spack-built
-#  MPI issue (TRILFRAME-552)
-opt-set-cmake-var ROL_example_PinT_parabolic-control_AugmentedSystem_test_MPI_2_DISABLE BOOL FORCE : ON
-
 # This is run serially to try to prevent some unpredictable issues where these tests may be trying
 #  overlap other executing tests on the same GPU after introducing usage for multiple GPUs for testing.
 #  (https://github.com/trilinos/Trilinos/pull/11391)
@@ -2347,10 +2343,6 @@ use USE-RDC|YES
 use PACKAGE-ENABLES|ALL-NO-EPETRA
 
 opt-set-cmake-var CMAKE_CXX_FLAGS                          STRING FORCE : -Wall -Wunused-parameter -Werror=unused-parameter -Wshadow -Werror=shadow -pedantic -Werror=pedantic -Werror=sign-compare -Werror=sign-compare -Wtype-limits -Werror=type-limits -Wuninitialized -Werror=uninitialized
-
-# This is temporarily disabled because it seems to be particularly sensitive to the spack-built
-#  MPI issue (TRILFRAME-552)
-opt-set-cmake-var ROL_example_PinT_parabolic-control_AugmentedSystem_test_MPI_2_DISABLE BOOL FORCE : ON
 
 [rhel8_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.1.4_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 # uses sems-v2 modules
@@ -2447,10 +2439,6 @@ opt-set-cmake-var ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE BOOL : ON
 opt-set-cmake-var STKUnit_tests_stk_mesh_unit_tests_MPI_4_DISABLE BOOL : ON
 # This was failing fairly reliably and Nate said it should be okay to disable (https://github.com/trilinos/Trilinos/issues/11678)
 opt-set-cmake-var Kokkos_CoreUnitTest_CudaTimingBased_MPI_1_DISABLE BOOL : ON
-
-# This is temporarily disabled because it seems to be particularly sensitive to the spack-built
-#  MPI issue (TRILFRAME-552)
-opt-set-cmake-var ROL_example_PinT_parabolic-control_AugmentedSystem_test_MPI_2_DISABLE BOOL FORCE : ON
 
 use PACKAGE-ENABLES|NO-EPETRA
 
@@ -2592,10 +2580,6 @@ opt-set-cmake-var ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE BOOL : ON
 opt-set-cmake-var STKUnit_tests_stk_mesh_unit_tests_MPI_4_DISABLE BOOL : ON
 # This was failing fairly reliably and Nate said it should be okay to disable (https://github.com/trilinos/Trilinos/issues/11678)
 opt-set-cmake-var Kokkos_CoreUnitTest_CudaTimingBased_MPI_1_DISABLE BOOL : ON
-
-# This is temporarily disabled because it seems to be particularly sensitive to the spack-built
-#  MPI issue (TRILFRAME-552)
-opt-set-cmake-var ROL_example_PinT_parabolic-control_AugmentedSystem_test_MPI_2_DISABLE BOOL FORCE : ON
 
 use PACKAGE-ENABLES|NO-EPETRA
 


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Want new Clang configuration usable.  This test was previously disabled, so carry that forwards.

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-650