### PR TITLE
tacho: fix unused variable triggering -Werror

### DIFF
--- a/packages/amesos2/test/solvers/Solver_Test.cpp
+++ b/packages/amesos2/test/solvers/Solver_Test.cpp
@@ -1515,7 +1515,7 @@ bool do_kokkos_test_with_types(const string& mm_file,
       auto row_map = A2->graph.row_map;
       Kokkos::RangePolicy<execution_space> policy(0, vals.size());
       Kokkos::parallel_for(policy, KOKKOS_LAMBDA(size_t i) {
-        if(i < row_map(1)) { // just do 1st row
+        if(i < size_t(row_map(1))) { // just do 1st row
           vals(i) = vals(i) * vals(i);
         }
       });

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -2056,11 +2056,12 @@ public:
         for (ordinal_type lvl = 0; lvl < _team_serial_level_cut; ++lvl) {
           const ordinal_type pbeg = _h_level_ptr(lvl);
           // the first supernode in this lvl (where the CRS matrix is stored)
-          auto &s0 = _h_supernodes(_h_level_sids(pbeg));
 #if defined(KOKKOS_ENABLE_CUDA)
+          auto &s0 = _h_supernodes(_h_level_sids(pbeg));
           cusparseDestroySpMat(s0.U_cusparse);
           cusparseDestroySpMat(s0.L_cusparse);
 #elif defined(KOKKOS_ENABLE_HIP)
+          auto &s0 = _h_supernodes(_h_level_sids(pbeg));
           rocsparse_destroy_spmat_descr(s0.descrU);
           rocsparse_destroy_spmat_descr(s0.descrL);
 #endif

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -2054,7 +2054,9 @@ public:
       Kokkos::fence();
       if (release_all) {
         for (ordinal_type lvl = 0; lvl < _team_serial_level_cut; ++lvl) {
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
           const ordinal_type pbeg = _h_level_ptr(lvl);
+#endif
           // the first supernode in this lvl (where the CRS matrix is stored)
 #if defined(KOKKOS_ENABLE_CUDA)
           auto &s0 = _h_supernodes(_h_level_sids(pbeg));


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/shylu @iyamazaki 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

Fix `-Werror=unused-variable` breaking PR_gcc-openmpi-openmp builds, crept in with #13318 and encountered in PRs #13334 and https://github.com/trilinos/Trilinos/pull/13332

```
https://github.com/trilinos/Trilinos//blob/d8badb3e29a5693d5ec638d02da83d32d261cee8/workspace/PR_gcc-openmpi-openmp/Trilinos/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp#L2059 :17: error: unused variable 's0' [-Werror=unused-variable]
           auto &s0 = _h_supernodes(_h_level_sids(pbeg));
```

The compilation errors likely contributed to `TrilinosInstallTests_doInstall` test failures in the `rhel8_sems-gnu-8.5.0-openmpi-4.1.6-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables` jobs with output:

```
...
CMake Error at /scratch/trilinos/workspace/PR_gcc-openmpi-openmp/pull_request_test/packages/shylu/shylu_node/tacho/src/cmake_install.cmake:46 (file):
  file INSTALL cannot find
  "/scratch/trilinos/workspace/PR_gcc-openmpi-openmp/pull_request_test/packages/shylu/shylu_node/tacho/src/libtacho.a":
  No such file or directory.
Call Stack (most recent call first):
  /scratch/trilinos/workspace/PR_gcc-openmpi-openmp/pull_request_test/packages/shylu/shylu_node/tacho/cmake_install.cmake:47 (include)
  /scratch/trilinos/workspace/PR_gcc-openmpi-openmp/pull_request_test/packages/shylu/shylu_node/cmake_install.cmake:52 (include)
  /scratch/trilinos/workspace/PR_gcc-openmpi-openmp/pull_request_test/cmake_install.cmake:277 (include)

```



## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Blocks #13334 and https://github.com/trilinos/Trilinos/pull/13332

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
