### PR TITLE
build_env_info: resolve issues with ninja

### DIFF
--- a/packages/kokkos/cmake/build_env_info.cmake
+++ b/packages/kokkos/cmake/build_env_info.cmake
@@ -4,7 +4,7 @@ find_package(Git QUIET)
 
 set(CURRENT_LIST_DIR ${CMAKE_CURRENT_LIST_DIR})
 set(pre_configure_dir ${CMAKE_CURRENT_LIST_DIR})
-set(post_configure_dir ${CMAKE_BINARY_DIR}/generated)
+set(post_configure_dir ${CMAKE_CURRENT_BINARY_DIR}/generated)
 
 set(pre_configure_file ${pre_configure_dir}/Kokkos_Version_Info.cpp.in)
 set(post_configure_file ${post_configure_dir}/Kokkos_Version_Info.cpp)
@@ -105,7 +105,7 @@ function(check_git_setup)
                            ${CURRENT_LIST_DIR}/build_env_info.cmake BYPRODUCTS ${post_configure_file}
   )
 
-  add_library(impl_git_version ${CMAKE_BINARY_DIR}/generated/Kokkos_Version_Info.cpp)
+  add_library(impl_git_version ${CMAKE_CURRENT_BINARY_DIR}/generated/Kokkos_Version_Info.cpp)
   target_include_directories(impl_git_version PUBLIC ${CMAKE_BINARY_DIR}/generated)
   target_compile_features(impl_git_version PRIVATE cxx_raw_string_literals)
   add_dependencies(impl_git_version AlwaysCheckGit)


### PR DESCRIPTION
This PR resolves issues with ninja as generator reported in https://github.com/trilinos/Trilinos/issues/13643

In Trilinos builds with ninja as generator, calling `make clean` followed by recompiling resulted in compilation errors due to a missing generated file Kokkos_Version_Info.cpp that was deleted during clean

The changes in this PR resolve the issue

Added notes:

* The issue did not occur with Unix Makefiles as generator
* The issue did not ocur with standalond kokkos

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos 

