### PR TITLE
Framework: Turn off all warnings when compiling deprecated packages

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1738,42 +1738,51 @@ opt-set-cmake-var KokkosKernels_batched_dla_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE
 opt-set-cmake-var Intrepid2_unit-test_MonolithicExecutable_Intrepid2_Tests_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
 
 [GCC_PACKAGE_SPECIFIC_WARNING_FLAGS]
-opt-set-cmake-var Amesos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Amesos2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Belos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Domi_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Epetra_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var EpetraExt_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var FEI_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Galeri_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Ifpack_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Intrepid_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Intrepid2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror -Wno-error=shadow
-opt-set-cmake-var Isorropia_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var ML_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Moertel_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var NOX_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Pamgen_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Phalanx_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Pike_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-opt-set-cmake-var Piro_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var ROL_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Sacado_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Shards_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var ShyLU_Node_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var STK_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Stokhos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# Supported packages
+opt-set-cmake-var Amesos2_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Belos_CXX_FLAGS       STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Domi_CXX_FLAGS        STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var FEI_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Galeri_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Intrepid2_CXX_FLAGS   STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror -Wno-error=shadow
+opt-set-cmake-var Moertel_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var NOX_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Pamgen_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Phalanx_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Pike_CXX_FLAGS        STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var Piro_CXX_FLAGS        STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var ROL_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Sacado_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Shards_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var ShyLU_Node_CXX_FLAGS  STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var STK_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Stokhos_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Stratimikos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-# opt-set-cmake-var Tempus_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+# opt-set-cmake-var Tempus_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var Zoltan_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var TrilinosCouplings_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Zoltan_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+
+# Deprecated packages
+opt-set-cmake-var Amesos_CXX_FLAGS      STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var AztecOO_CXX_FLAGS     STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var Epetra_CXX_FLAGS      STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var EpetraExt_CXX_FLAGS   STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var Ifpack_CXX_FLAGS      STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var Intrepid_CXX_FLAGS    STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var Isorropia_CXX_FLAGS   STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var ML_CXX_FLAGS          STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var Pliris_CXX_FLAGS      STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var PyTrilinos_CXX_FLAGS  STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var ShyLU_DD_CXX_FLAGS    STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var Triutils_CXX_FLAGS    STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var ThyraEpetraAdapters_CXX_FLAGS     STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var ThyraEpetraExtAdapters_CXX_FLAGS  STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+
 
 [GCC_OPENMP_PACKAGE_SPECIFIC_WARNING_FLAGS]
 use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
-opt-set-cmake-var Panzer_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Panzer_CXX_FLAGS  STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Percept_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Pliris_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var ShyLU_DD_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 
 
 # Full configurations intended to be loaded.


### PR DESCRIPTION


<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Due to deprecated packages no longer being supported, turn off all of their generated warnings whenever their codes get compiled.

Additional motivation is that this will allow Trilinos to turn on more warnings-as-errors for supported packages more generally in the future rather than on a per-package basis.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

-  [TRILFRAME-658](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-658)


<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Locally tested on only the serial build with no issues. Going to let the AutoTester perform tests on the rest of the builds.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
