### PR TITLE
Tacho : new options (dofs-per-node, pivot-tol, amd)

### DIFF
--- a/packages/amesos2/src/Amesos2_Tacho_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Tacho_decl.hpp
@@ -196,6 +196,8 @@ private:
     int small_problem_threshold_size;
     int streams;
     bool verbose;
+    int dofs_per_node;
+    bool pivot_pert;
     // int num_kokkos_threads;
     // int max_num_superblocks;
   } data_;

--- a/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/main.cpp
+++ b/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/main.cpp
@@ -270,7 +270,6 @@ int main(int argc, char *argv[])
         } else {
             assert(false);
         }
-        writeMM("Laplace.mtx",KMonolithic);
 
         RCP<MultiVector<SC,LO,GO,NO> > xSolution = MultiVectorFactory<SC,LO,GO,NO>::Build(KMonolithic->getMap(),1);
         RCP<MultiVector<SC,LO,GO,NO> > xRightHandSide = MultiVectorFactory<SC,LO,GO,NO>::Build(KMonolithic->getMap(),1);

--- a/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/main.cpp
+++ b/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/main.cpp
@@ -270,6 +270,7 @@ int main(int argc, char *argv[])
         } else {
             assert(false);
         }
+        writeMM("Laplace.mtx",KMonolithic);
 
         RCP<MultiVector<SC,LO,GO,NO> > xSolution = MultiVectorFactory<SC,LO,GO,NO>::Build(KMonolithic->getMap(),1);
         RCP<MultiVector<SC,LO,GO,NO> > xRightHandSide = MultiVectorFactory<SC,LO,GO,NO>::Build(KMonolithic->getMap(),1);

--- a/packages/shylu/shylu_node/tacho/cmake/Tacho_config.h.in
+++ b/packages/shylu/shylu_node/tacho/cmake/Tacho_config.h.in
@@ -25,6 +25,9 @@
 /* Define if want to build with CHOLMOD enabled */
 #cmakedefine TACHO_HAVE_SUITESPARSE
 
+/* Define if want to build with TrilinosSS enabled */
+#cmakedefine TACHO_HAVE_TRILINOS_SS
+
 /* Define if want to build with VTune enabled */
 #cmakedefine TACHO_HAVE_VTUNE
 

