### PR TITLE
Stokhos: Do not specify template arg when using Kokkos atomics

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas2_gemv_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas2_gemv_MP_Vector.hpp
@@ -130,7 +130,7 @@ public:
             if (team.team_rank() == 0)
             {
                 tmp *= alpha_;
-                Kokkos::atomic_add<Scalar>(&y_(i), tmp);
+                Kokkos::atomic_add(&y_(i), tmp);
             }
         }
         for (IndexType i = 0; i < i_min; ++i)
@@ -144,7 +144,7 @@ public:
             if (team.team_rank() == 0)
             {
                 tmp *= alpha_;
-                Kokkos::atomic_add<Scalar>(&y_(i), tmp);
+                Kokkos::atomic_add(&y_(i), tmp);
             }
         }
     }


### PR DESCRIPTION
Let FTAD do its job, do not interfere.

@etphipp
@ndellingwood 