### PR TITLE
Fixup `Kokkos::atomic_{inc,dec}[rement]`

### DIFF
--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_def.hpp
@@ -330,7 +330,7 @@ void AggregationPhase1Algorithm<LocalOrdinal, GlobalOrdinal, Node>::
                 break;
               } else {
                 // Decrement back the value of aggSizesView(agg)
-                Kokkos::atomic_decrement(&aggSizesView(agg));
+                Kokkos::atomic_dec(&aggSizesView(agg));
               }
             }
           }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_def.hpp
@@ -255,7 +255,7 @@ void AggregationPhase3Algorithm<LocalOrdinal, GlobalOrdinal, Node>::
             procWinner(nodeIdx, 0)   = myRank;
             vertex2AggId(nodeIdx, 0) = aggId;
             // aggregates.SetIsRoot(nodeIdx);
-            Kokkos::atomic_decrement(&numNonAggregated());
+            Kokkos::atomic_dec(&numNonAggregated());
             for (int neigh = 0; neigh < neighbors.length; ++neigh) {
               neighIdx = neighbors(neigh);
               if ((neighIdx != nodeIdx) &&
@@ -264,7 +264,7 @@ void AggregationPhase3Algorithm<LocalOrdinal, GlobalOrdinal, Node>::
                 aggStat(neighIdx)         = AGGREGATED;
                 procWinner(neighIdx, 0)   = myRank;
                 vertex2AggId(neighIdx, 0) = aggId;
-                Kokkos::atomic_decrement(&numNonAggregated());
+                Kokkos::atomic_dec(&numNonAggregated());
               }
             }
             return;
@@ -279,7 +279,7 @@ void AggregationPhase3Algorithm<LocalOrdinal, GlobalOrdinal, Node>::
               aggStat(nodeIdx)         = AGGREGATED;
               procWinner(nodeIdx, 0)   = myRank;
               vertex2AggId(nodeIdx, 0) = vertex2AggId(neighIdx, 0);
-              Kokkos::atomic_decrement(&numNonAggregated());
+              Kokkos::atomic_dec(&numNonAggregated());
               return;
             }
           }
@@ -293,7 +293,7 @@ void AggregationPhase3Algorithm<LocalOrdinal, GlobalOrdinal, Node>::
                 aggStat(nodeIdx)         = AGGREGATED;
                 procWinner(nodeIdx, 0)   = myRank;
                 vertex2AggId(nodeIdx, 0) = vertex2AggId(otherNodeIdx, 0);
-                Kokkos::atomic_decrement(&numNonAggregated());
+                Kokkos::atomic_dec(&numNonAggregated());
                 return;
               }
             }
@@ -306,7 +306,7 @@ void AggregationPhase3Algorithm<LocalOrdinal, GlobalOrdinal, Node>::
             aggStat(nodeIdx)         = AGGREGATED;
             procWinner(nodeIdx, 0)   = myRank;
             vertex2AggId(nodeIdx, 0) = aggId;
-            Kokkos::atomic_decrement(&numNonAggregated());
+            Kokkos::atomic_dec(&numNonAggregated());
           }
         });
     // LBV on 09/27/19: here we could copy numNonAggregated to host

--- a/packages/nox/test/tpetra/1DFEM_Functors.hpp
+++ b/packages/nox/test/tpetra/1DFEM_Functors.hpp
@@ -67,26 +67,26 @@ struct RowCountsFunctor
   void operator() (const LO localRow, std::size_t& curNumLocalEntries) const
   {
     // Add a diagonal matrix entry
-    Kokkos::atomic_increment(&counts_(localRow));
+    Kokkos::atomic_inc(&counts_(localRow));
     ++curNumLocalEntries;
     // Contribute a matrix entry to the previous row
     if (localRow > 0) {
-      Kokkos::atomic_increment(&counts_(localRow-1));
+      Kokkos::atomic_inc(&counts_(localRow-1));
       ++curNumLocalEntries;
     }
     // Contribute a matrix entry to the next row
     if (localRow < numMyNodes_-1) {
-      Kokkos::atomic_increment(&counts_(localRow+1));
+      Kokkos::atomic_inc(&counts_(localRow+1));
       ++curNumLocalEntries;
     }
     // MPI process to the left sends us an entry
     if ((myRank_ > 0) && (localRow == 0)) {
-      Kokkos::atomic_increment(&counts_(localRow));
+      Kokkos::atomic_inc(&counts_(localRow));
       ++curNumLocalEntries;
     }
     // MPI process to the right sends us an entry
     if ((myRank_ < numProcs_-1) && (localRow == numMyNodes_-1)) {
-      Kokkos::atomic_increment(&counts_(localRow));
+      Kokkos::atomic_inc(&counts_(localRow));
       ++curNumLocalEntries;
     }
   }

