### PR TITLE
MueLu: Make AggregateQualityEstimateFactory a transfer factory

### DIFF
--- a/packages/muelu/src/Graph/PairwiseAggregation/MueLu_NotayAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/PairwiseAggregation/MueLu_NotayAggregationFactory_def.hpp
@@ -55,7 +55,6 @@ RCP<const ParameterList> NotayAggregationFactory<Scalar, LocalOrdinal, GlobalOrd
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))
   SET_VALID_ENTRY("aggregation: pairwise: size");
   SET_VALID_ENTRY("aggregation: pairwise: tie threshold");
-  SET_VALID_ENTRY("aggregation: compute aggregate qualities");
   SET_VALID_ENTRY("aggregation: Dirichlet threshold");
   SET_VALID_ENTRY("aggregation: ordering");
 #undef SET_VALID_ENTRY
@@ -64,21 +63,15 @@ RCP<const ParameterList> NotayAggregationFactory<Scalar, LocalOrdinal, GlobalOrd
   validParamList->set<RCP<const FactoryBase>>("A", null, "Generating factory of the matrix");
   validParamList->set<RCP<const FactoryBase>>("Graph", null, "Generating factory of the graph");
   validParamList->set<RCP<const FactoryBase>>("DofsPerNode", null, "Generating factory for variable \'DofsPerNode\', usually the same as for \'Graph\'");
-  validParamList->set<RCP<const FactoryBase>>("AggregateQualities", null, "Generating factory for variable \'AggregateQualities\'");
 
   return validParamList;
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void NotayAggregationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& currentLevel) const {
-  const ParameterList& pL = GetParameterList();
-
   Input(currentLevel, "A");
   Input(currentLevel, "Graph");
   Input(currentLevel, "DofsPerNode");
-  if (pL.get<bool>("aggregation: compute aggregate qualities")) {
-    Input(currentLevel, "AggregateQualities");
-  }
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_def.hpp
@@ -75,14 +75,12 @@ RCP<const ParameterList> UncoupledAggregationFactory<LocalOrdinal, GlobalOrdinal
   SET_VALID_ENTRY("aggregation: use interface aggregation");
   SET_VALID_ENTRY("aggregation: error on nodes with no on-rank neighbors");
   SET_VALID_ENTRY("aggregation: phase3 avoid singletons");
-  SET_VALID_ENTRY("aggregation: compute aggregate qualities");
   SET_VALID_ENTRY("aggregation: phase 1 algorithm");
 #undef SET_VALID_ENTRY
 
   // general variables needed in AggregationFactory
   validParamList->set<RCP<const FactoryBase>>("Graph", null, "Generating factory of the graph");
   validParamList->set<RCP<const FactoryBase>>("DofsPerNode", null, "Generating factory for variable \'DofsPerNode\', usually the same as for \'Graph\'");
-  validParamList->set<RCP<const FactoryBase>>("AggregateQualities", null, "Generating factory for variable \'AggregateQualities\'");
 
   // special variables necessary for OnePtAggregationAlgorithm
   validParamList->set<std::string>("OnePt aggregate map name", "", "Name of input map for single node aggregates. (default='')");
@@ -130,10 +128,6 @@ void UncoupledAggregationFactory<LocalOrdinal, GlobalOrdinal, Node>::DeclareInpu
     } else {
       Input(currentLevel, "nodeOnInterface");
     }
-  }
-
-  if (pL.get<bool>("aggregation: compute aggregate qualities")) {
-    Input(currentLevel, "AggregateQualities");
   }
 }
 
@@ -375,10 +369,6 @@ void UncoupledAggregationFactory<LocalOrdinal, GlobalOrdinal, Node>::Build(Level
   aggregates->ComputeAggregateSizes(true /*forceRecompute*/);
 
   Set(currentLevel, "Aggregates", aggregates);
-
-  if (pL.get<bool>("aggregation: compute aggregate qualities")) {
-    RCP<Xpetra::MultiVector<DefaultScalar, LO, GO, Node>> aggQualities = Get<RCP<Xpetra::MultiVector<DefaultScalar, LO, GO, Node>>>(currentLevel, "AggregateQualities");
-  }
 }
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -1098,7 +1098,6 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: preserve Dirichlet points", bool, aggParams);
     MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: error on nodes with no on-rank neighbors", bool, aggParams);
     MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: phase3 avoid singletons", bool, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: compute aggregate qualities", bool, aggParams);
     aggFactory->SetParameterList(aggParams);
     // make sure that the aggregation factory has all necessary data
     aggFactory->SetFactory("DofsPerNode", manager.GetFactory("Graph"));
