### PR TITLE
MueLu: Adapt offset calculation in amalgamation

### DIFF
--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_decl.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_decl.hpp
@@ -118,7 +118,7 @@ class AmalgamationFactory : public SingleLevelFactoryBase {
    *
    * @param stridedMap (const StridedMap&): strided map of operator A (matrix)
    */
-  static const GlobalOrdinal GidOffset(RCP<const StridedMap> stridedMap);
+  static const GlobalOrdinal DOFGidOffset(RCP<const StridedMap> stridedMap);
 
   /*! @brief Method to create merged  map for systems of PDEs.
    *

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_decl.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_decl.hpp
@@ -114,6 +114,12 @@ class AmalgamationFactory : public SingleLevelFactoryBase {
   static const GlobalOrdinal DOFGid2NodeId(GlobalOrdinal gid, LocalOrdinal blockSize, const GlobalOrdinal offset /*= 0*/,
                                            const GlobalOrdinal indexBase /* = 0*/);
 
+  /*! @brief Method to calculate the global (row) id offset from scratch.
+   *
+   * @param stridedMap (const StridedMap&): strided map of operator A (matrix)
+   */
+  static const GlobalOrdinal GidOffset(RCP<const StridedMap> stridedMap);
+
   /*! @brief Method to create merged  map for systems of PDEs.
    *
    * @param sourceMap (const Map&): source map with dofs which shall be amalgamated to a node map

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_def.hpp
@@ -106,7 +106,7 @@ void AmalgamationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level
     RCP<const StridedMap> stridedRowMap = Teuchos::rcp_dynamic_cast<const StridedMap>(A->getRowMap());
     TEUCHOS_TEST_FOR_EXCEPTION(stridedRowMap == Teuchos::null, Exceptions::BadCast, "MueLu::CoalesceFactory::Build: cast to strided row map failed.");
     fullblocksize = stridedRowMap->getFixedBlockSize();
-    offset        = GidOffset(stridedRowMap);
+    offset        = DOFGidOffset(stridedRowMap);
     blockid       = stridedRowMap->getStridedBlockId();
 
     if (blockid > -1) {
@@ -195,7 +195,7 @@ void AmalgamationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::AmalgamateM
     Teuchos::RCP<const Map> myMap         = A.getRowMap("stridedMaps");
     Teuchos::RCP<const StridedMap> strMap = Teuchos::rcp_dynamic_cast<const StridedMap>(myMap);
     TEUCHOS_TEST_FOR_EXCEPTION(strMap == null, Exceptions::RuntimeError, "Map is not of type StridedMap");
-    offset = GidOffset(strMap);
+    offset  = DOFGidOffset(strMap);
     blkSize = Teuchos::as<const LO>(strMap->getFixedBlockSize());
   }
 
@@ -233,8 +233,7 @@ const GlobalOrdinal AmalgamationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Nod
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-const GlobalOrdinal AmalgamationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GidOffset(RCP<const StridedMap> stridedRowMap) {
-
+const GlobalOrdinal AmalgamationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DOFGidOffset(RCP<const StridedMap> stridedRowMap) {
   GlobalOrdinal offset = stridedRowMap->getMinAllGlobalIndex();
 
   size_t nStridedOffset = 0;

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_def.hpp
@@ -106,7 +106,7 @@ void AmalgamationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level
     RCP<const StridedMap> stridedRowMap = Teuchos::rcp_dynamic_cast<const StridedMap>(A->getRowMap());
     TEUCHOS_TEST_FOR_EXCEPTION(stridedRowMap == Teuchos::null, Exceptions::BadCast, "MueLu::CoalesceFactory::Build: cast to strided row map failed.");
     fullblocksize = stridedRowMap->getFixedBlockSize();
-    offset        = stridedRowMap->getOffset();
+    offset        = GidOffset(stridedRowMap);
     blockid       = stridedRowMap->getStridedBlockId();
 
     if (blockid > -1) {
@@ -195,7 +195,7 @@ void AmalgamationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::AmalgamateM
     Teuchos::RCP<const Map> myMap         = A.getRowMap("stridedMaps");
     Teuchos::RCP<const StridedMap> strMap = Teuchos::rcp_dynamic_cast<const StridedMap>(myMap);
     TEUCHOS_TEST_FOR_EXCEPTION(strMap == null, Exceptions::RuntimeError, "Map is not of type StridedMap");
-    offset  = strMap->getOffset();
+    offset = GidOffset(strMap);
     blkSize = Teuchos::as<const LO>(strMap->getFixedBlockSize());
   }
 
@@ -230,6 +230,22 @@ const GlobalOrdinal AmalgamationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Nod
                                                                                                   const GlobalOrdinal offset, const GlobalOrdinal indexBase) {
   GlobalOrdinal globalblockid = ((GlobalOrdinal)gid - offset - indexBase) / blockSize + indexBase;
   return globalblockid;
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+const GlobalOrdinal AmalgamationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GidOffset(RCP<const StridedMap> stridedRowMap) {
+
+  GlobalOrdinal offset = stridedRowMap->getMinAllGlobalIndex();
+
+  size_t nStridedOffset = 0;
+  for (int j = 0; j < stridedRowMap->getStridedBlockId(); j++) {
+    nStridedOffset += stridedRowMap->getStridingData()[j];
+  }
+  const GO goStridedOffset = Teuchos::as<const GO>(nStridedOffset);
+
+  offset -= goStridedOffset + stridedRowMap->getIndexBase();
+
+  return offset;
 }
 
 }  // namespace MueLu

--- a/packages/muelu/test/unit_tests/AmalgamationFactory.cpp
+++ b/packages/muelu/test/unit_tests/AmalgamationFactory.cpp
@@ -132,10 +132,47 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(AmalgamationFactory, AmalgamateMap, Scalar, Lo
 
 }  // AmalgamateMap
 
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(AmalgamationFactory, GidOffset, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+  // Test static method AmalgamationFactory::GidOffset().
+#include <MueLu_UseShortNames.hpp>
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
+  out << "Test static method AmalgamationFactory::GidOffset()." << std::endl;
+
+  RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
+  Xpetra::UnderlyingLib lib           = MueLuTests::TestHelpers::Parameters::getLib();
+
+  const GO n         = 32;
+  const LO blkSize   = 2;
+  const GO indexBase = 3;
+  const GO offset    = 101;
+
+  std::vector<size_t> stridedInfo;
+  stridedInfo.push_back(blkSize);
+
+  // Case 1: Zero starting GIDs with offset set
+  RCP<StridedMap> correct_strided_map = RCP(new StridedMap(lib, n, indexBase, stridedInfo, comm, 0, offset));
+  TEST_EQUALITY(offset, AmalgamationFactory::GidOffset(correct_strided_map)); // -> offset = 101
+  TEST_EQUALITY(offset, correct_strided_map->getOffset());                    // -> offset = 101
+
+  // Case 2: Non-zero starting GIDs shifted by offset and variable correctly set
+  RCP<StridedMap> still_correct_strided_map = RCP(new StridedMap(correct_strided_map->getMap(), stridedInfo, indexBase, 0, offset));
+  TEST_EQUALITY(offset, AmalgamationFactory::GidOffset(still_correct_strided_map)); // -> offset = 101
+  TEST_EQUALITY(offset, still_correct_strided_map->getOffset());                    // -> offset = 101
+
+  // Case 3: Non-zero starting GIDs shifted by offset, but offset variable information not correctly available
+  // (this can happen if a Xpetra::BlockedCrsMatrix with offset is converted to Thyra -> offset information is lost, but GIDs preserved)
+  RCP<StridedMap> faulty_strided_map = RCP(new StridedMap(correct_strided_map->getMap(), stridedInfo, indexBase));
+  TEST_EQUALITY(offset, AmalgamationFactory::GidOffset(faulty_strided_map)); // -> offset = 101
+  TEST_INEQUALITY(offset, faulty_strided_map->getOffset());                  // -> offset = 0
+
+}  // AmalgamateMap
+
 #define MUELU_ETI_GROUP(Scalar, LO, GO, Node)                                                    \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AmalgamationFactory, Constructor, Scalar, LO, GO, Node)   \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AmalgamationFactory, DOFGid2NodeId, Scalar, LO, GO, Node) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AmalgamationFactory, AmalgamateMap, Scalar, LO, GO, Node)
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AmalgamationFactory, AmalgamateMap, Scalar, LO, GO, Node) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AmalgamationFactory, GidOffset, Scalar, LO, GO, Node)
 
 #include <MueLu_ETI_4arg.hpp>
 

--- a/packages/muelu/test/unit_tests/AmalgamationFactory.cpp
+++ b/packages/muelu/test/unit_tests/AmalgamationFactory.cpp
@@ -132,12 +132,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(AmalgamationFactory, AmalgamateMap, Scalar, Lo
 
 }  // AmalgamateMap
 
-TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(AmalgamationFactory, GidOffset, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
-  // Test static method AmalgamationFactory::GidOffset().
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(AmalgamationFactory, DOFGidOffset, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+  // Test static method AmalgamationFactory::DOFGidOffset().
 #include <MueLu_UseShortNames.hpp>
   MUELU_TESTING_SET_OSTREAM;
   MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
-  out << "Test static method AmalgamationFactory::GidOffset()." << std::endl;
+  out << "Test static method AmalgamationFactory::DOFGidOffset()." << std::endl;
 
   RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
   Xpetra::UnderlyingLib lib           = MueLuTests::TestHelpers::Parameters::getLib();
@@ -152,19 +152,19 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(AmalgamationFactory, GidOffset, Scalar, LocalO
 
   // Case 1: Zero starting GIDs with offset set
   RCP<StridedMap> correct_strided_map = RCP(new StridedMap(lib, n, indexBase, stridedInfo, comm, 0, offset));
-  TEST_EQUALITY(offset, AmalgamationFactory::GidOffset(correct_strided_map)); // -> offset = 101
-  TEST_EQUALITY(offset, correct_strided_map->getOffset());                    // -> offset = 101
+  TEST_EQUALITY(offset, AmalgamationFactory::DOFGidOffset(correct_strided_map));  // -> offset = 101
+  TEST_EQUALITY(offset, correct_strided_map->getOffset());                        // -> offset = 101
 
   // Case 2: Non-zero starting GIDs shifted by offset and variable correctly set
   RCP<StridedMap> still_correct_strided_map = RCP(new StridedMap(correct_strided_map->getMap(), stridedInfo, indexBase, 0, offset));
-  TEST_EQUALITY(offset, AmalgamationFactory::GidOffset(still_correct_strided_map)); // -> offset = 101
-  TEST_EQUALITY(offset, still_correct_strided_map->getOffset());                    // -> offset = 101
+  TEST_EQUALITY(offset, AmalgamationFactory::DOFGidOffset(still_correct_strided_map));  // -> offset = 101
+  TEST_EQUALITY(offset, still_correct_strided_map->getOffset());                        // -> offset = 101
 
   // Case 3: Non-zero starting GIDs shifted by offset, but offset variable information not correctly available
   // (this can happen if a Xpetra::BlockedCrsMatrix with offset is converted to Thyra -> offset information is lost, but GIDs preserved)
   RCP<StridedMap> faulty_strided_map = RCP(new StridedMap(correct_strided_map->getMap(), stridedInfo, indexBase));
-  TEST_EQUALITY(offset, AmalgamationFactory::GidOffset(faulty_strided_map)); // -> offset = 101
-  TEST_INEQUALITY(offset, faulty_strided_map->getOffset());                  // -> offset = 0
+  TEST_EQUALITY(offset, AmalgamationFactory::DOFGidOffset(faulty_strided_map));  // -> offset = 101
+  TEST_INEQUALITY(offset, faulty_strided_map->getOffset());                      // -> offset = 0
 
 }  // AmalgamateMap
 
@@ -172,7 +172,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(AmalgamationFactory, GidOffset, Scalar, LocalO
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AmalgamationFactory, Constructor, Scalar, LO, GO, Node)   \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AmalgamationFactory, DOFGid2NodeId, Scalar, LO, GO, Node) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AmalgamationFactory, AmalgamateMap, Scalar, LO, GO, Node) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AmalgamationFactory, GidOffset, Scalar, LO, GO, Node)
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(AmalgamationFactory, DOFGidOffset, Scalar, LO, GO, Node)
 
 #include <MueLu_ETI_4arg.hpp>
 


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
There are some edge cases, were the offset for a strided map is not set correctly or at all, when using block matrix conversions from `Xpetra` to `Thyra` and vice-versa. Thus this MR proposes to calculate the offset from scratch similar to the `Xpetra::StridedMap` constructor with user-defined non-contiguous (arbitrary) distribution (Definition at line [269](https://docs.trilinos.org/dev/packages/xpetra/doc/html/Xpetra__StridedMap__def_8hpp_source.html#l00269) of file [Xpetra_StridedMap_def.hpp](https://docs.trilinos.org/dev/packages/xpetra/doc/html/Xpetra__StridedMap__def_8hpp_source.html)). 

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes #12665
* Related to #13023 

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Additional Information
Relevant for block preconditioning with `Teko` for multi-physics problems and using `MueLu` to approximate the single field inverses.
@mayrmt

