### PR TITLE
Teko: Auto 'un-box' single sub-block hierarchical blocks

### DIFF
--- a/packages/teko/src/Teko_HierarchicalGaussSeidelPreconditionerFactory.cpp
+++ b/packages/teko/src/Teko_HierarchicalGaussSeidelPreconditionerFactory.cpp
@@ -46,6 +46,7 @@
 
 #include "Teko_BlockImplicitLinearOp.hpp"
 #include "Teko_HierarchicalGaussSeidelPreconditionerFactory.hpp"
+#include "Teko_Utilities.hpp"
 
 using Teuchos::rcp;
 using Teuchos::RCP;
@@ -233,7 +234,14 @@ void NestedBlockGS::upperTriangularImplicitApply(std::vector<BlockedMultiVector>
   const int blocks = blockToRow.size();
 
   for (int b = blocks - 1; b >= 0; b--) {
-    applyOp(blockToInvOp.at(b), r[b], z[b]);
+    int blockCount = Teko::blockCount(r[b]);
+    if (blockCount == 1) {
+      auto r_b = Teko::getBlock(0, r[b]);
+      auto z_b = Teko::getBlock(0, z[b]);
+      applyOp(blockToInvOp.at(b), r_b, z_b);
+    } else {
+      applyOp(blockToInvOp.at(b), r[b], z[b]);
+    }
 
     for (int i = 0; i < b; i++) {
       auto u_ib = Ab[index(i, b, blocks)];
@@ -251,7 +259,14 @@ void NestedBlockGS::lowerTriangularImplicitApply(std::vector<BlockedMultiVector>
   const int blocks = blockToRow.size();
 
   for (int b = 0; b < blocks; b++) {
-    applyOp(blockToInvOp.at(b), r[b], z[b]);
+    int blockCount = Teko::blockCount(r[b]);
+    if (blockCount == 1) {
+      auto r_b = Teko::getBlock(0, r[b]);
+      auto z_b = Teko::getBlock(0, z[b]);
+      applyOp(blockToInvOp.at(b), r_b, z_b);
+    } else {
+      applyOp(blockToInvOp.at(b), r[b], z[b]);
+    }
 
     // loop over each row
     for (int i = b + 1; i < blocks; i++) {
@@ -282,34 +297,15 @@ LinearOp HierarchicalGaussSeidelPreconditionerFactory::buildBlockInverse(
     const InverseFactory& invFact, const Teuchos::RCP<InverseFactory>& precFact,
     const BlockedLinearOp& matrix, BlockPreconditionerState& state,
     int hierarchicalBlockNum) const {
-  std::stringstream ss;
-  ss << "hierarchical_block_" << hierarchicalBlockNum;
-
-  ModifiableLinearOp& invOp  = state.getModifiableOp(ss.str());
-  ModifiableLinearOp& precOp = state.getModifiableOp("prec_" + ss.str());
-
-  if (precFact != Teuchos::null) {
-    if (precOp == Teuchos::null) {
-      precOp = precFact->buildInverse(matrix);
-      state.addModifiableOp("prec_" + ss.str(), precOp);
-    } else {
-      Teko::rebuildInverse(*precFact, matrix, precOp);
-    }
+  // special case: single 1x1 block system -- use non-block based inverses
+  const int nBlock = Teko::blockRowCount(matrix);
+  if (nBlock == 1) {
+    const auto& subblockMatrix = Teko::getBlock(0, 0, matrix);
+    return buildInverseImpl<LinearOp>(invFact, precFact, subblockMatrix, state,
+                                      hierarchicalBlockNum);
   }
 
-  if (invOp == Teuchos::null)
-    if (precOp.is_null())
-      invOp = Teko::buildInverse(invFact, matrix);
-    else
-      invOp = Teko::buildInverse(invFact, matrix, precOp);
-  else {
-    if (precOp.is_null())
-      Teko::rebuildInverse(invFact, matrix, invOp);
-    else
-      Teko::rebuildInverse(invFact, matrix, precOp, invOp);
-  }
-
-  return invOp;
+  return buildInverseImpl<BlockedLinearOp>(invFact, precFact, matrix, state, hierarchicalBlockNum);
 }
 
 void HierarchicalGaussSeidelPreconditionerFactory::initializeFromParameterList(

--- a/packages/teko/tests/src/tSIMPLEPreconditionerFactory_tpetra.cpp
+++ b/packages/teko/tests/src/tSIMPLEPreconditionerFactory_tpetra.cpp
@@ -786,7 +786,7 @@ bool tSIMPLEPreconditionerFactory_tpetra::test_hierarchicalSolves(int verbosity,
 
   ifl.sublist("HBGS").sublist("Hierarchical Block 2").set("Included Subblocks", "3");
   ifl.sublist("HBGS").sublist("Hierarchical Block 2").set("Inverse Type", "Belos");
-  ifl.sublist("HBGS").sublist("Hierarchical Block 2").set("Preconditioner Type", "SINGLE_BGS");
+  ifl.sublist("HBGS").sublist("Hierarchical Block 2").set("Preconditioner Type", "SINGLE_BLOCK");
 
   ifl.sublist("SIMPLE").set("Type", "NS SIMPLE");
   ifl.sublist("SIMPLE").set("Inverse Velocity Type", "Belos");
@@ -794,8 +794,7 @@ bool tSIMPLEPreconditionerFactory_tpetra::test_hierarchicalSolves(int verbosity,
   ifl.sublist("SIMPLE").set("Inverse Pressure Type", "Belos");
   ifl.sublist("SIMPLE").set("Preconditioner Pressure Type", "Ifpack2");
 
-  ifl.sublist("SINGLE_BGS").set("Type", "Block Gauss-Seidel");
-  ifl.sublist("SINGLE_BGS").set("Inverse Type", "Ifpack2");
+  ifl.sublist("SINGLE_BLOCK").set("Type", "Ifpack2");
 
   RCP<Teko::InverseLibrary> invLib        = Teko::InverseLibrary::buildFromParameterList(ifl);
   RCP<const Teko::InverseFactory> invFact = invLib->getInverseFactory("HBGS");


### PR DESCRIPTION
@trilinos/teko 

Motivation: it's really awkward to need to specify a full block Jacobi or block Gauss-Seidel solver in the context of the hierarchical block Gauss-Seidel solver. This PR automatically 'un-boxes' the block matrix to the single sub-block, allowing a user to directly use MueLu, Ifpack2, Belos, or Amesos2 to solve the sub-block.