--- a/packages/sacado/test/performance/fenl_assembly/fenl_functors.hpp
+++ b/packages/sacado/test/performance/fenl_assembly/fenl_functors.hpp
@@ -250,10 +250,10 @@ public:
           if ( result.success() ) {
 
             // If row node is owned then increment count
-            if ( row_node < row_count.extent(0) ) { atomic_increment( & row_count( row_node ) ); }
+            if ( row_node < row_count.extent(0) ) { Kokkos::atomic_inc( & row_count( row_node ) ); }
 
             // If column node is owned and not equal to row node then increment count
-            if ( col_node < row_count.extent(0) && col_node != row_node ) { atomic_increment( & row_count( col_node ) ); }
+            if ( col_node < row_count.extent(0) && col_node != row_node ) { Kokkos::atomic_inc( & row_count( col_node ) ); }
           }
           else if ( result.failed() ) {
             ++count ;
@@ -276,12 +276,12 @@ public:
       const unsigned col_node = key.second ;
 
       if ( row_node < row_count.extent(0) ) {
-        const unsigned offset = graph.row_map( row_node ) + atomic_fetch_add( & row_count( row_node ) , atomic_incr_type(1) );
+        const unsigned offset = graph.row_map( row_node ) + Kokkos::atomic_fetch_add( & row_count( row_node ) , atomic_incr_type(1) );
         graph.entries( offset ) = col_node ;
       }
 
       if ( col_node < row_count.extent(0) && col_node != row_node ) {
-        const unsigned offset = graph.row_map( col_node ) + atomic_fetch_add( & row_count( col_node ) , atomic_incr_type(1) );
+        const unsigned offset = graph.row_map( col_node ) + Kokkos::atomic_fetch_add( & row_count( col_node ) , atomic_incr_type(1) );
         graph.entries( offset ) = row_node ;
       }
     }
