### PR TITLE
Framework: Enable CCache on RHEL8

### DIFF
--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -52,6 +52,8 @@ function bootstrap_modules() {
         module unload sems-python
         module load sems-git/2.37.0
         module load sems-python/3.9.0
+        execute_command_checked "module load sems-ccache"
+        configure_ccache
 
         module list
     else


### PR DESCRIPTION
Complete oversight that this was not already on.

@trilinos/framework 

## Motivation
Want ccache everywhere that we can (especially for PR).

## Testing
`module load sems-ccache` works on the RHEL8 machine I was testing.