### PR TITLE
NOX,Panzer: minor changes to logic for a new Charon solver

### DIFF
--- a/packages/nox/src-thyra/NOX_Thyra_Group.C
+++ b/packages/nox/src-thyra/NOX_Thyra_Group.C
@@ -635,9 +635,13 @@ NOX::Thyra::Group::applyJacobianTransposeMultiVector(
                  NOX::Abstract::MultiVector& result) const
 {
   if ( !(this->isJacobian()) ) {
-    TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
-               "NOX Error - Jacobian is not valid.  " <<
-               "Call computeJacobian before calling applyJacobian!");
+    // Should throw if algorithm hasn't updated the Jacobian (force
+    // devs to think about efficiency of reevaluating J within an
+    // algorithm) but a certain application needs this temporarily.
+    const_cast<NOX::Thyra::Group*>(this)->computeJacobian();
+    // TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
+    //            "NOX Error - Jacobian is not valid.  " <<
+    //            "Call computeJacobian before calling applyJacobian!");
   }
 
   NOX_ASSERT(nonnull(lop_));

--- a/packages/panzer/disc-fe/src/Panzer_ModelEvaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ModelEvaluator_impl.hpp
@@ -1763,8 +1763,11 @@ evalModelImpl_basic_dgdp_scalar(const Thyra::ModelEvaluatorBase::InArgs<Scalar> 
         RCP<panzer::ResponseMESupportBase<panzer::Traits::Tangent> > resp =
           rcp_dynamic_cast<panzer::ResponseMESupportBase<panzer::Traits::Tangent> >(
             responseLibrary_->getResponse<panzer::Traits::Tangent>(responseName));
-        resp->setVector(vec);
-        is_active = true;
+
+        if (nonnull(resp)) {
+          resp->setVector(vec);
+          is_active = true;
+        }
       }
     }
 


### PR DESCRIPTION
@trilinos/nox @trilinos/panzer 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Charon is using the nox and loca groups as building blocks for a new solver algorithm. Added a safety check for a null vector in panzer that was triggered by their use case. Also temporarily disabled a throw in nox group logic that was forcing the Jacobian update to be handled explicitly by the user. It will now do an implicit update if needed.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Changes are to code that is covered under current unit tests.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
