### PR TITLE
Ifpack2 (and Tpetra): use while loop for Ctest perf tests

### DIFF
--- a/packages/ifpack2/example/CMakeLists.txt
+++ b/packages/ifpack2/example/CMakeLists.txt
@@ -62,14 +62,8 @@ IF(${PACKAGE_NAME}_ENABLE_Xpetra AND ${PACKAGE_NAME}_ENABLE_Galeri)
       set(COUNTER 2)
       set(MAX_COUNT 8)
 
-      set(NP 1)
-      set(COUNTER_INIT 0)
-      WHILE(COUNTER_INIT LESS COUNTER)
-        math(EXPR NP "${NP} * 2")
-        math(EXPR COUNTER_INIT "${COUNTER_INIT} + 1")
-      ENDWHILE()
-
       WHILE(COUNTER LESS MAX_COUNT)
+        math(EXPR NP "1 << ${COUNTER}")
         foreach(I_TEST RANGE ${N_TESTS})
           list(GET TEST_ARGS ${I_TEST} TEST_ARG)
           list(GET TEST_NAMES ${I_TEST} TEST_NAME)      
@@ -85,7 +79,6 @@ IF(${PACKAGE_NAME}_ENABLE_Xpetra AND ${PACKAGE_NAME}_ENABLE_Galeri)
 
         endforeach()
 
-        math(EXPR NP "${NP} * 2")
         math(EXPR COUNTER "${COUNTER} + 1")
       ENDWHILE()
     ENDIF()

--- a/packages/ifpack2/example/CMakeLists.txt
+++ b/packages/ifpack2/example/CMakeLists.txt
@@ -21,11 +21,139 @@ TRIBITS_ADD_EXECUTABLE(
 )
 
 
