### PR TITLE
Teuchos: pass `value_in` to `tpl::set` by universal ref

### DIFF
--- a/packages/teuchos/parameterlist/src/Teuchos_ParameterList.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_ParameterList.hpp
@@ -251,7 +251,7 @@ public:
   */
   template<typename T>
   ParameterList& set (std::string const& name, 
-		      T const& value, 
+		      T&& value, 
 		      std::string const& docString = "",
 		      RCP<const ParameterEntryValidator> const& validator = null);
 
@@ -921,7 +921,7 @@ ParameterList& ParameterList::setName( const std::string &name_in )
 template<typename T>
 inline
 ParameterList& ParameterList::set(
-  std::string const& name_in, T const& value_in, std::string const& docString_in,
+  std::string const& name_in, T&& value_in, std::string const& docString_in,
   RCP<const ParameterEntryValidator> const& validator_in
   )
 {
@@ -934,7 +934,7 @@ ParameterList& ParameterList::set(
     const RCP<const ParameterEntryValidator> validator =
       (nonnull(validator_in) ? validator_in : param->validator());
      // Create temp param to validate before setting
-    ParameterEntry param_new(value_in, false, false, docString, validator );
+    ParameterEntry param_new(std::forward<T>(value_in), false, false, docString, validator );
     if (nonnull(validator)) {
       validator->validate(param_new, name_in, this->name());
     }
@@ -942,7 +942,7 @@ ParameterList& ParameterList::set(
     *param = param_new;
   }
   else {
-    ParameterEntry param_new(value_in, false, false, docString_in, validator_in);
+    ParameterEntry param_new(std::forward<T>(value_in), false, false, docString_in, validator_in);
     if (nonnull(param_new.validator())) {
       param_new.validator()->validate(param_new, name_in, this->name());
     }

--- a/packages/teuchos/parameterlist/src/Teuchos_ParameterList.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_ParameterList.hpp
@@ -231,7 +231,7 @@ public:
    */
   ParameterList& disableRecursiveAll();
 
-  /*! \brief Set a parameter whose value has type T.
+  /*! \brief Templated set method.
 
     \param name [in] The parameter's name.
     \param value [in] The parameter's value.  This determines the
@@ -250,17 +250,21 @@ public:
     </ul>
   */
   template<typename T>
-  ParameterList& set (std::string const& name, 
-		      const T& value, 
-		      std::string const& docString = "",
-		      RCP<const ParameterEntryValidator> const& validator = null);
+  ParameterList& set (std::string const& name,
+                      T&& value,
+                      std::string const& docString = "",
+                      RCP<const ParameterEntryValidator> const& validator = null);
   
-  //! \overload
-  template<typename T, typename = std::enable_if_t<std::is_same_v<T, std::decay_t<T>>>>
-  ParameterList& set (std::string const& name, 
-		      T&& value, 
-		      std::string const& docString = "",
-		      RCP<const ParameterEntryValidator> const& validator = null);
+  /*! \overload
+    
+    \note This fallback is necessary to support legacy use cases that specify the type
+          of the parameter at the call site, and the type is hence not deduced.  
+  */
+  template<typename T, typename S, typename = std::enable_if_t< ! std::is_same_v<T, S> && std::is_same_v<T, std::decay_t<S>>>>
+  ParameterList& set (std::string const& name,
+                      S&& value,
+                      std::string const& docString = "",
+                      RCP<const ParameterEntryValidator> const& validator = null);
 
   /// \brief Specialization of set() for a parameter which is a <tt>char[]</tt>.
   ///
@@ -928,39 +932,6 @@ ParameterList& ParameterList::setName( const std::string &name_in )
 template<typename T>
 inline
 ParameterList& ParameterList::set(
-  std::string const& name_in, const T& value_in, std::string const& docString_in,
-  RCP<const ParameterEntryValidator> const& validator_in
-  )
-{
-  typedef StringIndexedOrderedValueObjectContainerBase SIOVOCB;
-  const Ordinal param_idx = params_.getObjOrdinalIndex(name_in);
-  if (param_idx != SIOVOCB::getInvalidOrdinal()) {
-    Ptr<ParameterEntry> param = params_.getNonconstObjPtr(param_idx);
-    const std::string docString =
-      (docString_in.length() ? docString_in : param->docString());
-    const RCP<const ParameterEntryValidator> validator =
-      (nonnull(validator_in) ? validator_in : param->validator());
-     // Create temp param to validate before setting
-    ParameterEntry param_new(value_in, false, false, docString, validator );
-    if (nonnull(validator)) {
-      validator->validate(param_new, name_in, this->name());
-    }
-    // Strong guarantee: (if exception is thrown, the value is not changed)
-    *param = param_new;
-  }
-  else {
-    ParameterEntry param_new(value_in, false, false, docString_in, validator_in);
-    if (nonnull(param_new.validator())) {
-      param_new.validator()->validate(param_new, name_in, this->name());
-    }
-    params_.setObj(name_in, param_new);
-  }
-  return *this;
-}
-
-template<typename T, typename>
-inline
-ParameterList& ParameterList::set(
   std::string const& name_in, T&& value_in, std::string const& docString_in,
   RCP<const ParameterEntryValidator> const& validator_in
   )
@@ -974,7 +945,7 @@ ParameterList& ParameterList::set(
     const RCP<const ParameterEntryValidator> validator =
       (nonnull(validator_in) ? validator_in : param->validator());
      // Create temp param to validate before setting
-    ParameterEntry param_new(std::move(value_in), false, false, docString, validator );
+    ParameterEntry param_new(std::forward<T>(value_in), false, false, docString, validator );
     if (nonnull(validator)) {
       validator->validate(param_new, name_in, this->name());
     }
@@ -982,13 +953,23 @@ ParameterList& ParameterList::set(
     *param = param_new;
   }
   else {
-    ParameterEntry param_new(std::move(value_in), false, false, docString_in, validator_in);
+    ParameterEntry param_new(std::forward<T>(value_in), false, false, docString_in, validator_in);
     if (nonnull(param_new.validator())) {
       param_new.validator()->validate(param_new, name_in, this->name());
     }
     params_.setObj(name_in, param_new);
   }
   return *this;
+}
+
+template<typename T, typename S, typename>
+inline
+ParameterList& ParameterList::set(
+  std::string const& name_in, S&& value_in, std::string const& docString_in,
+  RCP<const ParameterEntryValidator> const& validator_in
+  )
+{
+  return set<S>(name_in, std::forward<S>(value_in), docString_in, validator_in);
 }
 
 inline

--- a/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
+++ b/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
@@ -442,6 +442,18 @@ TEUCHOS_UNIT_TEST( ParameterList, set_get_string )
 
 }
 
+TEUCHOS_UNIT_TEST( ParameterList, set_string_move_semantics)
+{
+  ParameterList pl;
+
+  ECHO(std::string my_string{"my text"});
+  ECHO(pl.set("my string", std::move(my_string)));
+
+  // Check that the parameter value was moved by checking that my_string is now empty.
+  TEST_ASSERT(my_string.empty());
+
+  TEST_EQUALITY_CONST(pl.get<std::string>("my string"), "my text");
+}
 
 TEUCHOS_UNIT_TEST( ParameterList, get_nonexisting_param )
 {

--- a/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
+++ b/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
@@ -446,13 +446,38 @@ TEUCHOS_UNIT_TEST( ParameterList, set_string_move_semantics)
 {
   ParameterList pl;
 
-  ECHO(std::string my_string{"my text"});
-  ECHO(pl.set("my string", std::move(my_string)));
+  ECHO(std::string my_str_1{"my text 1"});
+  ECHO(pl.set("my string 1", std::move(my_str_1)));
 
-  // Check that the parameter value was moved by checking that my_string is now empty.
-  TEST_ASSERT(my_string.empty());
+  // Check that the parameter value was moved by checking that my_str_1 is now empty.
+  TEST_ASSERT(my_str_1.empty());
 
-  TEST_EQUALITY_CONST(pl.get<std::string>("my string"), "my text");
+  TEST_EQUALITY_CONST(pl.get<std::string>("my string 1"), "my text 1");
+
+  ECHO(std::string my_str_2{"my text 2"});
+  ECHO(pl.set<std::string>("my string 2", std::move(my_str_2)));
+  TEST_ASSERT(my_str_2.empty());
+  TEST_EQUALITY_CONST(pl.get<std::string>("my string 2"), "my text 2");
+  
+  ECHO(std::string my_str_3{"my text 3"});
+  ECHO(pl.set("my string 3", my_str_3));
+  TEST_ASSERT( ! my_str_3.empty());
+  TEST_EQUALITY_CONST(pl.get<std::string>("my string 3"), "my text 3");
+
+  ECHO(std::string my_str_4{"my text 4"});
+  ECHO(pl.set<std::string>("my string 4", my_str_4));
+  TEST_ASSERT( ! my_str_4.empty());
+  TEST_EQUALITY_CONST(pl.get<std::string>("my string 4"), "my text 4");
+
+  ECHO(const std::string my_str_5{"my text 5"});
+  ECHO(pl.set("my string 5", my_str_5));
+  TEST_ASSERT( ! my_str_5.empty());
+  TEST_EQUALITY_CONST(pl.get<std::string>("my string 5"), "my text 5");
+
+  ECHO(const std::string my_str_6{"my text 6"});
+  ECHO(pl.set<std::string>("my string 6", my_str_6));
+  TEST_ASSERT( ! my_str_6.empty());
+  TEST_EQUALITY_CONST(pl.get<std::string>("my string 6"), "my text 6");
 }
 
 TEUCHOS_UNIT_TEST( ParameterList, get_nonexisting_param )

--- a/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
+++ b/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
@@ -453,31 +453,35 @@ TEUCHOS_UNIT_TEST( ParameterList, set_string_move_semantics)
   TEST_ASSERT(my_str_1.empty());
 
   TEST_EQUALITY_CONST(pl.get<std::string>("my string 1"), "my text 1");
+}
 
+TEUCHOS_UNIT_TEST( ParameterList, set_string_specified_template_argument)
+{
+  // Check the templated set method and its overload when the template argument is specified.
+
+   ParameterList pl;
+
+  // The parameter value can be passed by rvalue reference.
+  // The main templated set method is called, and the parameter value is moved.
   ECHO(std::string my_str_2{"my text 2"});
   ECHO(pl.set<std::string>("my string 2", std::move(my_str_2)));
   TEST_ASSERT(my_str_2.empty());
   TEST_EQUALITY_CONST(pl.get<std::string>("my string 2"), "my text 2");
   
+  // The parameter value cannot be passed by rvalue reference.
+  // The overload of the templated set method is called, and the parameter value is not moved.
   ECHO(std::string my_str_3{"my text 3"});
-  ECHO(pl.set("my string 3", my_str_3));
+  ECHO(pl.set<std::string>("my string 3", my_str_3));
   TEST_ASSERT( ! my_str_3.empty());
   TEST_EQUALITY_CONST(pl.get<std::string>("my string 3"), "my text 3");
 
-  ECHO(std::string my_str_4{"my text 4"});
+  ECHO(const std::string my_str_4{"my text 4"});
   ECHO(pl.set<std::string>("my string 4", my_str_4));
   TEST_ASSERT( ! my_str_4.empty());
   TEST_EQUALITY_CONST(pl.get<std::string>("my string 4"), "my text 4");
 
-  ECHO(const std::string my_str_5{"my text 5"});
-  ECHO(pl.set("my string 5", my_str_5));
-  TEST_ASSERT( ! my_str_5.empty());
+  ECHO(pl.set<std::string>("my string 5", "my text 5"));
   TEST_EQUALITY_CONST(pl.get<std::string>("my string 5"), "my text 5");
-
-  ECHO(const std::string my_str_6{"my text 6"});
-  ECHO(pl.set<std::string>("my string 6", my_str_6));
-  TEST_ASSERT( ! my_str_6.empty());
-  TEST_EQUALITY_CONST(pl.get<std::string>("my string 6"), "my text 6");
 }
 
 TEUCHOS_UNIT_TEST( ParameterList, get_nonexisting_param )


### PR DESCRIPTION
@trilinos/teuchos
@bartlettroscoe 
@romintomasetti 

This PR is a minor change to how a parameter's value is passed to `ParameterList::set`.

Currently, the parameter value is passed by const ref. This PR changes this to passing by universal ref.

The intent of this change is to allow move semantics along the chain of calls that is made when setting a parameter.

This change is consistent with a similar change made to `ParameterEntry`'s constructor a while ago in:
- https://github.com/trilinos/Trilinos/commit/68a1cd7e39c247553a7e111dcd2507fa4270f51d
