### PR TITLE
Framework: Rename AT2 builds to indicate production-readiness

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -1,4 +1,4 @@
-name: AT2-EXPERIMENTAL
+name: AT2
 
 on:
   pull_request:
@@ -128,7 +128,7 @@ jobs:
           echo "https://github.com/trilinos/Trilinos/wiki/Containers" >> $GITHUB_STEP_SUMMARY
           echo "https://gitlab-ex.sandia.gov/trilinos-project/trilinos-containers/-/wikis/Containers-at-Sandia" >> $GITHUB_STEP_SUMMARY
 
-  gcc830-serial-EXPERIMENTAL:
+  gcc830:
     needs: pre-checks
     runs-on: [self-hosted, gcc-8.3.0_serial]
     if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}
@@ -314,7 +314,7 @@ jobs:
           echo "https://github.com/trilinos/Trilinos/wiki/Containers" >> $GITHUB_STEP_SUMMARY
           echo "https://gitlab-ex.sandia.gov/trilinos-project/trilinos-containers/-/wikis/Containers-at-Sandia" >> $GITHUB_STEP_SUMMARY
 
-  framework-tests-EXPERIMENTAL:
+  framework-tests:
     needs: pre-checks
     runs-on: [self-hosted, python-3.9]
     if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Change main workflow name from AT2-EXPERIMENTAL back to AT2. Mark those individual runs that are anticipated to be transitioned to required as no longer EXPERIMENTAL.