### PR TITLE
KokkosKernels: match #2353

### DIFF
--- a/packages/kokkos-kernels/sparse/impl/KokkosSparse_sort_crs_impl.hpp
+++ b/packages/kokkos-kernels/sparse/impl/KokkosSparse_sort_crs_impl.hpp
@@ -329,11 +329,32 @@ Kokkos::View<typename Rowmap::non_const_value_type*, ExecSpace> computeEntryPerm
 }
 
 // Heuristic for choosing bulk sorting algorithm
-template <typename Ordinal>
+template <typename ExecSpace, typename Ordinal>
 bool useBulkSortHeuristic(Ordinal avgDeg, Ordinal maxDeg) {
-  // Use bulk sort if matrix is highly imbalanced,
-  // OR the longest rows have many entries.
-  return (maxDeg / 10 > avgDeg) || (maxDeg > 1024);
+  // Issue 2352: the KokkosSparse::sort_crs_matrix uses Kokkos::Experimental::sort_by_key when this returns true.
+  // sort_by_key executes on the host when a thrust-like library is not available, which really kills the performance in
+  // a scenario where the bulk sort algorithm would otherwise be appropriate. Additionally, On MI300A, sorting via
+  // ROCTHRUST was observed to be ~3x slower than the Kokkos kernels native implementation on some matrices of interest,
+  // so on that architecture only always bypass bulk sort.
+  // * GPU execution space, SYLC is enabled, but no ONEDPL does not have sort_by_key
+  // * GPU execution space, HIP is enabled, but no ROCTHRUST
+  // * GPU execution space, HIP is enabled, and GPU is GFX942
+  // (Kokkos seems to require thrust when CUDA is enabled)
+  if constexpr (KokkosKernels::Impl::kk_is_gpu_exec_space<ExecSpace>()) {
+#if (defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ONEDPL_HAS_SORT_BY_KEY)) || \
+    (defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_ROCTHRUST)) ||        \
+    (defined(KOKKOS_ENABLE_HIP) && defined(KOKKOS_ARCH_AMD_GFX942))
+    return false;
+#else
+    // Use bulk sort if matrix is highly imbalanced,
+    // OR the longest rows have many entries.
+    return (maxDeg / 10 > avgDeg) || (maxDeg > 1024);
+#endif
+  } else {
+    // Use bulk sort if matrix is highly imbalanced,
+    // OR the longest rows have many entries.
+    return (maxDeg / 10 > avgDeg) || (maxDeg > 1024);
+  }
 }
 #endif
 

--- a/packages/kokkos-kernels/sparse/src/KokkosSparse_SortCrs.hpp
+++ b/packages/kokkos-kernels/sparse/src/KokkosSparse_SortCrs.hpp
@@ -77,7 +77,7 @@ void sort_crs_matrix(const execution_space& exec, const rowmap_t& rowmap, const 
 #ifndef KK_DISABLE_BULK_SORT_BY_KEY
     Ordinal maxDeg   = KokkosSparse::Impl::graph_max_degree(exec, rowmap);
     bool useBulkSort = false;
-    if (KokkosSparse::Impl::useBulkSortHeuristic(avgDeg, maxDeg)) {
+    if (KokkosSparse::Impl::useBulkSortHeuristic<execution_space>(avgDeg, maxDeg)) {
       // Calculate the true number of columns if user didn't pass it in
       if (numCols == Kokkos::ArithTraits<Ordinal>::max()) {
         KokkosKernels::Impl::kk_view_reduce_max(exec, entries.extent(0), entries, numCols);
@@ -255,7 +255,7 @@ void sort_crs_graph(const execution_space& exec, const rowmap_t& rowmap, const e
 #ifndef KK_DISABLE_BULK_SORT_BY_KEY
     Ordinal maxDeg   = KokkosSparse::Impl::graph_max_degree(exec, rowmap);
     bool useBulkSort = false;
-    if (KokkosSparse::Impl::useBulkSortHeuristic(avgDeg, maxDeg)) {
+    if (KokkosSparse::Impl::useBulkSortHeuristic<execution_space>(avgDeg, maxDeg)) {
       // Calculate the true number of columns if user didn't pass it in
       if (numCols == Kokkos::ArithTraits<Ordinal>::max()) {
         KokkosKernels::Impl::kk_view_reduce_max(exec, entries.extent(0), entries, numCols);


### PR DESCRIPTION
@trilinos/kokkos-kernels

Matching patch for https://github.com/kokkos/kokkos-kernels/pull/2353/

A performance regression in `KokkosSparse::sort_crs_matrix` was introduced in https://github.com/trilinos/Trilinos/pull/13401, where `sort_crs_matrix` was changed to use `Kokkos::Experimental::sort_by_key` in certain cases. 
One of the MueLu setup performance tests catches one of those cases:

```bash
muelu/test/scaling/MueLu_Driver.exe" "--stacked-timer" "--nx=120" "--ny=120" "--nz=120" "--matrixType=Laplace3D"
```

On MI300 this manifested as a ~60x slowdown in Tpetra's matrix transpose because `sort_by_key` is only fast on AMD when Kokkos can use the rocThrust TPL, which Trilinos does not support. This PR also preemptively attempts to avoid falling in to the same trap on SYCL. For CUDA, Thrust TPL is always available, so this is not a problem.

| Config | Local Transpose Time (s) |
|-|-|
| Before 13401 | 0.056 |
| After 13401 | 0.34 |
| This PR | 0.056 |

