### PR TITLE
Piro: tempus/transient solver mods.

### DIFF
--- a/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter.hpp
+++ b/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter.hpp
@@ -40,31 +40,13 @@ public:
   //@{
   /// Destructor
 
-  virtual ~ObserverToTempusIntegrationObserverAdapter();
+  virtual ~ObserverToTempusIntegrationObserverAdapter() = default;
 
   /// Observe the beginning of the time integrator.
   virtual void observeStartIntegrator(const Tempus::Integrator<Scalar>& integrator) override;
 
-  /// Observe the beginning of the time step loop.
-  virtual void observeStartTimeStep(const Tempus::Integrator<Scalar>& integrator) override;
-
-  /// Observe after the next time step size is selected.
-  virtual void observeNextTimeStep(const Tempus::Integrator<Scalar>& integrator) override;
-
-  /// Observe before Stepper takes step.
-  virtual void observeBeforeTakeStep(const Tempus::Integrator<Scalar>& integrator) override;
-
-  /// Observe after Stepper takes step.
-  virtual void observeAfterTakeStep(const Tempus::Integrator<Scalar>& integrator) override;
-
-  /// Observe after checking time step.  Observer can still fail the time step here.
-  virtual void observeAfterCheckTimeStep(const Tempus::Integrator<Scalar>& integrator) override;
-
   /// Observe the end of the time step loop.
   virtual void observeEndTimeStep(const Tempus::Integrator<Scalar>& integrator) override;
-
-  /// Observe the end of the time integrator.
-  virtual void observeEndIntegrator(const Tempus::Integrator<Scalar>& integrator) override;
   //@}
 
 private:

--- a/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter_Def.hpp
+++ b/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter_Def.hpp
@@ -33,12 +33,6 @@ Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::ObserverToTempusIntegr
 }
 
 template <typename Scalar>
-Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::~ObserverToTempusIntegrationObserverAdapter()
-{
-  //Nothing to do
-}
-
-template <typename Scalar>
 void
 Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::
 observeStartIntegrator(const Tempus::Integrator<Scalar>& integrator)
@@ -63,49 +57,6 @@ observeStartIntegrator(const Tempus::Integrator<Scalar>& integrator)
 
   this->observeTimeStep();
 }
-
-template <typename Scalar>
-void
-Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::
-observeStartTimeStep(const Tempus::Integrator<Scalar>& )
-{
-  //Nothing to do
-}
-
-template <typename Scalar>
-void
-Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::
-observeNextTimeStep(const Tempus::Integrator<Scalar>& )
-{
-  //Nothing to do
-}
-
-template <typename Scalar>
-void
-Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::
-observeBeforeTakeStep(const Tempus::Integrator<Scalar>& )
-{
-  //Nothing to do
-}
-
-
-template <typename Scalar>
-void
-Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::
-observeAfterTakeStep(const Tempus::Integrator<Scalar>& )
-{
-  //Nothing to do
-}
-
-
-template<class Scalar>
-void
-Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::
-observeAfterCheckTimeStep(const Tempus::Integrator<Scalar>& integrator)
-{
-  //Nothing to do
-}
-
 
 template<class Scalar>
 void
@@ -137,35 +88,6 @@ observeEndTimeStep(const Tempus::Integrator<Scalar>& integrator)
         <<std::endl;
   }
   this->observeTimeStep();
-}
-
-
-template <typename Scalar>
-void
-Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::
-observeEndIntegrator(const Tempus::Integrator<Scalar>& integrator)
-{
-  //this->observeTimeStep();
-
-  std::string exitStatus;
-  //const Scalar runtime = integrator.getIntegratorTimer()->totalElapsedTime();
-  if (integrator.getSolutionHistory()->getCurrentState()->getSolutionStatus() ==
-      Tempus::Status::FAILED or integrator.getStatus() == Tempus::Status::FAILED) {
-    exitStatus = "Time integration FAILURE!";
-  } else {
-    exitStatus = "Time integration complete.";
-  }
-  std::time_t end = std::time(nullptr);
-  const Scalar runtime = integrator.getIntegratorTimer()->totalElapsedTime();
-  const Teuchos::RCP<Teuchos::FancyOStream> out = integrator.getOStream();
-  Teuchos::OSTab ostab(out,0,"ScreenOutput");
-  *out << "============================================================================\n"
-       << "  Total runtime = " << runtime << " sec = "
-       << runtime/60.0 << " min\n"
-       << std::asctime(std::localtime(&end))
-       << exitStatus << "\n"
-       << std::endl;
-
 }
 
 template <typename Scalar>

