### PR TITLE
Ifpack2: add use a LIDs option and a `are_same` to skip serial 

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_def.hpp
@@ -74,7 +74,7 @@ namespace Ifpack2 {
             (block_size == -1, "A pointwise matrix and block_size = -1 were given as inputs.");
           {
             IFPACK2_BLOCKHELPER_TIMER("BlockTriDiContainer::setA::convertToBlockCrsMatrix");
-            impl_->A = Tpetra::convertToBlockCrsMatrix(*Teuchos::rcp_dynamic_cast<const crs_matrix_type>(matrix), block_size, false);
+            impl_->A = Tpetra::convertToBlockCrsMatrix(*Teuchos::rcp_dynamic_cast<const crs_matrix_type>(matrix), block_size, true);
             IFPACK2_BLOCKHELPER_TIMER_FENCE(typename BlockHelperDetails::ImplType<MatrixType>::execution_space)
           }
         }


### PR DESCRIPTION
Add use a LIDs option to use LID for the explicit `convertToBlockCrsMatrix ` and a `are_same` to skip the serial loop `loop_over_local_elements`.