### PR TITLE
Add-License-Identifier

### DIFF
--- a/packages/PyTrilinos2/LICENSE
+++ b/packages/PyTrilinos2/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: BSD-3-Clause
 
 Copyright (c) 2022 NTESS and the PyTrilinos2 contributors.
 

--- a/packages/TrilinosInstallTests/LICENSE
+++ b/packages/TrilinosInstallTests/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: BSD-3-Clause
 
 Copyright (c) 2001-2024 NTESS and the Trilinos contributors.
 

--- a/packages/adelus/LICENSE
+++ b/packages/adelus/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: BSD-3-Clause
 
 Copyright (c) 2020 NTESS and the Adelus contributors.
 

--- a/packages/amesos2/LICENSE
+++ b/packages/amesos2/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: BSD-3-Clause
 
 Copyright (c) 2011 NTESS and the Amesos2 contributors.
 

--- a/packages/amesos2/src/KLU2/LICENSE
+++ b/packages/amesos2/src/KLU2/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: LGPL-2.1-or-later
 
 Copyright (c) 2011 NTESS and the KLU2 contributors.
 

--- a/packages/amesos2/src/basker/LICENSE
+++ b/packages/amesos2/src/basker/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: LGPL-2.1-or-later
 
 Copyright (c) 2011 NTESS and the Basker contributors.
 

--- a/packages/anasazi/LICENSE
+++ b/packages/anasazi/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: BSD-3-Clause
 
 Copyright (c) 2004 NTESS and the Anasazi contributors.
 

--- a/packages/belos/LICENSE
+++ b/packages/belos/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: BSD-3-Clause
 
 Copyright (c) 2004-2016 NTESS and the Belos contributors.
 

--- a/packages/galeri/LICENSE
+++ b/packages/galeri/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: BSD-3-Clause
 
 Copyright (c) 2006 ETHZ/NTESS and the Galeri contributors.
 

--- a/packages/ifpack2/LICENSE
+++ b/packages/ifpack2/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: BSD-3-Clause
 
 Copyright (c) 2009 NTESS and the Ifpack2 contributors.
 

--- a/packages/intrepid2/LICENSE
+++ b/packages/intrepid2/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: BSD-3-Clause
 
 Copyright (c) 2007 NTESS and the Intrepid2 contributors.
 

--- a/packages/minitensor/LICENSE
+++ b/packages/minitensor/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: BSD-3-Clause
 
 Copyright (c) 2016 NTESS and the MiniTensor contributors.
 

--- a/packages/muelu/LICENSE
+++ b/packages/muelu/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: BSD-3-Clause
 
 Copyright (c) 2012 NTESS and the MueLu contributors.
 

--- a/packages/pamgen/LICENSE
+++ b/packages/pamgen/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: LGPL-2.1-or-later
 
 Copyright (c) 2004 NTESS and the Pamgen contributors.
 

--- a/packages/panzer/LICENSE
+++ b/packages/panzer/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: BSD-3-Clause
 
 Copyright (c) 2011 NTESS and the Panzer contributors.
 

--- a/packages/phalanx/LICENSE
+++ b/packages/phalanx/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: BSD-3-Clause
 
 Copyright (c) 2008 NTESS and the Phalanx contributors.
 

--- a/packages/tempus/LICENSE
+++ b/packages/tempus/LICENSE
@@ -1,3 +1,4 @@
+SPDX-License-Identifier: BSD-3-Clause
 
 Copyright (c) 2017 NTESS and the Tempus contributors.
 


### PR DESCRIPTION
Add missing License Identifier to LICENSE files.  This is just a one-line addition to multiple packages.

@trilinos/framework 

