### PR TITLE
Framework: Fix kokkos integration cdash group

### DIFF
--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -170,7 +170,7 @@ sig_merge_old=$(get_md5sum ${REPO_ROOT:?}/packages/framework/pr_tools/PullReques
 if [[ ${on_kokkos_develop} == "1" ]]; then
     message_std "PRDriver> --kokkos-develop is set - setting kokkos and kokkos-kernels packages to current develop and pointing at them"
     "${SCRIPTPATH}"/SetKokkosDevelop.sh
-    extra_configure_args="\"-DKokkos_SOURCE_DIR_OVERRIDE:string=kokkos;-DKokkosKernels_SOURCE_DIR_OVERRIDE:string=kokkos-kernels\"${extra_configure_args:+;${extra_configure_args}}"
+    extra_configure_args="-DKokkos_SOURCE_DIR_OVERRIDE:string=kokkos;-DKokkosKernels_SOURCE_DIR_OVERRIDE:string=kokkos-kernels${extra_configure_args:+;${extra_configure_args}}"
 else
     print_banner "Merge Source into Target"
     message_std "PRDriver> " "TRILINOS_SOURCE_SHA: ${TRILINOS_SOURCE_SHA:?}"

--- a/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
@@ -292,6 +292,7 @@ def parse_args():
     print("| - [O] workspace-dir               : {workspace_dir}".format(**vars(arguments)))
     print("| - [O] extra_configure_args        : {extra_configure_args}".format(**vars(arguments)))
     print("| - [O] dashboard_build_name        : {dashboard_build_name}".format(**vars(arguments)))
+    print("| - [O] use_explicit_cacefile       : {use_explicit_cachefile}".format(**vars(arguments)))
     #print("| - [O] : {}".format(**vars(arguments)))
     print("+" + "="*78 + "+")
 

--- a/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
@@ -292,7 +292,7 @@ def parse_args():
     print("| - [O] workspace-dir               : {workspace_dir}".format(**vars(arguments)))
     print("| - [O] extra_configure_args        : {extra_configure_args}".format(**vars(arguments)))
     print("| - [O] dashboard_build_name        : {dashboard_build_name}".format(**vars(arguments)))
-    print("| - [O] use_explicit_cacefile       : {use_explicit_cachefile}".format(**vars(arguments)))
+    print("| - [O] use_explicit_cachefile       : {use_explicit_cachefile}".format(**vars(arguments)))
     #print("| - [O] : {}".format(**vars(arguments)))
     print("+" + "="*78 + "+")
 

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
@@ -77,7 +77,7 @@ class TrilinosPRConfigurationStandard(TrilinosPRConfigurationBase):
                f"-Dpackage_enables:FILEPATH={self.arg_filename_packageenables}",
                f"-Dsubprojects_file:FILEPATH={self.arg_filename_subprojects}",
                f"-DCTEST_DROP_SITE:STRING={self.arg_ctest_drop_site}",
-                "-DUSE_EXPLICIT_TRILINOS_CACHEFILE:BOOL=" + "ON" if self.arg_use_explicit_cachefile else "OFF",
+                "-DUSE_EXPLICIT_TRILINOS_CACHEFILE:BOOL=" + ("ON" if self.arg_use_explicit_cachefile else "OFF"),
              ]
 
         if self.arg_extra_configure_args:


### PR DESCRIPTION
@trilinos/framework 

## Motivation
I modified some argument handling logic recently to clean things up and enable extra configure arguments more cleanly, and it appears I caused an issue where the Kokkos builds stopped showing up in the correct group on CDash.

## Related Issues
Fixes bug introduced in #13427

## Testing
I tested manually and confirmed that the issue was present without this change, and works as expected with this change.