@@ -1180,7 +1179,6 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: pairwise: tie threshold", double, aggParams);
     MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: Dirichlet threshold", double, aggParams);
     MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: ordering", std::string, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: compute aggregate qualities", bool, aggParams);
     aggFactory->SetParameterList(aggParams);
     aggFactory->SetFactory("DofsPerNode", manager.GetFactory("Graph"));
     aggFactory->SetFactory("Graph", manager.GetFactory("Graph"));
@@ -1199,25 +1197,6 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   RCP<Factory> coarseMap = rcp(new CoarseMapFactory());
   coarseMap->SetFactory("Aggregates", manager.GetFactory("Aggregates"));
   manager.SetFactory("CoarseMap", coarseMap);
-
-  // Aggregate qualities
-  if (MUELU_TEST_PARAM_2LIST(paramList, defaultList, "aggregation: compute aggregate qualities", bool, true)) {
-    RCP<Factory> aggQualityFact = rcp(new AggregateQualityEstimateFactory());
-    ParameterList aggQualityParams;
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: good aggregate threshold", double, aggQualityParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: file output", bool, aggQualityParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: file base", std::string, aggQualityParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: check symmetry", bool, aggQualityParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: algorithm", std::string, aggQualityParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: zero threshold", double, aggQualityParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: percentiles", Teuchos::Array<double>, aggQualityParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: mode", std::string, aggQualityParams);
-    aggQualityFact->SetParameterList(aggQualityParams);
-    manager.SetFactory("AggregateQualities", aggQualityFact);
-
-    assert(aggType == "uncoupled");
-    aggFactory->SetFactory("AggregateQualities", aggQualityFact);
-  }
 
   // Tentative P
   MUELU_KOKKOS_FACTORY(Ptent, TentativePFactory, TentativePFactory_kokkos);
@@ -1317,6 +1296,28 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       RAP->SetFactory("R", manager.GetFactory("R"));
     else
       RAPs->SetFactory("R", manager.GetFactory("R"));
