### PR TITLE
Add "reorder" as promoted warning

### DIFF
--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -43,7 +43,7 @@ IF (KokkosEnable)
 ENDIF()
 
 set(upcoming_warnings shadow ${Trilinos_ADDITIONAL_WARNINGS})
-set(promoted_warnings parentheses sign-compare unused-variable)
+set(promoted_warnings parentheses sign-compare unused-variable reorder)
 
 if("${Trilinos_WARNINGS_MODE}" STREQUAL "WARN")
     enable_warnings("${upcoming_warnings}")

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_def.hpp
@@ -149,8 +149,8 @@ class ExpansionFunctor {
     , colors(colors_)
     , lclLWGraph(lclLWGraph_)
     , aggPenalties(aggPenalties_)
-    , connectWeight(connectWeight_)
     , aggPenaltyUpdates(aggPenaltyUpdates_)
+    , connectWeight(connectWeight_)
     , penaltyConnectWeight(penaltyConnectWeight_)
     , color(color_)
     , myRank(rank_) {}


### PR DESCRIPTION
@trilinos/framework 

## Motivation
- MueLu: Silence "reorder" warning.
- Add "reorder" as promoted warning so that we error out in the future.