### PR TITLE
Ifpack2: Fix repeat calls to ILUT::compute

### DIFF
--- a/packages/ifpack2/src/Ifpack2_ILUT_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_ILUT_decl.hpp
@@ -407,6 +407,8 @@ private:
   Teuchos::RCP<crs_matrix_type> L_;
   lno_urow_view_t     L_rowmap_;
   lno_urow_view_t     U_rowmap_;
+  lno_urow_view_t     L_rowmap_orig_;
+  lno_urow_view_t     U_rowmap_orig_;
   //! Sparse triangular solver for L
   Teuchos::RCP<LocalSparseTriangularSolver<row_matrix_type> > L_solver_;
   //! U factor of the incomplete LU factorization of A_local_.

--- a/packages/ifpack2/src/Ifpack2_ILUT_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_ILUT_def.hpp
@@ -522,11 +522,16 @@ void ILUT<MatrixType>::initialize ()
       const int NumMyRows = A_local_crs->getRowMap()->getLocalNumElements();
       L_rowmap_ = ulno_row_view_t("L_row_map", NumMyRows + 1);
       U_rowmap_ = ulno_row_view_t("U_row_map", NumMyRows + 1);
+      L_rowmap_orig_ = ulno_row_view_t("L_row_map_orig", NumMyRows + 1);
+      U_rowmap_orig_ = ulno_row_view_t("U_row_map_orig", NumMyRows + 1);
 
       KokkosSparse::Experimental::par_ilut_symbolic(KernelHandle_.getRawPtr(),
                                                     A_local_crs_device.graph.row_map, A_local_crs_device.graph.entries,
                                                     L_rowmap_,
                                                     U_rowmap_);
+
+      Kokkos::deep_copy(L_rowmap_orig_, L_rowmap_);
+      Kokkos::deep_copy(U_rowmap_orig_, U_rowmap_);
     }
 
     IsInitialized_ = true;
@@ -902,6 +907,13 @@ void ILUT<MatrixType>::compute ()
 
   } //if (!this->useKokkosKernelsParILUT_)
   else {
+    // Set L, U rowmaps back to original state. Par_ilut can change them, which invalidates them
+    // if compute is called again.
+    if (this->isComputed()) {
+      Kokkos::deep_copy(L_rowmap_, L_rowmap_orig_);
+      Kokkos::deep_copy(U_rowmap_, U_rowmap_orig_);
+    }
+
     RCP<const crs_matrix_type> A_local_crs = Teuchos::rcp_dynamic_cast<const crs_matrix_type>(A_local_);
     {//Make sure values in A is picked up even in case of pattern reuse
       if(A_local_crs.is_null()) {
@@ -980,7 +992,6 @@ void ILUT<MatrixType>::compute ()
     L_solver_->compute ();//NOTE: Only do compute if the pointer changed. Otherwise, do nothing
     U_solver_->setMatrix (U_);
     U_solver_->compute ();//NOTE: Only do compute if the pointer changed. Otherwise, do nothing
-
   } //if (!this->useKokkosKernelsParILUT_) ... else ...
 
   } // Timer scope for timing compute()


### PR DESCRIPTION
L_rowmap and U_rowmap are in/out parameters to par_ilut_numeric and therefore can be changed by that call. If they do change, they will no longer accurately reflect the original A. This PR ensures that L_rowmap and U_rowmap will be restored to original symbolic values in case ILUT::compute is called again.

@trilinos/ifpack2 

## Motivation

Aria was trying to use ILUT and having problems due to multiple compute calls.

## Testing
I will have Aria devs test this.