### PR TITLE
Framework: Update at2 build names

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -103,7 +103,7 @@ jobs:
             --workspace-dir /home/runner/_work/Trilinos \
             --source-dir ${GITHUB_WORKSPACE} \
             --build-dir /home/Trilinos/build \
-            --dashboard-build-name `cat /etc/hostname` \
+            --dashboard-build-name=PR-${{ github.event.pull_request.number }}_${AT2_IMAGE}_debug_shared \
             --ctest-driver /home/runner/_work/Trilinos/Trilinos/cmake/SimpleTesting/cmake/ctest-driver.cmake \
             --ctest-drop-site sems-cdash-son.sandia.gov/cdash \
             --filename-subprojects ./package_subproject_list.cmake \
@@ -196,7 +196,7 @@ jobs:
             --workspace-dir /home/runner/_work/Trilinos \
             --source-dir ${GITHUB_WORKSPACE} \
             --build-dir /home/Trilinos/build \
-            --dashboard-build-name `cat /etc/hostname` \
+            --dashboard-build-name=PR-${{ github.event.pull_request.number }}_${AT2_IMAGE}_release-debug_shared \
             --ctest-driver /home/runner/_work/Trilinos/Trilinos/cmake/SimpleTesting/cmake/ctest-driver.cmake \
             --ctest-drop-site sems-cdash-son.sandia.gov/cdash \
             --filename-subprojects ./package_subproject_list.cmake \
@@ -288,7 +288,7 @@ jobs:
             --workspace-dir /home/runner/_work/Trilinos \
             --source-dir ${GITHUB_WORKSPACE} \
             --build-dir /home/Trilinos/build \
-            --dashboard-build-name `cat /etc/hostname` \
+            --dashboard-build-name=PR-${{ github.event.pull_request.number }}_${AT2_IMAGE}_release_static_uvm \
             --ctest-driver /home/runner/_work/Trilinos/Trilinos/cmake/SimpleTesting/cmake/ctest-driver.cmake \
             --ctest-drop-site sems-cdash-son.sandia.gov/cdash \
             --filename-subprojects ./package_subproject_list.cmake \
@@ -380,7 +380,7 @@ jobs:
             --workspace-dir /home/runner/_work/Trilinos \
             --source-dir ${GITHUB_WORKSPACE} \
             --build-dir /home/Trilinos/build \
-            --dashboard-build-name `cat /etc/hostname` \
+            --dashboard-build-name=PR-${{ github.event.pull_request.number }}_${AT2_IMAGE}_framework-tests \
             --ctest-driver /home/runner/_work/Trilinos/Trilinos/cmake/SimpleTesting/cmake/ctest-driver.cmake \
             --ctest-drop-site sems-cdash-son.sandia.gov/cdash \
             --filename-subprojects ./package_subproject_list.cmake \

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -257,12 +257,16 @@ test_cmd_options=(
     --build-dir=${TRILINOS_BUILD_DIR:?}
     --ctest-driver=${WORKSPACE:?}/Trilinos/cmake/SimpleTesting/cmake/ctest-driver.cmake
     --ctest-drop-site=${TRILINOS_CTEST_DROP_SITE:?}
-    --dashboard-build-name=${DASHBOARD_BUILD_NAME}
 )
+
+if [[ ${DASHBOARD_BUILD_NAME:-} ]]
+then
+    test_cmd_options+=( "--dashboard-build-name=${DASHBOARD_BUILD_NAME} ")
+fi
 
 if [[ ${extra_configure_args} ]]
 then
-    test_cmd_options+=( "--extra-configure-args=\"${extra_configure_args}\"")
+    test_cmd_options+=( "--extra-configure-args=\"${extra_configure_args}\" ")
 fi
 
 if [[ ${GENCONFIG_BUILD_NAME} == *"gnu"* ]]

--- a/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
@@ -70,14 +70,12 @@ def parse_args():
     required.add_argument('--source-repo-url',
                           dest="source_repo_url",
                           action='store',
-                          default="UNKNOWN",
                           help='Repo with the new changes',
                           required=False)
 
     required.add_argument('--target-repo-url',
                           dest="target_repo_url",
                           action='store',
-                          default="UNKNOWN",
                           help='Repo to merge into',
                           required=False)
 
@@ -90,7 +88,6 @@ def parse_args():
     required.add_argument('--pullrequest-build-name',
                           dest="pullrequest_build_name",
                           action='store',
-                          default="UNKNOWN",
                           help='The Jenkins job base name',
                           required=False)
 
