### PR TITLE
Add `uninitialized` to promoted warnings list

### DIFF
--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -43,7 +43,7 @@ IF (KokkosEnable)
 ENDIF()
 
 set(upcoming_warnings shadow ${Trilinos_ADDITIONAL_WARNINGS})
-set(promoted_warnings parentheses sign-compare unused-variable reorder)
+set(promoted_warnings parentheses sign-compare unused-variable reorder uninitialized)
 
 if("${Trilinos_WARNINGS_MODE}" STREQUAL "WARN")
     enable_warnings("${upcoming_warnings}")

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1249,8 +1249,10 @@ opt-set-cmake-var Sacado_ENABLE_HIERARCHICAL_DFAD BOOL FORCE : ON
 opt-set-cmake-var Tpetra_INST_SERIAL BOOL FORCE : ON
 opt-set-cmake-var Zoltan_ENABLE_Scotch BOOL FORCE : OFF
 
-[CUDA11-RUN-SERIAL-TESTS]
+[CUDA-RUN-SERIAL-TESTS]
 opt-set-cmake-var Kokkos_CoreUnitTest_Cuda1_SET_RUN_SERIAL BOOL FORCE : ON
+opt-set-cmake-var Kokkos_CoreUnitTest_CudaTimingBased_SET_RUN_SERIAL BOOL FORCE : ON
+opt-set-cmake-var Kokkos_CoreUnitTest_Default_SET_RUN_SERIAL BOOL FORCE : ON
 opt-set-cmake-var KokkosKernels_sparse_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
 opt-set-cmake-var KokkosKernels_batched_dla_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
 opt-set-cmake-var Intrepid2_unit-test_MonolithicExecutable_Intrepid2_Tests_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
@@ -1532,7 +1534,7 @@ opt-set-cmake-var Adelus_vector_random_npr4_rhs1_MPI_4_DISABLE BOOL : ON
 
 use PACKAGE-ENABLES|NO-EPETRA
 
-use CUDA11-RUN-SERIAL-TESTS
+use CUDA-RUN-SERIAL-TESTS
 
 [rhel8_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.1.4_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_all]
 # uses sems-v2 modules
@@ -1561,8 +1563,7 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 use PACKAGE-ENABLES|NO-EPETRA
 use COMMON_SPACK_TPLS
 use SEMS_COMMON_CUDA
-
-use CUDA11-RUN-SERIAL-TESTS
+use CUDA-RUN-SERIAL-TESTS
 
 opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : OFF
 
@@ -1678,7 +1679,7 @@ opt-set-cmake-var Adelus_vector_random_npr4_rhs1_MPI_4_DISABLE BOOL : ON
 
 use PACKAGE-ENABLES|NO-EPETRA
 
-use CUDA11-RUN-SERIAL-TESTS
+use CUDA-RUN-SERIAL-TESTS
 
 [rhel8_sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_all]
 # uses sems-v2 modules
@@ -2113,6 +2114,8 @@ use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-EPETRA
 use SEMS_COMMON_CUDA
+use CUDA-RUN-SERIAL-TESTS
+
 opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL : ON
 opt-set-cmake-var TPL_ENABLE_X11 BOOL : OFF
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS STRING FORCE : --bind-to;none --mca btl ^smcuda
@@ -2120,7 +2123,6 @@ opt-set-cmake-var Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC BOOL : OFF
 
 [rhel8_cuda-11-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use rhel8_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables
-use CUDA11-RUN-SERIAL-TESTS
 opt-set-cmake-var ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE BOOL : ON
 
 [rhel8_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables]
@@ -2139,7 +2141,7 @@ use USE-UVM|YES
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-EPETRA
 use SEMS_COMMON_CUDA
-use CUDA11-RUN-SERIAL-TESTS
+use CUDA-RUN-SERIAL-TESTS
 
 opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL FORCE : OFF
 opt-set-cmake-var Kokkos_ENABLE_TESTS BOOL FORCE : ON


### PR DESCRIPTION
@dc-snl 

## Motivation
In analyzing an internal customer (RAMSES) configuration for Trilinos, I noticed they were passing `-Wno-uninitialized`.  I wanted to see if we could add that warning to our PR configurations to help guard against warnings/errors that they had previously seen, and ideally obviate the need for them to pass that flag as part of their configuration.

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-680

## Testing
I tested this with a GCC 8.5.0 build and everything built cleanly.
