### PR TITLE
Some small fixes necessary for the Xyce Epetra->Tpetra transition

### DIFF
--- a/packages/ifpack/src/Ifpack_CrsRiluk.cpp
+++ b/packages/ifpack/src/Ifpack_CrsRiluk.cpp
@@ -379,7 +379,7 @@ int Ifpack_CrsRiluk::Factor() {
   int NumIn, NumL, NumU;
 
   // Get Maximun Row length
-  int MaxNumEntries = L_->MaxNumEntries() + U_->MaxNumEntries() + 1;
+  int MaxNumEntries = L_->MaxNumEntries() + U_->MaxNumEntries() + 2;
 
   std::vector<int> InI(MaxNumEntries); // Allocate temp space
   std::vector<double> InV(MaxNumEntries);

--- a/packages/trilinoscouplings/src/epetraext/EpetraExt_Isorropia_CrsGraph.cpp
+++ b/packages/trilinoscouplings/src/epetraext/EpetraExt_Isorropia_CrsGraph.cpp
@@ -27,6 +27,14 @@ operator()( OriginalTypeRef orig )
 {
   origObj_ = &orig;
 
+#ifndef EPETRA_NO_64BIT_GLOBAL_INDICES
+  const Epetra_BlockMap & OldMap = orig.RowMap();
+  if(OldMap.GlobalIndicesLongLong()) {
+    // There is nothing we can do since Isorropia does not support Epetra 64-bit integers, just create a copy of the original graph.
+    NewGraph_ = Teuchos::rcp( new Epetra_CrsGraph( orig ) );
+  } 
+  else
+#endif
   if (orig.NumGlobalRows() == 0)
   {
     // If there is nothing to do, just create a copy of the original empty graph.


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack @trilinos/epetraext 

## Motivation
The transition from Epetra->Tpetra for Xyce includes several intermediate steps, including moving to newer compilers and introducing a global ordinal type that is 64-bit.  This effort has uncovered a few issues in some Trilinos classes that need to be addressed so that we can continue this transition.  This includes:

- Change AMD transformation in EpetraExt to be correct for 64-bit global ordinals
- Fix memory allocation in Ifpack CrsRiluk preconditioner to not seg-fault if a subdomain is allocated zero rows
- Fix Isorropia transformation in EpetraExt to be a no-op for 64-bit global ordinals


## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

These changes have been used to correct regression test failures for Xyce on
FreeBSD / MPI+Clang 18
OSX / MPI+Clang15

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
