### PR TITLE
tpetra: replace use of impl_dualview_is_single_device

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -1795,7 +1795,7 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
     // - CombineMode needs to be INSERT.
     // - The number of vectors needs to be 1, otherwise we need to
     //   reorder the received data.
-    if ((dual_view_type::impl_dualview_is_single_device::value ||
+    if ((std::is_same_v<typename dual_view_type::t_dev::device_type, typename dual_view_type::t_host::device_type> ||
          (Details::Behavior::assumeMpiIsGPUAware () && !this->need_sync_device()) ||
          (!Details::Behavior::assumeMpiIsGPUAware () && !this->need_sync_host())) &&
         areRemoteLIDsContiguous &&

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -730,7 +730,7 @@ namespace {
         // MV::imports_ and MV::view_ have the same memory space, the
         // imports_ view is aliased to the data view of the target MV.
         if ((myImageID == collectRank) && (myImageID == 0)) {
-          if (mv_type::dual_view_type::impl_dualview_is_single_device::value)
+          if (std::is_same_v<typename mv_type::dual_view_type::t_dev::device_type, typename mv_type::dual_view_type::t_host::device_type>)
             TEUCHOS_ASSERT(tgt_mv->importsAreAliased());
           // else {
           //   We do not know if copyAndPermute was run on host or device.
@@ -800,7 +800,7 @@ namespace {
         // MV::imports_ and MV::view_ have the same memory space, the
         // imports_ view is aliased to the data view of the target MV.
         if ((myImageID == collectRank) && (myImageID == 0)) {
-          if (mv_type::dual_view_type::impl_dualview_is_single_device::value)
+          if (std::is_same_v<typename mv_type::dual_view_type::t_dev::device_type, typename mv_type::dual_view_type::t_host::device_type>)
             TEUCHOS_ASSERT(tgt_mv->importsAreAliased());
           // else {
           //   We do not know if copyAndPermute was run on host or device.


### PR DESCRIPTION
replace use of Kokkos impl_* routine, preemptive change in case internal impl routines become private members

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Preemptive change in case internal impl routines become private members

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

Related to https://github.com/kokkos/kokkos/issues/7495

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
AT
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
