### PR TITLE
Seacas fix fmt use in external include

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_Field.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Field.h
@@ -8,9 +8,6 @@
 
 #include "Ioss_CodeTypes.h"
 #include <cstddef> // for size_t
-#if !defined BUILT_IN_SIERRA
-#include <fmt/ostream.h>
-#endif
 #include <stdint.h>
 #include <string> // for string
 #include <vector> // for vector
@@ -247,13 +244,3 @@ namespace Ioss {
   };
   IOSS_EXPORT std::ostream &operator<<(std::ostream &os, const Field &fld);
 } // namespace Ioss
-
-#if !defined BUILT_IN_SIERRA
-#if FMT_VERSION >= 90000
-namespace fmt {
-  template <> struct formatter<Ioss::Field> : ostream_formatter
-  {
-  };
-} // namespace fmt
-#endif
-#endif

--- a/packages/seacas/libraries/ioss/src/Ioss_Region.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Region.h
@@ -24,9 +24,6 @@
 #include "Ioss_Utils.h"
 #include "Ioss_VariableType.h"
 #include "ioss_export.h"
-#if !defined BUILT_IN_SIERRA
-#include <fmt/ostream.h>
-#endif
 #include <functional> // for less
 #include <iosfwd>     // for ostream
 #include <map>        // for map, map<>::value_compare
@@ -484,17 +481,9 @@ namespace Ioss {
 
         if (found && field.get_role() != role) {
           std::ostringstream errmsg;
-#if defined BUILT_IN_SIERRA
           errmsg << "ERROR: Field " << field.get_name() << " with role " << field.role_string()
                  << " on entity " << entity->name() << " does not match previously found role "
                  << Ioss::Field::role_string(role) << ".\n",
-#else
-          fmt::print(errmsg,
-                     "ERROR: Field {} with role {} on entity {} does not match previously found "
-                     "role {}.\n",
-                     field.get_name(), field.role_string(), entity->name(),
-                     Ioss::Field::role_string(role));
-#endif
               IOSS_ERROR(errmsg);
         }
 

--- a/packages/seacas/libraries/ioss/src/Ioss_StructuredBlock.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_StructuredBlock.h
@@ -12,7 +12,6 @@
 #include "Ioss_NodeBlock.h"
 #include "Ioss_Property.h"
 #include "Ioss_ZoneConnectivity.h"
-#include <fmt/ostream.h>
 #include <array>
 #include <cassert>
 #include <iosfwd>
@@ -350,10 +349,3 @@ namespace Ioss {
   };
 } // namespace Ioss
 
-#if FMT_VERSION >= 90000
-namespace fmt {
-  template <> struct formatter<Ioss::BoundaryCondition> : ostream_formatter
-  {
-  };
-} // namespace fmt
-#endif

--- a/packages/seacas/libraries/ioss/src/Ioss_Utils.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Utils.C
@@ -1369,7 +1369,7 @@ void Ioss::Utils::info_fields(const Ioss::GroupingEntity *ige, Ioss::Field::Role
   for (const auto &field_name : fields) {
     if (detail) {
       const auto &field_ref = ige->get_fieldref(field_name);
-      fmt::print("{}{}", field_ref, suffix);
+      std::cout << field_ref << suffix;
     }
     else {
       const Ioss::VariableType *var_type   = ige->get_field(field_name).raw_storage();

--- a/packages/seacas/libraries/ioss/src/Ioss_ZoneConnectivity.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_ZoneConnectivity.h
@@ -10,8 +10,6 @@
 #include <array>
 #include <cassert>
 #include <cmath>
-#include <fmt/core.h>
-#include <fmt/ostream.h>
 #include <iosfwd>
 #include <stdlib.h>
 #include <string>
@@ -142,11 +140,3 @@ namespace Ioss {
 
   IOSS_EXPORT std::ostream &operator<<(std::ostream &os, const ZoneConnectivity &zgc);
 } // namespace Ioss
-
-#if FMT_VERSION >= 90000
-namespace fmt {
-  template <> struct formatter<Ioss::ZoneConnectivity> : ostream_formatter
-  {
-  };
-} // namespace fmt
-#endif

--- a/packages/seacas/libraries/ioss/src/main/io_info.C
+++ b/packages/seacas/libraries/ioss/src/main/io_info.C
@@ -317,11 +317,7 @@ namespace {
       if (!sb->m_zoneConnectivity.empty()) {
         fmt::print("\tConnectivity with other blocks:\n");
         for (const auto &zgc : sb->m_zoneConnectivity) {
-#if defined __NVCC__
           std::cout << zgc << "\n";
-#else
-          fmt::print("{}\n", zgc);
-#endif
         }
       }
       if (!sb->m_boundaryConditions.empty()) {
@@ -335,11 +331,7 @@ namespace {
                    });
 
         for (const auto &bc : sb_bc) {
-#if defined __NVCC__
           std::cout << bc << "\n";
-#else
-          fmt::print("{}\n", bc);
-#endif
         }
       }
       if (interFace.compute_bbox()) {


### PR DESCRIPTION

@trilinos/seacas 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
The latest snapshot added the use of lib::fmt includes in externally accessible include files.  Since fmt is not a published TPL dependency, any client using those include files will fial.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes #11487 

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
