### PR TITLE
Tpetra: fix warnings

### DIFF
--- a/packages/tpetra/core/example/advanced/Benchmarks/import.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/import.cpp
@@ -297,6 +297,8 @@ int main (int argc, char* argv[]) {
     Epetra_SerialComm epetraComm;
     tpetraComm = rcp (new Teuchos::SerialComm<int>);
 #  endif // EPETRA_MPI
+#else
+    tpetraComm = Tpetra::getDefaultComm ();
 #endif // HAVE_TPETRACORE_EPETRA
 
     const int numProcs = tpetraComm->getSize ();

--- a/packages/tpetra/core/example/advanced/Benchmarks/vector.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/vector.cpp
@@ -323,6 +323,8 @@ main (int argc, char* argv[])
     Epetra_SerialComm epetraComm;
     tpetraComm = rcp (new Teuchos::SerialComm<int>);
 #  endif // EPETRA_MPI
+#else
+    tpetraComm = Tpetra::getDefaultComm ();
 #endif // HAVE_TPETRACORE_EPETRA
 
     //const int numProcs = tpetraComm->getSize (); // unused

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -5847,7 +5847,7 @@ namespace Tpetra {
 
     execute_sync_host_uvm_access(); // protect host UVM access
     totalNumPackets = 0;
-    for (LO i=0; i<numExportLIDs; ++i) {
+    for (size_t i=0; i<numExportLIDs; ++i) {
          const LO lclRow = exportLIDs_h[i];
          const GO gblRow = rowMap.getGlobalElement (lclRow);
          if (gblRow == Tpetra::Details::OrdinalTraits<GO>::invalid ()) {

--- a/packages/tpetra/core/src/Tpetra_Util.hpp
+++ b/packages/tpetra/core/src/Tpetra_Util.hpp
@@ -514,12 +514,12 @@ namespace Tpetra {
 
     Kokkos::parallel_for("apply_permutation_1",
                         Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, n),
-                        KOKKOS_LAMBDA(const int j) {
+                        [=](const int j) {
                             tmp(j) = first[indices[j]];
     });
     Kokkos::parallel_for("apply_permutation_2",
                         Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, n),
-                        KOKKOS_LAMBDA(const int j) {
+                        [=](const int j) {
                             first[j] = tmp(j);
     });
   }

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -202,8 +202,9 @@ namespace {
     first_gid  = 0;
   }
 
+  template<>
   void
-  getFirstGID(long long &first_gid) {
+  getFirstGID<long long>(long long &first_gid) {
     first_gid  = 3000000000L;
   }
 


### PR DESCRIPTION
- comparing signed vs. unsigned
- template specialization written incorrectly
- Comm pointer null in benchmarks when Epetra not enabled
- calling std::vector methods in device code

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Supersedes the Tpetra changes in #13192
* Part of #13107 

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Albany wants to build Trilinos warning-free. Only the sign-compare warning actually affected that build, the others were things that showed up in my own local build with a newer GCC.

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
