### PR TITLE
Teuchos: fix templated set method of `ParameterList`

### DIFF
--- a/packages/teuchos/parameterlist/src/Teuchos_ParameterList.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_ParameterList.hpp
@@ -260,9 +260,9 @@ public:
     \note This fallback is necessary to support legacy use cases that specify the type
           of the parameter at the call site, and the type is hence not deduced.  
   */
-  template<typename T, typename S, typename = std::enable_if_t< ! std::is_same_v<T, S> && std::is_same_v<T, std::decay_t<S>>>>
+  template<typename T, typename S, typename = std::enable_if_t<std::is_convertible_v<S, std::remove_const_t<T>>>>
   ParameterList& set (std::string const& name,
-                      S&& value,
+                      const S& value,
                       std::string const& docString = "",
                       RCP<const ParameterEntryValidator> const& validator = null);
 
@@ -965,11 +965,11 @@ ParameterList& ParameterList::set(
 template<typename T, typename S, typename>
 inline
 ParameterList& ParameterList::set(
-  std::string const& name_in, S&& value_in, std::string const& docString_in,
+  std::string const& name_in, const S& value_in, std::string const& docString_in,
   RCP<const ParameterEntryValidator> const& validator_in
   )
 {
-  return set<S>(name_in, std::forward<S>(value_in), docString_in, validator_in);
+  return set(name_in, static_cast<const T&>(value_in), docString_in, validator_in);
 }
 
 inline

--- a/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
+++ b/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
@@ -484,6 +484,24 @@ TEUCHOS_UNIT_TEST( ParameterList, set_string_specified_template_argument)
   TEST_EQUALITY_CONST(pl.get<std::string>("my string 5"), "my text 5");
 }
 
+struct MyWrappedInt
+{
+    operator const int&() const { return value; }
+
+    int value;
+};
+
+TEUCHOS_UNIT_TEST( ParameterList, set_int_user_defined_conversion_function)
+{
+  // Check the templated set method and its overload when the template argument is specified
+  // and the parameter is set via a user defined conversion function. 
+  ParameterList pl;
+
+  ECHO(MyWrappedInt my_wrapped_int{42});
+  ECHO(pl.set<int>("my int", my_wrapped_int));
+  TEST_EQUALITY_CONST(pl.get<int>("my int"), my_wrapped_int.value);
+}
+
 TEUCHOS_UNIT_TEST( ParameterList, get_nonexisting_param )
 {
   ParameterList pl;


### PR DESCRIPTION
@trilinos/teuchos
@bartlettroscoe 
@rppawlo
@MalachiTimothyPhillips
@romintomasetti 

This PR is a fix that follows: 
- https://github.com/trilinos/Trilinos/pull/13409

In that PR, the templated set method of `Teuchos::ParameterList` was replaced with a version that passes the parameter value by universal reference, along with a fallback to cover legacy use cases in which the parameter type is hardcoded at the call site, and hence not deduced.

However, after merging that PR, compilation errors arose in user code in use cases in which the parameter value is set via a user defined conversion function.

Thus, this PR adds a test to cover such use cases. And it proposes a fix to the fallback method. 
