### PR TITLE
KokkosKernels: improve CRS sorting performance

### DIFF
--- a/packages/kokkos-kernels/common/src/KokkosKernels_Utils.hpp
+++ b/packages/kokkos-kernels/common/src/KokkosKernels_Utils.hpp
@@ -1076,6 +1076,12 @@ void view_reduce_max(size_t num_elements, view_type view_to_reduce,
   kk_view_reduce_max<view_type, MyExecSpace>(num_elements, view_to_reduce, max_reduction);
 }
 
+template <typename view_type, typename MyExecSpace>
+void view_reduce_max(const MyExecSpace &exec, size_t num_elements, view_type view_to_reduce,
+                     typename view_type::non_const_value_type &max_reduction) {
+  kk_view_reduce_max<view_type, MyExecSpace>(exec, num_elements, view_to_reduce, max_reduction);
+}
+
 template <typename size_type>
 struct ReduceRowSizeFunctor {
   const size_type *rowmap_view_begins;

--- a/packages/kokkos-kernels/perf_test/sparse/CMakeLists.txt
+++ b/packages/kokkos-kernels/perf_test/sparse/CMakeLists.txt
@@ -116,6 +116,15 @@ KOKKOSKERNELS_ADD_EXECUTABLE(
         SOURCES KokkosSparse_mdf.cpp
 )
 
+# For the sake of build times, don't build this CRS sorting perf test by default.
+# It can be enabled if needed by setting -DKokkosKernels_ENABLE_SORT_CRS_PERFTEST=ON.
+if (KokkosKernels_ENABLE_SORT_CRS_PERFTEST)
+  KOKKOSKERNELS_ADD_EXECUTABLE(
+    sparse_sort_crs
+    SOURCES KokkosSparse_sort_crs.cpp
+)
+endif ()
+
 if (KokkosKernels_ENABLE_BENCHMARK)
   KOKKOSKERNELS_ADD_BENCHMARK(
     sparse_par_ilut

--- a/packages/kokkos-kernels/perf_test/sparse/KokkosSparse_sort_crs.cpp
+++ b/packages/kokkos-kernels/perf_test/sparse/KokkosSparse_sort_crs.cpp
@@ -1,0 +1,103 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <iostream>
+#include <algorithm>
+#include "KokkosKernels_config.h"
+#include "KokkosSparse_IOUtils.hpp"
+#include "KokkosKernels_perf_test_utilities.hpp"
+
+#include "KokkosSparse_CrsMatrix.hpp"
+#include "KokkosSparse_SortCrs.hpp"
+
+using perf_test::CommonInputParams;
+
+struct LocalParams {
+  std::string mtxFile;
+};
+
+void print_options() {
+  std::cerr << "Options\n" << std::endl;
+
+  std::cerr << perf_test::list_common_options();
+
+  std::cerr << "\t[Required] --mtx <path> :: matrix to sort\n";
+  std::cerr << "\t[Optional] --repeat      :: how many times to repeat sorting\n";
+}
+
+int parse_inputs(LocalParams& params, int argc, char** argv) {
+  for (int i = 1; i < argc; ++i) {
+    if (perf_test::check_arg_str(i, argc, argv, "--mtx", params.mtxFile)) {
+      ++i;
+    } else {
+      std::cerr << "Unrecognized command line argument #" << i << ": " << argv[i] << std::endl;
+      print_options();
+      return 1;
+    }
+  }
+  return 0;
+}
+
+template <typename exec_space>
+void run_experiment(int argc, char** argv, const CommonInputParams& common_params) {
+  using namespace KokkosSparse;
+
+  using mem_space = typename exec_space::memory_space;
+  using device_t  = typename Kokkos::Device<exec_space, mem_space>;
+  using size_type = default_size_type;
+  using lno_t     = default_lno_t;
+  using scalar_t  = default_scalar;
+  using crsMat_t  = KokkosSparse::CrsMatrix<scalar_t, lno_t, device_t, void, size_type>;
+
+  using graph_t = typename crsMat_t::StaticCrsGraphType;
+
+  LocalParams params;
+  if (parse_inputs(params, argc, argv)) return;
+
+  crsMat_t A = KokkosSparse::Impl::read_kokkos_crst_matrix<crsMat_t>(params.mtxFile.c_str());
+  std::cout << "Loaded matrix: " << A.numRows() << "x" << A.numCols() << " with " << A.nnz() << " entries.\n";
+  // This first sort call serves as a warm-up
+  KokkosSparse::sort_crs_matrix(A);
+  lno_t m          = A.numRows();
+  lno_t n          = A.numCols();
+  auto rowmapHost  = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.graph.row_map);
+  auto entriesHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), A.graph.entries);
+  typename crsMat_t::index_type shuffledEntries("shuffled entries", A.nnz());
+  // Randomly shuffle the entries within each row, so that the rows aren't
+  // already sorted. Leave the values alone; this changes the matrix numerically
+  // but this doesn't affect sorting.
+  for (lno_t i = 0; i < m; i++) {
+    std::random_shuffle(entriesHost.data() + i, entriesHost.data() + i + 1);
+  }
+  Kokkos::deep_copy(shuffledEntries, entriesHost);
+  exec_space exec;
+  Kokkos::Timer timer;
+  double totalTime = 0;
+  for (int rep = 0; rep < common_params.repeat; rep++) {
+    Kokkos::deep_copy(exec, A.graph.entries, shuffledEntries);
+    exec.fence();
+    timer.reset();
+    KokkosSparse::sort_crs_matrix(exec, A);
+    exec.fence();
+    totalTime += timer.seconds();
+  }
+  std::cout << "Mean sort_crs_matrix time over " << common_params.repeat << " trials: ";
+  std::cout << totalTime / common_params.repeat << "\n";
+}
+
+#define KOKKOSKERNELS_PERF_TEST_NAME run_experiment
+#include "KokkosKernels_perf_test_instantiation.hpp"
+int main(int argc, char** argv) { return main_instantiation(argc, argv); }  // main

