### PR TITLE
Teuchos: Enable non-printable parameter list entries

### DIFF
--- a/packages/teuchos/core/src/Teuchos_Exceptions.hpp
+++ b/packages/teuchos/core/src/Teuchos_Exceptions.hpp
@@ -163,6 +163,24 @@ public:
 
 };
 
+/**
+ * @brief Exception class for non-printable parameter entries,
+ * such as enum class/std::vector and many more
+ * which don't define an operator<<.
+ * Thrown during runtime when trying to print a parameter list
+ * with a non-printable parameter entry.
+ *
+ * \relates ParameterEntry
+ */
+class NonprintableParameterEntryException : public ExceptionBase {
+
+public:
+    NonprintableParameterEntryException(const std::string& what_arg) :
+            ExceptionBase(what_arg) {}
+
+};
+
+
 
 } // end namespace Teuchos
 

--- a/packages/teuchos/core/src/Teuchos_Exceptions.hpp
+++ b/packages/teuchos/core/src/Teuchos_Exceptions.hpp
@@ -164,7 +164,7 @@ public:
 };
 
 /**
- * @brief Exception class for non-printable parameter entries,
+ * @brief Exception class for non-printable parameter types,
  * such as enum class/std::vector and many more
  * which don't define an operator<<.
  * Thrown during runtime when trying to print a parameter list
@@ -172,10 +172,10 @@ public:
  *
  * \relates ParameterEntry
  */
