### PR TITLE
Framework: Fix AT2 update column

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -71,7 +71,6 @@ jobs:
           export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/packages/framework/GenConfig
           export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/packages/framework/pr_tools
 
-          sed -i "/\[rhel8\]/a `cat /etc/hostname`" /home/runner/_work/Trilinos/Trilinos/packages/framework/ini-files/supported-systems.ini
           printf "\n\n\n"
 
           echo "image: ${AT2_IMAGE:-unknown}"
@@ -149,7 +148,6 @@ jobs:
           export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/packages/framework/GenConfig
           export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/packages/framework/pr_tools
 
-          sed -i "/\[rhel8\]/a `cat /etc/hostname`" /home/runner/_work/Trilinos/Trilinos/packages/framework/ini-files/supported-systems.ini
           printf "\n\n\n"
 
           echo "image: ${AT2_IMAGE:-unknown}"
@@ -226,7 +224,6 @@ jobs:
           export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/packages/framework/GenConfig
           export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/packages/framework/pr_tools
 
-          sed -i "/\[rhel8\]/a `cat /etc/hostname`" /home/runner/_work/Trilinos/Trilinos/packages/framework/ini-files/supported-systems.ini
           printf "\n\n\n"
 
           echo "image: ${AT2_IMAGE:-unknown}"

--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -79,7 +79,6 @@ jobs:
             --target-branch-name ${{ github.event.pull_request.base.ref }} \
             --genconfig-build-name rhel8_gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables \
             --pullrequest-number ${{ github.event.pull_request.number }} \
-            --jenkins-job-number 0 \
             --pullrequest-env-config-file ${GITHUB_WORKSPACE}/packages/framework/pr_tools/trilinos_pr.ini \
             --pullrequest-gen-config-file ${GITHUB_WORKSPACE}/packages/framework/GenConfig/src/gen-config.ini \
             --workspace-dir /home/runner/_work/Trilinos \
@@ -153,7 +152,6 @@ jobs:
             --target-branch-name ${{ github.event.pull_request.base.ref }} \
             --genconfig-build-name rhel8_gcc-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables \
             --pullrequest-number ${{ github.event.pull_request.number }} \
-            --jenkins-job-number 0 \
             --pullrequest-env-config-file ${GITHUB_WORKSPACE}/packages/framework/pr_tools/trilinos_pr.ini \
             --pullrequest-gen-config-file ${GITHUB_WORKSPACE}/packages/framework/GenConfig/src/gen-config.ini \
             --workspace-dir /home/runner/_work/Trilinos \
@@ -226,7 +224,6 @@ jobs:
             --target-branch-name ${{ github.event.pull_request.base.ref }} \
             --genconfig-build-name rhel8_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables \
             --pullrequest-number ${{ github.event.pull_request.number }} \
-            --jenkins-job-number 0 \
             --pullrequest-env-config-file ${GITHUB_WORKSPACE}/packages/framework/pr_tools/trilinos_pr.ini \
             --pullrequest-gen-config-file ${GITHUB_WORKSPACE}/packages/framework/GenConfig/src/gen-config.ini \
             --workspace-dir /home/runner/_work/Trilinos \

--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -76,10 +76,7 @@ jobs:
           echo "image: ${AT2_IMAGE:-unknown}"
 
           python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
-            --source-repo-url ${GITHUB_WORKSPACE} \
-            --target-repo-url ${GITHUB_WORKSPACE} \
             --target-branch-name ${{ github.event.pull_request.base.ref }} \
-            --pullrequest-build-name PR-${{ github.event.pull_request.number }} \
             --genconfig-build-name rhel8_gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables \
             --pullrequest-number ${{ github.event.pull_request.number }} \
             --jenkins-job-number 0 \
@@ -153,10 +150,7 @@ jobs:
           echo "image: ${AT2_IMAGE:-unknown}"
 
           python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
-            --source-repo-url ${GITHUB_WORKSPACE} \
-            --target-repo-url ${GITHUB_WORKSPACE} \
             --target-branch-name ${{ github.event.pull_request.base.ref }} \
-            --pullrequest-build-name PR-${{ github.event.pull_request.number }} \
             --genconfig-build-name rhel8_gcc-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables \
             --pullrequest-number ${{ github.event.pull_request.number }} \
             --jenkins-job-number 0 \
@@ -229,10 +223,7 @@ jobs:
           echo "image: ${AT2_IMAGE:-unknown}"
           type python
           python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
