### PR TITLE
Framework: Drop verbosity level under Jenkins

### DIFF
--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
@@ -56,8 +56,12 @@ class TrilinosPRConfigurationStandard(TrilinosPRConfigurationBase):
             gc.write_cmake_fragment()
 
         # Execute the call to ctest.
+        verbosity_flag = "-VV"
+        if "BUILD_NUMBER" in os.environ:
+            print("Running under Jenkins, keeping output less verbose to avoid space issues")
+            verbosity_flag = "-V"
         cmd = ['ctest',
-               "-VV",
+               verbosity_flag,
                 "-S", f"{self.arg_ctest_driver}",
                f"-Dsource_dir:PATH={self.arg_source_dir}",
                f"-Dbuild_dir:PATH={self.arg_build_dir}",


### PR DESCRIPTION
I turned up the build/test console verbosity without really thinking about what this meant for our Jenkins console output storage.  Long story short, we're running out of space. Automatically detect whether we're using Jenkins or not to dynamically adjust the verbosity.

@trilinos/framework 