### PR TITLE
Framework: Enable additional warnings-as-errors in Trilinos

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -3110,7 +3110,7 @@ opt-set-cmake-var TPL_ENABLE_Scotch   BOOL FORCE : OFF
 opt-set-cmake-var TPL_Netcdf_LIBRARIES STRING FORCE : ${NETCDF_C_LIB|ENV}/libnetcdf.so
 
 opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
-opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -Werror=shadow -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-label -Werror=parentheses -Werror=sign-compare -Werror=unused-variable -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
 

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -3144,7 +3144,7 @@ use COMMON_SPACK_TPLS
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : --bind-to;none --mca btl vader,self
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL         : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-parentheses -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address -Werror=sign-compare -Werror=unused-variable -Werror=parentheses -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 # TPL_BLAS_LIBRARIES is redefined here with libm for SuperLU to properly link
 opt-set-cmake-var TPL_BLAS_LIBRARIES STRING FORCE : -L${BLAS_ROOT|ENV}/lib;-lblas;-lgfortran;-lgomp;-lm
@@ -3187,7 +3187,7 @@ opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL   
 opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE                     BOOL         : ON
 opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE                     BOOL         : ON
 
-opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-error -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
+opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -Werror=sign-compare -Werror=unused-variable -Werror=parentheses -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS
 
 # Test failures as of 11-28-22
 opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL : ON

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1738,42 +1738,51 @@ opt-set-cmake-var KokkosKernels_batched_dla_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE
 opt-set-cmake-var Intrepid2_unit-test_MonolithicExecutable_Intrepid2_Tests_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
 
 [GCC_PACKAGE_SPECIFIC_WARNING_FLAGS]
-opt-set-cmake-var Amesos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Amesos2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Belos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Domi_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Epetra_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var EpetraExt_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var FEI_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Galeri_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Ifpack_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Intrepid_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Intrepid2_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror -Wno-error=shadow
-opt-set-cmake-var Isorropia_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var ML_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Moertel_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var NOX_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Pamgen_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Phalanx_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Pike_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-opt-set-cmake-var Piro_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var ROL_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Sacado_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Shards_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var ShyLU_Node_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var STK_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Stokhos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# Supported packages
+opt-set-cmake-var Amesos2_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Belos_CXX_FLAGS       STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Domi_CXX_FLAGS        STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var FEI_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Galeri_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Intrepid2_CXX_FLAGS   STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror -Wno-error=shadow
+opt-set-cmake-var Moertel_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var NOX_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Pamgen_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Phalanx_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Pike_CXX_FLAGS        STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var Piro_CXX_FLAGS        STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var ROL_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Sacado_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Shards_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var ShyLU_Node_CXX_FLAGS  STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var STK_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Stokhos_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Stratimikos_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-# opt-set-cmake-var Tempus_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+# opt-set-cmake-var Tempus_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
+opt-set-cmake-var Zoltan_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var TrilinosCouplings_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Zoltan_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+
+# Deprecated packages
+opt-set-cmake-var Amesos_CXX_FLAGS      STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var AztecOO_CXX_FLAGS     STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var Epetra_CXX_FLAGS      STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var EpetraExt_CXX_FLAGS   STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var Ifpack_CXX_FLAGS      STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var Intrepid_CXX_FLAGS    STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var Isorropia_CXX_FLAGS   STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var ML_CXX_FLAGS          STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var Pliris_CXX_FLAGS      STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var PyTrilinos_CXX_FLAGS  STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var ShyLU_DD_CXX_FLAGS    STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var Triutils_CXX_FLAGS    STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var ThyraEpetraAdapters_CXX_FLAGS     STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+opt-set-cmake-var ThyraEpetraExtAdapters_CXX_FLAGS  STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w
+
 
 [GCC_OPENMP_PACKAGE_SPECIFIC_WARNING_FLAGS]
 use GCC_PACKAGE_SPECIFIC_WARNING_FLAGS
-opt-set-cmake-var Panzer_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+opt-set-cmake-var Panzer_CXX_FLAGS  STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Percept_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Pliris_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var ShyLU_DD_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 
 
 # Full configurations intended to be loaded.


### PR DESCRIPTION
# THIS PR WILL HAVE A MERGE DEADLINE OF 08/22/24 !!!

@trilinos/framework

## Motivation
Begin enabling as much warnings-as-errors as possible back into Trilinos, beginning with `-Werror=sign-compare -Werror=unused-variable -Werror=parentheses`.

With the introduction of deprecated package header warnings in #12828, `-Werror` had to be turned off from several PR testing configurations (gcc-serial, gcc-openmpi, & gcc-openmpi-openmp). Since then, we cannot be confident that Trilinos can compile with minimal warnings related to all currently supported packages. See Related Issues section for more context on how this began.

## Fixing errors caused by these flags

Enabling these warnings in this PR is likely to cause several build errors across several packages that need to be fixed individually by the packages' maintainers. To give time for package developers to resolve the new warnings-as-errors present, there will be a deadline for this PR getting merged. Packages containing errors will be pinged in this thread to resolve the issues.

Instructions for how to reproduce a specific packages' results with the new flags can be reference in #13311 

**NOTE:** You should not use this branch to reproduce the errors seen reported to CDash in this PR.


## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

- [TRILFRAME-658](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-658)
- #13107 
- #13127 
- #13213
- #13311 

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->

## Testing
Letting the AutoTester to figure out which packages need fixes and when these flags are ready for a general release into `CMAKE_CXX_FLAGS`.