- TRIBITS_ADD_TEST(
-    BlockTriDiagonalSolver
-    NAME BlockTriDiExample
-    ARGS ""
-    COMM serial mpi
-    NUM_MPI_PROCS 1-4
-    STANDARD_PASS_OUTPUT
-    )
+TRIBITS_ADD_TEST(
+  BlockTriDiagonalSolver
+  NAME BlockTriDiExample
+  ARGS ""
+  COMM serial mpi
+  NUM_MPI_PROCS 1-4
+  STANDARD_PASS_OUTPUT
+)
+
+ASSERT_DEFINED (
+  ${PACKAGE_NAME}_ENABLE_Xpetra
+  ${PACKAGE_NAME}_ENABLE_Galeri
+)
+
+IF(${PACKAGE_NAME}_ENABLE_Xpetra AND ${PACKAGE_NAME}_ENABLE_Galeri)
+
+  set(COMMON_ARGS "--withoutOverlapCommAndComp --matrixType=Laplace3D --blockSize=11 --nx=256 --ny=128 --nz=128 --tol=0 --numIters=5 --withStackedTimer --numRepeats=5")
+  set(BTDS_ARGS "${COMMON_ARGS} --sublinesPerLine=1 --sublinesPerLineSchur=1")
+  set(BTDS_SCHUR_ARGS "${COMMON_ARGS} --sublinesPerLine=1 --sublinesPerLineSchur=2")
+  set(BTDS_DEFAULT_SCHUR_ARGS "${COMMON_ARGS} --sublinesPerLine=1 --sublinesPerLineSchur=-1")
+  set(BLOCK_JACOBI_ARGS "${COMMON_ARGS} --sublinesPerLine=-1")
+
+  set(TEST_ARGS ${BTDS_ARGS} ${BTDS_SCHUR_ARGS} ${BTDS_DEFAULT_SCHUR_ARGS} ${BLOCK_JACOBI_ARGS})
+  set(TEST_NAMES "BTDS" "BTDS_Schur" "BTDS_Schur_Default" "BTDS_Jacobi")
+
+  list(LENGTH TEST_ARGS len1)
+  math(EXPR N_TESTS "${len1} - 1")
+
+  ASSERT_DEFINED(
+    Tpetra_INST_SERIAL
+    Tpetra_INST_CUDA
+    Tpetra_INST_HIP
+  )
+
+  IF (Tpetra_INST_SERIAL)
+    MESSAGE(STATUS "Ifpack2: BlockTriDiagonalSolver SERIAL test ENABLED")
+    set(COUNTER 2)
+    set(MAX_COUNT 8)
+
+    set(NP 1)
+    set(COUNTER_INIT 0)
+    WHILE(COUNTER_INIT LESS COUNTER)
+      math(EXPR NP "${NP} * 2")
+      math(EXPR COUNTER_INIT "${COUNTER_INIT} + 1")
+    ENDWHILE()
+
+    WHILE(COUNTER LESS MAX_COUNT)
+      foreach(I_TEST RANGE ${N_TESTS})
+        list(GET TEST_ARGS ${I_TEST} TEST_ARG)
+        list(GET TEST_NAMES ${I_TEST} TEST_NAME)      
+        TRIBITS_ADD_TEST(
+          BlockTriDiagonalSolver
+          NAME "${TEST_NAME}_Serial"
+          COMM mpi
+          ARGS ${TEST_ARG}
+          NUM_MPI_PROCS ${NP}
+          RUN_SERIAL
+          CATEGORIES PERFORMANCE
+        )
+
+      endforeach()
+
+      math(EXPR NP "${NP} * 2")
+      math(EXPR COUNTER "${COUNTER} + 1")
+    ENDWHILE()
+
+  ENDIF()
+
+  IF (Tpetra_INST_CUDA)
+    MESSAGE(STATUS "Ifpack2: BlockTriDiagonalSolver CUDA test ENABLED")
+    set(COUNTER 2)
+    set(MAX_COUNT 8)
+
+    set(NP 1)
+    set(COUNTER_INIT 0)
+    WHILE(COUNTER_INIT LESS COUNTER)
+      math(EXPR NP "${NP} * 2")
+      math(EXPR COUNTER_INIT "${COUNTER_INIT} + 1")
+    ENDWHILE()
+
+    WHILE(COUNTER LESS MAX_COUNT)
+      foreach(I_TEST RANGE ${N_TESTS})
+        list(GET TEST_ARGS ${I_TEST} TEST_ARG)
+        list(GET TEST_NAMES ${I_TEST} TEST_NAME)      
+        TRIBITS_ADD_TEST(
+          BlockTriDiagonalSolver
+          NAME "${TEST_NAME}_CUDA"
+          COMM mpi
+          ARGS ${TEST_ARG}
+          NUM_MPI_PROCS ${NP}
+          RUN_SERIAL
+          CATEGORIES PERFORMANCE
+        )
+
+      endforeach()
+
+      math(EXPR NP "${NP} * 2")
+      math(EXPR COUNTER "${COUNTER} + 1")
+    ENDWHILE()
+
+  ENDIF()
+
+  IF (Tpetra_INST_HIP)
+    MESSAGE(STATUS "Ifpack2: BlockTriDiagonalSolver HIP test ENABLED")
+    set(COUNTER 2)
+    set(MAX_COUNT 8)
+
+    set(NP 1)
+    set(COUNTER_INIT 0)
+    WHILE(COUNTER_INIT LESS COUNTER)
+      math(EXPR NP "${NP} * 2")
+      math(EXPR COUNTER_INIT "${COUNTER_INIT} + 1")
+    ENDWHILE()
+
+    WHILE(COUNTER LESS MAX_COUNT)
+      foreach(I_TEST RANGE ${N_TESTS})
+        list(GET TEST_ARGS ${I_TEST} TEST_ARG)
+        list(GET TEST_NAMES ${I_TEST} TEST_NAME)      
+        TRIBITS_ADD_TEST(
+          BlockTriDiagonalSolver
+          NAME "${TEST_NAME}_HIP"
+          COMM mpi
+          ARGS ${TEST_ARG}
+          NUM_MPI_PROCS ${NP}
+          RUN_SERIAL
+          CATEGORIES PERFORMANCE
+        )
+
+      endforeach()
+
+      math(EXPR NP "${NP} * 2")
+      math(EXPR COUNTER "${COUNTER} + 1")
+    ENDWHILE()
+
+  ENDIF()
+ENDIF()

--- a/packages/ifpack2/example/CMakeLists.txt
+++ b/packages/ifpack2/example/CMakeLists.txt
@@ -45,6 +45,7 @@ IF(${PACKAGE_NAME}_ENABLE_Xpetra AND ${PACKAGE_NAME}_ENABLE_Galeri)
 
   set(TEST_ARGS ${BTDS_ARGS} ${BTDS_SCHUR_ARGS} ${BTDS_DEFAULT_SCHUR_ARGS} ${BLOCK_JACOBI_ARGS})
   set(TEST_NAMES "BTDS" "BTDS_Schur" "BTDS_Schur_Default" "BTDS_Jacobi")
