### PR TITLE
Stokhos: use exec instance in `deep_copy` of `View` of `MP::Vector`

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
@@ -326,7 +326,7 @@ void deep_copy(
 /* Specialize for deep copy of MP::Vector */
 template< class ExecSpace, class DT , class ... DP , class ST , class ... SP >
 inline
-void deep_copy( const ExecSpace &,
+void deep_copy( const ExecSpace & exec,
                 const View<DT,DP...> & dst ,
                 const View<ST,SP...> & src
   , typename std::enable_if<(
@@ -359,7 +359,7 @@ void deep_copy( const ExecSpace &,
   //   typename View<ST,SP...>::array_type( src ) );
 
   Kokkos::deep_copy(
-    ExecSpace() ,
+    exec ,
     typename FlatArrayType< View<DT,DP...> >::type( dst ) ,
     typename FlatArrayType< View<ST,SP...> >::type( src ) );
 }


### PR DESCRIPTION
@trilinos/stokhos
@etphipp
@romintomasetti 

This PR modifies the `Stokhos` specialisation of the `deep_copy` overload that takes an execution space instance and copies between two views. 

The `Stokhos` specialisation works by calling the `Kokkos` implementation with views of `FlatArrayType` type. However, currently, the `Stokhos` specialisation discards the passed execution space instance. Instead, it passes a default execution space instance to the `Kokkos` implementation. Thus, the deep copy operation is ultimately not enqueued in the right stream.  

The change made in this PR is thus to let the `Stokhos` specialisation pass the received execution space instance to the `Kokkos` implementation.

(Just for context, our code calls `create_mirror_view` at some point using view constructor properties. This is how we noted the issue in PR #13433. Then, to make sure that everything works, we wrote an additional test, and this is where we noted the present issue.)