### PR TITLE
Piro: update perfanalysis for transient analysis and modify `ThyraProductME_TempusFinalObjective` to override member functions

### DIFF
--- a/packages/piro/src/Piro_PerformAnalysis.cpp
+++ b/packages/piro/src/Piro_PerformAnalysis.cpp
@@ -917,7 +917,7 @@ Piro::PerformROLTransientAnalysis(
 
   if(useTempusDriver) {
 
-    Piro::ThyraProductME_TempusFinalObjective<double> tempus_obj(model, forward_integrator, adjoint_integrator, adjointModel, g_index, piroParams, nt, analysisVerbosityLevel, observer);
+    Piro::ThyraProductME_TempusFinalObjective<double> tempus_obj(model, piroTempusSolver, forward_integrator, adjoint_integrator, adjointModel, g_index, piroParams, nt, analysisVerbosityLevel, observer);
 
     ROL::Ptr<ROL::Objective<double> > obj_ptr = ROL::makePtrFromRef(tempus_obj);
 

--- a/packages/piro/src/Piro_TempusIntegrator.hpp
+++ b/packages/piro/src/Piro_TempusIntegrator.hpp
@@ -60,6 +60,8 @@ public:
 
   void setObserver(Teuchos::RCP<Tempus::IntegratorObserver<Scalar>> obs = Teuchos::null);
 
+  void clearSolutionHistory();
+
   void initialize();
 
   void initializeSolutionHistory(Scalar t0,

--- a/packages/piro/src/Piro_TempusIntegrator_Def.hpp
+++ b/packages/piro/src/Piro_TempusIntegrator_Def.hpp
@@ -241,6 +241,21 @@ Piro::TempusIntegrator<Scalar>::setObserver(Teuchos::RCP<Tempus::IntegratorObser
 
 template <typename Scalar>
 void
+Piro::TempusIntegrator<Scalar>::clearSolutionHistory()
+{
+  if (basicIntegrator_ != Teuchos::null) {
+    basicIntegrator_->getNonConstSolutionHistory()->clear();
+  }
+  if (fwdSensIntegrator_ != Teuchos::null) {
+    fwdSensIntegrator_->getNonConstSolutionHistory()->clear();
+  }
+  if (adjSensIntegrator_ != Teuchos::null) {
+    adjSensIntegrator_->getNonConstSolutionHistory()->clear();
+  }
+}
+
+template <typename Scalar>
+void
 Piro::TempusIntegrator<Scalar>::initialize()
 {
   if (basicIntegrator_ != Teuchos::null) {

--- a/packages/piro/src/Piro_TempusSolver.hpp
+++ b/packages/piro/src/Piro_TempusSolver.hpp
@@ -132,6 +132,9 @@ public:
   Teuchos::RCP<const Piro::TempusIntegrator<Scalar>> 
   getPiroTempusIntegrator() const {return piroTempusIntegrator_;} 
 
+  Teuchos::RCP<Piro::TempusIntegrator<Scalar>> 
+  getNonconstPiroTempusIntegrator() const {return piroTempusIntegrator_;} 
+
   Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >
   getSubModel() {return model_;}
   Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >
@@ -148,7 +151,9 @@ private:
   //@}
 
   /** \brief . */
-  Teuchos::RCP<const Teuchos::ParameterList> getValidTempusParameters() const;
+  Teuchos::RCP<const Teuchos::ParameterList> getValidTempusParameters(
+    const std::string integratorName = "Tempus Integrator", 
+    const std::string stepperName = "Tempus Stepper") const;
 
   Teuchos::RCP<Piro::TempusIntegrator<Scalar>> piroTempusIntegrator_; 
   Teuchos::RCP<Tempus::Stepper<Scalar> > fwdStateStepper_;

--- a/packages/piro/src/Piro_ThyraProductME_Tempus_FinalObjective.hpp
+++ b/packages/piro/src/Piro_ThyraProductME_Tempus_FinalObjective.hpp
@@ -30,6 +30,8 @@
 #include "ROL_Vector.hpp"
 #include "ROL_ThyraVector.hpp"
 
+#include "Piro_TempusIntegrator.hpp"
+
 namespace Piro {
 
 template <typename Real>
@@ -38,6 +40,7 @@ public:
 
   ThyraProductME_TempusFinalObjective(
     const Teuchos::RCP<Thyra::ModelEvaluator<Real>> & model,
+    const Teuchos::RCP<Piro::TempusSolver<Real>> & piroTempusSolver,
     const Teuchos::RCP<Tempus::Integrator<Real> >& integrator,
     const Teuchos::RCP<Tempus::Integrator<Real>> & adjoint_integrator,
     const Teuchos::RCP<Thyra::ModelEvaluator<Real>> & modelAdjoin,
@@ -50,9 +53,9 @@ public:
   virtual ~ThyraProductME_TempusFinalObjective() {}
 
   //! Compute value of objective
-  Real value( const ROL::Vector<Real> &p, Real &tol );
+  Real value( const ROL::Vector<Real> &p, Real &tol ) override;
 
-  void gradient( ROL::Vector<Real> &grad, const ROL::Vector<Real> &p, Real &tol ) const;
+  void gradient( ROL::Vector<Real> &grad, const ROL::Vector<Real> &p, Real &tol ) override;
 
   //! Helper function to run tempus, computing responses and derivatives
   void run_tempus(ROL::Vector<Real>& r, const ROL::Vector<Real>& p) const;
@@ -87,6 +90,7 @@ private:
   const Teuchos::RCP<Tempus::Integrator<Real> > integrator_;
   const Teuchos::RCP<Thyra::ModelEvaluator<Real>> thyra_model_;
   const Teuchos::RCP<Thyra::ModelEvaluator<Real>> thyra_adjoint_model_;
+  Teuchos::RCP<Piro::TempusIntegrator<Real>> piroTempusIntegrator_;
   std::string sensitivity_method_;
   const int g_index_;
   int Nt_;
@@ -108,6 +112,7 @@ template <typename Real>
 ThyraProductME_TempusFinalObjective<Real>::
 ThyraProductME_TempusFinalObjective(
   const Teuchos::RCP<Thyra::ModelEvaluator<Real>> & model,
+  const Teuchos::RCP<Piro::TempusSolver<Real>> & piroTempusSolver,
   const Teuchos::RCP<Tempus::Integrator<Real> >& integrator,
   const Teuchos::RCP<Tempus::Integrator<Real>> & adjoint_integrator,
   const Teuchos::RCP<Thyra::ModelEvaluator<Real>> & modelAdjoin,
@@ -119,6 +124,7 @@ ThyraProductME_TempusFinalObjective(
   integrator_(integrator),
   thyra_model_(model),
   thyra_adjoint_model_(modelAdjoin),
+  piroTempusIntegrator_(piroTempusSolver->getNonconstPiroTempusIntegrator()),
   sensitivity_method_("Adjoint"),
   g_index_(g_index),
   Nt_(Nt),
@@ -160,7 +166,7 @@ value( const ROL::Vector<Real> &p, Real &tol )
 template <typename Real>
 void
 ThyraProductME_TempusFinalObjective<Real>::
-gradient( ROL::Vector<Real> &grad, const ROL::Vector<Real> &p, Real &tol ) const
+gradient( ROL::Vector<Real> &grad, const ROL::Vector<Real> &p, Real &tol )
 {
   *out_ << "Piro::ThyraProductME_TempusFinalObjective::gradient" << std::endl;
 
@@ -260,30 +266,85 @@ run_tempus(const Thyra::ModelEvaluatorBase::InArgs<Real>&  inArgs,
   RCP<const Thyra::VectorBase<Real> > x, x_dot;
   RCP<const Thyra::MultiVectorBase<double> > dxdp, dxdotdp;
   RCP<Thyra::VectorBase<Real> > g = outArgs.get_g(g_index_);
+  const bool compute_dgdp = !outArgs.get_DgDp(g_index_, 0).isEmpty();
+
+
+  RCP<Thyra::MultiVectorBase<Real> > dgdp_mv =
+    outArgs.get_DgDp(g_index_, 0).getMultiVector();
+  MEB::EDerivativeMultiVectorOrientation dgdp_orientation =
+    outArgs.get_DgDp(g_index_, 0).getMultiVectorOrientation();
+  Teko::BlockedLinearOp dgdp_op =
+    Teuchos::rcp_dynamic_cast<Thyra::PhysicallyBlockedLinearOpBase<Real>>(outArgs.get_DgDp(g_index_, 0).getLinearOp());
+
+  piroTempusIntegrator_->clearSolutionHistory();
 
   // Create and run integrator
-  SENS_METHOD sens_method = Piro::NONE; 
-  Teuchos::RCP<Piro::TempusIntegrator<Real> > integrator 
-    = Teuchos::rcp(new Piro::TempusIntegrator<Real>(tempus_params_, wrapped_model, sens_method));
-  const bool integratorStatus = integrator->advanceTime(time_final_);
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    !integratorStatus, std::logic_error, "Integrator failed!");
+  if (compute_dgdp && sensitivity_method_ == "Adjoint") {
+    const bool integratorStatus = piroTempusIntegrator_->advanceTime(time_final_);
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      !integratorStatus, std::logic_error, "Integrator failed!");
 
-  // Get final state
-  t = integrator->getTime();
-  x = integrator->getX();
-  x_dot = integrator->getXDot();
+    // Get final state
+    t = piroTempusIntegrator_->getTime();
+    x = piroTempusIntegrator_->getX();
+    x_dot = piroTempusIntegrator_->getXDot();
+    if(!dgdp_mv.is_null())
+      Thyra::assign(dgdp_mv.ptr(), *(piroTempusIntegrator_->getDgDp()));
+    else {
+      //dgdp_op->setBlock(0, 0, piroTempusIntegrator->getDgDp());
+      dgdp_mv = Teuchos::rcp_dynamic_cast<Thyra::MultiVectorBase<Real>>( Teuchos::rcp_dynamic_cast<Thyra::DefaultScaledAdjointLinearOp<Real>>(dgdp_op->getNonconstBlock(0, 0))->getNonconstOp() );
+      Thyra::assign(dgdp_mv.ptr(), *(piroTempusIntegrator_->getDgDp()));
+    }
+  }
+  else {
+    RCP<Tempus::IntegratorBasic<Real> > integrator =
+      Tempus::createIntegratorBasic<Real>(tempus_params_, wrapped_model);
+    const bool integratorStatus = integrator->advanceTime();
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      !integratorStatus, std::logic_error, "Integrator failed!");
 
+    // Get final state
+    t = integrator->getTime();
+    x = integrator->getX();
+    x_dot = integrator->getXDot();
+  }
 
   // Evaluate response at final state
+  const int num_g = thyra_model_->get_g_space(g_index_)->dim();
   MEB::InArgs<Real> modelInArgs   = inArgs;
   MEB::OutArgs<Real> modelOutArgs = outArgs;
   modelInArgs.set_x(x);
   if (modelInArgs.supports(MEB::IN_ARG_x_dot)) modelInArgs.set_x_dot(x_dot);
   if (modelInArgs.supports(MEB::IN_ARG_t)) modelInArgs.set_t(t);
   RCP<Thyra::MultiVectorBase<Real> > dgdx, dgdxdot;
+  MEB::EDerivativeMultiVectorOrientation dgdx_orientation =
+    MEB::DERIV_MV_JACOBIAN_FORM;
+  MEB::EDerivativeMultiVectorOrientation dgdxdot_orientation =
+    MEB::DERIV_MV_JACOBIAN_FORM;
+  if (compute_dgdp && sensitivity_method_ == "Adjoint") {
+    // Clear dg/dp as an out arg since it was already computed by the adjoint
+    // integrator
+    modelOutArgs.set_DgDp(g_index_, 0,
+                          MEB::Derivative<Real>());
+  }
 
   thyra_model_->evalModel(modelInArgs, modelOutArgs);
+
+  // dg/dp = dg/dp + dg/dx*dx/dp + dg/dx_dot*dx_dot/dp
+  // We assume dg/dx, dg/dxdot are in gradient form while dxdp, dxdotdp are in
+  // Jacobian form
+  if (compute_dgdp && dgdx != Teuchos::null) {
+    if (dgdp_orientation == MEB::DERIV_MV_JACOBIAN_FORM)
+      dgdx->apply(Thyra::TRANS, *dxdp, dgdp_mv.ptr(), Real(1.0), Real(1.0));
+    else
+      dxdp->apply(Thyra::TRANS, *dgdx, dgdp_mv.ptr(), Real(1.0), Real(1.0));
+  }
+  if (compute_dgdp && dgdxdot != Teuchos::null) {
+    if (dgdp_orientation == MEB::DERIV_MV_JACOBIAN_FORM)
+      dgdxdot->apply(Thyra::TRANS, *dxdotdp, dgdp_mv.ptr(), Real(1.0), Real(1.0));
+    else
+      dxdotdp->apply(Thyra::TRANS, *dgdxdot, dgdp_mv.ptr(), Real(1.0), Real(1.0));
+  }
 }
 
 

--- a/packages/piro/src/Piro_ThyraProductME_Tempus_FinalObjective.hpp
+++ b/packages/piro/src/Piro_ThyraProductME_Tempus_FinalObjective.hpp
@@ -310,17 +310,12 @@ run_tempus(const Thyra::ModelEvaluatorBase::InArgs<Real>&  inArgs,
   }
 
   // Evaluate response at final state
-  const int num_g = thyra_model_->get_g_space(g_index_)->dim();
   MEB::InArgs<Real> modelInArgs   = inArgs;
   MEB::OutArgs<Real> modelOutArgs = outArgs;
   modelInArgs.set_x(x);
   if (modelInArgs.supports(MEB::IN_ARG_x_dot)) modelInArgs.set_x_dot(x_dot);
   if (modelInArgs.supports(MEB::IN_ARG_t)) modelInArgs.set_t(t);
   RCP<Thyra::MultiVectorBase<Real> > dgdx, dgdxdot;
-  MEB::EDerivativeMultiVectorOrientation dgdx_orientation =
-    MEB::DERIV_MV_JACOBIAN_FORM;
-  MEB::EDerivativeMultiVectorOrientation dgdxdot_orientation =
-    MEB::DERIV_MV_JACOBIAN_FORM;
   if (compute_dgdp && sensitivity_method_ == "Adjoint") {
     // Clear dg/dp as an out arg since it was already computed by the adjoint
     // integrator

--- a/packages/piro/test/Main_AnalysisDriver_Tempus.cpp
+++ b/packages/piro/test/Main_AnalysisDriver_Tempus.cpp
@@ -46,47 +46,11 @@
 #endif
 
 const Teuchos::RCP<Piro::TempusSolver<double> > solverNew(
+    const Teuchos::RCP<Teuchos::ParameterList>  piroParams,
     const Teuchos::RCP<Thyra::ModelEvaluatorDefaultBase<double> > &thyraModel,
-    const Teuchos::RCP<Thyra::ModelEvaluatorDefaultBase<double> > &thyraAdjointModel,
-    double finalTime, 
-    const std::string sens_method_string)
+    const Teuchos::RCP<Thyra::ModelEvaluatorDefaultBase<double> > &thyraAdjointModel)
 {
-  Teuchos::RCP<Teuchos::ParameterList> analysisPL =
-    Teuchos::rcp(new Teuchos::ParameterList("Analysis"));
-  auto tempusPL = analysisPL->sublist("Tempus");
-  analysisPL->sublist("Tempus").sublist("Tempus", false, "");
-  /*
-  analysisPL->sublist("Tempus").sublist("Albany Time Step Control Options", false, "");
-  analysisPL->sublist("Tempus").sublist("Albany Time Step Control Options", false, "").set<double>("Initial Time", 0.0, "");
-  analysisPL->sublist("Tempus").sublist("Albany Time Step Control Options", false, "").set<double>("Initial Time Step", 0.1, "");
-  analysisPL->sublist("Tempus").sublist("Albany Time Step Control Options", false, "").set<double>("Minimum Time Step", 0.1, "");
-  analysisPL->sublist("Tempus").sublist("Albany Time Step Control Options", false, "").set<double>("Maximum Time Step", 0.1, "");
-  analysisPL->sublist("Tempus").sublist("Albany Time Step Control Options", false, "").set<double>("Final Time", 1.0, "");
-  analysisPL->sublist("Tempus").sublist("Albany Time Step Control Options", false, "").set<double>("Reduction Factor", 1.0, "");
-  analysisPL->sublist("Tempus").sublist("Albany Time Step Control Options", false, "").set<double>("Amplification Factor", 1.0, "");
-  */
-  analysisPL->sublist("Tempus").sublist("Stratimikos", false, "");
-  analysisPL->sublist("Tempus").sublist("NonLinear Solver", false, "");
-  //analysisPL->sublist("Tempus").set<std::string>("Verbosity Level", "", "");
-  analysisPL->sublist("Tempus").set<bool>("Lump Mass Matrix", false, "Boolean to tell code whether to lump mass matrix");
-  analysisPL->sublist("Tempus").set<bool>("Invert Mass Matrix", true, "Boolean to tell code whether or not to invert mass matrix");
-  analysisPL->sublist("Tempus").set<bool>("Constant Mass Matrix", false, "Boolean to tell code if mass matrix is constant in time");
-  analysisPL->sublist("Tempus").set<bool>("Abort on Failure", true, "");
-  analysisPL->sublist("Tempus").set("Integrator Name", "Tempus Integrator");
-  analysisPL->sublist("Tempus").sublist("Tempus Integrator").set("Integrator Type", "Integrator Basic");
-  analysisPL->sublist("Tempus").sublist("Tempus Integrator").set("Stepper Name", "Tempus Stepper");
-  analysisPL->sublist("Tempus").sublist("Tempus Integrator").sublist("Solution History").set("Storage Type", "Unlimited");
-  analysisPL->sublist("Tempus").sublist("Tempus Integrator").sublist("Solution History").set("Storage Limit", 20);
-  analysisPL->sublist("Tempus").sublist("Tempus Integrator").sublist("Time Step Control").set("Initial Time", 0.0);
-  analysisPL->sublist("Tempus").sublist("Tempus Integrator").sublist("Time Step Control").set("Final Time", finalTime);
-  analysisPL->sublist("Tempus").sublist("Tempus Stepper").set("Stepper Type", "Backward Euler");
-  analysisPL->sublist("Tempus").sublist("Tempus Stepper").set("Zero Initial Guess", false);
-  analysisPL->sublist("Tempus").sublist("Tempus Stepper").set("Solver Name", "Demo Solver");
-  analysisPL->sublist("Tempus").sublist("Tempus Stepper").sublist("Demo Solver").sublist("NOX").sublist("Direction").set("Method","Newton");
-  analysisPL->sublist("Tempus").sublist("Sensitivities", false, "");
-  analysisPL->set("Sensitivity Method", "Adjoint");
-
-  return Teuchos::rcp(new Piro::TempusSolver<double>(analysisPL, thyraModel, thyraAdjointModel));
+  return Teuchos::rcp(new Piro::TempusSolver<double>(piroParams, thyraModel, thyraAdjointModel));
 }
 
 
@@ -251,7 +215,11 @@ int main(int argc, char *argv[]) {
         if(Teuchos::nonnull(adjointModel))
           adjointModelWithSolve= rcp(new Thyra::DefaultModelEvaluatorWithSolveFactory<double>(adjointModel, lowsFactory));
 
-        const RCP<Thyra::ModelEvaluatorDefaultBase<double>> piro = solverNew(Teuchos::rcp_dynamic_cast<Thyra::ModelEvaluatorDefaultBase<double>>(modelWithSolve), Teuchos::rcp_dynamic_cast<Thyra::ModelEvaluatorDefaultBase<double>>(adjointModelWithSolve), 10., "Adjoint");
+        const RCP<Thyra::ModelEvaluatorDefaultBase<double>> piro = 
+          solverNew(
+            piroParams,
+            Teuchos::rcp_dynamic_cast<Thyra::ModelEvaluatorDefaultBase<double>>(modelWithSolve), 
+            Teuchos::rcp_dynamic_cast<Thyra::ModelEvaluatorDefaultBase<double>>(adjointModelWithSolve));
 
         // Call the analysis routine
         RCP<Thyra::VectorBase<double>> p;
@@ -260,6 +228,7 @@ int main(int argc, char *argv[]) {
         if (Teuchos::nonnull(p)) { //p might be null if the package ROL is not enabled
           Thyra::DetachedVectorView<double> p_view(p);
           double p_exact[2];
+          double tol = 1e-5;
           if (mockModel=="MockModelEval_A_Tpetra") {
             p_exact[0] = 1;
             p_exact[1] = 3;
@@ -275,8 +244,8 @@ int main(int argc, char *argv[]) {
           if (mockModel=="MassSpringDamperModel") {
             p_exact[0] = 1.;
             p_exact[1] = 0.5;
+            tol = 1e-3;
           }
-          double tol = 1e-5;
 
           double l2_diff = std::sqrt(std::pow(p_view(0)-p_exact[0],2) + std::pow(p_view(1)-p_exact[1],2));
           if(l2_diff > tol) {

--- a/packages/piro/test/_input_Analysis_ROL_ReducedSpace_Transient.xml
+++ b/packages/piro/test/_input_Analysis_ROL_ReducedSpace_Transient.xml
@@ -3,6 +3,12 @@
     <Parameter name="Sensitivity Method" type="string" value="Adjoint" />
     <Parameter name="Explicit Adjoint Model Evaluator" type="bool" value="true" />
     <ParameterList name="Tempus">
+      <ParameterList name="Stratimikos">
+      </ParameterList>
+      <ParameterList name="NonLinear Solver">
+      </ParameterList>
+      <ParameterList name="Sensitivities">
+      </ParameterList>
       <Parameter name="Integrator Name" type="string" value="Demo Integrator" />
       <ParameterList name="Demo Integrator">
         <Parameter name="Integrator Type" type="string" value="Integrator Basic" />

--- a/packages/piro/test/_input_Analysis_ROL_ReducedSpace_Transient_2_parameters.xml
+++ b/packages/piro/test/_input_Analysis_ROL_ReducedSpace_Transient_2_parameters.xml
@@ -3,6 +3,12 @@
     <Parameter name="Sensitivity Method" type="string" value="Adjoint" />
     <Parameter name="Explicit Adjoint Model Evaluator" type="bool" value="true" />
     <ParameterList name="Tempus">
+      <ParameterList name="Stratimikos">
+      </ParameterList>
+      <ParameterList name="NonLinear Solver">
+      </ParameterList>
+      <ParameterList name="Sensitivities">
+      </ParameterList>
       <Parameter name="Integrator Name" type="string" value="Demo Integrator" />
       <ParameterList name="Demo Integrator">
         <Parameter name="Integrator Type" type="string" value="Integrator Basic" />

--- a/packages/piro/test/_input_Analysis_ROL_ReducedSpace_Transient_Integrated_Response_MSD.xml
+++ b/packages/piro/test/_input_Analysis_ROL_ReducedSpace_Transient_Integrated_Response_MSD.xml
@@ -6,6 +6,12 @@
     <Parameter name="Sensitivity Method" type="string" value="Adjoint" />
     <Parameter name="Explicit Adjoint Model Evaluator" type="bool" value="true" />
     <ParameterList name="Tempus">
+      <ParameterList name="Stratimikos">
+      </ParameterList>
+      <ParameterList name="NonLinear Solver">
+      </ParameterList>
+      <ParameterList name="Sensitivities">
+      </ParameterList>
       <Parameter name="Integrator Name" type="string" value="Demo Integrator" />
       <ParameterList name="Demo Integrator">
         <Parameter name="Integrator Type" type="string" value="Integrator Basic" />

--- a/packages/piro/test/_input_Analysis_ROL_ReducedSpace_Transient_MSD.xml
+++ b/packages/piro/test/_input_Analysis_ROL_ReducedSpace_Transient_MSD.xml
@@ -6,6 +6,12 @@
     <Parameter name="Sensitivity Method" type="string" value="Adjoint" />
     <Parameter name="Explicit Adjoint Model Evaluator" type="bool" value="true" />
     <ParameterList name="Tempus">
+      <ParameterList name="Stratimikos">
+      </ParameterList>
+      <ParameterList name="NonLinear Solver">
+      </ParameterList>
+      <ParameterList name="Sensitivities">
+      </ParameterList>
       <Parameter name="Integrator Name" type="string" value="Demo Integrator" />
       <ParameterList name="Demo Integrator">
         <Parameter name="Integrator Type" type="string" value="Integrator Basic" />

--- a/packages/piro/test/_input_Analysis_ROL_Tempus_Transient_MSD.xml
+++ b/packages/piro/test/_input_Analysis_ROL_Tempus_Transient_MSD.xml
@@ -3,6 +3,16 @@
     <Parameter name="Sensitivity Method" type="string" value="Adjoint" />
     <Parameter name="Explicit Adjoint Model Evaluator" type="bool" value="true" />
     <ParameterList name="Tempus">
+      <ParameterList name="Stratimikos">
+      </ParameterList>
+      <ParameterList name="NonLinear Solver">
+      </ParameterList>
+      <ParameterList name="Sensitivities">
+      </ParameterList>
+      <Parameter name="Lump Mass Matrix" type="bool" value="false" />
+      <Parameter name="Invert Mass Matrix" type="bool" value="true" />
+      <Parameter name="Constant Mass Matrix" type="bool" value="false" />
+      <Parameter name="Abort on Failure" type="bool" value="true" />
       <Parameter name="Integrator Name" type="string" value="Demo Integrator" />
       <ParameterList name="Demo Integrator">
         <Parameter name="Integrator Type" type="string" value="Integrator Basic" />
@@ -18,7 +28,7 @@
         </ParameterList>
       </ParameterList>
       <ParameterList name="Demo Stepper">
-        <Parameter name="Stepper Type" type="string" value="RK Crank-Nicolson" />
+        <Parameter name="Stepper Type" type="string" value="Backward Euler" />
         <Parameter name="Zero Initial Guess" type="bool" value="false" />
         <Parameter name="Solver Name" type="string" value="Demo Solver" />
         <ParameterList name="Demo Solver">
@@ -178,6 +188,7 @@
       <Parameter name="Output Level" type="int" value="3" />
       <Parameter name="Analysis Package" type="string" value="ROL" />
       <ParameterList name="ROL">
+        <Parameter name="Redirect Tempus Output" type="bool" value="true" />
         <Parameter name="Response Vector Index" type="int" value="0" />
         <Parameter name="Parameter Vector Index 0" type="int" value="0" />
         <Parameter name="Response Depends Only On Final Time" type="bool" value="true" />


### PR DESCRIPTION
Previously `ThyraProductME_TempusFinalObjective` did not override virtual member functions of `ROL::Objective`.

This PR changes that and fixes the evaluation of the objective function and gradient for `ThyraProductME_TempusFinalObjective`.

The PR adds as well couple of improvements to perfanalysis for transient problems to check gradients either after or before the optimization.

For the Tempus driven problem, I checked the accuracy of the gradient before optimization using the ROL `checkGradient` function which looked good.