### PR TITLE
zoltan2: replace use of char* code with std::string with istringstream

### DIFF
--- a/packages/zoltan2/test/core/unit/input/XpetraMultiVectorInput.cpp
+++ b/packages/zoltan2/test/core/unit/input/XpetraMultiVectorInput.cpp
@@ -168,7 +168,6 @@ void readChacoGraphHeaderInfo(
   std::ifstream &fp, 
   size_t &nIDs, 
   size_t &nEdges, 
-  char *code, 
   int &nWgts)
 {
   // Read the header info from a Chaco .graph file
@@ -176,8 +175,9 @@ void readChacoGraphHeaderInfo(
   std::getline(fp, line);
   while (line[0]=='#') std::getline(fp, line); // skip comments
   std::istringstream issHeader(line);
-  issHeader >> nIDs >> nEdges >> code;
-  if (!strcmp(code, "010") || !strcmp(code, "011")) {
+  std::string s_code;
+  issHeader >> nIDs >> nEdges >> s_code;
+  if (!strcmp(s_code.c_str(), "010") || !strcmp(s_code.c_str(), "011")) {
     if (!(issHeader >> nWgts)) nWgts = 1;
   }
 }
@@ -205,7 +205,6 @@ int verifyGenerateFiles(
 
     size_t nIDsGen, nIDsInp;
     size_t nEdgesGen, nEdgesInp;
-    char codeGen[4], codeInp[4];
     int nWgtsGen = 0, nWgtsInp = 0;
     std::string lineGen, lineInp;
 
@@ -217,11 +216,11 @@ int verifyGenerateFiles(
 
     // Read header info from generated file
     fpGen.open(graphFilenameGen.c_str(), std::ios::in);
-    readChacoGraphHeaderInfo(fpGen, nIDsGen, nEdgesGen, codeGen, nWgtsGen);
+    readChacoGraphHeaderInfo(fpGen, nIDsGen, nEdgesGen, nWgtsGen);
 
     // Read header info from input file
     fpInp.open(graphFilenameInp.c_str(), std::ios::in);
-    readChacoGraphHeaderInfo(fpInp, nIDsInp, nEdgesInp, codeInp, nWgtsInp);
+    readChacoGraphHeaderInfo(fpInp, nIDsInp, nEdgesInp, nWgtsInp);
 
     // input file and generated file should have same number of IDs
     if (nIDsGen != nIDsInp) {


### PR DESCRIPTION
Replace the use of char* code with a std::string in the readChacoGraphHeaderInfo routine

This resolves compilation errors with cuda/12.4+gcc/13.2.0 with c++20:
```
/home/ndellin/Trilinos/packages/zoltan2/test/core/unit/input/XpetraMultiVectorInput.cpp(179): error: no operator ">>" matches these operands
            operand types are: std::basic_istream<char, std::char_traits<char>> >> char *
    issHeader >> nIDs >> nEdges >> code;
```

The `char* code` variable is not used outside of the `readChacoGraphHeaderInfo` routine, so it was removed from the function signature and the corresponding input variables were removed as well, replaced by use of `std::string s_code` variable within the routine to receive the istringstream input and for comparison (via c_str())

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 @egboman 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Change made to resolve compilation errors in builds with cuda/12.4 + gcc/13.2.0 with c++20 support enabled:

```
/home/ndellin/Trilinos/packages/zoltan2/test/core/unit/input/XpetraMultiVectorInput.cpp(179): error: no operator ">>" matches these operands
            operand types are: std::basic_istream<char, std::char_traits<char>> >> char *
    issHeader >> nIDs >> nEdges >> code;
```


## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
Local testing with sems modules:

```
export TRILINOS_DIR=<your-path>
export KOKKOS_DIR=$TRILINOS_DIR/packages/kokkos
module load sems-gcc/13.2.0 sems-cuda/12.4.0 sems-openblas/0.3.10 sems-openmpi/4.1.6 sems-cmake sems-ninja
export OMPI_CXX=$KOKKOS_DIR/bin/nvcc_wrapper

cmake \
 -GNinja \
 -DCMAKE_INSTALL_PREFIX="${PWD}/install" \
 -DCMAKE_CXX_STANDARD="20" \
 -DTPL_ENABLE_MPI:BOOL=ON \
  -DTPL_ENABLE_CUDA=ON \
  -DTPL_ENABLE_BLAS:STRING=ON \
   -DBLAS_LIBRARY_DIRS:FILEPATH="$OPENBLAS_ROOT/lib" \
   -DBLAS_LIBRARY_NAMES:STRING="openblas" \
  -DTPL_ENABLE_LAPACK:STRING=ON \
   -DLAPACK_INCLUDE_DIRS:FILEPATH="$OPENBLAS_ROOT/include" \
   -DLAPACK_LIBRARY_DIRS:FILEPATH="$OPENBLAS_ROOT/lib" \
   -DLAPACK_LIBRARY_NAMES:STRING="openblas" \
  -DTPL_ENABLE_CUSPARSE:BOOL=ON \
  -DTPL_ENABLE_CUBLAS:BOOL=ON \
 -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES=OFF \
 -DTrilinos_ENABLE_TESTS=ON \
 -DTrilinos_MUST_FIND_ALL_TPL_LIBS=TRUE \
 -DTrilinos_ENABLE_ALL_PACKAGES=OFF \
 -DTrilinos_ENABLE_COMPLEX=ON \
 -DTrilinos_ENABLE_OpenMP=OFF \
 -DTrilinos_ENABLE_Kokkos=ON \
   -D Kokkos_ENABLE_TESTS=ON \
 -DKokkos_ENABLE_CUDA=ON \
 -DKokkos_ENABLE_CUDA_LAMBDA=ON \
 -DKokkos_ENABLE_CUDA_UVM=OFF \
  -DTrilinos_ENABLE_KokkosKernels=ON \
   -D KokkosKernels_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_Tpetra=ON \
   -D Tpetra_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_Sacado=ON \
   -D Sacado_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_Stokhos=ON \
   -D Stokhos_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_Adelus=ON \
   -D Adelus_ENABLE_TESTS=OFF \
  -DTrilinos_ENABLE_Compadre=ON \
   -D Compadre_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_Amesos2=ON \
   -D Amesos2_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_Zoltan2=ON \
   -D Zoltan2_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_Ifpack2=OFF \
   -D Ifpack2_ENABLE_TESTS=OFF \
  -DTrilinos_ENABLE_Belos=ON \
   -D Belos_ENABLE_TESTS=ON \
\
  -DTPL_ENABLE_Matio=OFF \
  -DTrilinos_ENABLE_ShyLU_NodeTacho=OFF \
\
$TRILINOS_DIR
```

<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
