### PR TITLE
Ifpack2: fix a bad memory access on V100

### DIFF
--- a/packages/ifpack2/example/BlockTriDi.cpp
+++ b/packages/ifpack2/example/BlockTriDi.cpp
@@ -18,7 +18,7 @@ namespace { // (anonymous)
 
 // Values of command-line arguments.
 struct CmdLineArgs {
-  CmdLineArgs ():blockSize(-1),numIters(10),numRepeats(1),tol(1e-12),nx(172),ny(-1),nz(-1),mx(1),my(1),mz(1),sublinesPerLine(1),sublinesPerLineSchur(1),useStackedTimer(false),usePointMatrix(false),overlapCommAndComp(false){}
+  CmdLineArgs ():blockSize(-1),numIters(10),numRepeats(1),tol(1e-12),nx(172),ny(-1),nz(-1),mx(1),my(1),mz(1),sublinesPerLine(1),sublinesPerLineSchur(1),useStackedTimer(false),usePointMatrix(false),overlapCommAndComp(false),useSingleFile(false){}
 
   std::string mapFilename;
   std::string matrixFilename;
@@ -39,6 +39,7 @@ struct CmdLineArgs {
   bool useStackedTimer;
   bool usePointMatrix;
   bool overlapCommAndComp;
+  bool useSingleFile;
   std::string problemName;
   std::string matrixType;
 };
@@ -72,7 +73,9 @@ getCmdLineArgs (CmdLineArgs& args, int argc, char* argv[])
   cmdp.setOption ("withPointMatrix", "withoutPointMatrix", &args.usePointMatrix,
       "Whether to run with a point matrix");
   cmdp.setOption ("withOverlapCommAndComp", "withoutOverlapCommAndComp", &args.overlapCommAndComp,
-		  "Whether to run with overlapCommAndComp)");
+		  "Whether to run with overlapCommAndComp");
+  cmdp.setOption ("useSingeFile", "useOneFilePerRank", &args.useSingleFile,
+		  "Whether to read the matrix from one file or one file per rank");
   cmdp.setOption("problemName", &args.problemName, "Human-readable problem name for Watchr plot");
   cmdp.setOption("matrixType", &args.matrixType, "matrixType");
   cmdp.setOption("sublinesPerLineSchur", &args.sublinesPerLineSchur, "sublinesPerLineSchur");
@@ -473,7 +476,7 @@ main (int argc, char* argv[])
       // Read matrix
       if(rank0) std::cout<<"Reading matrix (as point)..."<<std::endl;
       RCP<const map_type> dummy_col_map;
-      if (comm->getSize() == 1)
+      if (args.useSingleFile || comm->getSize() == 1)
         A = reader_type::readSparseFile(args.matrixFilename, point_map, dummy_col_map, point_map, point_map);
       else {
         if(rank0) std::cout<<"Using per-rank reader..."<<std::endl;

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -4371,7 +4371,7 @@ namespace Ifpack2 {
         (void) npacks;
 
         internal_vector_scratch_type_3d_view
-          WW(member.team_scratch(0), blocksize, num_vectors, vector_loop_size);
+          WW(member.team_scratch(0), blocksize, 1, vector_loop_size);
 
         Kokkos::parallel_for
           (Kokkos::ThreadVectorRange(member, vector_loop_size),[&](const int &v) {

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -4364,7 +4364,6 @@ namespace Ifpack2 {
         const local_ordinal_type r0 = part2packrowidx0_sub(partidx,local_subpartidx);
         const local_ordinal_type nrows = partptr_sub(subpartidx,1) - partptr_sub(subpartidx,0);
         const local_ordinal_type blocksize = e_internal_vector_values.extent(2);
-        const local_ordinal_type num_vectors = blocksize;
 
         //(void) i0;
         //(void) nrows;


### PR DESCRIPTION
@tmranse observed a memory error with the BTDS with Schur complement on a specific case.

This PR fixes the issue and adds an option for the Ifpack2 driver to use only one file for all MPI ranks.