### PR TITLE
Tpetra and Ifpack2: Use `TEUCHOS_FUNC_TIME_MONITOR_DIFF` instead of `TEUCHOS_FUNC_TIME_MONITOR`

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockComputeResidualVector.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockComputeResidualVector.hpp
@@ -790,7 +790,7 @@ namespace Ifpack2 {
                const MultiVectorLocalViewTypeB &b_,
                const MultiVectorLocalViewTypeX &x_) {
         IFPACK2_BLOCKHELPER_PROFILER_REGION_BEGIN;
-        IFPACK2_BLOCKHELPER_TIMER_WITH_FENCE("BlockTriDi::ComputeResidual::<SeqTag>", execution_space);
+        IFPACK2_BLOCKHELPER_TIMER_WITH_FENCE("BlockTriDi::ComputeResidual::<SeqTag>", ComputeResidual0, execution_space);
 
         y = y_; b = b_; x = x_;
         if constexpr (is_device<execution_space>::value) {
@@ -818,7 +818,7 @@ namespace Ifpack2 {
                const MultiVectorLocalViewTypeX &x_,
                const MultiVectorLocalViewTypeX_Remote &x_remote_) {
         IFPACK2_BLOCKHELPER_PROFILER_REGION_BEGIN;
-        IFPACK2_BLOCKHELPER_TIMER_WITH_FENCE("BlockTriDi::ComputeResidual::<AsyncTag>", execution_space);
+        IFPACK2_BLOCKHELPER_TIMER_WITH_FENCE("BlockTriDi::ComputeResidual::<AsyncTag>", ComputeResidual0, execution_space);
 
         b = b_; x = x_; x_remote = x_remote_;
         if constexpr (is_device<execution_space>::value) {
@@ -892,7 +892,7 @@ namespace Ifpack2 {
                const MultiVectorLocalViewTypeX_Remote &x_remote_,
                const bool compute_owned) {
         IFPACK2_BLOCKHELPER_PROFILER_REGION_BEGIN;
-        IFPACK2_BLOCKHELPER_TIMER_WITH_FENCE("BlockTriDi::ComputeResidual::<OverlapTag>", execution_space);
+        IFPACK2_BLOCKHELPER_TIMER_WITH_FENCE("BlockTriDi::ComputeResidual::<OverlapTag>", ComputeResidual0, execution_space);
 
         b = b_; x = x_; x_remote = x_remote_;
         if constexpr (is_device<execution_space>::value) {

--- a/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
@@ -396,7 +396,7 @@ namespace Ifpack2 {
       void ireduce(const int sweep, const bool force = false) {
         if ( ! force && sweep % sweep_step_) return;
 
-        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NormManager::Ireduce");
+        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NormManager::Ireduce", Ireduce);
 
         work_[1] = work_[0];
 #ifdef HAVE_IFPACK2_MPI
@@ -425,7 +425,7 @@ namespace Ifpack2 {
         // early return
         if (sweep <= 0) return false;
 
-        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NormManager::CheckDone");
+        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NormManager::CheckDone", CheckDone);
 
         TEUCHOS_ASSERT(sweep >= 1);
         if ( ! force && (sweep - 1) % sweep_step_) return false;
@@ -473,7 +473,7 @@ namespace Ifpack2 {
     void reduceVector(const ConstUnmanaged<typename BlockHelperDetails::ImplType<MatrixType>::impl_scalar_type_1d_view> zz,
                       /* */ typename BlockHelperDetails::ImplType<MatrixType>::magnitude_type *vals) {
       IFPACK2_BLOCKHELPER_PROFILER_REGION_BEGIN;
-      IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::ReduceVector");
+      IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::ReduceVector", ReduceVector);
 
       using impl_type = BlockHelperDetails::ImplType<MatrixType>;
       using local_ordinal_type = typename impl_type::local_ordinal_type;

--- a/packages/ifpack2/src/Ifpack2_BlockHelper_Timers.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockHelper_Timers.hpp
@@ -16,18 +16,18 @@ namespace Ifpack2 {
   namespace BlockHelperDetails {
 
 #if defined(HAVE_IFPACK2_BLOCKTRIDICONTAINER_TIMERS)
-#define IFPACK2_BLOCKHELPER_TIMER(label) TEUCHOS_FUNC_TIME_MONITOR(label);
+#define IFPACK2_BLOCKHELPER_TIMER(label, varname) TEUCHOS_FUNC_TIME_MONITOR_DIFF(label, varname);
 #define IFPACK2_BLOCKHELPER_TIMER_FENCE(execution_space) execution_space().fence();
 #define IFPACK2_BLOCKHELPER_TIMER_DEFAULT_FENCE() Kokkos::DefaultExecutionSpace().fence();
 #else
-#define IFPACK2_BLOCKHELPER_TIMER(label)
+#define IFPACK2_BLOCKHELPER_TIMER(label, varname)
 #define IFPACK2_BLOCKHELPER_TIMER_FENCE(execution_space)
 #define IFPACK2_BLOCKHELPER_TIMER_DEFAULT_FENCE()
 #endif
 
-#define IFPACK2_BLOCKHELPER_TIMER_WITH_FENCE(label, execution_space) \
+#define IFPACK2_BLOCKHELPER_TIMER_WITH_FENCE(label, varname, execution_space) \
   IFPACK2_BLOCKHELPER_TIMER_FENCE(execution_space) \
-  IFPACK2_BLOCKHELPER_TIMER(label)
+  IFPACK2_BLOCKHELPER_TIMER(label, varname)
 
   } // namespace BlockHelperDetails
 

--- a/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
@@ -608,7 +608,7 @@ initialize ()
     Teuchos::RCP<const row_graph_type> graph = A_->getGraph ();
 
     if(!hasBlockCrsMatrix_ && List_.isParameter("relaxation: container") && List_.get<std::string>("relaxation: container") == "BlockTriDi" ) {
-      IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::convertToBlockCrsMatrix");
+      IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::convertToBlockCrsMatrix", convertToBlockCrsMatrix);
       int block_size = List_.get<int>("partitioner: block size");
       bool use_explicit_conversion = List_.isParameter("partitioner: explicit convert to BlockCrs") && List_.get<bool>("partitioner: explicit convert to BlockCrs");
       TEUCHOS_TEST_FOR_EXCEPT_MSG
@@ -645,22 +645,22 @@ initialize ()
     Partitioner_ = Teuchos::null;
 
     if (PartitionerType_ == "linear") {
-      IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::linear");
+      IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::linear", linear);
       Partitioner_ =
         rcp (new Ifpack2::LinearPartitioner<row_graph_type> (graph));
       IFPACK2_BLOCKHELPER_TIMER_DEFAULT_FENCE();
     } else if (PartitionerType_ == "line") {
-      IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::line");
+      IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::line", line);
       Partitioner_ =
         rcp (new Ifpack2::LinePartitioner<row_graph_type,typename MatrixType::scalar_type> (graph));
       IFPACK2_BLOCKHELPER_TIMER_DEFAULT_FENCE();
     } else if (PartitionerType_ == "user") {
-      IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::user");
+      IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::user", user);
       Partitioner_ =
         rcp (new Ifpack2::Details::UserPartitioner<row_graph_type> (graph ) );
       IFPACK2_BLOCKHELPER_TIMER_DEFAULT_FENCE();
     } else if (PartitionerType_ == "zoltan2") {
-      IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::zoltan2");
+      IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::zoltan2", zoltan2);
       #if defined(HAVE_IFPACK2_ZOLTAN2)
       if (graph->getComm ()->getSize () == 1) {
         // Only one MPI, so call zoltan2 with global graph
@@ -688,7 +688,7 @@ initialize ()
 
     // need to partition the graph of A
     {
-      IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::Partitioner");
+      IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::Partitioner", Partitioner);
       Partitioner_->setParameters (List_);
       Partitioner_->compute ();
       IFPACK2_BLOCKHELPER_TIMER_DEFAULT_FENCE();
@@ -714,7 +714,7 @@ initialize ()
 
     // Extract the submatrices
     {
-      IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::ExtractSubmatricesStructure");
+      IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::ExtractSubmatricesStructure", ExtractSubmatricesStructure);
       ExtractSubmatricesStructure ();
       IFPACK2_BLOCKHELPER_TIMER_DEFAULT_FENCE();
     }
@@ -746,7 +746,7 @@ initialize ()
       //    only needed when Schwarz combine mode is ADD as opposed to ZERO (which is RAS)
 
       if (schwarzCombineMode_ == "ADD") {
-        IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::ADD");
+        IFPACK2_BLOCKHELPER_TIMER("Ifpack2::BlockRelaxation::initialize::ADD", ADD);
         typedef Tpetra::MultiVector<        typename MatrixType::scalar_type, typename MatrixType::local_ordinal_type,  typename MatrixType::global_ordinal_type,typename MatrixType::node_type> scMV;
         Teuchos::RCP<const import_type> theImport = A_->getGraph()->getImporter();
         if (!theImport.is_null()) {

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -161,7 +161,7 @@ namespace Ifpack2 {
     template<typename MatrixType>
     typename Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_import_type>
     createBlockCrsTpetraImporter(const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_row_matrix_type> &A) {
-      IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::CreateBlockCrsTpetraImporter");
+      IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::CreateBlockCrsTpetraImporter", CreateBlockCrsTpetraImporter);
       using impl_type = BlockHelperDetails::ImplType<MatrixType>;
       using tpetra_map_type = typename impl_type::tpetra_map_type;
       using tpetra_mv_type = typename impl_type::tpetra_block_multivector_type;
@@ -523,7 +523,7 @@ namespace Ifpack2 {
       }
 
       void asyncSendRecvVar1(const impl_scalar_type_2d_view_tpetra &mv) {
-        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::AsyncableImport::AsyncSendRecv");
+        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::AsyncableImport::AsyncSendRecv", AsyncSendRecv);
 
 #ifdef HAVE_IFPACK2_MPI
         // constants and reallocate data buffers if necessary
@@ -612,7 +612,7 @@ namespace Ifpack2 {
       }
 
       void syncRecvVar1() {
-        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::AsyncableImport::SyncRecv");
+        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::AsyncableImport::SyncRecv", SyncRecv);
 #ifdef HAVE_IFPACK2_MPI
         // 0. wait for receive async.
         for (local_ordinal_type i=0;i<static_cast<local_ordinal_type>(pids.recv.extent(0));++i) {
@@ -719,7 +719,7 @@ namespace Ifpack2 {
       /// standard comm
       ///
       void asyncSendRecvVar0(const impl_scalar_type_2d_view_tpetra &mv) {
-        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::AsyncableImport::AsyncSendRecv");
+        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::AsyncableImport::AsyncSendRecv", AsyncSendRecv);
 
 #ifdef HAVE_IFPACK2_MPI
         // constants and reallocate data buffers if necessary
@@ -790,7 +790,7 @@ namespace Ifpack2 {
       }
 
       void syncRecvVar0() {
-        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::AsyncableImport::SyncRecv");
+        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::AsyncableImport::SyncRecv", SyncRecv);
 #ifdef HAVE_IFPACK2_MPI
         // receive async.
         for (local_ordinal_type i=0,iend=pids.recv.extent(0);i<iend;++i) {
@@ -845,7 +845,7 @@ namespace Ifpack2 {
       }
 
       void syncExchange(const impl_scalar_type_2d_view_tpetra &mv) {
-        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::AsyncableImport::SyncExchange");
+        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::AsyncableImport::SyncExchange", SyncExchange);
         asyncSendRecv(mv);
         syncRecv();
         IFPACK2_BLOCKHELPER_TIMER_FENCE(execution_space)
@@ -882,7 +882,7 @@ namespace Ifpack2 {
     template<typename MatrixType>
     Teuchos::RCP<AsyncableImport<MatrixType> >
     createBlockCrsAsyncImporter(const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_row_matrix_type> &A) {
-      IFPACK2_BLOCKHELPER_TIMER("createBlockCrsAsyncImporter");
+      IFPACK2_BLOCKHELPER_TIMER("createBlockCrsAsyncImporter", createBlockCrsAsyncImporter);
       using impl_type = BlockHelperDetails::ImplType<MatrixType>;
       using tpetra_map_type = typename impl_type::tpetra_map_type;
       using local_ordinal_type = typename impl_type::local_ordinal_type;
@@ -910,7 +910,7 @@ namespace Ifpack2 {
 
       bool separate_remotes = true, found_first = false, need_owned_permutation = false;
       {
-        IFPACK2_BLOCKHELPER_TIMER("createBlockCrsAsyncImporter::loop_over_local_elements");
+        IFPACK2_BLOCKHELPER_TIMER("createBlockCrsAsyncImporter::loop_over_local_elements", loop_over_local_elements);
 
         global_indices_array_device_type column_map_global_iD = column_map->getMyGlobalIndicesDevice();
         global_indices_array_device_type domain_map_global_iD = domain_map->getMyGlobalIndicesDevice();
@@ -952,7 +952,7 @@ namespace Ifpack2 {
       }
 
       if (separate_remotes) {
-        IFPACK2_BLOCKHELPER_TIMER("createBlockCrsAsyncImporter::separate_remotes");
+        IFPACK2_BLOCKHELPER_TIMER("createBlockCrsAsyncImporter::separate_remotes", separate_remotes);
         const auto invalid = Teuchos::OrdinalTraits<global_ordinal_type>::invalid();
         const auto parsimonious_col_map
           = need_owned_permutation ? 
@@ -1044,7 +1044,7 @@ namespace Ifpack2 {
                         const Teuchos::RCP<const typename BlockHelperDetails::ImplType<MatrixType>::tpetra_crs_graph_type> &G,
                         const Teuchos::Array<Teuchos::Array<typename BlockHelperDetails::ImplType<MatrixType>::local_ordinal_type> > &partitions,
                         const typename BlockHelperDetails::ImplType<MatrixType>::local_ordinal_type n_subparts_per_part_in) {
-      IFPACK2_BLOCKHELPER_TIMER("createPartInterface");
+      IFPACK2_BLOCKHELPER_TIMER("createPartInterface", createPartInterface);
       using impl_type = BlockHelperDetails::ImplType<MatrixType>;
       using local_ordinal_type = typename impl_type::local_ordinal_type;
       using local_ordinal_type_1d_view = typename impl_type::local_ordinal_type_1d_view;
@@ -1179,7 +1179,7 @@ namespace Ifpack2 {
       local_ordinal_type pack_nrows = 0;
       local_ordinal_type pack_nrows_sub = 0;
       if (jacobi) {
-        IFPACK2_BLOCKHELPER_TIMER("compute part indices (Jacobi)");
+        IFPACK2_BLOCKHELPER_TIMER("compute part indices (Jacobi)", Jacobi);
         for (local_ordinal_type ip=0;ip<nparts;++ip) {
           constexpr local_ordinal_type ipnrows = 1;
           //assume No overlap.
@@ -1321,7 +1321,7 @@ namespace Ifpack2 {
         }        
         IFPACK2_BLOCKHELPER_TIMER_FENCE(typename BlockHelperDetails::ImplType<MatrixType>::execution_space)
       } else {
-        IFPACK2_BLOCKHELPER_TIMER("compute part indices");
+        IFPACK2_BLOCKHELPER_TIMER("compute part indices", indices);
         for (local_ordinal_type ip=0;ip<nparts;++ip) {
           const auto* part = &partitions[p[ip]];
           const local_ordinal_type ipnrows = part->size();
@@ -1484,7 +1484,7 @@ namespace Ifpack2 {
       Kokkos::deep_copy(interf.rowidx2part, rowidx2part);
 
       { // Fill packptr.
-        IFPACK2_BLOCKHELPER_TIMER("Fill packptr");
+        IFPACK2_BLOCKHELPER_TIMER("Fill packptr", packptr0);
         local_ordinal_type npacks = ceil(float(nparts)/vector_length) * (part2packrowidx0_sub.extent(1)-1);
         npacks = 0;
         for (local_ordinal_type ip=1;ip<=nparts;++ip) //n_sub_parts_and_schur
@@ -1618,7 +1618,7 @@ namespace Ifpack2 {
     template<typename MatrixType>
     BlockTridiags<MatrixType>
     createBlockTridiags(const BlockHelperDetails::PartInterface<MatrixType> &interf) {
-      IFPACK2_BLOCKHELPER_TIMER("createBlockTridiags");
+      IFPACK2_BLOCKHELPER_TIMER("createBlockTridiags", createBlockTridiags0);
       using impl_type = BlockHelperDetails::ImplType<MatrixType>;
       using execution_space = typename impl_type::execution_space;
       using local_ordinal_type = typename impl_type::local_ordinal_type;
@@ -1865,7 +1865,7 @@ namespace Ifpack2 {
                          BlockTridiags<MatrixType> &btdm,
                          BlockHelperDetails::AmD<MatrixType> &amd,
                          const bool overlap_communication_and_computation) {
-      IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::SymbolicPhase");
+      IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::SymbolicPhase", SymbolicPhase);
 
       using impl_type = BlockHelperDetails::ImplType<MatrixType>;
 
@@ -3469,7 +3469,7 @@ namespace Ifpack2 {
 #ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_PRINTF
         printf("Start ExtractAndFactorizeSubLineTag\n");
 #endif
-          IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NumericPhase::ExtractAndFactorizeSubLineTag");
+          IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NumericPhase::ExtractAndFactorizeSubLineTag", ExtractAndFactorizeSubLineTag0);
           Kokkos::TeamPolicy<execution_space,ExtractAndFactorizeSubLineTag>
             policy(packindices_sub.extent(0), team_size, vector_loop_size);
 
@@ -3500,7 +3500,7 @@ namespace Ifpack2 {
             write5DMultiVectorValuesToFile(part2packrowidx0_sub.extent(0), e_scalar_values, "e_scalar_values_before_extract.mm");
 
             {
-              IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NumericPhase::ExtractBCDTag");
+              IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NumericPhase::ExtractBCDTag", ExtractBCDTag0);
               Kokkos::TeamPolicy<execution_space,ExtractBCDTag>
                 policy(packindices_schur.extent(0)*packindices_schur.extent(1), team_size, vector_loop_size);
 
@@ -3519,7 +3519,7 @@ namespace Ifpack2 {
 #endif
             write5DMultiVectorValuesToFile(part2packrowidx0_sub.extent(0), e_scalar_values, "e_scalar_values_after_extract.mm");
             {
-              IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NumericPhase::ComputeETag");
+              IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NumericPhase::ComputeETag", ComputeETag0);
               Kokkos::TeamPolicy<execution_space,ComputeETag>
                 policy(packindices_sub.extent(0), team_size, vector_loop_size);
 
@@ -3539,7 +3539,7 @@ namespace Ifpack2 {
 #ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_PRINTF
         printf("Start ComputeSchurTag\n");
 #endif
-            IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NumericPhase::ComputeSchurTag");
+            IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NumericPhase::ComputeSchurTag", ComputeSchurTag0);
             writeBTDValuesToFile(part2packrowidx0_sub.extent(0), scalar_values_schur, "before_schur.mm");
             Kokkos::TeamPolicy<execution_space,ComputeSchurTag>
               policy(packindices_schur.extent(0)*packindices_schur.extent(1), team_size, vector_loop_size);
@@ -3558,7 +3558,7 @@ namespace Ifpack2 {
 #ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_PRINTF
         printf("Start FactorizeSchurTag\n");
 #endif
-            IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NumericPhase::FactorizeSchurTag");
+            IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NumericPhase::FactorizeSchurTag", FactorizeSchurTag0);
             Kokkos::TeamPolicy<execution_space,FactorizeSchurTag>
               policy(packindices_schur.extent(0), team_size, vector_loop_size);
             policy.set_scratch_size(0,Kokkos::PerTeam(per_team_scratch));
@@ -3587,7 +3587,7 @@ namespace Ifpack2 {
                         const BlockHelperDetails::PartInterface<MatrixType> &interf,
                         BlockTridiags<MatrixType> &btdm,
                         const typename BlockHelperDetails::ImplType<MatrixType>::magnitude_type tiny) {
-      IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NumericPhase");
+      IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::NumericPhase", NumericPhase);
       ExtractAndFactorizeTridiags<MatrixType> function(btdm, interf, A, G, tiny);
       function.run();
       IFPACK2_BLOCKHELPER_TIMER_FENCE(typename BlockHelperDetails::ImplType<MatrixType>::execution_space)
@@ -3712,7 +3712,7 @@ namespace Ifpack2 {
 
       void run(const const_impl_scalar_type_2d_view_tpetra &scalar_multivector_) {
         IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
-        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::MultiVectorConverter");
+        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::MultiVectorConverter", MultiVectorConverter0);
 
         scalar_multivector = scalar_multivector_;
         if constexpr (BlockHelperDetails::is_device<execution_space>::value) {
@@ -4696,7 +4696,7 @@ namespace Ifpack2 {
       void run(const impl_scalar_type_2d_view_tpetra &Y,
                const impl_scalar_type_1d_view &Z) {
         IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
-        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::SolveTridiags");
+        IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::SolveTridiags", SolveTridiags);
 
         /// set vectors
         this->Y_scalar_multivector = Y;
@@ -4747,7 +4747,7 @@ namespace Ifpack2 {
                 policy, *this);                                            \
             } \
             { \
-              IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::ApplyInverseJacobi::SingleVectorSubLineTag"); \
+              IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::ApplyInverseJacobi::SingleVectorSubLineTag", SingleVectorSubLineTag0); \
               write4DMultiVectorValuesToFile(part2packrowidx0_sub.extent(0), X_internal_scalar_values, "x_scalar_values_before_SingleVectorSubLineTag.mm"); \
               Kokkos::TeamPolicy<execution_space,SingleVectorSubLineTag<B> >       \
                 policy(packindices_sub.extent(0), team_size, vector_loop_size); \
@@ -4759,7 +4759,7 @@ namespace Ifpack2 {
               IFPACK2_BLOCKHELPER_TIMER_FENCE(execution_space) \
             } \
             { \
-              IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::ApplyInverseJacobi::SingleVectorApplyCTag"); \
+              IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::ApplyInverseJacobi::SingleVectorApplyCTag", SingleVectorApplyCTag0); \
               write4DMultiVectorValuesToFile(part2packrowidx0_sub.extent(0), X_internal_scalar_values, "x_scalar_values_before_SingleVectorApplyCTag.mm"); \
               Kokkos::TeamPolicy<execution_space,SingleVectorApplyCTag<B> >       \
                 policy(packindices_sub.extent(0), team_size, vector_loop_size); \
@@ -4771,7 +4771,7 @@ namespace Ifpack2 {
               IFPACK2_BLOCKHELPER_TIMER_FENCE(execution_space) \
             } \
             { \
-              IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::ApplyInverseJacobi::SingleVectorSchurTag"); \
+              IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::ApplyInverseJacobi::SingleVectorSchurTag", SingleVectorSchurTag0); \
               write4DMultiVectorValuesToFile(part2packrowidx0_sub.extent(0), X_internal_scalar_values, "x_scalar_values_before_SingleVectorSchurTag.mm"); \
               Kokkos::TeamPolicy<execution_space,SingleVectorSchurTag<B> >       \
                 policy(packindices_schur.extent(0), team_size, vector_loop_size); \
@@ -4783,7 +4783,7 @@ namespace Ifpack2 {
               IFPACK2_BLOCKHELPER_TIMER_FENCE(execution_space) \
             } \
             { \
-              IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::ApplyInverseJacobi::SingleVectorApplyETag"); \
+              IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::ApplyInverseJacobi::SingleVectorApplyETag", SingleVectorApplyETag0); \
               write4DMultiVectorValuesToFile(part2packrowidx0_sub.extent(0), X_internal_scalar_values, "x_scalar_values_before_SingleVectorApplyETag.mm"); \
               Kokkos::TeamPolicy<execution_space,SingleVectorApplyETag<B> >       \
                 policy(packindices_sub.extent(0), team_size, vector_loop_size); \
@@ -4862,7 +4862,7 @@ namespace Ifpack2 {
                        const int max_num_sweeps,
                        const typename BlockHelperDetails::ImplType<MatrixType>::magnitude_type tol,
                        const int check_tol_every) {
-      IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::ApplyInverseJacobi");
+      IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::ApplyInverseJacobi", ApplyInverseJacobi);
 
       using impl_type = BlockHelperDetails::ImplType<MatrixType>;
       using node_memory_space = typename impl_type::node_memory_space;

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
@@ -265,7 +265,7 @@ namespace Tpetra {
   Teuchos::RCP<Tpetra::CrsGraph<LO, GO, Node> >
   getBlockCrsGraph(const Tpetra::CrsMatrix<Scalar, LO, GO, Node>& pointMatrix, const LO &blockSize, bool use_LID)
   {
-      TEUCHOS_FUNC_TIME_MONITOR("Tpetra::getBlockCrsGraph");
+      TEUCHOS_FUNC_TIME_MONITOR_DIFF("Tpetra::getBlockCrsGraph", getBlockCrsGraph0);
       /*
         ASSUMPTIONS:
 
@@ -299,7 +299,7 @@ namespace Tpetra {
       const map_type &pointRangeMap = *(pointMatrix.getRangeMap());
 
       {
-        TEUCHOS_FUNC_TIME_MONITOR("Tpetra::getBlockCrsGraph::createMeshMaps");
+        TEUCHOS_FUNC_TIME_MONITOR_DIFF("Tpetra::getBlockCrsGraph::createMeshMaps", getBlockCrsGraph1);
         meshRowMap = createMeshMap<LO,GO,Node>(blockSize, pointRowMap, use_LID);
         meshColMap = createMeshMap<LO,GO,Node>(blockSize, pointColMap, use_LID);
         meshDomainMap = createMeshMap<LO,GO,Node>(blockSize, pointDomainMap, use_LID);
@@ -318,7 +318,7 @@ namespace Tpetra {
       const offset_type bs2 = blockSize * blockSize;
 
       if (use_LID) {
-        TEUCHOS_FUNC_TIME_MONITOR("Tpetra::getBlockCrsGraph::LID");
+        TEUCHOS_FUNC_TIME_MONITOR_DIFF("Tpetra::getBlockCrsGraph::LID", getBlockCrsGraph2);
         auto pointLocalGraph = pointMatrix.getCrsGraph()->getLocalGraphDevice();
         auto pointRowptr = pointLocalGraph.row_map;
         auto pointColind = pointLocalGraph.entries;
@@ -352,7 +352,7 @@ namespace Tpetra {
         Kokkos::DefaultExecutionSpace().fence();
       }
       else {
-        TEUCHOS_FUNC_TIME_MONITOR("Tpetra::getBlockCrsGraph::GID");
+        TEUCHOS_FUNC_TIME_MONITOR_DIFF("Tpetra::getBlockCrsGraph::GID", getBlockCrsGraph3);
         auto pointLocalGraph = pointMatrix.getCrsGraph()->getLocalGraphDevice();
         auto pointRowptr = pointLocalGraph.row_map;
         auto pointColind = pointLocalGraph.entries;
@@ -406,7 +406,7 @@ namespace Tpetra {
   Teuchos::RCP<BlockCrsMatrix<Scalar, LO, GO, Node> >
   convertToBlockCrsMatrix(const Tpetra::CrsMatrix<Scalar, LO, GO, Node>& pointMatrix, const LO &blockSize, bool use_LID)
   {
-      TEUCHOS_FUNC_TIME_MONITOR("Tpetra::convertToBlockCrsMatrix");
+      TEUCHOS_FUNC_TIME_MONITOR_DIFF("Tpetra::convertToBlockCrsMatrix", convertToBlockCrsMatrix0);
       /*
         ASSUMPTIONS:
 
@@ -439,7 +439,7 @@ namespace Tpetra {
       auto meshCrsGraph = getBlockCrsGraph(pointMatrix, blockSize, use_LID);
 
       if (use_LID) {
-        TEUCHOS_FUNC_TIME_MONITOR("Tpetra::convertToBlockCrsMatrix::LID");
+        TEUCHOS_FUNC_TIME_MONITOR_DIFF("Tpetra::convertToBlockCrsMatrix::LID", convertToBlockCrsMatrix1);
         auto pointLocalGraph = pointMatrix.getCrsGraph()->getLocalGraphDevice();
         auto pointRowptr = pointLocalGraph.row_map;
         auto pointColind = pointLocalGraph.entries;
@@ -471,7 +471,7 @@ namespace Tpetra {
         Kokkos::DefaultExecutionSpace().fence();
       }
       else {
-        TEUCHOS_FUNC_TIME_MONITOR("Tpetra::convertToBlockCrsMatrix::GID");
+        TEUCHOS_FUNC_TIME_MONITOR_DIFF("Tpetra::convertToBlockCrsMatrix::GID", convertToBlockCrsMatrix2);
         auto localMeshColMap = meshCrsGraph->getColMap()->getLocalMap();
         auto localPointColMap = pointMatrix.getColMap()->getLocalMap();
 


### PR DESCRIPTION
As discussed in #12358, when using nested `TEUCHOS_FUNC_TIME_MONITOR` we have a variable shadowing.
This PR fixes that by using `TEUCHOS_FUNC_TIME_MONITOR_DIFF` instead.

Issue #12358 can be closed once this PR is merged.