+  set(ARCHS "SERIAL" "CUDA" "HIP")
 
   list(LENGTH TEST_ARGS len1)
   math(EXPR N_TESTS "${len1} - 1")
@@ -55,105 +56,38 @@ IF(${PACKAGE_NAME}_ENABLE_Xpetra AND ${PACKAGE_NAME}_ENABLE_Galeri)
     Tpetra_INST_HIP
   )
 
-  IF (Tpetra_INST_SERIAL)
-    MESSAGE(STATUS "Ifpack2: BlockTriDiagonalSolver SERIAL test ENABLED")
-    set(COUNTER 2)
-    set(MAX_COUNT 8)
+  foreach(ARCH ${ARCHS})
+    IF (Tpetra_INST_${ARCH})
+      MESSAGE(STATUS "Ifpack2: BlockTriDiagonalSolver ${ARCH} test ENABLED")
+      set(COUNTER 2)
+      set(MAX_COUNT 8)
 
-    set(NP 1)
-    set(COUNTER_INIT 0)
-    WHILE(COUNTER_INIT LESS COUNTER)
-      math(EXPR NP "${NP} * 2")
-      math(EXPR COUNTER_INIT "${COUNTER_INIT} + 1")
-    ENDWHILE()
+      set(NP 1)
+      set(COUNTER_INIT 0)
+      WHILE(COUNTER_INIT LESS COUNTER)
+        math(EXPR NP "${NP} * 2")
+        math(EXPR COUNTER_INIT "${COUNTER_INIT} + 1")
+      ENDWHILE()
 
-    WHILE(COUNTER LESS MAX_COUNT)
-      foreach(I_TEST RANGE ${N_TESTS})
-        list(GET TEST_ARGS ${I_TEST} TEST_ARG)
-        list(GET TEST_NAMES ${I_TEST} TEST_NAME)      
-        TRIBITS_ADD_TEST(
-          BlockTriDiagonalSolver
-          NAME "${TEST_NAME}_Serial"
-          COMM mpi
-          ARGS ${TEST_ARG}
-          NUM_MPI_PROCS ${NP}
-          RUN_SERIAL
-          CATEGORIES PERFORMANCE
-        )
+      WHILE(COUNTER LESS MAX_COUNT)
+        foreach(I_TEST RANGE ${N_TESTS})
+          list(GET TEST_ARGS ${I_TEST} TEST_ARG)
+          list(GET TEST_NAMES ${I_TEST} TEST_NAME)      
+          TRIBITS_ADD_TEST(
+            BlockTriDiagonalSolver
+            NAME "${TEST_NAME}_${ARCH}"
+            COMM mpi
+            ARGS ${TEST_ARG}
+            NUM_MPI_PROCS ${NP}
+            RUN_SERIAL
+            CATEGORIES PERFORMANCE
+          )
 
-      endforeach()
+        endforeach()
 
