### PR TITLE
Phalanx/Panzer: long term fix to view-of-views for kokkos serial backend changes

### DIFF
--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_Tpetra_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherSolution_Tpetra_decl.hpp
@@ -186,7 +186,7 @@ private:
   std::vector<int> fieldIds_; // field IDs needing mapping
 
   std::vector< PHX::MDField<ScalarT,Cell,NODE> > gatherFields_;
-  PHX::ViewOfViews3<1,PHX::View<ScalarT**>> gatherFieldsVoV_;
+  PHX::ViewOfViews<1,PHX::View<ScalarT**>> gatherFieldsVoV_;
 
   std::vector<std::string> indexerNames_;
   bool useTimeDerivativeSolutionVector_;
@@ -197,7 +197,7 @@ private:
   // Fields for storing tangent components dx/dp of solution vector x
   bool has_tangent_fields_;
   std::vector< std::vector< PHX::MDField<const RealT,Cell,NODE> > > tangentFields_;
-  PHX::ViewOfViews3<2,PHX::View<const RealT**>> tangentFieldsVoV_;
+  PHX::ViewOfViews<2,PHX::View<const RealT**>> tangentFieldsVoV_;
   PHX::View<size_t*> tangentInnerVectorSizes_;
 
   GatherSolution_Tpetra();

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangent_Tpetra_decl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_GatherTangent_Tpetra_decl.hpp
@@ -114,7 +114,7 @@ private:
   std::vector<int> fieldIds_; // field IDs needing mapping
 
   std::vector< PHX::MDField<ScalarT,Cell,NODE> > gatherFields_;
-  PHX::ViewOfViews3<1,PHX::View<ScalarT**>> gatherFieldsVoV_;
+  PHX::ViewOfViews<1,PHX::View<ScalarT**>> gatherFieldsVoV_;
 
   Teuchos::RCP<std::vector<std::string> > indexerNames_;
   bool useTimeDerivativeSolutionVector_;

--- a/packages/panzer/dof-mgr/src/Panzer_DOFManager.cpp
+++ b/packages/panzer/dof-mgr/src/Panzer_DOFManager.cpp
@@ -408,7 +408,7 @@ DOFManager::getGIDFieldOffsetsKokkos(const std::string & blockID, int fieldNum) 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-const PHX::ViewOfViews3<1,PHX::View<const int*>>
+const PHX::ViewOfViews<1,PHX::View<const int*>>
 DOFManager::getGIDFieldOffsetsKokkos(const std::string & blockID, const std::vector<int> & fieldNums) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(!buildConnectivityRun_,std::logic_error, "DOFManager::getGIDFieldOffsets: cannot be called before "
@@ -418,7 +418,7 @@ DOFManager::getGIDFieldOffsetsKokkos(const std::string & blockID, const std::vec
     TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"DOFManager::fieldInBlock: invalid block name");
   }
 
-  PHX::ViewOfViews3<1,PHX::View<const int*>> vov("panzer::getGIDFieldOffsetsKokkos vector version",fieldNums.size());
+  PHX::ViewOfViews<1,PHX::View<const int*>> vov("panzer::getGIDFieldOffsetsKokkos vector version",fieldNums.size());
   vov.disableSafetyCheck(); // Its going to be moved/copied
 
   int bid=bitr->second;

--- a/packages/panzer/dof-mgr/src/Panzer_DOFManager.hpp
+++ b/packages/panzer/dof-mgr/src/Panzer_DOFManager.hpp
@@ -221,7 +221,7 @@ public:
    *  @param[in] blockID - The element block id
    *  @param[in] fieldNum - A vector field numbers
    */
-  const PHX::ViewOfViews3<1,PHX::View<const int*>> getGIDFieldOffsetsKokkos(const std::string & blockID, const std::vector<int> & fieldNum) const;
+  const PHX::ViewOfViews<1,PHX::View<const int*>> getGIDFieldOffsetsKokkos(const std::string & blockID, const std::vector<int> & fieldNum) const;
 
   //! get associated GIDs for a given local element
   void getElementGIDs(panzer::LocalOrdinal localElementID, std::vector<panzer::GlobalOrdinal> & gids, const std::string & blockIdHint="") const;

--- a/packages/phalanx/src/Phalanx_KokkosViewOfViews.hpp
+++ b/packages/phalanx/src/Phalanx_KokkosViewOfViews.hpp
@@ -21,230 +21,34 @@ namespace PHX {
   }
 
   // ****************************
-  // ViewOfViews: original version
+  // Functions to free inner view memory (assumes outer views are on host)
   // ****************************
-
-  /** Wrapper class that correctly handles ViewOfViews construction
-      and object lifetime. Can be used for more than just Views as the
-      inner object. This class makes sure the host view stays in scope
-      for the life of the device view and makes sure that the device
-      is synced to host before use.
-
-      Main restrictions:
-
-      1. When UVM is not used in the outer view, we need to allocate
-      the VofV on host and copy to device to set up the inner views
-      correctly.
-
-      2. Step 1 means that the host view must exist as long as the
-      device view is being used, otherwise the views may go out of
-      scope. This object exists to pair up the host and device view to
-      make sure the inner views are not deleted early.
-  */
-  template<int OuterViewRank,typename InnerViewType,typename MemorySpace>
-  class ViewOfViews {
-
-  public:
-    // Layout of the outer view doesn't matter for performance so we
-    // use a raw Kokkos::View instead of PHX::View. The inner views are
-    // what is important for performance.
-    using OuterDataType = typename PHX::v_of_v_utils::add_pointer<InnerViewType,OuterViewRank>::type;
-    using OuterViewType = Kokkos::View<OuterDataType,MemorySpace>;
-
-  private:
-    typename OuterViewType::HostMirror view_host_;
-    OuterViewType view_device_;
-    bool device_view_is_synced_;
-
-  public:
-    template<typename... Extents>
-    ViewOfViews(const std::string name,
-                Extents... extents)
-      : view_host_(name,extents...),
-        view_device_(name,extents...),
-        device_view_is_synced_(false)
-    {
-      // Inner view must be unmanaged if the outerview is not using UVM!
-      static_assert(InnerViewType::memory_traits::is_unmanaged,
-                    "ERROR: PHX::ViewOfViews - Inner view must be unmanaged!");
+  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
+  auto freeInnerViewsOfHostHostViewOfViews(Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>*,OuterProps...>& v_of_v) {
+    for (std::size_t i=0; i < v_of_v.extent(0); ++i) {
+      v_of_v(i) = Kokkos::View<InnerViewDataType,InnerProps...>();
     }
-
-    ~ViewOfViews()
-    {
-      // Make sure there is not another object pointing to device view
-      // since the host view will delete the inner views on exit.
-      if (view_device_.impl_track().use_count() != 1)
-        Kokkos::abort("\n ERROR - PHX::ViewOfViews - please free all instances of device ViewOfView \n before deleting the host ViewOfView!\n\n");
-    }
-
-    template<typename... Indices>
-    void addView(InnerViewType v,Indices... i)
-    {
-      view_host_(i...) = v;
-      device_view_is_synced_ = false;
-    }
-
-    void syncHostToDevice()
-    {
-      Kokkos::deep_copy(view_device_,view_host_);
-      device_view_is_synced_ = true;
-    }
-
-    auto getViewHost()
-    {
-      return view_host_;
-    }
-
-    auto getViewDevice()
-    {
-      TEUCHOS_ASSERT(device_view_is_synced_);
-      return view_device_;
-    }
-  };
-
-  // ****************************
-  // ViewOfViews: new version (inner views use Unmanaged template parameter)
-  // ****************************
-
-  namespace details {
-
-    // Trick to pull out inner view template parameters and expand the
-    // view properties.
-    template<typename... Props>
-    auto
-    getUnmanaged(const Kokkos::View<Props...>& v) {
-      Kokkos::View<Props..., Kokkos::MemoryTraits<Kokkos::Unmanaged>> tmp = v;
-      return tmp;
-    }
-
   }
 
-  /** Wrapper class that correctly handles ViewOfViews construction
-      and object lifetime. This class makes sure the host view stays
-      in scope for the life of the device view and makes sure that the
-      device is synced to host before use.
-
-      Main restrictions:
-
-      1. When UVM is not used in the outer view, we need to allocate
-      the VofV on host and deep_copy to device to set up the inner views
-      correctly.
-
-      2. Step 1 means that the host view must exist as long as the
-      device view is being used, otherwise the inner views may go out
-      of scope and delete memory. This object exists to pair up the
-      host and device view to make sure the inner views are not
-      deleted early.
-
-      3. The InnerViewType template parameter must be managed. We
-      will add the unmanaged tag internally.
-
-      4. This object assumes that all inner views are on device. When
-      the accessors reference Host/Device it is with respect to the
-      outer view. If a user wants to initialize the inner view data,
-      they must do that manually external to this object and deep_copy
-      to the device views.
-
-      @param OuterViewRank The rank of the outerview.
-      @param InnerViewType The type of inner view. Currently MUST be a Managed view!
-      @param OuterViewProps View properties for the outer view (i.e. space, layout, memory traits, ...).
-  */
-  template<int OuterViewRank,typename InnerViewType,typename... OuterViewProps>
-  class ViewOfViews2 {
-
-  public:
-    using InnerViewTypeManaged = InnerViewType;
-    using InnerViewTypeUnmanaged = decltype(PHX::details::getUnmanaged(std::declval<InnerViewType>()));
-    using OuterViewDataTypeManagedInner = typename PHX::v_of_v_utils::add_pointer<InnerViewTypeManaged,OuterViewRank>::type;
-    using OuterViewDataTypeUnmanagedInner = typename PHX::v_of_v_utils::add_pointer<InnerViewTypeUnmanaged,OuterViewRank>::type;
-    using OuterViewManaged = Kokkos::View<OuterViewDataTypeManagedInner,OuterViewProps...>;
-    using OuterViewUnmanaged = Kokkos::View<OuterViewDataTypeUnmanagedInner,OuterViewProps...>;
-    using OuterViewManagedHostMirror = typename OuterViewManaged::HostMirror;
-    using OuterViewUnmanagedHostMirror = typename OuterViewUnmanaged::HostMirror;
-
-  private:
-
-    // Host view with managed inner views so that the inner views
-    // can't be deleted before the outer device view is deleted.
-    OuterViewManagedHostMirror view_host_managed_;
-
-    // Host view with unmanaged inner views. Needed for deep_copy to
-    // device.
-    OuterViewUnmanagedHostMirror view_host_unmanaged_;
-
-    // Device view with unmanaged inner views.
-    OuterViewUnmanaged view_device_;
-
-    // True if device view is updated with host view data.
-    bool device_view_is_synced_;
-
-    // True if the outer view has been allocated via ctor or call to initialize().
-    bool is_initialized_;
-
-  public:
-
-    template<typename... Extents>
-    ViewOfViews2(const std::string name, Extents... extents)
-    { this->initialize(name,extents...); }
-
-    ViewOfViews2() :
-      device_view_is_synced_(false),
-      is_initialized_(false)
-    {}
-
-    ~ViewOfViews2()
-    {
-      // Make sure there is not another object pointing to device view
-      // since the host view will delete the inner views on exit.
-      if (view_device_.impl_track().use_count() != 1)
-        Kokkos::abort("\n ERROR - PHX::ViewOfViews - please free all instances of device ViewOfView \n before deleting the host ViewOfView!\n\n");
+  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
+  auto freeInnerViewsOfHostHostViewOfViews(Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>**,OuterProps...>& v_of_v) {
+    for (std::size_t i=0; i < v_of_v.extent(0); ++i) {
+      for (std::size_t j=0; j < v_of_v.extent(1); ++j) {
+        v_of_v(i,j) = Kokkos::View<InnerViewDataType,InnerProps...>();
+      }
     }
+  }
 
-    /// Allocate the out view objects. Extents are for the outer view.
-    template<typename... Extents>
-    void initialize(const std::string name,Extents... extents)
-    {
-      view_host_managed_ = OuterViewManagedHostMirror(name,extents...);
-      view_host_unmanaged_ = OuterViewUnmanagedHostMirror(name,extents...);
-      view_device_ = OuterViewUnmanaged(name,extents...);
-      device_view_is_synced_ = false;
-      is_initialized_ = true;
+  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
+  auto freeInnerViewsOfHostHostViewOfViews(Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>***,OuterProps...>& v_of_v) {
+    for (std::size_t i=0; i < v_of_v.extent(0); ++i) {
+      for (std::size_t j=0; j < v_of_v.extent(1); ++j) {
+        for (std::size_t k=0; k < v_of_v.extent(2); ++k) {
+          v_of_v(i,j,k) = Kokkos::View<InnerViewDataType,InnerProps...>();
+        }
+      }
     }
-
-    /// Set an inner device view on the outer view. Indices are the outer view indices.
-    template<typename... Indices>
-    void setView(InnerViewType v,Indices... i)
-    {
-      TEUCHOS_ASSERT(is_initialized_);
-      view_host_managed_(i...) = v;
-      view_host_unmanaged_(i...) = v;
-      device_view_is_synced_ = false;
-    }
-
-    /// Note this only syncs the outer view. The inner views are
-    /// assumed to be on device for both host and device outer views.
-    void syncHostToDevice()
-    {
-      TEUCHOS_ASSERT(is_initialized_);
-      Kokkos::deep_copy(view_device_,view_host_unmanaged_);
-      device_view_is_synced_ = true;
-    }
-
-    /// Returns a host mirror view for the outer view, where the inner
-    /// views are still on device.
-    auto getViewHost()
-    {
-      TEUCHOS_ASSERT(is_initialized_);
-      return view_host_managed_;
-    }
-
-    /// Returns device view of views
-    auto getViewDevice()
-    {
-      KOKKOS_ASSERT(device_view_is_synced_);
-      return view_device_;
-    }
-  };
+  }
 
   // ****************************
   // ViewOfViews: third version (inner views are runtime unmanaged - no Unmanaged template parameter)
@@ -360,6 +164,16 @@ namespace PHX {
           if ( (view_host_.impl_track().use_count() == 1) && (view_device_.impl_track().use_count() > use_count_) ) {
             Kokkos::abort("\n ERROR - PHX::ViewOfViews - please free all instances of device ViewOfView \n before deleting the host ViewOfView!\n\n");
           }
+        }
+        // We must manually delete the inner views now. The Serial
+        // backend has been updated for thread safety, causing
+        // deadlock from a view dtor mutex - nested views cause nested
+        // parallel_for calls. Details:
+        // Commit to kokkos that caused issue: https://github.com/kokkos/kokkos/pull/7080
+        // Kokkos issue that reports failures: https://github.com/kokkos/kokkos/issues/7092
+        // Phalanx: fixes: https://github.com/trilinos/Trilinos/pull/13188
+        if (view_host_.impl_track().use_count() == 1) {
+          PHX::freeInnerViewsOfHostHostViewOfViews(view_host_);
         }
       ))
     }
@@ -488,132 +302,60 @@ namespace PHX {
     }
   };
 
