### PR TITLE
DO NOT MERGE Framework: Remove options for dropped packages and test that settings are used

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -861,7 +861,6 @@ opt-set-cmake-var Trilinos_ENABLE_AztecOO BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_Belos BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_Epetra BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_EpetraExt BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_FEI BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_Galeri BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_Ifpack BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_Ifpack2 BOOL : ON
@@ -1232,10 +1231,8 @@ opt-set-cmake-var Stratimikos_test_single_amesos2_tpetra_solver_driver_SuperLU_D
 
 #opt-set-cmake-var Anasazi_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 #opt-set-cmake-var Belos_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var Domi_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 #opt-set-cmake-var Epetra_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 #opt-set-cmake-var EpetraExt_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-#opt-set-cmake-var FEI_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 #opt-set-cmake-var Ifpack_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 #opt-set-cmake-var Ifpack2_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 opt-set-cmake-var Intrepid2_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
@@ -1246,7 +1243,6 @@ opt-set-cmake-var Intrepid2_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -W
 #opt-set-cmake-var NOX_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 #opt-set-cmake-var Panzer_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 #opt-set-cmake-var Phalanx_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
-opt-set-cmake-var Pike_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 #opt-set-cmake-var Piro_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 #opt-set-cmake-var ROL_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 #opt-set-cmake-var Sacado_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
@@ -1277,13 +1273,7 @@ opt-set-cmake-var ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_gdsw_MPI_4_DISA
 opt-set-cmake-var ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_rgdsw_MPI_4_DISABLE BOOL : ON
 opt-set-cmake-var ShyLU_DDFROSch_test_frosch_interfacesets_2D_MPI_4_DISABLE BOOL : ON
 # Disable for clang
-opt-set-cmake-var FEI_elemDOF_Aztec_MPI_2_DISABLE BOOL : ON
-opt-set-cmake-var FEI_lagrange_20quad_old_MPI_2_DISABLE BOOL : ON
-opt-set-cmake-var FEI_lagrange_20quad_old_MPI_4_DISABLE BOOL : ON
-opt-set-cmake-var FEI_multifield_vbr_az_MPI_2_DISABLE BOOL : ON
-opt-set-cmake-var FEI_multifield_vbr_az_MPI_3_DISABLE BOOL : ON
 opt-set-cmake-var ROL_example_PinT_parabolic-control_example_01_MPI_1_DISABLE BOOL : ON
-opt-set-cmake-var Rythmos_StepperBuilder_UnitTest_MPI_1_DISABLE BOOL : ON
 
 [WEAVER_TEST_DISABLES|CUDA]
 opt-set-cmake-var MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE BOOL : ON
@@ -1741,22 +1731,17 @@ opt-set-cmake-var Intrepid2_unit-test_MonolithicExecutable_Intrepid2_Tests_MPI_1
 # Supported packages
 opt-set-cmake-var Amesos2_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Belos_CXX_FLAGS       STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Domi_CXX_FLAGS        STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var FEI_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Galeri_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Intrepid2_CXX_FLAGS   STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror -Wno-error=shadow
-opt-set-cmake-var Moertel_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var NOX_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Pamgen_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Phalanx_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Pike_CXX_FLAGS        STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 opt-set-cmake-var ROL_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Sacado_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Shards_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var ShyLU_Node_CXX_FLAGS  STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var STK_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var Stokhos_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-# opt-set-cmake-var Tempus_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror
 opt-set-cmake-var Zoltan_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 opt-set-cmake-var TrilinosCouplings_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 
@@ -2077,11 +2062,7 @@ use rhel7_sems-clang-11.0.1-openmpi-1.10.1-serial_release-debug_shared_no-kokkos
 use PACKAGE-ENABLES|ALL
 use USE-ASAN|YES
 
-opt-set-cmake-var Trilinos_ENABLE_Domi BOOL CACHE FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_TriKota BOOL CACHE FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Moertel BOOL CACHE FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Komplex BOOL CACHE FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_Rythmos BOOL CACHE FORCE : OFF
 
 # Under loading and debug, these Tempus run too long and timeout (fail). 2023-12-21
 opt-set-cmake-var Tempus_BackwardEuler_CDR_MPI_1_DISABLE BOOL FORCE : ON
@@ -3465,12 +3446,7 @@ opt-set-cmake-var TPL_BLAS_LIBRARIES   STRING : -qmkl=sequential
 opt-set-cmake-var TPL_LAPACK_LIBRARIES STRING : -qmkl=sequential
 
 opt-set-cmake-var Trilinos_ENABLE_PyTrilinos BOOL : OFF
-opt-set-cmake-var Trilinos_ENABLE_Rythmos BOOL : OFF
-opt-set-cmake-var Trilinos_ENABLE_Pike BOOL : OFF
-opt-set-cmake-var Trilinos_ENABLE_Komplex BOOL : OFF
 opt-set-cmake-var Trilinos_ENABLE_TriKota BOOL : OFF
-opt-set-cmake-var Trilinos_ENABLE_Moertel BOOL : OFF
-opt-set-cmake-var Trilinos_ENABLE_Domi BOOL : OFF
 opt-set-cmake-var ML_ENABLE_SuperLU BOOL FORCE : OFF
 
 [ubuntu_gnu_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1729,21 +1729,21 @@ opt-set-cmake-var Intrepid2_unit-test_MonolithicExecutable_Intrepid2_Tests_MPI_1
 
 [GCC_PACKAGE_SPECIFIC_WARNING_FLAGS]
 # Supported packages
-opt-set-cmake-var Amesos2_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Belos_CXX_FLAGS       STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Galeri_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Intrepid2_CXX_FLAGS   STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror -Wno-error=shadow
-opt-set-cmake-var NOX_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Pamgen_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Phalanx_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var ROL_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Sacado_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Shards_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var ShyLU_Node_CXX_FLAGS  STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var STK_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Stokhos_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var Zoltan_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
-opt-set-cmake-var TrilinosCouplings_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# opt-set-cmake-var Amesos2_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# opt-set-cmake-var Belos_CXX_FLAGS       STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# opt-set-cmake-var Galeri_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# opt-set-cmake-var Intrepid2_CXX_FLAGS   STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Werror -Wno-error=shadow
+# opt-set-cmake-var NOX_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# opt-set-cmake-var Pamgen_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# opt-set-cmake-var Phalanx_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# opt-set-cmake-var ROL_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# opt-set-cmake-var Sacado_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# opt-set-cmake-var Shards_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# opt-set-cmake-var ShyLU_Node_CXX_FLAGS  STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# opt-set-cmake-var STK_CXX_FLAGS         STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# opt-set-cmake-var Stokhos_CXX_FLAGS     STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# opt-set-cmake-var Zoltan_CXX_FLAGS      STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
+# opt-set-cmake-var TrilinosCouplings_CXX_FLAGS STRING : ${CMAKE_CXX_FLAGS|CMAKE} -Wno-error=shadow
 
 # Deprecated packages
 opt-set-cmake-var Amesos_CXX_FLAGS      STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} -w


### PR DESCRIPTION
@trilinos/framework 

## Motivation
- Remove options for packages that have already been dropped (Domi, FEI, Komplex, Moertel, Pike, Rythmos).
- Remove all package exceptions for warnings to test whether this is being tested by the AT. I DO NOT WANT TO MERGE THIS.