### PR TITLE
Tpetra: Use a stable sort only for makeColMap and makeOptimizedColMap

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_makeColMap_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_makeColMap_def.hpp
@@ -195,7 +195,7 @@ makeColMapImpl(Teuchos::RCP<const Tpetra::Map<LO, GO, NT>>& colMap,
   // NOTE (mfh 02 Sep 2014) This needs to be a stable sort, so that
   // it respects either of the possible orderings of GIDs (sorted,
   // or original order) specified above.
-  sort2 (remotePIDs.begin (), remotePIDs.end (), remoteColGIDs.begin ());
+  sort2 (remotePIDs.begin (), remotePIDs.end (), remoteColGIDs.begin (), true);
 
   // Copy the local GIDs into myColumns. Two cases:
   // 1. If the number of Local column GIDs is the same as the number

--- a/packages/tpetra/core/src/Tpetra_Details_makeOptimizedColMap.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_makeOptimizedColMap.hpp
@@ -274,7 +274,7 @@ namespace Details {
         out << os.str ();
       }
       using Tpetra::sort2;
-      sort2 (remotePids.begin (), remotePids.end (), remoteGids.begin ());
+      sort2 (remotePids.begin (), remotePids.end (), remoteGids.begin (), true);
       if (verbose) {
         std::ostringstream os;
         os << *verboseHeader << "- After sort2:" << endl

--- a/packages/tpetra/core/src/Tpetra_Util.hpp
+++ b/packages/tpetra/core/src/Tpetra_Util.hpp
@@ -584,7 +584,7 @@ namespace Tpetra {
    *   first N elements of the second array.
    */
   template<class IT1, class IT2>
-  void sort2(const IT1 &first1, const IT1 &last1, const IT2 &first2) {
+  void sort2(const IT1 &first1, const IT1 &last1, const IT2 &first2, const bool stableSort=false) {
     // Quicksort uses best-case N log N time whether or not the input
     // data is sorted.  However, the common case in Tpetra is that the
     // input data are sorted, so we first check whether this is the
@@ -592,7 +592,10 @@ namespace Tpetra {
     if(SortDetails::isAlreadySorted(first1, last1)){
       return;
     }
-    SortDetails::std_sort2(first1, last1, first2, first2+(last1-first1));
+    if(stableSort)
+      SortDetails::std_sort2(first1, last1, first2, first2+(last1-first1));
+    else
+      SortDetails::sh_sort2(first1, last1, first2, first2+(last1-first1));
 #ifdef HAVE_TPETRA_DEBUG
     if(!SortDetails::isAlreadySorted(first1, last1)){
       std::cout << "Trouble: sort() did not sort !!" << std::endl;
@@ -684,7 +687,7 @@ namespace Tpetra {
    */
   template<class IT1, class IT2, class IT3>
   void sort3(const IT1 &first1, const IT1 &last1, const IT2 &first2,
-    const IT3 &first3)
+    const IT3 &first3, const bool stableSort=false)
   {
     // Quicksort uses best-case N log N time whether or not the input
     // data is sorted.  However, the common case in Tpetra is that the
@@ -693,9 +696,12 @@ namespace Tpetra {
     if(SortDetails::isAlreadySorted(first1, last1)){
       return;
     }
-    SortDetails::std_sort3(first1, last1, first2, first2+(last1-first1), first3,
-                    first3+(last1-first1));
-
+    if(stableSort)
+      SortDetails::std_sort3(first1, last1, first2, first2+(last1-first1), first3,
+                      first3+(last1-first1));
+    else
+      SortDetails::sh_sort3(first1, last1, first2, first2+(last1-first1), first3,
+                      first3+(last1-first1));
 #ifdef HAVE_TPETRA_DEBUG
     if(!SortDetails::isAlreadySorted(first1, last1)){
         std::cout << " Trouble sort did not actually sort... !!!!!!" <<


### PR DESCRIPTION
Following the merge of #13082, we observed performance regression in Tpetra nightly performance tests.

This PR enables the usage of a stable sort (slower and requires extra memory) only when constructing the column map, otherwise a (unstable) shell sort is used as before #13082.