### PR TITLE
Intrepid2: Disable test

### DIFF
--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_Cn_FEM/CMakeLists.txt
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_Cn_FEM/CMakeLists.txt
@@ -151,6 +151,13 @@ FOREACH(I RANGE ${ETI_DEVICE_COUNT})
         ENDIF()
       ENDIF()
 
+      IF(${ETI_NAME} STREQUAL "test_02_CUDA_DFAD_DFAD")
+        IF(${CUDAToolkit_VERSION_MAJOR} LESS "12")
+          MESSAGE(STATUS "Skipping TEST: HGRAD_TET_Cn_FEM ${ETI_NAME}.cpp for CUDA <12 (known compile issue)")
+          CONTINUE()
+        ENDIF()
+      ENDIF()
+
       MESSAGE(STATUS "Generating TEST: HGRAD_TRI_Cn_FEM ${ETI_NAME}.cpp")
       CONFIGURE_FILE(eti/${ETI_FILE}_ETI.in ${ETI_NAME}.cpp)
 


### PR DESCRIPTION
@trilinos/intrepid2 

## Motivation
Repeated compile failures building `Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_02_CUDA_DFAD_DFAD` ([example](https://sems-cdash-son.sandia.gov/cdash/viewBuildError.php?buildid=343224)).  With the approach of the AT2 CUDA build being transitioned to production, we need the line clean.


## Testing
Same paradigm as used elsewhere.

I did some diagnosis on this, since it was apparently succeeding to build with the AT1 configuration/machine, and I didn't want to disable it if at all possible.  The load numbers on the AT2 machine show the CPU spiking to over 100%, but only for 1-2 minutes.  When I checked one of the AT1 machines, I saw the same spike, but only to about 60%.  This makes sense, since the parallelism for these machines is higher, given that they have more CPUs.  To me, this indicates that something (small number) are using a lot of CPU resources, as opposed to the entire. build hitting the machine too hard.  I think the trade-off of disabling this test vs. slowing down the build of all other tests is justified (though unfortunate).  We shall see what this does to the load numbers.  Some sort of randomized compile order could also help avoid this type of issue happening repeatedly in the future.

Memory usage looked fine on both machines.

AT1:
![at1_gpu_load](https://github.com/user-attachments/assets/416e4e01-80de-4968-af7b-c3afda9dcbd5)
AT2:
![at2_gpu_load](https://github.com/user-attachments/assets/6f9c1b6f-6851-4f44-bc52-1117209a7cc1)