-class NonprintableParameterEntryException : public ExceptionBase {
+class NonprintableTypeException : public ExceptionBase {
 
 public:
-    NonprintableParameterEntryException(const std::string& what_arg) :
+    NonprintableTypeException(const std::string& what_arg) :
             ExceptionBase(what_arg) {}
 
 };

--- a/packages/teuchos/core/src/Teuchos_any.hpp
+++ b/packages/teuchos/core/src/Teuchos_any.hpp
@@ -54,6 +54,7 @@
 
 #include "Teuchos_Assert.hpp"
 #include "Teuchos_TypeNameTraits.hpp"
+#include "Teuchos_Exceptions.hpp"
 
 //
 // This file was taken from the boost library which contained the
@@ -133,8 +134,9 @@ struct print;
 template <class T>
 struct print<T, std::false_type> {
   std::ostream& operator()(std::ostream& s, T const&) const {
-    TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
-        "Trying to print type " << typeid(T).name() << " which is not printable");
+    TEUCHOS_TEST_FOR_EXCEPTION_PURE_MSG(true, NonprintableParameterEntryException,
+        "Trying to print type " << Teuchos::demangleName(typeid(T).name()) <<
+        " which is not printable (i.e. does not have operator<<() defined)!");
 #ifndef __CUDACC__
     return s;
 #endif

--- a/packages/teuchos/core/src/Teuchos_any.hpp
+++ b/packages/teuchos/core/src/Teuchos_any.hpp
@@ -134,7 +134,7 @@ struct print;
 template <class T>
 struct print<T, std::false_type> {
   std::ostream& operator()(std::ostream& s, T const&) const {
-    TEUCHOS_TEST_FOR_EXCEPTION_PURE_MSG(true, NonprintableParameterEntryException,
+    TEUCHOS_TEST_FOR_EXCEPTION_PURE_MSG(true, NonprintableTypeException,
         "Trying to print type " << Teuchos::demangleName(typeid(T).name()) <<
         " which is not printable (i.e. does not have operator<<() defined)!");
 #ifndef __CUDACC__

--- a/packages/teuchos/parameterlist/src/Teuchos_ParameterEntry.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_ParameterEntry.hpp
@@ -331,6 +331,10 @@ ParameterEntry::ParameterEntry(
     docString_(docString_in),
     validator_(validator_in)
 {
+
+  static_assert(std::is_same<typename Teuchos::is_comparable<T>::type, std::true_type>::value, "ParameterList values must be comparable");
+  static_assert(std::is_same<typename Teuchos::is_printable<T>::type, std::true_type>::value, "ParameterList values must be printable");
+
   static_assert(std::is_same<typename Teuchos::is_comparable<T>::type, std::true_type>::value &&
                 std::is_same<typename Teuchos::is_printable<T>::type, std::true_type>::value,
                 "ParameterList values must be comparable and printable!");
@@ -345,6 +349,9 @@ void ParameterEntry::setValue(
   RCP<const ParameterEntryValidator> const& validator_in
   )
 {
+  static_assert(std::is_same<typename Teuchos::is_comparable<T>::type, std::true_type>::value, "ParameterList values must be comparable");
+  static_assert(std::is_same<typename Teuchos::is_printable<T>::type, std::true_type>::value, "ParameterList values must be printable");
+
   static_assert(std::is_same<typename Teuchos::is_comparable<T>::type, std::true_type>::value &&
                 std::is_same<typename Teuchos::is_printable<T>::type, std::true_type>::value,
                 "ParameterList values must be comparable and printable!");

--- a/packages/teuchos/parameterlist/src/Teuchos_ParameterEntry.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_ParameterEntry.hpp
@@ -331,13 +331,6 @@ ParameterEntry::ParameterEntry(
     docString_(docString_in),
     validator_(validator_in)
 {
-
-  static_assert(std::is_same<typename Teuchos::is_comparable<T>::type, std::true_type>::value, "ParameterList values must be comparable");
-  static_assert(std::is_same<typename Teuchos::is_printable<T>::type, std::true_type>::value, "ParameterList values must be printable");
-
-  static_assert(std::is_same<typename Teuchos::is_comparable<T>::type, std::true_type>::value &&
-                std::is_same<typename Teuchos::is_printable<T>::type, std::true_type>::value,
-                "ParameterList values must be comparable and printable!");
 }
 
 // Set Methods
@@ -349,12 +342,6 @@ void ParameterEntry::setValue(
   RCP<const ParameterEntryValidator> const& validator_in
   )
 {
-  static_assert(std::is_same<typename Teuchos::is_comparable<T>::type, std::true_type>::value, "ParameterList values must be comparable");
-  static_assert(std::is_same<typename Teuchos::is_printable<T>::type, std::true_type>::value, "ParameterList values must be printable");
-
-  static_assert(std::is_same<typename Teuchos::is_comparable<T>::type, std::true_type>::value &&
-                std::is_same<typename Teuchos::is_printable<T>::type, std::true_type>::value,
-                "ParameterList values must be comparable and printable!");
   val_ = value_in;
   isDefault_ = isDefault_in;
   if(docString_in.length())

--- a/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
+++ b/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
@@ -1208,6 +1208,13 @@ TEUCHOS_UNIT_TEST( ParameterList, print ) {
   }
 }
 
+TEUCHOS_UNIT_TEST( ParameterList, NonPrintableParameterEntries){
+    enum class Shape : int { CIRCLE, SQUARE, TRIANGLE };
+    ParameterList paramList = ParameterList("MyParameters");
+    paramList.set("test enum class", Shape::SQUARE);
+    paramList.print();
+  }
+
 } // namespace Teuchos
 
 

--- a/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
+++ b/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
@@ -1208,20 +1208,27 @@ TEUCHOS_UNIT_TEST( ParameterList, print ) {
   }
 }
 
+// define enum class Shape in anonymous namespace outside of unittest
+// "NonPrintableParameterEntries" to avoid polution of class type in string comparison
+namespace {
+    enum class Shape : int { CIRCLE, SQUARE, TRIANGLE };
+}
+
 TEUCHOS_UNIT_TEST( ParameterList, NonPrintableParameterEntries){
   // test printing std::vector<int> from a parameter list
   {
-    ParameterList paramList = ParameterList("std::vector test");
     std::vector<int> testVec = {1};
+    ParameterList paramList = ParameterList("std::vector test");
     paramList.set("My std::vector<int>", testVec);
 
     try {
       paramList.print();  // Should throw!
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "If you get here then the test failed!");
     }
-    catch (const NonprintableParameterEntryException &except) {
+    catch (const NonprintableTypeException &except) {
       std::string actualMessage = except.what();
-      std::string expectedMessage = "Trying to print type std::vector<int, std::allocator<int> > which is not printable (i.e. does not have operator<<() defined)!";
+      std::string expectedMessage = "Trying to print type std::vector<int, std::allocator<int> > "
+                                    "which is not printable (i.e. does not have operator<<() defined)!";
       TEST_ASSERT(actualMessage.find(expectedMessage) != std::string::npos);
     }
   }
@@ -1229,19 +1236,17 @@ TEUCHOS_UNIT_TEST( ParameterList, NonPrintableParameterEntries){
   // test printing enum class from a parameter list
   {
     ParameterList paramList = ParameterList("enum class test");
-    enum class Shape : int { CIRCLE, SQUARE, TRIANGLE };
     paramList.set("My enum class", Shape::SQUARE);
 
     try {
       paramList.print();  // Should throw!
       TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "If you get here then the test failed!" );
     }
-    catch (const NonprintableParameterEntryException &except) {
+    catch (const NonprintableTypeException &except) {
       std::string actualMessage = except.what();
       std::string expectedMessage =
-              "Trying to print type "
-              "Teuchos::ParameterList_NonPrintableParameterEntries_UnitTest::runUnitTestImpl(Teuchos::basic_FancyOStream<char, std::char_traits<char> >&, bool&) const::Shape "
-              "which is not printable (i.e. does not have operator<<() defined)!";
+              "Trying to print type Teuchos::(anonymous namespace)::Shape which is not printable "
+              "(i.e. does not have operator<<() defined)!";
       TEST_ASSERT(actualMessage.find(expectedMessage) != std::string::npos);
     }
   }

--- a/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
+++ b/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
@@ -1238,7 +1238,6 @@ TEUCHOS_UNIT_TEST( ParameterList, NonPrintableParameterEntries){
     }
     catch (const NonprintableParameterEntryException &except) {
       std::string actualMessage = except.what();
-      std::cout << "\n\nactual Message: \n" << actualMessage << std::endl;
       std::string expectedMessage =
               "Trying to print type "
               "Teuchos::ParameterList_NonPrintableParameterEntries_UnitTest::runUnitTestImpl(Teuchos::basic_FancyOStream<char, std::char_traits<char> >&, bool&) const::Shape "

--- a/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
+++ b/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
@@ -1209,11 +1209,47 @@ TEUCHOS_UNIT_TEST( ParameterList, print ) {
 }
 
 TEUCHOS_UNIT_TEST( ParameterList, NonPrintableParameterEntries){
-    enum class Shape : int { CIRCLE, SQUARE, TRIANGLE };
-    ParameterList paramList = ParameterList("MyParameters");
-    paramList.set("test enum class", Shape::SQUARE);
-    paramList.print();
+  // test printing std::vector<int> from a parameter list
+  {
+    ParameterList paramList = ParameterList("std::vector test");
+    std::vector<int> testVec = {1};
+    paramList.set("My std::vector<int>", testVec);
+
+    try {
+      paramList.print();  // Should throw!
+      TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "If you get here then the test failed!");
+    }
+    catch (const NonprintableParameterEntryException &except) {
+      std::string actualMessage = except.what();
+      std::string expectedMessage = "Trying to print type std::vector<int, std::allocator<int> > which is not printable (i.e. does not have operator<<() defined)!";
+      TEST_ASSERT(actualMessage.find(expectedMessage) != std::string::npos);
+    }
   }
+
+  // test printing enum class from a parameter list
+  {
+    ParameterList paramList = ParameterList("enum class test");
+    enum class Shape : int { CIRCLE, SQUARE, TRIANGLE };
+    paramList.set("My enum class", Shape::SQUARE);
+
+    try {
+      paramList.print();  // Should throw!
+      TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "If you get here then the test failed!" );
+    }
+    catch (const NonprintableParameterEntryException &except) {
+      std::string actualMessage = except.what();
+      std::cout << "\n\nactual Message: \n" << actualMessage << std::endl;
+      std::string expectedMessage =
+              "Trying to print type "
+              "Teuchos::ParameterList_NonPrintableParameterEntries_UnitTest::runUnitTestImpl(Teuchos::basic_FancyOStream<char, std::char_traits<char> >&, bool&) const::Shape "
+              "which is not printable (i.e. does not have operator<<() defined)!";
+      TEST_ASSERT(actualMessage.find(expectedMessage) != std::string::npos);
+    }
+  }
+}
+
+
+
 
 } // namespace Teuchos
 


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos @bartlettroscoe

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

<del>As discussed in #13204, here is a simple example in a unit test that won't compile due to the `static_assert` for an `enum class` in the ParameterEntryValidator. <del>

<del>I have added a separate `static_assert` for checking printability and comparability to split the check during debugging.<del>

As highlighted in #13204 there are use cases for non-printable parameter list entries. This PR enables them by removing the compile time `static_assert()` and now throws a more meaningful runtime error message when trying to print a `ParameterList` with non-printable entries. Appropriate unit tests have been added for `std::vector<int>` and `enum class`. 


## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->
#13204

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
