### PR TITLE
Piro: update FinalObjective and fix the tempus redirection

### DIFF
--- a/packages/piro/src/Piro_PerformAnalysis.cpp
+++ b/packages/piro/src/Piro_PerformAnalysis.cpp
@@ -939,8 +939,9 @@ Piro::PerformROLTransientAnalysis(
         auto algo = ROL::TypeB::AlgorithmFactory<double>(rolParams.sublist("ROL Options"));
 
         std::streambuf *coutbuf;
+        std::ofstream out_file;
         if(rolParams.get<bool>("Redirect Tempus Output", true)) {
-          std::ofstream out_file(rolParams.get<string>("Tempus Output Filename", "log_tempus.txt"));
+          out_file.open(rolParams.get<string>("Tempus Output Filename", "log_tempus.txt"));
           coutbuf = std::cout.rdbuf();
           std::cout.rdbuf(out_file.rdbuf());
         }
@@ -955,8 +956,9 @@ Piro::PerformROLTransientAnalysis(
         auto algo = ROL::TypeU::AlgorithmFactory<double>(rolParams.sublist("ROL Options"));
         
         std::streambuf *coutbuf;
-        if(rolParams.get<bool>("Redirect Tempus Output", true)) {
-          std::ofstream out_file(rolParams.get<string>("Tempus Output Filename", "log_tempus.txt"));
+        std::ofstream out_file;
+        if(rolParams.get<bool>("", true)) {
+          out_file.open(rolParams.get<string>("Tempus Output Filename", "log_tempus.txt"));
           coutbuf = std::cout.rdbuf();
           std::cout.rdbuf(out_file.rdbuf());
         }
@@ -1044,8 +1046,9 @@ Piro::PerformROLTransientAnalysis(
         }
 
         std::streambuf *coutbuf;
+        std::ofstream out_file;
         if(rolParams.get<bool>("Redirect Tempus Output", true)) {
-          std::ofstream out_file(rolParams.get<string>("Tempus Output Filename", "log_tempus.txt"));
+          out_file.open(rolParams.get<string>("Tempus Output Filename", "log_tempus.txt"));
           coutbuf = std::cout.rdbuf();
           std::cout.rdbuf(out_file.rdbuf());
         }

--- a/packages/piro/test/Main_AnalysisDriver_Tempus.cpp
+++ b/packages/piro/test/Main_AnalysisDriver_Tempus.cpp
@@ -244,7 +244,6 @@ int main(int argc, char *argv[]) {
           if (mockModel=="MassSpringDamperModel") {
             p_exact[0] = 1.;
             p_exact[1] = 0.5;
-            tol = 1e-3;
           }
 
           double l2_diff = std::sqrt(std::pow(p_view(0)-p_exact[0],2) + std::pow(p_view(1)-p_exact[1],2));


### PR DESCRIPTION
This PR fixes the FinalObjective which makes the Piro Tempus driven test pass the checkGradient after the optimization (it passed before the optimization before but not after).
The PR makes the associated test more strict in term of the value check.

The PR fixes the Tempus redirection as well. Before the file was created but was empty.