### PR TITLE
Framework: Fix duplicate AutoTester2 runs with a dependent pre-check job

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -17,6 +17,17 @@ permissions:
   contents: read
 
 jobs:
+  # Jobs depend on the output of pre-checks to run
+  pre-checks:
+        runs-on: ubuntu-latest
+        outputs:
+            should_skip: ${{ steps.skip_check.outputs.should_skip }}
+        steps:
+        - id: skip_check
+          uses: fkirc/skip-duplicate-actions@v5
+          with:
+            skip_after_successful_duplicate: 'true'
+
   gcc10-openmpi416-EXPERIMENTAL:
     runs-on: [self-hosted, gcc-10.3.0_openmpi-4.1.6]
     if: ${{ github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED' }}
@@ -174,8 +185,9 @@ jobs:
             --filename-packageenables ./packageEnables.cmake
 
   cuda11-uvm-EXPERIMENTAL:
+    needs: pre-checks
     runs-on: [self-hosted, cuda-11.4.2_gcc-10.3.0_openmpi-4.1.6]
-    if: ${{ github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED' }}
+    if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}
     steps:
       - name: env
         env:

--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -13,7 +13,9 @@ on:
     - develop
   workflow_dispatch:
 
+# actions: write needed by skip-duplicate-actions
 permissions:
+  actions: write
   contents: read
 
 jobs:

--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -31,8 +31,9 @@ jobs:
             skip_after_successful_duplicate: 'true'
 
   gcc10-openmpi416-EXPERIMENTAL:
+    needs: pre-checks
     runs-on: [self-hosted, gcc-10.3.0_openmpi-4.1.6]
-    if: ${{ github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED' }}
+    if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}
     steps:
       - name: env
         env:
@@ -109,8 +110,9 @@ jobs:
             --filename-packageenables ./packageEnables.cmake
 
   gcc830-serial-EXPERIMENTAL:
+    needs: pre-checks
     runs-on: [self-hosted, gcc-8.3.0_serial]
-    if: ${{ github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED' }}
+    if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}
     steps:
       - name: env
         env:


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Current behavior of GitHub Actions with the AutoTester2 workflow is that there is a case where duplicate run will happen when the workflow is triggered by different events. Below are the following GitHub Actions cases that need to be accounted for:

Use case 1:
- Sandian 1 submits PR or pushes commit to PR (`pull_request` event)
- AT2 workflow runs and passes
- Sandian 2 submits a review approval triggering the workflow (`pull_request_review` event)
- AT2 workflow runs again with no changes made to the code, using extra resources
(Desired result is to not run and respect the first result)

Use case 2:
- Non-sandian submits PR (`pull_request` event)
- AT2 workflow runs, but fails due to workflow being triggered by non-sandian
- Sandian approves PR triggering the workflow (`pull_request_review` event)
- AT2 workflow runs and passes due to the `pull_request_review` event

This PR adds a pre-check job and uses the [skip-duplicate-actions](https://github.com/marketplace/actions/skip-duplicate-actions) marketplace action available to check if a previous workflow run has already been completed and return a value based on if other jobs should skip or not. Dependent jobs can then use the output of the pre-checks job to determine if the job should run.


This PR is WIP and is only being applied to the CUDA AT2 job for now.


## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

- [TRILFRAME-667](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-667)

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
This PR will be used for testing with AT2. I've performed smaller tests with this actions plugin on my own fork and observed that it would satisfy Use Case 1 and the results can be seen here:
- First workflow that completed https://github.com/achauphan/Trilinos/actions/runs/10498938271
- Second workflow that skipped due to previous completed run with no changes https://github.com/achauphan/Trilinos/actions/runs/10498954533

Further testing needed to check if Use Case 2 behavior remains the same.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
