### PR TITLE
Phalanx: Fix for kokkos serial changes

### DIFF
--- a/packages/phalanx/test/ViewOfViews/tPhalanxViewOfViews.cpp
+++ b/packages/phalanx/test/ViewOfViews/tPhalanxViewOfViews.cpp
@@ -590,6 +590,9 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,CreateHostHost) {
       TEST_FLOATING_EQUALITY(vov_host(2)(cell),4.0,tol);
       TEST_FLOATING_EQUALITY(vov_host(3)(cell),10.0,tol);
     }
+
+    // NOTE: you must call this on the host-host version to avoid deadlock!
+    PHX::freeInnerViewsOfHostHostViewOfViews(vov_host);
   }
 
   // Rank 2 outer view
@@ -616,6 +619,9 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,CreateHostHost) {
       TEST_FLOATING_EQUALITY(vov_host(1,0)(cell),4.0,tol);
       TEST_FLOATING_EQUALITY(vov_host(1,1)(cell),11.0,tol);
     }
+
+    // NOTE: you must call this on the host-host version to avoid deadlock!
+    PHX::freeInnerViewsOfHostHostViewOfViews(vov_host);
   }
 
   // Rank 3 outer view
@@ -642,6 +648,9 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,CreateHostHost) {
       TEST_FLOATING_EQUALITY(vov_host(2,2,2)(cell),4.0,tol);
       TEST_FLOATING_EQUALITY(vov_host(0,1,2)(cell),12.0,tol);
     }
+
+    // NOTE: you must call this on the host-host version to avoid deadlock!
+    PHX::freeInnerViewsOfHostHostViewOfViews(vov_host);
   }
 
 }


### PR DESCRIPTION

@trilinos/phalanx 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Now have to manually delete the inner views of a host-host mirror of a view-of-views. See Kokkos issue 7092 for details: https://github.com/kokkos/kokkos/issues/7092 

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->



<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
covered in view of view tests.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