--- a/packages/shylu/shylu_node/tacho/example/Tacho_ExampleDriver.hpp
+++ b/packages/shylu/shylu_node/tacho/example/Tacho_ExampleDriver.hpp
@@ -257,6 +257,7 @@ template <typename value_type> int driver(int argc, char *argv[]) {
 
     std::cout << std::endl;
     std::cout << " Initi Time " << initi_time << std::endl;
+    std::cout << " > nnz = " << solver.getNumNonZerosU() << std::endl;
     std::cout << " Facto Time " << facto_time / (double)nfacts << std::endl;
     std::cout << " Solve Time " << solve_time / (double)nsolves << std::endl;
     std::cout << std::endl;

--- a/packages/shylu/shylu_node/tacho/example/Tacho_ExampleDriver.hpp
+++ b/packages/shylu/shylu_node/tacho/example/Tacho_ExampleDriver.hpp
@@ -25,8 +25,11 @@ template <typename value_type> int driver(int argc, char *argv[]) {
   std::string file = "test.mtx";
   std::string graph_file = "";
   std::string weight_file = "";
+  int dofs_per_node = 1;
+  bool perturbPivot = false;
   int nrhs = 1;
   bool randomRHS = true;
+  bool onesRHS = false;
   std::string method_name = "chol";
   int method = 1; // 1 - Chol, 2 - LDL, 3 - SymLU
   int small_problem_thres = 1024;
@@ -47,6 +50,8 @@ template <typename value_type> int driver(int argc, char *argv[]) {
   opts.set_option<std::string>("file", "Input file (MatrixMarket SPD matrix)", &file);
   opts.set_option<std::string>("graph", "Input condensed graph", &graph_file);
   opts.set_option<std::string>("weight", "Input condensed graph weight", &weight_file);
+  opts.set_option<int>("dofs-per-node", "# DoFs per node", &dofs_per_node);
+  opts.set_option<bool>("perturb", "Flag to perturb tiny pivots", &perturbPivot);
   opts.set_option<int>("nrhs", "Number of RHS vectors", &nrhs);
   opts.set_option<std::string>("method", "Solution method: chol, ldl, lu", &method_name);
   opts.set_option<int>("small-problem-thres", "LAPACK is used smaller than this thres", &small_problem_thres);
@@ -55,6 +60,7 @@ template <typename value_type> int driver(int argc, char *argv[]) {
   opts.set_option<int>("device-solve-thres", "Device function is used above this subproblem size", &device_solve_thres);
   opts.set_option<int>("variant", "algorithm variant in levelset scheduling; 0, 1 and 2", &variant);
   opts.set_option<int>("nstreams", "# of streams used in CUDA; on host, it is ignored", &nstreams);
+  opts.set_option<bool>("one-rhs", "Set RHS to be ones", &onesRHS);
   opts.set_option<bool>("no-warmup", "Flag to turn off warmup", &no_warmup);
   opts.set_option<int>("nfacts", "# of factorizations to perform", &nfacts);
   opts.set_option<int>("nsolves", "# of solves to perform", &nsolves);
@@ -125,6 +131,8 @@ template <typename value_type> int driver(int argc, char *argv[]) {
           if (!in.good()) {
             std::cout << "Failed in open the file: " << graph_file << std::endl;
             return -1;
+          } else if (verbose) {
+            std::cout << " > Condensed graph file: " << graph_file << std::endl;
           }
           in >> m_graph;
 
@@ -135,8 +143,10 @@ template <typename value_type> int driver(int argc, char *argv[]) {
           aj_graph = ordinal_type_array_host("aj", ap_graph(m_graph));
           for (ordinal_type i = 0; i < m_graph; ++i) {
             const ordinal_type jbeg = ap_graph(i), jend = ap_graph(i + 1);
-            for (ordinal_type j = jbeg; j < jend; ++j)
+            for (ordinal_type j = jbeg; j < jend; ++j) {
               in >> aj_graph(j);
+              aj_graph(j) --; // base-one
+            }
           }
         }
 
@@ -146,6 +156,8 @@ template <typename value_type> int driver(int argc, char *argv[]) {
           if (!in.good()) {
             std::cout << "Failed in open the file: " << weight_file << std::endl;
             return -1;
+          } else if (verbose) {
+            std::cout << " > Weight file for condensed graph: " << weight_file << std::endl;
           }
           ordinal_type m(0);
           in >> m;
@@ -160,17 +172,21 @@ template <typename value_type> int driver(int argc, char *argv[]) {
     Tacho::Driver<value_type, device_type> solver;
 
     /// common options
-    solver.setSolutionMethod(method);
-    solver.setSmallProblemThresholdsize(small_problem_thres);
     solver.setVerbose(verbose);
+    solver.setSolutionMethod(method);
+    solver.setLevelSetOptionAlgorithmVariant(variant);
+    solver.setLevelSetOptionNumStreams(nstreams);
 
     /// graph options
     solver.setOrderConnectedGraphSeparately();
 
     /// levelset options
+    solver.setSmallProblemThresholdsize(small_problem_thres);
     solver.setLevelSetOptionDeviceFunctionThreshold(device_factor_thres, device_solve_thres);
-    solver.setLevelSetOptionAlgorithmVariant(variant);
-    solver.setLevelSetOptionNumStreams(nstreams);
+    if (perturbPivot) {
+      if (verbose) std::cout << " > perturb tiny pivots" << std::endl;
+      solver.useDefaultPivotTolerance();
+    }
 
     auto values_on_device = Kokkos::create_mirror_view(typename device_type::memory_space(), A.Values());
     Kokkos::deep_copy(values_on_device, A.Values());
@@ -178,7 +194,10 @@ template <typename value_type> int driver(int argc, char *argv[]) {
     /// inputs are used for graph reordering and analysis
     if (m_graph > 0 && m_graph < A.NumRows())
       solver.analyze(A.NumRows(), A.RowPtr(), A.Cols(), m_graph, ap_graph, aj_graph, aw_graph);
-    else
+    else if (dofs_per_node > 1) {
+      if (verbose) std::cout << " > DoFs / node = " << dofs_per_node << std::endl;
+      solver.analyze(A.NumRows(), dofs_per_node, A.RowPtr(), A.Cols());
+    } else
       solver.analyze(A.NumRows(), A.RowPtr(), A.Cols());
 
     /// create numeric tools and levelset tools
@@ -202,7 +221,10 @@ template <typename value_type> int driver(int argc, char *argv[]) {
         t("t", A.NumRows(), nrhs);                  // temp workspace (store permuted rhs)
 
     {
-      if (randomRHS) {
+      if (onesRHS) {
+        const value_type one(1.0);
+        Kokkos::deep_copy (b, one);
+      } else if (randomRHS) {
         Kokkos::Random_XorShift64_Pool<typename device_type::execution_space> random(13718);
         Kokkos::fill_random(b, random, value_type(1));
       } else {

--- a/packages/shylu/shylu_node/tacho/src/Tacho_CrsMatrixBase.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_CrsMatrixBase.hpp
@@ -371,7 +371,8 @@ inline static void applyPermutationToCrsMatrixLower(/* */ CrsMatrixType &A, cons
 template <typename ValueType, typename DeviceType>
 inline double computeRelativeResidual(const CrsMatrixBase<ValueType, DeviceType> &A,
                                       const Kokkos::View<ValueType **, Kokkos::LayoutLeft, DeviceType> &x,
-                                      const Kokkos::View<ValueType **, Kokkos::LayoutLeft, DeviceType> &b) {
+                                      const Kokkos::View<ValueType **, Kokkos::LayoutLeft, DeviceType> &b,
+                                      const bool verbose = false) {
   const bool test = (size_t(A.NumRows()) != size_t(A.NumCols()) || size_t(A.NumRows()) != size_t(b.extent(0)) ||
                      size_t(x.extent(0)) != size_t(b.extent(0)) || size_t(x.extent(1)) != size_t(b.extent(1)));
   if (test)
@@ -405,6 +406,8 @@ inline double computeRelativeResidual(const CrsMatrixBase<ValueType, DeviceType>
       diff += arith_traits::real((h_b(i, p) - s) * arith_traits::conj(h_b(i, p) - s));
     }
   }
+  if (verbose)
+    std::cout << " Relative residual norm = " << sqrt(diff) << " / " << sqrt(norm) << " = " << sqrt(diff/norm) << std::endl;
   return sqrt(diff / norm);
 }
 

--- a/packages/shylu/shylu_node/tacho/src/Tacho_Driver.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_Driver.hpp
@@ -393,9 +393,9 @@ public:
     if (blk_size > 1) {
       //condense graph before calling analyze
       const size_type nnz = ap(m);
-      size_type m_graph = m / blk_size;
+      ordinal_type m_graph = m / blk_size;
       size_type nnz_graph = nnz / (blk_size*blk_size);
-      TACHO_TEST_FOR_EXCEPTION((m != blk_size * m_graph || nnz != blk_size*blk_size * nnz_graph),
+      TACHO_TEST_FOR_EXCEPTION((m != blk_size * m_graph || nnz != size_type(blk_size*blk_size) * nnz_graph),
         std::logic_error, "Failed to initialize the condensed graph");
 
       size_type_array_host ap_graph
@@ -407,7 +407,7 @@ public:
       // condense the graph
       nnz_graph = 0;
       ap_graph(0) = 0;
-      for (size_type i = 0; i < m; i += blk_size) {
+      for (ordinal_type i = 0; i < m; i += blk_size) {
         for (size_type k = ap(i); k < ap(i+1); k++) {
           if (aj(k)%blk_size == 0) {
             aj_graph(nnz_graph) = aj(k)/blk_size;
@@ -417,7 +417,7 @@ public:
           ap_graph((i/blk_size)+1) = nnz_graph;
         }
       }
-      TACHO_TEST_FOR_EXCEPTION((nnz != blk_size*blk_size * nnz_graph),
+      TACHO_TEST_FOR_EXCEPTION((nnz != size_type(blk_size*blk_size) * nnz_graph),
         std::logic_error, "Failed to condense graph");
       return analyze(m, ap, aj, m_graph, ap_graph, aj_graph, aw_graph, duplicate);
     } else {

--- a/packages/shylu/shylu_node/tacho/src/Tacho_Driver.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_Driver.hpp
@@ -113,6 +113,7 @@ private:
   ordinal_type_array_host _h_peri_graph;
 
   // ** symbolic factorization output
+  ordinal_type _nnz_u;
   // supernodes output
   ordinal_type _nsupernodes;
   ordinal_type_array _supernodes;
@@ -217,6 +218,7 @@ public:
   ///
   /// get interface
   ///
+  ordinal_type getNumNonZerosU() const;
   ordinal_type getNumSupernodes() const;
   ordinal_type_array getSupernodes() const;
   ordinal_type_array getPermutationVector() const;

--- a/packages/shylu/shylu_node/tacho/src/Tacho_Driver.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_Driver.hpp
@@ -16,6 +16,7 @@
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
 
 #include "Tacho.hpp"
+#include "Tacho_Util.hpp"
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Timer.hpp>
@@ -24,7 +25,7 @@ namespace Tacho {
 
 /// forward decl
 class Graph;
-#if defined(TACHO_HAVE_METIS)
+#if defined(TACHO_HAVE_METIS) || defined(TACHO_HAVE_TRILINOS_SS)
 class GraphTools_Metis;
 #else
 class GraphTools;
@@ -42,6 +43,7 @@ template <typename ValueType, typename DeviceType, int Var> class NumericToolsLe
 template <typename ValueType, typename DeviceType> struct Driver {
 public:
   using value_type = ValueType;
+  using mag_type = typename ArithTraits<ValueType>::mag_type;
   using device_type = DeviceType;
   using exec_space = typename device_type::execution_space;
   using exec_memory_space = typename device_type::memory_space;
@@ -63,7 +65,7 @@ public:
   using crs_matrix_type = CrsMatrixBase<value_type, device_type>;
   using crs_matrix_type_host = CrsMatrixBase<value_type, host_device_type>;
 
-#if defined(TACHO_HAVE_METIS)
+#if defined(TACHO_HAVE_METIS) || defined(TACHO_HAVE_TRILINOS_SS)
   using graph_tools_type = GraphTools_Metis;
 #else
   using graph_tools_type = GraphTools;
@@ -160,6 +162,8 @@ private:
   ordinal_type _variant;             // algorithmic variant in levelset 0: naive, 1: invert diagonals
   ordinal_type _nstreams;            // on cuda, multi streams are used
 
+  mag_type _pivot_tol;               // tolerance for tiny pivot perturbation
+
   // parallelism and memory constraint is made via this parameter
   ordinal_type _max_num_superblocks; // # of superblocks in the memoyrpool
 
@@ -206,6 +210,10 @@ public:
   void setLevelSetOptionNumStreams(const ordinal_type nstreams);
   void setLevelSetOptionAlgorithmVariant(const ordinal_type variant);
 
+  void setPivotTolerance(const mag_type pivot_tol);
+  void useNoPivotTolerance();
+  void useDefaultPivotTolerance();
+
   ///
   /// get interface
   ///
@@ -222,6 +230,7 @@ public:
   template <typename arg_size_type_array, typename arg_ordinal_type_array>
   int analyze(const ordinal_type m, const arg_size_type_array &ap, const arg_ordinal_type_array &aj,
               const bool duplicate = false) {
+
     _m = m;
 
     if (duplicate) {
@@ -270,6 +279,7 @@ public:
               const arg_perm_type_array &perm, const arg_perm_type_array &peri, const bool duplicate = false) {
     _m = m;
 
+    // this takes the user-specified perm, such that analyze() won't call graph partitioner
     if (duplicate) {
       /// for most cases, ap and aj are from host; so construct ap and aj and mirror to device
       _h_ap = size_type_array_host(Kokkos::ViewAllocateWithoutInitializing("h_ap"), ap.extent(0));
@@ -373,6 +383,46 @@ public:
     _nnz_graph = _h_ap_graph(m_graph);
 
     return analyze();
+  }
+
+  template <typename arg_size_type_array, typename arg_ordinal_type_array>
+  int analyze(const ordinal_type m, const ordinal_type blk_size,
+              const arg_size_type_array &ap, const arg_ordinal_type_array &aj,
+              const bool duplicate = false) {
+
+    if (blk_size > 1) {
+      //condense graph before calling analyze
+      const size_type nnz = ap(m);
+      size_type m_graph = m / blk_size;
+      size_type nnz_graph = nnz / (blk_size*blk_size);
+      TACHO_TEST_FOR_EXCEPTION((m != blk_size * m_graph || nnz != blk_size*blk_size * nnz_graph),
+        std::logic_error, "Failed to initialize the condensed graph");
+
+      size_type_array_host ap_graph
+        (Kokkos::ViewAllocateWithoutInitializing("ap_graph"), 1+m_graph);
+      ordinal_type_array_host aj_graph
+        (Kokkos::ViewAllocateWithoutInitializing("aj_graph"), nnz_graph);
+      ordinal_type_array_host aw_graph
+        (Kokkos::ViewAllocateWithoutInitializing("wgs"), m_graph);
+      // condense the graph
+      nnz_graph = 0;
+      ap_graph(0) = 0;
+      for (size_type i = 0; i < m; i += blk_size) {
+        for (size_type k = ap(i); k < ap(i+1); k++) {
+          if (aj(k)%blk_size == 0) {
+            aj_graph(nnz_graph) = aj(k)/blk_size;
+            nnz_graph++;
+          }
+          aw_graph(i/blk_size) = blk_size;
+          ap_graph((i/blk_size)+1) = nnz_graph;
+        }
+      }
+      TACHO_TEST_FOR_EXCEPTION((nnz != blk_size*blk_size * nnz_graph),
+        std::logic_error, "Failed to condense graph");
+      return analyze(m, ap, aj, m_graph, ap_graph, aj_graph, aw_graph, duplicate);
+    } else {
+      return analyze(m, ap, aj, duplicate);
+    }
   }
 
   int initialize();

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol.hpp
@@ -32,10 +32,10 @@ struct CholAlgorithm {
 };
 
 struct CholAlgorithm_Team {
-#if defined(KOKKOS_ENABLE_OPENMP)
-  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
-#else
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
+#else
+  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
 #endif
 };
 } // namespace Tacho

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Driver_Impl.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Driver_Impl.hpp
@@ -24,7 +24,7 @@ template <typename VT, typename DT>
 Driver<VT, DT>::Driver()
     : _method(1), _order_connected_graph_separately(1), _m(0), _nnz(0), _ap(), _h_ap(), _aj(), _h_aj(), _perm(),
       _h_perm(), _peri(), _h_peri(), _m_graph(0), _nnz_graph(0), _h_ap_graph(), _h_aj_graph(), _h_perm_graph(),
-      _h_peri_graph(), _nsupernodes(0), _N(nullptr), _verbose(0), _small_problem_thres(1024), _serial_thres_size(-1),
+      _h_peri_graph(), _nnz_u(0), _nsupernodes(0), _N(nullptr), _verbose(0), _small_problem_thres(1024), _serial_thres_size(-1),
       _mb(-1), _nb(-1), _front_update_mode(-1), _levelset(0), _device_level_cut(0), _device_factor_thres(128),
       _device_solve_thres(128), _variant(2), _nstreams(16), _pivot_tol(0.0), _max_num_superblocks(-1) {}
 
@@ -173,6 +173,7 @@ template <typename VT, typename DT> void Driver<VT, DT>::useDefaultPivotToleranc
 ///
 /// get interface
 ///
+template <typename VT, typename DT> ordinal_type Driver<VT, DT>::getNumNonZerosU() const { return _nnz_u; }
 template <typename VT, typename DT> ordinal_type Driver<VT, DT>::getNumSupernodes() const { return _nsupernodes; }
 
 template <typename VT, typename DT> typename Driver<VT, DT>::ordinal_type_array Driver<VT, DT>::getSupernodes() const {
@@ -192,11 +193,11 @@ typename Driver<VT, DT>::ordinal_type_array Driver<VT, DT>::getInversePermutatio
 // internal only
 template <typename VT, typename DT> int Driver<VT, DT>::analyze() {
   int r_val(0);
-  if (_m < _small_problem_thres) {
+  if (_m <= _small_problem_thres) {
     /// do nothing
     if (_verbose) {
-      printf("TachoSolver: Analyze\n");
-      printf("====================\n");
+      printf("TachoSolver: Analyze (Small Problem)\n");
+      printf("====================================\n");
       printf("  Linear system A\n");
       printf("             number of equations:                             %10d\n", _m);
       printf("\n");
@@ -255,6 +256,7 @@ template <typename VT, typename DT> int Driver<VT, DT>::analyze_linear_system() 
     symbolic_tools_type S(_m, _h_ap, _h_aj, _h_perm, _h_peri);
     S.symbolicFactorize(_verbose);
 
+    _nnz_u = S.NumNonzerosU();
     _nsupernodes = S.NumSupernodes();
     _stree_level = S.SupernodesTreeLevel();
     _stree_roots = S.SupernodesTreeRoots();
@@ -300,6 +302,7 @@ template <typename VT, typename DT> int Driver<VT, DT>::analyze_condensed_graph(
     S.symbolicFactorize(_verbose);
     S.evaporateSymbolicFactors(_h_aw_graph, _verbose);
 
+    _nnz_u = S.NumNonzerosU();
     _nsupernodes = S.NumSupernodes();
     _stree_level = S.SupernodesTreeLevel();
     _stree_roots = S.SupernodesTreeRoots();
@@ -343,7 +346,7 @@ template <typename VT, typename DT> int Driver<VT, DT>::initialize() {
   ///
   /// initialize numeric tools
   ///
-  if (_m < _small_problem_thres) {
+  if (_m <= _small_problem_thres) {
     /// do nothing
   } else {
     ///
@@ -383,7 +386,7 @@ template <typename VT, typename DT> int Driver<VT, DT>::factorize(const value_ty
     }
   }
 
-  if (_m < _small_problem_thres) {
+  if (_m <= _small_problem_thres) {
     factorize_small_host(ax);
   } else {
     _N->factorize(ax, _pivot_tol, _verbose);
@@ -476,7 +479,7 @@ int Driver<VT, DT>::solve(const value_type_matrix &x, const value_type_matrix &b
     }
   }
 
-  if (_m < _small_problem_thres) {
+  if (_m <= _small_problem_thres) {
     solve_small_host(x, b, t);
   } else {
     TACHO_TEST_FOR_EXCEPTION(t.extent(0) < x.extent(0) || t.extent(1) < x.extent(1), std::logic_error,
@@ -566,7 +569,7 @@ void Driver<VT, DT>::computeSpMV(const value_type_array &ax, const value_type_ma
 }
 
 template <typename VT, typename DT> int Driver<VT, DT>::exportFactorsToCrsMatrix(crs_matrix_type &A) {
-  if (_m < _small_problem_thres) {
+  if (_m <= _small_problem_thres) {
     typedef ArithTraits<value_type> ats;
     const typename ats::mag_type zero(0);
 
@@ -644,6 +647,7 @@ template <typename VT, typename DT> int Driver<VT, DT>::release() {
     _h_perm_graph = ordinal_type_array_host();
     _h_peri_graph = ordinal_type_array_host();
 
+    _nnz_u = 0;
     _nsupernodes = 0;
     _supernodes = ordinal_type_array();
 

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm.hpp
@@ -31,10 +31,10 @@ struct GemmAlgorithm {
 };
 
 struct GemmAlgorithm_Team {
-#if defined(KOKKOS_ENABLE_OPENMP)
-  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
-#else
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
+#else
+  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
 #endif
 };
 

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv.hpp
@@ -31,10 +31,10 @@ struct GemvAlgorithm {
 };
 
 struct GemvAlgorithm_Team {
-#if defined(KOKKOS_ENABLE_OPENMP)
-  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
-#else
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
+#else
+  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
 #endif
 };
 } // namespace Tacho

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_GraphTools.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_GraphTools.hpp
@@ -67,6 +67,11 @@ public:
       _perm(i) = i;
       _peri(i) = i;
     }
+    if (verbose) {
+      printf("Summary: GraphTools (Default)\n");
+      printf("=============================\n");
+      printf( " Use Natural Ordering\n\n" );
+    }
   }
 
   ordinal_type_array PermVector() const { return _perm; }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_GraphTools_Metis.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_GraphTools_Metis.hpp
@@ -16,11 +16,12 @@
 
 #include "Tacho_Util.hpp"
 
-#if defined(TACHO_HAVE_METIS)
 #include "Tacho_Graph.hpp"
 
 #include "trilinos_amd.h"
-#include "metis.h"
+#if defined(TACHO_HAVE_METIS)
+ #include "metis.h"
+#endif
 
 namespace Tacho {
 
@@ -28,6 +29,9 @@ class GraphTools_Metis {
 public:
   typedef typename UseThisDevice<Kokkos::DefaultHostExecutionSpace>::type host_device_type;
 
+  #if !defined(TACHO_HAVE_METIS)
+  typedef ordinal_type idx_t;
+  #endif
   typedef Kokkos::View<idx_t *, host_device_type> idx_t_array;
   typedef Kokkos::View<ordinal_type *, host_device_type> ordinal_type_array;
 
@@ -36,7 +40,10 @@ private:
   idx_t _nvts;
   idx_t_array _xadj, _adjncy, _vwgt;
 
+  int _algo;
+  #if defined(TACHO_HAVE_METIS)
   idx_t _options[METIS_NOPTIONS];
+  #endif
 
   // metis output
   idx_t_array _perm_t, _peri_t;
@@ -61,6 +68,7 @@ public:
 
   void setVerbose(const bool verbose);
   void setOption(const int id, const idx_t value);
+  void setAlgorithm(const int algo);
 
   template <typename ordering_type>
   ordering_type amd_order(ordering_type n, const ordering_type *xadj,
@@ -81,5 +89,4 @@ public:
 };
 
 } // namespace Tacho
-#endif
 #endif

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk.hpp
@@ -31,10 +31,10 @@ struct HerkAlgorithm {
 };
 
 struct HerkAlgorithm_Team {
-#if defined(KOKKOS_ENABLE_OPENMP)
-  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
-#else
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
+#else
+  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
 #endif
 };
 } // namespace Tacho

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL.hpp
@@ -32,10 +32,10 @@ struct LDL_Algorithm {
 };
 
 struct LDL_Algorithm_Team {
-#if defined(KOKKOS_ENABLE_OPENMP)
-  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
-#else
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
+#else
+  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
 #endif
 };
 } // namespace Tacho

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU.hpp
@@ -32,10 +32,10 @@ struct LU_Algorithm {
 };
 
 struct LU_Algorithm_Team {
-#if defined(KOKKOS_ENABLE_OPENMP)
-  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
-#else
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
+#else
+  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
 #endif
 };
 

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_External.hpp
@@ -61,6 +61,12 @@ template <> struct LU<Algo::External> {
     }
   }
 
+  template <typename MemberType, typename ViewTypeA, typename ViewTypeP>
+  KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const double /*tol*/, const ViewTypeA &A, const ViewTypeP &P) {
+    // tol is not used, for now
+    return invoke(member, A, P);
+  }
+
   template <typename ViewTypeP> inline static int modify(const ordinal_type m, const ViewTypeP &P) {
 
     static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeP::execution_space>;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_Internal.hpp
@@ -25,7 +25,6 @@ template <> struct LU<Algo::Internal> {
   template <typename MemberType, typename ViewTypeA, typename ViewTypeP>
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A, const ViewTypeP &P) {
     typedef typename ViewTypeA::non_const_value_type value_type;
-    // typedef typename ViewTypeP::non_const_value_type p_value_type;
 
     static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
     static_assert(ViewTypeP::rank == 1, "P is not rank 1 view.");
@@ -37,6 +36,24 @@ template <> struct LU<Algo::Internal> {
     if (m > 0 && n > 0) {
       /// factorize LU
       LapackTeam<value_type>::getrf(member, m, n, A.data(), A.stride_1(), P.data(), &r_val);
+    }
+    return r_val;
+  }
+
+  template <typename MemberType, typename ViewTypeA, typename ViewTypeP>
+  KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const double tol, const ViewTypeA &A, const ViewTypeP &P) {
+    typedef typename ViewTypeA::non_const_value_type value_type;
+
+    static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
+    static_assert(ViewTypeP::rank == 1, "P is not rank 1 view.");
+
+    TACHO_TEST_FOR_ABORT(P.extent(0) < 4 * A.extent(0), "P should be 4*A.extent(0) .");
+
+    int r_val(0);
+    const ordinal_type m = A.extent(0), n = A.extent(1);
+    if (m > 0 && n > 0) {
+      /// factorize LU
+      LapackTeam<value_type>::getrf(member, tol, m, n, A.data(), A.stride_1(), P.data(), &r_val);
     }
     return r_val;
   }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_Serial.hpp
@@ -61,6 +61,12 @@ template <> struct LU<Algo::Serial> {
     }
   }
 
+  template <typename MemberType, typename ViewTypeA, typename ViewTypeP>
+  inline static int invoke(MemberType &member, const double /*tol*/, const ViewTypeA &A, const ViewTypeP &P) {
+    // tol is not used, for now
+    return invoke(member, A, P);
+  }
+
   template <typename ViewTypeP> inline static int modify(const ordinal_type m, const ViewTypeP &P) {
 
     static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeP::execution_space>;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Lapack_Team.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Lapack_Team.hpp
@@ -257,9 +257,9 @@ template <typename T> struct LapackTeam {
         Kokkos::parallel_reduce(
             Kokkos::TeamVectorRange(member, 1 + iend),
             [&](const int &i, reducer_value_type &update) {
-              const mag_type val = arith_traits::abs(ABR[i * as0]);
-              if (val > update.val) {
-                update.val = val;
+              const mag_type val_i = arith_traits::abs(ABR[i * as0]);
+              if (val_i > update.val) {
+                update.val = val_i;
                 update.loc = i;
               }
             },
@@ -324,9 +324,9 @@ template <typename T> struct LapackTeam {
         Kokkos::parallel_reduce(
             Kokkos::TeamVectorRange(member, 1 + iend),
             [&](const int &i, reducer_value_type &update) {
-              const mag_type val = arith_traits::abs(ABR[i * as0]);
-              if (val > update.val) {
-                update.val = val;
+              const mag_type val_i = arith_traits::abs(ABR[i * as0]);
+              if (val_i > update.val) {
+                update.val = val_i;
                 update.loc = i;
               }
             },

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_Base.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_Base.hpp
@@ -24,6 +24,7 @@ namespace Tacho {
 template <typename ValueType, typename DeviceType> class NumericToolsBase {
 public:
   using value_type = ValueType;
+  using mag_type = typename ArithTraits<ValueType>::mag_type;
   using device_type = DeviceType;
   using exec_space = typename device_type::execution_space;
   using exec_memory_space = typename device_type::memory_space;
@@ -243,7 +244,7 @@ public:
     }
   }
 
-  inline virtual void factorize(const value_type_array &ax, const ordinal_type verbose = 0) {
+  inline virtual void factorize(const value_type_array &ax, const mag_type pivot_tol = 0.0, const ordinal_type verbose = 0) {
     TACHO_TEST_FOR_EXCEPTION(true, std::logic_error, "The function should be overriden by derived classes");
   }
 

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -2288,7 +2288,7 @@ public:
       printf("=====================================================\n");
       printf( "\n  ** Team = %f s, Device = %f s, Update = %f s **\n",time_parallel,time_device,time_update );
       if (variant == 3) {
-        printf( " extractCRS with total nnzL = %d and nnzU = %d\n\n",colindL.extent(0),colindU.extent(0) );
+        printf( " extractCRS with total nnzL = %ld and nnzU = %ld\n\n",colindL.extent(0),colindU.extent(0) );
       } else {
         printf( "\n" );
       }
@@ -4375,7 +4375,7 @@ public:
       printf("================================================\n");
       printf( "\n  ** Team = %f s, Device = %f s, Update = %f s (%d streams) **\n",time_parallel,time_device,time_update,_nstreams );
       if (variant == 3) {
-        printf( " extractCRS with total nnzL = %d and nnzU = %d\n\n",colindL.extent(0),colindU.extent(0) );
+        printf( " extractCRS with total nnzL = %ld and nnzU = %ld\n\n",colindL.extent(0),colindU.extent(0) );
       } else {
         printf( "\n" );
       }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -4281,9 +4281,6 @@ public:
         team_policy_update policy_update(1, 1, 1);
         functor_type functor(_info, _factorize_mode, _level_sids, _piv, _buf, &rval);
         if (pivot_tol > 0.0) {
-          using arith_traits = ArithTraits<value_type>;
-          using mag_type = typename arith_traits::mag_type;
-          const mag_type tol = sqrt(arith_traits::epsilon());
           functor.setDiagPertubationTol(pivot_tol);
         }
         // get max vector length

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -2286,7 +2286,12 @@ public:
     if (verbose) {
       printf("Summary: LevelSetTools-Variant-%d (CholeskyFactorize)\n", variant);
       printf("=====================================================\n");
-      printf( "\n  ** Team = %f s, Device = %f s, Update = %f s **\n\n",time_parallel,time_device,time_update );
+      printf( "\n  ** Team = %f s, Device = %f s, Update = %f s **\n",time_parallel,time_device,time_update );
+      if (variant == 3) {
+        printf( " extractCRS with total nnzL = %d and nnzU = %d\n\n",colindL.extent(0),colindU.extent(0) );
+      } else {
+        printf( "\n" );
+      }
       print_stat_factor();
       fflush(stdout);
     }
@@ -4368,7 +4373,12 @@ public:
     if (verbose) {
       printf("Summary: LevelSetTools-Variant-%d (LU Factorize)\n", variant);
       printf("================================================\n");
-      printf( "\n  ** Team = %f s, Device = %f s, Update = %f s (%d streams) **\n\n",time_parallel,time_device,time_update,_nstreams );
+      printf( "\n  ** Team = %f s, Device = %f s, Update = %f s (%d streams) **\n",time_parallel,time_device,time_update,_nstreams );
+      if (variant == 3) {
+        printf( " extractCRS with total nnzL = %d and nnzU = %d\n\n",colindL.extent(0),colindU.extent(0) );
+      } else {
+        printf( "\n" );
+      }
       print_stat_factor();
       fflush(stdout);
     }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -410,7 +410,7 @@ public:
   /// initialization / release
   ///
   inline void initialize(const ordinal_type device_level_cut, const ordinal_type device_factorize_thres,
-                         const ordinal_type device_solve_thres, const int nstreams = 1, const ordinal_type verbose = 0) {
+                         const ordinal_type device_solve_thres, const int nstreams_in = 1, const ordinal_type verbose = 0) {
     stat_level.n_device_factorize = 0;
     stat_level.n_device_solve = 0;
     stat_level.n_team_factorize = 0;
@@ -419,6 +419,8 @@ public:
     Kokkos::Timer timer;
 
     timer.reset();
+    // # of streams needs to be at least 1
+    const int nstreams = max(1, nstreams_in);
 
     ///
     /// level data structure
@@ -792,6 +794,8 @@ public:
   }
 
   inline void createStream(const ordinal_type nstreams, const ordinal_type verbose = 0) {
+    // # of streams needs to be at least 1
+    if (nstreams <= 0) return;
 #if defined(KOKKOS_ENABLE_CUDA)
     _nstreams = nstreams;
     if (_streams.size() == size_t(nstreams)) return;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_Serial.hpp
@@ -45,6 +45,7 @@ public:
   using typename base_type::ordinal_type_array;
   using typename base_type::ordinal_type_array_host;
   using typename base_type::size_type_array;
+  using typename base_type::mag_type;
   using typename base_type::value_type;
   using typename base_type::value_type_array;
   using typename base_type::value_type_matrix;
@@ -475,7 +476,7 @@ public:
   ///
   /// main interface
   ///
-  inline void factorize(const value_type_array &ax, const ordinal_type verbose = 0) override {
+  inline void factorize(const value_type_array &ax, const mag_type pivot_tol = 0.0, const ordinal_type verbose = 0) override {
     {
       const bool test = !std::is_same<exec_memory_space, Kokkos::HostSpace>::value;
       TACHO_TEST_FOR_EXCEPTION(test, std::logic_error, "Serial interface works on host device only");

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_SymbolicTools.cpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_SymbolicTools.cpp
@@ -665,6 +665,7 @@ SymbolicTools::SymbolicTools(const ordinal_type m, const size_type_array &ap, co
                              const ordinal_type_array &perm, const ordinal_type_array &peri)
     : _m(m), _ap(ap), _aj(aj), _perm(perm), _peri(peri) {}
 
+ordinal_type SymbolicTools::NumNonzerosU() const { return stat.nnz_u; }
 ordinal_type SymbolicTools::NumSupernodes() const { return _supernodes.extent(0) - 1; }
 ordinal_type_array SymbolicTools::Supernodes() const { return _supernodes; }
 size_type_array SymbolicTools::gidSuperPanelPtr() const { return _gid_super_panel_ptr; }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_SymbolicTools.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_SymbolicTools.hpp
@@ -169,6 +169,7 @@ public:
     Kokkos::deep_copy(_peri, G.InvPermVector());
   }
 
+  ordinal_type NumNonzerosU() const;
   ordinal_type NumSupernodes() const;
   ordinal_type_array Supernodes() const;
   size_type_array gidSuperPanelPtr() const;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_ExtractCRS.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_ExtractCRS.hpp
@@ -192,7 +192,7 @@ public:
                                [&](const int& i) {
                                  // diagonal block
                                  ordinal_type j;
-                                 for (ordinal_type j = i; j < s.m; j++) {
+                                 for (j = i; j < s.m; j++) {
                                    if (AT(i,j) != zero) {
                                      int nnz = _rowptr[i+offm];
                                      _colind[nnz] = j+offm;
@@ -202,8 +202,8 @@ public:
                                  }
                                  // off-diagonal blocksa
                                  j = s.m;
-                                 for (ordinal_type id = s.sid_col_begin + 1; id < s.sid_col_end - 1; id++) {
-                                   for (ordinal_type k = _info.sid_block_colidx(id).second; k < _info.sid_block_colidx(id + 1).second; k++) {
+                                 for (ordinal_type blk_id = s.sid_col_begin + 1; blk_id < s.sid_col_end - 1; blk_id++) {
+                                   for (ordinal_type k = _info.sid_block_colidx(blk_id).second; k < _info.sid_block_colidx(blk_id + 1).second; k++) {
                                      if (AT(i,j) != zero) {
                                        int nnz = _rowptr[i+offm];
                                        _colind[nnz] = _info.gid_colidx(k+offn);
@@ -262,8 +262,8 @@ public:
                                  }
                                  // off-diagonals (each thread extract col, needing atomic-add)
                                  ordinal_type i = s.m;
-                                 for (ordinal_type id = s.sid_col_begin + 1; id < s.sid_col_end - 1; id++) {
-                                   for (ordinal_type k = _info.sid_block_colidx(id).second; k < _info.sid_block_colidx(id + 1).second; k++) {
+                                 for (ordinal_type blk_id = s.sid_col_begin + 1; blk_id < s.sid_col_end - 1; blk_id++) {
+                                   for (ordinal_type k = _info.sid_block_colidx(blk_id).second; k < _info.sid_block_colidx(blk_id + 1).second; k++) {
                                      if (AL(i, j) != zero) {
                                        ordinal_type gid_i = _info.gid_colidx(k+offn);
                                        Kokkos::atomic_add(&(_rowptr[1+gid_i]), 1);
@@ -329,8 +329,8 @@ public:
                                  }
                                  // off-diagonals (each thread extract col, needing atomic-add)
                                  ordinal_type i = s.m;
-                                 for (ordinal_type id = s.sid_col_begin + 1; id < s.sid_col_end - 1; id++) {
-                                   for (ordinal_type k = _info.sid_block_colidx(id).second; k < _info.sid_block_colidx(id + 1).second; k++) {
+                                 for (ordinal_type blk_id = s.sid_col_begin + 1; blk_id < s.sid_col_end - 1; blk_id++) {
+                                   for (ordinal_type k = _info.sid_block_colidx(blk_id).second; k < _info.sid_block_colidx(blk_id + 1).second; k++) {
                                      if (AL(i, j) != zero) {
                                        ordinal_type gid_i = _info.gid_colidx(k+offn);
                                        ordinal_type nnz = Kokkos::atomic_fetch_add(&(_rowptr[gid_i]), 1);

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm.hpp
@@ -30,10 +30,10 @@ struct TrsmAlgorithm {
 };
 
 struct TrsmAlgorithm_Team {
-#if defined(KOKKOS_ENABLE_OPENMP)
-  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
-#else
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
+#else
+  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
 #endif
 };
 

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv.hpp
@@ -30,10 +30,10 @@ struct TrsvAlgorithm {
 };
 
 struct TrsvAlgorithm_Team {
-#if defined(KOKKOS_ENABLE_OPENMP)
-  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
-#else
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   using type = ActiveAlgorithm<runsOnCudaOrHIP()>::type;
+#else
+  using type = ActiveHostAlgorithm<runsWithOMP()>::type;
 #endif
 };
 


### PR DESCRIPTION

@trilinos/shylu 

## Motivation

This PR adds some new features to Tacho

- Tolerance to replace tiny pivots for team LU
- Internally compress graph based on "DoFs per node" for symbolic
- Use AMD if Metis is not enabled

## Testing

## Additional Information
