### PR TITLE
Tpetra: Fixing AMD Unified Memory issue in packCrs[Graph|Matrix] test / ImportExport2 test compile error

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
@@ -209,10 +209,12 @@ public:
 
   //! Host function for getting the error.
   int getError () const {
-    typedef typename device_type::execution_space execution_space;
     auto error_h = Kokkos::create_mirror_view (error_);
     // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
-    Kokkos::deep_copy (execution_space(), error_h, error_);
+    // Note: In the UVM case, this would otherwise be a no-op
+    // and thus not fence, so the value might not be correct on return
+    // In the non-UVM case, create_mirror_view will block for the allocation
+    Kokkos::deep_copy (error_h, error_);
     return error_h ();
   }
 

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -2356,7 +2356,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, 
       os << *prefix << "Calling 4-arg doPostsAndWaits" << std::endl;
       std::cerr << os.str ();
     }
-    Kokkos::View<char*, Kokkos::HostSpace> importsView(imports.data(), imports.size());
+    using char_host_mirror_view = typename Kokkos::View<char*, typename map_type::node_type::memory_space>::HostMirror;
+    char_host_mirror_view importsView(imports.data(), imports.size());
     distor.doPostsAndWaits(exports.view_host(),numExportPackets(),importsView,numImportPackets());
     auto importsView_d = Kokkos::create_mirror_view(Node::device_type::memory_space(), importsView);
     deep_copy(importsView_d,importsView);


### PR DESCRIPTION
Issue: #13473
Test: packCrsGraph/packCrsMatrix now pass, ImportExport2 test now compiles
Stakeholder Feedback:  As the stakeholder, I approve.

Also, adding some kernel labels.