### PR TITLE
Tpetra: Fix hanging tests after Serial thread-safety fixes 

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -5846,10 +5846,8 @@ namespace Tpetra {
     }
 
     execute_sync_host_uvm_access(); // protect host UVM access
-    Kokkos::parallel_reduce
-      ("Tpetra::CrsGraph::pack: totalNumPackets",
-       inputRange,
-       [=, &prefix] (const LO i, size_t& curTotalNumPackets) {
+    totalNumPackets = 0;
+    for (LO i=0; i<numExportLIDs; ++i) {
          const LO lclRow = exportLIDs_h[i];
          const GO gblRow = rowMap.getGlobalElement (lclRow);
          if (gblRow == Tpetra::Details::OrdinalTraits<GO>::invalid ()) {
@@ -5865,10 +5863,9 @@ namespace Tpetra {
          else {
            const size_t numEnt = this->getNumEntriesInGlobalRow (gblRow);
            numPacketsPerLID_h(i) = numEnt;
-           curTotalNumPackets += numEnt;
+           totalNumPackets += numEnt;
          }
-      },
-      totalNumPackets);
+      }
 
     if (verbose) {
       std::ostringstream os;


### PR DESCRIPTION
@trilinos/tpetra

## Motivation
This pull request fixes the hanging Tpetra tests @ndellingwood was observing in https://github.com/kokkos/kokkos/issues/7092 after https://github.com/kokkos/kokkos/pull/7080. `Tpetra` calls in multiple places non-KOKKOS_FUNCTION functions from parallel constructs. Some of them allocate and deallocate data or call `Kokkos::fence`. This leads to hangs even with the `Serial` backend that now ensures that kernels submitted to the same execution space instance from multiple threads are not running concurrently.
This pull request either makes sure that data is not allocated via a `View` (which fences when deallocating) or replaces parallel constructs with serial for-loops.

## Related Issues

* Closes https://github.com/kokkos/kokkos/issues/7092

## Testing

Running the respective Tpetra tests with the configuration described in https://github.com/kokkos/kokkos/issues/7092.