-  /** \brief Returns a rank-1 view of views where both the outer and inner views are on host. Values are deep_copied from input v_of_v.
-
-      IMPORTANT: The user must manually call free on the inner views
-      of the returned object with the
-      PHX::freeInnerViewsOfHostHostViewOfViews() before deleting the
-      host-host view of view. Failure to do so will result in
-      deadlock. The outer view dtor calls a parallel_for and the inner
-      view dtor calls another parallel_for. Nested parallel_fors are
-      blocked by a mutex even on Serial backend now!
-  */
-  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
-  auto createHostHostViewOfViews(const Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>*,OuterProps...>& v_of_v) {
-    // Host outer view pointing to device inner views
-    auto host_device = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),v_of_v);
-
-    // Host outer view point to host inner views
-    using HostInnerViewType = decltype(Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),host_device(0)));
-    using HostDeviceMirrorType = decltype(host_device);
-    Kokkos::View<HostInnerViewType *,
-                 typename HostDeviceMirrorType::HostMirror::array_layout,
-                 typename HostDeviceMirrorType::HostMirror::device_type> host_host(host_device.label(),
-                                                                                   host_device.extent(0));
-
-    for (std::size_t i=0; i < host_device.extent(0); ++i) {
-      auto tmp = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),host_device(i));
-      // HostInnerViewType t = tmp;
-      host_host(i) = tmp;
+  /// Returns a rank-1 view of views where both the outer and inner views are on host. Values are deep_copied from input v_of_v.
+  template<typename InnerViewType,typename... OuterViewProps>
+  auto createHostHostViewOfViews(const PHX::ViewOfViews3<1,InnerViewType,OuterViewProps...>& vov)
+  {
+    auto outer_host_inner_device_vov = vov.getViewHost();
+    using HostInnerViewType = decltype(Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),outer_host_inner_device_vov(0)));
+    PHX::ViewOfViews3<1,HostInnerViewType,OuterViewProps...> host_host_vov("OuterHostInnerHost VOV: "+vov.getViewHost().label(),
+                                                                           vov.getViewHost().extent(0));
+    for (size_t i=0; i < outer_host_inner_device_vov.extent(0); ++i) {
+      host_host_vov.addView(Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),outer_host_inner_device_vov(i)),i);
     }
-    return host_host;
+    return host_host_vov;
   }
 
-  /** \brief Returns a rank-2 view of views where both the outer and inner views are on host. Values are deep_copied from input v_of_v.
-
-      IMPORTANT: The user must manually call free on the inner views
-      of the returned object with the
-      PHX::freeInnerViewsOfHostHostViewOfViews() before deleting the
-      host-host view of view. Failure to do so will result in
-      deadlock. The outer view dtor calls a parallel_for and the inner
-      view dtor calls another parallel_for. Nested parallel_fors are
-      blocked by a mutex even on Serial backend now!
-  */
-  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
-  auto createHostHostViewOfViews(const Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>**,OuterProps...>& v_of_v) {
-    // Host outer view pointing to device inner views
-    auto host_device = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),v_of_v);
-
-    // Host outer view point to host inner views
-    using HostInnerViewType = decltype(Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),host_device(0,0)));
-    using HostDeviceMirrorType = decltype(host_device);
-    Kokkos::View<HostInnerViewType **,
-                 typename HostDeviceMirrorType::HostMirror::array_layout,
-                 typename HostDeviceMirrorType::HostMirror::device_type> host_host(host_device.label(),
-                                                                                   host_device.extent(0),
-                                                                                   host_device.extent(1));
-
-    for (std::size_t i=0; i < host_device.extent(0); ++i) {
-      for (std::size_t j=0; j < host_device.extent(1); ++j) {
-        auto tmp = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),host_device(i,j));
-        host_host(i,j) = tmp;
+  /// Returns a rank-2 view of views where both the outer and inner views are on host. Values are deep_copied from input v_of_v.
+  template<typename InnerViewType,typename... OuterViewProps>
+  auto createHostHostViewOfViews(const PHX::ViewOfViews3<2,InnerViewType,OuterViewProps...>& vov)
+  {
+    auto outer_host_inner_device_vov = vov.getViewHost();
+    using HostInnerViewType = decltype(Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),outer_host_inner_device_vov(0,0)));
+    PHX::ViewOfViews3<2,HostInnerViewType,OuterViewProps...> host_host_vov("OuterHostInnerHost VOV: "+vov.getViewHost().label(),
+                                                                           vov.getViewHost().extent(0),
+                                                                           vov.getViewHost().extent(1));
+    for (size_t i=0; i < outer_host_inner_device_vov.extent(0); ++i) {
+      for (size_t j=0; j < outer_host_inner_device_vov.extent(1); ++j) {
+        host_host_vov.addView(Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),outer_host_inner_device_vov(i,j)),i,j);
       }
     }
-    return host_host;
+    return host_host_vov;
   }
 
-  /** \brief Returns a rank-3 view of views where both the outer and inner views are on host. Values are deep_copied from input v_of_v.
-
-      IMPORTANT: The user must manually call free on the inner views
-      of the returned object with the
-      PHX::freeInnerViewsOfHostHostViewOfViews() before deleting the
-      host-host view of view. Failure to do so will result in
-      deadlock. The outer view dtor calls a parallel_for and the inner
-      view dtor calls another parallel_for. Nested parallel_fors are
-      blocked by a mutex even on Serial backend now!
-  */
-  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
-  auto createHostHostViewOfViews(const Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>***,OuterProps...>& v_of_v) {
-    // Host outer view pointing to device inner views
-    auto host_device = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),v_of_v);
-
-    // Host outer view point to host inner views
-    using HostInnerViewType = decltype(Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),host_device(0,0,0)));
-    using HostDeviceMirrorType = decltype(host_device);
-    Kokkos::View<HostInnerViewType ***,
-                 typename HostDeviceMirrorType::HostMirror::array_layout,
-                 typename HostDeviceMirrorType::HostMirror::device_type> host_host(host_device.label(),
-                                                                                   host_device.extent(0),
-                                                                                   host_device.extent(1),
-                                                                                   host_device.extent(2));
-
-    for (std::size_t i=0; i < host_device.extent(0); ++i) {
-      for (std::size_t j=0; j < host_device.extent(1); ++j) {
-        for (std::size_t k=0; k < host_device.extent(2); ++k) {
-          auto tmp = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),host_device(i,j,k));
-          host_host(i,j,k) = tmp;
+  /// Returns a rank-3 view of views where both the outer and inner views are on host. Values are deep_copied from input v_of_v.
+  template<typename InnerViewType,typename... OuterViewProps>
+  auto createHostHostViewOfViews(const PHX::ViewOfViews3<3,InnerViewType,OuterViewProps...>& vov)
+  {
+    auto outer_host_inner_device_vov = vov.getViewHost();
+    using HostInnerViewType = decltype(Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),outer_host_inner_device_vov(0,0,0)));
+    PHX::ViewOfViews3<3,HostInnerViewType,OuterViewProps...> host_host_vov("OuterHostInnerHost VOV: "+vov.getViewHost().label(),
+                                                                           vov.getViewHost().extent(0),
+                                                                           vov.getViewHost().extent(1),
+                                                                           vov.getViewHost().extent(2));
+    for (size_t i=0; i < outer_host_inner_device_vov.extent(0); ++i) {
+      for (size_t j=0; j < outer_host_inner_device_vov.extent(1); ++j) {
+        for (size_t k=0; k < outer_host_inner_device_vov.extent(2); ++k) {
+          host_host_vov.addView(Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),outer_host_inner_device_vov(i,j,k)),i,j,k);
         }
       }
     }
-    return host_host;
+    return host_host_vov;
   }
 
-  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
-  auto freeInnerViewsOfHostHostViewOfViews(Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>*,OuterProps...>& v_of_v) {
-    for (std::size_t i=0; i < v_of_v.extent(0); ++i) {
-      v_of_v(i) = Kokkos::View<InnerViewDataType,InnerProps...>();
-    }
-  }
-
-  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
-  auto freeInnerViewsOfHostHostViewOfViews(Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>**,OuterProps...>& v_of_v) {
-    for (std::size_t i=0; i < v_of_v.extent(0); ++i) {
-      for (std::size_t j=0; j < v_of_v.extent(1); ++j) {
-        v_of_v(i,j) = Kokkos::View<InnerViewDataType,InnerProps...>();
-      }
-    }
-  }
-
-  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
-  auto freeInnerViewsOfHostHostViewOfViews(Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>***,OuterProps...>& v_of_v) {
-    for (std::size_t i=0; i < v_of_v.extent(0); ++i) {
-      for (std::size_t j=0; j < v_of_v.extent(1); ++j) {
-        for (std::size_t k=0; k < v_of_v.extent(2); ++k) {
-          v_of_v(i,j,k) = Kokkos::View<InnerViewDataType,InnerProps...>();
-        }
-      }
-    }
-  }
+  // Old declaration for backwards compatibility
+  template<int OuterViewRank,typename InnerViewType,typename... OuterViewProps>
+  using ViewOfViews = ViewOfViews3<OuterViewRank,InnerViewType,OuterViewProps...>;
 
 } // namespace PHX
 

