### PR TITLE
MueLu: Tell aggregate export about Graph and Aggregates

### DIFF
--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -1332,6 +1332,8 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: output file: build colormap", bool, aggExportParams);
     aggExport->SetParameterList(aggExportParams);
     aggExport->SetFactory("DofsPerNode", manager.GetFactory("DofsPerNode"));
+    aggExport->SetFactory("Aggregates", manager.GetFactory("Aggregates"));
+    aggExport->SetFactory("Graph", manager.GetFactory("Graph"));
 
     if (!RAP.is_null())
       RAP->AddTransferFactory(aggExport);

--- a/packages/muelu/src/Utils/MueLu_AggregationExportFactory_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_AggregationExportFactory_decl.hpp
@@ -123,7 +123,7 @@ class AggregationExportFactory : public TwoLevelFactoryBase, public Visualizatio
   // Data that the different styles need to have available when building geometry
   mutable Teuchos::RCP<CoordinateMultiVector> coords_;        // fine local coordinates
   mutable Teuchos::RCP<CoordinateMultiVector> coordsCoarse_;  // coarse local coordinates
-  mutable Teuchos::ArrayRCP<LocalOrdinal> vertex2AggId_;
+  mutable Teuchos::RCP<LocalOrdinalMultiVector> vertex2AggId_;
   mutable Teuchos::ArrayRCP<LocalOrdinal> aggSizes_;
   mutable std::vector<bool> isRoot_;
   mutable bool doFineGraphEdges_;


### PR DESCRIPTION
@trilinos/muelu

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
The export of the aggregates triggers the aggregation process several times. This MR fixes the issue by telling the aggregate export, which factory it should use for `Graph` and `Aggregates`.

@cgcgcg @jhux2 