### PR TITLE
FROSch : fix issues with multiple blocks

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_GDSWCoarseOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_GDSWCoarseOperator_def.hpp
@@ -247,14 +247,7 @@ namespace FROSch {
 
         // Das könnte man noch ändern
         // TODO: DAS SOLLTE ALLES IN EINE FUNKTION IN HARMONICCOARSEOPERATOR
-        this->GammaDofs_.resize(this->GammaDofs_.size()+1);
-        this->IDofs_.resize(this->IDofs_.size()+1);
-        this->InterfaceCoarseSpaces_.resize(this->InterfaceCoarseSpaces_.size()+1);
-        this->DofsMaps_.resize(this->DofsMaps_.size()+1);
-        this->DofsPerNode_.resize(this->DofsPerNode_.size()+1);
-        this->NumberOfBlocks_++;
-
-        resetCoarseSpaceBlock(this->NumberOfBlocks_-1,dimension,dofsPerNode,nodesMap,dofsMaps,dirichletBoundaryDofs,nodeList);
+        resetCoarseSpaceBlock(this->NumberOfBlocks_,dimension,dofsPerNode,nodesMap,dofsMaps,dirichletBoundaryDofs,nodeList);
 
         return 0;
     }
@@ -273,13 +266,7 @@ namespace FROSch {
         // Das könnte man noch ändern
         // TODO: DAS SOLLTE ALLES IN EINE FUNKTION IN HARMONICCOARSEOPERATOR
         for (UN i=0; i<repeatedNodesMapVec.size(); i++) {
-            this->GammaDofs_.resize(this->GammaDofs_.size()+1);
-            this->IDofs_.resize(this->IDofs_.size()+1);
-            this->InterfaceCoarseSpaces_.resize(this->InterfaceCoarseSpaces_.size()+1);
-            this->DofsMaps_.resize(this->DofsMaps_.size()+1);
-            this->DofsPerNode_.resize(this->DofsPerNode_.size()+1);
-            this->NumberOfBlocks_++;
-            resetCoarseSpaceBlock(this->NumberOfBlocks_-1,dimension,dofsPerNodeVec[i],repeatedNodesMapVec[i],repeatedDofMapsVec[i],dirichletBoundaryDofsVec[i],nodeListVec[i]);
+            resetCoarseSpaceBlock(this->NumberOfBlocks_,dimension,dofsPerNodeVec[i],repeatedNodesMapVec[i],repeatedDofMapsVec[i],dirichletBoundaryDofsVec[i],nodeListVec[i]);
         }
         return 0;
     }
