### PR TITLE
Seacas, Tpetra: fix warning-free build

### DIFF
--- a/packages/seacas/libraries/ioss/src/exodus/Ioex_DecompositionData.C
+++ b/packages/seacas/libraries/ioss/src/exodus/Ioex_DecompositionData.C
@@ -291,10 +291,6 @@ namespace Ioex {
             "exodus", filename, Ioss::READ_RESTART, Ioss::ParallelUtils::comm_self(), properties);
         Ioss::Region region(dbi, "line_decomp_region");
 
-        int status = Ioss::DecompUtils::line_decompose(
-            region, m_processorCount, m_decomposition.m_method, m_decomposition.m_decompExtra,
-            element_to_proc_global, INT(0));
-
 	if (m_decomposition.m_showHWM || m_decomposition.m_showProgress) {
 	  Ioss::DecompUtils::output_decomposition_statistics(element_to_proc_global, m_processorCount);
 	}

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -5792,7 +5792,7 @@ namespace Tpetra {
     const char tfecfFuncName[] = "packFillActiveNew: ";
     const bool verbose = verbose_;
 
-    const auto numExportLIDs = exportLIDs.extent (0);
+    const LO numExportLIDs = exportLIDs.extent (0);
     std::unique_ptr<std::string> prefix;
     if (verbose) {
       prefix = this->createPrefix("CrsGraph", "packFillActiveNew");
@@ -5802,8 +5802,9 @@ namespace Tpetra {
          << numPacketsPerLID.extent(0) << endl;
       std::cerr << os.str();
     }
+    const LO numPacketsPerLID_extent = numPacketsPerLID.extent (0);
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (numExportLIDs != numPacketsPerLID.extent (0), std::runtime_error,
+      (numExportLIDs !=  numPacketsPerLID_extent, std::runtime_error,
        "exportLIDs.extent(0) = " << numExportLIDs
        << " != numPacketsPerLID.extent(0) = "
        << numPacketsPerLID.extent (0) << ".");


### PR DESCRIPTION
Not long ago, a warning-free build of Trilinos broke; see #13168.  This PR should fix the problem.  The changes are to @trilinos/tpetra and @trilinos/seacas .