### PR TITLE
Panzer: fix for changes in kokkos 4.5 for MI300A

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_BasisValues2_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BasisValues2_impl.hpp
@@ -1120,7 +1120,7 @@ getBasisValues(const bool weighted,
       // while create_mirror_view creates views in UVMSpace or
       // HIPSpace. These are not "assignable" in kokkos. We do an
       // inefficient copy if UVM or UNIFIED_MEMORY is enabled.
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
 #ifdef KOKKOS_ENABLE_CUDA
       if constexpr (std::is_same<Kokkos::CudaUVMSpace,typename decltype(tmp_basis_scalar.get_view())::memory_space>::value) {
 #else
@@ -1174,7 +1174,7 @@ getBasisValues(const bool weighted,
         } else if(element_space == PureBasis::HGRAD || element_space == PureBasis::CONST) {
           fst::HGRADtransformVALUE(s_aux,s_ref);
         }
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
       }
 #endif
       PHX::Device().fence();
@@ -1292,7 +1292,7 @@ getVectorBasisValues(const bool weighted,
       // while create_mirror_view creates views in UVMSpace or
       // HIPSpace. These are not "assignable" in kokkos. We do an
       // inefficient copy if UVM or UNIFIED_MEMORY is enabled.
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
 #ifdef KOKKOS_ENABLE_CUDA
       if constexpr (std::is_same<Kokkos::CudaUVMSpace,typename decltype(tmp_basis_vector.get_view())::memory_space>::value) {
 #else
@@ -1352,7 +1352,7 @@ getVectorBasisValues(const bool weighted,
           auto s_jac_det = Kokkos::subview(cubature_jacobian_determinant_.get_view(), cell_range, Kokkos::ALL());
           fst::HDIVtransformVALUE(s_aux,s_jac, s_jac_det, s_ref);
         }
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
       }
 #endif
       PHX::Device().fence();
@@ -1456,7 +1456,7 @@ getGradBasisValues(const bool weighted,
       // while create_mirror_view creates views in UVMSpace or
       // HIPSpace. These are not "assignable" in kokkos. We do an
       // inefficient copy if UVM or UNIFIED_MEMORY is enabled.
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
 #ifdef KOKKOS_ENABLE_CUDA
       if constexpr (std::is_same<Kokkos::CudaUVMSpace,typename decltype(tmp_grad_basis.get_view())::memory_space>::value) {
 #else
@@ -1506,7 +1506,7 @@ getGradBasisValues(const bool weighted,
         // Apply transformation
         using fst=Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>;
         fst::HGRADtransformGRAD(s_aux, s_jac_inv, s_ref);
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
       }
 #endif
       PHX::Device().fence();
@@ -1611,7 +1611,7 @@ getCurl2DVectorBasis(const bool weighted,
       // while create_mirror_view creates views in UVMSpace or
       // HIPSpace. These are not "assignable" in kokkos. We do an
       // inefficient copy if UVM or UNIFIED_MEMORY is enabled.
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
 #ifdef KOKKOS_ENABLE_CUDA
       if constexpr (std::is_same<Kokkos::CudaUVMSpace,typename decltype(tmp_curl_basis_scalar.get_view())::memory_space>::value) {
 #else
@@ -1665,7 +1665,7 @@ getCurl2DVectorBasis(const bool weighted,
         // the divergence space in 2D!
         using fst=Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>;
         fst::HDIVtransformDIV(s_aux,s_jac_det,s_ref);
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
       }
 #endif
       PHX::Device().fence();
@@ -1767,7 +1767,7 @@ getCurlVectorBasis(const bool weighted,
       // while create_mirror_view creates views in UVMSpace or
       // HIPSpace. These are not "assignable" in kokkos. We do an
       // inefficient copy if UVM or UNIFIED_MEMORY is enabled.
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
 #ifdef KOKKOS_ENABLE_CUDA
       if constexpr (std::is_same<Kokkos::CudaUVMSpace,typename decltype(tmp_curl_basis_vector.get_view())::memory_space>::value) {
 #else
@@ -1817,7 +1817,7 @@ getCurlVectorBasis(const bool weighted,
 
         using fst=Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>;
         fst::HCURLtransformCURL(s_aux, s_jac, s_jac_det, s_ref);
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
       }
 #endif
       PHX::Device().fence();
@@ -1917,7 +1917,7 @@ getDivVectorBasis(const bool weighted,
       // while create_mirror_view creates views in UVMSpace or
       // HIPSpace. These are not "assignable" in kokkos. We do an
       // inefficient copy if UVM or UNIFIED_MEMORY is enabled.
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
 #ifdef KOKKOS_ENABLE_CUDA
       if constexpr (std::is_same<Kokkos::CudaUVMSpace,typename decltype(tmp_div_basis.get_view())::memory_space>::value) {
 #else
@@ -1965,7 +1965,7 @@ getDivVectorBasis(const bool weighted,
 
         using fst=Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>;
         fst::HDIVtransformDIV(s_aux,s_jac_det,s_ref);
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_IMPL_HIP_UNIFIED_MEMORY)
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_IMPL_HIP_UNIFIED_MEMORY)
       }
 #endif
       PHX::Device().fence();


### PR DESCRIPTION

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Panzer fails to compile on MI300A after upgrade to kokkos 4.5. They renamed an internal macro that panzer uses.


## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
N/A

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
