### PR TITLE
Framework: Update get_dependencies.sh script to use open-sourced repo

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -74,7 +74,7 @@ jobs:
       - name: get dependencies
         working-directory: ./packages/framework
         run: |
-          bash -l -c "./get_dependencies.sh --container"
+          bash -l -c "./get_dependencies.sh"
       - name: PullRequestLinuxDriverTest.py
         shell: bash -l {0}
         working-directory: /home/Trilinos/build
@@ -167,7 +167,7 @@ jobs:
       - name: get dependencies
         working-directory: ./packages/framework
         run: |
-          bash -l -c "./get_dependencies.sh --container"
+          bash -l -c "./get_dependencies.sh"
       - name: PullRequestLinuxDriverTest.py
         shell: bash -l {0}
         working-directory: /home/Trilinos/build
@@ -260,7 +260,7 @@ jobs:
       - name: get dependencies
         working-directory: ./packages/framework
         run: |
-          bash -l -c "./get_dependencies.sh --container"
+          bash -l -c "./get_dependencies.sh"
       - name: PullRequestLinuxDriverTest.py
         shell: bash -l {0}
         working-directory: /home/Trilinos/build
@@ -353,7 +353,7 @@ jobs:
       - name: get dependencies
         working-directory: ./packages/framework
         run: |
-          bash -l -c "./get_dependencies.sh --container"
+          bash -l -c "./get_dependencies.sh"
       - name: PullRequestLinuxDriverTest.py
         shell: bash -l {0}
         working-directory: /home/Trilinos/build

--- a/packages/framework/get_dependencies.sh
+++ b/packages/framework/get_dependencies.sh
@@ -3,7 +3,7 @@ ini_file_option=$1
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 # Data that needs to be updated when GenConfig changes!
-genconfig_sha1=HEAD
+genconfig_sha1=88c44e347c0377a170ec9ca45a47732a9630b4ec
 
 
 # The following code contains no changing data
@@ -60,7 +60,7 @@ function tril_genconfig_clone_or_update_repo() {
   if [[ "${has_submodules}" == "has-submodules" ]] ; then
     echo
     echo "STATUS: ${sub_dir}: Update submodules"
-    cmd="git submodule update --force --init"
+    cmd="git submodule update --force --init --recursive"
     retry_command "${cmd}"
     cd - > /dev/null
   elif [[ "${has_submodules}" != "" ]] ; then

--- a/packages/framework/get_dependencies.sh
+++ b/packages/framework/get_dependencies.sh
@@ -3,7 +3,8 @@ ini_file_option=$1
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 # Data that needs to be updated when GenConfig changes!
-genconfig_sha1=924a08af66f0a0573b5dd1128179731489339aec
+genconfig_sha1=HEAD
+
 
 # The following code contains no changing data
 
@@ -59,7 +60,7 @@ function tril_genconfig_clone_or_update_repo() {
   if [[ "${has_submodules}" == "has-submodules" ]] ; then
     echo
     echo "STATUS: ${sub_dir}: Update submodules"
-    cmd="git submodule update --force --init --recursive"
+    cmd="git submodule update --force --init"
     retry_command "${cmd}"
     cd - > /dev/null
   elif [[ "${has_submodules}" != "" ]] ; then
@@ -70,15 +71,10 @@ function tril_genconfig_clone_or_update_repo() {
   popd &> /dev/null
 }
 
-# Clone or update the repos
-if [[ "$ini_file_option" == "--container" ]] ; then
-  echo "In a container it is assumed that GenConfig is already in the container at /GenConfig"
-else
-  #Clone GenConfig from gitlab-ex
-  tril_genconfig_clone_or_update_repo \
-    git@gitlab-ex.sandia.gov:trilinos-devops-consolidation/code/GenConfig.git \
-    GenConfig  has-submodules ${genconfig_sha1}
-fi
+# Clone GenConfig from GitHub
+tril_genconfig_clone_or_update_repo \
+  https://github.com/sandialabs/GenConfig.git \
+  GenConfig  has-submodules ${genconfig_sha1}
 
 if [[ "$ini_file_option" == "--srn" ]] ; then
   #Clone srn-ini-files from cee-gitlab
@@ -92,10 +88,6 @@ elif [[ "$ini_file_option" == "--son" ]] ; then
     git@gitlab-ex.sandia.gov:trilinos-project/son-ini-files.git \
     son-ini-files
   
-elif [[ "$ini_file_option" == "--container" ]] ; then
-  #Copy Genconfig into place from /GenConfig
-  cp -R /GenConfig ${script_dir}
-    
 elif [[ "$ini_file_option" != "" ]] ; then
   echo "ERROR: Option '${ini_file_option}' not allowed! Must select '--son', '--srn' or ''."
   exit 1


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

GenConfig has released its repositories on GitHub. Our Framework scripts should utilizes these repositories instead of the versions hosted on internal repositories. This effort also contributes to the eventual release of our Framework containers.

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Manually tested this script on SRN and in our containerized environment and was able to load existing configurations.

Further testing should be observed in the CI.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
