### PR TITLE
Framework: Update config for RHEL8 Intel PR

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2266,7 +2266,7 @@ use USE-DEPRECATED|NO
 use rhel7_sems-intel-2021.3-sems-openmpi-4.0.5_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-off_no-package-enables
 use PACKAGE-ENABLES|ALL
 
-[rhel8_sems-intel-2021.3-sems-openmpi-4.1.4_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+[rhel8_sems-intel-2021.3-sems-openmpi-4.1.6_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 # uses sems-v2 modules
 use RHEL7_COMPILER|INTEL
 use BUILD-TYPE|RELEASE-DEBUG
@@ -2327,9 +2327,9 @@ opt-set-cmake-var Tempus_Test_NewmarkImplicitAForm_HarmonicOscillator_Damped_Fir
 opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats BOOL FORCE : OFF
 
-[rhel8_sems-intel-2021.3-sems-openmpi-4.1.4_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+[rhel8_sems-intel-2021.3-sems-openmpi-4.1.6_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 # uses sems-v2 modules
-use rhel8_sems-intel-2021.3-sems-openmpi-4.1.4_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use rhel8_sems-intel-2021.3-sems-openmpi-4.1.6_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel7_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.0.5_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -185,7 +185,7 @@ sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6
 sems-clang-11.0.1-openmpi-4.0.5-serial
 sems-gnu-8.5.0-openmpi-4.1.6-serial
 sems-gnu-8.5.0-openmpi-4.1.6-openmp
-sems-intel-2021.3-sems-openmpi-4.1.4
+sems-intel-2021.3-sems-openmpi-4.1.6
 
 [ats2]
 cuda-11.2.152-gnu-8.3.1-spmpi-rolling


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Had some issues with the OpenMPI 4.1.4 stack disappearing.  4.1.6 is the preferable version anyway, so update to use that.

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-652

## Testing
I built and ran the full tests on my blade, and everything passed.
