### PR TITLE
MueLu MultiPhys: Fix includes

### DIFF
--- a/packages/muelu/src/Operators/MueLu_MultiPhys_decl.hpp
+++ b/packages/muelu/src/Operators/MueLu_MultiPhys_decl.hpp
@@ -24,10 +24,6 @@
 #include "MueLu_PerfUtils_fwd.hpp"
 #include "MueLu_SmootherBase.hpp"
 
-#if defined(HAVE_MUELU_KOKKOS_REFACTOR)
-#include "MueLu_Utilities_kokkos_fwd.hpp"
-#endif
-
 #include "Xpetra_Map_fwd.hpp"
 #include "Xpetra_Matrix_fwd.hpp"
 #include "Xpetra_MatrixFactory_fwd.hpp"

--- a/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
@@ -29,9 +29,6 @@
 #include "MueLu_ParameterListInterpreter.hpp"
 #include "MueLu_HierarchyManager.hpp"
 #include <MueLu_HierarchyUtils.hpp>
-#if defined(HAVE_MUELU_KOKKOS_REFACTOR)
-#include "MueLu_Utilities_kokkos.hpp"
-#endif
 #include "MueLu_VerbosityLevel.hpp"
 #include <MueLu_CreateXpetraPreconditioner.hpp>
 #include <MueLu_ML2MueLuParameterTranslator.hpp>


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Break builds if they were still configured with removed variable `MueLu_ENABLE_KOKKOS_REFACTOR`