-      math(EXPR NP "${NP} * 2")
-      math(EXPR COUNTER "${COUNTER} + 1")
-    ENDWHILE()
-
-  ENDIF()
-
-  IF (Tpetra_INST_CUDA)
-    MESSAGE(STATUS "Ifpack2: BlockTriDiagonalSolver CUDA test ENABLED")
-    set(COUNTER 2)
-    set(MAX_COUNT 8)
-
-    set(NP 1)
-    set(COUNTER_INIT 0)
-    WHILE(COUNTER_INIT LESS COUNTER)
-      math(EXPR NP "${NP} * 2")
-      math(EXPR COUNTER_INIT "${COUNTER_INIT} + 1")
-    ENDWHILE()
-
-    WHILE(COUNTER LESS MAX_COUNT)
-      foreach(I_TEST RANGE ${N_TESTS})
-        list(GET TEST_ARGS ${I_TEST} TEST_ARG)
-        list(GET TEST_NAMES ${I_TEST} TEST_NAME)      
-        TRIBITS_ADD_TEST(
-          BlockTriDiagonalSolver
-          NAME "${TEST_NAME}_CUDA"
-          COMM mpi
-          ARGS ${TEST_ARG}
-          NUM_MPI_PROCS ${NP}
-          RUN_SERIAL
-          CATEGORIES PERFORMANCE
-        )
-
-      endforeach()
-
-      math(EXPR NP "${NP} * 2")
-      math(EXPR COUNTER "${COUNTER} + 1")
-    ENDWHILE()
-
-  ENDIF()
-
-  IF (Tpetra_INST_HIP)
-    MESSAGE(STATUS "Ifpack2: BlockTriDiagonalSolver HIP test ENABLED")
-    set(COUNTER 2)
-    set(MAX_COUNT 8)
-
-    set(NP 1)
-    set(COUNTER_INIT 0)
-    WHILE(COUNTER_INIT LESS COUNTER)
-      math(EXPR NP "${NP} * 2")
-      math(EXPR COUNTER_INIT "${COUNTER_INIT} + 1")
-    ENDWHILE()
-
-    WHILE(COUNTER LESS MAX_COUNT)
-      foreach(I_TEST RANGE ${N_TESTS})
-        list(GET TEST_ARGS ${I_TEST} TEST_ARG)
-        list(GET TEST_NAMES ${I_TEST} TEST_NAME)      
-        TRIBITS_ADD_TEST(
-          BlockTriDiagonalSolver
-          NAME "${TEST_NAME}_HIP"
-          COMM mpi
-          ARGS ${TEST_ARG}
-          NUM_MPI_PROCS ${NP}
-          RUN_SERIAL
-          CATEGORIES PERFORMANCE
-        )
-
-      endforeach()
-
-      math(EXPR NP "${NP} * 2")
-      math(EXPR COUNTER "${COUNTER} + 1")
-    ENDWHILE()
-
-  ENDIF()
+        math(EXPR NP "${NP} * 2")
+        math(EXPR COUNTER "${COUNTER} + 1")
+      ENDWHILE()
+    ENDIF()
+  endforeach()
 ENDIF()

--- a/packages/ifpack2/example/CMakeLists.txt
+++ b/packages/ifpack2/example/CMakeLists.txt
@@ -45,13 +45,12 @@ IF(${PACKAGE_NAME}_ENABLE_Xpetra AND ${PACKAGE_NAME}_ENABLE_Galeri)
 
   set(TEST_ARGS ${BTDS_ARGS} ${BTDS_SCHUR_ARGS} ${BTDS_DEFAULT_SCHUR_ARGS} ${BLOCK_JACOBI_ARGS})
   set(TEST_NAMES "BTDS" "BTDS_Schur" "BTDS_Schur_Default" "BTDS_Jacobi")
-  set(ARCHS "SERIAL" "CUDA" "HIP")
+  set(ARCHS "CUDA" "HIP")
 
   list(LENGTH TEST_ARGS len1)
   math(EXPR N_TESTS "${len1} - 1")
 
   ASSERT_DEFINED(
-    Tpetra_INST_SERIAL
     Tpetra_INST_CUDA
     Tpetra_INST_HIP
   )
@@ -71,7 +70,7 @@ IF(${PACKAGE_NAME}_ENABLE_Xpetra AND ${PACKAGE_NAME}_ENABLE_Galeri)
             BlockTriDiagonalSolver
             NAME "${TEST_NAME}_${ARCH}"
             COMM mpi
-            ARGS ${TEST_ARG}
+            ARGS "${TEST_ARG} --problemName=${TEST_NAME}_${ARCH}"
             NUM_MPI_PROCS ${NP}
             RUN_SERIAL
             CATEGORIES PERFORMANCE

--- a/packages/tpetra/core/test/PerformanceCGSolve/CMakeLists.txt
+++ b/packages/tpetra/core/test/PerformanceCGSolve/CMakeLists.txt
@@ -13,157 +13,53 @@ IF (Tpetra_INST_DOUBLE)
                             CATEGORIES BASIC PERFORMANCE
     )
 
-    TRIBITS_ADD_TEST(
-      Performance-CGSolve
-      NAME Performance_StrongScaling_CGSolve
-      ARGS "--size=200"
-      COMM mpi
-      NUM_MPI_PROCS 1
-      STANDARD_PASS_OUTPUT
-      RUN_SERIAL
-      CATEGORIES PERFORMANCE
-    )
+    IF (Tpetra_INST_SERIAL)
 
