### PR TITLE
Tpetra MatrixMatrix: sort for cuSparse

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
@@ -170,7 +170,20 @@ void KernelWrappers<Scalar,LocalOrdinal,GlobalOrdinal,Tpetra::KokkosCompat::Kokk
   KokkosSparse::SPGEMMAlgorithm alg_enum = KokkosSparse::StringToSPGEMMAlgorithm(myalg);
 
   // Merge the B and Bimport matrices
-  const KCRS Bmerged = Tpetra::MMdetails::merge_matrices(Aview,Bview,Acol2Brow,Acol2Irow,Bcol2Ccol,Icol2Ccol,C.getColMap()->getLocalNumElements());
+  KCRS Bmerged = Tpetra::MMdetails::merge_matrices(Aview,Bview,Acol2Brow,Acol2Irow,Bcol2Ccol,Icol2Ccol,C.getColMap()->getLocalNumElements());
+
+
+  // if Kokkos Kernels is going to use the cuSparse TPL for SpGEMM, this matrix
+  // needs to be sorted
+  // Try to mirror the Kokkos Kernels internal SpGEMM TPL use logic
+  // inspired by https://github.com/trilinos/Trilinos/pull/11709
+#if defined(KOKKOS_ENABLE_CUDA) \
+ && defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) \
+ && ((CUDA_VERSION < 11000) || (CUDA_VERSION >= 11040))
+  if constexpr (std::is_same_v<typename device_t::execution_space, Kokkos::Cuda>) {
+    KokkosSparse::sort_crs_matrix(Bmerged);
+  }
+#endif
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
   MM = Teuchos::null; MM = rcp(new TimeMonitor (*TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix CudaCore"))));

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
@@ -177,11 +177,14 @@ void KernelWrappers<Scalar,LocalOrdinal,GlobalOrdinal,Tpetra::KokkosCompat::Kokk
   // needs to be sorted
   // Try to mirror the Kokkos Kernels internal SpGEMM TPL use logic
   // inspired by https://github.com/trilinos/Trilinos/pull/11709
+  // and https://github.com/kokkos/kokkos-kernels/pull/2008
 #if defined(KOKKOS_ENABLE_CUDA) \
  && defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) \
  && ((CUDA_VERSION < 11000) || (CUDA_VERSION >= 11040))
   if constexpr (std::is_same_v<typename device_t::execution_space, Kokkos::Cuda>) {
-    KokkosSparse::sort_crs_matrix(Bmerged);
+    if (!KokkosSparse::isCrsGraphSorted(Bmerged.graph.row_map, Bmerged.graph.entries)) {
+      KokkosSparse::sort_crs_matrix(Bmerged);
+    }
   }
 #endif
 


### PR DESCRIPTION
@trilinos/tpetra 

Sorts the inputs to KokkosSparse::spgemm when Kokkos Kernels is going to use the cuSparse TPL.
Kokkos Kernels doesn't really provide a good way to access this information, nor for Tpetra to provide whether or not the matrix is sorted.

Fix for https://github.com/trilinos/Trilinos/issues/13339

Related Kokkos Kernels issue https://github.com/kokkos/kokkos-kernels/issues/2194

See unmerged https://github.com/trilinos/Trilinos/pull/11709, where it was proposed for Tpetra to always sort a matrix before giving it to Kokkos Kernels.

