### PR TITLE
Framework: Add RHEL8 Anaconda3 configuration

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1829,6 +1829,65 @@ opt-set-cmake-var Trilinos_ENABLE_BUILD_STATS BOOL FORCE   : OFF
 
 use RHEL7_POST
 
+[rhel8_aue-gnu-12.1.0-anaconda3-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_pr-framework]
+use COMMON
+
+use COMPILER|GNU
+use NODE-TYPE|SERIAL
+use BUILD-TYPE|DEBUG
+use LIB-TYPE|SHARED
+use KOKKOS-ARCH|NO-KOKKOS-ARCH
+use USE-ASAN|NO
+use USE-FPIC|NO
+use USE-MPI|NO
+use USE-PT|NO
+use USE-COMPLEX|NO
+use USE-RDC|NO
+use USE-UVM|NO
+use USE-DEPRECATED|YES
+
+use PACKAGE-ENABLES|PR-FRAMEWORK
+
+# Use the below option only when submitting to the dashboard
+#opt-set-cmake-var CTEST_USE_LAUNCHERS BOOL FORCE : ON
+
+opt-set-cmake-var TFW_Python3_Testing BOOL FORCE : ON
+opt-set-cmake-var TFW_Python_Testing BOOL FORCE : ON
+
+opt-set-cmake-var PYTHON_PIP_EXECUTABLE STRING FORCE : pip3
+opt-set-cmake-var PYTHON_EXECUTABLE_SEARCH_PATHS STRING FORCE : ${PYTHON_EXECUTABLE_SEARCH_PATHS|ENV}
+
+# Note: there is no way to capture the below cmake logic in our ini files.
+# Instead, we just set the PYTHON_EXECUTABLE to the result of
+# 'envvar-find-in-path PYTHON_EXECUTABLE : python3' from environment-specs.ini
+
+# find_program(PYTHON_EXECUTABLE
+#     NAMES python3 python
+#     PATHS ${PYTHON_EXECUTABLE_SEARCH_PATHS}
+#     PATH_SUFFIXES bin
+#     DOC "Set by default for PR testing"
+#     NO_DEFAULT_PATH
+#     )
+# if(DEFINED PYTHON_EXECUTABLE_NOTFOUND)
+#     message(FATAL_ERROR "Unable to locate Python in ${PYTHON_EXECUTABLE_SEARCH_PATHS}")
+# else()
+#     message(STATUS "PYTHON FOUND: ${PYTHON_EXECUTABLE}")
+# endif()
+opt-set-cmake-var PYTHON_EXECUTABLE STRING FORCE : ${PYTHON_EXECUTABLE|ENV}
+
+
+opt-set-cmake-var TPL_ENABLE_Boost    BOOL FORCE : OFF
+opt-set-cmake-var TPL_ENABLE_BoostLib BOOL FORCE : OFF
+opt-set-cmake-var TPL_ENABLE_ParMETIS BOOL FORCE : OFF
+opt-set-cmake-var TPL_ENABLE_Zlib     BOOL FORCE : OFF
+opt-set-cmake-var TPL_ENABLE_HDF5     BOOL FORCE : OFF
+opt-set-cmake-var TPL_ENABLE_Netcdf   BOOL FORCE : OFF
+opt-set-cmake-var TPL_ENABLE_SuperLU  BOOL FORCE : OFF
+opt-set-cmake-var TPL_ENABLE_Scotch   BOOL FORCE : OFF
+
+# No build stats for Python-only PR (#7376)
+opt-set-cmake-var Trilinos_ENABLE_BUILD_STATS BOOL FORCE   : OFF
+
 [rhel7_sems-gnu-8.3.0-openmpi-1.10.1-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 #uses sems-archive modules
 use RHEL7_SEMS_COMPILER|GNU

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -173,6 +173,7 @@ ascdo-gnu-12.1.0-openmpi-4.1.4-serial
 gnu
 
 [rhel8]
+aue-gnu-12.1.0-anaconda3-serial
 oneapi-intelmpi
 cuda-gcc-openmpi
 gcc-openmpi


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Need this environment for running the Framework unit tests.

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-653
https://cee-gitlab.sandia.gov/trilinos-project/srn-ini-files/-/merge_requests/76


## Testing
I ran the config + tests, and the only one that failed was because I don't have pytest-cov installed.  The scripts should take care of that for us, so this should be good to go (odds are, at least).
