### PR TITLE
Framework: Deprecated packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,19 +99,6 @@ SET(Trilinos_MUST_FIND_ALL_TPL_LIBS_DEFAULT TRUE)
 # Some CMake and TriBiTS tweaks just for Trilinos
 include(TrilinosTweaks)
 
-
-SET(deprecated_packages Amesos AztecOO Epetra EpetraExt Ifpack Intrepid Isorropia ML NewPackage Pliris PyTrilinos ShyLU_DDCore ThyraEpetraAdapters ThyraEpetraExtAdapters Triutils)
-
-SET(Trilinos_DISABLE_DEPRECATED_PACKAGES OFF CACHE BOOL "Flag to easily disable all deprecated packages")
-IF(Trilinos_DISABLE_DEPRECATED_PACKAGES)
-  FOREACH(package ${deprecated_packages})
-    IF(Trilinos_ENABLE_${package})
-      message(WARNING "Deprecated packages are disabled, but disabled package '${package}' was enabled; disabling it")
-    ENDIF()
-    set(Trilinos_ENABLE_${package} OFF)
-  ENDFOREACH()
-ENDIF()
-
 # Do all of the processing for this Tribits project
 TRIBITS_PROJECT()
 
@@ -124,7 +111,7 @@ IF(${PROJECT_NAME}_ENABLE_YouCompleteMe)
   INCLUDE(CodeCompletion)
 ENDIF()
 
-
+set(deprecated_packages Amesos AztecOO Epetra EpetraExt Ifpack Intrepid Isorropia ML NewPackage Pliris PyTrilinos ShyLU_DDCore ThyraEpetraAdapters ThyraEpetraExtAdapters Triutils)
 set(enabled_deprecated_packages "")
 FOREACH(package ${deprecated_packages})
   IF(Trilinos_ENABLE_${package})

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2446,6 +2446,10 @@ opt-set-cmake-var STKUnit_tests_stk_mesh_unit_tests_MPI_4_DISABLE BOOL : ON
 # This was failing fairly reliably and Nate said it should be okay to disable (https://github.com/trilinos/Trilinos/issues/11678)
 opt-set-cmake-var Kokkos_CoreUnitTest_CudaTimingBased_MPI_1_DISABLE BOOL : ON
 
+# Unstable
+opt-set-cmake-var Adelus_vector_random_npr3_rhs1_MPI_3_DISABLE BOOL : ON
+opt-set-cmake-var Adelus_vector_random_npr4_rhs1_MPI_4_DISABLE BOOL : ON
+
 use PACKAGE-ENABLES|NO-EPETRA
 
 use RHEL7_POST
@@ -2586,6 +2590,10 @@ opt-set-cmake-var ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE BOOL : ON
 opt-set-cmake-var STKUnit_tests_stk_mesh_unit_tests_MPI_4_DISABLE BOOL : ON
 # This was failing fairly reliably and Nate said it should be okay to disable (https://github.com/trilinos/Trilinos/issues/11678)
 opt-set-cmake-var Kokkos_CoreUnitTest_CudaTimingBased_MPI_1_DISABLE BOOL : ON
+
+# Unstable
+opt-set-cmake-var Adelus_vector_random_npr3_rhs1_MPI_3_DISABLE BOOL : ON
+opt-set-cmake-var Adelus_vector_random_npr4_rhs1_MPI_4_DISABLE BOOL : ON
 
 use PACKAGE-ENABLES|NO-EPETRA
 

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -907,34 +907,40 @@ opt-set-cmake-var Trilinos_ENABLE_Zoltan2Core BOOL : ON
 [PACKAGE-ENABLES|ALL-NO-EPETRA]
 opt-set-cmake-var Trilinos_ENABLE_ALL_PACKAGES BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_Amesos BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Domi BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_AztecOO BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_Epetra BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_EpetraExt BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_FEI BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_Ifpack BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_Intrepid BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Komplex BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Moertel BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Isorropia BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_ML BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Rythmos BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_TriKota BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_NewPackage BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Pliris BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_PyTrilinos BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_ShyLU_DDCore BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_ThyraEpetraAdapters BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_ThyraEpetraExtAdapters BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Triutils BOOL FORCE : OFF
 
 [PACKAGE-ENABLES|NO-EPETRA]
 # Identical from ALL-NO-EPETRA directive, but without enabling all of the
 # packages first. This directive can be used in builds that may be enabling
 # certain packages directly without any of the directives pre-defined above.
 opt-set-cmake-var Trilinos_ENABLE_Amesos BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Domi BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_AztecOO BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_Epetra BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_EpetraExt BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_FEI BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_Ifpack BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_Intrepid BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Komplex BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Moertel BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Isorropia BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_ML BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Rythmos BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_TriKota BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_NewPackage BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Pliris BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_PyTrilinos BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_ShyLU_DDCore BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_ThyraEpetraAdapters BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_ThyraEpetraExtAdapters BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Triutils BOOL FORCE : OFF
 
 [PACKAGE-ENABLES|NO-PACKAGE-ENABLES]
 # Nothing to do here.

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -906,13 +906,35 @@ opt-set-cmake-var Trilinos_ENABLE_Zoltan2Core BOOL : ON
 
 [PACKAGE-ENABLES|ALL-NO-EPETRA]
 opt-set-cmake-var Trilinos_ENABLE_ALL_PACKAGES BOOL FORCE : ON
-opt-set-cmake-var Trilinos_DISABLE_DEPRECATED_PACKAGES BOOL FORCE : ON
+opt-set-cmake-var Trilinos_ENABLE_Amesos BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Domi BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Epetra BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_EpetraExt BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_FEI BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Ifpack BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Intrepid BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Komplex BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Moertel BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_ML BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Rythmos BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_TriKota BOOL FORCE : OFF
 
 [PACKAGE-ENABLES|NO-EPETRA]
 # Identical from ALL-NO-EPETRA directive, but without enabling all of the
 # packages first. This directive can be used in builds that may be enabling
 # certain packages directly without any of the directives pre-defined above.
-opt-set-cmake-var Trilinos_DISABLE_DEPRECATED_PACKAGES BOOL FORCE : ON
+opt-set-cmake-var Trilinos_ENABLE_Amesos BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Domi BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Epetra BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_EpetraExt BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_FEI BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Ifpack BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Intrepid BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Komplex BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Moertel BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_ML BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_Rythmos BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_TriKota BOOL FORCE : OFF
 
 [PACKAGE-ENABLES|NO-PACKAGE-ENABLES]
 # Nothing to do here.


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Want an updated deprecated packages list.

## Testing
Reverting to previous methodology for deprecated package disablement because the new approach from #11310 does not work with how we pass around files.  The configuration options end up in a file that is included via `Trilinos_CONFIGURE_OPTIONS_FILE` which is not included until we enter TriBITS, so I can't use the values in the root-level CMakeLists.txt.