### PR TITLE
MueLu: Fix boundary detection for non-kokkos distance laplacian dropping

### DIFF
--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp
@@ -1251,6 +1251,7 @@ void CoalesceDropFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level
               isBoundary = pointBoundaryNodes[row];
             } else {
               // The amalgamated row is marked as Dirichlet iff all point rows are Dirichlet
+              isBoundary = true;
               for (LO j = 0; j < blkSize; j++) {
                 if (!pointBoundaryNodes[row * blkSize + j]) {
                   isBoundary = false;
@@ -1514,7 +1515,7 @@ void CoalesceDropFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level
       }
     }
 
-    if ((GetVerbLevel() & Statistics1) && !(A->GetFixedBlockSize() > 1 && threshold != STS::zero())) {
+    if (GetVerbLevel() & Statistics1) {
       RCP<const Teuchos::Comm<int>> comm = A->getRowMap()->getComm();
       GO numGlobalTotal, numGlobalDropped;
       MueLu_sumAll(comm, numTotal, numGlobalTotal);


### PR DESCRIPTION
@trilinos/muelu

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Dirichlet boundary detection is not working properly for numDofsPerNode > 1 in the non-kokkos distance laplacian dropping.

This fixes the issue and removes additional conditions from the printing statement.