### PR TITLE
Stokhos:  Deprecate the PCE scalar type

### DIFF
--- a/packages/stokhos/CMakeLists.txt
+++ b/packages/stokhos/CMakeLists.txt
@@ -10,13 +10,7 @@ TRIBITS_PACKAGE(Stokhos)
 
 TRIBITS_ADD_EXPLICIT_INSTANTIATION_OPTION()
 
-SET (Stokhos_ENABLE_DEPRECATED_CODE_DEFAULT ON)
-TRIBITS_ADD_OPTION_AND_DEFINE(
-  Stokhos_ENABLE_DEPRECATED_CODE
-  STOKHOS_ENABLE_DEPRECATED_CODE
-  "Whether Stokhos enables deprecated code (that is, anything marked with the STOKHOS_DEPRECATED macro) at compile time.  Default is ON (deprecated code enabled)."
-  ${Stokhos_ENABLE_DEPRECATED_CODE_DEFAULT}
-)
+TRIBITS_ADD_SHOW_DEPRECATED_WARNINGS_OPTION()
 
 TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_ENABLE_DEBUG
   STOKHOS_DEBUG
@@ -59,7 +53,7 @@ SET(Stokhos_ENABLE_Ensemble_Scalar_Type_Default OFF)
 SET(Stokhos_ENABLE_PCE_Scalar_Type_Default OFF)
 IF(Stokhos_ENABLE_Sacado)
   SET(Stokhos_ENABLE_Ensemble_Scalar_Type_Default ON)
-  IF(Stokhos_ENABLE_DEPRECATED_CODE)
+  IF(NOT Stokhos_HIDE_DEPRECATED_CODE)
     SET(Stokhos_ENABLE_PCE_Scalar_Type_Default ON)
   ENDIF()
 ENDIF()
@@ -75,10 +69,10 @@ TRIBITS_ADD_OPTION_AND_DEFINE(Stokhos_ENABLE_PCE_Scalar_Type
   ${Stokhos_ENABLE_PCE_Scalar_Type_Default}  )
 
 IF(Stokhos_ENABLE_PCE_Scalar_Type)
-  IF(Stokhos_ENABLE_DEPRECATED_CODE)
-    MESSAGE(WARNING "The PCE scalar type is deprecated in Stokhos but Stokhos_ENABLE_DEPRECATED_CODE=ON.")
+  IF(Stokhos_HIDE_DEPRECATED_CODE)
+    MESSAGE(FATAL_ERROR "The PCE scalar type is deprecated in Stokhos but Stokhos_HIDE_DEPRECATED_CODE=ON.  You must set Stokhos_ENABLE_PCE_Scalar_Type=OFF or Stokhos_HIDE_DEPRECATED_CODE=OFF.")
   ELSE()
-    MESSAGE(FATAL_ERROR "The PCE scalar type is deprecated in Stokhos but Stokhos_ENABLE_DEPRECATED_CODE=OFF.  You must set Stokhos_ENABLE_PCE_Scalar_Type=OFF or Stokhos_ENABLE_DEPRECATED_CODE=ON.")
+    MESSAGE(WARNING "The PCE scalar type is deprecated in Stokhos but Stokhos_HIDE_DEPRECATED_CODE=OFF.")
   ENDIF()
 ENDIF()
 

--- a/packages/stokhos/CMakeLists.txt
+++ b/packages/stokhos/CMakeLists.txt
@@ -10,6 +10,14 @@ TRIBITS_PACKAGE(Stokhos)
 
 TRIBITS_ADD_EXPLICIT_INSTANTIATION_OPTION()
 
+SET (Stokhos_ENABLE_DEPRECATED_CODE_DEFAULT ON)
+TRIBITS_ADD_OPTION_AND_DEFINE(
+  Stokhos_ENABLE_DEPRECATED_CODE
+  STOKHOS_ENABLE_DEPRECATED_CODE
+  "Whether Stokhos enables deprecated code (that is, anything marked with the STOKHOS_DEPRECATED macro) at compile time.  Default is ON (deprecated code enabled)."
+  ${Stokhos_ENABLE_DEPRECATED_CODE_DEFAULT}
+)
+
 TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_ENABLE_DEBUG
   STOKHOS_DEBUG
   "Enable debug code in stokhos"
