### PR TITLE
Framework: Match CPU parallelism with AT1 args

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -107,7 +107,9 @@ jobs:
             --ctest-driver /home/runner/_work/Trilinos/Trilinos/cmake/SimpleTesting/cmake/ctest-driver.cmake \
             --ctest-drop-site sems-cdash-son.sandia.gov/cdash \
             --filename-subprojects ./package_subproject_list.cmake \
-            --filename-packageenables ./packageEnables.cmake
+            --filename-packageenables ./packageEnables.cmake \
+            --max-cores-allowed=29 \
+            --num-concurrent-tests=16
       - name: Summary
         if: ${{ !cancelled() }}
         shell: bash -l {0}
@@ -198,7 +200,9 @@ jobs:
             --ctest-driver /home/runner/_work/Trilinos/Trilinos/cmake/SimpleTesting/cmake/ctest-driver.cmake \
             --ctest-drop-site sems-cdash-son.sandia.gov/cdash \
             --filename-subprojects ./package_subproject_list.cmake \
-            --filename-packageenables ./packageEnables.cmake
+            --filename-packageenables ./packageEnables.cmake \
+            --max-cores-allowed=29 \
+            --num-concurrent-tests=16
       - name: Summary
         if: ${{ !cancelled() }}
         shell: bash -l {0}


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Will allow us to better compare AT1 vs. AT2 performance and evaluate if we're ready to move builds onto the new system.