--- a/packages/phalanx/src/design/Phalanx_KokkosViewOfViews.hpp
+++ b/packages/phalanx/src/design/Phalanx_KokkosViewOfViews.hpp
@@ -1,0 +1,620 @@
+#ifndef PHALANX_KOKKOS_VIEW_OF_VIEWS_HPP
+#define PHALANX_KOKKOS_VIEW_OF_VIEWS_HPP
+
+#include "Sacado.hpp" // for IsADType
+#include <utility> // for declval
+
+namespace PHX {
+
+  // ****************************
+  // Add pointer (used to construct the static data type)
+  // ****************************
+
+  namespace v_of_v_utils {
+    template<typename Data,int N> struct add_pointer;
+
+    template<typename Data,int N> struct add_pointer
+    { using type = typename add_pointer<Data*,N-1>::type; };
+
+    template<typename Data> struct add_pointer<Data,0>
+    { using type = Data; };
+  }
+
+  // ****************************
+  // ViewOfViews: original version
+  // ****************************
+
+  /** Wrapper class that correctly handles ViewOfViews construction
+      and object lifetime. Can be used for more than just Views as the
+      inner object. This class makes sure the host view stays in scope
+      for the life of the device view and makes sure that the device
+      is synced to host before use.
+
+      Main restrictions:
+
+      1. When UVM is not used in the outer view, we need to allocate
+      the VofV on host and copy to device to set up the inner views
+      correctly.
+
+      2. Step 1 means that the host view must exist as long as the
+      device view is being used, otherwise the views may go out of
+      scope. This object exists to pair up the host and device view to
+      make sure the inner views are not deleted early.
+  */
+  template<int OuterViewRank,typename InnerViewType,typename MemorySpace>
+  class ViewOfViews {
+
+  public:
+    // Layout of the outer view doesn't matter for performance so we
+    // use a raw Kokkos::View instead of PHX::View. The inner views are
+    // what is important for performance.
+    using OuterDataType = typename PHX::v_of_v_utils::add_pointer<InnerViewType,OuterViewRank>::type;
+    using OuterViewType = Kokkos::View<OuterDataType,MemorySpace>;
+
+  private:
+    typename OuterViewType::HostMirror view_host_;
+    OuterViewType view_device_;
+    bool device_view_is_synced_;
+
+  public:
+    template<typename... Extents>
+    ViewOfViews(const std::string name,
+                Extents... extents)
+      : view_host_(name,extents...),
+        view_device_(name,extents...),
+        device_view_is_synced_(false)
+    {
+      // Inner view must be unmanaged if the outerview is not using UVM!
+      static_assert(InnerViewType::memory_traits::is_unmanaged,
+                    "ERROR: PHX::ViewOfViews - Inner view must be unmanaged!");
+    }
+
+    ~ViewOfViews()
+    {
+      // Make sure there is not another object pointing to device view
+      // since the host view will delete the inner views on exit.
+      if (view_device_.impl_track().use_count() != 1)
+        Kokkos::abort("\n ERROR - PHX::ViewOfViews - please free all instances of device ViewOfView \n before deleting the host ViewOfView!\n\n");
+    }
+
+    template<typename... Indices>
+    void addView(InnerViewType v,Indices... i)
+    {
+      view_host_(i...) = v;
+      device_view_is_synced_ = false;
+    }
+
+    void syncHostToDevice()
+    {
+      Kokkos::deep_copy(view_device_,view_host_);
+      device_view_is_synced_ = true;
+    }
+
+    auto getViewHost()
+    {
+      return view_host_;
+    }
+
+    auto getViewDevice()
+    {
+      TEUCHOS_ASSERT(device_view_is_synced_);
+      return view_device_;
+    }
+  };
+
+  // ****************************
+  // ViewOfViews: new version (inner views use Unmanaged template parameter)
+  // ****************************
+
+  namespace details {
+
+    // Trick to pull out inner view template parameters and expand the
+    // view properties.
+    template<typename... Props>
+    auto
+    getUnmanaged(const Kokkos::View<Props...>& v) {
+      Kokkos::View<Props..., Kokkos::MemoryTraits<Kokkos::Unmanaged>> tmp = v;
+      return tmp;
+    }
+
+  }
+
+  /** Wrapper class that correctly handles ViewOfViews construction
+      and object lifetime. This class makes sure the host view stays
+      in scope for the life of the device view and makes sure that the
+      device is synced to host before use.
+
+      Main restrictions:
+
+      1. When UVM is not used in the outer view, we need to allocate
+      the VofV on host and deep_copy to device to set up the inner views
+      correctly.
+
+      2. Step 1 means that the host view must exist as long as the
+      device view is being used, otherwise the inner views may go out
+      of scope and delete memory. This object exists to pair up the
+      host and device view to make sure the inner views are not
+      deleted early.
+
+      3. The InnerViewType template parameter must be managed. We
+      will add the unmanaged tag internally.
+
+      4. This object assumes that all inner views are on device. When
+      the accessors reference Host/Device it is with respect to the
+      outer view. If a user wants to initialize the inner view data,
+      they must do that manually external to this object and deep_copy
+      to the device views.
+
+      @param OuterViewRank The rank of the outerview.
+      @param InnerViewType The type of inner view. Currently MUST be a Managed view!
+      @param OuterViewProps View properties for the outer view (i.e. space, layout, memory traits, ...).
+  */
+  template<int OuterViewRank,typename InnerViewType,typename... OuterViewProps>
+  class ViewOfViews2 {
+
+  public:
+    using InnerViewTypeManaged = InnerViewType;
+    using InnerViewTypeUnmanaged = decltype(PHX::details::getUnmanaged(std::declval<InnerViewType>()));
+    using OuterViewDataTypeManagedInner = typename PHX::v_of_v_utils::add_pointer<InnerViewTypeManaged,OuterViewRank>::type;
+    using OuterViewDataTypeUnmanagedInner = typename PHX::v_of_v_utils::add_pointer<InnerViewTypeUnmanaged,OuterViewRank>::type;
+    using OuterViewManaged = Kokkos::View<OuterViewDataTypeManagedInner,OuterViewProps...>;
+    using OuterViewUnmanaged = Kokkos::View<OuterViewDataTypeUnmanagedInner,OuterViewProps...>;
+    using OuterViewManagedHostMirror = typename OuterViewManaged::HostMirror;
+    using OuterViewUnmanagedHostMirror = typename OuterViewUnmanaged::HostMirror;
+
+  private:
+
+    // Host view with managed inner views so that the inner views
+    // can't be deleted before the outer device view is deleted.
+    OuterViewManagedHostMirror view_host_managed_;
+
+    // Host view with unmanaged inner views. Needed for deep_copy to
+    // device.
+    OuterViewUnmanagedHostMirror view_host_unmanaged_;
+
+    // Device view with unmanaged inner views.
+    OuterViewUnmanaged view_device_;
+
+    // True if device view is updated with host view data.
+    bool device_view_is_synced_;
+
+    // True if the outer view has been allocated via ctor or call to initialize().
+    bool is_initialized_;
+
+  public:
+
+    template<typename... Extents>
+    ViewOfViews2(const std::string name, Extents... extents)
+    { this->initialize(name,extents...); }
+
+    ViewOfViews2() :
+      device_view_is_synced_(false),
+      is_initialized_(false)
+    {}
+
+    ~ViewOfViews2()
+    {
+      // Make sure there is not another object pointing to device view
+      // since the host view will delete the inner views on exit.
+      if (view_device_.impl_track().use_count() != 1)
+        Kokkos::abort("\n ERROR - PHX::ViewOfViews - please free all instances of device ViewOfView \n before deleting the host ViewOfView!\n\n");
+    }
+
+    /// Allocate the out view objects. Extents are for the outer view.
+    template<typename... Extents>
+    void initialize(const std::string name,Extents... extents)
+    {
+      view_host_managed_ = OuterViewManagedHostMirror(name,extents...);
+      view_host_unmanaged_ = OuterViewUnmanagedHostMirror(name,extents...);
+      view_device_ = OuterViewUnmanaged(name,extents...);
+      device_view_is_synced_ = false;
+      is_initialized_ = true;
+    }
+
+    /// Set an inner device view on the outer view. Indices are the outer view indices.
+    template<typename... Indices>
+    void setView(InnerViewType v,Indices... i)
+    {
+      TEUCHOS_ASSERT(is_initialized_);
+      view_host_managed_(i...) = v;
+      view_host_unmanaged_(i...) = v;
+      device_view_is_synced_ = false;
+    }
+
+    /// Note this only syncs the outer view. The inner views are
+    /// assumed to be on device for both host and device outer views.
+    void syncHostToDevice()
+    {
+      TEUCHOS_ASSERT(is_initialized_);
+      Kokkos::deep_copy(view_device_,view_host_unmanaged_);
+      device_view_is_synced_ = true;
+    }
+
+    /// Returns a host mirror view for the outer view, where the inner
+    /// views are still on device.
+    auto getViewHost()
+    {
+      TEUCHOS_ASSERT(is_initialized_);
+      return view_host_managed_;
+    }
+
+    /// Returns device view of views
+    auto getViewDevice()
+    {
+      KOKKOS_ASSERT(device_view_is_synced_);
+      return view_device_;
+    }
+  };
+
+  // ****************************
+  // ViewOfViews: third version (inner views are runtime unmanaged - no Unmanaged template parameter)
+  // ****************************
+
+  /** Wrapper class that correctly handles ViewOfViews construction
+      and object lifetime. This class makes sure the host view stays
+      in scope for the life of the device view and makes sure that the
+      device is synced to host before use.
+
+      Main restrictions:
+
+      1. When UVM is not used in the outer view, we need to allocate
+      the outer VofV on host and copy to device to initialize the
+      inner views correctly (tracking object).
+
+      2. Step 1 means that the host view must exist as long as the
+      device view is being used, otherwise the views may go out of
+      scope. This object exists to pair up the host and device view to
+      make sure the inner views are not deleted early.
+
+      3. Normally we use an unmanaged view (constructed with the
+      Unmanaged template parameter) for the inner views to prevent
+      double deletion. However, there are use cases where it's painful
+      to pass around views built with the unmanaged template parameter
+      (libraries with functions that block the unmanaged argument). We
+      can generate an unmanged view without the template parameter by
+      constructing the view with a raw pointer. This thrid
+      implementation does that here.
+  */
+  template<int OuterViewRank,typename InnerViewType,typename... OuterViewProps>
+  class ViewOfViews3 {
+
+  public:
+    // Layout of the outer view doesn't matter for performance so we
+    // use a raw Kokkos::View instead of PHX::View. The inner views are
+    // what is important for performance.
+    using OuterDataType = typename PHX::v_of_v_utils::add_pointer<InnerViewType,OuterViewRank>::type;
+    using OuterViewType = Kokkos::View<OuterDataType,OuterViewProps...>;
+
+  private:
+    // Inner views are mananged - used to prevent early deletion
+    typename OuterViewType::HostMirror view_host_;
+    // Inner views are unmanaged by runtime construction with pointer
+    // (avoids template parameter). Used to correctly initialize outer
+    // device view on device.
+    typename OuterViewType::HostMirror view_host_unmanaged_;
+    // Device view
+    OuterViewType view_device_;
+    // True if the host view has not been synced to device
+    bool device_view_is_synced_;
+    // True if the outer view has been initialized
+    bool is_initialized_;
+    // Use count of device view after initialization. This changes based on whether the view_device_ is accessible to host space. If not accessible, the use_count_ is 1. If it is accessible, the value is 2 due to using create_mirror_view in initialization if view_host_unmanaged_.
+    int use_count_;
+    // A safety check. If true, this makes sure there are no external references to the device view of views.
+    bool check_use_count_;
+
+  public:
+    /// Ctor that uses the default execution space instance.
+    template<typename... Extents>
+    ViewOfViews3(const std::string name,Extents... extents)
+      : view_host_(name,extents...),
+        view_device_(name,extents...),
+        device_view_is_synced_(false),
+        is_initialized_(true),
+        use_count_(0),
+        check_use_count_(true)
+    {
+      view_host_unmanaged_ = Kokkos::create_mirror_view(view_device_);
+      use_count_ = view_device_.impl_track().use_count();
+    }
+
+    /// Ctor that uses a user specified execution space instance.
+    /// NOTE: Consistent with Kokkos, when a user supplies the
+    /// execution space instance, the function does not internally
+    /// fence. Be sure to manually fence as needed.
+    template<typename ExecSpace,typename... Extents>
+    ViewOfViews3(const ExecSpace& e_space,const std::string name,Extents... extents)
+      : view_host_(Kokkos::view_alloc(typename OuterViewType::HostMirror::execution_space(),name),extents...),
+        view_device_(Kokkos::view_alloc(e_space,name),extents...),
+        device_view_is_synced_(false),
+        is_initialized_(true),
+        use_count_(0),
+        check_use_count_(true)
+    {
+      view_host_unmanaged_ = Kokkos::create_mirror_view(Kokkos::view_alloc(typename OuterViewType::HostMirror::execution_space()),view_device_);
+      use_count_ = view_device_.impl_track().use_count();
+    }
+
+    ViewOfViews3()
+      : device_view_is_synced_(false),
+        is_initialized_(false),
+        use_count_(0),
+        check_use_count_(true)
+    {}
+
+    ViewOfViews3(const ViewOfViews3<OuterViewRank,InnerViewType,OuterViewProps...>& ) = default;
+    ViewOfViews3& operator=(const ViewOfViews3<OuterViewRank,InnerViewType,OuterViewProps...>& ) = default;
+    ViewOfViews3(ViewOfViews3<OuterViewRank,InnerViewType,OuterViewProps...>&& src) = default;
+    ViewOfViews3& operator=(ViewOfViews3<OuterViewRank,InnerViewType,OuterViewProps...>&& ) = default;
+
+    // Making this a kokkos function eliminates cuda compiler warnings
+    // in objects that contain ViewOfViews3 that are copied to device.
+    KOKKOS_INLINE_FUNCTION
+    ~ViewOfViews3()
+    {
+      // Make sure there is not another object pointing to the device
+      // view if the host view is about to be deleted. The host view
+      // may delete the inner views if it is the last owner.
+      KOKKOS_IF_ON_HOST((
+        if ( check_use_count_ ) {
+          if ( (view_host_.impl_track().use_count() == 1) && (view_device_.impl_track().use_count() > use_count_) ) {
+            Kokkos::abort("\n ERROR - PHX::ViewOfViews - please free all instances of device ViewOfView \n before deleting the host ViewOfView!\n\n");
+          }
+        }
+      ))
+    }
+
+    /// Enable safety check in dtor for external references.
+    void enableSafetyCheck() { check_use_count_ = true; }
+
+    /// Disable safety check in dtor for external references.
+    void disableSafetyCheck() { check_use_count_ = false; }
+
+    /// Allocate the out view objects. Extents are for the outer view. Uses the default execution space.
+    template<typename... Extents>
+    void initialize(const std::string name,Extents... extents)
+    {
+      view_host_ = typename OuterViewType::HostMirror(name,extents...);
+      view_device_ = OuterViewType(name,extents...);
+      view_host_unmanaged_ = Kokkos::create_mirror_view(view_device_);
+      device_view_is_synced_ = false;
+      is_initialized_ = true;
+      use_count_ = view_device_.impl_track().use_count();
+    }
+
+    /// Allocate the out view objects. Extents are for the outer
+    /// view. Uses a user supplied execution space.  NOTE: Consistent
+    /// with Kokkos, when a user supplies the execution space
+    /// instance, the function does not internally fence. Be sure to
+    /// manually fence as needed.
+    template<typename ExecSpace,typename... Extents>
+    void initialize(const ExecSpace& e_space,const std::string name,Extents... extents)
+    {
+      view_host_ = typename OuterViewType::HostMirror(Kokkos::view_alloc(typename OuterViewType::HostMirror::execution_space(),name),extents...);
+      view_device_ = OuterViewType(Kokkos::view_alloc(e_space,name),extents...);
+      view_host_unmanaged_ = Kokkos::create_mirror_view(Kokkos::view_alloc(typename OuterViewType::HostMirror::execution_space()),view_device_);
+      device_view_is_synced_ = false;
+      is_initialized_ = true;
+      use_count_ = view_device_.impl_track().use_count();
+    }
+
+    // Returns true if the outer view has been initialized.
+    bool isInitialized() const {return is_initialized_;}
+
+    bool deviceViewIsSynced() const {return device_view_is_synced_;}
+
+    bool safetyCheck() const {return check_use_count_;}
+
+    template<typename... Indices>
+    void addView(InnerViewType v,Indices... i)
+    {
+      static_assert(sizeof...(Indices)==OuterViewRank,
+        "Error: PHX::ViewOfViews3::addView() - the number of indices must match the outer view rank!");
+
+      TEUCHOS_ASSERT(is_initialized_);
+
+      // Store the managed version so inner views don't get deleted.
+      view_host_(i...) = v;
+
+      // Store a runtime unmanaged view for deep_copy to
+      // device. Unmanaged is required to prevent double deletion on
+      // device. For FAD types, we need to adjust the layout to
+      // account for the derivative array. The layout() method reutrns
+      // the non-fad adjusted layout.
+      if (Sacado::IsADType<typename InnerViewType::value_type>::value) {
+        auto layout = v.layout();
+        layout.dimension[InnerViewType::rank] = Kokkos::dimension_scalar(v);
+        view_host_unmanaged_(i...) = InnerViewType(v.data(),layout);
+      }
+      else
+        view_host_unmanaged_(i...) = InnerViewType(v.data(),v.layout());
+
+      device_view_is_synced_ = false;
+    }
+
+    /// deep_copy the outer view to device. Uses default execution
+    /// space. Note this only syncs the outer view. The inner views
+    /// are assumed to be on device for both host and device outer
+    /// views.
+    void syncHostToDevice()
+    {
+      TEUCHOS_ASSERT(is_initialized_);
+      Kokkos::deep_copy(view_device_,view_host_unmanaged_);
+      device_view_is_synced_ = true;
+    }
+
+    /// deep_copy the outer view to device. Uses a user supplied
+    /// execution space.  Note this only syncs the outer view. The
+    /// inner views are assumed to be on device for both host and
+    /// device outer views.  NOTE: Consistent with Kokkos, when a user
+    /// supplies the execution space instance, the function does not
+    /// internally fence. Be sure to manually fence as needed.
+    template<typename ExecSpace>
+    void syncHostToDevice(const ExecSpace& e_space)
+    {
+      TEUCHOS_ASSERT(is_initialized_);
+      Kokkos::deep_copy(e_space,view_device_,view_host_unmanaged_);
+      device_view_is_synced_ = true;
+    }
+
+    /// Returns a host mirror view for the outer view, where the inner
+    /// views are still on device.
+    auto getViewHost()
+    {
+      TEUCHOS_ASSERT(is_initialized_);
+      return view_host_;
+    }
+
+    /// Returns a host mirror view for the outer view, where the inner
+    /// views are still on device.
+    auto getViewHost() const
+    {
+      TEUCHOS_ASSERT(is_initialized_);
+      return view_host_;
+    }
+
+    /// Returns device view of views
+    auto getViewDevice()
+    {
+      KOKKOS_ASSERT(device_view_is_synced_);
+      return view_device_;
+    }
+
+    /// Returns device view of views
+    auto getViewDevice() const
+    {
+      KOKKOS_ASSERT(device_view_is_synced_);
+      return view_device_;
+    }
+  };
+
+  /** \brief Returns a rank-1 view of views where both the outer and inner views are on host. Values are deep_copied from input v_of_v.
+
+      IMPORTANT: The user must manually call free on the inner views
+      of the returned object with the
+      PHX::freeInnerViewsOfHostHostViewOfViews() before deleting the
+      host-host view of view. Failure to do so will result in
+      deadlock. The outer view dtor calls a parallel_for and the inner
+      view dtor calls another parallel_for. Nested parallel_fors are
+      blocked by a mutex even on Serial backend now!
+  */
+  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
+  auto createHostHostViewOfViews(const Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>*,OuterProps...>& v_of_v) {
+    // Host outer view pointing to device inner views
+    auto host_device = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),v_of_v);
+
+    // Host outer view point to host inner views
+    using HostInnerViewType = decltype(Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),host_device(0)));
+    using HostDeviceMirrorType = decltype(host_device);
+    Kokkos::View<HostInnerViewType *,
+                 typename HostDeviceMirrorType::HostMirror::array_layout,
+                 typename HostDeviceMirrorType::HostMirror::device_type> host_host(host_device.label(),
+                                                                                   host_device.extent(0));
+
+    for (std::size_t i=0; i < host_device.extent(0); ++i) {
+      auto tmp = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),host_device(i));
+      // HostInnerViewType t = tmp;
+      host_host(i) = tmp;
+    }
+    return host_host;
+  }
+
+  /** \brief Returns a rank-2 view of views where both the outer and inner views are on host. Values are deep_copied from input v_of_v.
+
+      IMPORTANT: The user must manually call free on the inner views
+      of the returned object with the
+      PHX::freeInnerViewsOfHostHostViewOfViews() before deleting the
+      host-host view of view. Failure to do so will result in
+      deadlock. The outer view dtor calls a parallel_for and the inner
+      view dtor calls another parallel_for. Nested parallel_fors are
+      blocked by a mutex even on Serial backend now!
+  */
+  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
+  auto createHostHostViewOfViews(const Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>**,OuterProps...>& v_of_v) {
+    // Host outer view pointing to device inner views
+    auto host_device = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),v_of_v);
+
+    // Host outer view point to host inner views
+    using HostInnerViewType = decltype(Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),host_device(0,0)));
+    using HostDeviceMirrorType = decltype(host_device);
+    Kokkos::View<HostInnerViewType **,
+                 typename HostDeviceMirrorType::HostMirror::array_layout,
+                 typename HostDeviceMirrorType::HostMirror::device_type> host_host(host_device.label(),
+                                                                                   host_device.extent(0),
+                                                                                   host_device.extent(1));
+
+    for (std::size_t i=0; i < host_device.extent(0); ++i) {
+      for (std::size_t j=0; j < host_device.extent(1); ++j) {
+        auto tmp = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),host_device(i,j));
+        host_host(i,j) = tmp;
+      }
+    }
+    return host_host;
+  }
+
+  /** \brief Returns a rank-3 view of views where both the outer and inner views are on host. Values are deep_copied from input v_of_v.
+
+      IMPORTANT: The user must manually call free on the inner views
+      of the returned object with the
+      PHX::freeInnerViewsOfHostHostViewOfViews() before deleting the
+      host-host view of view. Failure to do so will result in
+      deadlock. The outer view dtor calls a parallel_for and the inner
+      view dtor calls another parallel_for. Nested parallel_fors are
+      blocked by a mutex even on Serial backend now!
+  */
+  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
+  auto createHostHostViewOfViews(const Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>***,OuterProps...>& v_of_v) {
+    // Host outer view pointing to device inner views
+    auto host_device = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),v_of_v);
+
+    // Host outer view point to host inner views
+    using HostInnerViewType = decltype(Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),host_device(0,0,0)));
+    using HostDeviceMirrorType = decltype(host_device);
+    Kokkos::View<HostInnerViewType ***,
+                 typename HostDeviceMirrorType::HostMirror::array_layout,
+                 typename HostDeviceMirrorType::HostMirror::device_type> host_host(host_device.label(),
+                                                                                   host_device.extent(0),
+                                                                                   host_device.extent(1),
+                                                                                   host_device.extent(2));
+
+    for (std::size_t i=0; i < host_device.extent(0); ++i) {
+      for (std::size_t j=0; j < host_device.extent(1); ++j) {
+        for (std::size_t k=0; k < host_device.extent(2); ++k) {
+          auto tmp = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),host_device(i,j,k));
+          host_host(i,j,k) = tmp;
+        }
+      }
+    }
+    return host_host;
+  }
+
+  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
+  auto freeInnerViewsOfHostHostViewOfViews(Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>*,OuterProps...>& v_of_v) {
+    for (std::size_t i=0; i < v_of_v.extent(0); ++i) {
+      v_of_v(i) = Kokkos::View<InnerViewDataType,InnerProps...>();
+    }
+  }
+
+  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
+  auto freeInnerViewsOfHostHostViewOfViews(Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>**,OuterProps...>& v_of_v) {
+    for (std::size_t i=0; i < v_of_v.extent(0); ++i) {
+      for (std::size_t j=0; j < v_of_v.extent(1); ++j) {
+        v_of_v(i,j) = Kokkos::View<InnerViewDataType,InnerProps...>();
+      }
+    }
+  }
+
+  template<typename InnerViewDataType,typename... InnerProps,typename... OuterProps>
+  auto freeInnerViewsOfHostHostViewOfViews(Kokkos::View<Kokkos::View<InnerViewDataType,InnerProps...>***,OuterProps...>& v_of_v) {
+    for (std::size_t i=0; i < v_of_v.extent(0); ++i) {
+      for (std::size_t j=0; j < v_of_v.extent(1); ++j) {
+        for (std::size_t k=0; k < v_of_v.extent(2); ++k) {
+          v_of_v(i,j,k) = Kokkos::View<InnerViewDataType,InnerProps...>();
+        }
+      }
+    }
+  }
+
+} // namespace PHX
+
+#endif

