### PR TITLE
Sacado: Band-aid fix for LayoutContiguous

### DIFF
--- a/packages/sacado/src/Kokkos_LayoutContiguous.hpp
+++ b/packages/sacado/src/Kokkos_LayoutContiguous.hpp
@@ -73,6 +73,7 @@ struct inner_layout< LayoutContiguous<Layout, Stride> > {
 
 } // namespace Kokkos
 
+// FIXME This is evil and needs refactoring urgently.
 // Make LayoutContiguous<Layout> equivalent to Layout
 namespace std {
 
@@ -82,10 +83,15 @@ namespace std {
   };
 
   template <class Layout, unsigned Stride>
+  static constexpr bool is_same_v< Kokkos::LayoutContiguous<Layout,Stride>, Layout> = is_same<Kokkos::LayoutContiguous<Layout,Stride>, Layout>::value;
+
+  template <class Layout, unsigned Stride>
   struct is_same< Layout, Kokkos::LayoutContiguous<Layout,Stride> > {
     static const bool value = true;
   };
 
+  template <class Layout, unsigned Stride>
+  static constexpr bool is_same_v< Layout, Kokkos::LayoutContiguous<Layout,Stride>> = is_same<Kokkos::LayoutContiguous<Layout,Stride>, Layout>::value;
 }
 
 #include "impl/Kokkos_ViewMapping.hpp"


### PR DESCRIPTION
@trilinos/sacado

Fixes https://github.com/kokkos/kokkos/issues/7258. `Sacado` defines `ContiguousLayout` in the `Kokkos` namespace, see
[trilinos/Trilinos@2ad2602/packages/sacado/src/Kokkos_LayoutContiguous.hpp#L30-L74](https://github.com/trilinos/Trilinos/blob/2ad26029e5e3592de143b1640480382a296c401a/packages/sacado/src/Kokkos_LayoutContiguous.hpp#L30-L74)
and specializes `std::is_same` for this class, see [trilinos/Trilinos@2ad2602/packages/sacado/src/Kokkos_LayoutContiguous.hpp#L76-L87](https://github.com/trilinos/Trilinos/blob/2ad26029e5e3592de143b1640480382a296c401a/packages/sacado/src/Kokkos_LayoutContiguous.hpp#L76-L87). 
Both of these aren't legal usage of `Kokkos` or the `std` namespace.

Thus, changing all `std::is_same<>::value` to `std::is_same_v`led to a bunch of problems since `ContigousLayout<Layout>` currently behaves as-if it it identical `Layout` in certain cases. It seems that this was done to be able to use some functionalities in `Kokkos` (like `Kokkos::resize`) that are restricted to `Kokkos` policies (`Kokkos::LayoutLeft`/`Kokkos::LayoutRight`). Simply relaxing the respective `SFINAE` checks doesn't work since underlying classes are specialized on `Kokkos::LayoutLeft`/`Kokkos::LayoutRight`.

This pull request adds a band-aid fit that continues to use this evil workaround but suggests to find a proper solution urgently.