### PR TITLE
Github Actions: Fixing AT2 Permissions

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -13,15 +13,17 @@ on:
     - develop
   workflow_dispatch:
 
-# actions: write needed by skip-duplicate-actions
-permissions:
-  actions: write
+# actions: write needed by skip-duplicate-actions (handled below as per OpenSSF scorecard)
+permissions: 
   contents: read
 
 jobs:
   # Jobs depend on the output of pre-checks to run
   pre-checks:
         runs-on: ubuntu-latest
+        # actions: write needed by skip-duplicate-actions
+        permissions:
+          actions: write
         outputs:
             should_skip: ${{ steps.skip_check.outputs.should_skip }}
         steps:


### PR DESCRIPTION
As per the OpenSSF, we should _not_ have write permission at the top level, but rather reserve it for individual jobs in the pipeline.  See:

https://github.com/ossf/scorecard/blob/v5.0.0/docs/checks.md#token-permissions

This shows up in our OpenSSF scorecard in an unhappy way, so I figured I'd try to fix it.  I _think_ what I changed should work.  @achauphan thoughts?