@@ -109,28 +106,24 @@ def parse_args():
     required.add_argument('--jenkins-job-number',
                           dest="jenkins_job_number",
                           action='store',
-                          default="UNKNOWN",
                           help='The Jenkins build number',
                           required=False)
 
     optional.add_argument('--dashboard-build-name',
                           dest="dashboard_build_name",
                           action='store',
-                          default="UNKNOWN",
                           help='The build name posted by ctest to a dashboard',
                           required=False)
 
     optional.add_argument('--source-dir',
                           dest="source_dir",
                           action='store',
-                          default="UNKNOWN",
                           help="Directory containing the source code to compile/test.",
                           required=False)
 
     optional.add_argument('--build-dir',
                           dest="build_dir",
                           action='store',
-                          default="UNKNOWN",
                           help="Path to the build directory.",
                           required=False)
 
@@ -144,7 +137,6 @@ def parse_args():
     optional.add_argument('--ctest-driver',
                           dest="ctest_driver",
                           action='store',
-                          default="UNKNOWN",
                           help="Location of the CTest driver script to load via `-S`.",
                           required=False)
 

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -496,12 +496,12 @@ class TrilinosPRConfigurationBase(object):
         """
         if "Pull Request" in self.arg_pullrequest_cdash_track:
             output = f"PR-{self.arg_pullrequest_number}-test-{self.arg_pr_genconfig_job_name}"
-            if not self.arg_jenkins_job_number or "UNKNOWN" not in str(self.arg_jenkins_job_number):
+            if self.arg_jenkins_job_number:
                 output = f"{output}-{self.arg_jenkins_job_number}"
-        elif self.arg_dashboard_build_name != "__UNKNOWN__":
+        elif self.arg_dashboard_build_name:
             output = self.arg_dashboard_build_name
         else:
-            output = self.arg_pr_genconfig_job_name            
+            output = self.arg_pr_genconfig_job_name
         return output
 
 

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -494,12 +494,12 @@ class TrilinosPRConfigurationBase(object):
 
         PR-<PR Number>-test-<Jenkins Job Name>-<Job Number>
         """
-        if "Pull Request" in self.arg_pullrequest_cdash_track:
+        if self.arg_dashboard_build_name:
+            output = self.arg_dashboard_build_name
+        elif "Pull Request" in self.arg_pullrequest_cdash_track:
             output = f"PR-{self.arg_pullrequest_number}-test-{self.arg_pr_genconfig_job_name}"
             if self.arg_jenkins_job_number:
                 output = f"{output}-{self.arg_jenkins_job_number}"
-        elif self.arg_dashboard_build_name:
-            output = self.arg_dashboard_build_name
         else:
             output = self.arg_pr_genconfig_job_name
         return output

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -348,7 +348,8 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         expected_build_name = "PR-{}-test-{}-{}".format(args.pullrequest_number, args.genconfig_build_name, args.jenkins_job_number)
         self.assertEqual(build_name, expected_build_name)
 
-    def test_TrilinosPRConfigurationBaseBuildNameContainsPullRequest(self):
+
+    def test_TrilinosPRConfigurationBaseBuildGroupContainsPullRequest(self):
         """Test that a group containing 'Pull Request' causes the build name to reflect a PR build."""
         args = self.dummy_args_gcc_720()
         args.pullrequest_cdash_track = "Pull Request (Non-blocking)"
@@ -358,11 +359,11 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         expected_build_name = "PR-{}-test-{}-{}".format(args.pullrequest_number, args.genconfig_build_name, args.jenkins_job_number)
         self.assertEqual(build_name, expected_build_name)
 
+
     def test_TrilinosPRConfigurationBaseBuildNameNonPRTrack(self):
+        """Test that the default (non-PR) dashboard name is the GenConfig build ID."""
         args = self.dummy_args_non_pr_track()
-
         pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
-
         build_name = pr_config.pullrequest_build_name
         expected_build_name = args.dashboard_build_name
         self.assertEqual(build_name, expected_build_name)

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -212,7 +212,7 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
             target_branch_name="develop",
             pullrequest_build_name="Trilinos-pullrequest-gcc",
             genconfig_build_name="rhel8_sems-gnu-openmpi_release_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-package-enables",
-            dashboard_build_name="gnu-openmpi_release_static",
+            dashboard_build_name=None,
             jenkins_job_number=99,
             pullrequest_number='0000',
             pullrequest_cdash_track="Pull Request",
@@ -331,21 +331,11 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         self.assertEqual(cdash_track, "Pull Request")
 
 
-    def test_TrilinosPRConfigurationBuildNamePython2(self):
-        args = self.dummy_args_python3()
-        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
-        build_name = pr_config.pullrequest_build_name
-        print("--- build_name = {}".format(build_name))
-        expected_build_name = "PR-{}-test-{}-{}".format(args.pullrequest_number, args.genconfig_build_name, args.jenkins_job_number)
-        self.assertEqual(build_name, expected_build_name)
-
-
     def test_TrilinosPRConfigurationBaseBuildNameGCC720(self):
         args = self.dummy_args_gcc_720()
         pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
         build_name = pr_config.pullrequest_build_name