@@ -650,12 +650,12 @@ public:
     for( unsigned i = 0 ; i < FunctionCount ; i++ ) {
       const unsigned row = node_index[i] ;
       if ( row < this->residual.extent(0) ) {
-        atomic_add( & this->residual( row ) , res[i] );
+              Kokkos::atomic_add( & this->residual( row ) , res[i] );
 
         for( unsigned j = 0 ; j < FunctionCount ; j++ ) {
           const unsigned entry = this->elem_graph( ielem , i , j );
           if ( entry != ~0u ) {
-            atomic_add( & this->jacobian.coeff( entry ) , mat[i][j] );
+                  Kokkos::atomic_add( & this->jacobian.coeff( entry ) , mat[i][j] );
           }
         }
       }
@@ -835,12 +835,12 @@ public:
     for( unsigned i = 0 ; i < FunctionCount ; i++ ) {
       const unsigned row = node_index[i] ;
       if ( row < this->residual.extent(0) ) {
-        atomic_add( & this->residual( row ) , res[i].val() );
+              Kokkos::atomic_add( & this->residual( row ) , res[i].val() );
 
         for( unsigned j = 0 ; j < FunctionCount ; j++ ) {
           const unsigned entry = this->elem_graph( ielem , i , j );
           if ( entry != ~0u ) {
-            atomic_add( & this->jacobian.coeff( entry ) ,
+                  Kokkos::atomic_add( & this->jacobian.coeff( entry ) ,
                         res[i].fastAccessDx(j) );
           }
         }

--- a/packages/sacado/test/performance/fenl_assembly_view/fenl_functors.hpp
+++ b/packages/sacado/test/performance/fenl_assembly_view/fenl_functors.hpp
@@ -250,10 +250,10 @@ public:
           if ( result.success() ) {
 
             // If row node is owned then increment count
-            if ( row_node < row_count.extent(0) ) { atomic_increment( & row_count( row_node ) ); }
+            if ( row_node < row_count.extent(0) ) { atomic_inc( & row_count( row_node ) ); }
 
             // If column node is owned and not equal to row node then increment count
-            if ( col_node < row_count.extent(0) && col_node != row_node ) { atomic_increment( & row_count( col_node ) ); }
+            if ( col_node < row_count.extent(0) && col_node != row_node ) { atomic_inc( & row_count( col_node ) ); }
           }
           else if ( result.failed() ) {
             ++count ;

--- a/packages/shylu/shylu_node/basker/src/shylubasker_thread.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_thread.hpp
@@ -272,8 +272,7 @@ namespace BaskerNS
     BASKER_INLINE
     void atomic_barrier_fanout(volatile Int &value, const Int l_size)
     {
-      Kokkos::atomic_increment(&(value));
-      while(value < l_size)
+      while(Kokkos::atomic_inc_fetch(&value) < l_size)
       {
         BASKER_NO_OP;
       }

--- a/packages/shylu/shylu_node/basker/src/shylubasker_thread.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_thread.hpp
@@ -272,7 +272,8 @@ namespace BaskerNS
     BASKER_INLINE
     void atomic_barrier_fanout(volatile Int &value, const Int l_size)
     {
-      while(Kokkos::atomic_inc_fetch(&value) < l_size)
+      Kokkos::atomic_inc(&(value))
+      while(value < l_size)
       {
         BASKER_NO_OP;
       }

--- a/packages/stk/stk_performance_tests/stk_mesh/calculate_centroid.hpp
+++ b/packages/stk/stk_performance_tests/stk_mesh/calculate_centroid.hpp
@@ -237,7 +237,7 @@ std::vector<double> get_centroid_average_from_device(stk::mesh::BulkData &bulk, 
                                    for(size_t dim = 0; dim < 3; dim++) {
                                      Kokkos::atomic_add(&deviceAverageView(dim), ngpField(elem, dim));
                                    }
-                                   Kokkos::atomic_increment(&deviceAverageView(3));
+                                   Kokkos::atomic_inc(&deviceAverageView(3));
                                  });
 
   Kokkos::deep_copy(hostAverageView, deviceAverageView);

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
@@ -107,7 +107,7 @@ public:
     typedef typename hash_type::result_type hash_value_type;
 
     const hash_value_type hashVal = hash_type::hashFunc (keys_[i], size_);
-    Kokkos::atomic_increment (&counts_[hashVal]);
+    Kokkos::atomic_inc (&counts_[hashVal]);
   }
 
   using value_type = Kokkos::pair<int, key_type>;
@@ -128,7 +128,7 @@ public:
       dst.second = keyVal;
     }
     else {
-      Kokkos::atomic_increment (&counts_[hashVal]);
+      Kokkos::atomic_inc (&counts_[hashVal]);
     }
   }
 

--- a/packages/trilinoscouplings/examples/fenl/fenl_functors.hpp
+++ b/packages/trilinoscouplings/examples/fenl/fenl_functors.hpp
@@ -221,8 +221,8 @@ public:
 
           if ( result.success() ) {
             // First time this pair was inserted
-            if ( row_node < row_count.extent(0) ) { atomic_increment( & row_count( row_node ) ); }
-            if ( col_node < row_count.extent(0) && col_node != row_node ) { atomic_increment( & row_count( col_node ) ); }
+            if ( row_node < row_count.extent(0) ) { Kokkos::atomic_inc( & row_count( row_node ) ); }
+            if ( col_node < row_count.extent(0) && col_node != row_node ) { Kokkos::atomic_inc( & row_count( col_node ) ); }
           }
           else if ( result.failed() ) {
             // Ran out of memory for insertion.
@@ -244,12 +244,12 @@ public:
       using atomic_incr_type = typename std::remove_reference< decltype( row_count(0) ) >::type;
 
       if ( row_node < row_count.extent(0) ) {
-        const unsigned offset = graph.row_map( row_node ) + atomic_fetch_add( & row_count( row_node ) , atomic_incr_type(1) );
+        const unsigned offset = graph.row_map( row_node ) + Kokkos::atomic_fetch_add( & row_count( row_node ) , atomic_incr_type(1) );
         graph.entries( offset ) = col_node ;
       }
 
       if ( col_node < row_count.extent(0) && col_node != row_node ) {
-        const unsigned offset = graph.row_map( col_node ) + atomic_fetch_add( & row_count( col_node ) , atomic_incr_type(1) );
+        const unsigned offset = graph.row_map( col_node ) + Kokkos::atomic_fetch_add( & row_count( col_node ) , atomic_incr_type(1) );
         graph.entries( offset ) = row_node ;
       }
     }


### PR DESCRIPTION
`Kokkos::atomic_{increment,decrement}` have been deprecated.
This PR is mostly a search and replace with `atomic_{inc,dec}`.  (**edit** the inc/dec atomic functions are available since 4.0, these changes are backward compatible with respect to Kokkos)

In the Sacado and TilinosCoupling FENL performance tests/example, I qualified all uses of Kokkos atomic functions.
Please note that opening the Kokkos namespace is not legal (see https://kokkos.org/kokkos-core-wiki/ProgrammingGuide/Compatibility.html)

cc @ndellingwood 