### PR TITLE
KokkosKernels: patch PR 2345

### DIFF
--- a/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
+++ b/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_SVD_Serial_Internal.hpp
@@ -51,11 +51,10 @@ struct SerialSVDInternal {
   template <typename value_type>
   KOKKOS_INLINE_FUNCTION static void symEigen2x2(value_type a11, value_type a21, value_type a22, value_type& e1,
                                                  value_type& e2) {
-    value_type a = Kokkos::ArithTraits<value_type>::one();
-    value_type b = -a11 - a22;
-    value_type c = a11 * a22 - a21 * a21;
-    using Kokkos::sqrt;
-    value_type sqrtDet = sqrt(b * b - 4 * a * c);
+    value_type a       = Kokkos::ArithTraits<value_type>::one();
+    value_type b       = -a11 - a22;
+    value_type c       = a11 * a22 - a21 * a21;
+    value_type sqrtDet = Kokkos::sqrt(b * b - 4 * a * c);
     e1                 = (-b + sqrtDet) / (2 * a);
     e2                 = (-b - sqrtDet) / (2 * a);
   }
@@ -78,7 +77,7 @@ struct SerialSVDInternal {
     value_type e1, e2, mu;
     symEigen2x2(dm * dm + fmm1 * fmm1, dm * fm, target, e1, e2);
     // the shift is the eigenvalue closer to the last diagonal entry of B^T*B
-    if (fabs(e1 - target) < fabs(e2 - target))
+    if (Kokkos::abs(e1 - target) < Kokkos::abs(e2 - target))
       mu = e1;
     else
       mu = e2;
@@ -124,7 +123,7 @@ struct SerialSVDInternal {
   // Assumes i is not the last row.
   // U is m*m, B is n*n
   template <typename value_type>
-  KOKKOS_INLINE_FUNCTION static void svdZeroRow(int i, value_type* B, int n, int Bs0, int Bs1, value_type* U, int m,
+  KOKKOS_INLINE_FUNCTION static void svdZeroRow(int i, value_type* B, int n, int Bs0, int Bs1, value_type* U, int Um,
                                                 int Us0, int Us1) {
     Kokkos::pair<value_type, value_type> G;
     for (int j = i + 1; j < n; j++) {
@@ -138,17 +137,16 @@ struct SerialSVDInternal {
                                                                          &SVDIND(B, j, j + 1), Bs1);
       }
       if (U) {
-        KokkosBatched::SerialApplyRightGivensInternal::invoke<value_type>(G, m, &SVDIND(U, 0, i), Us0, &SVDIND(U, 0, j),
-                                                                          Us0);
+        KokkosBatched::SerialApplyRightGivensInternal::invoke<value_type>(G, Um, &SVDIND(U, 0, i), Us0,
+                                                                          &SVDIND(U, 0, j), Us0);
       }
     }
   }
 
   template <typename value_type>
-  KOKKOS_INLINE_FUNCTION static void svdZeroLastColumn(value_type* B, int n, int Bs0, int Bs1, value_type* Vt, int Vts0,
-                                                       int Vts1) {
-    // Deal with B(n-1, n-1) = 0, by chasing the superdiagonal nonzero up the
-    // last column.
+  KOKKOS_INLINE_FUNCTION static void svdZeroLastColumn(value_type* B, int n, int Bs0, int Bs1, int vn, value_type* Vt,
+                                                       int Vts0, int Vts1) {
+    // Deal with B(n-1, n-1) = 0, by chasing the superdiagonal nonzero up the last column.
     Kokkos::pair<value_type, value_type> G;
     for (int j = n - 2; j >= 0; j--) {
       KokkosBatched::SerialGivensInternal::invoke<value_type>(SVDIND(B, j, j), SVDIND(B, j, n - 1), &G,
@@ -159,7 +157,7 @@ struct SerialSVDInternal {
                                                                           &SVDIND(B, j - 1, j), Bs0);
       }
       if (Vt) {
-        KokkosBatched::SerialApplyLeftGivensInternal::invoke<value_type>(G, n, &SVDIND(Vt, n - 1, 0), Vts1,
+        KokkosBatched::SerialApplyLeftGivensInternal::invoke<value_type>(G, vn, &SVDIND(Vt, n - 1, 0), Vts1,
                                                                          &SVDIND(Vt, j, 0), Vts1);
       }
     }
@@ -224,8 +222,9 @@ struct SerialSVDInternal {
     while (true) {
       // Zero out tiny superdiagonal entries
       for (int i = 0; i < n - 1; i++) {
-        if (fabs(SVDIND(B, i, i + 1)) < eps * (fabs(SVDIND(B, i, i)) + fabs(SVDIND(B, i + 1, i + 1))) ||
-            fabs(SVDIND(B, i, i + 1)) < tol) {
+        if (Kokkos::abs(SVDIND(B, i, i + 1)) <
+                eps * (Kokkos::abs(SVDIND(B, i, i)) + Kokkos::abs(SVDIND(B, i + 1, i + 1))) ||
+            Kokkos::abs(SVDIND(B, i, i + 1)) < tol) {
           SVDIND(B, i, i + 1) = KAT::zero();
         }
       }
@@ -246,25 +245,32 @@ struct SerialSVDInternal {
       for (p = q - 1; p > 0; p--) {
         if (SVDIND(B, p - 1, p) == KAT::zero()) break;
       }
+      value_type* Bsub  = &SVDIND(B, p, p);
+      value_type* Usub  = &SVDIND(U, 0, p);
+      value_type* Vtsub = &SVDIND(Vt, p, 0);
+      int nsub          = q - p;
       // If there are zero diagonals in this range, eliminate the entire row
       //(effectively decoupling into two subproblems)
       for (int i = q - 1; i >= p; i--) {
         if (SVDIND(B, i, i) == KAT::zero()) {
-          if (i == n - 1) {
+          if (i == q - 1) {
             // Last diagonal entry being 0 is a special case.
             // Zero out the superdiagonal above it.
-            // Deal with B(n-1, n-1) = 0, by chasing the superdiagonal nonzero
-            // up the last column.
-            svdZeroLastColumn(B, n, Bs0, Bs1, Vt, Vts0, Vts1);
+            // Deal with B(q-1, q-1) = 0, by chasing the superdiagonal nonzero
+            // B(q-2, q-1) up the last column.
+            //
+            // Once that nonzero reaches B(p, q-1), we are either at the top of B
+            // (if p == 0) or the superdiag above B(p, p) is zero.
+            // In either case, the chase stops after eliminating B(p, q-1) because no
+            // new entry is introduced by the Givens.
+            svdZeroLastColumn(Bsub, nsub, Bs0, Bs1, n, Vtsub, Vts0, Vts1);
           } else if (SVDIND(B, i, i + 1) != KAT::zero()) {
-            svdZeroRow(i, B, n, Bs0, Bs1, U, m, Us0, Us1);
+            svdZeroRow(i - p, Bsub, nsub, Bs0, Bs1, Usub, m, Us0, Us1);
           }
         }
-        continue;
       }
-      int nsub = q - p;
       // B22 is nsub * nsub, Usub is m * nsub, and Vtsub is nsub * n
-      svdStep(&SVDIND(B, p, p), &SVDIND(U, 0, p), &SVDIND(Vt, p, 0), m, n, nsub, Bs0, Bs1, Us0, Us1, Vts0, Vts1);
+      svdStep(Bsub, Usub, Vtsub, m, n, nsub, Bs0, Bs1, Us0, Us1, Vts0, Vts1);
     }
     for (int i = 0; i < n; i++) {
       sigma[i * ss] = SVDIND(B, i, i);

--- a/packages/kokkos-kernels/batched/dense/unit_test/Test_Batched_SerialSVD.hpp
+++ b/packages/kokkos-kernels/batched/dense/unit_test/Test_Batched_SerialSVD.hpp
@@ -103,40 +103,6 @@ void verifySVD(const AView& A, const UView& U, const VtView& Vt, const SigmaView
   }
 }
 
-template <typename Matrix>
-Matrix createRandomMatrix(int m, int n, int deficiency, double maxval = 1.0) {
-  using Scalar = typename Matrix::non_const_value_type;
-  Matrix mat("A", m, n);
-  auto mhost = Kokkos::create_mirror_view(mat);
-  // Fill mat with random values first
-  if (maxval != 0.0) {
-    Kokkos::Random_XorShift64_Pool<Kokkos::DefaultHostExecutionSpace> rand_pool(13718);
-    Scalar minrand, maxrand;
-    Test::getRandomBounds<Scalar>(maxval, minrand, maxrand);
-    Kokkos::fill_random(mhost, rand_pool, minrand, maxrand);
-  }
-  // Apply the rank deficiency.
-  // If m < n, make some rows a multiple of the first row.
-  // Otherwise, make some columns a multiple of the first column.
-  if (m < n) {
-    for (int i = 0; i < deficiency; i++) {
-      // make row i + 1 a multiple of row 0
-      for (int j = 0; j < n; j++) {
-        mhost(i + 1, j) = (double)(i + 2) * mhost(0, j);
-      }
-    }
-  } else {
-    for (int i = 0; i < deficiency; i++) {
-      // make col i + 1 a multiple of col 0
-      for (int j = 0; j < m; j++) {
-        mhost(j, i + 1) = (double)(i + 2) * mhost(j, 0);
-      }
-    }
-  }
-  Kokkos::deep_copy(mat, mhost);
-  return mat;
-}
-
 template <typename Matrix, typename Vector>
 struct SerialSVDFunctor_Full {
   SerialSVDFunctor_Full(const Matrix& A_, const Matrix& U_, const Matrix& Vt_, const Vector& sigma_,
@@ -172,12 +138,39 @@ struct SerialSVDFunctor_SingularValuesOnly {
   Vector work;
 };
 
+template <typename Matrix>
+Matrix randomMatrixWithRank(int m, int n, int rank) {
+  Matrix A("A", m, n);
+  if (rank == Kokkos::min(m, n)) {
+    // A is full-rank so as a shortcut, fill it with random values directly.
+    Kokkos::Random_XorShift64_Pool<typename Matrix::device_type> rand_pool(13318);
+    Kokkos::fill_random(A, rand_pool, -1.0, 1.0);
+  } else {
+    // A is rank-deficient, so compute it as a product of two random matrices
+    using MatrixHost = typename Matrix::HostMirror;
+    auto Ahost       = Kokkos::create_mirror_view(A);
+    Kokkos::Random_XorShift64_Pool<Kokkos::DefaultHostExecutionSpace> rand_pool(13318);
+    MatrixHost U("U", m, rank);
+    MatrixHost Vt("Vt", rank, n);
+    Kokkos::fill_random(U, rand_pool, -1.0, 1.0);
+    Kokkos::fill_random(Vt, rand_pool, -1.0, 1.0);
+    Test::vanillaGEMM(1.0, U, Vt, 0.0, Ahost);
+    Kokkos::deep_copy(A, Ahost);
+  }
+  return A;
+}
+
+template <typename Matrix>
+Matrix randomMatrixWithRank(int m, int n) {
+  return randomMatrixWithRank<Matrix>(m, n, Kokkos::min(m, n));
+}
+
 template <typename Scalar, typename Layout, typename Device>
-void testSerialSVD(int m, int n, int deficiency, double maxval = 1.0) {
+void testSerialSVD(int m, int n, int rank) {
   using Matrix    = Kokkos::View<Scalar**, Layout, Device>;
   using Vector    = Kokkos::View<Scalar*, Device>;
   using ExecSpace = typename Device::execution_space;
-  Matrix A        = createRandomMatrix<Matrix>(m, n, deficiency, maxval);
+  Matrix A        = randomMatrixWithRank<Matrix>(m, n, rank);
   // Fill U, Vt, sigma with nonzeros as well to make sure they are properly
   // overwritten
   Matrix U("U", m, m);
@@ -185,6 +178,8 @@ void testSerialSVD(int m, int n, int deficiency, double maxval = 1.0) {
   int maxrank = std::min(m, n);
   Vector sigma("sigma", maxrank);
   Vector work("work", std::max(m, n));
+  // Fill these views with an arbitrary value, to make sure SVD
+  // doesn't rely on them being zero initialized.
   Kokkos::deep_copy(U, -5.0);
   Kokkos::deep_copy(Vt, -5.0);
   Kokkos::deep_copy(sigma, -5.0);
@@ -205,11 +200,16 @@ void testSerialSVD(int m, int n, int deficiency, double maxval = 1.0) {
 }
 
 template <typename Scalar, typename Layout, typename Device>
+void testSerialSVD(int m, int n) {
+  testSerialSVD<Scalar, Layout, Device>(m, n, Kokkos::min(m, n));
+}
+
+template <typename Scalar, typename Layout, typename Device>
 void testSerialSVDSingularValuesOnly(int m, int n) {
   using Matrix    = Kokkos::View<Scalar**, Layout, Device>;
   using Vector    = Kokkos::View<Scalar*, Device>;
   using ExecSpace = typename Device::execution_space;
-  Matrix A        = createRandomMatrix<Matrix>(m, n, 0);
+  Matrix A        = randomMatrixWithRank<Matrix>(m, n);
   // Fill U, Vt, sigma with nonzeros as well to make sure they are properly
   // overwritten
   Matrix U("U", m, m);
@@ -248,7 +248,7 @@ void testSerialSVDZeroLastRow(int n) {
   // Generate a bidiagonal matrix
   using Matrix = Kokkos::View<Scalar**, Layout, Kokkos::HostSpace>;
   using KAT    = Kokkos::ArithTraits<Scalar>;
-  Matrix B     = createRandomMatrix<Matrix>(n, n, 0, 1.0);
+  Matrix B     = randomMatrixWithRank<Matrix>(n, n);
   // Zero out entries to make B bidiagonal
   for (int i = 0; i < n; i++) {
     for (int j = 0; j < n; j++) {
@@ -265,7 +265,7 @@ void testSerialSVDZeroLastRow(int n) {
   Matrix BVt("UBVt", n, n);
   Test::vanillaGEMM(1.0, B, Vt, 0.0, BVt);
   // Run the routine (just on host)
-  KokkosBatched::SerialSVDInternal::svdZeroLastColumn<Scalar>(B.data(), n, B.stride(0), B.stride(1), Vt.data(),
+  KokkosBatched::SerialSVDInternal::svdZeroLastColumn<Scalar>(B.data(), n, B.stride(0), B.stride(1), n, Vt.data(),
                                                               Vt.stride(0), Vt.stride(1));
   // Check that B is still bidiagonal (to a tight tolerance, but not exactly
   // zero)
@@ -298,7 +298,7 @@ void testSerialSVDZeroDiagonal(int n, int row) {
   using KAT    = Kokkos::ArithTraits<Scalar>;
   int m        = n + 2;  // Make U somewhat bigger to make sure the Givens transforms
                          // are applied correctly
-  Matrix B = createRandomMatrix<Matrix>(m, n, 0, 1.0);
+  Matrix B = randomMatrixWithRank<Matrix>(m, n);
   // Zero out entries to make B bidiagonal
   for (int i = 0; i < m; i++) {
     for (int j = 0; j < n; j++) {
@@ -342,19 +342,18 @@ void testSerialSVDZeroDiagonal(int n, int row) {
 
 template <typename Scalar, typename Layout, typename Device>
 void testSVD() {
-  testSerialSVD<Scalar, Layout, Device>(0, 0, 0);
-  testSerialSVD<Scalar, Layout, Device>(1, 0, 0);
-  testSerialSVD<Scalar, Layout, Device>(0, 1, 0);
-  testSerialSVD<Scalar, Layout, Device>(2, 2, 0);
+  testSerialSVD<Scalar, Layout, Device>(0, 0);
+  testSerialSVD<Scalar, Layout, Device>(1, 0);
+  testSerialSVD<Scalar, Layout, Device>(0, 1);
+  testSerialSVD<Scalar, Layout, Device>(2, 2);
   testSerialSVD<Scalar, Layout, Device>(2, 2, 1);
-  testSerialSVD<Scalar, Layout, Device>(10, 8, 0);
-  testSerialSVD<Scalar, Layout, Device>(8, 10, 0);
-  testSerialSVD<Scalar, Layout, Device>(10, 1, 0);
+  testSerialSVD<Scalar, Layout, Device>(10, 8);
+  testSerialSVD<Scalar, Layout, Device>(8, 10);
+  testSerialSVD<Scalar, Layout, Device>(10, 1);
   testSerialSVD<Scalar, Layout, Device>(1, 10, 0);
   testSerialSVD<Scalar, Layout, Device>(10, 8, 3);
   testSerialSVD<Scalar, Layout, Device>(8, 10, 4);
-  // Test with all-zero matrix
-  testSerialSVD<Scalar, Layout, Device>(8, 10, 0, 0.0);
+  testSerialSVD<Scalar, Layout, Device>(8, 10, 7);
   // Test some important internal routines which are not called often
   testSerialSVDZeroLastRow<Scalar, Layout>(10);
   testSerialSVDZeroDiagonal<Scalar, Layout>(10, 3);
@@ -425,6 +424,119 @@ void testIssue1786() {
   }
 }
 
+// Generate specific test cases
+template <typename Scalar, typename Layout, typename Device>
+Kokkos::View<Scalar**, Layout, Device> getTestCase(int testCase) {
+  using MatrixHost = Kokkos::View<Scalar**, Layout, Kokkos::HostSpace>;
+  MatrixHost Ahost;
+  int m, n;
+  switch (testCase) {
+    case 0:
+      // Issue #2344 case 1
+      m           = 3;
+      n           = 3;
+      Ahost       = MatrixHost("A0", m, n);
+      Ahost(1, 0) = 3.58442287931538747e-02;
+      Ahost(1, 1) = 3.81743062695684907e-02;
+      Ahost(2, 2) = -5.55555555555555733e-02;
+      break;
+    case 1:
+      // Test a matrix that is strictly lower triangular (so the diagonal
+      // is zero)
+      m     = 8;
+      n     = 8;
+      Ahost = MatrixHost("A1", m, n);
+      for (int i = 0; i < m; i++) {
+        for (int j = 0; j < i; j++) {
+          Ahost(i, j) = 1;
+        }
+      }
+      break;
+    case 2:
+      // Test a matrix that's already diagonal, except for one superdiagonal in the middle
+      m     = 10;
+      n     = 5;
+      Ahost = MatrixHost("A2", m, n);
+      for (int i = 0; i < n; i++) Ahost(i, i) = 1.0;
+      Ahost(2, 3) = 2.2;
+      break;
+    case 3:
+      // Test a matrix that is already bidiagonal, and has a zero diagonal in the middle
+      m     = 10;
+      n     = 7;
+      Ahost = MatrixHost("A3", m, n);
+      for (int i = 0; i < n; i++) Ahost(i, i) = 1.0;
+      for (int i = 0; i < n - 1; i++) Ahost(i, i + 1) = 0.7;
+      Ahost(4, 4) = 0;
+      break;
+    case 4: {
+      // Issue #2344 case 2
+      m           = 3;
+      n           = 4;
+      Ahost       = MatrixHost("A4", m, n);
+      Ahost(0, 0) = -2.0305040121856084e-02;
+      Ahost(1, 0) = 0.0000000000000000e+00;
+      Ahost(2, 0) = 0.0000000000000000e+00;
+      Ahost(0, 1) = -0.0000000000000000e+00;
+      Ahost(1, 1) = -0.0000000000000000e+00;
+      Ahost(2, 1) = 1.9506119814028472e-02;
+      Ahost(0, 2) = -2.0305040121856091e-02;
+      Ahost(1, 2) = 0.0000000000000000e+00;
+      Ahost(2, 2) = 0.0000000000000000e+00;
+      Ahost(0, 3) = -0.0000000000000000e+00;
+      Ahost(1, 3) = -0.0000000000000000e+00;
+      Ahost(2, 3) = 1.9506119814028472e-02;
+      break;
+    }
+    case 5: {
+      // Test with all-zero matrix
+      m     = 17;
+      n     = 19;
+      Ahost = MatrixHost("A5", m, n);
+      break;
+    }
+    default: throw std::runtime_error("Test case out of bounds.");
+  }
+  Kokkos::View<Scalar**, Layout, Device> A(Ahost.label(), m, n);
+  Kokkos::deep_copy(A, Ahost);
+  return A;
+}
+
+template <typename Scalar, typename Layout, typename Device>
+void testSpecialCases() {
+  using Matrix    = Kokkos::View<Scalar**, Layout, Device>;
+  using Vector    = Kokkos::View<Scalar*, Device>;
+  using ExecSpace = typename Device::execution_space;
+  for (int i = 0; i < 6; i++) {
+    Matrix A = getTestCase<Scalar, Layout, Device>(i);
+    int m    = A.extent(0);
+    int n    = A.extent(1);
+    Matrix U("U", m, m);
+    Matrix Vt("Vt", n, n);
+    int maxrank = std::min(m, n);
+    Vector sigma("sigma", maxrank);
+    Vector work("work", std::max(m, n));
+    Kokkos::deep_copy(U, -5.0);
+    Kokkos::deep_copy(Vt, -5.0);
+    Kokkos::deep_copy(sigma, -5.0);
+    Kokkos::deep_copy(work, -5.0);
+    // Make a copy of A (before SVD) for verification, since the original will be
+    // overwritten
+    typename Matrix::HostMirror Acopy("Acopy", m, n);
+    Kokkos::deep_copy(Acopy, A);
+    // Run the SVD
+    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, 1),
+                         SerialSVDFunctor_Full<Matrix, Vector>(A, U, Vt, sigma, work));
+    // Get the results back
+    auto Uhost     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), U);
+    auto Vthost    = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), Vt);
+    auto sigmaHost = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), sigma);
+
+    // Verify the SVD is correct
+    verifySVD(Acopy, Uhost, Vthost, sigmaHost);
+  }
+}
+
 #if defined(KOKKOSKERNELS_INST_DOUBLE)
 TEST_F(TestCategory, batched_scalar_serial_svd_double) {
   // Test general SVD on a few different input sizes (full rank randomized)
@@ -432,6 +544,8 @@ TEST_F(TestCategory, batched_scalar_serial_svd_double) {
   testSVD<double, Kokkos::LayoutRight, TestDevice>();
   testIssue1786<double, Kokkos::LayoutLeft, TestDevice>();
   testIssue1786<double, Kokkos::LayoutRight, TestDevice>();
+  testSpecialCases<double, Kokkos::LayoutLeft, TestDevice>();
+  testSpecialCases<double, Kokkos::LayoutRight, TestDevice>();
 }
 #endif
 
@@ -442,5 +556,7 @@ TEST_F(TestCategory, batched_scalar_serial_svd_float) {
   testSVD<float, Kokkos::LayoutRight, TestDevice>();
   testIssue1786<float, Kokkos::LayoutLeft, TestDevice>();
   testIssue1786<float, Kokkos::LayoutRight, TestDevice>();
+  testSpecialCases<float, Kokkos::LayoutLeft, TestDevice>();
+  testSpecialCases<float, Kokkos::LayoutRight, TestDevice>();
 }
 #endif


### PR DESCRIPTION
Fix batched serial SVD hanging for some inputs.
This fixes the kernel and adds some new test cases.

See https://github.com/kokkos/kokkos-kernels/pull/2345 for original PR.

@trilinos/kokkos-kernels 
@vbrunini 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Fixes SVD hanging in 2 matrices that @vbrunini found.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->
Fixes issue 
* Closes https://github.com/kokkos/kokkos-kernels/issues/2344

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
This adds test cases that replicated the original issue, and these are now passing.
<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