-        print("--- build_name = {}".format(build_name))
-        expected_build_name = "PR-{}-test-{}-{}".format(args.pullrequest_number, args.genconfig_build_name, args.jenkins_job_number)
+        expected_build_name = f"PR-{args.pullrequest_number}-test-{args.genconfig_build_name}-{args.jenkins_job_number}"
         self.assertEqual(build_name, expected_build_name)
 
 
@@ -355,8 +345,7 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         args.pullrequest_cdash_track = "Pull Request (Non-blocking)"
         pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
         build_name = pr_config.pullrequest_build_name
-        print("--- build_name = {}".format(build_name))
-        expected_build_name = "PR-{}-test-{}-{}".format(args.pullrequest_number, args.genconfig_build_name, args.jenkins_job_number)
+        expected_build_name = f"PR-{args.pullrequest_number}-test-{args.genconfig_build_name}-{args.jenkins_job_number}"
         self.assertEqual(build_name, expected_build_name)
 
 
@@ -369,19 +358,14 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         self.assertEqual(build_name, expected_build_name)
 
 
-    def test_TrilinosPRConfigurationBaseBuildNameDefaultDashboardName(self):
-        """
-        Test the build name output when dashboard_build_name contains
-        the default Jenkins parameter value, '__UNKNOWN__'.
-        """
-        args = self.dummy_args_non_pr_track()
-        args.dashboard_build_name = "__UNKNOWN__"
-
+    def test_TrilinosPRConfigurationBaseBuildNamePassed(self):
+        """Test that a passed build name is used."""
+        args = self.dummy_args()
+        args.dashboard_build_name = "some-dashboard-build-name"
         pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
-
-        result_build_name = pr_config.pullrequest_build_name
-        expected_build_name = args.genconfig_build_name
-        self.assertEqual(expected_build_name, result_build_name)
+        build_name = pr_config.pullrequest_build_name
+        expected_build_name = args.dashboard_build_name
+        self.assertEqual(build_name, expected_build_name)
 
 
     def test_TrilinosPRConfigurationBaseDashboardModelPRTrack(self):

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -365,7 +365,7 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         args = self.dummy_args_non_pr_track()
         pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
         build_name = pr_config.pullrequest_build_name
-        expected_build_name = args.dashboard_build_name
+        expected_build_name = args.genconfig_build_name
         self.assertEqual(build_name, expected_build_name)
 
 

--- a/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
@@ -67,12 +67,12 @@ class Test_parse_args(unittest.TestCase):
                                          target_branch_name='real_trash',
                                          pullrequest_build_name='Some_odd_compiler',
                                          genconfig_build_name='Some_odd_compiler_and_options',
-                                         dashboard_build_name='UNKNOWN',
+                                         dashboard_build_name=None,
                                          pullrequest_number='4242',
                                          jenkins_job_number='2424',
-                                         source_dir='UNKNOWN',
-                                         build_dir='UNKNOWN',
-                                         ctest_driver='UNKNOWN',
+                                         source_dir=None,
+                                         build_dir=None,
+                                         ctest_driver=None,
                                          ctest_drop_site='testing.sandia.gov',
                                          pullrequest_cdash_track='Pull Request',
                                          pullrequest_env_config_file='/dev/null/Trilinos_clone/pr_config/pullrequest.ini',
@@ -97,9 +97,9 @@ class Test_parse_args(unittest.TestCase):
                 | - [R] genconfig-build-name        : Some_odd_compiler_and_options
                 | - [R] pullrequest-number          : 4242
                 | - [R] jenkins-job-number          : 2424
-                | - [R] source-dir                  : UNKNOWN
-                | - [R] build-dir                   : UNKNOWN
-                | - [R] ctest-driver                : UNKNOWN
+                | - [R] source-dir                  : None
+                | - [R] build-dir                   : None
+                | - [R] ctest-driver                : None
                 | - [R] ctest-drop-site             : testing.sandia.gov
                 |
                 | - [O] dry-run                     : False
@@ -157,7 +157,6 @@ class Test_parse_args(unittest.TestCase):
         '''
         No inputs
         '''
-        import difflib
         with self.m_argv, self.stdoutRedirect as m_stdout:
             returned_default = PullRequestLinuxDriverTest.parse_args()
 


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Want dashboard build names to be simultaneously clear/concise and descriptive, so that users can understand which build is which at a glance.  To that end, new format is:

`PR-<pull-request-number>_<image-basename>_<release-or-debug>_<static-or-shared>_<optional-special-characteristics>`
Image basename is fairly descriptive, e.g. `ubi8-gcc-10.3.0-openmpi-4.1.6` (usually it's a combination of the OS, compiler, and MPI).

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-684