### PR TITLE
Tacho : fix version check for CuSparse SpMV/SpMM flags

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2179,6 +2179,72 @@ use USE-DEPRECATED|NO
 use rhel7_sems-intel-2021.3-sems-openmpi-4.0.5_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-off_no-package-enables
 use PACKAGE-ENABLES|ALL
 
+[rhel8_sems-intel-2021.3-sems-openmpi-4.1.4_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+# uses sems-v2 modules
+use RHEL7_COMPILER|INTEL
+use BUILD-TYPE|RELEASE-DEBUG
+use RHEL7_SEMS_LIB-TYPE|SHARED
+use KOKKOS-ARCH|NO-KOKKOS-ARCH
+use USE-ASAN|NO
+use USE-COMPLEX|NO
+use USE-FPIC|YES
+use USE-MPI|YES
+use USE-PT|NO
+use USE-RDC|NO
+use USE-UVM|NO
+use USE-DEPRECATED|YES
+use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
+use COMMON_SPACK_TPLS
+
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING     : --bind-to;none --mca btl vader,self
+
+opt-set-cmake-var TPL_Netcdf_LIBRARIES STRING FORCE : -L${NETCDF_C_LIB|ENV}/lib;${NETCDF_C_LIB|ENV}/libnetcdf.so;${PARALLEL_NETCDF_LIB|ENV}/libpnetcdf.a
+opt-set-cmake-var TPL_HDF5_LIBRARIES STRING FORCE : ${HDF5_LIB|ENV}/libhdf5_hl.so;${HDF5_LIB|ENV}/libhdf5.a;${ZLIB_LIB|ENV}/libz.a;-ldl
+
+# I get the following error if I do not disable ML_ENABLE_SuperLU:
+# ML CONFIGURATION ERROR:  SuperLU_5.0 detected - only SuperLU version < 5.0 currently supported for this package.
+opt-set-cmake-var ML_ENABLE_SuperLU BOOL FORCE : OFF
+
+opt-set-cmake-var Zoltan_ch_simple_parmetis_parallel_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Zoltan_ch_7944_parmetis_parallel_DISABLE BOOL FORCE   : ON
+opt-set-cmake-var Zoltan_ch_simple_scotch_parallel_DISABLE BOOL FORCE   : ON
+opt-set-cmake-var Epetra_Directory_test_LL_MPI_1_DISABLE BOOL FORCE     : ON
+opt-set-cmake-var SEACASAprepro_lib_aprepro_lib_array_test_DISABLE BOOL FORCE     : ON
+
+# Under loading and debug, these Tempus run too long and timeout (fail). 2023-12-21
+opt-set-cmake-var Tempus_BackwardEuler_CDR_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_Staggered_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_VanDerPol_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BackwardEuler_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BDF2_CDR_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_BDF2_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_ASA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Combined_FSA_SDIRK_5_Stage_4th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Combined_FSA_SDIRK_5_Stage_5th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Staggered_FSA_SDIRK_5_Stage_4th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_DIRK_Staggered_FSA_SDIRK_5_Stage_5th_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_ExplicitRK_ASA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_HHTAlpha_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Combined_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Combined_FSA_Tangent_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Combined_FSA_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_General_Partioned_IMEX_RK_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Partitioned_Staggered_FSA_Tangent_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Staggered_FSA_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_IMEX_RK_Staggered_FSA_Tangent_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_Newmark_MPI_1_DISABLE BOOL FORCE : ON
+opt-set-cmake-var Tempus_Test_NewmarkImplicitAForm_HarmonicOscillator_Damped_FirstOrder_MPI_1_DISABLE BOOL FORCE : ON
+
+opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats BOOL FORCE : OFF
+
+[rhel8_sems-intel-2021.3-sems-openmpi-4.1.4_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+# uses sems-v2 modules
+use rhel8_sems-intel-2021.3-sems-openmpi-4.1.4_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use PACKAGE-ENABLES|ALL
+
 [rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 # uses sems-v2 modules
 use RHEL7_SEMS_COMPILER|CUDA

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -184,6 +184,7 @@ sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6
 sems-clang-11.0.1-openmpi-4.0.5-serial
 sems-gnu-8.5.0-openmpi-4.1.6-serial
 sems-gnu-8.5.0-openmpi-4.1.6-openmp
+sems-intel-2021.3-sems-openmpi-4.1.4
 
 [ats2]
 cuda-11.2.152-gnu-8.3.1-spmpi-rolling

--- a/packages/muelu/test/scaling/MMKernelDriver.cpp
+++ b/packages/muelu/test/scaling/MMKernelDriver.cpp
@@ -69,9 +69,10 @@
 #include <Tpetra_Import_Util2.hpp>           // Import_Util::sortCrsEntries
 #include "Tpetra_Map_decl.hpp"               // for Map
 #include <Xpetra_IO.hpp>
-#include "Xpetra_BlockedMap.hpp"  // for LO, GO, NO
-#include "Xpetra_Map.hpp"         // for UnderlyingLib
-#include "Xpetra_Parameters.hpp"  // for Parameters
+#include "Xpetra_BlockedMap.hpp"    // for LO, GO, NO
+#include "Xpetra_Map.hpp"           // for UnderlyingLib
+#include "Xpetra_Parameters.hpp"    // for Parameters
+#include "Xpetra_MatrixMatrix.hpp"  //Xpetra SpGEMM
 namespace Teuchos {
 class ParameterList;
 }  // namespace Teuchos
@@ -194,6 +195,10 @@ std::chrono::steady_clock::time_point kk_def_copyout_start;
 std::chrono::steady_clock::time_point kk_def_mult_stop;
 std::chrono::steady_clock::time_point kk_def_copyout_stop;
 
+// Xpetra
+std::chrono::steady_clock::time_point xpetra_mult_start;
+std::chrono::steady_clock::time_point xpetra_mult_stop;
+
 #undef remove_pedantic_macro_warning_type
 #else
 #define DescriptiveTime(x) x
@@ -221,7 +226,8 @@ enum class Experiments { ViennaCL = 0,
                          KK_DENSE,
                          KK_DEFAULT,
                          LTG,
-                         SERIAL };
+                         SERIAL,
+                         XPETRA };
 
 static inline std::string to_string(const Experiments &experiment_id) {
   switch (experiment_id) {
@@ -239,6 +245,8 @@ static inline std::string to_string(const Experiments &experiment_id) {
       return ("LTG");
     case Experiments::SERIAL:
       return ("SERIAL");
+    case Experiments::XPETRA:
+      return ("XPETRA");
     default:
       return ("UNDEFINED");
   }
@@ -775,7 +783,7 @@ void Multiply_KokkosKernels(const Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrd
 }
 
 // =========================================================================
-// Kokkos Kernels Testing
+// LTG Testing
 // =========================================================================
 #include "Tpetra_Import_Util2.hpp"
 #include "TpetraExt_MatrixMatrix.hpp"
@@ -925,6 +933,30 @@ struct LTG_Tests<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::Kokk
   }
 };
 #endif  // HAVE OPENMP
+
+// =========================================================================
+// Xpetra Testing
+// =========================================================================
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void Multiply_Xpetra(const Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> &A, const Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> &B, Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > &C, Teuchos::RCP<Teuchos::ParameterList> params = Teuchos::null) {
+#ifdef USE_DESCRIPTIVE_STATS
+  xpetra_mult_start = std::chrono::steady_clock::now();
+#endif
+  Teuchos::FancyOStream fos(Teuchos::rcpFromRef(std::cout));
+  Xpetra::MatrixMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Multiply(A, false, B, false, C, fos, true, true, std::string(""), params);
+#ifdef USE_DESCRIPTIVE_STATS
+  xpetra_mult_stop = std::chrono::steady_clock::now();
+  {
+    std::chrono::duration<double> ds;
+    ds = ltg_mult_stop - ltg_mult_start;
+    my_experiment_timings["Xpetra: Call"].push_back(std::chrono::duration_cast<std::chrono::nanoseconds>(ds).count());
+  }
+#endif
+}
+
+// =========================================================================
+// Utilities
+// =========================================================================
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void dump_matrix(const std::string &prefix,
@@ -1079,12 +1111,14 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
     clp.setOption("trackRssHWM", "noTrackRssHWM", &trackRssHWM, "Track the RSS high water mark (assumes no HP usage)");
 
     // the kernels
-    bool do_viennaCL   = true;
-    bool do_mkl        = true;
-    bool do_kk_mem     = true;
-    bool do_kk_dense   = true;
-    bool do_kk_default = true;
-    bool do_ltg        = true;
+    bool is_serial     = comm->getSize() == 1;
+    bool do_viennaCL   = is_serial;
+    bool do_mkl        = is_serial;
+    bool do_kk_mem     = is_serial;
+    bool do_kk_dense   = is_serial;
+    bool do_kk_default = is_serial;
+    bool do_ltg        = is_serial;
+    bool do_xpetra     = true;
 
 #ifndef HAVE_MUELU_VIENNACL
     do_viennaCL = false;
@@ -1099,6 +1133,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
     clp.setOption("kk_dense", "nokk_dense", &do_kk_dense, "Evaluate KK Dense");
     clp.setOption("kk_default", "nokk_default", &do_kk_default, "Evaluate KK Default");
     clp.setOption("ltg", "noltg", &do_ltg, "Evaluate LTG");
+    clp.setOption("xpetra", "noxpetra", &do_ltg, "Evaluate Xpetra");
 
     std::string dump_result = "";
     clp.setOption("dump_result", &dump_result, "Dump the resulting matrices (once)");
@@ -1148,7 +1183,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
     if (do_kk_dense) my_experiments.push_back(Experiments::KK_DENSE);      // KK Dense
     if (do_kk_default) my_experiments.push_back(Experiments::KK_DEFAULT);  // KK Default
     if (do_ltg) my_experiments.push_back(Experiments::LTG);                // LTG
-
+    if (do_xpetra) my_experiments.push_back(Experiments::XPETRA);          // Xpetra
     if (printTypes) {
       out << "========================================================" << endl
           << xpetraParameters
@@ -1174,9 +1209,6 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
     //    if (dump_result != "") dump_matrices = true;
 
     // Teuchos::TimeMonitor::setStackedTimer(Teuchos::null);
-
-    // At the moment, this test only runs on one MPI rank
-    if (comm->getSize() != 1) exit(1);
 
     std::stringstream ss;
 
@@ -1361,6 +1393,14 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
                 TimeMonitor t(*TimeMonitor::getNewTimer("MM LTG: Total"));
                 using ltg_tester = LTG_Tests<SC, LO, GO, Node>;
                 DescriptiveTime(ltg_tester::Multiply_LTG(*A, *B, *C));
+              }
+              break;
+            // Xpetra
+            case Experiments::XPETRA:
+              C = Xpetra::MatrixFactory<SC, LO, GO, Node>::Build(A->getRowMap(), 0);
+              {
+                TimeMonitor t(*TimeMonitor::getNewTimer("MM XPETRA: Total"));
+                DescriptiveTime(Multiply_Xpetra(*A, *B, C));
               }
               break;
 

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -73,6 +73,16 @@ Sandia National Laboratories, Albuquerque, NM, USA
 //#define TACHO_TEST_LEVELSET_TOOLS_KERNEL_OVERHEAD
 //#define TACHO_ENABLE_LEVELSET_TOOLS_USE_LIGHT_KERNEL
 
+#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE))
+  #if (CUSPARSE_VERSION >= 11400)
+  #define TACHO_CUSPARSE_SPMV_ALG CUSPARSE_SPMV_ALG_DEFAULT
+  #define TACHO_CUSPARSE_SPMM_ALG CUSPARSE_SPMM_ALG_DEFAULT
+  #else
+  #define TACHO_CUSPARSE_SPMV_ALG CUSPARSE_MV_ALG_DEFAULT
+  #define TACHO_CUSPARSE_SPMM_ALG CUSPARSE_MM_ALG_DEFAULT
+  #endif
+#endif
+
 namespace Tacho {
 
 template <typename ValueType, typename DeviceType, int Var>
@@ -1770,22 +1780,12 @@ public:
                         CUSPARSE_INDEX_BASE_ZERO, computeType);
 
 #ifdef USE_SPMM_FOR_WORKSPACE_SIZE
-      #if (12000 >= CUDA_VERSION)
-      cusparseSpMMAlg_t spmm_algo = CUSPARSE_SPMM_ALG_DEFAULT;
-      #else
-      cusparseSpMMAlg_t spmm_algo = CUSPARSE_MM_ALG_DEFAULT;
-      #endif
       cusparseSpMM_bufferSize(s0.cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, CUSPARSE_OPERATION_NON_TRANSPOSE,
                               &alpha, s0.U_cusparse, vecX, &beta, vecY,
-                              computeType, spmm_algo, &buffer_size_U);
+                              computeType, TACHO_CUSPARSE_SPMM_ALG, &buffer_size_U);
 #else
-      #if (12000 >= CUDA_VERSION)
-      cusparseSpMVAlg_t spmv_algo = CUSPARSE_SPMV_ALG_DEFAULT;
-      #else
-      cusparseSpMVAlg_t spmv_algo = CUSPARSE_MV_ALG_DEFAULT;
-      #endif
       cusparseSpMV_bufferSize(s0.cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, s0.U_cusparse, vecX, &beta, vecY,
-                              computeType, spmv_algo, &buffer_size_U);
+                              computeType, TACHO_CUSPARSE_SPMV_ALG, &buffer_size_U);
 #endif
       if (s0.spmv_explicit_transpose) {
         // create matrix (transpose or L)
@@ -1798,10 +1798,10 @@ public:
 #ifdef USE_SPMM_FOR_WORKSPACE_SIZE
         cusparseSpMM_bufferSize(s0.cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, CUSPARSE_OPERATION_NON_TRANSPOSE,
                                 &alpha, s0.L_cusparse, vecX, &beta, vecY,
-                                computeType, spmm_algo, &buffer_size_L);
+                                computeType, TACHO_CUSPARSE_SPMM_ALG, &buffer_size_L);
 #else
         cusparseSpMV_bufferSize(s0.cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, s0.L_cusparse, vecX, &beta, vecY,
-                                computeType, spmv_algo, &buffer_size_L);
+                                computeType, TACHO_CUSPARSE_SPMV_ALG, &buffer_size_L);
 #endif
       } else {
         // create matrix (L_cusparse stores the same ptrs as descrU, but optimized for trans)
@@ -1813,10 +1813,10 @@ public:
 #ifdef USE_SPMM_FOR_WORKSPACE_SIZE
         cusparseSpMM_bufferSize(s0.cusparseHandle, CUSPARSE_OPERATION_TRANSPOSE, CUSPARSE_OPERATION_NON_TRANSPOSE,
                                 &alpha, s0.L_cusparse, vecX, &beta, vecY,
-                                computeType, spmm_algo, &buffer_size_L);
+                                computeType, TACHO_CUSPARSE_SPMM_ALG, &buffer_size_L);
 #else
         cusparseSpMV_bufferSize(s0.cusparseHandle, CUSPARSE_OPERATION_TRANSPOSE, &alpha, s0.L_cusparse, vecX, &beta, vecY,
-                                computeType, spmv_algo, &buffer_size_L);
+                                computeType, TACHO_CUSPARSE_SPMV_ALG, &buffer_size_L);
 #endif
       }
       // allocate workspace
