### PR TITLE
Framework: Disable deprecated packages for CUDA PR

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2339,6 +2339,7 @@ use USE-RDC|NO
 use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
+use PACKAGE-ENABLES|NO-EPETRA
 use COMMON_SPACK_TPLS
 use SEMS_COMMON_CUDA_11
 
@@ -2417,8 +2418,6 @@ opt-set-cmake-var ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE BOOL : ON
 opt-set-cmake-var STKUnit_tests_stk_mesh_unit_tests_MPI_4_DISABLE BOOL : ON
 # This was failing fairly reliably and Nate said it should be okay to disable (https://github.com/trilinos/Trilinos/issues/11678)
 opt-set-cmake-var Kokkos_CoreUnitTest_CudaTimingBased_MPI_1_DISABLE BOOL : ON
-
-use PACKAGE-ENABLES|NO-EPETRA
 
 use RHEL7_POST
 
@@ -2480,6 +2479,7 @@ use USE-UVM|NO
 use USE-DEPRECATED|YES
 
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
+use PACKAGE-ENABLES|NO-EPETRA
 use COMMON_SPACK_TPLS
 use SEMS_COMMON_CUDA_11
 
@@ -2558,8 +2558,6 @@ opt-set-cmake-var ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE BOOL : ON
 opt-set-cmake-var STKUnit_tests_stk_mesh_unit_tests_MPI_4_DISABLE BOOL : ON
 # This was failing fairly reliably and Nate said it should be okay to disable (https://github.com/trilinos/Trilinos/issues/11678)
 opt-set-cmake-var Kokkos_CoreUnitTest_CudaTimingBased_MPI_1_DISABLE BOOL : ON
-
-use PACKAGE-ENABLES|NO-EPETRA
 
 use RHEL7_POST
 


### PR DESCRIPTION
@trilinos/framework 

## Motivation
We previously had disabled the deprecated (mostly Epetra-based) packages for the GPU PR configurations.  I missed that when converting the configurations to RHEL8, so restore that behavior here.