--- a/packages/phalanx/src/design/README.txt
+++ b/packages/phalanx/src/design/README.txt
@@ -1,7 +1,7 @@
 The design directory contains some ideas and tests we should keep for
 informational purposes.
 
-The ViewOfView files show three different designs. The firsst two were
+The ViewOfView files show three different designs. The first two were
 too restrictive due to added template parameters for the inner view to
 force it to be unmanaged. If codes wanted to grab an inner view and
 pass through functions, then they needed to have an exact match on the

--- a/packages/phalanx/src/design/README.txt
+++ b/packages/phalanx/src/design/README.txt
@@ -1,0 +1,17 @@
+The design directory contains some ideas and tests we should keep for
+informational purposes.
+
+The ViewOfView files show three different designs. The firsst two were
+too restrictive due to added template parameters for the inner view to
+force it to be unmanaged. If codes wanted to grab an inner view and
+pass through functions, then they needed to have an exact match on the
+template arguments or template their functions on the view type. This
+was difficult for some codes to support. The final version constructs
+unmanaged inner views at runtime by passing a pointer. This disables
+padding so might not be a performance hit, but we have not really seen
+this.
+
+The Darma serialization file contains the code to serialize a
+view-of-views using the Darma checkpoint library (maestro). Until
+Darma is added to Trilinos as a TPL, we can't add this code to
+trilinos to test against.

