### PR TITLE
Draft: Framework: Promote all clean warnings

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -45,6 +45,7 @@ Framework
     if either of these modes are enabled, all warnings are disabled for any
     deprecated packages, in the interest of not spending effort cleaning them.
     By default, no warnings or errors are added.
+  - Set all currently-clean GCC 10 warnings as 'promoted'.
 
 
 ###############################################################################

--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -1,5 +1,6 @@
 tribits_get_package_enable_status(Kokkos  KokkosEnable "")
 
+
 macro(disable_warnings_for_deprecated_packages)
     message(STATUS "Disabling all warnings/errors for deprecated packages")
     foreach(package ${DEPRECATED_PACKAGES})
@@ -43,7 +44,33 @@ IF (KokkosEnable)
 ENDIF()
 
 set(upcoming_warnings shadow ${Trilinos_ADDITIONAL_WARNINGS})
-set(promoted_warnings parentheses sign-compare unused-variable reorder uninitialized)
+set(promoted_warnings
+    address
+    aggressive-loop-optimizations
+    builtin-declaration-mismatch
+    cast-align
+    deprecated-declarations
+    div-by-zero
+    format-extra-args
+    format
+    format-zero-length
+    init-self
+    int-to-pointer-cast
+    parentheses
+    reorder
+    return-type
+    sequence-point
+    sign-compare
+    strict-aliasing
+    type-limits
+    uninitialized
+    unused-function
+    unused-label
+    unused-value
+    unused-variable
+    variadic-macros
+    write-strings
+)
 
 if("${Trilinos_WARNINGS_MODE}" STREQUAL "WARN")
     enable_warnings("${upcoming_warnings}")

--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -17,6 +17,14 @@ macro(enable_warnings warnings)
 endmacro()
 
 
+macro(disable_warnings warnings)
+    message(STATUS "Trilinos warnings disabled: ${warnings}")
+    foreach(warning ${warnings})
+        set(CMAKE_CXX_FLAGS "-Wno-${warning} ${CMAKE_CXX_FLAGS}")
+    endforeach()
+endmacro()
+
+
 macro(enable_errors errors)
     message(STATUS "Trilinos warnings-as-errors enabled: ${errors}")
     foreach(error ${errors})
@@ -43,13 +51,19 @@ IF (KokkosEnable)
   # being treated as an internal package.
 ENDIF()
 
-set(upcoming_warnings shadow ${Trilinos_ADDITIONAL_WARNINGS})
+set(explicitly_disabled_warnings
+    deprecated-declarations
+    inline
+)
+set(upcoming_warnings
+    shadow
+    ${Trilinos_ADDITIONAL_WARNINGS}
+)
 set(promoted_warnings
     address
     aggressive-loop-optimizations
     builtin-declaration-mismatch
     cast-align
-    deprecated-declarations
     div-by-zero
     format-extra-args
     format
@@ -80,3 +94,5 @@ elseif("${Trilinos_WARNINGS_MODE}" STREQUAL "ERROR")
     enable_errors("${promoted_warnings};${upcoming_warnings}")
     disable_warnings_for_deprecated_packages()
 endif()
+
+disable_warnings("${explicitly_disabled_warnings}")

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1603,7 +1603,7 @@ opt-set-cmake-var TPL_ENABLE_Scotch   BOOL FORCE : OFF
 opt-set-cmake-var TPL_Netcdf_LIBRARIES STRING FORCE : ${NETCDF_C_LIB|ENV}/libnetcdf.so
 
 opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
-opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-label
+opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare
 
 [rhel8_sems-gnu-8.5.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel8_sems-gnu-8.5.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
@@ -1636,7 +1636,7 @@ use SPACK_NETLIB_BLAS_LAPACK
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : --bind-to;none --mca btl vader,self
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL         : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-inline -Wno-nonnull-compare -Wno-address
+opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare
 
 opt-set-cmake-var TPL_HDF5_LIBRARIES STRING : ${HDF5_LIB|ENV}/libhdf5_hl.so;${HDF5_LIB|ENV}/libhdf5.so;${ZLIB_LIB|ENV}/libz.so;-ldl
 
@@ -1672,7 +1672,7 @@ opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL   
 opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE                     BOOL         : ON
 opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE                     BOOL         : ON
 
-opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline
+opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare
 
 # Test failures as of 11-28-22
 opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL : ON
@@ -1766,7 +1766,7 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 use COMMON_SPACK_TPLS
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                                STRING       : --bind-to;none --mca btl vader,self
-opt-set-cmake-var CMAKE_CXX_FLAGS                                            STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline
+opt-set-cmake-var CMAKE_CXX_FLAGS                                            STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare
 
 opt-set-cmake-var TPL_ENABLE_SuperLUDist      BOOL FORCE : ON
 opt-set-cmake-var TPL_ENABLE_ParMETIS         BOOL FORCE : ON
@@ -1814,7 +1814,7 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use COMMON_SPACK_TPLS
 
-opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-label
+opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-unused-but-set-variable
 
 opt-set-cmake-var TPL_Netcdf_LIBRARIES      STRING FORCE : ""
 
@@ -1853,7 +1853,7 @@ opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE     BOO
 opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL         : ON
 opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE                         BOOL         : ON
 opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE                         BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                                            STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline
+opt-set-cmake-var CMAKE_CXX_FLAGS                                            STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare
 
 opt-set-cmake-var TPL_ENABLE_SuperLUDist BOOL FORCE: OFF
 


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Trilinos should have the cleanest compile output currently possible and prevent introducing as many warnings as possible in the future.

## Testing
I looped over a (theoretically) complete list of warnings that are supported by GCC 10 and checked which of them do not occur anywhere in Trilinos (non-deprecated packages only).