### PR TITLE
KokkosKernels: restore size_t as default offset

### DIFF
--- a/packages/kokkos-kernels/cmake/kokkoskernels_eti_offsets.cmake
+++ b/packages/kokkos-kernels/cmake/kokkoskernels_eti_offsets.cmake
@@ -1,5 +1,15 @@
-SET(KOKKOSKERNELS_INST_OFFSET_SIZE_T_DEFAULT OFF)
-SET(KOKKOSKERNELS_INST_OFFSET_INT_DEFAULT ${KOKKOSKERNELS_ADD_DEFAULT_ETI})
+IF(KOKKOSKERNELS_HAS_TRILINOS)
+  # In a Trilinos build, size_t is the default offset because this is what Tpetra uses
+  # TODO: update this when Tpetra can use different offsets
+  SET(KOKKOSKERNELS_INST_OFFSET_SIZE_T_DEFAULT ${KOKKOSKERNELS_ADD_DEFAULT_ETI})
+  SET(KOKKOSKERNELS_INST_OFFSET_INT_DEFAULT OFF)
+ELSE()
+  # But in a standalone KokkosKernels build, int is the default offset type
+  # This provides the maximum TPL compatibility
+  SET(KOKKOSKERNELS_INST_OFFSET_SIZE_T_DEFAULT OFF)
+  SET(KOKKOSKERNELS_INST_OFFSET_INT_DEFAULT ${KOKKOSKERNELS_ADD_DEFAULT_ETI})
+ENDIF()
+
 SET(OFFSETS
   OFFSET_INT
   OFFSET_SIZE_T
@@ -12,14 +22,14 @@ KOKKOSKERNELS_ADD_OPTION(
   INST_OFFSET_INT
   ${KOKKOSKERNELS_INST_OFFSET_INT_DEFAULT}
   BOOL
-  "Whether to pre instantiate kernels for the offset type int.  This option is KokkosKernels_INST_OFFSET_INT=OFF by default. Default: OFF"
+  "Whether to pre instantiate kernels for the offset type int.  This option is KokkosKernels_INST_OFFSET_INT=OFF by default. Default: ${KOKKOSKERNELS_INST_OFFSET_INT_DEFAULT}"
   )
 
 KOKKOSKERNELS_ADD_OPTION(
   INST_OFFSET_SIZE_T
   ${KOKKOSKERNELS_INST_OFFSET_SIZE_T_DEFAULT}
   BOOL
-  "Whether to pre instantiate kernels for the offset type size_t.  This option is KokkosKernels_INST_OFFSET_SIZE_T=ON by default. Default: ON"
+  "Whether to pre instantiate kernels for the offset type size_t.  This option is KokkosKernels_INST_OFFSET_SIZE_T=ON by default. Default: ${KOKKOSKERNELS_INST_OFFSET_SIZE_T_DEFAULT}"
   )
 
 IF (KOKKOSKERNELS_INST_OFFSET_INT)


### PR DESCRIPTION
Revert the change in 4.4.0 release (https://github.com/kokkos/kokkos-kernels/pull/2140) that made int the default offset type instead of size_t. This is because Tpetra still uses size_t for CrsGraph and CrsMatrix local data structures.

This change is only about speeding up compilation time; instantiating for offset=size_t means that Tpetra can actually use the functions compiled into the KokkosKernels library. Tpetra's special codepaths in ``CrsMatrix::apply``, ``BsrMatrix::apply`` and ``MatrixMatrix::multiply`` using offset=int will still work.

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Speed up compilation times. Right now, we are instantiating KokkosKernels for types that the Tpetra stack doesn't use (except for the few exceptions above). For the types that Tpetra does use, we are instantiating the same kernels again implicitly. Some commonly used kernels might be implicitly instantiated many times.