### PR TITLE
ifpack: Fix-Non-UTF-8-Encoded-Characters

### DIFF
--- a/packages/PyTrilinos/doc/UsersGuide/biblio.bib
+++ b/packages/PyTrilinos/doc/UsersGuide/biblio.bib
@@ -1391,7 +1391,7 @@ MRREVIEWER = {Jan Mandel},
 }
 
 @article{stuben01review,
- author = {K. Stüben},
+ author = {K. St\"uben},
  title = {A review of algebraic multigrid},
  journal = {Journal of Computational and Applied Mathematics},
  volume = {128},
@@ -2336,7 +2336,7 @@ for the 3{D} Compressible {E}uler Equations},
 @InProceedings{deconinck01upwind,
   author = 	 {H. Deconinck, K. Sermeus, A. \'Cs\'ik and M. Ricchiuto},
   title = 	 {Upwind residual distribution schemes for hyperbolic conservation laws},
-  booktitle = 	 {1er Congrès National de Mathématiques Appliquées et Industrielles, Pompadour, France},
+  booktitle = 	 {1er Congr\'es National de Math\'ematiques Appliqu\'ees et Industrielles, Pompadour, France},
   year =         {2001}
 }
 
@@ -2677,7 +2677,7 @@ Approximation Spaces for Elliptic Problems},
   ALTauthor = 	 {},
   editor = 	 {},
   title = 	 {Computational Fluid Dynamics Lecture Series LS 2000-05},
-  publisher = 	 {VKI Rhode-Saint Genèse},
+  publisher =    {VKI Rhode-Saint Gen\'ese},
   year = 	 {2000},
   OPTkey = 	 {},
   OPTvolume = 	 {},

--- a/packages/ifpack/doc/UsersGuide/biblio.bib
+++ b/packages/ifpack/doc/UsersGuide/biblio.bib
@@ -1391,7 +1391,7 @@ MRREVIEWER = {Jan Mandel},
 }
 
 @article{stuben01review,
- author = {K. Stüben},
+ author = {K. St\"uben},
  title = {A review of algebraic multigrid},
  journal = {Journal of Computational and Applied Mathematics},
  volume = {128},
@@ -2336,7 +2336,7 @@ for the 3{D} Compressible {E}uler Equations},
 @InProceedings{deconinck01upwind,
   author = 	 {H. Deconinck, K. Sermeus, A. \'Cs\'ik and M. Ricchiuto},
   title = 	 {Upwind residual distribution schemes for hyperbolic conservation laws},
-  booktitle = 	 {1er Congrès National de Mathématiques Appliquées et Industrielles, Pompadour, France},
+  booktitle = 	 {1er Congr\'es National de Math\'ematiques Appliqu\'ees et Industrielles, Pompadour, France},
   year =         {2001}
 }
 
@@ -2677,7 +2677,7 @@ Approximation Spaces for Elliptic Problems},
   ALTauthor = 	 {},
   editor = 	 {},
   title = 	 {Computational Fluid Dynamics Lecture Series LS 2000-05},
-  publisher = 	 {VKI Rhode-Saint Genèse},
+  publisher = 	 {VKI Rhode-Saint Gen\'ese},
   year = 	 {2000},
   OPTkey = 	 {},
   OPTvolume = 	 {},


### PR DESCRIPTION
These bib files had non-UTF-8 encoded characters (e.g., umlaut). Placed them with the latex equivalent.

@trilinos/ifpack 
@trilinos/pytrilinos 