+  }
+
+  // Aggregate qualities
+  if (MUELU_TEST_PARAM_2LIST(paramList, defaultList, "aggregation: compute aggregate qualities", bool, true)) {
+    RCP<Factory> aggQualityFact = rcp(new AggregateQualityEstimateFactory());
+    ParameterList aggQualityParams;
+    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: good aggregate threshold", double, aggQualityParams);
+    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: file output", bool, aggQualityParams);
+    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: file base", std::string, aggQualityParams);
+    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: check symmetry", bool, aggQualityParams);
+    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: algorithm", std::string, aggQualityParams);
+    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: zero threshold", double, aggQualityParams);
+    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: percentiles", Teuchos::Array<double>, aggQualityParams);
+    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: mode", std::string, aggQualityParams);
+    aggQualityFact->SetParameterList(aggQualityParams);
+    aggQualityFact->SetFactory("Aggregates", manager.GetFactory("Aggregates"));
+    aggQualityFact->SetFactory("CoarseMap", manager.GetFactory("CoarseMap"));
+
+    if (!RAP.is_null())
+      RAP->AddTransferFactory(aggQualityFact);
+    else
+      RAPs->AddTransferFactory(aggQualityFact);
   }
 
   if (MUELU_TEST_PARAM_2LIST(paramList, defaultList, "aggregation: export visualization data", bool, true)) {

--- a/packages/muelu/src/Utils/MueLu_AggregateQualityEstimateFactory_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_AggregateQualityEstimateFactory_decl.hpp
@@ -11,7 +11,7 @@
 #define MUELU_AGGREGATEQUALITYESTIMATEFACTORY_DECL_HPP
 
 #include "MueLu_ConfigDefs.hpp"
-#include "MueLu_SingleLevelFactoryBase.hpp"
+#include "MueLu_TwoLevelFactoryBase.hpp"
 #include "MueLu_AggregateQualityEstimateFactory_fwd.hpp"
 
 #include <Xpetra_Matrix_fwd.hpp>
@@ -41,8 +41,11 @@ namespace MueLu {
   computing, 34(2), A1079-A1109.
 */
 
-template <class Scalar = double, class LocalOrdinal = int, class GlobalOrdinal = LocalOrdinal, class Node = Tpetra::KokkosClassic::DefaultNode::DefaultNodeType>
-class AggregateQualityEstimateFactory : public SingleLevelFactoryBase {
+template <class Scalar        = DefaultScalar,
+          class LocalOrdinal  = DefaultLocalOrdinal,
+          class GlobalOrdinal = DefaultGlobalOrdinal,
+          class Node          = DefaultNode>
+class AggregateQualityEstimateFactory : public TwoLevelFactoryBase {
 #undef MUELU_AGGREGATEQUALITYESTIMATEFACTORY_SHORT
 #include "MueLu_UseShortNames.hpp"
 
@@ -70,7 +73,7 @@ class AggregateQualityEstimateFactory : public SingleLevelFactoryBase {
     If the Build method of this class requires some data, but the generating factory is not specified in DeclareInput, then this class
     will fall back to the settings in FactoryManager.
   */
-  void DeclareInput(Level& currentLevel) const;
+  void DeclareInput(Level& fineLevel, Level& coarseLevel) const;
 
   //@}
 
@@ -78,7 +81,7 @@ class AggregateQualityEstimateFactory : public SingleLevelFactoryBase {
   //@{
 
   //! Build aggregate quality esimates with this factory.
-  void Build(Level& currentLevel) const;
+  void Build(Level& fineLevel, Level& coarseLevel) const;
 
   //@}
 

--- a/packages/muelu/src/Utils/MueLu_AggregateQualityEstimateFactory_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_AggregateQualityEstimateFactory_def.hpp
@@ -34,10 +34,10 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 AggregateQualityEstimateFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~AggregateQualityEstimateFactory() {}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void AggregateQualityEstimateFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& currentLevel) const {
-  Input(currentLevel, "A");
-  Input(currentLevel, "Aggregates");
-  Input(currentLevel, "CoarseMap");
+void AggregateQualityEstimateFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel, Level& coarseLevel) const {
+  Input(fineLevel, "A");
+  Input(fineLevel, "Aggregates");
+  Input(fineLevel, "CoarseMap");
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -64,13 +64,13 @@ RCP<const ParameterList> AggregateQualityEstimateFactory<Scalar, LocalOrdinal, G
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void AggregateQualityEstimateFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level& currentLevel) const {
-  FactoryMonitor m(*this, "Build", currentLevel);
+void AggregateQualityEstimateFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level& fineLevel, Level& coarseLevel) const {
+  FactoryMonitor m(*this, "Build", fineLevel);
 
-  RCP<Matrix> A              = Get<RCP<Matrix>>(currentLevel, "A");
-  RCP<Aggregates> aggregates = Get<RCP<Aggregates>>(currentLevel, "Aggregates");
+  RCP<Matrix> A              = Get<RCP<Matrix>>(fineLevel, "A");
+  RCP<Aggregates> aggregates = Get<RCP<Aggregates>>(fineLevel, "Aggregates");
 
-  RCP<const Map> map = Get<RCP<const Map>>(currentLevel, "CoarseMap");
+  RCP<const Map> map = Get<RCP<const Map>>(fineLevel, "CoarseMap");
 
   assert(!aggregates->AggregatesCrossProcessors());
   ParameterList pL = GetParameterList();
@@ -81,15 +81,15 @@ void AggregateQualityEstimateFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>:
   if (mode == "eigenvalue" || mode == "both") {
     aggregate_qualities = Xpetra::MultiVectorFactory<magnitudeType, LO, GO, NO>::Build(map, 1);
     ComputeAggregateQualities(A, aggregates, aggregate_qualities);
-    OutputAggQualities(currentLevel, aggregate_qualities);
+    OutputAggQualities(fineLevel, aggregate_qualities);
   }
   if (mode == "size" || mode == "both") {
     RCP<LocalOrdinalVector> aggregate_sizes = Xpetra::VectorFactory<LO, LO, GO, NO>::Build(map);
     ComputeAggregateSizes(A, aggregates, aggregate_sizes);
-    Set(currentLevel, "AggregateSizes", aggregate_sizes);
-    OutputAggSizes(currentLevel, aggregate_sizes);
+    Set(fineLevel, "AggregateSizes", aggregate_sizes);
+    OutputAggSizes(fineLevel, aggregate_sizes);
   }
-  Set(currentLevel, "AggregateQualities", aggregate_qualities);
+  Set(coarseLevel, "AggregateQualities", aggregate_qualities);
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/muelu/test/interface/default/EasyParameterListInterpreter/aggregatequalities.xml
+++ b/packages/muelu/test/interface/default/EasyParameterListInterpreter/aggregatequalities.xml
@@ -1,0 +1,7 @@
+<ParameterList name="MueLu">
+  <Parameter name="aggregation: drop scheme"                      type="string" value="distance laplacian"/>
+  <Parameter name="aggregation: drop tol"                         type="double" value="0.05"/>
+  <Parameter name="aggregation: compute aggregate qualities"      type="bool"   value="true"/>
+  <Parameter name="aggregate qualities: check symmetry"           type="bool"   value="false"/>
+  <Parameter name="aggregate qualities: good aggregate threshold" type="double" value="100.0"/>
+</ParameterList>

--- a/packages/muelu/test/interface/default/FactoryParameterListInterpreter/aggregatequalities.xml
+++ b/packages/muelu/test/interface/default/FactoryParameterListInterpreter/aggregatequalities.xml
@@ -47,6 +47,7 @@
       <Parameter name="factory"                             type="string"   value="RAPFactory"/>
 
       <ParameterList name="TransferFactories">
+        <Parameter name="For AggregateQualities"            type="string"   value="myAggregateQualityFact"/>
         <Parameter name="For Coordinates"                   type="string"   value="myTransferCoordinatesFact"/>
       </ParameterList>
 
@@ -58,15 +59,14 @@
 
     <ParameterList name="All">
       <Parameter name="startLevel"                          type="int"      value="0"/>
-
       <Parameter name="A"                                   type="string"   value="myRAPFact"/>
-      <Parameter name="Coordinates"                         type="string"   value="myTransferCoordinatesFact"/>
       <Parameter name="DofsPerNode"                         type="string"   value="myCoalesceDropFact"/>
       <Parameter name="Graph"                               type="string"   value="myCoalesceDropFact"/>
       <Parameter name="P"                                   type="string"   value="myPFact"/>
       <Parameter name="Aggregates"                          type="string"   value="myAggregateFact"/>
-      <Parameter name="CoarseMap"                           type="string"   value="myCoarseMapFact"/>
       <Parameter name="AggregateQualities"                  type="string"   value="myAggregateQualityFact"/>
+      <Parameter name="CoarseMap"                           type="string"   value="myCoarseMapFact"/>
+      <Parameter name="Coordinates"                         type="string"   value="myTransferCoordinatesFact"/>
     </ParameterList>
 
   </ParameterList>

--- a/packages/muelu/test/interface/default/Output/aggregatequalities_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregatequalities_epetra.gold
@@ -26,13 +26,9 @@ BuildAggregatesNonKokkos (Phase 1 (main))
 BuildAggregatesNonKokkos (Phase 2a (secondary))
 BuildAggregatesNonKokkos (Phase 2b (expansion))
 BuildAggregatesNonKokkos (Phase 3 (cleanup))
-Build (MueLu::AggregateQualityEstimateFactory)
-Build (MueLu::CoarseMapFactory)
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
-aggregate qualities: good aggregate threshold = 100   [unused]
-aggregate qualities: check symmetry = 0   [unused]
-aggregation: compute aggregate qualities = 1
+Build (MueLu::CoarseMapFactory)
 matrixmatrix: kernel params -> 
  [empty list]
 matrixmatrix: kernel params -> 
@@ -41,6 +37,10 @@ Transpose P (MueLu::TransPFactory)
 matrixmatrix: kernel params -> 
  [empty list]
 Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::AggregateQualityEstimateFactory
+Build (MueLu::AggregateQualityEstimateFactory)
+aggregate qualities: good aggregate threshold = 100   [unused]
+aggregate qualities: check symmetry = 0   [unused]
 RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
 Build (MueLu::CoordinatesTransferFactory)
 Transferring coordinates
@@ -71,13 +71,9 @@ BuildAggregatesNonKokkos (Phase 1 (main))
 BuildAggregatesNonKokkos (Phase 2a (secondary))
 BuildAggregatesNonKokkos (Phase 2b (expansion))
 BuildAggregatesNonKokkos (Phase 3 (cleanup))
-Build (MueLu::AggregateQualityEstimateFactory)
-Build (MueLu::CoarseMapFactory)
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
-aggregate qualities: good aggregate threshold = 100   [unused]
-aggregate qualities: check symmetry = 0   [unused]
-aggregation: compute aggregate qualities = 1
+Build (MueLu::CoarseMapFactory)
 matrixmatrix: kernel params -> 
  [empty list]
 matrixmatrix: kernel params -> 
@@ -86,6 +82,10 @@ Transpose P (MueLu::TransPFactory)
 matrixmatrix: kernel params -> 
  [empty list]
 Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::AggregateQualityEstimateFactory
+Build (MueLu::AggregateQualityEstimateFactory)
+aggregate qualities: good aggregate threshold = 100   [unused]
+aggregate qualities: check symmetry = 0   [unused]
 RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
 Build (MueLu::CoordinatesTransferFactory)
 Transferring coordinates

--- a/packages/muelu/test/interface/default/Output/aggregatequalities_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregatequalities_tpetra.gold
@@ -27,13 +27,9 @@ BuildAggregatesNonKokkos (Phase 1 (main))
 BuildAggregatesNonKokkos (Phase 2a (secondary))
 BuildAggregatesNonKokkos (Phase 2b (expansion))
 BuildAggregatesNonKokkos (Phase 3 (cleanup))
-Build (MueLu::AggregateQualityEstimateFactory)
-Build (MueLu::CoarseMapFactory)
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
-aggregate qualities: good aggregate threshold = 100   [unused]
-aggregate qualities: check symmetry = 0   [unused]
-aggregation: compute aggregate qualities = 1
+Build (MueLu::CoarseMapFactory)
 matrixmatrix: kernel params -> 
  [empty list]
 matrixmatrix: kernel params -> 
@@ -42,6 +38,10 @@ Transpose P (MueLu::TransPFactory)
 matrixmatrix: kernel params -> 
  [empty list]
 Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::AggregateQualityEstimateFactory
+Build (MueLu::AggregateQualityEstimateFactory)
+aggregate qualities: good aggregate threshold = 100   [unused]
+aggregate qualities: check symmetry = 0   [unused]
 RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
 Build (MueLu::CoordinatesTransferFactory)
 Transferring coordinates
@@ -73,13 +73,9 @@ BuildAggregatesNonKokkos (Phase 1 (main))
 BuildAggregatesNonKokkos (Phase 2a (secondary))
 BuildAggregatesNonKokkos (Phase 2b (expansion))
 BuildAggregatesNonKokkos (Phase 3 (cleanup))
-Build (MueLu::AggregateQualityEstimateFactory)
-Build (MueLu::CoarseMapFactory)
 Nullspace factory (MueLu::NullspaceFactory)
 Fine level nullspace = Nullspace
-aggregate qualities: good aggregate threshold = 100   [unused]
-aggregate qualities: check symmetry = 0   [unused]
-aggregation: compute aggregate qualities = 1
+Build (MueLu::CoarseMapFactory)
 matrixmatrix: kernel params -> 
  [empty list]
 matrixmatrix: kernel params -> 
@@ -88,6 +84,10 @@ Transpose P (MueLu::TransPFactory)
 matrixmatrix: kernel params -> 
  [empty list]
 Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::AggregateQualityEstimateFactory
+Build (MueLu::AggregateQualityEstimateFactory)
+aggregate qualities: good aggregate threshold = 100   [unused]
+aggregate qualities: check symmetry = 0   [unused]
 RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
 Build (MueLu::CoordinatesTransferFactory)
 Transferring coordinates


### PR DESCRIPTION
@trilinos/muelu

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Using the aggregate quality calculation results in several executions of `AggregateQualityEstimateFactory` and thus also triggering the aggregation process several times.

This MR proposes to make it a transfer factory as several other utility factories already are (e.g. aggregate output), means it only gets executed once during the RAPFactory call per level.

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
@cgcgcg 