### PR TITLE
Belos: Fix missing $ in latex docstring

### DIFF
--- a/packages/belos/src/BelosStatusTestGenResSubNorm.hpp
+++ b/packages/belos/src/BelosStatusTestGenResSubNorm.hpp
@@ -254,7 +254,7 @@ class StatusTestGenResSubNorm<ScalarType,Thyra::MultiVectorBase<ScalarType>,Thyr
     \f$\|r^{(0)}\|\f$ is the corresponding norm of the initial residual.
     The used norm can be specified by defineResForm and defineScaleForm.
 
-    @param Tolerance: Specifies tolerance \f$\tau\f
+    @param Tolerance: Specifies tolerance \f$\tau\f$
     @param subIdx: index of block row in the n x n block system we want to check the residual of
     @param quorum: Number of residual (sub-)vectors which are needed to be within the tolerance before check is considered to be passed
     @param showMaxResNormOnly: for output only


### PR DESCRIPTION
@trilinos/belos
@hkthorn

This PR fixes a missing $ in a latex docstring.

Found and tested by compiling the `Belos` `doxygen` doc using "warn as error".