### PR TITLE
Tacho : require RocBLAS, RocSparse, and RocSolver for HIP backend

### DIFF
--- a/packages/shylu/shylu_node/tacho/CMakeLists.txt
+++ b/packages/shylu/shylu_node/tacho/CMakeLists.txt
@@ -9,7 +9,7 @@ ENDIF()
 
 IF (Kokkos_ENABLE_HIP)
   IF (NOT (TPL_ENABLE_ROCBLAS AND TPL_ENABLE_ROCSPARSE AND TPL_ENABLE_ROCSOLVER))
-    MESSAGE(FATAL_ERROR "Tacho can not be build with HIP without enabling ROCBLAS, ROCSPARSE, and ROCSOLVER TPLs.")
+    MESSAGE(FATAL_ERROR "Tacho can not be build with HIP without enabling ROCBLAS, ROCSPARSE, and ROCSOLVER TPLs. Please disable Tacho, or enable these three TPLs")
   ENDIF()
 ENDIF()
 

--- a/packages/shylu/shylu_node/tacho/CMakeLists.txt
+++ b/packages/shylu/shylu_node/tacho/CMakeLists.txt
@@ -7,6 +7,12 @@ IF (Kokkos_ENABLE_CUDA)
   ENDIF()
 ENDIF()
 
+IF (Kokkos_ENABLE_HIP)
+  IF (NOT (TPL_ENABLE_ROCBLAS AND TPL_ENABLE_ROCSPARSE AND TPL_ENABLE_ROCSOLVER))
+    MESSAGE(FATAL_ERROR "Tacho can not be build with HIP without enabling ROCBLAS, ROCSPARSE, and ROCSOLVER TPLs.")
+  ENDIF()
+ENDIF()
+
 IF (Kokkos_ENABLE_THREADS)
   IF (NOT Kokkos_ENABLE_OPENMP)
     MESSAGE(FATAL_ERROR "Tacho can not be build with Pthreads as the Kokkos Host Backend.")


### PR DESCRIPTION

@trilinos/shylu 

## Motivation

To solve some issues with required libraries, we now require RocBLAS, RocSparse, and RocSolver TPLs for building Tacho with HIP backend.

## Related Issues

- https://github.com/trilinos/Trilinos/issues/13636

## Testing

## Additional Information