-            --source-repo-url ${GITHUB_WORKSPACE} \
-            --target-repo-url ${GITHUB_WORKSPACE} \
             --target-branch-name ${{ github.event.pull_request.base.ref }} \
-            --pullrequest-build-name PR-${{ github.event.pull_request.number }} \
             --genconfig-build-name rhel8_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables \
             --pullrequest-number ${{ github.event.pull_request.number }} \
             --jenkins-job-number 0 \

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -856,6 +856,7 @@ opt-set-cmake-var Xpetra_ENABLE_DEPRECATED_CODE  BOOL : OFF
 opt-set-cmake-var Trilinos_ENABLE_ALL_PACKAGES BOOL : ON
 
 [PACKAGE-ENABLES|PR-FRAMEWORK]
+opt-set-cmake-var Trilinos_ENABLE_ALL_PACKAGES BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL : ON
 
 [PACKAGE-ENABLES|RDC-MINIMAL]
@@ -907,7 +908,6 @@ opt-set-cmake-var Trilinos_ENABLE_Xpetra BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_Zoltan BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_Zoltan2 BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_Zoltan2Core BOOL : ON
-
 
 [PACKAGE-ENABLES|ALL-NO-EPETRA]
 opt-set-cmake-var Trilinos_ENABLE_ALL_PACKAGES BOOL FORCE : ON

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -190,10 +190,7 @@ print_banner "Launch the Test Driver"
 
 # Prepare the command for the TEST operation
 test_cmd_options=(
-    --source-repo-url=${TRILINOS_SOURCE_REPO:?}
-    --target-repo-url=${TRILINOS_TARGET_REPO:?}
     --target-branch-name=${TRILINOS_TARGET_BRANCH:?}
-    --pullrequest-build-name=${JOB_BASE_NAME:?}
     --genconfig-build-name=${GENCONFIG_BUILD_NAME:?}
     --pullrequest-env-config-file=${LOADENV_CONFIG_FILE:?}
     --pullrequest-gen-config-file=${GENCONFIG_CONFIG_FILE:?}

--- a/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
@@ -109,8 +109,9 @@ def parse_args():
     required.add_argument('--jenkins-job-number',
                           dest="jenkins_job_number",
                           action='store',
+                          default="UNKNOWN",
                           help='The Jenkins build number',
-                          required=True)
+                          required=False)
 
     optional.add_argument('--dashboard-build-name',
                           dest="dashboard_build_name",

--- a/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
@@ -70,14 +70,16 @@ def parse_args():
     required.add_argument('--source-repo-url',
                           dest="source_repo_url",
                           action='store',
+                          default="UNKNOWN",
                           help='Repo with the new changes',
-                          required=True)
+                          required=False)
 
     required.add_argument('--target-repo-url',
                           dest="target_repo_url",
                           action='store',
+                          default="UNKNOWN",
                           help='Repo to merge into',
-                          required=True)
+                          required=False)
 
     required.add_argument('--target-branch-name',
                           dest="target_branch_name",
@@ -88,8 +90,9 @@ def parse_args():
     required.add_argument('--pullrequest-build-name',
                           dest="pullrequest_build_name",
                           action='store',
+                          default="UNKNOWN",
                           help='The Jenkins job base name',
-                          required=True)
+                          required=False)
 
     required.add_argument('--genconfig-build-name',
                           dest="genconfig_build_name",

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -484,7 +484,7 @@ class TrilinosPRConfigurationBase(object):
         """
         if "Pull Request" in self.arg_pullrequest_cdash_track:
             output = f"PR-{self.arg_pullrequest_number}-test-{self.arg_pr_genconfig_job_name}"
-            if "UNKNOWN" not in self.arg_jenkins_job_number:
+            if not self.arg_jenkins_job_number or "UNKNOWN" not in str(self.arg_jenkins_job_number):
                 output = f"{output}-{self.arg_jenkins_job_number}"
         elif self.arg_dashboard_build_name != "__UNKNOWN__":
             output = self.arg_dashboard_build_name

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -480,10 +480,12 @@ class TrilinosPRConfigurationBase(object):
         """
         Generate the build name string to report back to CDash.
 
-        PR-<PR Number>-test-<Jenkins Job Name>-<Job Number">
+        PR-<PR Number>-test-<Jenkins Job Name>-<Job Number>
         """
         if "Pull Request" in self.arg_pullrequest_cdash_track:
-            output = "PR-{}-test-{}-{}".format(self.arg_pullrequest_number, self.arg_pr_genconfig_job_name, self.arg_jenkins_job_number)
+            output = f"PR-{self.arg_pullrequest_number}-test-{self.arg_pr_genconfig_job_name}"
+            if "UNKNOWN" not in self.arg_jenkins_job_number:
+                output = f"{output}-{self.arg_jenkins_job_number}"
         elif self.arg_dashboard_build_name != "__UNKNOWN__":
             output = self.arg_dashboard_build_name
         else:

--- a/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
@@ -116,12 +116,13 @@ class Test_parse_args(unittest.TestCase):
                 ''')
 
         self.help_output = dedent('''\
-                usage: programName [-h] --source-repo-url SOURCE_REPO_URL --target-repo-url
-                                   TARGET_REPO_URL --target-branch-name TARGET_BRANCH_NAME
-                                   --pullrequest-build-name PULLREQUEST_BUILD_NAME
+                usage: programName [-h] [--source-repo-url SOURCE_REPO_URL]
+                                   [--target-repo-url TARGET_REPO_URL] --target-branch-name
+                                   TARGET_BRANCH_NAME
+                                   [--pullrequest-build-name PULLREQUEST_BUILD_NAME]
                                    --genconfig-build-name GENCONFIG_BUILD_NAME
                                    --pullrequest-number PULLREQUEST_NUMBER
-                                   --jenkins-job-number JENKINS_JOB_NUMBER
+                                   [--jenkins-job-number JENKINS_JOB_NUMBER]
                                    [--dashboard-build-name DASHBOARD_BUILD_NAME]
                                    [--source-dir SOURCE_DIR] [--build-dir BUILD_DIR]
                                    [--use-explicit-cachefile] [--ctest-driver CTEST_DRIVER]
@@ -225,12 +226,12 @@ class Test_parse_args(unittest.TestCase):
                 ''')
 
         self.usage_output = dedent('''\
-                usage: programName [-h] --source-repo-url SOURCE_REPO_URL --target-repo-url TARGET_REPO_URL
+                usage: programName [-h] [--source-repo-url SOURCE_REPO_URL] [--target-repo-url TARGET_REPO_URL]
                                    --target-branch-name TARGET_BRANCH_NAME
-                                   --pullrequest-build-name PULLREQUEST_BUILD_NAME
+                                   [--pullrequest-build-name PULLREQUEST_BUILD_NAME]
                                    --genconfig-build-name GENCONFIG_BUILD_NAME
                                    --pullrequest-number PULLREQUEST_NUMBER
-                                   --jenkins-job-number JENKINS_JOB_NUMBER
+                                   [--jenkins-job-number JENKINS_JOB_NUMBER]
                                    [--dashboard-build-name DASHBOARD_BUILD_NAME]
                                    [--source-dir SOURCE_DIR] [--build-dir BUILD_DIR]
                                    [--use-explicit-cachefile] [--ctest-driver CTEST_DRIVER]
@@ -246,7 +247,7 @@ class Test_parse_args(unittest.TestCase):
                                    [--max-cores-allowed MAX_CORES_ALLOWED]
                                    [--num-concurrent-tests NUM_CONCURRENT_TESTS]
                                    [--enable-ccache] [--dry-run] [--extra-configure-args EXTRA_CONFIGURE_ARGS]
-                programName: error: the following arguments are required: --source-repo-url, --target-repo-url, --target-branch-name, --pullrequest-build-name, --genconfig-build-name, --pullrequest-number, --jenkins-job-number
+                programName: error: the following arguments are required: --target-branch-name, --genconfig-build-name, --pullrequest-number
                 ''')
 
         self.m_cwd = mock.patch('PullRequestLinuxDriverTest.os.getcwd',


### PR DESCRIPTION
@trilinos/framework 

## Motivation
The 'Update' column on CDash is red when we make a local change to a source file.  This could be confusing to end users.  It appears that we do not need to make that modification when running through the PR scripts, because they pass the `--force` option to GenConfig (end users WILL have to do that, but that's expected).  So remove that sed command, cleaning the dashboard.

I also started cleaning up the options to the PR scripts, since a lot of stuff is marked required but not REALLY needed.

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-665

## Testing
I tested the changes in a container and the update column reported successfully.  I also tested the later changes (CLI cleanup) and they worked too.