@@ -48,8 +56,12 @@ IF(HAVE_STOKHOS_ENSEMBLE_GEMV)
 ENDIF()
 
 SET(Stokhos_ENABLE_Ensemble_Scalar_Type_Default OFF)
+SET(Stokhos_ENABLE_PCE_Scalar_Type_Default OFF)
 IF(Stokhos_ENABLE_Sacado)
   SET(Stokhos_ENABLE_Ensemble_Scalar_Type_Default ON)
+  IF(Stokhos_ENABLE_DEPRECATED_CODE)
+    SET(Stokhos_ENABLE_PCE_Scalar_Type_Default ON)
+  ENDIF()
 ENDIF()
 
 TRIBITS_ADD_OPTION_AND_DEFINE(Stokhos_ENABLE_Ensemble_Scalar_Type
@@ -60,7 +72,15 @@ TRIBITS_ADD_OPTION_AND_DEFINE(Stokhos_ENABLE_Ensemble_Scalar_Type
 TRIBITS_ADD_OPTION_AND_DEFINE(Stokhos_ENABLE_PCE_Scalar_Type
   HAVE_STOKHOS_PCE_SCALAR_TYPE
   "Enable use of the PCE UQ scalar type in stokhos"
-  ${Stokhos_ENABLE_Ensemble_Scalar_Type_Default} )
+  ${Stokhos_ENABLE_PCE_Scalar_Type_Default}  )
+
+IF(Stokhos_ENABLE_PCE_Scalar_Type)
+  IF(Stokhos_ENABLE_DEPRECATED_CODE)
+    MESSAGE(WARNING "The PCE scalar type is deprecated in Stokhos but Stokhos_ENABLE_DEPRECATED_CODE=ON.")
+  ELSE()
+    MESSAGE(FATAL_ERROR "The PCE scalar type is deprecated in Stokhos but Stokhos_ENABLE_DEPRECATED_CODE=OFF.  You must set Stokhos_ENABLE_PCE_Scalar_Type=OFF or Stokhos_ENABLE_DEPRECATED_CODE=ON.")
+  ENDIF()
+ENDIF()
 
 IF(Stokhos_ENABLE_Ensemble_Scalar_Type AND NOT Stokhos_ENABLE_Sacado)
   MESSAGE(FATAL_ERROR "Ensemble scalar type cannot be enabled unless Sacado is enabled!")

--- a/packages/stokhos/cmake/Stokhos_config.h.in
+++ b/packages/stokhos/cmake/Stokhos_config.h.in
@@ -132,3 +132,7 @@
 #define STOKHOS_GEMV_CACHE_SIZE @Stokhos_Ensemble_GEMV_Cache_Size@
 #define STOKHOS_GEMV_TEAM_SIZE @Stokhos_Ensemble_GEMV_Team_Size@
 #endif // HAVE_STOKHOS_ENSEMBLE_GEMV
+
+@STOKHOS_DEPRECATED_DECLARATIONS@
+
+#cmakedefine Stokhos_SHOW_DEPRECATED_WARNINGS

--- a/packages/stokhos/src/sacado/kokkos/pce/Stokhos_Sacado_Kokkos_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/Stokhos_Sacado_Kokkos_UQ_PCE.hpp
@@ -12,6 +12,8 @@
 
 #include "Stokhos_ConfigDefs.h"
 
+#warning "The PCE scalar type is deprecated."
+
 #include "Kokkos_Macros.hpp"
 
 #include "Stokhos_Sacado_Kokkos_MathFunctions.hpp"

--- a/packages/stokhos/src/sacado/kokkos/pce/Stokhos_Sacado_Kokkos_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/Stokhos_Sacado_Kokkos_UQ_PCE.hpp
@@ -12,7 +12,11 @@
 
 #include "Stokhos_ConfigDefs.h"
 
+#if defined(Stokhos_SHOW_DEPRECATED_WARNINGS)
+#ifdef __GNUC__
 #warning "The PCE scalar type is deprecated."
+#endif
+#endif
 
 #include "Kokkos_Macros.hpp"
 


### PR DESCRIPTION
Adds Stokhos_ENABLE_DEPRECATED_CODE option (default is ON), and the PCE scalar type can only be enabled if Stokhos_ENABLE_DEPRECATED_CODE=ON. If off, and the PCE scalar type is enabled, cmake errors out.  Also prints a cmake warning if deprecated code is on and the PCE scalar type is on, and copius compiler warnings.