-    TRIBITS_ADD_TEST(
-      Performance-CGSolve
-      NAME Performance_StrongScaling_CGSolve
-      ARGS "--size=200"
-      COMM mpi
-      NUM_MPI_PROCS 4
-      STANDARD_PASS_OUTPUT
-      RUN_SERIAL
-      CATEGORIES PERFORMANCE
-    )
+      set(COUNTER 1)
+      set(MAX_COUNT 11)
 
-    TRIBITS_ADD_TEST(
-      Performance-CGSolve
-      NAME Performance_StrongScaling_CGSolve
-      ARGS "--size=200"
-      COMM mpi
-      NUM_MPI_PROCS 9
-      STANDARD_PASS_OUTPUT
-      RUN_SERIAL
-      CATEGORIES PERFORMANCE
-    )
+      WHILE(COUNTER LESS MAX_COUNT)
+        math(EXPR NP "${COUNTER} * ${COUNTER}")
 
-    TRIBITS_ADD_TEST(
-      Performance-CGSolve
-      NAME Performance_StrongScaling_CGSolve
-      ARGS "--size=200"
-      COMM mpi
-      NUM_MPI_PROCS 16
-      STANDARD_PASS_OUTPUT
-      RUN_SERIAL
-      CATEGORIES PERFORMANCE
-    )
+        TRIBITS_ADD_TEST(
+          Performance-CGSolve
+          NAME Performance_StrongScaling_CGSolve
+          ARGS "--size=200"
+          COMM mpi
+          NUM_MPI_PROCS ${NP}
+          STANDARD_PASS_OUTPUT
+          RUN_SERIAL
+          CATEGORIES PERFORMANCE
+        )
 
-  TRIBITS_ADD_TEST(
-      Performance-CGSolve
-      NAME Performance_StrongScaling_CGSolve
-      ARGS "--size=200"
-      COMM mpi
-      NUM_MPI_PROCS 25
-      STANDARD_PASS_OUTPUT
-      RUN_SERIAL
-      CATEGORIES PERFORMANCE
-    )
+        math(EXPR COUNTER "${COUNTER} + 1")
+      ENDWHILE()
 
-    # For big machines
+    ENDIF()
 
-    TRIBITS_ADD_TEST(
-      Performance-CGSolve
-      NAME Performance_StrongScaling_CGSolve
-      ARGS "--size=200"
-      COMM mpi
-      NUM_MPI_PROCS 81
-      STANDARD_PASS_OUTPUT
-      RUN_SERIAL
-      CATEGORIES PERFORMANCE
-    )
+    IF (Tpetra_INST_CUDA)
+      MESSAGE(STATUS "Tpetra: Performance-CGSolve CUDA_LAUNCH_BLOCKING test ENABLED")
+      set(COUNTER 1)
+      set(MAX_COUNT 11)
 
-    TRIBITS_ADD_TEST(
-      Performance-CGSolve
-      NAME Performance_StrongScaling_CGSolve
-      ARGS "--size=200"
-      COMM mpi
-      NUM_MPI_PROCS 100
-      STANDARD_PASS_OUTPUT
-      RUN_SERIAL
-      CATEGORIES PERFORMANCE
-    )
-
-
-
-    IF (Tpetra_ENABLE_CUDA)
-        MESSAGE(STATUS "Tpetra: Performance-CGSolve CUDA_LAUNCH_BLOCKING test ENABLED")
+      WHILE(COUNTER LESS MAX_COUNT)
+        math(EXPR NP "${COUNTER} * ${COUNTER}")
 
         TRIBITS_ADD_TEST(
           Performance-CGSolve
           NAME Performance_StrongScaling_CGSolve_CUDA_LAUNCH_BLOCKING
           ARGS "--size=200"
           COMM mpi
-          NUM_MPI_PROCS 1
+          NUM_MPI_PROCS ${NP}
           ENVIRONMENT CUDA_LAUNCH_BLOCKING=1
           STANDARD_PASS_OUTPUT
           RUN_SERIAL
           CATEGORIES PERFORMANCE
         )
 
-        TRIBITS_ADD_TEST(
-          Performance-CGSolve
-          NAME Performance_StrongScaling_CGSolve_CUDA_LAUNCH_BLOCKING
-          ARGS "--size=200"
-          COMM mpi
-          NUM_MPI_PROCS 4
-          ENVIRONMENT CUDA_LAUNCH_BLOCKING=1
-          STANDARD_PASS_OUTPUT
-          RUN_SERIAL
-          CATEGORIES PERFORMANCE
-        )
+        math(EXPR COUNTER "${COUNTER} + 1")
+      ENDWHILE()
 
