### PR TITLE
Check for changed GenConfig remote URL and error out

### DIFF
--- a/packages/framework/get_dependencies.sh
+++ b/packages/framework/get_dependencies.sh
@@ -36,11 +36,23 @@ function tril_genconfig_clone_or_update_repo() {
   echo
 
   if [[ -d ${sub_dir} ]] ; then
-    echo "STATUS: ${sub_dir}: Fetching remote repo"
     cd ${sub_dir}
-    tril_genconfig_assert_pwd_is_git_repo
-    cmd="git fetch"
-    retry_command "${cmd}"
+    remote=$(git remote get-url origin)
+    if [[ ${git_url} == *"${remote}"* ]]
+    then
+      echo "STATUS: ${sub_dir}: Fetching remote repo"
+      tril_genconfig_assert_pwd_is_git_repo
+      cmd="git fetch"
+      retry_command "${cmd}"
+    else
+      echo "ERROR: Current remote origin does not match expected!" >&2
+      echo "Please remove/move '$(pwd)' and re-run this script" >&2
+      echo "" >&2
+      echo "Current:  ${remote}" >&2
+      echo "Expected: ${git_url}" >&2
+      echo "" >&2
+      exit 1
+    fi
   else
     echo "STATUS: ${sub_dir}: Cloning from '${git_url}'"
     cmd="git clone ${git_url} ${sub_dir}"

--- a/packages/framework/normalize_git_repo_url.py
+++ b/packages/framework/normalize_git_repo_url.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import sys
+
+def removeStartingSubstr(inputStr, substrToRemove):
+  if inputStr.startswith(substrToRemove):
+    substrToRemoveLen = len(substrToRemove)
+    return inputStr[substrToRemoveLen:]
+  return inputStr
+
+def removeTrailingSubstr(inputStr, substrToRemove):
+  if inputStr.endswith(substrToRemove):
+    substrToRemoveLen = len(substrToRemove)
+    return inputStr[:-substrToRemoveLen]
+  return inputStr
+
+def normalizeGitRepoUrl(inputUrl):
+  url = inputUrl
+  url = removeStartingSubstr(url, "https://")
+  url = removeStartingSubstr(url, "git@")
+  url = removeTrailingSubstr(url, ".git")
+  url = url.replace(":", "/")
+  url = url.lower()
+  return url
+
+# Main
+
+def main():
+  if len(sys.argv) != 2:
+    print("Usage: normalize_git_repo_url.py <string>")
+    sys.exit(1)
+  inputUrl = sys.argv[1]
+  print(normalizeGitRepoUrl(inputUrl))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Internal Issues

* [TRILINOSHD-278](https://sems-atlassian-son.sandia.gov/jira/servicedesk/customer/portal/7/TRILINOSHD-278)

## Description

This addresses the problem where someone has an existing GenConfig repo clone before the GenConfig repos got moved to GitHub and tries to run the get_dependencies.py tool and gets a strange error message.  This PR updates the get_dependencies.py to check that the remote URL of the base GenConfig repo is correct and errors out with a good error message if it does not.

This also normalizes the comparison of the remote URLs too allow for developers to use the git@ protocol to do development on the GenConfig repos and still be able to run the get_dependencies.py as part of there development and testing workflow.

NOTE: The new utility script `normalize_git_repo_url.py` is maintained with unit tests in the little internal repo:

* https://gitlab-ex.sandia.gov/rabartl/normalize_git_repo_url

That makes this reusable for other such purposes in other projects as well.