--- a/packages/piro/src/Piro_TempusIntegrator.hpp
+++ b/packages/piro/src/Piro_TempusIntegrator.hpp
@@ -82,6 +82,7 @@ public:
   //The following routine is only for adjoint sensitivities
   Teuchos::RCP<const Thyra::MultiVectorBase<Scalar>> getDgDp() const;
 
+  Teuchos::RCP<const Tempus::Integrator<Scalar> > getIntegrator () const;
 private:
 
   Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > basicIntegrator_;

--- a/packages/piro/src/Piro_TempusIntegrator_Def.hpp
+++ b/packages/piro/src/Piro_TempusIntegrator_Def.hpp
@@ -363,3 +363,22 @@ Piro::TempusIntegrator<Scalar>::getDgDp() const
 		 "which is not of type Tempus::IntegratorAdjointSensitivity!\n");
   }
 }
+
+
+template <typename Scalar>
+Teuchos::RCP<const Tempus::Integrator<Scalar> >
+Piro::TempusIntegrator<Scalar>:: getIntegrator () const
+{
+  Teuchos::RCP<const Tempus::Integrator<Scalar> > out;
+  if (basicIntegrator_ != Teuchos::null) {
+    out = basicIntegrator_;
+  } else if (fwdSensIntegrator_ != Teuchos::null) {
+    out = fwdSensIntegrator_;
+  } else if (adjSensIntegrator_ != Teuchos::null) {
+    out = adjSensIntegrator_;
+  } else {
+    TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
+                 "Error in Piro::TempusIntegrator: no integrator stored!\n");
+  }
+  return out;
+}

--- a/packages/piro/src/Piro_TempusSolver.hpp
+++ b/packages/piro/src/Piro_TempusSolver.hpp
@@ -161,7 +161,6 @@ private:
 
   Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > model_;
   Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > adjointModel_;
-  Teuchos::RCP<Thyra::ModelEvaluatorDefaultBase<double> > thyraModel_;
 
   Scalar t_initial_;
   Scalar t_final_;

--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -167,24 +167,10 @@ void Piro::TempusSolver<Scalar>::initialize(
     const std::string stepperType = stepperPL->get<std::string>("Stepper Type", "Backward Euler");
     //*out_ << "Stepper Type = " << stepperType << "\n";
 
-    //
-    // *out_ << "\nB) Create the Stratimikos linear solver factory ...\n";
-    //
-    // This is the linear solve strategy that will be used to solve for the
-    // linear system with the W.
-    //
-    Stratimikos::DefaultLinearSolverBuilder linearSolverBuilder;
-
-#ifdef HAVE_PIRO_MUELU
-    Stratimikos::enableMueLu(linearSolverBuilder);
-#endif
-
-    linearSolverBuilder.setParameterList(sublist(tempusPL, "Stratimikos", true));
     tempusPL->validateParameters(*getValidTempusParameters(
       tempusPL->get<std::string>("Integrator Name", "Tempus Integrator"), 
       integratorPL->get<std::string>("Stepper Name", "Tempus Stepper")
     ), 0);
-    RCP<Thyra::LinearOpWithSolveFactoryBase<double> > lowsFactory = createLinearSolveStrategy(linearSolverBuilder);
 
     //
     *out_ << "\nC) Create and initalize the forward model ...\n";
@@ -287,11 +273,6 @@ void Piro::TempusSolver<Scalar>::initialize(
       }	
     }
     
-    // C.2) Create the Thyra-wrapped ModelEvaluator
-
-    thyraModel_ = rcp(new Thyra::DefaultModelEvaluatorWithSolveFactory<Scalar>(model_, lowsFactory));
-    const RCP<const Thyra::VectorSpaceBase<double> > x_space = thyraModel_->get_x_space();
-
     //
     *out_ << "\nD) Create the stepper and integrator for the forward problem ...\n";
 

