### PR TITLE
Xpetra: Add IteratorOps to CMake

### DIFF
--- a/packages/xpetra/src/CMakeLists.txt
+++ b/packages/xpetra/src/CMakeLists.txt
@@ -85,6 +85,7 @@ SET(HEADERS "")
 APPEND_GLOB(SOURCES
   Utils/Xpetra_Utils.cpp
   Utils/Xpetra_EpetraUtils.cpp
+  Utils/Xpetra_IteratorOps.cpp
   Platform/Xpetra_DefaultPlatform.cpp
   )
 IF (${PACKAGE_NAME}_ENABLE_Epetra)


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@cgcgcg @mayrmt 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
PR https://github.com/trilinos/Trilinos/pull/13191 breaks our in-house solver build with the following error:

```shell
/usr/bin/ld: ../../../src/libmuelu.a(ETI_MueLu_SaPFactory.cpp.o): in function `Xpetra::IteratorOps<double, int, int, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> >::Jacobi(double, Xpetra::Vector<double, int, int, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> > const&, Xpetra::Matrix<double, int, int, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> > const&, Xpetra::Matrix<double, int, int, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> > const&, Teuchos::RCP<Xpetra::Matrix<double, int, int, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> > >, Teuchos::basic_FancyOStream<char, std::char_traits<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Teuchos::RCP<Teuchos::ParameterList>&)':
ETI_MueLu_SaPFactory.cpp:(.text._ZN6Xpetra11IteratorOpsIdiiN6Tpetra12KokkosCompat23KokkosDeviceWrapperNodeIN6Kokkos6SerialENS4_9HostSpaceEEEE6JacobiEdRKNS_6VectorIdiiS7_EERKNS_6MatrixIdiiS7_EESG_N7Teuchos3RCPISE_EERNSH_18basic_FancyOStreamIcSt11char_traitsIcEEERKNSt7__cxx1112basic_stringIcSM_SaIcEEERNSI_INSH_13ParameterListEEE[_ZN6Xpetra11IteratorOpsIdiiN6Tpetra12KokkosCompat23KokkosDeviceWrapperNodeIN6Kokkos6SerialENS4_9HostSpaceEEEE6JacobiEdRKNS_6VectorIdiiS7_EERKNS_6MatrixIdiiS7_EESG_N7Teuchos3RCPISE_EERNSH_18basic_FancyOStreamIcSt11char_traitsIcEEERKNSt7__cxx1112basic_stringIcSM_SaIcEEERNSI_INSH_13ParameterListEEE]+0x155): undefined reference to `void Xpetra::Jacobi<double, int, int, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> >(double, Xpetra::Vector<double, int, int, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> > const&, Xpetra::Matrix<double, int, int, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> > const&, Xpetra::Matrix<double, int, int, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> > const&, Xpetra::Matrix<double, int, int, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> >&, bool, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Teuchos::RCP<Teuchos::ParameterList> const&)'
collect2: error: ld returned 1 exit status
make[2]: *** [packages/muelu/doc/Tutorial/src/CMakeFiles/MueLu_tutorial_laplace2d.dir/build.make:162: packages/muelu/doc/Tutorial/src/MueLu_tutorial_laplace2d.exe] Error 1
make[1]: *** [CMakeFiles/Makefile2:58424: packages/muelu/doc/Tutorial/src/CMakeFiles/MueLu_tutorial_laplace2d.dir/all] Error 2
```
To me it seems like `Xpetra::IteratorOps` is not picked up by CMake correctly, this PR fixes the issue.
