### PR TITLE
Intrepid2: support shards::Node in getCellTopologyData().

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellData.cpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellData.cpp
@@ -21,6 +21,9 @@ const CellTopologyData*
 Intrepid2::getCellTopologyData(const unsigned& cellTopologyKey){
     const CellTopologyData* cellTopologyData;
     switch (cellTopologyKey) {
+      case shards::Node::key:
+      cellTopologyData = shards::getCellTopologyData<shards::Node>();
+      break;
       case shards::Line<2>::key:
       cellTopologyData = shards::getCellTopologyData<shards::Line<2>>();
       break;


### PR DESCRIPTION
@trilinos/intrepid2

## Motivation
In PR #13437, the `Basis` class switched from employing a `shards::CellTopology` (as member `basisCellTopology_`) to storing the `unsigned shards::CellTopology::key` corresponding to the `CellTopology` (as member `basisCellTopologyKey_`).   The method `getCellTopologyData()` returns a `CellTopologyData*` for a given `shards::CellTopology::key`.  However, it does not do so for `Node` cell topologies.  This breaks a subclass Camellia implements for defining basis functions on a vertex.

This PR adds support for `Node` cell topologies in `Intrepid2::getCellTopologyData()`.