--- a/packages/piro/src/Piro_TransientSolver_Def.hpp
+++ b/packages/piro/src/Piro_TransientSolver_Def.hpp
@@ -352,8 +352,12 @@ Piro::TransientSolver<Scalar>::evalConvergedModelResponsesAndSensitivities(
     if (x->space()->isCompatible(*gx_out->space())) {
       Thyra::copy(*modelInArgs.get_x(), gx_out.ptr());
     } else {
-      *out_ << "  WARNING: x and gx_out are not compatible (likely, because adaptation occurred).\n"
-               "    If you need the solution, you will have to retrieve it in another way.\n";
+      *out_ << "  WARNING [PIRO::TransientSolver::evalConvergedModelResponsesAndSensitivities]\n"
+               "    The solution from inArgs (x) is incompatible with the last response in outArgs (gx),\n"
+               "    which was created as a vector with the same vector-space of x. Since the responses\n"
+               "    were created BEFORE calling the transient solver, the most likely explanation for this\n"
+               "    incompatibility is that during the time integration the solution vector space changed,\n"
+               "    for instance because the underlying spatial mesh was adapted (with topological changes).\n";
     }
   }
 

--- a/packages/piro/src/Piro_TransientSolver_Def.hpp
+++ b/packages/piro/src/Piro_TransientSolver_Def.hpp
@@ -348,7 +348,13 @@ Piro::TransientSolver<Scalar>::evalConvergedModelResponsesAndSensitivities(
   // Solution at convergence is the response at index num_g_
   RCP<Thyra::VectorBase<Scalar> > gx_out = outArgs.get_g(num_g_);
   if (Teuchos::nonnull(gx_out)) {
-    Thyra::copy(*modelInArgs.get_x(), gx_out.ptr());
+    auto x = modelInArgs.get_x();
+    if (x->space()->isCompatible(*gx_out->space())) {
+      Thyra::copy(*modelInArgs.get_x(), gx_out.ptr());
+    } else {
+      *out_ << "  WARNING: x and gx_out are not compatible (likely, because adaptation occurred).\n"
+               "    If you need the solution, you will have to retrieve it in another way.\n";
+    }
   }
 
   // Setup output for final evalution of underlying model

--- a/packages/piro/test/CMakeLists.txt
+++ b/packages/piro/test/CMakeLists.txt
@@ -264,6 +264,7 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(copyTestInputFiles
         input_Analysis_ROL_ReducedSpace_TrustRegion_BoundConstrained_ExplicitAdjointME_NOXSolver.xml
         input_Analysis_ROL_FullSpace_AugmentedLagrangian_BoundConstrained.xml
         input_Tempus_BackwardEuler_SinCos.xml 
+        input_tempus_be_nox_solver.yaml
   SOURCE_DIR   ${PACKAGE_SOURCE_DIR}/test
   SOURCE_PREFIX "_"
   EXEDEPS ${ThyraSolverTpetra_EXENAME} ${AnalysisDriverTpetra_EXENAME}

--- a/packages/piro/test/CMakeLists.txt
+++ b/packages/piro/test/CMakeLists.txt
@@ -153,6 +153,19 @@ ENDIF(Piro_ENABLE_NOX)
 
 IF (Piro_ENABLE_Tempus)
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    TempusSolver_UnitTests_Tpetra
+    SOURCES
+    Piro_TempusSolver_UnitTests.cpp
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+    Piro_Test_ThyraSupport.hpp
+    MockModelEval_A_Tpetra.hpp
+    MockModelEval_A_Tpetra.cpp
+    MatrixBased_LOWS.cpp
+    NUM_MPI_PROCS 1-4
+    STANDARD_PASS_OUTPUT
+  )
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
     TempusSolver_SensitivitySinCos_Combined_FSA_UnitTests
     SOURCES
     Piro_TempusSolver_SensitivitySinCos_Combined_FSA_UnitTests.cpp
@@ -380,6 +393,7 @@ IF (PIRO_HAVE_EPETRA_STACK)
       MockModelEval_A.cpp
       NUM_MPI_PROCS 1-4
       STANDARD_PASS_OUTPUT
+      TARGET_DEFINES TEST_USE_EPETRA
     )
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
       TempusSolverForwardOnly_UnitTests
