### PR TITLE
KokkosKernels: patch #2296

### DIFF
--- a/packages/kokkos-kernels/sparse/src/KokkosSparse_spadd_handle.hpp
+++ b/packages/kokkos-kernels/sparse/src/KokkosSparse_spadd_handle.hpp
@@ -102,10 +102,6 @@ class SPADDHandle {
    */
   size_type get_c_nnz() { return this->result_nnz_size; }
 
-  void set_sort_option(int option) { this->sort_option = option; }
-
-  int get_sort_option() { return this->sort_option; }
-
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
   SpaddCusparseData cusparseData;
 #endif


### PR DESCRIPTION
SpAdd handle: delete sort_option getter/setter. Patch of https://github.com/kokkos/kokkos-kernels/pull/2296

SpAdd handle was originally a copy-paste of the spgemm handle way back in #122, and included get_sort_option() and set_sort_option() from spgemm. But these try to use the member bool sort_option, which doesn't exist. Somehow these functions never produced compile errors until someone tried to call them.

Fixes build errors on Sunspot (and probably Aurora as well) on some newer oneapi toolchains.

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Fixes a reference to a member variable that doesn't exist. On most compilers, the functions with the problem don't get compiled at all until they're called. But on some recent Intel oneapi compilers, this causes a build error.

## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Reported by @jczhang07 for PETSc (he was using a KokkosKernels release version, not Trilinos, but the fix should still go into Trilinos).

## Testing
No behavior change; the deleted functions couldn't be called at all without triggering build errors.