--- a/packages/phalanx/src/design/tPhalanxViewOfViews.cpp
+++ b/packages/phalanx/src/design/tPhalanxViewOfViews.cpp
@@ -1,0 +1,813 @@
+#include "Sacado.hpp"
+#include "Kokkos_View_Fad.hpp"
+#include "Kokkos_Core.hpp"
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Phalanx_KokkosDeviceTypes.hpp"
+#include "Phalanx_KokkosViewOfViews.hpp"
+#include "Phalanx_Kokkos_Tools_CheckStreams.hpp"
+#include <vector>
+
+// ********************************
+// This test demonstrates how to create a view of views for double and FAD types.
+// Original implementation
+// ********************************
+using exec_t = Kokkos::DefaultExecutionSpace;
+using mem_t = Kokkos::DefaultExecutionSpace::memory_space;
+
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,OldImpl) {
+
+  const int num_cells = 10;
+  const int num_pts = 8;
+  const int num_equations = 32;
+
+  Kokkos::View<double***,mem_t> a("a",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> b("b",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> c("c",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> d("d",num_cells,num_pts,num_equations);
+
+  Kokkos::deep_copy(a,2.0);
+  Kokkos::deep_copy(b,3.0);
+  Kokkos::deep_copy(c,4.0);
+
+  {
+    using InnerView = Kokkos::View<double***,mem_t,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    constexpr int OuterViewRank = 2;
+    PHX::ViewOfViews<OuterViewRank,InnerView,mem_t> v_of_v("outer host",2,2);
+
+    v_of_v.addView(a,0,0);
+    v_of_v.addView(b,0,1);
+    v_of_v.addView(c,1,0);
+    v_of_v.addView(d,1,1);
+
+    v_of_v.syncHostToDevice();
+
+    {
+      auto v_dev = v_of_v.getViewDevice();
+      auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0},{num_cells,num_pts,num_equations});
+      Kokkos::parallel_for("view of view test",policy,KOKKOS_LAMBDA (const int cell,const int pt, const int eq) {
+        v_dev(1,1)(cell,pt,eq) = v_dev(0,0)(cell,pt,eq) + v_dev(0,1)(cell,pt,eq) + v_dev(1,0)(cell,pt,eq);
+      });
+    }
+
+    // Uncomment the line below to prove the ViewOfViews prevents
+    // device views from outliving host view. This line will cause a
+    // Kokkos::abort() and error message since v_dev above is still in
+    // scope when the ViewOfViews is destoryed.
+    // v_of_v = PHX::ViewOfViews<OuterViewRank,InnerView,mem_t>("outer host",2,2);
+  }
+
+  auto d_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),d);
+
+  const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+  for (int cell=0; cell < num_cells; ++cell)
+    for (int pt=0; pt < num_pts; ++pt)
+      for (int eq=0; eq < num_equations; ++eq) {
+        TEST_FLOATING_EQUALITY(d_host(cell,pt,eq),9.0,tol);
+      }
+}
+
+// ********************************
+// New implementation (automatically adds the unmanaged memory trait to inner view)
+// ********************************
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,NewImpl) {
+
+  const int num_cells = 10;
+  const int num_pts = 8;
+  const int num_equations = 32;
+
+  using InnerView = Kokkos::View<double***,mem_t>;
+  constexpr int OuterViewRank = 2;
+  PHX::ViewOfViews2<OuterViewRank,InnerView,mem_t> v_of_v("outer host",2,2);
+
+  {
+
+    // Let originals go out of scope to check correct memory management
+    {
+      Kokkos::View<double***,mem_t> a("a",num_cells,num_pts,num_equations);
+      Kokkos::View<double***,mem_t> b("b",num_cells,num_pts,num_equations);
+      Kokkos::View<double***,mem_t> c("c",num_cells,num_pts,num_equations);
+      Kokkos::View<double***,mem_t> d("d",num_cells,num_pts,num_equations);
+
+      Kokkos::deep_copy(a,2.0);
+      Kokkos::deep_copy(b,3.0);
+      Kokkos::deep_copy(c,4.0);
+
+      v_of_v.setView(a,0,0);
+      v_of_v.setView(b,0,1);
+      v_of_v.setView(c,1,0);
+      v_of_v.setView(d,1,1);
+    }
+
+    v_of_v.syncHostToDevice();
+
+    {
+      auto v_dev = v_of_v.getViewDevice();
+      auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0},{num_cells,num_pts,num_equations});
+      Kokkos::parallel_for("view of view test",policy,KOKKOS_LAMBDA (const int cell,const int pt, const int eq) {
+        v_dev(1,1)(cell,pt,eq) = v_dev(0,0)(cell,pt,eq) + v_dev(0,1)(cell,pt,eq) + v_dev(1,0)(cell,pt,eq);
+      });
+    }
+
+    // Uncomment the line below to prove the ViewOfViews prevents
+    // device views from outliving host view. This line will cause a
+    // Kokkos::abort() and error message since v_dev above is still in
+    // scope when the ViewOfViews is destoryed.
+    // v_of_v = PHX::ViewOfViews<OuterViewRank,InnerView,mem_t>("outer host",2,2);
+  }
+
+  auto d = v_of_v.getViewHost()(1,1);
+  auto d_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),d);
+
+  const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+  for (int cell=0; cell < num_cells; ++cell)
+    for (int pt=0; pt < num_pts; ++pt)
+      for (int eq=0; eq < num_equations; ++eq) {
+        TEST_FLOATING_EQUALITY(d_host(cell,pt,eq),9.0,tol);
+      }
+
+}
+
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_DefaultStreamInitialize) {
+
+  const int num_cells = 10;
+  const int num_pts = 8;
+  const int num_equations = 32;
+
+  Kokkos::View<double***,mem_t> a("a",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> b("b",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> c("c",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> d("d",num_cells,num_pts,num_equations);
+
+  Kokkos::deep_copy(a,2.0);
+  Kokkos::deep_copy(b,3.0);
+  Kokkos::deep_copy(c,4.0);
+
+  {
+    using InnerView = Kokkos::View<double***,mem_t>;
+    constexpr int OuterViewRank = 2;
+    PHX::ViewOfViews3<OuterViewRank,InnerView,mem_t> v_of_v;
+
+    TEST_ASSERT(!v_of_v.isInitialized());
+    v_of_v.initialize("outer host",2,2);
+    TEST_ASSERT(v_of_v.isInitialized());
+
+    v_of_v.addView(a,0,0);
+    v_of_v.addView(b,0,1);
+    v_of_v.addView(c,1,0);
+    v_of_v.addView(d,1,1);
+
+    TEST_ASSERT(!v_of_v.deviceViewIsSynced());
+    v_of_v.syncHostToDevice();
+    TEST_ASSERT(v_of_v.deviceViewIsSynced());
+
+    {
+      auto v_dev = v_of_v.getViewDevice();
+      auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0},{num_cells,num_pts,num_equations});
+      Kokkos::parallel_for("view of view test",policy,KOKKOS_LAMBDA (const int cell,const int pt, const int eq) {
+        v_dev(1,1)(cell,pt,eq) = v_dev(0,0)(cell,pt,eq) + v_dev(0,1)(cell,pt,eq) + v_dev(1,0)(cell,pt,eq);
+      });
+    }
+
+    // Test the query objectes used for VT serialization
+    TEST_ASSERT(v_of_v.safetyCheck());
+    v_of_v.disableSafetyCheck();
+    TEST_ASSERT(!v_of_v.safetyCheck());
+    v_of_v.enableSafetyCheck();
+    TEST_ASSERT(v_of_v.safetyCheck());
+
+    // Uncomment the line below to prove the ViewOfViews prevents
+    // device views from outliving host view. This line will cause a
+    // Kokkos::abort() and error message since v_dev above is still in
+    // scope when the ViewOfViews is destoryed.
+    // v_of_v = PHX::ViewOfViews<OuterViewRank,InnerView,mem_t>("outer host",2,2);
+
+    // Test the const versions of accessors
+    {
+      const PHX::ViewOfViews3<OuterViewRank,InnerView,mem_t>& const_v_of_v = v_of_v;
+      const_v_of_v.getViewHost();
+      const_v_of_v.getViewDevice();
+    }
+  }
+
+  auto d_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),d);
+
+  const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+  for (int cell=0; cell < num_cells; ++cell)
+    for (int pt=0; pt < num_pts; ++pt)
+      for (int eq=0; eq < num_equations; ++eq) {
+        TEST_FLOATING_EQUALITY(d_host(cell,pt,eq),9.0,tol);
+      }
+}
+
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_DefaultStreamCtor) {
+
+  const int num_cells = 10;
+  const int num_pts = 8;
+  const int num_equations = 32;
+
+  Kokkos::View<double***,mem_t> a("a",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> b("b",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> c("c",num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> d("d",num_cells,num_pts,num_equations);
+
+  Kokkos::deep_copy(a,2.0);
+  Kokkos::deep_copy(b,3.0);
+  Kokkos::deep_copy(c,4.0);
+
+  {
+    using InnerView = Kokkos::View<double***,mem_t>;
+    constexpr int OuterViewRank = 2;
+    PHX::ViewOfViews3<OuterViewRank,InnerView,mem_t> v_of_v("outer host",2,2);
+
+    TEST_ASSERT(v_of_v.isInitialized());
+
+    v_of_v.addView(a,0,0);
+    v_of_v.addView(b,0,1);
+    v_of_v.addView(c,1,0);
+    v_of_v.addView(d,1,1);
+
+    v_of_v.syncHostToDevice();
+
+    {
+      auto v_dev = v_of_v.getViewDevice();
+      auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0},{num_cells,num_pts,num_equations});
+      Kokkos::parallel_for("view of view test",policy,KOKKOS_LAMBDA (const int cell,const int pt, const int eq) {
+        v_dev(1,1)(cell,pt,eq) = v_dev(0,0)(cell,pt,eq) + v_dev(0,1)(cell,pt,eq) + v_dev(1,0)(cell,pt,eq);
+      });
+    }
+
+    // Uncomment the line below to prove the ViewOfViews prevents
+    // device views from outliving host view. This line will cause a
+    // Kokkos::abort() and error message since v_dev above is still in
+    // scope when the ViewOfViews is destoryed.
+    // v_of_v = PHX::ViewOfViews<OuterViewRank,InnerView,mem_t>("outer host",2,2);
+  }
+
+  auto d_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),d);
+
+  const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+  for (int cell=0; cell < num_cells; ++cell)
+    for (int pt=0; pt < num_pts; ++pt)
+      for (int eq=0; eq < num_equations; ++eq) {
+        TEST_FLOATING_EQUALITY(d_host(cell,pt,eq),9.0,tol);
+      }
+}
+
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_UserStreamCtor) {
+
+  const int num_cells = 10;
+  const int num_pts = 8;
+  const int num_equations = 32;
+
+  std::vector<PHX::Device> streams;
+  if (PHX::Device().concurrency() >= 4) {
+    std::cout << "Using partition_space, concurrency=" << PHX::Device().concurrency() << std::endl;
+    streams = Kokkos::Experimental::partition_space(PHX::Device(),1,1,1,1);
+  }
+  else {
+    std::cout << "NOT using partition_space, concurrency=" << PHX::Device().concurrency() << std::endl;
+    for (int i=0; i < 4; ++i)
+      streams.push_back(PHX::Device());
+  }
+
+  PHX::set_enforce_no_default_stream_use();
+
+  Kokkos::View<double***,mem_t> a(Kokkos::view_alloc(streams[0],"a"),num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> b(Kokkos::view_alloc(streams[1],"b"),num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> c(Kokkos::view_alloc(streams[2],"c"),num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> d(Kokkos::view_alloc(streams[3],"d"),num_cells,num_pts,num_equations);
+
+  Kokkos::deep_copy(streams[0],a,2.0);
+  Kokkos::deep_copy(streams[1],b,3.0);
+  Kokkos::deep_copy(streams[2],c,4.0);
+
+  streams[0].fence();
+  streams[1].fence();
+  streams[2].fence();
+  streams[3].fence();
+
+  {
+    using InnerView = Kokkos::View<double***,mem_t>;
+    constexpr int OuterViewRank = 2;
+    PHX::ViewOfViews3<OuterViewRank,InnerView,mem_t> v_of_v(streams[3],"outer host",2,2);
+
+    TEST_ASSERT(v_of_v.isInitialized());
+
+    // For UVM=ON builds, need to fence here. The outer views are
+    // being accessed before the initialization is completed on
+    // device. The failure only shows up if you overload the cuda card
+    // with multiple tests to slow down the initialization.
+    streams[3].fence(); // PHX_UVM_ON_FENCE
+
+    v_of_v.addView(a,0,0);
+    v_of_v.addView(b,0,1);
+    v_of_v.addView(c,1,0);
+    v_of_v.addView(d,1,1);
+
+    v_of_v.syncHostToDevice(streams[3]);
+
+    {
+      auto v_dev = v_of_v.getViewDevice();
+      auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<3>>(streams[3],{0,0,0},{num_cells,num_pts,num_equations});
+      Kokkos::parallel_for("view of view test",policy,KOKKOS_LAMBDA (const int cell,const int pt, const int eq) {
+        v_dev(1,1)(cell,pt,eq) = v_dev(0,0)(cell,pt,eq) + v_dev(0,1)(cell,pt,eq) + v_dev(1,0)(cell,pt,eq);
+      });
+    }
+
+    // Uncomment the line below to prove the ViewOfViews prevents
+    // device views from outliving host view. This line will cause a
+    // Kokkos::abort() and error message since v_dev above is still in
+    // scope when the ViewOfViews is destoryed.
+    // v_of_v = PHX::ViewOfViews<OuterViewRank,InnerView,mem_t>("outer host",2,2);
+  }
+
+  streams[3].fence();
+
+  PHX::unset_enforce_no_default_stream_use();
+
+  auto d_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),d);
+
+  const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+  for (int cell=0; cell < num_cells; ++cell)
+    for (int pt=0; pt < num_pts; ++pt)
+      for (int eq=0; eq < num_equations; ++eq) {
+        TEST_FLOATING_EQUALITY(d_host(cell,pt,eq),9.0,tol);
+      }
+}
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_UserStreamInitialize) {
+
+  const int num_cells = 10;
+  const int num_pts = 8;
+  const int num_equations = 32;
+
+  std::vector<PHX::Device> streams;
+  if (PHX::Device().concurrency() >= 4) {
+    std::cout << "Using partition_space, concurrency=" << PHX::Device().concurrency() << std::endl;
+    streams = Kokkos::Experimental::partition_space(PHX::Device(),1,1,1,1);
+  }
+  else {
+    std::cout << "NOT using partition_space, concurrency=" << PHX::Device().concurrency() << std::endl;
+    for (int i=0; i < 4; ++i)
+      streams.push_back(PHX::Device());
+  }
+
+  PHX::set_enforce_no_default_stream_use();
+
+  Kokkos::View<double***,mem_t> a(Kokkos::view_alloc(streams[0],"a"),num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> b(Kokkos::view_alloc(streams[1],"b"),num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> c(Kokkos::view_alloc(streams[2],"c"),num_cells,num_pts,num_equations);
+  Kokkos::View<double***,mem_t> d(Kokkos::view_alloc(streams[3],"d"),num_cells,num_pts,num_equations);
+
+  Kokkos::deep_copy(streams[0],a,2.0);
+  Kokkos::deep_copy(streams[1],b,3.0);
+  Kokkos::deep_copy(streams[2],c,4.0);
+
+  streams[0].fence();
+  streams[1].fence();
+  streams[2].fence();
+  streams[3].fence();
+
+  {
+    using InnerView = Kokkos::View<double***,mem_t>;
+    constexpr int OuterViewRank = 2;
+    PHX::ViewOfViews3<OuterViewRank,InnerView,mem_t> v_of_v;
+
+    TEST_ASSERT(!v_of_v.isInitialized());
+    v_of_v.initialize(streams[3],"outer host",2,2);
+    TEST_ASSERT(v_of_v.isInitialized());
+
+    // For UVM=ON builds, need to fence here. The outer views are
+    // being accessed before the initialization is completed on
+    // device. The failure only shows up if you overload the cuda card
+    // with multiple tests to slow down the initialization.
+    streams[3].fence(); // PHX_UVM_ON_FENCE
+
+    v_of_v.addView(a,0,0);
+    v_of_v.addView(b,0,1);
+    v_of_v.addView(c,1,0);
+    v_of_v.addView(d,1,1);
+
+    v_of_v.syncHostToDevice(streams[3]);
+
+    {
+      auto v_dev = v_of_v.getViewDevice();
+      auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<3>>(streams[3],{0,0,0},{num_cells,num_pts,num_equations});
+      Kokkos::parallel_for("view of view test",policy,KOKKOS_LAMBDA (const int cell,const int pt, const int eq) {
+        v_dev(1,1)(cell,pt,eq) = v_dev(0,0)(cell,pt,eq) + v_dev(0,1)(cell,pt,eq) + v_dev(1,0)(cell,pt,eq);
+      });
+    }
+
+    // Uncomment the line below to prove the ViewOfViews prevents
+    // device views from outliving host view. This line will cause a
+    // Kokkos::abort() and error message since v_dev above is still in
+    // scope when the ViewOfViews is destoryed.
+    // v_of_v = PHX::ViewOfViews<OuterViewRank,InnerView,mem_t>("outer host",2,2);
+  }
+
+  streams[3].fence();
+
+  PHX::unset_enforce_no_default_stream_use();
+
+  auto d_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),d);
+
+  const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+  for (int cell=0; cell < num_cells; ++cell)
+    for (int pt=0; pt < num_pts; ++pt)
+      for (int eq=0; eq < num_equations; ++eq) {
+        TEST_FLOATING_EQUALITY(d_host(cell,pt,eq),9.0,tol);
+      }
+}
+
+/* Temporarily disable:
+   https://github.com/kokkos/kokkos-tools/issues/224
+   https://github.com/trilinos/Trilinos/pull/11391
+
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,KokkosToolsDefaultStreamCheck) {
+  PHX::set_enforce_no_default_stream_use();
+  // Checks are only active for CUDA and HIP backends
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+  TEST_THROW(PHX::Device().fence(),std::runtime_error);
+#endif
+  PHX::unset_enforce_no_default_stream_use();
+}
+
+*/
+
+// Make sure that an uninitialized ViewOviews3 can be default
+// constructed and destoryed. Happens in application unit tests.
+struct MeshEvaluationTestStruct {
+    using InnerView = Kokkos::View<double***,mem_t>;
+    PHX::ViewOfViews3<2,InnerView,mem_t> v_of_v_;
+};
+
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_DefaultCtorDtor) {
+  auto mesh_eval = std::make_shared<MeshEvaluationTestStruct>();
+  TEST_ASSERT(!mesh_eval->v_of_v_.isInitialized());
+  mesh_eval = nullptr;
+}
+
+// ********************************
+// Demonstrates an alternative path for ViewOfViews that uses a user
+// defined wrapper and the assignment operator on device to disable
+// the reference tracking.
+// ********************************
+
+// Force this test to always run without UVM.
+// For Cuda builds, ignore the default memory space in the Cuda
+// execution space since it can be set to UVM in Trilinos
+// configure. For non-Cuda builds, just use the default memory space
+// in the execution space.
+namespace Kokkos {
+  class Cuda;
+  class CudaSpace;
+}
+using DeviceExecutionSpace = Kokkos::DefaultExecutionSpace;
+using DeviceMemorySpace = std::conditional<std::is_same<DeviceExecutionSpace,Kokkos::Cuda>::value,
+                                           Kokkos::CudaSpace,
+                                           Kokkos::DefaultExecutionSpace::memory_space>::type;
+using view = Kokkos::View<double*,DeviceMemorySpace>;
+using view_host = view::HostMirror;
+
+class Wrapper {
+public:
+  view a_;
+  view b_;
+  KOKKOS_INLINE_FUNCTION
+  Wrapper() : a_(nullptr,0),b_(nullptr,0) {}
+
+  Wrapper(const view_host& a, const view_host& b)
+    : a_(a.label(),a.layout()),b_(b.label(),b.layout())
+  {
+    Kokkos::deep_copy(a_,a);
+    Kokkos::deep_copy(b_,b);
+  }
+
+  KOKKOS_DEFAULTED_FUNCTION
+  Wrapper& operator=(const Wrapper& src) = default;
+
+  KOKKOS_INLINE_FUNCTION
+  double multiply(int i) const {return a_(i) * b_(i);}
+};
+
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,WrapperExample) {
+
+  constexpr int num_objects = 3;
+  constexpr int view_size = 20;
+
+  // This object must exist for lifetime if v_of_uo to keep inner
+  // views in scope.
+  std::vector<Wrapper> uo(num_objects);
+  {
+    view_host a("a",view_size);
+    view_host b("b",view_size);
+    view_host c("c",view_size);
+    view_host d("d",view_size);
+    view_host e("e",view_size);
+    view_host f("f",view_size);
+
+    Kokkos::deep_copy(a,0.0);
+    Kokkos::deep_copy(b,1.0);
+    Kokkos::deep_copy(c,2.0);
+    Kokkos::deep_copy(d,3.0);
+    Kokkos::deep_copy(e,4.0);
+    Kokkos::deep_copy(f,5.0);
+
+    uo[0] = Wrapper(a,b);
+    uo[1] = Wrapper(c,d);
+    uo[2] = Wrapper(e,f);
+  }
+
+  Kokkos::View<Wrapper*,DeviceMemorySpace> v_of_uo("v_of_uo",num_objects);
+
+  for (int i=0; i < 3; ++i) {
+    Wrapper tmp = uo[i];
+    Kokkos::parallel_for("initialize view_of_uo",1,KOKKOS_LAMBDA(const int ) {
+      // reference counting is disabled on device
+      v_of_uo(i) = tmp;
+    });
+    Kokkos::fence();
+  }
+
+  Kokkos::View<double**,DeviceMemorySpace> results("results",num_objects,view_size);
+  Kokkos::MDRangePolicy<exec_t,Kokkos::Rank<2>> policy({0,0},{num_objects,view_size});
+  Kokkos::parallel_for("v_of_uo",policy,KOKKOS_LAMBDA(const int i,const int j) {
+    results(i,j) = v_of_uo(i).multiply(j) + static_cast<double>(j);
+  });
+  Kokkos::fence();
+
+  auto results_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),results);
+
+  constexpr auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+  for (int i=0; i < num_objects; ++i) {
+    for (int j=0; j < view_size; ++j) {
+
+      double gold_value = static_cast<double>(j);
+      if (i == 1)
+        gold_value += 6.0;
+      else if (i == 2)
+        gold_value += 20.0;
+
+      TEST_FLOATING_EQUALITY(results_host(i,j),gold_value,tol);
+    }
+  }
+}
+
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,CreateHostHost) {
+
+  const int num_cells = 5;
+
+  using InnerView = Kokkos::View<double*,mem_t>;
+  InnerView a("a",num_cells);
+  InnerView b("b",num_cells);
+  InnerView c("c",num_cells);
+  InnerView d("d",num_cells);
+
+  Kokkos::deep_copy(a,2.0);
+  Kokkos::deep_copy(b,3.0);
+  Kokkos::deep_copy(c,4.0);
+
+  // Rank 1 outer view
+  {
+    PHX::ViewOfViews3<1,InnerView,mem_t> pvov("vov1",4);
+    pvov.addView(a,0);
+    pvov.addView(b,1);
+    pvov.addView(c,2);
+    pvov.addView(d,3);
+    pvov.syncHostToDevice();
+
+    auto vov = pvov.getViewDevice();
+
+    Kokkos::parallel_for("vov1",num_cells,KOKKOS_LAMBDA(const int cell) {
+      vov(3)(cell) = vov(0)(cell) * vov(1)(cell) + vov(2)(cell);
+    });
+
+    auto vov_host = PHX::createHostHostViewOfViews(vov);
+
+    const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+    for (int cell=0; cell < num_cells; ++cell) {
+      TEST_FLOATING_EQUALITY(vov_host(0)(cell),2.0,tol);
+      TEST_FLOATING_EQUALITY(vov_host(1)(cell),3.0,tol);
+      TEST_FLOATING_EQUALITY(vov_host(2)(cell),4.0,tol);
+      TEST_FLOATING_EQUALITY(vov_host(3)(cell),10.0,tol);
+    }
+
+    // NOTE: you must call this on the host-host version to avoid deadlock!
+    PHX::freeInnerViewsOfHostHostViewOfViews(vov_host);
+  }
+
+  // Rank 2 outer view
+  {
+    PHX::ViewOfViews3<2,InnerView,mem_t> pvov("vov1",2,2);
+    pvov.addView(a,0,0);
+    pvov.addView(b,0,1);
+    pvov.addView(c,1,0);
+    pvov.addView(d,1,1);
+    pvov.syncHostToDevice();
+
+    auto vov = pvov.getViewDevice();
+
+    Kokkos::parallel_for("vov1",num_cells,KOKKOS_LAMBDA(const int cell) {
+      vov(1,1)(cell) = vov(0,0)(cell) * vov(0,1)(cell) + vov(1,0)(cell) + 1.0;
+    });
+
+    auto vov_host = PHX::createHostHostViewOfViews(vov);
+
+    const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+    for (int cell=0; cell < num_cells; ++cell) {
+      TEST_FLOATING_EQUALITY(vov_host(0,0)(cell),2.0,tol);
+      TEST_FLOATING_EQUALITY(vov_host(0,1)(cell),3.0,tol);
+      TEST_FLOATING_EQUALITY(vov_host(1,0)(cell),4.0,tol);
+      TEST_FLOATING_EQUALITY(vov_host(1,1)(cell),11.0,tol);
+    }
+
+    // NOTE: you must call this on the host-host version to avoid deadlock!
+    PHX::freeInnerViewsOfHostHostViewOfViews(vov_host);
+  }
+
+  // Rank 3 outer view
+  {
+    PHX::ViewOfViews3<3,InnerView,mem_t> pvov("vov1",3,3,3);
+    pvov.addView(a,0,0,0);
+    pvov.addView(b,1,1,1);
+    pvov.addView(c,2,2,2);
+    pvov.addView(d,0,1,2);
+    pvov.syncHostToDevice();
+
+    auto vov = pvov.getViewDevice();
+
+    Kokkos::parallel_for("vov1",num_cells,KOKKOS_LAMBDA(const int cell) {
+        vov(0,1,2)(cell) = vov(0,0,0)(cell) * vov(1,1,1)(cell) + vov(2,2,2)(cell) + 2.0;
+    });
+
+    auto vov_host = PHX::createHostHostViewOfViews(vov);
+
+    const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+    for (int cell=0; cell < num_cells; ++cell) {
+      TEST_FLOATING_EQUALITY(vov_host(0,0,0)(cell),2.0,tol);
+      TEST_FLOATING_EQUALITY(vov_host(1,1,1)(cell),3.0,tol);
+      TEST_FLOATING_EQUALITY(vov_host(2,2,2)(cell),4.0,tol);
+      TEST_FLOATING_EQUALITY(vov_host(0,1,2)(cell),12.0,tol);
+    }
+
+    // NOTE: you must call this on the host-host version to avoid deadlock!
+    PHX::freeInnerViewsOfHostHostViewOfViews(vov_host);
+  }
+
+}
+
+using ScalarType = Sacado::Fad::DFad<double>;
+
+PHX::ViewOfViews3<2,PHX::View<ScalarType**>,PHX::Device> createVoV()
+{
+  PHX::ViewOfViews3<2,PHX::View<ScalarType**>,PHX::Device> tmp;
+
+  tmp.initialize("tmp",2,2);
+  const int num_cells = 10;
+  const int num_pts = 5;
+  const int num_deriv = 2;
+  PHX::View<ScalarType**> a("a",num_cells,num_pts,num_deriv+1);
+  PHX::View<ScalarType**> b("b",num_cells,num_pts,num_deriv+1);
+  PHX::View<ScalarType**> c("c",num_cells,num_pts,num_deriv+1);
+  // Don't assign the "d" array. Simulates a jagged outer array.
+  // PHX::View<double*> d("d",5,num_deriv+1);
+  tmp.addView(a,0,0);
+  tmp.addView(b,0,1);
+  tmp.addView(c,1,0);
+  // tmp.addView(d,1,1);
+  tmp.syncHostToDevice();
+
+  return tmp;
+}
+
+// Simulates panzer DOFManager use case where the DOFManager creates a
+// VoV and returns it to an evaluator in the evalauteFields method.
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,FadAndAssignment) {
+  PHX::ViewOfViews3<2,PHX::View<ScalarType**>,PHX::Device> vov;
+
+  for (int i=0; i < 2; ++i) {
+    vov = createVoV();
+
+    auto Mat_h = vov.getViewHost();
+    auto a = Mat_h(0,0);
+    auto b = Mat_h(0,1);
+    auto c = Mat_h(1,0);
+
+    // Initialize a and b
+    {
+      Kokkos::MDRangePolicy<PHX::Device::execution_space,Kokkos::Rank<2>> policy({0,0},{a.extent(0),a.extent(1)});
+      Kokkos::parallel_for("FadAndAssignment init",policy,KOKKOS_LAMBDA(const int cell, const int pt) {
+        a(cell,pt).val() = double(cell) + double(pt);
+        a(cell,pt).fastAccessDx(0) = 0.0;
+        a(cell,pt).fastAccessDx(1) = 2.0 * double(cell) + double(pt);
+        b(cell,pt).val() = double(cell);
+        b(cell,pt).fastAccessDx(0) = 0.0;
+        b(cell,pt).fastAccessDx(1) = 0.0;
+      });
+      PHX::Device::execution_space().fence();
+    }
+
+    // Compute c using device vov
+    auto Mat = vov.getViewDevice();
+    const bool use_hierarchic = true;
+    if (use_hierarchic) {
+      Kokkos::TeamPolicy<PHX::exec_space> policy(a.extent(0),Kokkos::AUTO());
+      Kokkos::parallel_for("FadAndAssignement compute",policy,KOKKOS_LAMBDA(const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) {
+        const auto cell = team.league_rank();
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,a.extent(1)), [&] (const int& pt) {
+          Mat(1,0)(cell,pt) = Mat(0,0)(cell,pt) * Mat(0,1)(cell,pt);
+        });
+      });
+    } else {
+      Kokkos::MDRangePolicy<PHX::Device::execution_space,Kokkos::Rank<2>> policy({0,0},{a.extent(0),a.extent(1)});
+      Kokkos::parallel_for("FadAndAssignement compute",policy,KOKKOS_LAMBDA(const int cell, const int pt) {
+        Mat(1,0)(cell,pt) = Mat(0,0)(cell,pt) * Mat(0,1)(cell,pt);
+      });
+    }
+    PHX::Device::execution_space().fence();
+
+    // Check the results
+    auto c_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),c);
+    const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+    for (size_t cell=0; cell < a.extent(0); ++cell) {
+      for (size_t pt=0; pt < a.extent(1); ++pt) {
+        // printf("c(%zu,%zu).val=%f, c.dx(0)=%f, c.dx(1)=%f\n",cell,pt,c_h(cell,pt).val(),c_h(cell,pt).fastAccessDx(0),c_h(cell,pt).fastAccessDx(1));
+        double gold_val = double(cell) * (double(cell) + double(pt));
+        TEST_FLOATING_EQUALITY( c_h(cell,pt).val(),gold_val,tol);
+        double gold_dx1 = (2.0 * double(cell) + double(pt)) * double(cell);
+        TEST_FLOATING_EQUALITY( c_h(cell,pt).fastAccessDx(1),gold_dx1,tol);
+      }
+    }
+
+  }
+}
+
+// This unit test is to check view-of-views with fad data types. There
+// is an issue with sacado where MDRange does not index into the
+// derivative array correctly if HIERARCHIC parallelism in sacado is
+// enabled. Flat and Team kernels work fine. MDRange is using the
+// hierarchic parallelism for the calculation and leaves no
+// parallelism for sacado to use on the hidden fad dimension. Team
+// uses hierarchic, but leaves the vector level parallelism for sacado
+// (if we write the kernels correctly).
+
+enum class PHX_KERNEL_TYPE {TEAM,MDRANGE,FLAT};
+TEUCHOS_UNIT_TEST(PhalanxViewOfViews,FadHierarchicMDRangeBug) {
+  using ST = Sacado::Fad::DFad<double>;
+  using VT = PHX::View<ST**>; // PHX::View is a Kokkos::View with Contiguous layout for FAD types.
+  const int num_cell = 2;
+  const int num_pt = 3;
+  const int num_deriv = 2+1;
+  VT a("a",num_cell,num_pt,num_deriv);
+  VT b("b",num_cell,num_pt,num_deriv);
+
+  {
+    Kokkos::MDRangePolicy<PHX::Device::execution_space,Kokkos::Rank<2>> policy({0,0},{a.extent(0),a.extent(1)});
+    Kokkos::parallel_for("FadRawPtr init",policy,KOKKOS_LAMBDA(const int cell, const int pt) {
+      a(cell,pt).val() = double(cell) + double(pt);
+      a(cell,pt).fastAccessDx(1) = 2.0 + double(cell) + double(pt);
+    });
+    PHX::exec_space().fence(); // don't need this but being safe for debugging
+  }
+
+  std::cout << std::endl;
+  const PHX_KERNEL_TYPE kernel = PHX_KERNEL_TYPE::TEAM; // This passes
+  // const PHX_KERNEL_TYPE kernel = PHX_KERNEL_TYPE::MDRANGE; // This fails for FAD scalar types
+  // const PHX_KERNEL_TYPE kernel = PHX_KERNEL_TYPE::FLAT; // This passes
+  if (kernel == PHX_KERNEL_TYPE::TEAM) {
+    Kokkos::TeamPolicy<PHX::exec_space> policy(num_cell,Kokkos::AUTO());
+    Kokkos::parallel_for("FadRawPtr b=a*a",policy,KOKKOS_LAMBDA(const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) {
+      const auto cell = team.league_rank();
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(team,0,a.extent(1)), [&] (const int& pt) {
+        b(cell,pt) = a(cell,pt) * a(cell,pt);
+        // printf("DEVICE: b(%d,%d).val()=%f, b.dx(1)=%f\n",cell,pt,b(cell,pt).val(),b(cell,pt).fastAccessDx(1));
+      });
+    });
+  } else if (kernel == PHX_KERNEL_TYPE::MDRANGE) {
+    Kokkos::MDRangePolicy<PHX::Device::execution_space,Kokkos::Rank<2>> policy({0,0},{a.extent(0),a.extent(1)});
+    Kokkos::parallel_for("FadRawPtr b=a*a",policy,KOKKOS_LAMBDA(const int cell, const int pt) {
+      b(cell,pt) = a(cell,pt) * a(cell,pt);
+      // printf("DEVICE: b(%d,%d).val()=%f, b.dx(1)=%f\n",cell,pt,b(cell,pt).val(),b(cell,pt).fastAccessDx(1));
+    });
+  } else {
+    Kokkos::parallel_for("FadRawPtr b=a*a",a.extent(0),KOKKOS_LAMBDA(const int cell) {
+      for (size_t pt=0; pt < a.extent(1); ++pt) {
+        b(cell,pt) = a(cell,pt) * a(cell,pt);
+        // printf("DEVICE: b(%d,%d).val()=%f, b.dx(1)=%f\n",cell,pt,b(cell,pt).val(),b(cell,pt).fastAccessDx(1));
+      }
+    });
+  }
+
+  PHX::exec_space().fence();
+
+  auto b_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),b);
+  const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+  for (size_t cell=0; cell < a.extent(0); ++cell) {
+    for (size_t pt=0; pt < a.extent(1); ++pt) {
+      out << "b_h(" << cell << "," << pt << ")\n";
+      double gold_val = (double(cell) + double(pt)) * (double(cell) + double(pt));
+      TEST_FLOATING_EQUALITY( b_h(cell,pt).val(),gold_val,tol);
+      double gold_dx1 = 2.0 * (2.0 + double(cell) + double(pt)) * (double(cell) + double(pt));
+      TEST_FLOATING_EQUALITY( b_h(cell,pt).fastAccessDx(1),gold_dx1,tol);
+    }
+  }
+}

