### PR TITLE
Framework: Remove misleading RHEL8 configuration comments

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2978,7 +2978,6 @@ use rhel8_sems-gnu-8.5.0-openmpi-4.1.6-openmp_release-debug_static_no-kokkos-arc
 use PACKAGE-ENABLES|ALL
 
 [rhel8_sems-gnu-8.5.0-openmpi-4.1.6-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
-#uses sems-archive modules
 use COMPILER|GNU
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|DEBUG
@@ -3041,23 +3040,19 @@ opt-set-cmake-var Tempus_Test_NewmarkImplicitAForm_HarmonicOscillator_Damped_Fir
 use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
 
 [rhel8_sems-gnu-8.5.0-openmpi-4.1.6-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
-#uses sems-archive modules
 use rhel8_sems-gnu-8.5.0-openmpi-4.1.6-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel8_sems-gnu-8.5.0-openmpi-4.1.6-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all-no-epetra]
-#uses sems-archive modules
 use rhel8_sems-gnu-8.5.0-openmpi-4.1.6-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL-NO-EPETRA
 
 [rhel8_sems-gnu-8.5.0-openmpi-4.1.6-serial_debug-coverage_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
-#uses sems-archive modules
 use rhel8_sems-gnu-8.5.0-openmpi-4.1.6-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use BUILD-TYPE|DEBUG-COVERAGE-GNU
 use PACKAGE-ENABLES|ALL
 
 [rhel8_sems-gnu-8.5.0-openmpi-4.1.6-serial_debug_shared_no-kokkos-arch_no-asan_complex-float_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
-#uses sems-archive modules
 use rhel8_sems-gnu-8.5.0-openmpi-4.1.6-serial_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 opt-set-cmake-var Trilinos_ENABLE_DOUBLE                                 BOOL FORCE   : OFF
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_DOUBLE                         BOOL FORCE   : OFF
@@ -3065,7 +3060,6 @@ opt-set-cmake-var Trilinos_ENABLE_FLOAT                                  BOOL FO
 opt-set-cmake-var Trilinos_ENABLE_COMPLEX_FLOAT                          BOOL FORCE   : ON
 
 [rhel8_sems-gnu-8.5.0-openmpi-4.1.6-serial_debug_shared_no-kokkos-arch_no-asan_complex-float_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
-#uses sems-archive modules
 use rhel8_sems-gnu-8.5.0-openmpi-4.1.6-serial_debug_shared_no-kokkos-arch_no-asan_complex-float_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Several of the new RHEL8 configurations contain comments indicating that those configurations utilize sems-archive modules which is incorrect. Remove those comments so that when users want to use those configurations, they do not use the incorrect version of sems-modules.


## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->
- #13099
- [Mentioned in this comment](https://github.com/trilinos/Trilinos/pull/13099#discussion_r1642794940)

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Parts touched by these changes are only comments.
<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
