### PR TITLE
Tpetra: Initialize KokkosKernels TPLs during init

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Core.cpp
+++ b/packages/tpetra/core/src/Tpetra_Core.cpp
@@ -19,6 +19,7 @@
 #include "Tpetra_Details_checkLaunchBlocking.hpp"
 #include "Tpetra_Details_KokkosTeuchosTimerInjection.hpp"
 #include "Tpetra_Details_Behavior.hpp"
+#include "KokkosKernels_EagerInitialize.hpp"
 
 namespace Tpetra {
 
@@ -129,6 +130,9 @@ namespace Tpetra {
         (! kokkosIsInitialized, std::logic_error, "At the end of "
          "initKokkosIfNeeded, Kokkos is not initialized.  "
          "Please report this bug to the Tpetra developers.");
+      // Now that the Kokkos backend(s) are initialized,
+      // initialize all KokkosKernels TPLs.
+      KokkosKernels::eager_initialize();
     }
 
 #ifdef HAVE_TPETRACORE_MPI


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

Now that KokkosKernels 4.5 is out, call ``KokkosKernels::eager_initialize()`` inside all versions of ``Tpetra::initialize()``. 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
From https://github.com/kokkos/kokkos-kernels/pull/2317:
There have been 3 instances I know of where TPL handle initialization caused specific kernel calls to take way longer than expected. The current behavior makes it hard to understand the true performance cost of that kernel from a Trilinos StackedTimer or Kokkos tools profile.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
``Tpetra::initialize`` is well tested in tpetra/core/test/Core.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