--- a/packages/phalanx/test/Kokkos/tKokkosClassOnDevice.cpp
+++ b/packages/phalanx/test/Kokkos/tKokkosClassOnDevice.cpp
@@ -33,7 +33,7 @@ class MyClass {
   Vector<double,3> d_;
   // To test for cuda warnings when MyClass is lambda captured to
   // device
-  PHX::ViewOfViews3<1,Kokkos::View<double*>> e_;
+  PHX::ViewOfViews<1,Kokkos::View<double*>> e_;
 
 public:
   MyClass() :

--- a/packages/phalanx/test/ViewOfViews/tPhalanxViewOfViews.cpp
+++ b/packages/phalanx/test/ViewOfViews/tPhalanxViewOfViews.cpp
@@ -14,119 +14,6 @@
 using exec_t = Kokkos::DefaultExecutionSpace;
 using mem_t = Kokkos::DefaultExecutionSpace::memory_space;
 
-TEUCHOS_UNIT_TEST(PhalanxViewOfViews,OldImpl) {
-
-  const int num_cells = 10;
-  const int num_pts = 8;
-  const int num_equations = 32;
-
-  Kokkos::View<double***,mem_t> a("a",num_cells,num_pts,num_equations);
-  Kokkos::View<double***,mem_t> b("b",num_cells,num_pts,num_equations);
-  Kokkos::View<double***,mem_t> c("c",num_cells,num_pts,num_equations);
-  Kokkos::View<double***,mem_t> d("d",num_cells,num_pts,num_equations);
-
-  Kokkos::deep_copy(a,2.0);
-  Kokkos::deep_copy(b,3.0);
-  Kokkos::deep_copy(c,4.0);
-
-  {
-    using InnerView = Kokkos::View<double***,mem_t,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-    constexpr int OuterViewRank = 2;
-    PHX::ViewOfViews<OuterViewRank,InnerView,mem_t> v_of_v("outer host",2,2);
-
-    v_of_v.addView(a,0,0);
-    v_of_v.addView(b,0,1);
-    v_of_v.addView(c,1,0);
-    v_of_v.addView(d,1,1);
-
-    v_of_v.syncHostToDevice();
-
-    {
-      auto v_dev = v_of_v.getViewDevice();
-      auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0},{num_cells,num_pts,num_equations});
-      Kokkos::parallel_for("view of view test",policy,KOKKOS_LAMBDA (const int cell,const int pt, const int eq) {
-        v_dev(1,1)(cell,pt,eq) = v_dev(0,0)(cell,pt,eq) + v_dev(0,1)(cell,pt,eq) + v_dev(1,0)(cell,pt,eq);
-      });
-    }
-
-    // Uncomment the line below to prove the ViewOfViews prevents
-    // device views from outliving host view. This line will cause a
-    // Kokkos::abort() and error message since v_dev above is still in
-    // scope when the ViewOfViews is destoryed.
-    // v_of_v = PHX::ViewOfViews<OuterViewRank,InnerView,mem_t>("outer host",2,2);
-  }
-
-  auto d_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),d);
-
-  const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
-  for (int cell=0; cell < num_cells; ++cell)
-    for (int pt=0; pt < num_pts; ++pt)
-      for (int eq=0; eq < num_equations; ++eq) {
-        TEST_FLOATING_EQUALITY(d_host(cell,pt,eq),9.0,tol);
-      }
-}
-
-// ********************************
-// New implementation (automatically adds the unmanaged memory trait to inner view)
-// ********************************
-TEUCHOS_UNIT_TEST(PhalanxViewOfViews,NewImpl) {
-
-  const int num_cells = 10;
-  const int num_pts = 8;
-  const int num_equations = 32;
-
-  using InnerView = Kokkos::View<double***,mem_t>;
-  constexpr int OuterViewRank = 2;
-  PHX::ViewOfViews2<OuterViewRank,InnerView,mem_t> v_of_v("outer host",2,2);
-
-  {
-
-    // Let originals go out of scope to check correct memory management
-    {
-      Kokkos::View<double***,mem_t> a("a",num_cells,num_pts,num_equations);
-      Kokkos::View<double***,mem_t> b("b",num_cells,num_pts,num_equations);
-      Kokkos::View<double***,mem_t> c("c",num_cells,num_pts,num_equations);
-      Kokkos::View<double***,mem_t> d("d",num_cells,num_pts,num_equations);
-
-      Kokkos::deep_copy(a,2.0);
-      Kokkos::deep_copy(b,3.0);
-      Kokkos::deep_copy(c,4.0);
-
-      v_of_v.setView(a,0,0);
-      v_of_v.setView(b,0,1);
-      v_of_v.setView(c,1,0);
-      v_of_v.setView(d,1,1);
-    }
-
-    v_of_v.syncHostToDevice();
-
-    {
-      auto v_dev = v_of_v.getViewDevice();
-      auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0},{num_cells,num_pts,num_equations});
-      Kokkos::parallel_for("view of view test",policy,KOKKOS_LAMBDA (const int cell,const int pt, const int eq) {
-        v_dev(1,1)(cell,pt,eq) = v_dev(0,0)(cell,pt,eq) + v_dev(0,1)(cell,pt,eq) + v_dev(1,0)(cell,pt,eq);
-      });
-    }
-
-    // Uncomment the line below to prove the ViewOfViews prevents
-    // device views from outliving host view. This line will cause a
-    // Kokkos::abort() and error message since v_dev above is still in
-    // scope when the ViewOfViews is destoryed.
-    // v_of_v = PHX::ViewOfViews<OuterViewRank,InnerView,mem_t>("outer host",2,2);
-  }
-
-  auto d = v_of_v.getViewHost()(1,1);
-  auto d_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(),d);
-
-  const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
-  for (int cell=0; cell < num_cells; ++cell)
-    for (int pt=0; pt < num_pts; ++pt)
-      for (int eq=0; eq < num_equations; ++eq) {
-        TEST_FLOATING_EQUALITY(d_host(cell,pt,eq),9.0,tol);
-      }
-
-}
-
 TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_DefaultStreamInitialize) {
 
   const int num_cells = 10;
@@ -334,6 +221,7 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_UserStreamCtor) {
         TEST_FLOATING_EQUALITY(d_host(cell,pt,eq),9.0,tol);
       }
 }
