### PR TITLE
Framework: Unify deprecated packages list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,19 @@ SET(Trilinos_MUST_FIND_ALL_TPL_LIBS_DEFAULT TRUE)
 # Some CMake and TriBiTS tweaks just for Trilinos
 include(TrilinosTweaks)
 
+
+SET(deprecated_packages Amesos AztecOO Epetra EpetraExt Ifpack Intrepid Isorropia ML NewPackage Pliris PyTrilinos ShyLU_DDCore ThyraEpetraAdapters ThyraEpetraExtAdapters Triutils)
+
+SET(Trilinos_DISABLE_DEPRECATED_PACKAGES OFF CACHE BOOL "Flag to easily disable all deprecated packages")
+IF(Trilinos_DISABLE_DEPRECATED_PACKAGES)
+  FOREACH(package ${deprecated_packages})
+    IF(Trilinos_ENABLE_${package})
+      message(WARNING "Deprecated packages are disabled, but disabled package '${package}' was enabled; disabling it")
+    ENDIF()
+    set(Trilinos_ENABLE_${package} OFF)
+  ENDFOREACH()
+ENDIF()
+
 # Do all of the processing for this Tribits project
 TRIBITS_PROJECT()
 
@@ -111,7 +124,7 @@ IF(${PROJECT_NAME}_ENABLE_YouCompleteMe)
   INCLUDE(CodeCompletion)
 ENDIF()
 
-set(deprecated_packages Amesos AztecOO Epetra EpetraExt Ifpack Intrepid Isorropia ML NewPackage Pliris PyTrilinos ShyLU_DDCore ThyraEpetraAdapters ThyraEpetraExtAdapters Triutils)
+
 set(enabled_deprecated_packages "")
 FOREACH(package ${deprecated_packages})
   IF(Trilinos_ENABLE_${package})

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -901,35 +901,13 @@ opt-set-cmake-var Trilinos_ENABLE_Zoltan2Core BOOL : ON
 
 [PACKAGE-ENABLES|ALL-NO-EPETRA]
 opt-set-cmake-var Trilinos_ENABLE_ALL_PACKAGES BOOL FORCE : ON
-opt-set-cmake-var Trilinos_ENABLE_Amesos BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Domi BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Epetra BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_EpetraExt BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_FEI BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Ifpack BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Intrepid BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Komplex BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Moertel BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_ML BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Rythmos BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_TriKota BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_DISABLE_DEPRECATED_PACKAGES BOOL FORCE : ON
 
 [PACKAGE-ENABLES|NO-EPETRA]
 # Identical from ALL-NO-EPETRA directive, but without enabling all of the
 # packages first. This directive can be used in builds that may be enabling
 # certain packages directly without any of the directives pre-defined above.
-opt-set-cmake-var Trilinos_ENABLE_Amesos BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Domi BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Epetra BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_EpetraExt BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_FEI BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Ifpack BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Intrepid BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Komplex BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Moertel BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_ML BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Rythmos BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_TriKota BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_DISABLE_DEPRECATED_PACKAGES BOOL FORCE : ON
 
 [PACKAGE-ENABLES|NO-PACKAGE-ENABLES]
 # Nothing to do here.


### PR DESCRIPTION
@trilinos/framework 
## Motivation
I noticed that our no-epetra builds were warning about building Triutils even though it was deprecated.  Use the list of deprecated packages in `CMakeLists.txt` to disable those packages, instead of duplicating that information in `config-specs.ini`.

## Testing
I ran the following configures:
`cmake -DTrilinos_ENABLE_ALL_PACKAGES=ON -DTrilinos_DISABLE_DEPRECATED_PACKAGES=ON ..` -- all packages that are not deprecated were enabled.
`cmake -DTrilinos_ENABLE_ALL_PACKAGES=ON -DTrilinos_DISABLE_DEPRECATED_PACKAGES=ON -DTrilinos_ENABLE_Epetra ..` -- all packages that are not deprecated were enabled, and I got configure-time warnings that I had attempted to enable a deprecated package despite turning them off.

