### PR TITLE
Zoltan2: Fix runtime_error message with METIS

### DIFF
--- a/packages/zoltan2/core/src/algorithms/order/Zoltan2_AlgMetis.hpp
+++ b/packages/zoltan2/core/src/algorithms/order/Zoltan2_AlgMetis.hpp
@@ -119,7 +119,7 @@ class AlgMetis : public Algorithm<Adapter>
         int info = METIS_NodeND(&metis_nVtx, metis_rowptr.data(), metis_colidx.data(),
                                 NULL, NULL, metis_perm, metis_iperm);
         if (METIS_OK != info) {
-          throw std::runtime_error(std::string("METIS_NodeND returned info = " + info));
+          throw std::runtime_error("METIS_NodeND returned info = " + std::to_string(info));
         }
 
         // Copy result back


### PR DESCRIPTION
@trilinos/zoltan2

## Motivation

Compilers emit warnings such as
```
/tmp/trilinos/packages/zoltan2/core/src/algorithms/order/Zoltan2_AlgMetis.hpp:158:80: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
          throw std::runtime_error(std::string("METIS_NodeND returned info = " + info));
                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/tmp/trilinos/packages/zoltan2/core/src/algorithms/order/Zoltan2_AlgMetis.hpp:158:80: note: use array indexing to silence this warning
          throw std::runtime_error(std::string("METIS_NodeND returned info = " + info));
                                                                               ^
                                               &                               [     ]
```
and it seems the intention was to append `info` (as string) to the string literal instead of advancing the string literal pointer by some integer and converting to a `std::string`. Converting `info` into a `std::string`, it's not necessary to convert the string literal into a `std::string` explicitly. Also, see https://godbolt.org/z/cWodsWxv7.

## Related Issues

## Stakeholder Feedback

## Testing

https://godbolt.org/z/cWodsWxv7