### PR TITLE
Tempus: Change Recovery State

### DIFF
--- a/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
@@ -235,8 +235,16 @@ void SolutionHistory<Scalar>::initWorkingState()
         "Can not initialize working state without a current state!\n");
 
     // If workingState_ has a valid pointer, we are still working on it,
-    // i.e., step failed and trying again, so do not initialize it.
-    if (getWorkingState(false) != Teuchos::null) return;
+    // i.e., step failed and trying again.  There are a couple options:
+    //   1. Reuse the workingState as it might be a good guess.  This
+    //      could help with performance.  This was the initial implementation.
+    //   2. Reset the workingState to the last time step.  This could
+    //      be more robust in the case of the workingState failing with nans.
+    //      This is the current implementation.
+    if (getWorkingState(false) != Teuchos::null) {
+      Thyra::V_V(getWorkingState()->getX().ptr(), *(getCurrentState()->getX()));
+      return;
+    }
 
     Teuchos::RCP<SolutionState<Scalar> > newState;
     if (getNumStates() < storageLimit_) {

--- a/packages/tempus/unit_test/Tempus_UnitTest_SolutionHistory.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_SolutionHistory.cpp
@@ -556,7 +556,9 @@ TEUCHOS_UNIT_TEST(SolutionHistory, initWorkingState_Failing)
   sh->initialize();
   TEUCHOS_TEST_FOR_EXCEPT(!sh->isInitialized());
 
-  auto state1 = Tempus::createSolutionStateX<double>(icSoln);
+  auto currentSoln = icSoln->clone_v();
+  Thyra::V_S(currentSoln.ptr(), std::numeric_limits<double>::quiet_NaN());
+  auto state1 = Tempus::createSolutionStateX<double>(currentSoln);
   state1->setTime(1.0);
   state1->setTimeStep(1.0);
   state1->setIndex(1);
@@ -574,8 +576,11 @@ TEUCHOS_UNIT_TEST(SolutionHistory, initWorkingState_Failing)
 
   TEUCHOS_ASSERT(sh->getCurrentState() != Teuchos::null);
   TEUCHOS_ASSERT(sh->getCurrentState() == sh->getStateTimeIndexNM1());
+  TEUCHOS_ASSERT(get_ele(*(sh->getCurrentState()->getX()), 0) == 1.0 );
+
   TEUCHOS_ASSERT(sh->getWorkingState() != Teuchos::null);
   TEUCHOS_ASSERT(sh->getWorkingState() == sh->getStateTimeIndexN());
+  TEUCHOS_ASSERT(std::isnan(get_ele(*(sh->getWorkingState()->getX()), 0))); // !!!
 
   TEST_COMPARE(sh->getCurrentState()->getIndex(), ==, 0);
   TEST_FLOATING_EQUALITY(sh->getCurrentState()->getTime(), 0.0, 1.0e-14);
@@ -586,7 +591,8 @@ TEUCHOS_UNIT_TEST(SolutionHistory, initWorkingState_Failing)
   sh->initWorkingState();
 
   // State after initializing workingState.
-  // Should be unchanged as we are trying to redo FAILing time step.
+  // Should be unchanged except the workingState->getX() is reset
+  // to currentState->getX().
   TEST_COMPARE(sh->getNumStates(), ==, 2);
   TEST_FLOATING_EQUALITY(sh->getCurrentTime(), 0.0, 1.0e-14);
   TEST_COMPARE(sh->getCurrentIndex(), ==, 0);
@@ -595,8 +601,11 @@ TEUCHOS_UNIT_TEST(SolutionHistory, initWorkingState_Failing)
 
   TEUCHOS_ASSERT(sh->getCurrentState() != Teuchos::null);
   TEUCHOS_ASSERT(sh->getCurrentState() == sh->getStateTimeIndexNM1());
+  TEUCHOS_ASSERT(get_ele(*(sh->getCurrentState()->getX()), 0) == 1.0 );
+
   TEUCHOS_ASSERT(sh->getWorkingState() != Teuchos::null);
   TEUCHOS_ASSERT(sh->getWorkingState() == sh->getStateTimeIndexN());
+  TEUCHOS_ASSERT(get_ele(*(sh->getWorkingState()->getX()), 0) == 1.0 );  // !!!
 
   TEST_COMPARE(sh->getCurrentState()->getIndex(), ==, 0);
   TEST_FLOATING_EQUALITY(sh->getCurrentState()->getTime(), 0.0, 1.0e-14);

--- a/packages/tempus/unit_test/Tempus_UnitTest_SolutionHistory.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_SolutionHistory.cpp
@@ -576,11 +576,11 @@ TEUCHOS_UNIT_TEST(SolutionHistory, initWorkingState_Failing)
 
   TEUCHOS_ASSERT(sh->getCurrentState() != Teuchos::null);
   TEUCHOS_ASSERT(sh->getCurrentState() == sh->getStateTimeIndexNM1());
-  TEUCHOS_ASSERT(get_ele(*(sh->getCurrentState()->getX()), 0) == 1.0 );
+  TEUCHOS_ASSERT(get_ele(*(sh->getCurrentState()->getX()), 0) == 1.0);
 
   TEUCHOS_ASSERT(sh->getWorkingState() != Teuchos::null);
   TEUCHOS_ASSERT(sh->getWorkingState() == sh->getStateTimeIndexN());
-  TEUCHOS_ASSERT(std::isnan(get_ele(*(sh->getWorkingState()->getX()), 0))); // !!!
+  TEUCHOS_ASSERT(std::isnan(get_ele(*(sh->getWorkingState()->getX()), 0)));  // !!!
 
   TEST_COMPARE(sh->getCurrentState()->getIndex(), ==, 0);
   TEST_FLOATING_EQUALITY(sh->getCurrentState()->getTime(), 0.0, 1.0e-14);
@@ -601,11 +601,11 @@ TEUCHOS_UNIT_TEST(SolutionHistory, initWorkingState_Failing)
 
   TEUCHOS_ASSERT(sh->getCurrentState() != Teuchos::null);
   TEUCHOS_ASSERT(sh->getCurrentState() == sh->getStateTimeIndexNM1());
-  TEUCHOS_ASSERT(get_ele(*(sh->getCurrentState()->getX()), 0) == 1.0 );
+  TEUCHOS_ASSERT(get_ele(*(sh->getCurrentState()->getX()), 0) == 1.0);
 
   TEUCHOS_ASSERT(sh->getWorkingState() != Teuchos::null);
   TEUCHOS_ASSERT(sh->getWorkingState() == sh->getStateTimeIndexN());
-  TEUCHOS_ASSERT(get_ele(*(sh->getWorkingState()->getX()), 0) == 1.0 );  // !!!
+  TEUCHOS_ASSERT(get_ele(*(sh->getWorkingState()->getX()), 0) == 1.0);  // !!!
 
   TEST_COMPARE(sh->getCurrentState()->getIndex(), ==, 0);
   TEST_FLOATING_EQUALITY(sh->getCurrentState()->getTime(), 0.0, 1.0e-14);


### PR DESCRIPTION
When a timestep fails, the failing workingState solution was reused as it might be a good guess for the nonlinear solver and could help with performance.

However if the failing workingState failed with NaNs, it was never reset and the workingState would continue to have NaNs after failure. The new behavior is to reset the workingState to the last time step, currentState.  This will be more robust in this case.

@trilinos/tempus 

## Motivation
Stakeholder had the situation where the timestep failed with NaNs.  Although the timestep was halved, the solution had NaNs which continued to the next solution, causing another failure.  Thus the timestep crashed until the problem stopped.

## Stakeholder Feedback
@rppawlo tested this and found it resolved the issue.

## Testing
Added to a unit test to cover this situation.
