### PR TITLE
Tpetra: remove UVM ETI for FixedHashTable

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_Cuda.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_Cuda.cpp
@@ -21,17 +21,10 @@ namespace Details {
 
   typedef Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> cuda_device_type;
 
-  typedef Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace> cuda_uvm_device_type;
-
 #define TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT_CUDA( LO, GO ) \
   TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT( LO, GO, cuda_device_type )
 
   TPETRA_INSTANTIATE_LG( TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT_CUDA )
-
-#define TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT_CUDA_UVM( LO, GO ) \
-  TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT( LO, GO, cuda_uvm_device_type )
-
-  TPETRA_INSTANTIATE_LG( TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT_CUDA_UVM )
 
   // mfh 26 Sep 2015: Make sure that the {KeyType = LO, ValueType =
   // LO} and {KeyType = int, ValueType = LO} specializations get
@@ -40,8 +33,7 @@ namespace Details {
   // KeyType = int doesn't get built if GO = int is disabled.
 #ifndef HAVE_TPETRA_INST_INT_INT
 #  define TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT_CUDA_INT( LO ) \
-  TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT( LO, int, cuda_device_type ) \
-  TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT( LO, int, cuda_uvm_device_type )
+  TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT( LO, int, cuda_device_type )
 
   TPETRA_INSTANTIATE_L( TPETRA_DETAILS_FIXEDHASHTABLE_INSTANT_CUDA_INT )
 


### PR DESCRIPTION
Closes #12189.

@trilinos/tpetra

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->



<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
n/a

## Testing

existing unit tests and dashboard