-        TRIBITS_ADD_TEST(
-          Performance-CGSolve
-          NAME Performance_StrongScaling_CGSolve_CUDA_LAUNCH_BLOCKING
-          ARGS "--size=200"
-          COMM mpi
-          NUM_MPI_PROCS 9
-          ENVIRONMENT CUDA_LAUNCH_BLOCKING=1
-          STANDARD_PASS_OUTPUT
-          RUN_SERIAL
-          CATEGORIES PERFORMANCE
-        )
-
-        TRIBITS_ADD_TEST(
-          Performance-CGSolve
-          NAME Performance_StrongScaling_CGSolve_CUDA_LAUNCH_BLOCKING
-          ARGS "--size=200"
-          COMM mpi
-          NUM_MPI_PROCS 16
-          ENVIRONMENT CUDA_LAUNCH_BLOCKING=1
-          STANDARD_PASS_OUTPUT
-          RUN_SERIAL
-          CATEGORIES PERFORMANCE
-        )
-
-        TRIBITS_ADD_TEST(
-          Performance-CGSolve
-          NAME Performance_StrongScaling_CGSolve_CUDA_LAUNCH_BLOCKING
-          ARGS "--size=200"
-          COMM mpi
-          NUM_MPI_PROCS 25
-          ENVIRONMENT CUDA_LAUNCH_BLOCKING=1
-          STANDARD_PASS_OUTPUT
-          RUN_SERIAL
-          CATEGORIES PERFORMANCE
-        )
     ENDIF()
 
 ENDIF()
-
-#TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyXmlForTpetraPerfCgSolve
-#  SOURCE_DIR ${Tpetra_SOURCE_DIR}/test/
-#  SOURCE_FILES Tpetra_PerformanceTests.xml
-#  EXEDEPS Performance-CGSolve
-#)
-
-

--- a/packages/tpetra/core/test/PerformanceCGSolve/CMakeLists.txt
+++ b/packages/tpetra/core/test/PerformanceCGSolve/CMakeLists.txt
@@ -13,31 +13,28 @@ IF (Tpetra_INST_DOUBLE)
                             CATEGORIES BASIC PERFORMANCE
     )
 
-    IF (Tpetra_INST_SERIAL)
 
-      set(COUNTER 1)
-      set(MAX_COUNT 11)
+    set(COUNTER 1)
+    set(MAX_COUNT 11)
 
-      WHILE(COUNTER LESS MAX_COUNT)
-        math(EXPR NP "${COUNTER} * ${COUNTER}")
+    WHILE(COUNTER LESS MAX_COUNT)
+      math(EXPR NP "${COUNTER} * ${COUNTER}")
 
-        TRIBITS_ADD_TEST(
-          Performance-CGSolve
-          NAME Performance_StrongScaling_CGSolve
-          ARGS "--size=200"
-          COMM mpi
-          NUM_MPI_PROCS ${NP}
-          STANDARD_PASS_OUTPUT
-          RUN_SERIAL
-          CATEGORIES PERFORMANCE
-        )
+      TRIBITS_ADD_TEST(
+        Performance-CGSolve
+        NAME Performance_StrongScaling_CGSolve
+        ARGS "--size=200"
+        COMM mpi
+        NUM_MPI_PROCS ${NP}
+        STANDARD_PASS_OUTPUT
+        RUN_SERIAL
+        CATEGORIES PERFORMANCE
+      )
 
-        math(EXPR COUNTER "${COUNTER} + 1")
-      ENDWHILE()
+      math(EXPR COUNTER "${COUNTER} + 1")
+    ENDWHILE()
 
-    ENDIF()
-
-    IF (Tpetra_INST_CUDA)
+    IF (Tpetra_ENABLE_CUDA)
       MESSAGE(STATUS "Tpetra: Performance-CGSolve CUDA_LAUNCH_BLOCKING test ENABLED")
       set(COUNTER 1)
       set(MAX_COUNT 11)


### PR DESCRIPTION
This PR modifies the Performance CG test of Tpetra to use a loop over number of ranks.

This PR adds 4 new performance tests for the BTDS that use Galeri generated matrices.