+
 TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_UserStreamInitialize) {
 
   const int num_cells = 10;
@@ -581,18 +469,18 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,CreateHostHost) {
       vov(3)(cell) = vov(0)(cell) * vov(1)(cell) + vov(2)(cell);
     });
 
-    auto vov_host = PHX::createHostHostViewOfViews(vov);
+    auto pvov_host = PHX::createHostHostViewOfViews(pvov);
+    {
+      auto vov_host = pvov_host.getViewHost();
 
-    const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
-    for (int cell=0; cell < num_cells; ++cell) {
-      TEST_FLOATING_EQUALITY(vov_host(0)(cell),2.0,tol);
-      TEST_FLOATING_EQUALITY(vov_host(1)(cell),3.0,tol);
-      TEST_FLOATING_EQUALITY(vov_host(2)(cell),4.0,tol);
-      TEST_FLOATING_EQUALITY(vov_host(3)(cell),10.0,tol);
+      const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+      for (int cell=0; cell < num_cells; ++cell) {
+        TEST_FLOATING_EQUALITY(vov_host(0)(cell),2.0,tol);
+        TEST_FLOATING_EQUALITY(vov_host(1)(cell),3.0,tol);
+        TEST_FLOATING_EQUALITY(vov_host(2)(cell),4.0,tol);
+        TEST_FLOATING_EQUALITY(vov_host(3)(cell),10.0,tol);
+      }
     }
-
-    // NOTE: you must call this on the host-host version to avoid deadlock!
-    PHX::freeInnerViewsOfHostHostViewOfViews(vov_host);
   }
 
   // Rank 2 outer view