@@ -2246,11 +2246,6 @@ public:
 #if defined(KOKKOS_ENABLE_CUDA)
     cusparseStatus_t status;
     if (nrhs > 1) {
-      #if (12000 >= CUDA_VERSION)
-      cusparseSpMMAlg_t spmm_algo = CUSPARSE_SPMM_ALG_DEFAULT;
-      #else
-      cusparseSpMMAlg_t spmm_algo = CUSPARSE_MM_ALG_DEFAULT;
-      #endif
       if (lvl == nlvls-1) {
         // start : create DnMat for T
         cusparseCreateDnMat(&matT, m, nrhs, ldt, (void*)(t.data()), computeType, CUSPARSE_ORDER_COL);
@@ -2264,20 +2259,15 @@ public:
                               &alpha, s0.L_cusparse, 
                                       matX,
                               &beta,  matY,
-                              computeType, spmm_algo, (void*)buffer_L.data());
+                              computeType, TACHO_CUSPARSE_SPMM_ALG, (void*)buffer_L.data());
       } else {
         status = cusparseSpMM(s0.cusparseHandle, CUSPARSE_OPERATION_TRANSPOSE, CUSPARSE_OPERATION_NON_TRANSPOSE,
                               &alpha, s0.L_cusparse,  // L_cusparse stores the same ptrs as descrU, but optimized for trans
                                       matX,
                               &beta,  matY,
-                              computeType, spmm_algo, (void*)buffer_L.data());
+                              computeType, TACHO_CUSPARSE_SPMM_ALG, (void*)buffer_L.data());
       }
     } else {
-      #if (12000 >= CUDA_VERSION)
-      cusparseSpMVAlg_t spmv_algo = CUSPARSE_SPMV_ALG_DEFAULT;
-      #else
-      cusparseSpMVAlg_t spmv_algo = CUSPARSE_MV_ALG_DEFAULT;
-      #endif
       if (lvl == nlvls-1) {
         // start : create DnMat for T
         cusparseCreateDnVec(&vecT, m, (void*)(t.data()), computeType);
@@ -2291,13 +2281,13 @@ public:
                               &alpha, s0.L_cusparse, 
                                       vecX,
                               &beta,  vecY,
-                              computeType, spmv_algo, (void*)buffer_L.data());
+                              computeType, TACHO_CUSPARSE_SPMV_ALG, (void*)buffer_L.data());
       } else {
         status = cusparseSpMV(s0.cusparseHandle, CUSPARSE_OPERATION_TRANSPOSE,
                               &alpha, s0.L_cusparse, // L_cusparse stores the same ptrs as descrU, but optimized for trans
                                       vecX,
                               &beta,  vecY,
-                              computeType, spmv_algo, (void*)buffer_L.data());
+                              computeType, TACHO_CUSPARSE_SPMV_ALG, (void*)buffer_L.data());
       }
     }
     if (CUSPARSE_STATUS_SUCCESS != status) {
@@ -2606,11 +2596,6 @@ public:
 
     cusparseStatus_t status;
     if (nrhs > 1) {
-      #if (12000 >= CUDA_VERSION)
-      cusparseSpMMAlg_t spmm_algo = CUSPARSE_SPMM_ALG_DEFAULT;
-      #else
-      cusparseSpMMAlg_t spmm_algo = CUSPARSE_MM_ALG_DEFAULT;
-      #endif
       if (lvl == 0) {
         // start : create DnMat for T
         cusparseCreateDnMat(&matT, m, nrhs, ldt, (void*)(t.data()), computeType, CUSPARSE_ORDER_COL);
@@ -2622,13 +2607,8 @@ public:
                             &alpha, s0.U_cusparse, 
                                     vecX,
                             &beta,  vecY,
-                            computeType, spmm_algo, (void*)buffer_U.data());
+                            computeType, TACHO_CUSPARSE_SPMM_ALG, (void*)buffer_U.data());
     } else {
-      #if (12000 >= CUDA_VERSION)
-      cusparseSpMVAlg_t spmv_algo = CUSPARSE_SPMV_ALG_DEFAULT;
-      #else
-      cusparseSpMVAlg_t spmv_algo = CUSPARSE_MV_ALG_DEFAULT;
-      #endif
       if (lvl == 0) {
         // start : create DnMat for T
         cusparseCreateDnVec(&vecT, m, (void*)(t.data()), computeType);
@@ -2640,7 +2620,7 @@ public:
                             &alpha, s0.U_cusparse, 
                                     vecX,
                             &beta,  vecY,
-                            computeType, spmv_algo, (void*)buffer_U.data());
+                            computeType, TACHO_CUSPARSE_SPMV_ALG, (void*)buffer_U.data());
     }
     if (CUSPARSE_STATUS_SUCCESS != status) {
        printf( " Failed cusparseSpMV for SpMV\n" );


### PR DESCRIPTION

@trilinos/shylu 

## Motivation

This PR fixes the version check for CuSparse SpMV and SpMM (e.g., ``CUSPARSE_SPMV_ALG_DEFAULT`` instead of ``CUSPARSE_MV_ALG_DEFAULT``).

## Stakeholder Feedback

@crdohrm 

## Testing

Tested with Cuda 11.0, 11.2, 12.0, and 12.2 on Vortex..
