### PR TITLE
Phalanx: fix for gcc 15

### DIFF
--- a/packages/phalanx/src/Phalanx_TemplateIterator.hpp
+++ b/packages/phalanx/src/Phalanx_TemplateIterator.hpp
@@ -50,7 +50,7 @@ namespace PHX {
 
     //! Equal operator
     bool operator==(const TemplateIterator& t) const {
-      return object_iterator == t.objectIterator;
+      return object_iterator == t.object_iterator;
     }
 
     //! Not equal operator
@@ -128,7 +128,7 @@ namespace PHX {
 
     //! Equal operator
     bool operator==(const ConstTemplateIterator& t) const {
-      return object_iterator == t.objectIterator;
+      return object_iterator == t.object_iterator;
     }
 
     //! Not equal operator

--- a/packages/phalanx/test/TemplateManager/TemplateManagerTest.cpp
+++ b/packages/phalanx/test/TemplateManager/TemplateManagerTest.cpp
@@ -1,6 +1,6 @@
 // @HEADER
 // *****************************************************************************
-//        Phalanx: A Partial Differential Equation Field Evaluation 
+//        Phalanx: A Partial Differential Equation Field Evaluation
 //       Kernel for Flexible Management of Complex Dependency Chains
 //
 // Copyright 2008 NTESS and the Phalanx contributors.
@@ -57,4 +57,28 @@ TEUCHOS_UNIT_TEST(template_manager_test, basic)
   tm.deleteType<R>();
   auto r2 = tm.getAsObject<R>();
   TEST_ASSERT(r2.is_null());
+}
+
+TEUCHOS_UNIT_TEST(template_manager_test, iterator_ops)
+{
+  using namespace PHX;
+  DummyTemplateManager<MyTraits> tm;
+
+  auto start = tm.begin();
+  auto start_again = tm.begin();
+  auto end = tm.end();
+
+  TEST_ASSERT(start == start_again);
+  TEST_ASSERT(start != end);
+
+  ++start;
+  TEST_ASSERT(start != start_again);
+
+  start_again++;
+  TEST_ASSERT(start == start_again);
+
+  ++start;
+  start_again++;
+  TEST_ASSERT(start == end);
+  TEST_ASSERT(start_again == end);
 }


### PR DESCRIPTION
## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Needed to compile phalanx with gcc 15.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
New test added to template manager unit test to trigger a failure with older gcc compilers

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
