### PR TITLE
Revert "Teuchos: pass `value_in` to `tpl::set` by universal ref"

### DIFF
--- a/packages/teuchos/parameterlist/src/Teuchos_ParameterList.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_ParameterList.hpp
@@ -231,7 +231,7 @@ public:
    */
   ParameterList& disableRecursiveAll();
 
-  /*! \brief Templated set method.
+  /*! \brief Set a parameter whose value has type T.
 
     \param name [in] The parameter's name.
     \param value [in] The parameter's value.  This determines the
@@ -250,21 +250,10 @@ public:
     </ul>
   */
   template<typename T>
-  ParameterList& set (std::string const& name,
-                      T&& value,
-                      std::string const& docString = "",
-                      RCP<const ParameterEntryValidator> const& validator = null);
-  
-  /*! \overload
-    
-    \note This fallback is necessary to support legacy use cases that specify the type
-          of the parameter at the call site, and the type is hence not deduced.  
-  */
-  template<typename T, typename S, typename = std::enable_if_t< ! std::is_same_v<T, S> && std::is_same_v<T, std::decay_t<S>>>>
-  ParameterList& set (std::string const& name,
-                      S&& value,
-                      std::string const& docString = "",
-                      RCP<const ParameterEntryValidator> const& validator = null);
+  ParameterList& set (std::string const& name, 
+		      T const& value, 
+		      std::string const& docString = "",
+		      RCP<const ParameterEntryValidator> const& validator = null);
 
   /// \brief Specialization of set() for a parameter which is a <tt>char[]</tt>.
   ///
@@ -932,7 +921,7 @@ ParameterList& ParameterList::setName( const std::string &name_in )
 template<typename T>
 inline
 ParameterList& ParameterList::set(
-  std::string const& name_in, T&& value_in, std::string const& docString_in,
+  std::string const& name_in, T const& value_in, std::string const& docString_in,
   RCP<const ParameterEntryValidator> const& validator_in
   )
 {
@@ -945,7 +934,7 @@ ParameterList& ParameterList::set(
     const RCP<const ParameterEntryValidator> validator =
       (nonnull(validator_in) ? validator_in : param->validator());
      // Create temp param to validate before setting
-    ParameterEntry param_new(std::forward<T>(value_in), false, false, docString, validator );
+    ParameterEntry param_new(value_in, false, false, docString, validator );
     if (nonnull(validator)) {
       validator->validate(param_new, name_in, this->name());
     }
@@ -953,7 +942,7 @@ ParameterList& ParameterList::set(
     *param = param_new;
   }
   else {
-    ParameterEntry param_new(std::forward<T>(value_in), false, false, docString_in, validator_in);
+    ParameterEntry param_new(value_in, false, false, docString_in, validator_in);
     if (nonnull(param_new.validator())) {
       param_new.validator()->validate(param_new, name_in, this->name());
     }
@@ -962,15 +951,6 @@ ParameterList& ParameterList::set(
   return *this;
 }
 
-template<typename T, typename S, typename>
-inline
-ParameterList& ParameterList::set(
-  std::string const& name_in, S&& value_in, std::string const& docString_in,
-  RCP<const ParameterEntryValidator> const& validator_in
-  )
-{
-  return set<S>(name_in, std::forward<S>(value_in), docString_in, validator_in);
-}
 
 inline
 ParameterList& ParameterList::set(

--- a/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
+++ b/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
@@ -442,47 +442,6 @@ TEUCHOS_UNIT_TEST( ParameterList, set_get_string )
 
 }
 
-TEUCHOS_UNIT_TEST( ParameterList, set_string_move_semantics)
-{
-  ParameterList pl;
-
-  ECHO(std::string my_str_1{"my text 1"});
-  ECHO(pl.set("my string 1", std::move(my_str_1)));
-
-  // Check that the parameter value was moved by checking that my_str_1 is now empty.
-  TEST_ASSERT(my_str_1.empty());
-
-  TEST_EQUALITY_CONST(pl.get<std::string>("my string 1"), "my text 1");
-}
-
-TEUCHOS_UNIT_TEST( ParameterList, set_string_specified_template_argument)
-{
-  // Check the templated set method and its overload when the template argument is specified.
-
-   ParameterList pl;
-
-  // The parameter value can be passed by rvalue reference.
-  // The main templated set method is called, and the parameter value is moved.
-  ECHO(std::string my_str_2{"my text 2"});
-  ECHO(pl.set<std::string>("my string 2", std::move(my_str_2)));
-  TEST_ASSERT(my_str_2.empty());
-  TEST_EQUALITY_CONST(pl.get<std::string>("my string 2"), "my text 2");
-  
-  // The parameter value cannot be passed by rvalue reference.
-  // The overload of the templated set method is called, and the parameter value is not moved.
-  ECHO(std::string my_str_3{"my text 3"});
-  ECHO(pl.set<std::string>("my string 3", my_str_3));
-  TEST_ASSERT( ! my_str_3.empty());
-  TEST_EQUALITY_CONST(pl.get<std::string>("my string 3"), "my text 3");
-
-  ECHO(const std::string my_str_4{"my text 4"});
-  ECHO(pl.set<std::string>("my string 4", my_str_4));
-  TEST_ASSERT( ! my_str_4.empty());
-  TEST_EQUALITY_CONST(pl.get<std::string>("my string 4"), "my text 4");
-
-  ECHO(pl.set<std::string>("my string 5", "my text 5"));
-  TEST_EQUALITY_CONST(pl.get<std::string>("my string 5"), "my text 5");
-}
 
 TEUCHOS_UNIT_TEST( ParameterList, get_nonexisting_param )
 {


### PR DESCRIPTION
Reverts trilinos/Trilinos#13409 which broke backward compatibility.

Posting this revert PR is the first part of the plan to return backward compatibility but to provide a transition to the new implementation that supports move semantics.  See the plan in:

* https://github.com/trilinos/Trilinos/pull/13409#issuecomment-2338871492