--- a/packages/kokkos-kernels/sparse/impl/KokkosSparse_sort_crs_impl.hpp
+++ b/packages/kokkos-kernels/sparse/impl/KokkosSparse_sort_crs_impl.hpp
@@ -1,0 +1,366 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#ifndef _KOKKOSSPARSE_SORTCRS_IMPL_HPP
+#define _KOKKOSSPARSE_SORTCRS_IMPL_HPP
+
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Sort.hpp"
+#include "KokkosKernels_Sorting.hpp"
+
+// Workaround for issue with Kokkos::Experimental::sort_by_key, with nvcc and OpenMP enabled
+// (Kokkos issue #7036, fixed in 4.4 release)
+// Once support for Kokkos < 4.4 is dropped,
+// all code inside "ifdef KK_DISABLE_BULK_SORT_BY_KEY" can be deleted.
+#if (KOKKOS_VERSION < 40400) && defined(KOKKOS_ENABLE_CUDA)
+#define KK_DISABLE_BULK_SORT_BY_KEY
+#endif
+
+namespace KokkosSparse {
+namespace Impl {
+
+template <typename rowmap_t, typename entries_t, typename values_t>
+struct MatrixRadixSortFunctor {
+  using Offset          = typename rowmap_t::non_const_value_type;
+  using Ordinal         = typename entries_t::non_const_value_type;
+  using UnsignedOrdinal = typename std::make_unsigned<Ordinal>::type;
+  using Scalar          = typename values_t::non_const_value_type;
+  // The functor owns memory for entriesAux, so it can't have
+  // MemoryTraits<Unmanaged>
+  using entries_managed_t = Kokkos::View<typename entries_t::data_type, typename entries_t::device_type>;
+  using values_managed_t  = Kokkos::View<typename values_t::data_type, typename values_t::device_type>;
+
+  MatrixRadixSortFunctor(const rowmap_t& rowmap_, const entries_t& entries_, const values_t& values_)
+      : rowmap(rowmap_), entries(entries_), values(values_) {
+    entriesAux = entries_managed_t(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Entries aux"), entries.extent(0));
+    valuesAux  = values_managed_t(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Values aux"), values.extent(0));
+  }
+
+  KOKKOS_INLINE_FUNCTION void operator()(Ordinal i) const {
+    Offset rowStart = rowmap(i);
+    Offset rowEnd   = rowmap(i + 1);
+    Ordinal rowNum  = rowEnd - rowStart;
+    // Radix sort requires unsigned keys for comparison
+    KokkosKernels::SerialRadixSort2<Ordinal, UnsignedOrdinal, Scalar>(
+        (UnsignedOrdinal*)entries.data() + rowStart, (UnsignedOrdinal*)entriesAux.data() + rowStart,
+        values.data() + rowStart, valuesAux.data() + rowStart, rowNum);
+  }
+
+  rowmap_t rowmap;
+  entries_t entries;
+  entries_managed_t entriesAux;
+  values_t values;
+  values_managed_t valuesAux;
+};
+
+template <typename Policy, typename Ordinal, typename rowmap_t, typename entries_t, typename values_t>
+struct MatrixThreadSortFunctor {
+  using Offset = typename rowmap_t::non_const_value_type;
+
+  MatrixThreadSortFunctor(Ordinal numRows_, const rowmap_t& rowmap_, const entries_t& entries_, const values_t& values_)
+      : numRows(numRows_), rowmap(rowmap_), entries(entries_), values(values_) {}
+
+  KOKKOS_INLINE_FUNCTION void operator()(const typename Policy::member_type& t) const {
+    Ordinal i = t.league_rank() * t.team_size() + t.team_rank();
+    if (i >= numRows) return;
+    Offset rowStart = rowmap(i);
+    Offset rowEnd   = rowmap(i + 1);
+    auto rowEntries = Kokkos::subview(entries, Kokkos::make_pair(rowStart, rowEnd));
+    auto rowValues  = Kokkos::subview(values, Kokkos::make_pair(rowStart, rowEnd));
+    Kokkos::Experimental::sort_by_key_thread(t, rowEntries, rowValues);
+  }
+
+  Ordinal numRows;
+  rowmap_t rowmap;
+  entries_t entries;
+  values_t values;
+};
+
+template <typename rowmap_t, typename entries_t>
+struct GraphRadixSortFunctor {
+  using Offset          = typename rowmap_t::non_const_value_type;
+  using Ordinal         = typename entries_t::non_const_value_type;
+  using UnsignedOrdinal = typename std::make_unsigned<Ordinal>::type;
+  // The functor owns memory for entriesAux, so it can't have
+  // MemoryTraits<Unmanaged>
+  using entries_managed_t = Kokkos::View<typename entries_t::data_type, typename entries_t::device_type>;
+
+  GraphRadixSortFunctor(const rowmap_t& rowmap_, const entries_t& entries_) : rowmap(rowmap_), entries(entries_) {
+    entriesAux = entries_managed_t(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Entries aux"), entries.extent(0));
+  }
+
+  KOKKOS_INLINE_FUNCTION void operator()(Ordinal i) const {
+    Offset rowStart = rowmap(i);
+    Offset rowEnd   = rowmap(i + 1);
+    Ordinal rowNum  = rowEnd - rowStart;
+    // Radix sort requires unsigned keys for comparison
+    KokkosKernels::SerialRadixSort<Ordinal, UnsignedOrdinal>((UnsignedOrdinal*)entries.data() + rowStart,
+                                                             (UnsignedOrdinal*)entriesAux.data() + rowStart, rowNum);
+  }
+
+  rowmap_t rowmap;
+  entries_t entries;
+  entries_managed_t entriesAux;
+};
+
+template <typename Policy, typename Ordinal, typename rowmap_t, typename entries_t>
+struct GraphThreadSortFunctor {
+  using Offset = typename rowmap_t::non_const_value_type;
+
+  GraphThreadSortFunctor(Ordinal numRows_, const rowmap_t& rowmap_, const entries_t& entries_)
+      : numRows(numRows_), rowmap(rowmap_), entries(entries_) {}
+
+  KOKKOS_INLINE_FUNCTION void operator()(const typename Policy::member_type& t) const {
+    Ordinal i = t.league_rank() * t.team_size() + t.team_rank();
+    if (i >= numRows) return;
+    Offset rowStart = rowmap(i);
+    Offset rowEnd   = rowmap(i + 1);
+    auto rowEntries = Kokkos::subview(entries, Kokkos::make_pair(rowStart, rowEnd));
+    Kokkos::Experimental::sort_thread(t, rowEntries);
+  }
+
+  Ordinal numRows;
+  rowmap_t rowmap;
+  entries_t entries;
+};
+
+template <typename rowmap_t, typename entries_t>
+struct MergedRowmapFunctor {
+  using size_type  = typename rowmap_t::non_const_value_type;
+  using lno_t      = typename entries_t::non_const_value_type;
+  using c_rowmap_t = typename rowmap_t::const_type;
+
+  // Precondition: entries are sorted within each row
+  MergedRowmapFunctor(const rowmap_t& mergedCounts_, const c_rowmap_t& rowmap_, const entries_t& entries_)
+      : mergedCounts(mergedCounts_), rowmap(rowmap_), entries(entries_) {}
+
+  KOKKOS_INLINE_FUNCTION void operator()(lno_t row, size_type& lnewNNZ) const {
+    size_type rowBegin = rowmap(row);
+    size_type rowEnd   = rowmap(row + 1);
+    if (rowEnd == rowBegin) {
+      // Row was empty to begin with
+      mergedCounts(row) = 0;
+      return;
+    }
+    // Otherwise, the first entry in the row exists
+    lno_t uniqueEntries = 1;
+    for (size_type j = rowBegin + 1; j < rowEnd; j++) {
+      if (entries(j - 1) != entries(j)) uniqueEntries++;
+    }
+    mergedCounts(row) = uniqueEntries;
+    lnewNNZ += uniqueEntries;
+    if (row == lno_t((rowmap.extent(0) - 1) - 1)) mergedCounts(row + 1) = 0;
+  }
+
+  rowmap_t mergedCounts;
+  c_rowmap_t rowmap;
+  entries_t entries;
+};
+
+template <typename rowmap_t, typename entries_t, typename values_t>
+struct MatrixMergedEntriesFunctor {
+  using size_type = typename rowmap_t::non_const_value_type;
+  using lno_t     = typename entries_t::non_const_value_type;
+  using scalar_t  = typename values_t::non_const_value_type;
+
+  // Precondition: entries are sorted within each row
+  MatrixMergedEntriesFunctor(const typename rowmap_t::const_type& rowmap_, const entries_t& entries_,
+                             const values_t& values_, const rowmap_t& mergedRowmap_, const entries_t& mergedEntries_,
+                             const values_t& mergedValues_)
+      : rowmap(rowmap_),
+        entries(entries_),
+        values(values_),
+        mergedRowmap(mergedRowmap_),
+        mergedEntries(mergedEntries_),
+        mergedValues(mergedValues_) {}
+
+  KOKKOS_INLINE_FUNCTION void operator()(lno_t row) const {
+    size_type rowBegin = rowmap(row);
+    size_type rowEnd   = rowmap(row + 1);
+    if (rowEnd == rowBegin) {
+      // Row was empty to begin with, nothing to do
+      return;
+    }
+    // Otherwise, accumulate the value for each column
+    scalar_t accumVal   = values(rowBegin);
+    lno_t accumCol      = entries(rowBegin);
+    size_type insertPos = mergedRowmap(row);
+    for (size_type j = rowBegin + 1; j < rowEnd; j++) {
+      if (accumCol == entries(j)) {
+        // accumulate
+        accumVal += values(j);
+      } else {
+        // write out and reset
+        mergedValues(insertPos)  = accumVal;
+        mergedEntries(insertPos) = accumCol;
+        insertPos++;
+        accumVal = values(j);
+        accumCol = entries(j);
+      }
+    }
+    // always left with the last unique entry
+    mergedValues(insertPos)  = accumVal;
+    mergedEntries(insertPos) = accumCol;
+  }
+
+  typename rowmap_t::const_type rowmap;
+  entries_t entries;
+  values_t values;
+  rowmap_t mergedRowmap;
+  entries_t mergedEntries;
+  values_t mergedValues;
+};
+
+template <typename rowmap_t, typename entries_t>
+struct GraphMergedEntriesFunctor {
+  using size_type = typename rowmap_t::non_const_value_type;
+  using lno_t     = typename entries_t::non_const_value_type;
+
+  // Precondition: entries are sorted within each row
+  GraphMergedEntriesFunctor(const typename rowmap_t::const_type& rowmap_, const entries_t& entries_,
+                            const rowmap_t& mergedRowmap_, const entries_t& mergedEntries_)
+      : rowmap(rowmap_), entries(entries_), mergedRowmap(mergedRowmap_), mergedEntries(mergedEntries_) {}
+
+  KOKKOS_INLINE_FUNCTION void operator()(lno_t row) const {
+    size_type rowBegin = rowmap(row);
+    size_type rowEnd   = rowmap(row + 1);
+    if (rowEnd == rowBegin) {
+      // Row was empty to begin with, nothing to do
+      return;
+    }
+    // Otherwise, accumulate the value for each column
+    lno_t accumCol      = entries(rowBegin);
+    size_type insertPos = mergedRowmap(row);
+    for (size_type j = rowBegin + 1; j < rowEnd; j++) {
+      if (accumCol != entries(j)) {
+        // write out and reset
+        mergedEntries(insertPos) = accumCol;
+        insertPos++;
+        accumCol = entries(j);
+      }
+    }
+    // always left with the last unique entry
+    mergedEntries(insertPos) = accumCol;
+  }
+
+  typename rowmap_t::const_type rowmap;
+  entries_t entries;
+  rowmap_t mergedRowmap;
+  entries_t mergedEntries;
+};
+
+template <typename Offset, typename Keys, typename Entries>
+struct MaxScanFunctor {
+  using value_type = uint64_t;
+
+  MaxScanFunctor(uint64_t ncols_, const Keys& keys_, const Entries& entries_)
+      : ncols(ncols_), keys(keys_), entries(entries_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void init(uint64_t& update) const { update = 0; }
+
+  KOKKOS_INLINE_FUNCTION
+  void join(uint64_t& update, const uint64_t& input) const { update = Kokkos::max(update, input); }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(Offset i, uint64_t& lmax, bool finalPass) const {
+    lmax = Kokkos::max(lmax, keys(i));
+    if (finalPass) {
+      // lmax is the row containing entry i.
+      // The key is equivalent to the entry's linear
+      // index if the matrix were dense and row-major.
+      keys(i) = lmax * ncols + entries(i);
+    }
+  }
+
+  uint64_t ncols;
+  Keys keys;
+  Entries entries;
+};
+
+template <typename ExecSpace, typename Rowmap, typename Entries>
+Kokkos::View<uint64_t*, ExecSpace> generateBulkCrsKeys(const ExecSpace& exec, const Rowmap& rowmap,
+                                                       const Entries& entries,
+                                                       typename Entries::non_const_value_type ncols) {
+  using Offset    = typename Rowmap::non_const_value_type;
+  using Ordinal   = typename Entries::non_const_value_type;
+  Ordinal numRows = rowmap.extent(0) ? rowmap.extent(0) - 1 : 0;
+  Kokkos::View<uint64_t*, ExecSpace> keys("keys", entries.extent(0));
+  Kokkos::parallel_for(
+      "CRS bulk sorting: mark row begins", Kokkos::RangePolicy<ExecSpace>(exec, 0, numRows), KOKKOS_LAMBDA(Ordinal i) {
+        Offset rowBegin = rowmap(i);
+        // Only mark the beginnings of non-empty rows.
+        // Otherwise multiple rows could try to update the same key.
+        if (rowmap(i + 1) != rowBegin) {
+          keys(rowBegin) = uint64_t(i);
+        }
+      });
+  Kokkos::fence();
+  Kokkos::parallel_scan("CRS bulk sorting: compute keys", Kokkos::RangePolicy<ExecSpace>(exec, 0, entries.extent(0)),
+                        MaxScanFunctor<Offset, decltype(keys), Entries>(ncols, keys, entries));
+  Kokkos::fence();
+  return keys;
+}
+
+#ifndef KK_DISABLE_BULK_SORT_BY_KEY
+template <typename ExecSpace, typename Rowmap, typename Entries>
+Kokkos::View<typename Rowmap::non_const_value_type*, ExecSpace> computeEntryPermutation(
+    const ExecSpace& exec, const Rowmap& rowmap, const Entries& entries, typename Entries::non_const_value_type ncols) {
+  using Offset = typename Rowmap::non_const_value_type;
+  auto keys    = generateBulkCrsKeys(exec, rowmap, entries, ncols);
+  Kokkos::View<Offset*, ExecSpace> permutation(Kokkos::view_alloc(Kokkos::WithoutInitializing, "permutation"),
+                                               entries.extent(0));
+  // This initializes permutation as the identity
+  KokkosKernels::Impl::sequential_fill(exec, permutation);
+  Kokkos::Experimental::sort_by_key(exec, keys, permutation);
+  return permutation;
+}
+
+// Heuristic for choosing bulk sorting algorithm
+template <typename Ordinal>
+bool useBulkSortHeuristic(Ordinal avgDeg, Ordinal maxDeg) {
+  // Use bulk sort if matrix is highly imbalanced,
+  // OR the longest rows have many entries.
+  return (maxDeg / 10 > avgDeg) || (maxDeg > 1024);
+}
+#endif
+
+template <typename ExecSpace, typename Permutation, typename InView, typename OutView>
+void applyPermutation(const ExecSpace& exec, const Permutation& permutation, const InView& in, const OutView& out) {
+  Kokkos::parallel_for(
+      "CRS bulk sorting: permute", Kokkos::RangePolicy<ExecSpace>(exec, 0, in.extent(0)),
+      KOKKOS_LAMBDA(size_t i) { out(i) = in(permutation(i)); });
+}
+
+template <typename ExecSpace, typename Permutation, typename InView, typename OutView, typename Ordinal>
+void applyPermutationBlockValues(const ExecSpace& exec, const Permutation& permutation, const InView& in,
+                                 const OutView& out, Ordinal blockSize) {
+  uint64_t scalarsPerBlock = (uint64_t)blockSize * blockSize;
+  if (in.extent(0) % scalarsPerBlock)
+    throw std::invalid_argument(
+        "sort_bsr_matrix: matrix values extent not divisible by graph entries "
+        "extent");
+  Kokkos::parallel_for(
+      "BSR bulk sorting: permute", Kokkos::RangePolicy<ExecSpace>(exec, 0, in.extent(0)), KOKKOS_LAMBDA(size_t i) {
+        uint64_t blockIndex    = i / scalarsPerBlock;
+        uint64_t offsetInBlock = i % scalarsPerBlock;
+        out(i)                 = in(permutation(blockIndex) * scalarsPerBlock + offsetInBlock);
+      });
+}
+
+}  // namespace Impl
+}  // namespace KokkosSparse
+
+#endif

--- a/packages/kokkos-kernels/sparse/src/KokkosSparse_SortCrs.hpp
+++ b/packages/kokkos-kernels/sparse/src/KokkosSparse_SortCrs.hpp
@@ -16,37 +16,10 @@
 #ifndef _KOKKOSSPARSE_SORTCRS_HPP
 #define _KOKKOSSPARSE_SORTCRS_HPP
 
-#include "Kokkos_Core.hpp"
-#include "KokkosKernels_Sorting.hpp"
+#include "KokkosSparse_sort_crs_impl.hpp"
+#include "KokkosSparse_Utils.hpp"
 
 namespace KokkosSparse {
-
-// ----------------------------------
-// BSR matrix/graph sorting utilities
-// ----------------------------------
-
-// Sort a BRS matrix: within each row, sort entries ascending by column and
-// permute the values accordingly.
-template <typename execution_space, typename rowmap_t, typename entries_t, typename values_t,
-          typename lno_t = typename entries_t::non_const_value_type>
-void sort_bsr_matrix(const lno_t blockdim, const rowmap_t& rowmap, const entries_t& entries, const values_t& values);
-
-// Sort a BRS matrix on the given execution space instance: within each row,
-// sort entries ascending by column and permute the values accordingly.
-template <typename execution_space, typename rowmap_t, typename entries_t, typename values_t,
-          typename lno_t = typename entries_t::non_const_value_type>
-void sort_bsr_matrix(const execution_space& exec, const lno_t blockdim, const rowmap_t& rowmap,
-                     const entries_t& entries, const values_t& values);
-
-// Sort a BRS matrix: within each row, sort entries ascending by column and
-// permute the values accordingly.
-template <typename bsrMat_t>
-void sort_bsr_matrix(const bsrMat_t& A);
-
-// Sort a BRS matrix on the given execution space instance: within each row,
-// sort entries ascending by column and permute the values accordingly.
-template <typename bsrMat_t>
-void sort_bsr_matrix(const typename bsrMat_t::execution_space& exec, const bsrMat_t& A);
 
 // ----------------------------------
 // CRS matrix/graph sorting utilities
@@ -63,269 +36,13 @@ void sort_bsr_matrix(const typename bsrMat_t::execution_space& exec, const bsrMa
 // duplicated entries in A, A is sorted and returned (instead of a newly
 // allocated matrix).
 
-namespace Impl {
-
-template <typename execution_space, typename rowmap_t, typename entries_t, typename values_t>
-struct SortCrsMatrixFunctor {
-  using size_type = typename rowmap_t::non_const_value_type;
-  using lno_t     = typename entries_t::non_const_value_type;
-  using scalar_t  = typename values_t::non_const_value_type;
-  using team_mem  = typename Kokkos::TeamPolicy<execution_space>::member_type;
-  // The functor owns memory for entriesAux, so it can't have
-  // MemoryTraits<Unmanaged>
-  using entries_managed_t = Kokkos::View<typename entries_t::data_type, typename entries_t::device_type>;
-  using values_managed_t  = Kokkos::View<typename values_t::data_type, typename values_t::device_type>;
-
-  SortCrsMatrixFunctor(bool usingRangePol, const rowmap_t& rowmap_, const entries_t& entries_, const values_t& values_)
-      : rowmap(rowmap_), entries(entries_), values(values_) {
-    if (usingRangePol) {
-      entriesAux = entries_managed_t(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Entries aux"), entries.extent(0));
-      valuesAux  = values_managed_t(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Values aux"), values.extent(0));
-    }
-    // otherwise, aux arrays won't be allocated (sorting in place)
-  }
-
-  KOKKOS_INLINE_FUNCTION void operator()(const lno_t i) const {
-    size_type rowStart = rowmap(i);
-    size_type rowEnd   = rowmap(i + 1);
-    lno_t rowNum       = rowEnd - rowStart;
-    // Radix sort requires unsigned keys for comparison
-    using unsigned_lno_t = typename std::make_unsigned<lno_t>::type;
-    KokkosKernels::SerialRadixSort2<lno_t, unsigned_lno_t, scalar_t>(
-        (unsigned_lno_t*)entries.data() + rowStart, (unsigned_lno_t*)entriesAux.data() + rowStart,
-        values.data() + rowStart, valuesAux.data() + rowStart, rowNum);
-  }
-
-  KOKKOS_INLINE_FUNCTION void operator()(const team_mem t) const {
-    size_type i        = t.league_rank();
-    size_type rowStart = rowmap(i);
-    size_type rowEnd   = rowmap(i + 1);
-    lno_t rowNum       = rowEnd - rowStart;
-    KokkosKernels::TeamBitonicSort2<lno_t, lno_t, scalar_t, team_mem>(entries.data() + rowStart,
-                                                                      values.data() + rowStart, rowNum, t);
-  }
-
-  rowmap_t rowmap;
-  entries_t entries;
-  entries_managed_t entriesAux;
-  values_t values;
-  values_managed_t valuesAux;
-};
-
-template <typename execution_space, typename rowmap_t, typename entries_t>
-struct SortCrsGraphFunctor {
-  using size_type = typename rowmap_t::non_const_value_type;
-  using lno_t     = typename entries_t::non_const_value_type;
-  using team_mem  = typename Kokkos::TeamPolicy<execution_space>::member_type;
-  // The functor owns memory for entriesAux, so it can't have
-  // MemoryTraits<Unmanaged>
-  using entries_managed_t = Kokkos::View<typename entries_t::data_type, typename entries_t::device_type>;
-
-  SortCrsGraphFunctor(bool usingRangePol, const rowmap_t& rowmap_, const entries_t& entries_)
-      : rowmap(rowmap_), entries(entries_) {
-    if (usingRangePol) {
-      entriesAux = entries_managed_t(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Entries aux"), entries.extent(0));
-    }
-    // otherwise, aux arrays won't be allocated (sorting in place)
-  }
-
-  KOKKOS_INLINE_FUNCTION void operator()(const lno_t i) const {
-    size_type rowStart = rowmap(i);
-    size_type rowEnd   = rowmap(i + 1);
-    lno_t rowNum       = rowEnd - rowStart;
-    // Radix sort requires unsigned keys for comparison
-    using unsigned_lno_t = typename std::make_unsigned<lno_t>::type;
-    KokkosKernels::SerialRadixSort<lno_t, unsigned_lno_t>((unsigned_lno_t*)entries.data() + rowStart,
-                                                          (unsigned_lno_t*)entriesAux.data() + rowStart, rowNum);
-  }
-
-  KOKKOS_INLINE_FUNCTION void operator()(const team_mem t) const {
-    size_type i        = t.league_rank();
-    size_type rowStart = rowmap(i);
-    size_type rowEnd   = rowmap(i + 1);
-    lno_t rowNum       = rowEnd - rowStart;
-    KokkosKernels::TeamBitonicSort<lno_t, lno_t, team_mem>(entries.data() + rowStart, rowNum, t);
-  }
-
-  rowmap_t rowmap;
-  entries_t entries;
-  entries_managed_t entriesAux;
-};
-
-template <typename rowmap_t, typename entries_t>
-struct MergedRowmapFunctor {
-  using size_type  = typename rowmap_t::non_const_value_type;
-  using lno_t      = typename entries_t::non_const_value_type;
-  using c_rowmap_t = typename rowmap_t::const_type;
-
-  // Precondition: entries are sorted within each row
-  MergedRowmapFunctor(const rowmap_t& mergedCounts_, const c_rowmap_t& rowmap_, const entries_t& entries_)
-      : mergedCounts(mergedCounts_), rowmap(rowmap_), entries(entries_) {}
-
-  KOKKOS_INLINE_FUNCTION void operator()(lno_t row, size_type& lnewNNZ) const {
-    size_type rowBegin = rowmap(row);
-    size_type rowEnd   = rowmap(row + 1);
-    if (rowEnd == rowBegin) {
-      // Row was empty to begin with
-      mergedCounts(row) = 0;
-      return;
-    }
-    // Otherwise, the first entry in the row exists
-    lno_t uniqueEntries = 1;
-    for (size_type j = rowBegin + 1; j < rowEnd; j++) {
-      if (entries(j - 1) != entries(j)) uniqueEntries++;
-    }
-    mergedCounts(row) = uniqueEntries;
-    lnewNNZ += uniqueEntries;
-    if (row == lno_t((rowmap.extent(0) - 1) - 1)) mergedCounts(row + 1) = 0;
-  }
-
-  rowmap_t mergedCounts;
-  c_rowmap_t rowmap;
-  entries_t entries;
-};
-
-template <typename rowmap_t, typename entries_t, typename values_t>
-struct MatrixMergedEntriesFunctor {
-  using size_type = typename rowmap_t::non_const_value_type;
-  using lno_t     = typename entries_t::non_const_value_type;
-  using scalar_t  = typename values_t::non_const_value_type;
-
-  // Precondition: entries are sorted within each row
-  MatrixMergedEntriesFunctor(const typename rowmap_t::const_type& rowmap_, const entries_t& entries_,
-                             const values_t& values_, const rowmap_t& mergedRowmap_, const entries_t& mergedEntries_,
-                             const values_t& mergedValues_)
-      : rowmap(rowmap_),
-        entries(entries_),
-        values(values_),
-        mergedRowmap(mergedRowmap_),
-        mergedEntries(mergedEntries_),
-        mergedValues(mergedValues_) {}
-
-  KOKKOS_INLINE_FUNCTION void operator()(lno_t row) const {
-    size_type rowBegin = rowmap(row);
-    size_type rowEnd   = rowmap(row + 1);
-    if (rowEnd == rowBegin) {
-      // Row was empty to begin with, nothing to do
-      return;
-    }
-    // Otherwise, accumulate the value for each column
-    scalar_t accumVal   = values(rowBegin);
-    lno_t accumCol      = entries(rowBegin);
-    size_type insertPos = mergedRowmap(row);
-    for (size_type j = rowBegin + 1; j < rowEnd; j++) {
-      if (accumCol == entries(j)) {
-        // accumulate
-        accumVal += values(j);
-      } else {
-        // write out and reset
-        mergedValues(insertPos)  = accumVal;
-        mergedEntries(insertPos) = accumCol;
-        insertPos++;
-        accumVal = values(j);
-        accumCol = entries(j);
-      }
-    }
-    // always left with the last unique entry
-    mergedValues(insertPos)  = accumVal;
-    mergedEntries(insertPos) = accumCol;
-  }
-
-  typename rowmap_t::const_type rowmap;
-  entries_t entries;
-  values_t values;
-  rowmap_t mergedRowmap;
-  entries_t mergedEntries;
-  values_t mergedValues;
-};
-
-template <typename rowmap_t, typename entries_t>
-struct GraphMergedEntriesFunctor {
-  using size_type = typename rowmap_t::non_const_value_type;
-  using lno_t     = typename entries_t::non_const_value_type;
-
-  // Precondition: entries are sorted within each row
-  GraphMergedEntriesFunctor(const typename rowmap_t::const_type& rowmap_, const entries_t& entries_,
-                            const rowmap_t& mergedRowmap_, const entries_t& mergedEntries_)
-      : rowmap(rowmap_), entries(entries_), mergedRowmap(mergedRowmap_), mergedEntries(mergedEntries_) {}
-
-  KOKKOS_INLINE_FUNCTION void operator()(lno_t row) const {
-    size_type rowBegin = rowmap(row);
-    size_type rowEnd   = rowmap(row + 1);
-    if (rowEnd == rowBegin) {
-      // Row was empty to begin with, nothing to do
-      return;
-    }
-    // Otherwise, accumulate the value for each column
-    lno_t accumCol      = entries(rowBegin);
-    size_type insertPos = mergedRowmap(row);
-    for (size_type j = rowBegin + 1; j < rowEnd; j++) {
-      if (accumCol != entries(j)) {
-        // write out and reset
-        mergedEntries(insertPos) = accumCol;
-        insertPos++;
-        accumCol = entries(j);
-      }
-    }
-    // always left with the last unique entry
-    mergedEntries(insertPos) = accumCol;
-  }
-
-  typename rowmap_t::const_type rowmap;
-  entries_t entries;
-  rowmap_t mergedRowmap;
-  entries_t mergedEntries;
-};
-
-template <typename T>
-KOKKOS_INLINE_FUNCTION void kk_swap(T& a, T& b) {
-  T t = a;
-  a   = b;
-  b   = t;
-}
-
-template <typename row_map_type, typename entries_type, typename values_type>
-struct sort_bsr_functor {
-  using lno_t = typename entries_type::non_const_value_type;
-
-  row_map_type rowmap;
-  entries_type entries;
-  values_type values;
-  const lno_t blocksize;
-
-  sort_bsr_functor(row_map_type rowmap_, entries_type entries_, values_type values_, const lno_t blocksize_)
-      : rowmap(rowmap_), entries(entries_), values(values_), blocksize(blocksize_) {}
-
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const lno_t i) const {
-    const lno_t rowStart = rowmap(i);
-    const lno_t rowSize  = rowmap(i + 1) - rowStart;
-    auto* e              = entries.data() + rowStart;
-    auto* v              = values.data() + rowStart * blocksize;
-    bool done            = false;
-    while (!done) {
-      done = true;
-      for (lno_t j = 1; j < rowSize; ++j) {
-        const lno_t jp = j - 1;
-        if (e[jp] <= e[j]) continue;
-        Impl::kk_swap(e[jp], e[j]);
-        auto const vb  = v + j * blocksize;
-        auto const vbp = v + jp * blocksize;
-        for (lno_t k = 0; k < blocksize; ++k)  // std::swap_ranges(vb, vb + blocksize, vbp);
-          Impl::kk_swap(vb[k], vbp[k]);
-        done = false;
-      }
-    }
-  }
-};
-
-}  // namespace Impl
-
 // Sort a CRS matrix: within each row, sort entries ascending by column.
 // At the same time, permute the values.
 template <typename execution_space, typename rowmap_t, typename entries_t, typename values_t>
 void sort_crs_matrix(const execution_space& exec, const rowmap_t& rowmap, const entries_t& entries,
-                     const values_t& values) {
+                     const values_t& values,
+                     typename entries_t::non_const_value_type numCols =
+                         Kokkos::ArithTraits<typename entries_t::non_const_value_type>::max()) {
   static_assert(Kokkos::SpaceAccessibility<execution_space, typename rowmap_t::memory_space>::accessible,
                 "sort_crs_matrix: rowmap_t is not accessible from the given execution "
                 "space");
@@ -338,71 +55,156 @@ void sort_crs_matrix(const execution_space& exec, const rowmap_t& rowmap, const 
   static_assert(!std::is_const_v<typename entries_t::value_type>,
                 "sort_crs_matrix: entries_t must not be const-valued");
   static_assert(!std::is_const_v<typename values_t::value_type>, "sort_crs_matrix: value_t must not be const-valued");
-  using lno_t    = typename entries_t::non_const_value_type;
-  using team_pol = Kokkos::TeamPolicy<execution_space>;
-  bool useRadix  = !KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>();
-  lno_t numRows  = rowmap.extent(0) ? rowmap.extent(0) - 1 : 0;
-  if (numRows == 0) return;
-  Impl::SortCrsMatrixFunctor<execution_space, rowmap_t, entries_t, values_t> funct(useRadix, rowmap, entries, values);
-  if (useRadix) {
-    Kokkos::parallel_for("sort_crs_matrix", Kokkos::RangePolicy<execution_space>(exec, 0, numRows), funct);
+  using Ordinal = typename entries_t::non_const_value_type;
+  // This early return condition covers having 0 or 1 entries,
+  // which is also implied by having 0 rows or 0 columns.
+  // If only 1 entry, the matrix is already sorted.
+  if (entries.extent(0) <= size_t(1)) {
+    return;
+  }
+  Ordinal numRows = rowmap.extent(0) ? rowmap.extent(0) - 1 : 0;
+  if constexpr (!KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()) {
+    // On CPUs, use a sequential radix sort within each row.
+    Kokkos::parallel_for("sort_crs_matrix[CPU,radix]",
+                         Kokkos::RangePolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>(exec, 0, numRows),
+                         Impl::MatrixRadixSortFunctor<rowmap_t, entries_t, values_t>(rowmap, entries, values));
   } else {
-    // Try to get teamsize to be largest power of 2 not greater than avg entries
-    // per row
-    // TODO (probably important for performnce): add thread-level sort also, and
-    // use that for small avg degree. But this works for now.
-    lno_t idealTeamSize = 1;
-    lno_t avgDeg        = (entries.extent(0) + numRows - 1) / numRows;
-    while (idealTeamSize < avgDeg / 2) {
-      idealTeamSize *= 2;
+    // On GPUs:
+    //   If the matrix is highly imbalanced, or has long rows AND the dimensions
+    //   are not too large to do one large bulk sort, do that. Otherwise, sort
+    //   using one Kokkos thread per row.
+    Ordinal avgDeg = (entries.extent(0) + numRows - 1) / numRows;
+#ifndef KK_DISABLE_BULK_SORT_BY_KEY
+    Ordinal maxDeg   = KokkosSparse::Impl::graph_max_degree(exec, rowmap);
+    bool useBulkSort = false;
+    if (KokkosSparse::Impl::useBulkSortHeuristic(avgDeg, maxDeg)) {
+      // Calculate the true number of columns if user didn't pass it in
+      if (numCols == Kokkos::ArithTraits<Ordinal>::max()) {
+        KokkosKernels::Impl::kk_view_reduce_max(exec, entries.extent(0), entries, numCols);
+        numCols++;
+      }
+      uint64_t maxBulkKey = (uint64_t)numRows * (uint64_t)numCols;
+      useBulkSort         = maxBulkKey / numRows == (uint64_t)numCols;
     }
-    team_pol temp(exec, numRows, 1);
-    lno_t maxTeamSize = temp.team_size_max(funct, Kokkos::ParallelForTag());
-    lno_t teamSize    = std::min(idealTeamSize, maxTeamSize);
-    Kokkos::parallel_for("sort_crs_matrix", team_pol(exec, numRows, teamSize), funct);
+    if (useBulkSort) {
+      auto permutation = KokkosSparse::Impl::computeEntryPermutation(exec, rowmap, entries, numCols);
+      // Permutations cannot be done in-place
+      Kokkos::View<typename values_t::value_type*, execution_space> origValues(
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "origValues"), values.extent(0));
+      Kokkos::View<typename entries_t::value_type*, execution_space> origEntries(
+          Kokkos::view_alloc(Kokkos::WithoutInitializing, "origEntries"), entries.extent(0));
+      Kokkos::deep_copy(exec, origValues, values);
+      Kokkos::deep_copy(exec, origEntries, entries);
+      KokkosSparse::Impl::applyPermutation(exec, permutation, origEntries, entries);
+      KokkosSparse::Impl::applyPermutation(exec, permutation, origValues, values);
+    } else
+#else
+    (void)numCols;
+#endif
+    {
+      using TeamPol = Kokkos::TeamPolicy<execution_space>;
+      // Can't use bulk sort approach as matrix dimensions are too large.
+      // Fall back to parallel thread-level sort within each row.
+      Ordinal vectorLength = 1;
+      while (vectorLength < avgDeg / 2) {
+        vectorLength *= 2;
+      }
+      if (vectorLength > TeamPol ::vector_length_max()) vectorLength = TeamPol ::vector_length_max();
+      Impl::MatrixThreadSortFunctor<TeamPol, Ordinal, rowmap_t, entries_t, values_t> funct(numRows, rowmap, entries,
+                                                                                           values);
+      Ordinal teamSize = TeamPol(exec, 1, 1, vectorLength).team_size_recommended(funct, Kokkos::ParallelForTag());
+      Kokkos::parallel_for("sort_crs_matrix[GPU,bitonic]",
+                           TeamPol(exec, (numRows + teamSize - 1) / teamSize, teamSize, vectorLength), funct);
+    }
   }
 }
 
 template <typename execution_space, typename rowmap_t, typename entries_t, typename values_t>
-void sort_crs_matrix(const rowmap_t& rowmap, const entries_t& entries, const values_t& values) {
-  sort_crs_matrix(execution_space(), rowmap, entries, values);
+void sort_crs_matrix(const rowmap_t& rowmap, const entries_t& entries, const values_t& values,
+                     typename entries_t::const_value_type numCols =
+                         Kokkos::ArithTraits<typename entries_t::non_const_value_type>::max()) {
+  sort_crs_matrix(execution_space(), rowmap, entries, values, numCols);
 }
 
 template <typename rowmap_t, typename entries_t, typename values_t>
-void sort_crs_matrix(const rowmap_t& rowmap, const entries_t& entries, const values_t& values) {
-  sort_crs_matrix(typename entries_t::execution_space(), rowmap, entries, values);
+void sort_crs_matrix(const rowmap_t& rowmap, const entries_t& entries, const values_t& values,
+                     typename entries_t::const_value_type numCols =
+                         Kokkos::ArithTraits<typename entries_t::non_const_value_type>::max()) {
+  sort_crs_matrix(typename entries_t::execution_space(), rowmap, entries, values, numCols);
 }
 
 template <typename crsMat_t>
 void sort_crs_matrix(const typename crsMat_t::execution_space& exec, const crsMat_t& A) {
-  sort_crs_matrix(exec, A.graph.row_map, A.graph.entries, A.values);
+  sort_crs_matrix(exec, A.graph.row_map, A.graph.entries, A.values, A.numCols());
 }
 
 template <typename crsMat_t>
 void sort_crs_matrix(const crsMat_t& A) {
-  sort_crs_matrix(typename crsMat_t::execution_space(), A.graph.row_map, A.graph.entries, A.values);
+  sort_crs_matrix(typename crsMat_t::execution_space(), A.graph.row_map, A.graph.entries, A.values, A.numCols());
 }
 
 // Sort a BRS matrix: within each row, sort entries ascending by column and
 // permute the values accordingly.
-template <typename execution_space, typename rowmap_t, typename entries_t, typename values_t, typename lno_t>
-void sort_bsr_matrix(const execution_space& exec, const lno_t blockdim, const rowmap_t& rowmap,
-                     const entries_t& entries, const values_t& values) {
-  // TODO: this is O(N^2) mock for debugging - do regular implementation based
-  // on Radix/Bitonic sort (like CSR) IDEA: maybe we need only one general
-  // Radix2/Bitonic2 and CSR sorting may call it with blockSize=1 ?
-  lno_t numRows = rowmap.extent(0) ? rowmap.extent(0) - 1 : 0;
-  if (numRows == 0) return;
-  const lno_t blocksize = blockdim * blockdim;
-
-  assert(values.extent(0) == entries.extent(0) * blocksize);
-  Impl::sort_bsr_functor<rowmap_t, entries_t, values_t> bsr_sorter(rowmap, entries, values, blocksize);
-  Kokkos::parallel_for("sort_bsr_matrix", Kokkos::RangePolicy<execution_space>(exec, 0, numRows), bsr_sorter);
+template <typename execution_space, typename rowmap_t, typename entries_t, typename values_t,
+          typename Ordinal = typename entries_t::non_const_value_type>
+void sort_bsr_matrix(const execution_space& exec, Ordinal blockSize, const rowmap_t& rowmap, const entries_t& entries,
+                     const values_t& values,
+                     typename entries_t::non_const_value_type numCols =
+                         Kokkos::ArithTraits<typename entries_t::non_const_value_type>::max()) {
+  static_assert(std::is_same_v<Ordinal, typename entries_t::non_const_value_type>,
+                "sort_bsr_matrix: Ordinal type must match nonconst value type of "
+                "entries_t (default template parameter)");
+  if (entries.extent(0) <= size_t(1)) {
+    return;
+  }
+  Ordinal numRows = rowmap.extent(0) ? rowmap.extent(0) - 1 : 0;
+  if (numCols == Kokkos::ArithTraits<Ordinal>::max()) {
+    KokkosKernels::Impl::kk_view_reduce_max(exec, entries.extent(0), entries, numCols);
+    numCols++;
+  }
+  uint64_t maxBulkKey = (uint64_t)numRows * (uint64_t)numCols;
+  if (maxBulkKey / numRows != (uint64_t)numCols)
+    throw std::invalid_argument(
+        "sort_bsr_matrix: implementation requires that numRows * numCols is "
+        "representable in uint64_t");
+#ifdef KK_DISABLE_BULK_SORT_BY_KEY
+  using TeamPol = Kokkos::TeamPolicy<execution_space>;
+  using Offset  = typename rowmap_t::non_const_value_type;
+  // Temporary workaround: do not use Kokkos::Experimental::sort_by_key, instead
+  // sort bulk keys one row at a time
+  auto keys = Impl::generateBulkCrsKeys(exec, rowmap, entries, numCols);
+  Kokkos::View<Offset*, execution_space> permutation(Kokkos::view_alloc(Kokkos::WithoutInitializing, "permutation"),
+                                                     entries.extent(0));
+  KokkosKernels::Impl::sequential_fill(exec, permutation);
+  Ordinal vectorLength = 1;
+  Ordinal avgDeg       = (entries.extent(0) + numRows - 1) / numRows;
+  while (vectorLength < avgDeg / 2) {
+    vectorLength *= 2;
+  }
+  if (vectorLength > TeamPol ::vector_length_max()) vectorLength = TeamPol ::vector_length_max();
+  Impl::MatrixThreadSortFunctor<TeamPol, Ordinal, rowmap_t, decltype(keys), decltype(permutation)> funct(
+      numRows, rowmap, keys, permutation);
+  Ordinal teamSize = TeamPol(exec, 1, 1, vectorLength).team_size_recommended(funct, Kokkos::ParallelForTag());
+  Kokkos::parallel_for("sort_bulk_keys_by_row[GPU,bitonic]",
+                       TeamPol(exec, (numRows + teamSize - 1) / teamSize, teamSize, vectorLength), funct);
+#else
+  auto permutation = KokkosSparse::Impl::computeEntryPermutation(exec, rowmap, entries, numCols);
+#endif
+  // Permutations cannot be done in-place
+  Kokkos::View<typename values_t::value_type*, execution_space> origValues(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "origValues"), values.extent(0));
+  Kokkos::View<typename entries_t::value_type*, execution_space> origEntries(
+      Kokkos::view_alloc(Kokkos::WithoutInitializing, "origEntries"), entries.extent(0));
+  Kokkos::deep_copy(exec, origValues, values);
+  Kokkos::deep_copy(exec, origEntries, entries);
+  KokkosSparse::Impl::applyPermutation(exec, permutation, origEntries, entries);
+  KokkosSparse::Impl::applyPermutationBlockValues(exec, permutation, origValues, values, blockSize);
 }
 
-template <typename execution_space, typename rowmap_t, typename entries_t, typename values_t, typename lno_t>
-void sort_bsr_matrix(const lno_t blockdim, const rowmap_t& rowmap, const entries_t& entries, const values_t& values) {
-  sort_bsr_matrix(execution_space(), blockdim, rowmap, entries, values);
+template <typename execution_space, typename rowmap_t, typename entries_t, typename values_t, typename Ordinal>
+void sort_bsr_matrix(Ordinal blockdim, const rowmap_t& rowmap, const entries_t& entries, const values_t& values,
+                     Ordinal numCols = Kokkos::ArithTraits<Ordinal>::max()) {
+  sort_bsr_matrix(execution_space(), blockdim, rowmap, entries, values, numCols);
 }
 
 // Sort a BSR matrix (like CRS but single values are replaced with contignous
@@ -413,7 +215,7 @@ void sort_bsr_matrix(const typename bsrMat_t::execution_space& exec, const bsrMa
   // directly
   sort_bsr_matrix<typename bsrMat_t::execution_space, typename bsrMat_t::row_map_type,
                   typename bsrMat_t::index_type::non_const_type, typename bsrMat_t::values_type::non_const_type>(
-      exec, A.blockDim(), A.graph.row_map, A.graph.entries, A.values);
+      exec, A.blockDim(), A.graph.row_map, A.graph.entries, A.values, A.numCols());
 }
 
 template <typename bsrMat_t>
@@ -423,9 +225,10 @@ void sort_bsr_matrix(const bsrMat_t& A) {
 
 // Sort a CRS graph: within each row, sort entries ascending by column.
 template <typename execution_space, typename rowmap_t, typename entries_t>
-void sort_crs_graph(const execution_space& exec, const rowmap_t& rowmap, const entries_t& entries) {
-  using lno_t    = typename entries_t::non_const_value_type;
-  using team_pol = Kokkos::TeamPolicy<execution_space>;
+void sort_crs_graph(const execution_space& exec, const rowmap_t& rowmap, const entries_t& entries,
+                    typename entries_t::non_const_value_type numCols =
+                        Kokkos::ArithTraits<typename entries_t::non_const_value_type>::max()) {
+  using Ordinal = typename entries_t::non_const_value_type;
   static_assert(Kokkos::SpaceAccessibility<execution_space, typename rowmap_t::memory_space>::accessible,
                 "sort_crs_graph: rowmap_t is not accessible from the given execution "
                 "space");
@@ -433,27 +236,55 @@ void sort_crs_graph(const execution_space& exec, const rowmap_t& rowmap, const e
                 "sort_crs_graph: entries_t is not accessible from the given execution "
                 "space");
   static_assert(!std::is_const_v<typename entries_t::value_type>, "sort_crs_graph: entries_t must not be const-valued");
-  bool useRadix = !KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>();
-  lno_t numRows = rowmap.extent(0) ? rowmap.extent(0) - 1 : 0;
-  if (numRows == 0) return;
-  Impl::SortCrsGraphFunctor<execution_space, rowmap_t, entries_t> funct(useRadix, rowmap, entries);
-  if (useRadix) {
-    Kokkos::parallel_for("sort_crs_graph", Kokkos::RangePolicy<execution_space>(exec, 0, numRows), funct);
+  Ordinal numRows = rowmap.extent(0) ? rowmap.extent(0) - 1 : 0;
+  if (entries.extent(0) <= size_t(1)) {
+    return;
+  }
+  if constexpr (!KokkosKernels::Impl::kk_is_gpu_exec_space<execution_space>()) {
+    // If on CPU, sort each row independently. Don't need to know numCols for
+    // this.
+    Kokkos::parallel_for("sort_crs_graph[CPU,radix]",
+                         Kokkos::RangePolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>(exec, 0, numRows),
+                         Impl::GraphRadixSortFunctor<rowmap_t, entries_t>(rowmap, entries));
   } else {
-    // Try to get teamsize to be largest power of 2 less than or equal to
-    // half the entries per row. 0.5 * #entries is bitonic's parallelism within
-    // a row.
-    // TODO (probably important for performnce): add thread-level sort also, and
-    // use that for small avg degree. But this works for now.
-    lno_t idealTeamSize = 1;
-    lno_t avgDeg        = (entries.extent(0) + numRows - 1) / numRows;
-    while (idealTeamSize < avgDeg / 2) {
-      idealTeamSize *= 2;
+    // On GPUs:
+    //   If the graph is highly imbalanced AND the dimensions are not too large
+    //   to do one large bulk sort, do that. Otherwise, sort using one Kokkos
+    //   thread per row.
+    Ordinal avgDeg = (entries.extent(0) + numRows - 1) / numRows;
+#ifndef KK_DISABLE_BULK_SORT_BY_KEY
+    Ordinal maxDeg   = KokkosSparse::Impl::graph_max_degree(exec, rowmap);
+    bool useBulkSort = false;
+    if (KokkosSparse::Impl::useBulkSortHeuristic(avgDeg, maxDeg)) {
+      // Calculate the true number of columns if user didn't pass it in
+      if (numCols == Kokkos::ArithTraits<Ordinal>::max()) {
+        KokkosKernels::Impl::kk_view_reduce_max(exec, entries.extent(0), entries, numCols);
+        numCols++;
+      }
+      uint64_t maxBulkKey = (uint64_t)numRows * (uint64_t)numCols;
+      useBulkSort         = maxBulkKey / numRows == (uint64_t)numCols;
     }
-    team_pol temp(exec, numRows, 1);
-    lno_t maxTeamSize = temp.team_size_max(funct, Kokkos::ParallelForTag());
-    lno_t teamSize    = std::min(idealTeamSize, maxTeamSize);
-    Kokkos::parallel_for("sort_crs_graph", team_pol(exec, numRows, teamSize), funct);
+    if (useBulkSort) {
+      auto keys = KokkosSparse::Impl::generateBulkCrsKeys(exec, rowmap, entries, numCols);
+      Kokkos::Experimental::sort_by_key(exec, keys, entries);
+    } else
+#else
+    (void)numCols;
+#endif
+    {
+      using TeamPol = Kokkos::TeamPolicy<execution_space>;
+      // Fall back to thread-level sort within each row
+      Ordinal vectorLength = 1;
+      while (vectorLength < avgDeg / 2) {
+        vectorLength *= 2;
+      }
+      if (vectorLength > TeamPol ::vector_length_max()) vectorLength = TeamPol ::vector_length_max();
+
+      Impl::GraphThreadSortFunctor<TeamPol, Ordinal, rowmap_t, entries_t> funct(numRows, rowmap, entries);
+      Ordinal teamSize = TeamPol(exec, 1, 1, vectorLength).team_size_recommended(funct, Kokkos::ParallelForTag());
+      Kokkos::parallel_for("sort_crs_graph[GPU,bitonic]",
+                           TeamPol(exec, (numRows + teamSize - 1) / teamSize, teamSize, vectorLength), funct);
+    }
   }
 }
 
@@ -462,36 +293,38 @@ void sort_crs_graph(const rowmap_t& rowmap, const entries_t& entries) {
   sort_crs_graph(execution_space(), rowmap, entries);
 }
 
-// This overload covers 2 cases, while allowing all template args to be deduced:
-//  - sort_crs_graph(exec, G)
-//  - sort_crs_graph(rowmap, entries)
-template <typename Arg1, typename Arg2>
-void sort_crs_graph(const Arg1& a1, const Arg2& a2) {
-  if constexpr (Kokkos::is_execution_space_v<Arg1>) {
-    // a1 is an exec instance, a2 is a graph
-    sort_crs_graph(a1, a2.row_map, a2.entries);
-  } else if constexpr (Kokkos::is_view_v<Arg1>) {
-    // a1 is rowmap, a2 is entries
-    sort_crs_graph(typename Arg2::execution_space(), a1, a2);
-  } else {
-    static_assert(Arg1::doesnthavethisthing,
-                  "sort_crs_graph(arg1, arg2): expect either (exec, G) or "
-                  "(rowmap, entries)");
-  }
+template <typename rowmap_t, typename entries_t>
+typename std::enable_if_t<Kokkos::is_view_v<rowmap_t>> sort_crs_graph(
+    const rowmap_t& rowmap, const entries_t& entries,
+    typename entries_t::const_value_type& numCols =
+        Kokkos::ArithTraits<typename entries_t::non_const_value_type>::max()) {
+  sort_crs_graph(typename entries_t::execution_space(), rowmap, entries, numCols);
+}
+
+template <typename execution_space, typename crsGraph_t>
+typename std::enable_if_t<Kokkos::is_execution_space_v<execution_space>> sort_crs_graph(
+    const execution_space& exec, const crsGraph_t& G,
+    typename crsGraph_t::entries_type::const_value_type& numCols =
+        Kokkos::ArithTraits<typename crsGraph_t::entries_type::non_const_value_type>::max()) {
+  sort_crs_graph(exec, G.row_map, G.entries, numCols);
 }
 
 template <typename crsGraph_t>
-void sort_crs_graph(const crsGraph_t& G) {
-  sort_crs_graph(typename crsGraph_t::execution_space(), G);
+void sort_crs_graph(const crsGraph_t& G,
+                    typename crsGraph_t::entries_type::const_value_type& numCols =
+                        Kokkos::ArithTraits<typename crsGraph_t::entries_type::non_const_value_type>::max()) {
+  sort_crs_graph(typename crsGraph_t::execution_space(), G, numCols);
 }
 
 template <typename exec_space, typename rowmap_t, typename entries_t, typename values_t>
 void sort_and_merge_matrix(const exec_space& exec, const typename rowmap_t::const_type& rowmap_in,
                            const entries_t& entries_in, const values_t& values_in, rowmap_t& rowmap_out,
-                           entries_t& entries_out, values_t& values_out) {
+                           entries_t& entries_out, values_t& values_out,
+                           typename entries_t::const_value_type& numCols =
+                               Kokkos::ArithTraits<typename entries_t::non_const_value_type>::max()) {
   using nc_rowmap_t = typename rowmap_t::non_const_type;
-  using size_type   = typename nc_rowmap_t::value_type;
-  using ordinal_t   = typename entries_t::value_type;
+  using Offset      = typename nc_rowmap_t::value_type;
+  using Ordinal     = typename entries_t::value_type;
   using range_t     = Kokkos::RangePolicy<exec_space>;
   static_assert(Kokkos::SpaceAccessibility<exec_space, typename rowmap_t::memory_space>::accessible,
                 "sort_and_merge_matrix: rowmap_t is not accessible from the given "
@@ -507,8 +340,8 @@ void sort_and_merge_matrix(const exec_space& exec, const typename rowmap_t::cons
   static_assert(!std::is_const_v<typename values_t::value_type>,
                 "sort_and_merge_matrix: value_t must not be const-valued");
 
-  ordinal_t numRows = rowmap_in.extent(0) ? ordinal_t(rowmap_in.extent(0) - 1) : ordinal_t(0);
-  size_type nnz     = entries_in.extent(0);
+  Ordinal numRows = rowmap_in.extent(0) ? Ordinal(rowmap_in.extent(0) - 1) : Ordinal(0);
+  Offset nnz      = entries_in.extent(0);
 
   if (numRows == 0) {
     rowmap_out  = typename rowmap_t::non_const_type("SortedMerged rowmap", rowmap_in.extent(0));
@@ -517,13 +350,13 @@ void sort_and_merge_matrix(const exec_space& exec, const typename rowmap_t::cons
     return;
   }
 
-  sort_crs_matrix(exec, rowmap_in, entries_in, values_in);
+  sort_crs_matrix(exec, rowmap_in, entries_in, values_in, numCols);
 
   // Count entries per row into a new rowmap, in terms of merges that can be
   // done
   nc_rowmap_t nc_rowmap_out(Kokkos::view_alloc(exec, Kokkos::WithoutInitializing, "SortedMerged rowmap"), numRows + 1);
-  size_type numCompressedEntries = 0;
-  Kokkos::parallel_reduce(range_t(exec, 0, numRows),
+  Offset numCompressedEntries = 0;
+  Kokkos::parallel_reduce("KokkosSparse::Impl::MergedRowmapFunctor", range_t(exec, 0, numRows),
                           Impl::MergedRowmapFunctor<nc_rowmap_t, entries_t>(nc_rowmap_out, rowmap_in, entries_in),
                           numCompressedEntries);
   if (nnz == numCompressedEntries) {
@@ -555,7 +388,7 @@ void sort_and_merge_matrix(const exec_space& exec, const typename rowmap_t::cons
   values_out =
       values_t(Kokkos::view_alloc(exec, Kokkos::WithoutInitializing, "SortedMerged values"), numCompressedEntries);
   // Compute merged entries and values
-  Kokkos::parallel_for(range_t(exec, 0, numRows),
+  Kokkos::parallel_for("KokkosSparse::Impl::MatrixMergedEntriesFunctor", range_t(exec, 0, numRows),
                        Impl::MatrixMergedEntriesFunctor<rowmap_t, entries_t, values_t>(
                            rowmap_orig, entries_orig, values_orig, rowmap_out, entries_out, values_out));
 }
@@ -571,7 +404,8 @@ crsMat_t sort_and_merge_matrix(const typename crsMat_t::execution_space& exec, c
   entries_t entries_out;
   values_t values_out;
 
-  sort_and_merge_matrix(exec, A.graph.row_map, A.graph.entries, A.values, rowmap_out, entries_out, values_out);
+  sort_and_merge_matrix(exec, A.graph.row_map, A.graph.entries, A.values, rowmap_out, entries_out, values_out,
+                        A.numCols());
 
   return crsMat_t("SortedMerged", A.numRows(), A.numCols(), values_out.extent(0), values_out, rowmap_out, entries_out);
 }
@@ -584,23 +418,29 @@ crsMat_t sort_and_merge_matrix(const crsMat_t& A) {
 template <typename exec_space, typename rowmap_t, typename entries_t, typename values_t>
 void sort_and_merge_matrix(const typename rowmap_t::const_type& rowmap_in, const entries_t& entries_in,
                            const values_t& values_in, rowmap_t& rowmap_out, entries_t& entries_out,
-                           values_t& values_out) {
-  sort_and_merge_matrix(exec_space(), rowmap_in, entries_in, values_in, rowmap_out, entries_out, values_out);
+                           values_t& values_out,
+                           typename entries_t::const_value_type& numCols =
+                               Kokkos::ArithTraits<typename entries_t::non_const_value_type>::max()) {
+  sort_and_merge_matrix(exec_space(), rowmap_in, entries_in, values_in, rowmap_out, entries_out, values_out, numCols);
 }
 
 template <typename rowmap_t, typename entries_t, typename values_t>
 void sort_and_merge_matrix(const typename rowmap_t::const_type& rowmap_in, const entries_t& entries_in,
                            const values_t& values_in, rowmap_t& rowmap_out, entries_t& entries_out,
-                           values_t& values_out) {
+                           values_t& values_out,
+                           typename entries_t::const_value_type& numCols =
+                               Kokkos::ArithTraits<typename entries_t::non_const_value_type>::max()) {
   sort_and_merge_matrix(typename entries_t::execution_space(), rowmap_in, entries_in, values_in, rowmap_out,
-                        entries_out, values_out);
+                        entries_out, values_out, numCols);
 }
 
 template <typename exec_space, typename rowmap_t, typename entries_t>
 void sort_and_merge_graph(const exec_space& exec, const typename rowmap_t::const_type& rowmap_in,
-                          const entries_t& entries_in, rowmap_t& rowmap_out, entries_t& entries_out) {
-  using size_type   = typename rowmap_t::non_const_value_type;
-  using lno_t       = typename entries_t::value_type;
+                          const entries_t& entries_in, rowmap_t& rowmap_out, entries_t& entries_out,
+                          typename entries_t::const_value_type& numCols =
+                              Kokkos::ArithTraits<typename entries_t::non_const_value_type>::max()) {
+  using Offset      = typename rowmap_t::non_const_value_type;
+  using Ordinal     = typename entries_t::value_type;
   using range_t     = Kokkos::RangePolicy<exec_space>;
   using nc_rowmap_t = typename rowmap_t::non_const_type;
   static_assert(Kokkos::SpaceAccessibility<exec_space, typename rowmap_t::memory_space>::accessible,
@@ -612,19 +452,19 @@ void sort_and_merge_graph(const exec_space& exec, const typename rowmap_t::const
   static_assert(!std::is_const_v<typename entries_t::value_type>,
                 "sort_and_merge_graph: entries_t must not be const-valued");
 
-  lno_t numRows = rowmap_in.extent(0) ? rowmap_in.extent(0) - 1 : 0;
+  Ordinal numRows = rowmap_in.extent(0) ? rowmap_in.extent(0) - 1 : 0;
   if (numRows == 0) {
     rowmap_out  = typename rowmap_t::non_const_type("SortedMerged rowmap", rowmap_in.extent(0));
     entries_out = entries_t();
     return;
   }
   // Sort in place
-  sort_crs_graph(exec, rowmap_in, entries_in);
+  sort_crs_graph(exec, rowmap_in, entries_in, numCols);
   // Count entries per row into a new rowmap, in terms of merges that can be
   // done
   nc_rowmap_t nc_rowmap_out(Kokkos::view_alloc(exec, Kokkos::WithoutInitializing, "SortedMerged rowmap"), numRows + 1);
-  size_type numCompressedEntries = 0;
-  Kokkos::parallel_reduce(range_t(exec, 0, numRows),
+  Offset numCompressedEntries = 0;
+  Kokkos::parallel_reduce("KokkosSparse::Impl::MergedRowmapFunctor", range_t(exec, 0, numRows),
                           Impl::MergedRowmapFunctor<rowmap_t, entries_t>(nc_rowmap_out, rowmap_in, entries_in),
                           numCompressedEntries);
   if (entries_in.extent(0) == size_t(numCompressedEntries)) {
@@ -655,107 +495,50 @@ void sort_and_merge_graph(const exec_space& exec, const typename rowmap_t::const
   entries_out =
       entries_t(Kokkos::view_alloc(exec, Kokkos::WithoutInitializing, "SortedMerged entries"), numCompressedEntries);
   // Compute merged entries and values
-  Kokkos::parallel_for(range_t(exec, 0, numRows), Impl::GraphMergedEntriesFunctor<rowmap_t, entries_t>(
-                                                      rowmap_orig, entries_orig, rowmap_out, entries_out));
+  Kokkos::parallel_for(
+      "KokkosSparse::Impl::GraphMergedEntriesFunctor", range_t(exec, 0, numRows),
+      Impl::GraphMergedEntriesFunctor<rowmap_t, entries_t>(rowmap_orig, entries_orig, rowmap_out, entries_out));
 }
 
 template <typename exec_space, typename rowmap_t, typename entries_t>
 void sort_and_merge_graph(const typename rowmap_t::const_type& rowmap_in, const entries_t& entries_in,
-                          rowmap_t& rowmap_out, entries_t& entries_out) {
-  return sort_and_merge_graph(exec_space(), rowmap_in, entries_in, rowmap_out, entries_out);
+                          rowmap_t& rowmap_out, entries_t& entries_out,
+                          typename entries_t::const_value_type& numCols =
+                              Kokkos::ArithTraits<typename entries_t::non_const_value_type>::max()) {
+  return sort_and_merge_graph(exec_space(), rowmap_in, entries_in, rowmap_out, entries_out, numCols);
 }
 
 template <typename rowmap_t, typename entries_t>
 void sort_and_merge_graph(const typename rowmap_t::const_type& rowmap_in, const entries_t& entries_in,
-                          rowmap_t& rowmap_out, entries_t& entries_out) {
-  return sort_and_merge_graph(typename entries_t::execution_space(), rowmap_in, entries_in, rowmap_out, entries_out);
+                          rowmap_t& rowmap_out, entries_t& entries_out,
+                          typename entries_t::const_value_type& numCols =
+                              Kokkos::ArithTraits<typename entries_t::non_const_value_type>::max()) {
+  return sort_and_merge_graph(typename entries_t::execution_space(), rowmap_in, entries_in, rowmap_out, entries_out,
+                              numCols);
 }
 
 template <typename crsGraph_t>
-crsGraph_t sort_and_merge_graph(const typename crsGraph_t::execution_space& exec, const crsGraph_t& G) {
+crsGraph_t sort_and_merge_graph(
+    const typename crsGraph_t::execution_space& exec, const crsGraph_t& G,
+    typename crsGraph_t::entries_type::const_value_type& numCols =
+        Kokkos::ArithTraits<typename crsGraph_t::entries_type::non_const_value_type>::max()) {
   using rowmap_t  = typename crsGraph_t::row_map_type::non_const_type;
   using entries_t = typename crsGraph_t::entries_type;
   static_assert(!std::is_const<typename entries_t::value_type>::value,
                 "sort_and_merge_graph requires StaticCrsGraph entries to be non-const.");
   rowmap_t mergedRowmap;
   entries_t mergedEntries;
-  sort_and_merge_graph(exec, G.row_map, G.entries, mergedRowmap, mergedEntries);
+  sort_and_merge_graph(exec, G.row_map, G.entries, mergedRowmap, mergedEntries, numCols);
   return crsGraph_t(mergedEntries, mergedRowmap);
 }
 
 template <typename crsGraph_t>
-crsGraph_t sort_and_merge_graph(const crsGraph_t& G) {
-  return sort_and_merge_graph(typename crsGraph_t::execution_space(), G);
+crsGraph_t sort_and_merge_graph(
+    const crsGraph_t& G, typename crsGraph_t::entries_type::const_value_type& numCols =
+                             Kokkos::ArithTraits<typename crsGraph_t::entries_type::non_const_value_type>::max()) {
+  return sort_and_merge_graph(typename crsGraph_t::execution_space(), G, numCols);
 }
 
 }  // namespace KokkosSparse
-
-namespace KokkosKernels {
-
-// ----------------------------------
-// BSR matrix/graph sorting utilities
-// ----------------------------------
-
-// Sort a BRS matrix: within each row, sort entries ascending by column and
-// permute the values accordingly.
-template <typename execution_space, typename rowmap_t, typename entries_t, typename values_t,
-          typename lno_t = typename entries_t::non_const_value_type>
-[[deprecated]] void sort_bsr_matrix(const lno_t blockdim, const rowmap_t& rowmap, const entries_t& entries,
-                                    const values_t& values) {
-  KokkosSparse::sort_bsr_matrix(blockdim, rowmap, entries, values);
-}
-
-template <typename bsrMat_t>
-[[deprecated]] void sort_bsr_matrix(const bsrMat_t& A) {
-  KokkosSparse::sort_bsr_matrix(A);
-}
-
-// ----------------------------------
-// CRS matrix/graph sorting utilities
-// ----------------------------------
-
-// The sort_crs* functions sort the adjacent column list for each row into
-// ascending order.
-
-template <typename execution_space, typename rowmap_t, typename entries_t, typename values_t>
-[[deprecated]] void sort_crs_matrix(const rowmap_t& rowmap, const entries_t& entries, const values_t& values) {
-  KokkosSparse::sort_crs_matrix<execution_space, rowmap_t, entries_t>(rowmap, entries, values);
-}
-
-template <typename crsMat_t>
-[[deprecated]] void sort_crs_matrix(const crsMat_t& A) {
-  KokkosSparse::sort_crs_matrix(A);
-}
-
-template <typename execution_space, typename rowmap_t, typename entries_t>
-[[deprecated]] void sort_crs_graph(const rowmap_t& rowmap, const entries_t& entries) {
-  KokkosSparse::sort_crs_graph<execution_space, rowmap_t, entries_t>(rowmap, entries);
-}
-
-template <typename crsGraph_t>
-[[deprecated]] void sort_crs_graph(const crsGraph_t& G) {
-  KokkosSparse::sort_crs_graph(G);
-}
-
-// sort_and_merge_matrix produces a new matrix which is equivalent to A but is
-// sorted and has no duplicated entries: each (i, j) is unique. Values for
-// duplicated entries are summed.
-template <typename crsMat_t>
-[[deprecated]] crsMat_t sort_and_merge_matrix(const crsMat_t& A) {
-  KokkosSparse::sort_and_merge_matrix(A);
-}
-
-template <typename crsGraph_t>
-[[deprecated]] crsGraph_t sort_and_merge_graph(const crsGraph_t& G) {
-  KokkosSparse::sort_and_merge_graph(G);
-}
-
-template <typename exec_space, typename rowmap_t, typename entries_t>
-[[deprecated]] void sort_and_merge_graph(const typename rowmap_t::const_type& rowmap_in, const entries_t& entries_in,
-                                         rowmap_t& rowmap_out, entries_t& entries_out) {
-  KokkosSparse::sort_and_merge_graph(rowmap_in, entries_in, rowmap_out, entries_out);
-}
-
-}  // namespace KokkosKernels
 
 #endif  // _KOKKOSSPARSE_SORTCRS_HPP

--- a/packages/kokkos-kernels/sparse/src/KokkosSparse_Utils.hpp
+++ b/packages/kokkos-kernels/sparse/src/KokkosSparse_Utils.hpp
@@ -848,6 +848,19 @@ ordinal_t graph_max_degree(const rowmap_t &rowmap) {
   return val;
 }
 
+template <typename execution_space, typename rowmap_t>
+typename rowmap_t::non_const_value_type graph_max_degree(const execution_space &exec, const rowmap_t &rowmap) {
+  using Offset  = typename rowmap_t::non_const_value_type;
+  using Reducer = Kokkos::Max<Offset>;
+  Offset nrows  = rowmap.extent(0);
+  if (nrows) nrows--;
+  if (nrows == 0) return 0;
+  Offset val;
+  Kokkos::parallel_reduce(Kokkos::RangePolicy<execution_space>(exec, 0, nrows),
+                          MaxDegreeFunctor<Reducer, Offset, rowmap_t>(rowmap), Reducer(val));
+  return val;
+}
+
 template <typename device_t, typename ordinal_t, typename rowmap_t>
 void graph_min_max_degree(const rowmap_t &rowmap, ordinal_t &min_degree, ordinal_t &max_degree) {
   using Reducer   = Kokkos::MinMax<ordinal_t>;


### PR DESCRIPTION
The changes exactly match this KokkosKernels PR (its description has some performance measurements): kokkos/kokkos-kernels/pull/2293. The highlight is that for Sierra TF's abnormal_energy matrix, this improves performance of sort_crs_matrix by 6.3x on V100.

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
sort_crs_matrix being very slow for irregular matrices was directly reported by @vbrunini for Sierra TF. But this will give an uplift for other applications running on GPUs with either very regular, or very irregular matrices (see the KK PR for details).

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
All sort_crs_ functions are tested in KokkosKernels sparse unit tests.
<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
