### PR TITLE
Intrepid2: Serialize unit test

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1251,7 +1251,6 @@ opt-set-cmake-var Kokkos_CoreUnitTest_CudaTimingBased_SET_RUN_SERIAL BOOL FORCE 
 opt-set-cmake-var Kokkos_CoreUnitTest_Default_SET_RUN_SERIAL BOOL FORCE : ON
 opt-set-cmake-var KokkosKernels_sparse_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
 opt-set-cmake-var KokkosKernels_batched_dla_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
-opt-set-cmake-var Intrepid2_unit-test_MonolithicExecutable_Intrepid2_Tests_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
 
 
 # Full configurations intended to be loaded.

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CMakeLists.txt
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CMakeLists.txt
@@ -13,6 +13,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   NUM_MPI_PROCS 1
   PASS_REGULAR_EXPRESSION "TEST PASSED"
   ADD_DIR_TO_NAME
+  RUN_SERIAL
   )
 
 # add single-group tests; allows for easier targeted builds and debugging (especially useful under CUDA)


### PR DESCRIPTION
@trilinos/intrepid2 

## Motivation
Frequent timeouts on GCC/OpenMPI Debug Shared configuration in PR testing, and before it was marked serial for CUDA had repeated failures there as well (though those were not timeouts).

It repeats often enough that I do wonder if this is exposing a code issue, but debugging that is outside of my area of expertise unfortunately.