### PR TITLE
ShyLU_DDFROSch: Fix `type-limits` compiler warning for GCC10

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/InterfaceSets/FROSch_InterfaceEntity_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/InterfaceSets/FROSch_InterfaceEntity_def.hpp
@@ -117,7 +117,7 @@ namespace FROSch {
         FROSCH_ASSERT(nDofs<=DofsPerNode_,"nDofs>DofsPerNode_.");
 
         for (unsigned i=0; i<nDofs; i++) {
-            if ((0<=dofIDs[i])&&(dofIDs[i]<=DofsPerNode_)) {
+            if (dofIDs[i]<=DofsPerNode_) {
                 NodeVector_[iD].DofsGlobal_[dofIDs[i]] = dofsGlobal[dofIDs[i]];
             } else {
                 FROSCH_ASSERT(false,"dofIDs[i] is out of range.");


### PR DESCRIPTION
@trilinos/shylu

## Motivation
The containerized AT2 build was showing a compile error (`type-limits`) in ShyLU.  Not positive why it didn't show up in the AT1 build, my guess is conflict with another warning flag from `config-specs.ini` or a compiler version difference?

## Related Issues
#13700 


## Testing
I did a build and test with GCC + OpenMPI and all ShyLU_DDFROSch tests built and passed.