@@ -610,18 +498,18 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,CreateHostHost) {
       vov(1,1)(cell) = vov(0,0)(cell) * vov(0,1)(cell) + vov(1,0)(cell) + 1.0;
     });
 
-    auto vov_host = PHX::createHostHostViewOfViews(vov);
+    auto pvov_host = PHX::createHostHostViewOfViews(pvov);
+    {
+      auto vov_host = pvov_host.getViewHost();
 
-    const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
-    for (int cell=0; cell < num_cells; ++cell) {
-      TEST_FLOATING_EQUALITY(vov_host(0,0)(cell),2.0,tol);
-      TEST_FLOATING_EQUALITY(vov_host(0,1)(cell),3.0,tol);
-      TEST_FLOATING_EQUALITY(vov_host(1,0)(cell),4.0,tol);
-      TEST_FLOATING_EQUALITY(vov_host(1,1)(cell),11.0,tol);
+      const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+      for (int cell=0; cell < num_cells; ++cell) {
+        TEST_FLOATING_EQUALITY(vov_host(0,0)(cell),2.0,tol);
+        TEST_FLOATING_EQUALITY(vov_host(0,1)(cell),3.0,tol);
+        TEST_FLOATING_EQUALITY(vov_host(1,0)(cell),4.0,tol);
+        TEST_FLOATING_EQUALITY(vov_host(1,1)(cell),11.0,tol);
+      }
     }
-
-    // NOTE: you must call this on the host-host version to avoid deadlock!
-    PHX::freeInnerViewsOfHostHostViewOfViews(vov_host);
   }
 
   // Rank 3 outer view
@@ -639,18 +527,18 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,CreateHostHost) {
         vov(0,1,2)(cell) = vov(0,0,0)(cell) * vov(1,1,1)(cell) + vov(2,2,2)(cell) + 2.0;
     });
 
-    auto vov_host = PHX::createHostHostViewOfViews(vov);
+    auto pvov_host = PHX::createHostHostViewOfViews(pvov);
+    {
+      auto vov_host = pvov_host.getViewHost();
 
-    const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
-    for (int cell=0; cell < num_cells; ++cell) {
-      TEST_FLOATING_EQUALITY(vov_host(0,0,0)(cell),2.0,tol);
-      TEST_FLOATING_EQUALITY(vov_host(1,1,1)(cell),3.0,tol);
-      TEST_FLOATING_EQUALITY(vov_host(2,2,2)(cell),4.0,tol);
-      TEST_FLOATING_EQUALITY(vov_host(0,1,2)(cell),12.0,tol);
+      const auto tol = std::numeric_limits<double>::epsilon() * 100.0;
+      for (int cell=0; cell < num_cells; ++cell) {
+        TEST_FLOATING_EQUALITY(vov_host(0,0,0)(cell),2.0,tol);
+        TEST_FLOATING_EQUALITY(vov_host(1,1,1)(cell),3.0,tol);
+        TEST_FLOATING_EQUALITY(vov_host(2,2,2)(cell),4.0,tol);
+        TEST_FLOATING_EQUALITY(vov_host(0,1,2)(cell),12.0,tol);
+      }
     }
-
-    // NOTE: you must call this on the host-host version to avoid deadlock!
-    PHX::freeInnerViewsOfHostHostViewOfViews(vov_host);
   }
 
 }
@@ -661,7 +549,7 @@ PHX::ViewOfViews3<2,PHX::View<ScalarType**>,PHX::Device> createVoV()
 {
   PHX::ViewOfViews3<2,PHX::View<ScalarType**>,PHX::Device> tmp;
 
-  tmp.initialize("tmp",2,2);
+  tmp.initialize("tmp from createVoV()",2,2);
   const int num_cells = 10;
   const int num_pts = 5;
   const int num_deriv = 2;

--- a/packages/phalanx/test/ViewOfViews/tPhalanxViewOfViews.cpp
+++ b/packages/phalanx/test/ViewOfViews/tPhalanxViewOfViews.cpp
@@ -32,7 +32,7 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_DefaultStreamInitialize) {
   {
     using InnerView = Kokkos::View<double***,mem_t>;
     constexpr int OuterViewRank = 2;
-    PHX::ViewOfViews3<OuterViewRank,InnerView,mem_t> v_of_v;
+    PHX::ViewOfViews<OuterViewRank,InnerView,mem_t> v_of_v;
 
     TEST_ASSERT(!v_of_v.isInitialized());
     v_of_v.initialize("outer host",2,2);
@@ -70,7 +70,7 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_DefaultStreamInitialize) {
 
     // Test the const versions of accessors
     {
-      const PHX::ViewOfViews3<OuterViewRank,InnerView,mem_t>& const_v_of_v = v_of_v;
+      const PHX::ViewOfViews<OuterViewRank,InnerView,mem_t>& const_v_of_v = v_of_v;
       const_v_of_v.getViewHost();
       const_v_of_v.getViewDevice();
     }
@@ -104,7 +104,7 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_DefaultStreamCtor) {
   {
     using InnerView = Kokkos::View<double***,mem_t>;
     constexpr int OuterViewRank = 2;
-    PHX::ViewOfViews3<OuterViewRank,InnerView,mem_t> v_of_v("outer host",2,2);
+    PHX::ViewOfViews<OuterViewRank,InnerView,mem_t> v_of_v("outer host",2,2);
 
     TEST_ASSERT(v_of_v.isInitialized());
 
@@ -176,7 +176,7 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_UserStreamCtor) {
   {
     using InnerView = Kokkos::View<double***,mem_t>;
     constexpr int OuterViewRank = 2;
-    PHX::ViewOfViews3<OuterViewRank,InnerView,mem_t> v_of_v(streams[3],"outer host",2,2);
+    PHX::ViewOfViews<OuterViewRank,InnerView,mem_t> v_of_v(streams[3],"outer host",2,2);
 
     TEST_ASSERT(v_of_v.isInitialized());
 
@@ -258,7 +258,7 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_UserStreamInitialize) {
   {
     using InnerView = Kokkos::View<double***,mem_t>;
     constexpr int OuterViewRank = 2;
-    PHX::ViewOfViews3<OuterViewRank,InnerView,mem_t> v_of_v;
+    PHX::ViewOfViews<OuterViewRank,InnerView,mem_t> v_of_v;
 
     TEST_ASSERT(!v_of_v.isInitialized());
     v_of_v.initialize(streams[3],"outer host",2,2);
@@ -325,7 +325,7 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,KokkosToolsDefaultStreamCheck) {
 // constructed and destoryed. Happens in application unit tests.
 struct MeshEvaluationTestStruct {
     using InnerView = Kokkos::View<double***,mem_t>;
-    PHX::ViewOfViews3<2,InnerView,mem_t> v_of_v_;
+    PHX::ViewOfViews<2,InnerView,mem_t> v_of_v_;
 };
 
 TEUCHOS_UNIT_TEST(PhalanxViewOfViews,ViewOfView3_DefaultCtorDtor) {
@@ -456,7 +456,7 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,CreateHostHost) {
 
   // Rank 1 outer view
   {
-    PHX::ViewOfViews3<1,InnerView,mem_t> pvov("vov1",4);
+    PHX::ViewOfViews<1,InnerView,mem_t> pvov("vov1",4);
     pvov.addView(a,0);
     pvov.addView(b,1);
     pvov.addView(c,2);
@@ -485,7 +485,7 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,CreateHostHost) {
 
   // Rank 2 outer view
   {
-    PHX::ViewOfViews3<2,InnerView,mem_t> pvov("vov1",2,2);
+    PHX::ViewOfViews<2,InnerView,mem_t> pvov("vov1",2,2);
     pvov.addView(a,0,0);
     pvov.addView(b,0,1);
     pvov.addView(c,1,0);
@@ -514,7 +514,7 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,CreateHostHost) {
 
   // Rank 3 outer view
   {
-    PHX::ViewOfViews3<3,InnerView,mem_t> pvov("vov1",3,3,3);
+    PHX::ViewOfViews<3,InnerView,mem_t> pvov("vov1",3,3,3);
     pvov.addView(a,0,0,0);
     pvov.addView(b,1,1,1);
     pvov.addView(c,2,2,2);
@@ -545,9 +545,9 @@ TEUCHOS_UNIT_TEST(PhalanxViewOfViews,CreateHostHost) {
 
 using ScalarType = Sacado::Fad::DFad<double>;
 
-PHX::ViewOfViews3<2,PHX::View<ScalarType**>,PHX::Device> createVoV()
+PHX::ViewOfViews<2,PHX::View<ScalarType**>,PHX::Device> createVoV()
 {
-  PHX::ViewOfViews3<2,PHX::View<ScalarType**>,PHX::Device> tmp;
+  PHX::ViewOfViews<2,PHX::View<ScalarType**>,PHX::Device> tmp;
 
   tmp.initialize("tmp from createVoV()",2,2);
   const int num_cells = 10;
@@ -570,7 +570,7 @@ PHX::ViewOfViews3<2,PHX::View<ScalarType**>,PHX::Device> createVoV()
 // Simulates panzer DOFManager use case where the DOFManager creates a
 // VoV and returns it to an evaluator in the evalauteFields method.
 TEUCHOS_UNIT_TEST(PhalanxViewOfViews,FadAndAssignment) {
-  PHX::ViewOfViews3<2,PHX::View<ScalarType**>,PHX::Device> vov;
+  PHX::ViewOfViews<2,PHX::View<ScalarType**>,PHX::Device> vov;
 
   for (int i=0; i < 2; ++i) {
     vov = createVoV();


### PR DESCRIPTION

@trilinos/phalanx 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Changes to the kokkos serial backend in https://github.com/kokkos/kokkos/pull/7080 was causing deadlock in the destructor of  a host-host view-of-views as reported in https://github.com/kokkos/kokkos/issues/7092. A short term fix that required users to call a function to free the inner host-host view was added in  https://github.com/trilinos/Trilinos/pull/13188. This commit cleans up the v-of-v and provides a long term fix so that users don't have to call the free function. Also did some cleanup on the naming and removed some older alternate experimental versions of v-of-v.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Fixed.

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
All the v-of-v tests.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