@@ -296,7 +283,7 @@ namespace FROSch {
     {
         FROSCH_DETAILTIMER_START_LEVELID(resetCoarseSpaceBlockTime,"GDSWCoarseOperator::resetCoarseSpaceBlock");
         FROSCH_ASSERT(dofsMaps.size()==dofsPerNode,"dofsMaps.size()!=dofsPerNode");
-        FROSCH_ASSERT(blockId<this->NumberOfBlocks_,"Block does not exist yet and can therefore not be reset.");
+        FROSCH_ASSERT(blockId<=this->NumberOfBlocks_,"Block does not exist yet and can therefore not be reset("+to_string(blockId)+" <= "+to_string(this->NumberOfBlocks_)+". ");
 
         if (!this->DistributionList_->get("Type","linear").compare("ZoltanDual")) {
             FROSCH_ASSERT(false,"RGDSWCoarseOperator:: Distribution Type ZoltanDual only works for IPOUHarmonicCoarseOperator");
@@ -356,155 +343,28 @@ namespace FROSch {
             useFaceRotations = false;
         }
 
-        this->DofsMaps_[blockId] = dofsMaps;
-        this->DofsPerNode_[blockId] = dofsPerNode;
+        if (useForCoarseSpace) {
+            this->NumberOfBlocks_++;
 
-        Array<GO> tmpDirichletBoundaryDofs(dirichletBoundaryDofs()); // Here, we do a copy. Maybe, this is not necessary
-        sortunique(tmpDirichletBoundaryDofs);
+            this->GammaDofs_.resize(this->GammaDofs_.size()+1);
+            this->IDofs_.resize(this->IDofs_.size()+1);
+            this->InterfaceCoarseSpaces_.resize(this->InterfaceCoarseSpaces_.size()+1);
+            this->DofsMaps_.resize(this->DofsMaps_.size()+1);
+            this->DofsPerNode_.resize(this->DofsPerNode_.size()+1);
 
-        DDInterface_.reset(new DDInterface<SC,LO,GO,NO>(dimension,this->DofsPerNode_[blockId],nodesMap.getConst(),verbosity,this->LevelID_,communicationStrategy));
-        DDInterface_->resetGlobalDofs(dofsMaps);
-        DDInterface_->removeDirichletNodes(tmpDirichletBoundaryDofs());
+            this->DofsMaps_[blockId] = dofsMaps;
+            this->DofsPerNode_[blockId] = dofsPerNode;
 
-        EntitySetPtr interface = this->DDInterface_->getInterface();
-        EntitySetPtr interior = this->DDInterface_->getInterior();
+            Array<GO> tmpDirichletBoundaryDofs(dirichletBoundaryDofs()); // Here, we do a copy. Maybe, this is not necessary
+            sortunique(tmpDirichletBoundaryDofs);
 
-        if (useForCoarseSpace && (useVertexTranslations||useShortEdgeTranslations||useShortEdgeRotations||useStraightEdgeTranslations||useStraightEdgeRotations||useEdgeTranslations||useEdgeRotations||useFaceTranslations||useFaceRotations)) {
+            DDInterface_.reset(new DDInterface<SC,LO,GO,NO>(dimension,this->DofsPerNode_[blockId],nodesMap.getConst(),verbosity,this->LevelID_,communicationStrategy));
+            DDInterface_->resetGlobalDofs(dofsMaps);
+            DDInterface_->removeDirichletNodes(tmpDirichletBoundaryDofs());
 
-            if (this->Verbose_) {
-                cout
-                << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                << setw(89) << "-----------------------------------------------------------------------------------------"
-                << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                << "| "
-                << left << setw(74) << "GDSWCoarseOperator " << right << setw(8) << "(Level " << setw(2) << this->LevelID_ << ")"
-                << " |"
-                << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                << setw(89) << "========================================================================================="
-                << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                << "| " << left << setw(41) << "Block" << right
-                << " | " << setw(41) << blockId
-                << " |"
-                << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                << "| " << left << setw(41) << "Spatial dimensions" << right
-                << " | " << setw(41) << dimension
-                << " |"
-                << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                << "| " << left << setw(41) << "Number of degrees of freedom per node" << right
-                << " | " << setw(41) << dofsPerNode
-                << " |"
-                << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                << setw(89) << "-----------------------------------------------------------------------------------------"
-                << endl;
-            }
-
-            // Check for interface
-            if (interface->getEntity(0)->getNumNodes()==0) {
-                FROSCH_NOTIFICATION("FROSch::GDSWCoarseOperator",this->Verbose_,"No interface found => Volume functions will be used instead.");
-                this->computeVolumeFunctions(blockId,dimension,nodesMap,nodeList,interior);
-            } else {
-                this->GammaDofs_[blockId] = LOVecPtr(this->DofsPerNode_[blockId]*interface->getEntity(0)->getNumNodes());
-                this->IDofs_[blockId] = LOVecPtr(this->DofsPerNode_[blockId]*interior->getEntity(0)->getNumNodes());
-                for (UN k=0; k<this->DofsPerNode_[blockId]; k++) {
-                    for (UN i=0; i<interface->getEntity(0)->getNumNodes(); i++) {
-                        this->GammaDofs_[blockId][this->DofsPerNode_[blockId]*i+k] = interface->getEntity(0)->getLocalDofID(i,k);
-                    }
-                    for (UN i=0; i<interior->getEntity(0)->getNumNodes(); i++) {
-                        this->IDofs_[blockId][this->DofsPerNode_[blockId]*i+k] = interior->getEntity(0)->getLocalDofID(i,k);
-                    }
-                }
-
-                this->InterfaceCoarseSpaces_[blockId].reset(new CoarseSpace<SC,LO,GO,NO>(this->MpiComm_,this->SerialComm_));
-
-                if (this->ParameterList_->get("Test Unconnected Interface",true)) {
-                    DDInterface_->divideUnconnectedEntities(this->K_);
-                }
-
-                DDInterface_->sortVerticesEdgesFaces(nodeList);
-
-                EntitySetPtr interface = DDInterface_->getInterface();
-                EntitySetPtr interior = DDInterface_->getInterior();
-
-                ////////////////////////////////
-                // Build Processor Map Coarse //
-                ////////////////////////////////
-                DDInterface_->buildEntityMaps(useVertexTranslations,
-                                              useShortEdgeTranslations||useShortEdgeRotations,
-                                              useStraightEdgeTranslations || useStraightEdgeRotations,
-                                              useEdgeTranslations || useEdgeRotations,
-                                              useFaceTranslations || useFaceRotations,
-                                              false);
-
-                // Vertices
-                if (useVertexTranslations) {
-                    XMultiVectorPtrVecPtr translations = this->computeTranslations(blockId,DDInterface_->getVertices());
-                    ConstXMapPtr verticesEntityMap = DDInterface_->getVertices()->getEntityMap();
-                    for (UN i=0; i<translations.size(); i++) {
-                        this->InterfaceCoarseSpaces_[blockId]->addSubspace(verticesEntityMap,null,translations[i]);
-                    }
-                }
-                // ShortEdges
-                if (useShortEdgeTranslations) {
-                    XMultiVectorPtrVecPtr translations = this->computeTranslations(blockId,DDInterface_->getShortEdges());
-                    ConstXMapPtr shortEdgesEntityMap = DDInterface_->getShortEdges()->getEntityMap();
-                    for (UN i=0; i<translations.size(); i++) {
-                        this->InterfaceCoarseSpaces_[blockId]->addSubspace(shortEdgesEntityMap,null,translations[i]);
-                    }
-                }
-                if (useShortEdgeRotations) {
-                    XMultiVectorPtrVecPtr rotations = this->computeRotations(blockId,dimension,nodeList,DDInterface_->getShortEdges(),(dimension==3));
-                    ConstXMapPtr shortEdgesEntityMap = DDInterface_->getShortEdges()->getEntityMap();
-                    for (UN i=0; i<rotations.size(); i++) {
-                        this->InterfaceCoarseSpaces_[blockId]->addSubspace(shortEdgesEntityMap,null,rotations[i]);
-                    }
-                }
-                // StraightEdges
-                if (useStraightEdgeTranslations) {
-                    XMultiVectorPtrVecPtr translations = this->computeTranslations(blockId,DDInterface_->getStraightEdges());
-                    ConstXMapPtr straightEdgesEntityMap = DDInterface_->getStraightEdges()->getEntityMap();
-                    for (UN i=0; i<translations.size(); i++) {
-                        this->InterfaceCoarseSpaces_[blockId]->addSubspace(straightEdgesEntityMap,null,translations[i]);
-                    }
-                }
-                if (useStraightEdgeRotations) {
-                    XMultiVectorPtrVecPtr rotations = this->computeRotations(blockId,dimension,nodeList,DDInterface_->getStraightEdges(),(dimension==3));
-                    ConstXMapPtr straightEdgesEntityMap = DDInterface_->getStraightEdges()->getEntityMap();
-                    for (UN i=0; i<rotations.size(); i++) {
-                        this->InterfaceCoarseSpaces_[blockId]->addSubspace(straightEdgesEntityMap,null,rotations[i]);
-                    }
-                }
-                // Edges
-                if (useEdgeTranslations) {
-                    XMultiVectorPtrVecPtr translations = this->computeTranslations(blockId,DDInterface_->getEdges());
-                    ConstXMapPtr edgesEntityMap = DDInterface_->getEdges()->getEntityMap();
-                    for (UN i=0; i<translations.size(); i++) {
-                        this->InterfaceCoarseSpaces_[blockId]->addSubspace(edgesEntityMap,null,translations[i]);
-                    }
-                }
-                if (useEdgeRotations) {
-                    XMultiVectorPtrVecPtr rotations = this->computeRotations(blockId,dimension,nodeList,DDInterface_->getEdges());
-                    ConstXMapPtr edgesEntityMap = DDInterface_->getEdges()->getEntityMap();
-                    for (UN i=0; i<rotations.size(); i++) {
-                        this->InterfaceCoarseSpaces_[blockId]->addSubspace(edgesEntityMap,null,rotations[i]);
-                    }
-                }
-                // Faces
-                if (useFaceTranslations) {
-                    XMultiVectorPtrVecPtr translations = this->computeTranslations(blockId,DDInterface_->getFaces());
-                    ConstXMapPtr facesEntityMap = DDInterface_->getFaces()->getEntityMap();
-                    for (UN i=0; i<translations.size(); i++) {
-                        this->InterfaceCoarseSpaces_[blockId]->addSubspace(facesEntityMap,null,translations[i]);
-                    }
-                }
-                if (useFaceRotations) {
-                    XMultiVectorPtrVecPtr rotations = this->computeRotations(blockId,dimension,nodeList,DDInterface_->getFaces());
-                    ConstXMapPtr facesEntityMap = DDInterface_->getFaces()->getEntityMap();
-                    for (UN i=0; i<rotations.size(); i++) {
-                        this->InterfaceCoarseSpaces_[blockId]->addSubspace(facesEntityMap,null,rotations[i]);
-                    }
-                }
-
-                this->InterfaceCoarseSpaces_[blockId]->assembleCoarseSpace();
+            if (useVertexTranslations||useShortEdgeTranslations||useShortEdgeRotations||useStraightEdgeTranslations||useStraightEdgeRotations||useEdgeTranslations||useEdgeRotations||useFaceTranslations||useFaceRotations) {
+                EntitySetPtr interface = this->DDInterface_->getInterface();
+                EntitySetPtr interior = this->DDInterface_->getInterior();
 
                 if (this->Verbose_) {
                     cout
@@ -512,49 +372,185 @@ namespace FROSch {
                     << setw(89) << "-----------------------------------------------------------------------------------------"
                     << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
                     << "| "
-                    << left << setw(74) << "> GDSW coarse space " << right << setw(8) << "(Level " << setw(2) << this->LevelID_ << ")"
+                    << left << setw(74) << "GDSWCoarseOperator " << right << setw(8) << "(Level " << setw(2) << this->LevelID_ << ")"
                     << " |"
                     << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
                     << setw(89) << "========================================================================================="
                     << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                    << "| " << left << setw(19) << "Vertices " << " | " << setw(19) << "Translations " << right
-                    << " | " << setw(41) << boolalpha << useVertexTranslations << noboolalpha
+                    << "| " << left << setw(41) << "Block" << right
+                    << " | " << setw(41) << blockId
                     << " |"
                     << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                    << "| " << left << setw(19) << "ShortEdges " << " | " << setw(19) << "Translations " << right
-                    << " | " << setw(41) << boolalpha << useShortEdgeTranslations << noboolalpha
+                    << "| " << left << setw(41) << "Spatial dimensions" << right
+                    << " | " << setw(41) << dimension
                     << " |"
                     << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                    << "| " << left << setw(19) << "ShortEdges " << " | " << setw(19) << "Rotations " << right
-                    << " | " << setw(41) << boolalpha << useShortEdgeRotations << noboolalpha
-                    << " |"
-                    << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                    << "| " << left << setw(19) << "StraightEdges " << " | " << setw(19) << "Translations " << right
-                    << " | " << setw(41) << boolalpha << useStraightEdgeTranslations << noboolalpha
-                    << " |"
-                    << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                    << "| " << left << setw(19) << "StraightEdges " << " | " << setw(19) << "Rotations " << right
-                    << " | " << setw(41) << boolalpha << useStraightEdgeRotations << noboolalpha
-                    << " |"
-                    << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                    << "| " << left << setw(19) << "Edges " << " | " << setw(19) << "Translations " << right
-                    << " | " << setw(41) << boolalpha << useEdgeTranslations << noboolalpha
-                    << " |"
-                    << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                    << "| " << left << setw(19) << "Edges " << " | " << setw(19) << "Rotations " << right
-                    << " | " << setw(41) << boolalpha << useEdgeRotations << noboolalpha
-                    << " |"
-                    << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                    << "| " << left << setw(19) << "Faces " << " | " << setw(19) << "Translations " << right
-                    << " | " << setw(41) << boolalpha << useFaceTranslations << noboolalpha
-                    << " |"
-                    << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
-                    << "| " << left << setw(19) << "Faces " << " | " << setw(19) << "Rotations " << right
-                    << " | " << setw(41) << boolalpha << useFaceRotations << noboolalpha
+                    << "| " << left << setw(41) << "Number of degrees of freedom per node" << right
+                    << " | " << setw(41) << dofsPerNode
                     << " |"
                     << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
                     << setw(89) << "-----------------------------------------------------------------------------------------"
                     << endl;
+                }
+
+                // Check for interface
+                if (interface->getEntity(0)->getNumNodes()==0) {
+                    FROSCH_NOTIFICATION("FROSch::GDSWCoarseOperator",this->Verbose_,"No interface found => Volume functions will be used instead.");
+                    this->computeVolumeFunctions(blockId,dimension,nodesMap,nodeList,interior);
+                } else {
+                    this->GammaDofs_[blockId] = LOVecPtr(this->DofsPerNode_[blockId]*interface->getEntity(0)->getNumNodes());
+                    this->IDofs_[blockId] = LOVecPtr(this->DofsPerNode_[blockId]*interior->getEntity(0)->getNumNodes());
+                    for (UN k=0; k<this->DofsPerNode_[blockId]; k++) {
+                        for (UN i=0; i<interface->getEntity(0)->getNumNodes(); i++) {
+                            this->GammaDofs_[blockId][this->DofsPerNode_[blockId]*i+k] = interface->getEntity(0)->getLocalDofID(i,k);
+                        }
+                        for (UN i=0; i<interior->getEntity(0)->getNumNodes(); i++) {
+                            this->IDofs_[blockId][this->DofsPerNode_[blockId]*i+k] = interior->getEntity(0)->getLocalDofID(i,k);
+                        }
+                    }
+
+                    this->InterfaceCoarseSpaces_[blockId].reset(new CoarseSpace<SC,LO,GO,NO>(this->MpiComm_,this->SerialComm_));
+
+                    if (this->ParameterList_->get("Test Unconnected Interface",true)) {
+                        DDInterface_->divideUnconnectedEntities(this->K_);
+                    }
+
+                    DDInterface_->sortVerticesEdgesFaces(nodeList);
+
+                    EntitySetPtr interface = DDInterface_->getInterface();
+                    EntitySetPtr interior = DDInterface_->getInterior();
+
+                    ////////////////////////////////
+                    // Build Processor Map Coarse //
+                    ////////////////////////////////
+                    DDInterface_->buildEntityMaps(useVertexTranslations,
+                                                  useShortEdgeTranslations||useShortEdgeRotations,
+                                                  useStraightEdgeTranslations || useStraightEdgeRotations,
+                                                  useEdgeTranslations || useEdgeRotations,
+                                                  useFaceTranslations || useFaceRotations,
+                                                  false);
+
+                    // Vertices
+                    if (useVertexTranslations) {
+                        XMultiVectorPtrVecPtr translations = this->computeTranslations(blockId,DDInterface_->getVertices());
+                        ConstXMapPtr verticesEntityMap = DDInterface_->getVertices()->getEntityMap();
+                        for (UN i=0; i<translations.size(); i++) {
+                            this->InterfaceCoarseSpaces_[blockId]->addSubspace(verticesEntityMap,null,translations[i]);
+                        }
+                    }
+                    // ShortEdges
+                    if (useShortEdgeTranslations) {
+                        XMultiVectorPtrVecPtr translations = this->computeTranslations(blockId,DDInterface_->getShortEdges());
+                        ConstXMapPtr shortEdgesEntityMap = DDInterface_->getShortEdges()->getEntityMap();
+                        for (UN i=0; i<translations.size(); i++) {
+                            this->InterfaceCoarseSpaces_[blockId]->addSubspace(shortEdgesEntityMap,null,translations[i]);
+                        }
+                    }
+                    if (useShortEdgeRotations) {
+                        XMultiVectorPtrVecPtr rotations = this->computeRotations(blockId,dimension,nodeList,DDInterface_->getShortEdges(),(dimension==3));
+                        ConstXMapPtr shortEdgesEntityMap = DDInterface_->getShortEdges()->getEntityMap();
+                        for (UN i=0; i<rotations.size(); i++) {
+                            this->InterfaceCoarseSpaces_[blockId]->addSubspace(shortEdgesEntityMap,null,rotations[i]);
+                        }
+                    }
+                    // StraightEdges
+                    if (useStraightEdgeTranslations) {
+                        XMultiVectorPtrVecPtr translations = this->computeTranslations(blockId,DDInterface_->getStraightEdges());
+                        ConstXMapPtr straightEdgesEntityMap = DDInterface_->getStraightEdges()->getEntityMap();
+                        for (UN i=0; i<translations.size(); i++) {
+                            this->InterfaceCoarseSpaces_[blockId]->addSubspace(straightEdgesEntityMap,null,translations[i]);
+                        }
+                    }
+                    if (useStraightEdgeRotations) {
+                        XMultiVectorPtrVecPtr rotations = this->computeRotations(blockId,dimension,nodeList,DDInterface_->getStraightEdges(),(dimension==3));
+                        ConstXMapPtr straightEdgesEntityMap = DDInterface_->getStraightEdges()->getEntityMap();
+                        for (UN i=0; i<rotations.size(); i++) {
+                            this->InterfaceCoarseSpaces_[blockId]->addSubspace(straightEdgesEntityMap,null,rotations[i]);
+                        }
+                    }
+                    // Edges
+                    if (useEdgeTranslations) {
+                        XMultiVectorPtrVecPtr translations = this->computeTranslations(blockId,DDInterface_->getEdges());
+                        ConstXMapPtr edgesEntityMap = DDInterface_->getEdges()->getEntityMap();
+                        for (UN i=0; i<translations.size(); i++) {
+                            this->InterfaceCoarseSpaces_[blockId]->addSubspace(edgesEntityMap,null,translations[i]);
+                        }
+                    }
+                    if (useEdgeRotations) {
+                        XMultiVectorPtrVecPtr rotations = this->computeRotations(blockId,dimension,nodeList,DDInterface_->getEdges());
+                        ConstXMapPtr edgesEntityMap = DDInterface_->getEdges()->getEntityMap();
+                        for (UN i=0; i<rotations.size(); i++) {
+                            this->InterfaceCoarseSpaces_[blockId]->addSubspace(edgesEntityMap,null,rotations[i]);
+                        }
+                    }
+                    // Faces
+                    if (useFaceTranslations) {
+                        XMultiVectorPtrVecPtr translations = this->computeTranslations(blockId,DDInterface_->getFaces());
+                        ConstXMapPtr facesEntityMap = DDInterface_->getFaces()->getEntityMap();
+                        for (UN i=0; i<translations.size(); i++) {
+                            this->InterfaceCoarseSpaces_[blockId]->addSubspace(facesEntityMap,null,translations[i]);
+                        }
+                    }
+                    if (useFaceRotations) {
+                        XMultiVectorPtrVecPtr rotations = this->computeRotations(blockId,dimension,nodeList,DDInterface_->getFaces());
+                        ConstXMapPtr facesEntityMap = DDInterface_->getFaces()->getEntityMap();
+                        for (UN i=0; i<rotations.size(); i++) {
+                            this->InterfaceCoarseSpaces_[blockId]->addSubspace(facesEntityMap,null,rotations[i]);
+                        }
+                    }
+
+                    this->InterfaceCoarseSpaces_[blockId]->assembleCoarseSpace();
+
+                    if (this->Verbose_) {
+                        cout
+                        << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
+                        << setw(89) << "-----------------------------------------------------------------------------------------"
+                        << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
+                        << "| "
+                        << left << setw(74) << "> GDSW coarse space " << right << setw(8) << "(Level " << setw(2) << this->LevelID_ << ")"
+                        << " |"
+                        << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
+                        << setw(89) << "========================================================================================="
+                        << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
+                        << "| " << left << setw(19) << "Vertices " << " | " << setw(19) << "Translations " << right
+                        << " | " << setw(41) << boolalpha << useVertexTranslations << noboolalpha
+                        << " |"
+                        << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
+                        << "| " << left << setw(19) << "ShortEdges " << " | " << setw(19) << "Translations " << right
+                        << " | " << setw(41) << boolalpha << useShortEdgeTranslations << noboolalpha
+                        << " |"
+                        << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
+                        << "| " << left << setw(19) << "ShortEdges " << " | " << setw(19) << "Rotations " << right
+                        << " | " << setw(41) << boolalpha << useShortEdgeRotations << noboolalpha
+                        << " |"
+                        << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
+                        << "| " << left << setw(19) << "StraightEdges " << " | " << setw(19) << "Translations " << right
+                        << " | " << setw(41) << boolalpha << useStraightEdgeTranslations << noboolalpha
+                        << " |"
+                        << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
+                        << "| " << left << setw(19) << "StraightEdges " << " | " << setw(19) << "Rotations " << right
+                        << " | " << setw(41) << boolalpha << useStraightEdgeRotations << noboolalpha
+                        << " |"
+                        << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
+                        << "| " << left << setw(19) << "Edges " << " | " << setw(19) << "Translations " << right
+                        << " | " << setw(41) << boolalpha << useEdgeTranslations << noboolalpha
+                        << " |"
+                        << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
+                        << "| " << left << setw(19) << "Edges " << " | " << setw(19) << "Rotations " << right
+                        << " | " << setw(41) << boolalpha << useEdgeRotations << noboolalpha
+                        << " |"
+                        << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
+                        << "| " << left << setw(19) << "Faces " << " | " << setw(19) << "Translations " << right
+                        << " | " << setw(41) << boolalpha << useFaceTranslations << noboolalpha
+                        << " |"
+                        << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
+                        << "| " << left << setw(19) << "Faces " << " | " << setw(19) << "Rotations " << right
+                        << " | " << setw(41) << boolalpha << useFaceRotations << noboolalpha
+                        << " |"
+                        << "\n" << setw(FROSCH_OUTPUT_INDENT) << " "
+                        << setw(89) << "-----------------------------------------------------------------------------------------"
+                        << endl;
+                    }
                 }
             }
         }

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_def.hpp
@@ -121,26 +121,19 @@ namespace FROSch {
     int HarmonicCoarseOperator<SC,LO,GO,NO>::addZeroCoarseSpaceBlock(ConstXMapPtr dofsMap)
     {
         FROSCH_DETAILTIMER_START_LEVELID(addZeroCoarseSpaceBlockTime,"HarmonicCoarseOperator::addZeroCoarseSpaceBlock");
+        /////
+        int blockId = NumberOfBlocks_-1;
+
+        // Process the parameter list
+        stringstream blockIdStringstream;
+        blockIdStringstream << blockId+1;
+        string blockIdString = blockIdStringstream.str();
+        RCP<ParameterList> coarseSpaceList = sublist(sublist(this->ParameterList_,"Blocks"),blockIdString.c_str());
         bool useForCoarseSpace = coarseSpaceList->get("Use For Coarse Space",true);
 
 	if (useForCoarseSpace) {
             // Das könnte man noch ändern
-            GammaDofs_->resize(GammaDofs_.size()+1);
-            IDofs_->resize(IDofs_.size()+1);
-            InterfaceCoarseSpaces_->resize(InterfaceCoarseSpaces_.size()+1);
-            DofsMaps_->resize(DofsMaps_.size()+1);
-            DofsPerNode_->resize(DofsPerNode_.size()+1);
-
             NumberOfBlocks_++;
-
-            /////
-            int blockId = NumberOfBlocks_-1;
-
-            // Process the parameter list
-            stringstream blockIdStringstream;
-            blockIdStringstream << blockId+1;
-            string blockIdString = blockIdStringstream.str();
-            RCP<ParameterList> coarseSpaceList = sublist(sublist(this->ParameterList_,"Blocks"),blockIdString.c_str());
 
             GammaDofs_[blockId] = LOVecPtr(0);
 
@@ -161,6 +154,12 @@ namespace FROSch {
                     mVPhiGamma->replaceLocalValue(i,i,ScalarTraits<SC>::one());
                 }
             }
+
+            GammaDofs_->resize(GammaDofs_.size()+1);
+            IDofs_->resize(IDofs_.size()+1);
+            InterfaceCoarseSpaces_->resize(InterfaceCoarseSpaces_.size()+1);
+            DofsMaps_->resize(DofsMaps_.size()+1);
+            DofsPerNode_->resize(DofsPerNode_.size()+1);
 
             IDofs_[blockId] = LOVecPtr(0);
 

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_IPOUHarmonicCoarseOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_IPOUHarmonicCoarseOperator_def.hpp
@@ -168,14 +168,7 @@ namespace FROSch {
 
         // Das könnte man noch ändern
         // Todo: Check the lengths of the vectors against NumberOfBlocks_
-        this->GammaDofs_.resize(this->GammaDofs_.size()+1);
-        this->IDofs_.resize(this->IDofs_.size()+1);
-        this->InterfaceCoarseSpaces_.resize(this->InterfaceCoarseSpaces_.size()+1);
-        this->DofsMaps_.resize(this->DofsMaps_.size()+1);
-        this->DofsPerNode_.resize(this->DofsPerNode_.size()+1);
-        this->NumberOfBlocks_++;
-
-        return resetCoarseSpaceBlock(this->NumberOfBlocks_-1,dimension,dofsPerNode,nodesMap,dofsMaps,nullSpaceBasis,dirichletBoundaryDofs,nodeList);
+        return resetCoarseSpaceBlock(this->NumberOfBlocks_,dimension,dofsPerNode,nodesMap,dofsMaps,nullSpaceBasis,dirichletBoundaryDofs,nodeList);
     }
 
     template <class SC,class LO,class GO,class NO>
@@ -189,27 +182,21 @@ namespace FROSch {
     {
         FROSCH_DETAILTIMER_START_LEVELID(buildCoarseSpaceTime,"IPOUHarmonicCoarseOperator::buildCoarseSpace");
 
-        this->NumberOfBlocks_ = repeatedNodesMapVec.size();
+        UN TotalNumberOfBlocks = repeatedNodesMapVec.size();
 
-        FROSCH_ASSERT(dofsPerNodeVec.size()==this->NumberOfBlocks_,"dofsPerNodeVec.size()!=this->NumberOfBlocks_");
-        FROSCH_ASSERT(repeatedDofMapsVec.size()==this->NumberOfBlocks_,"repeatedDofMapsVec.size()!=this->NumberOfBlocks_");
-        FROSCH_ASSERT(nullSpaceBasisVec.size()==this->NumberOfBlocks_,"nullSpaceBasisVec.size()!=this->NumberOfBlocks_");
-        FROSCH_ASSERT(dirichletBoundaryDofsVec.size()==this->NumberOfBlocks_,"dirichletBoundaryDofsVec.size()!=this->NumberOfBlocks_");
-        FROSCH_ASSERT(nodeListVec.size()==this->NumberOfBlocks_,"nodeListVec.size()!=this->NumberOfBlocks_");
+        FROSCH_ASSERT(dofsPerNodeVec.size()==TotalNumberOfBlocks,"dofsPerNodeVec.size()!=TotalNumberOfBlocks");
+        FROSCH_ASSERT(repeatedDofMapsVec.size()==TotalNumberOfBlocks,"repeatedDofMapsVec.size()!=TotalNumberOfBlocks");
+        FROSCH_ASSERT(nullSpaceBasisVec.size()==TotalNumberOfBlocks,"nullSpaceBasisVec.size()!=TotalNumberOfBlocks");
+        FROSCH_ASSERT(dirichletBoundaryDofsVec.size()==TotalNumberOfBlocks,"dirichletBoundaryDofsVec.size()!=TotalNumberOfBlocks");
+        FROSCH_ASSERT(nodeListVec.size()==TotalNumberOfBlocks,"nodeListVec.size()!=TotalNumberOfBlocks");
 
         // Todo: Move this to a function in HarmonicCoarseOperator at some point
-        for (UN i=0; i<this->NumberOfBlocks_; i++) {
+        for (UN i=0; i<TotalNumberOfBlocks; i++) {
             FROSCH_ASSERT(!repeatedNodesMapVec[i].is_null(),"repeatedNodesMapVec[i].is_null()");
             FROSCH_ASSERT(!repeatedDofMapsVec[i].is_null(),"repeatedDofMapsVec[i].is_null()");
             FROSCH_ASSERT(!nullSpaceBasisVec[i].is_null(),"nullSpaceBasisVec[i].is_null()");
 
-            this->GammaDofs_.resize(this->GammaDofs_.size()+1);
-            this->IDofs_.resize(this->IDofs_.size()+1);
-            this->InterfaceCoarseSpaces_.resize(this->InterfaceCoarseSpaces_.size()+1);
-            this->DofsMaps_.resize(this->DofsMaps_.size()+1);
-            this->DofsPerNode_.resize(this->DofsPerNode_.size()+1);
-
-            resetCoarseSpaceBlock(i,
+            resetCoarseSpaceBlock(this->NumberOfBlocks_,
                                   dimension,
                                   dofsPerNodeVec[i],
                                   repeatedNodesMapVec[i],
@@ -234,7 +221,7 @@ namespace FROSch {
     {
         FROSCH_DETAILTIMER_START_LEVELID(resetCoarseSpaceBlockTime,"IPOUHarmonicCoarseOperator::resetCoarseSpaceBlock");
         FROSCH_ASSERT(dofsMaps.size()==dofsPerNode,"dofsMaps.size()!=dofsPerNode");
-        FROSCH_ASSERT(blockId<this->NumberOfBlocks_,"Block does not exist yet and can therefore not be reset.");
+        FROSCH_ASSERT(blockId<=this->NumberOfBlocks_,"Block does not exist yet and can therefore not be reset ("+to_string(blockId)+", "+to_string(this->NumberOfBlocks_)+").");
 
         // Process the parameter list
         stringstream blockIdStringstream;
@@ -254,6 +241,12 @@ namespace FROSch {
         bool useForCoarseSpace = coarseSpaceList->get("Use For Coarse Space",true);
 
         if (useForCoarseSpace) {
+            this->GammaDofs_.resize(this->GammaDofs_.size()+1);
+            this->IDofs_.resize(this->IDofs_.size()+1);
+            this->InterfaceCoarseSpaces_.resize(this->InterfaceCoarseSpaces_.size()+1);
+            this->DofsMaps_.resize(this->DofsMaps_.size()+1);
+            this->DofsPerNode_.resize(this->DofsPerNode_.size()+1);
+            this->NumberOfBlocks_++;
 
             if (this->Verbose_) {
                 cout


### PR DESCRIPTION

@trilinos/shylu 

## Motivation

This PR fixes some issues with multiple blocks
- computeExtention with multiple blocks
- No coarse function on some blocks

## Testing

```
      Start  1: ShyLU_DDFROSch_test_interfacepartitionofunity_DIM2_TPETRA_MPI_4
 1/66 Test  #1: ShyLU_DDFROSch_test_interfacepartitionofunity_DIM2_TPETRA_MPI_4 .........................................   Passed    4.75 sec
      Start  2: ShyLU_DDFROSch_test_interfacesets_DIM2_CSCommCrsMatrix_TPETRA_MPI_4
 2/66 Test  #2: ShyLU_DDFROSch_test_interfacesets_DIM2_CSCommCrsMatrix_TPETRA_MPI_4 .....................................   Passed    4.35 sec
      Start  3: ShyLU_DDFROSch_test_interfacesets_DIM2_CSCommCrsGraph_TPETRA_MPI_4
 3/66 Test  #3: ShyLU_DDFROSch_test_interfacesets_DIM2_CSCommCrsGraph_TPETRA_MPI_4 ......................................   Passed    3.91 sec
      Start  4: ShyLU_DDFROSch_test_interfacesets_DIM2_CSOneToOne_TPETRA_MPI_4
 4/66 Test  #4: ShyLU_DDFROSch_test_interfacesets_DIM2_CSOneToOne_TPETRA_MPI_4 ..........................................   Passed    4.17 sec
      Start  5: ShyLU_DDFROSch_test_localpartitionofunitybasis_TPETRA_MPI_1
 5/66 Test  #5: ShyLU_DDFROSch_test_localpartitionofunitybasis_TPETRA_MPI_1 .............................................   Passed    4.29 sec
      Start  6: ShyLU_DDFROSch_test_solverfactory_amesos2_klu_DIM2_TPETRA_MPI_1
 6/66 Test  #6: ShyLU_DDFROSch_test_solverfactory_amesos2_klu_DIM2_TPETRA_MPI_1 .........................................   Passed    5.06 sec
      Start  7: ShyLU_DDFROSch_test_solverfactory_amesos2_klu_DIM3_TPETRA_MPI_1
 7/66 Test  #7: ShyLU_DDFROSch_test_solverfactory_amesos2_klu_DIM3_TPETRA_MPI_1 .........................................   Passed    5.68 sec
      Start  8: ShyLU_DDFROSch_test_solverfactory_belos_gmres_DIM2_TPETRA_MPI_4
 8/66 Test  #8: ShyLU_DDFROSch_test_solverfactory_belos_gmres_DIM2_TPETRA_MPI_4 .........................................   Passed    5.09 sec
      Start  9: ShyLU_DDFROSch_test_solverfactory_ifpack2_riluk_DIM2_TPETRA_MPI_4
 9/66 Test  #9: ShyLU_DDFROSch_test_solverfactory_ifpack2_riluk_DIM2_TPETRA_MPI_4 .......................................   Passed    5.50 sec
      Start 10: ShyLU_DDFROSch_test_solverfactory_froschpreconditioner_twolevelblockpreconditioner_DIM2_TPETRA_MPI_4
10/66 Test #10: ShyLU_DDFROSch_test_solverfactory_froschpreconditioner_twolevelblockpreconditioner_DIM2_TPETRA_MPI_4 ....   Passed    4.63 sec
      Start 11: ShyLU_DDFROSch_test_solverfactory_froschpreconditioner_twolevelpreconditioner_DIM2_TPETRA_MPI_4
11/66 Test #11: ShyLU_DDFROSch_test_solverfactory_froschpreconditioner_twolevelpreconditioner_DIM2_TPETRA_MPI_4 .........   Passed    3.75 sec
      Start 12: ShyLU_DDFROSch_test_solverfactory_thyrapreconditioner_frosch_onelevelpreconditioner_DIM2_TPETRA_MPI_4
12/66 Test #12: ShyLU_DDFROSch_test_solverfactory_thyrapreconditioner_frosch_onelevelpreconditioner_DIM2_TPETRA_MPI_4 ...   Passed    3.74 sec
      Start 13: ShyLU_DDFROSch_test_solverfactory_thyrasolver_belos_gmres_DIM2_TPETRA_MPI_4
13/66 Test #13: ShyLU_DDFROSch_test_solverfactory_thyrasolver_belos_gmres_DIM2_TPETRA_MPI_4 .............................   Passed    4.34 sec
      Start 14: ShyLU_DDFROSch_test_overlap_Graph_DIM2_DPN1_TPETRA_MPI_4
14/66 Test #14: ShyLU_DDFROSch_test_overlap_Graph_DIM2_DPN1_TPETRA_MPI_4 ................................................   Passed    5.00 sec
      Start 15: ShyLU_DDFROSch_test_overlap_Graph_DIM2_DPN2_TPETRA_MPI_4
15/66 Test #15: ShyLU_DDFROSch_test_overlap_Graph_DIM2_DPN2_TPETRA_MPI_4 ................................................   Passed    3.80 sec
      Start 16: ShyLU_DDFROSch_test_overlap_Matrix_DIM2_DPN1_TPETRA_MPI_4
16/66 Test #16: ShyLU_DDFROSch_test_overlap_Matrix_DIM2_DPN1_TPETRA_MPI_4 ...............................................   Passed    4.03 sec
      Start 17: ShyLU_DDFROSch_test_overlap_Matrix_DIM2_DPN2_TPETRA_MPI_4
17/66 Test #17: ShyLU_DDFROSch_test_overlap_Matrix_DIM2_DPN2_TPETRA_MPI_4 ...............................................   Passed    3.80 sec
      Start 18: ShyLU_DDFROSch_test_overlap_Old_DIM2_DPN1_TPETRA_MPI_4
18/66 Test #18: ShyLU_DDFROSch_test_overlap_Old_DIM2_DPN1_TPETRA_MPI_4 ..................................................   Passed    3.95 sec
      Start 19: ShyLU_DDFROSch_test_overlap_Old_DIM2_DPN2_TPETRA_MPI_4
19/66 Test #19: ShyLU_DDFROSch_test_overlap_Old_DIM2_DPN2_TPETRA_MPI_4 ..................................................   Passed    3.96 sec
      Start 20: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_GDSWP_DIM2_TPETRA_MPI_4
20/66 Test #20: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_GDSWP_DIM2_TPETRA_MPI_4 .....................................   Passed    4.64 sec
      Start 21: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_RGDSWP_DIM2_TPETRA_MPI_4
21/66 Test #21: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_RGDSWP_DIM2_TPETRA_MPI_4 ....................................   Passed    4.49 sec
      Start 22: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_RGDSWP_DIM2_TPETRA_SingleReduce_MPI_4
22/66 Test #22: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_RGDSWP_DIM2_TPETRA_SingleReduce_MPI_4 .......................   Passed    3.76 sec
      Start 23: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_GDSW_DIM2_TPETRA_MPI_4
23/66 Test #23: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_GDSW_DIM2_TPETRA_MPI_4 ..................................   Passed    3.71 sec
      Start 24: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_RGDSW_DIM2_TPETRA_MPI_4
24/66 Test #24: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_RGDSW_DIM2_TPETRA_MPI_4 .................................   Passed    4.69 sec
      Start 25: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_IPOUHarmonic_GDSW_DIM2_TPETRA_MPI_4
25/66 Test #25: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_IPOUHarmonic_GDSW_DIM2_TPETRA_MPI_4 .....................   Passed    5.05 sec
      Start 26: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_IPOUHarmonic_GDSW_ML_DIM2_TPETRA_MPI_4
26/66 Test #26: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_IPOUHarmonic_GDSW_ML_DIM2_TPETRA_MPI_4 ..................   Passed    5.04 sec
      Start 27: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_IPOUHarmonic_GDSWStar_DIM2_TPETRA_MPI_4
27/66 Test #27: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_IPOUHarmonic_GDSWStar_DIM2_TPETRA_MPI_4 .................   Passed    5.69 sec
      Start 28: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_IPOUHarmonic_RGDSW_DIM2_TPETRA_MPI_4
28/66 Test #28: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_IPOUHarmonic_RGDSW_DIM2_TPETRA_MPI_4 ....................   Passed    5.20 sec
      Start 29: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_IPOUHarmonic_RGDSW_ML_DIM2_TPETRA_MPI_4
29/66 Test #29: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_IPOUHarmonic_RGDSW_ML_DIM2_TPETRA_MPI_4 .................   Passed    4.74 sec
      Start 30: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_IPOUHarmonic_RGDSW_DIM2_TPETRA_DropCoupling_MPI_4
30/66 Test #30: ShyLU_DDFROSch_test_thyra_xpetra_elasticity_TLP_IPOUHarmonic_RGDSW_DIM2_TPETRA_DropCoupling_MPI_4 .......   Passed    4.35 sec
      Start 31: ShyLU_DDFROSch_test_thyra_xpetra_laplace_GDSWP_DIM2_DPN1_ORD0_TPETRA_MPI_4
31/66 Test #31: ShyLU_DDFROSch_test_thyra_xpetra_laplace_GDSWP_DIM2_DPN1_ORD0_TPETRA_MPI_4 ..............................   Passed    6.93 sec
      Start 32: ShyLU_DDFROSch_test_thyra_xpetra_laplace_GDSWP_DIM2_DPN2_ORD0_TPETRA_MPI_4
32/66 Test #32: ShyLU_DDFROSch_test_thyra_xpetra_laplace_GDSWP_DIM2_DPN2_ORD0_TPETRA_MPI_4 ..............................   Passed    4.20 sec
      Start 33: ShyLU_DDFROSch_test_thyra_xpetra_laplace_GDSWP_DIM2_DPN2_ORD1_TPETRA_MPI_4
33/66 Test #33: ShyLU_DDFROSch_test_thyra_xpetra_laplace_GDSWP_DIM2_DPN2_ORD1_TPETRA_MPI_4 ..............................   Passed    3.80 sec
      Start 34: ShyLU_DDFROSch_test_thyra_xpetra_laplace_RGDSWP_DIM2_DPN1_ORD0_TPETRA_MPI_4
34/66 Test #34: ShyLU_DDFROSch_test_thyra_xpetra_laplace_RGDSWP_DIM2_DPN1_ORD0_TPETRA_MPI_4 .............................   Passed    3.83 sec
      Start 35: ShyLU_DDFROSch_test_thyra_xpetra_laplace_RGDSWP_DIM2_DPN2_ORD0_TPETRA_MPI_4
35/66 Test #35: ShyLU_DDFROSch_test_thyra_xpetra_laplace_RGDSWP_DIM2_DPN2_ORD0_TPETRA_MPI_4 .............................   Passed    3.86 sec
      Start 36: ShyLU_DDFROSch_test_thyra_xpetra_laplace_RGDSWP_DIM2_DPN2_ORD1_TPETRA_MPI_4
36/66 Test #36: ShyLU_DDFROSch_test_thyra_xpetra_laplace_RGDSWP_DIM2_DPN2_ORD1_TPETRA_MPI_4 .............................   Passed    3.81 sec
      Start 37: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_GDSW_DIM2_DPN1_ORD0_TPETRA_MPI_4
37/66 Test #37: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_GDSW_DIM2_DPN1_ORD0_TPETRA_MPI_4 ...........................   Passed    4.37 sec
      Start 38: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_GDSW_DIM2_DPN2_ORD0_TPETRA_MPI_4
38/66 Test #38: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_GDSW_DIM2_DPN2_ORD0_TPETRA_MPI_4 ...........................   Passed    4.27 sec
      Start 39: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_GDSW_DIM2_DPN2_ORD1_TPETRA_MPI_4
39/66 Test #39: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_GDSW_DIM2_DPN2_ORD1_TPETRA_MPI_4 ...........................   Passed    4.57 sec
      Start 40: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_RGDSW_DIM2_DPN1_ORD0_TPETRA_MPI_4
40/66 Test #40: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_RGDSW_DIM2_DPN1_ORD0_TPETRA_MPI_4 ..........................   Passed    4.30 sec
      Start 41: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_RGDSW_DIM2_DPN2_ORD0_TPETRA_MPI_4
41/66 Test #41: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_RGDSW_DIM2_DPN2_ORD0_TPETRA_MPI_4 ..........................   Passed    4.67 sec
      Start 42: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_RGDSW_DIM2_DPN2_ORD1_TPETRA_MPI_4
42/66 Test #42: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_RGDSW_DIM2_DPN2_ORD1_TPETRA_MPI_4 ..........................   Passed    4.56 sec
      Start 43: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_GDSW_DIM2_DPN1_ORD0_TPETRA_MPI_4
43/66 Test #43: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_GDSW_DIM2_DPN1_ORD0_TPETRA_MPI_4 ..............   Passed    5.35 sec
      Start 44: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_GDSW_DIM2_DPN2_ORD0_TPETRA_MPI_4
44/66 Test #44: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_GDSW_DIM2_DPN2_ORD0_TPETRA_MPI_4 ..............   Passed    5.26 sec
      Start 45: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_GDSW_DIM2_DPN2_ORD1_TPETRA_MPI_4
45/66 Test #45: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_GDSW_DIM2_DPN2_ORD1_TPETRA_MPI_4 ..............   Passed    4.94 sec
      Start 46: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_GDSW_ML_DIM2_DPN1_ORD0_TPETRA_MPI_4
46/66 Test #46: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_GDSW_ML_DIM2_DPN1_ORD0_TPETRA_MPI_4 ...........   Passed    4.59 sec
      Start 47: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_GDSWStar_DIM2_DPN1_ORD0_TPETRA_MPI_4
47/66 Test #47: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_GDSWStar_DIM2_DPN1_ORD0_TPETRA_MPI_4 ..........   Passed    5.19 sec
      Start 48: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_GDSWStar_DIM2_DPN2_ORD0_TPETRA_MPI_4
48/66 Test #48: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_GDSWStar_DIM2_DPN2_ORD0_TPETRA_MPI_4 ..........   Passed    4.37 sec
      Start 49: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_GDSWStar_DIM2_DPN2_ORD1_TPETRA_MPI_4
49/66 Test #49: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_GDSWStar_DIM2_DPN2_ORD1_TPETRA_MPI_4 ..........   Passed    4.38 sec
      Start 50: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_RGDSW_DIM2_DPN1_ORD0_TPETRA_MPI_4
50/66 Test #50: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_RGDSW_DIM2_DPN1_ORD0_TPETRA_MPI_4 .............   Passed    4.76 sec
      Start 51: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_RGDSW_DIM2_DPN2_ORD0_TPETRA_MPI_4
51/66 Test #51: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_RGDSW_DIM2_DPN2_ORD0_TPETRA_MPI_4 .............   Passed    4.71 sec
      Start 52: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_RGDSW_DIM2_DPN2_ORD1_TPETRA_MPI_4
52/66 Test #52: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLP_IPOUHarmonic_RGDSW_DIM2_DPN2_ORD1_TPETRA_MPI_4 .............   Passed    4.21 sec
      Start 53: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB2_GDSW_DIM2_DPN1_ORD0_TPETRA_MPI_4
53/66 Test #53: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB2_GDSW_DIM2_DPN1_ORD0_TPETRA_MPI_4 ......................   Passed    4.15 sec
      Start 54: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB2_GDSW_DIM2_DPN2_ORD0_TPETRA_MPI_4
54/66 Test #54: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB2_GDSW_DIM2_DPN2_ORD0_TPETRA_MPI_4 ......................   Passed    4.80 sec
      Start 55: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB2_GDSW_DIM2_DPN1_ORD1_TPETRA_MPI_4
55/66 Test #55: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB2_GDSW_DIM2_DPN1_ORD1_TPETRA_MPI_4 ......................   Passed    4.89 sec
      Start 56: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB2_GDSW_DIM2_DPN2_ORD1_TPETRA_MPI_4
56/66 Test #56: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB2_GDSW_DIM2_DPN2_ORD1_TPETRA_MPI_4 ......................   Passed    4.58 sec
      Start 57: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB3_GDSW_DIM2_DPN1_ORD0_TPETRA_MPI_4
57/66 Test #57: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB3_GDSW_DIM2_DPN1_ORD0_TPETRA_MPI_4 ......................   Passed    4.46 sec
      Start 58: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB3_GDSW_DIM2_DPN2_ORD0_TPETRA_MPI_4
58/66 Test #58: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB3_GDSW_DIM2_DPN2_ORD0_TPETRA_MPI_4 ......................   Passed    4.29 sec
      Start 59: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB3_GDSW_DIM2_DPN1_ORD1_TPETRA_MPI_4
59/66 Test #59: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB3_GDSW_DIM2_DPN1_ORD1_TPETRA_MPI_4 ......................   Passed    4.78 sec
      Start 60: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB3_GDSW_DIM2_DPN2_ORD1_TPETRA_MPI_4
60/66 Test #60: ShyLU_DDFROSch_test_thyra_xpetra_laplace_TLBP_NB3_GDSW_DIM2_DPN2_ORD1_TPETRA_MPI_4 ......................   Passed    4.60 sec
      Start 61: ShyLU_DDFROSch_test_thyra_xpetra_laplace_one_rank_TLP_GDSW_DIM2_TPETRA_MPI_1
61/66 Test #61: ShyLU_DDFROSch_test_thyra_xpetra_laplace_one_rank_TLP_GDSW_DIM2_TPETRA_MPI_1 ............................   Passed    5.81 sec
      Start 62: ShyLU_DDFROSch_test_thyra_xpetra_laplace_one_rank_TLP_GDSW_DIM3_TPETRA_MPI_1
62/66 Test #62: ShyLU_DDFROSch_test_thyra_xpetra_laplace_one_rank_TLP_GDSW_DIM3_TPETRA_MPI_1 ............................   Passed    5.42 sec
      Start 63: ShyLU_DDFROSch_test_thyra_xpetra_laplace_one_rank_TLP_RGDSW_DIM2_TPETRA_MPI_1
63/66 Test #63: ShyLU_DDFROSch_test_thyra_xpetra_laplace_one_rank_TLP_RGDSW_DIM2_TPETRA_MPI_1 ...........................   Passed    4.69 sec
      Start 64: ShyLU_DDFROSch_test_thyra_xpetra_laplace_one_rank_TLP_RGDSW_DIM3_TPETRA_MPI_1
64/66 Test #64: ShyLU_DDFROSch_test_thyra_xpetra_laplace_one_rank_TLP_RGDSW_DIM3_TPETRA_MPI_1 ...........................   Passed    5.35 sec
      Start 65: ShyLU_DDFROSch_test_thyra_xpetra_laplace_one_rank_TLP_IPOU_DIM2_TPETRA_MPI_1
65/66 Test #65: ShyLU_DDFROSch_test_thyra_xpetra_laplace_one_rank_TLP_IPOU_DIM2_TPETRA_MPI_1 ............................   Passed    4.12 sec
      Start 66: ShyLU_DDFROSch_test_thyra_xpetra_laplace_one_rank_TLP_IPOU_DIM3_TPETRA_MPI_1
66/66 Test #66: ShyLU_DDFROSch_test_thyra_xpetra_laplace_one_rank_TLP_IPOU_DIM3_TPETRA_MPI_1 ............................   Passed    4.59 sec

100% tests passed, 0 tests failed out of 66
```