### PR TITLE
Framework: Add support for using EXTRA_CONFIGURE_ARGS env variable

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1563,6 +1563,12 @@ opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : OFF
 use rhel8_sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL-NO-EPETRA
 
+[rhel8_sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_all-no-epetra]
+use rhel8_sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_all
+
+use CUDA11-RUN-SERIAL-TESTS
+opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : ON
+
 [rhel8_sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 # uses sems-v2 modules
 use RHEL8

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1557,7 +1557,7 @@ use SEMS_COMMON_CUDA_11
 
 use CUDA11-RUN-SERIAL-TESTS
 
-opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : OFF
 
 [rhel8_sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_all]
 use rhel8_sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1557,7 +1557,7 @@ use SEMS_COMMON_CUDA_11
 
 use CUDA11-RUN-SERIAL-TESTS
 
-opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL : OFF
 
 [rhel8_sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_all]
 use rhel8_sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables

--- a/packages/framework/pr_tools/LaunchDriver.py
+++ b/packages/framework/pr_tools/LaunchDriver.py
@@ -116,8 +116,11 @@ def main(argv):
   if args.kokkos_develop:
      cmd += " --kokkos-develop"
 
+  # extra-configure-args flag currently takes precedence over the env. var.
   if args.extra_configure_args:
      cmd += f" --extra-configure-args=\"{args.extra_configure_args}\""
+  elif os.getenv("EXTRA_CONFIGURE_ARGS"):
+     cmd += f" --extra-configure-args=\"{os.getenv('EXTRA_CONFIGURE_ARGS')}\""
 
   print("LaunchDriver> EXEC: " + cmd, flush=True)
 

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -790,7 +790,8 @@ class TrilinosPRConfigurationBase(object):
             "F77",
             "F90",
             "FC",
-            "MODULESHOME"
+            "MODULESHOME",
+            "EXTRA_CONFIGURE_ARGS"
             ]
         self.message("")
         tr_env.set_environment.pretty_print_envvars(envvar_filter=envvars_to_print)

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
@@ -17,7 +17,7 @@ class TrilinosPRConfigurationStandard(TrilinosPRConfigurationBase):
     Implements Standard mode Trilinos Pull Request Driver
     """
     def __init__(self, args):
-        super(TrilinosPRConfigurationStandard, self).__init__(args)
+        super().__init__(args)
 
 
     def execute_test(self):


### PR DESCRIPTION
EXTRA_CONFIGURE_ARGS can now be used to pass extra flags to our build scripts.

Also had to remove FORCE flag from `Trilinos_ENABLE_TESTS` (in config-specs.ini) so that we are able to override it.

See https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-674

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 