@@ -408,7 +422,6 @@ IF (PIRO_HAVE_EPETRA_STACK)
       NUM_MPI_PROCS 4
       STANDARD_PASS_OUTPUT
     )
-    
   ENDIF (Piro_ENABLE_Tempus)
 
   TRIBITS_COPY_FILES_TO_BINARY_DIR(copyEpetraTestInputFiles

--- a/packages/piro/test/MockModelEval_A_Tpetra.cpp
+++ b/packages/piro/test/MockModelEval_A_Tpetra.cpp
@@ -231,6 +231,7 @@ MockModelEval_A_Tpetra::createOutArgsImpl() const
 
   result.setSupports(Thyra::ModelEvaluatorBase::OUT_ARG_f, true);
   result.setSupports(Thyra::ModelEvaluatorBase::OUT_ARG_W_op, true);
+  result.setSupports(Thyra::ModelEvaluatorBase::OUT_ARG_W, true);
   result.set_W_properties(Thyra::ModelEvaluatorBase::DerivativeProperties(
       Thyra::ModelEvaluatorBase::DERIV_LINEARITY_UNKNOWN,
       Thyra::ModelEvaluatorBase::DERIV_RANK_FULL,

--- a/packages/piro/test/Piro_Test_MockTempusObserver.hpp
+++ b/packages/piro/test/Piro_Test_MockTempusObserver.hpp
@@ -1,0 +1,68 @@
+// @HEADER
+// *****************************************************************************
+//        Piro: Strategy package for embedded analysis capabilitites
+//
+// Copyright 2010 NTESS and the Piro contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef PIRO_TEST_MOCKTEMPUSOBSERVER_HPP
+#define PIRO_TEST_MOCKTEMPUSOBSERVER_HPP
+
+#include "Piro_Test_MockObserver.hpp"
+#include "Tempus_IntegratorObserverBasic.hpp"
+
+namespace Piro {
+
+namespace Test {
+
+template <typename Scalar>
+class MockTempusObserver : public MockObserver<Scalar>,
+                           public Tempus::IntegratorObserverBasic<Scalar>
+{
+public:
+  MockTempusObserver() = default;
+
+  void observeEndTimeStep(const Tempus::Integrator<Scalar>& integrator) override;
+};
+
+// ------------ IMPL ------------ //
+
+template <typename Scalar>
+void MockTempusObserver<Scalar>::
+observeEndTimeStep(const Tempus::Integrator<Scalar>& integrator)
+{
+  // Simply grab stuff from integrator and forward to the base class observeSolution method
+  // NOTE: this simple class IGNORES completely dxdp
+
+  auto sol_hist = integrator.getSolutionHistory();
+
+  auto x = sol_hist->getCurrentState()->getX();
+  auto x_dot = sol_hist->getCurrentState()->getXDot();
+  auto x_dotdot = sol_hist->getCurrentState()->getXDotDot();
+
+  const Scalar scalar_time = sol_hist->getCurrentState()->getTime();
+  typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType StampScalar;
+  const StampScalar time = Teuchos::ScalarTraits<Scalar>::real(scalar_time);
+
+  if (x_dot != Teuchos::null) {
+    if (x_dotdot != Teuchos::null) {
+      // x_dot AND x_dotdot
+      this->observeSolution(*x, *x_dot, *x_dotdot, time);
+    } else {
+      // no x_dotdot
+      this->observeSolution(*x, *x_dot, time);
+    }
+  } else {
+    //no x_dot
+    this->observeSolution(*x, time);
+  }
+}
+
+} // namespace Test
+
+} // namespace Piro
+
+#endif /* PIRO_TEST_MOCKTEMPUSOBSERVER_HPP */
+

--- a/packages/piro/test/_input_tempus_be_nox_solver.yaml
+++ b/packages/piro/test/_input_tempus_be_nox_solver.yaml
@@ -1,0 +1,90 @@
+Piro:
+  Solver Type: Tempus
+  Tempus:
+    Integrator Name: Demo Integrator
+    Demo Integrator:
+      Integrator Type: Integrator Basic
+      Screen Output Index List: '1'
+      Screen Output Index Interval: 100
+      Stepper Name: Demo Stepper
+      Solution History:
+        Storage Type: Unlimited
+        Storage Limit: 20
+      Time Step Control:
+        Initial Time: 0.0
+        Initial Time Index: 0
+        Initial Time Step: 5.0e-03
+        Final Time: 8.0e-1
+        Final Time Index: 10000
+        Maximum Absolute Error: 1.0e-08
+        Maximum Relative Error: 1.0e-08
+        Output Time List: ''
+        Output Index List: ''
+        Output Index Interval: 1000
+        Maximum Number of Stepper Failures: 10
+        Maximum Number of Consecutive Stepper Failures: 5
+    Demo Stepper:
+      Stepper Type: Backward Euler
+      Solver Name: Demo Solver
+      Demo Solver:
+        NOX:
+          Direction:
+            Method: Newton
+            Newton:
+              Forcing Term Method: Constant
+              Rescue Bad Newton Solve: true
+          Line Search:
+            Full Step:
+              Full Step: 1.0e+00
+            Method: Backtrack
+          Nonlinear Solver: Line Search Based
+          Printing:
+            Output Precision: 3
+            Output Processor: 0
+            Output Information:
+              Error: true
+              Warning: true
+              Outer Iteration: false
+              Parameters: true
+              Details: false
+              Linear Solver Details: true
+              Stepper Iteration: true
+              Stepper Details: true
+              Stepper Parameters: true
+          Solver Options:
+            Status Test Check Type: Minimal
+          Status Tests:
+            Test Type: Combo
+            Combo Type: OR
+            Number of Tests: 2
+            Test 0:
+              Test Type: NormF
+              Tolerance: 1.0e-08
+            Test 1:
+              Test Type: MaxIters
+              Maximum Iterations: 20
+    Stratimikos:
+      Linear Solver Type: Belos
+      Linear Solver Types:
+        Belos:
+          Solver Type: Block GMRES
+          Solver Types:
+            Block GMRES:
+              Convergence Tolerance: 1.0e-05
+              Output Frequency: 10
+              Output Style: 1
+              Verbosity: 33
+              Maximum Iterations: 200
+              Block Size: 1
+              Num Blocks: 4
+              Flexible Gmres: false
+      Preconditioner Type: Ifpack2
+      Preconditioner Types:
+        Ifpack2:
+          Prec Type: RILUK
+          Overlap: 1
+          Ifpack2 Settings:
+            'fact: drop tolerance': 0.0
+            'fact: iluk level-of-fill': 0
+            'fact: level-of-fill': 1
+...


### PR DESCRIPTION
This PR does two main things:

 1. In TempusSolver, allow to pass the user-provided observer directly to the tempus integrator (if compatible). That is, if the user-provided `Piro::ObserverBase` pointer also happens to inherit from `Tempus::IntegratorObserverBasic`, then don't create a `ObserverToTempusIntegrationObserverAdapter` (to wrap it into a tempus-compatible one), but just use it directly. That is because the user-provided
 
 2. In TransientSolver: avoid copying the final solution into the outArgs last response (a copy of the solution) if incompatible. This can happen if mesh adaptivity happened during the time integration. In this case, the gx_out response (the last response) would have a vector space corresponding to the initial mesh, which would not be compatible with the current solution. Since the input outArgs is const, and we can't "reset" a VectorBase space, we simply print a warning, and skip the copy, leaving it to the app to figure out how to retrieve the solution at the final time. Notice that every other response with vector space linked to that of X would also have some issue, but that's much harder to solve. Also, notice that sensitivities are only computed for "real" responses (not the dummy gx_out response); in the fwd case, they involve only dgdx and dxdp, which are retrieved from the model (rather than outArgs), so we assume the host app has the _correct_ versions of these.

 3. Remove pointless overrides for `Piro::ObserverToTempusIntegrationObserverAdapter` methods, since the impl in the base Tempus class is the same or better.
 
## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Albany development will require these mods in order for their mesh-adaptivity framework to work.

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
I added a unit test to verify that the solver uses the input observer "as-is", without wrapping in a `Piro::ObserverToTempusIntegratorObserverAdapter` if it is already inheriting from `Tempus::IntegratorObserver`.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
