### PR TITLE
Intrepid2: Explicitly cast pt0 + pt1 - 1 term in intrepid2 to ScalarType

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellDataDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellDataDef.hpp
@@ -840,7 +840,7 @@ refCenterDataStatic_ = {
   bool
   PointInclusion<shards::Triangle<>::key>::
   check(const PointViewType &point, const ScalarType threshold) {
-    const ScalarType distance = max( max( -point(0), -point(1) ), point(0) + point(1) - 1.0 );
+    const ScalarType distance = max( max( -point(0), -point(1) ), ScalarType( point(0) + point(1) - 1.0 ) );
     return distance < threshold;
   }
   


### PR DESCRIPTION
Fix changes in #13394 that introduced an issue with deducing the type when using float instead of double as `ScalarType`. 