### PR TITLE
Belos CG: Caching of state vectors

### DIFF
--- a/packages/belos/src/BelosBlockCGIter.hpp
+++ b/packages/belos/src/BelosBlockCGIter.hpp
@@ -36,6 +36,41 @@
 
 namespace Belos {
 
+//! @name BlockCGIteration Structures
+  //@{
+
+  /** \brief Structure to contain pointers to BlockCGIteration state variables.
+   *
+   * This struct is utilized by BlockCGIteration::initialize() and BlockCGIteration::getState().
+   */
+  template <class ScalarType, class MV>
+  class BlockCGIterationState : public CGIterationStateBase<ScalarType, MV> {
+
+  public:
+    BlockCGIterationState() = default;
+
+    BlockCGIterationState(Teuchos::RCP<const MV> tmp) {
+      initialize(tmp);
+    }
+
+    virtual ~BlockCGIterationState() = default;
+
+    void initialize(Teuchos::RCP<const MV> tmp, int _numRHS) {
+      using MVT = MultiVecTraits<ScalarType, MV>;
+      this->R = MVT::Clone( *tmp, _numRHS );
+      this->Z = MVT::Clone( *tmp, _numRHS );
+      this->P = MVT::Clone( *tmp, _numRHS );
+      this->AP = MVT::Clone(*tmp, _numRHS );
+
+      CGIterationStateBase<ScalarType, MV>::initialize(tmp, _numRHS);
+    }
+
+    bool matches(Teuchos::RCP<const MV> tmp, int _numRHS=1) const {
+      return CGIterationStateBase<ScalarType, MV>::matches(tmp, _numRHS);
+    }
+
+};
+
 /// \class BlockCGIter
 /// \brief Implementation of the block preconditioned Conjugate
 ///   Gradient (CG) iteration.
@@ -69,7 +104,7 @@ public:
     TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "Stub");
   }
 
-  void initializeCG (CGIterationState<ScalarType,MV>& /* newstate */) {
+  void initializeCG (Teuchos::RCP<BlockCGIterationState<ScalarType,MV> > /* newstate */, Teuchos::RCP<MV> /* R_0 */) {
     TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "Stub");
   }
 
@@ -77,7 +112,11 @@ public:
     TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "Stub");
   }
 
-  CGIterationState<ScalarType,MV> getState () const {
+  Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > getState () const {
+    TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "Stub");
+  }
+
+  void setState(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > state) {
     TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "Stub");
   }
 
@@ -118,11 +157,6 @@ public:
     TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "Stub");
   }
 
-
-private:
-  void setStateSize() {
-    TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "Stub");
-  }
 };
 
 /// \brief Partial specialization for ScalarType types for which
@@ -137,10 +171,10 @@ public:
   //
   // Convenience typedefs
   //
-  typedef MultiVecTraits<ScalarType,MV> MVT;
-  typedef OperatorTraits<ScalarType,MV,OP> OPT;
-  typedef Teuchos::ScalarTraits<ScalarType> SCT;
-  typedef typename SCT::magnitudeType MagnitudeType;
+  using MVT = MultiVecTraits<ScalarType, MV>;
+  using OPT = OperatorTraits<ScalarType, MV, OP>;
+  using SCT = Teuchos::ScalarTraits<ScalarType>;
+  using MagnitudeType = typename SCT::magnitudeType;
 
   //! @name Constructors/Destructor
   //@{
@@ -157,7 +191,7 @@ public:
                Teuchos::ParameterList &params );
 
   //! Destructor.
-  virtual ~BlockCGIter() {};
+  virtual ~BlockCGIter() = default;
   //@}
 
 
@@ -192,30 +226,37 @@ public:
    * \note For any pointer in \c newstate which directly points to the multivectors in
    * the solver, the data is not copied.
    */
-  void initializeCG(CGIterationState<ScalarType,MV>& newstate);
+  void initializeCG(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > newstate, Teuchos::RCP<MV> R_0);
 
   /*! \brief Initialize the solver with the initial vectors from the linear problem
    *  or random data.
    */
   void initialize()
   {
-    CGIterationState<ScalarType,MV> empty;
-    initializeCG(empty);
+    initializeCG(Teuchos::null, Teuchos::null);
   }
 
   /*! \brief Get the current state of the linear solver.
    *
    * The data is only valid if isInitialized() == \c true.
    *
-   * \returns A CGIterationState object containing const pointers to the current solver state.
+   * \returns A BlockCGIterationState object containing const pointers to the current solver state.
    */
-  CGIterationState<ScalarType,MV> getState() const {
-    CGIterationState<ScalarType,MV> state;
-    state.R = R_;
-    state.P = P_;
-    state.AP = AP_;
-    state.Z = Z_;
+  Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > getState() const {
+    auto state = Teuchos::rcp(new BlockCGIterationState<ScalarType,MV>());
+    state->R = R_;
+    state->P = P_;
+    state->AP = AP_;
+    state->Z = Z_;
     return state;
+  }
+
+  void setState(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > state) {
+    auto s = Teuchos::rcp_dynamic_cast<BlockCGIterationState<ScalarType,MV> >(state, true);
+    R_ = s->R;
+    Z_ = s->Z;
+    P_ = s->P;
+    AP_ = s->AP;
   }
 
   //@}
@@ -260,7 +301,7 @@ public:
   void setDoCondEst(bool /* val */){/*ignored*/}
 
   //! Gets the diagonal for condition estimation (NOT_IMPLEMENTED)
-  Teuchos::ArrayView<MagnitudeType> getDiag() { 
+  Teuchos::ArrayView<MagnitudeType> getDiag() {
     Teuchos::ArrayView<MagnitudeType> temp;
     return temp;
   }
@@ -276,9 +317,6 @@ public:
 
   //
   // Internal methods
-  //
-  //! Method for initalizing the state storage needed by block CG.
-  void setStateSize();
 
   //
   // Classes inputed through constructor that define the linear problem to be solved.
@@ -349,40 +387,6 @@ public:
   }
 
   template <class ScalarType, class MV, class OP>
-  void BlockCGIter<ScalarType,MV,OP,true>::setStateSize ()
-  {
-    if (! stateStorageInitialized_) {
-      // Check if there is any multivector to clone from.
-      Teuchos::RCP<const MV> lhsMV = lp_->getLHS();
-      Teuchos::RCP<const MV> rhsMV = lp_->getRHS();
-      if (lhsMV == Teuchos::null && rhsMV == Teuchos::null) {
-        stateStorageInitialized_ = false;
-        return;
-      }
-      else {
-        // Initialize the state storage If the subspace has not be
-        // initialized before, generate it using the LHS or RHS from
-        // lp_.
-        if (R_ == Teuchos::null || MVT::GetNumberVecs(*R_)!=blockSize_) {
-          // Get the multivector that is not null.
-          Teuchos::RCP<const MV> tmp = ( (rhsMV!=Teuchos::null)? rhsMV: lhsMV );
-          TEUCHOS_TEST_FOR_EXCEPTION
-            (tmp == Teuchos::null,std:: invalid_argument,
-             "Belos::BlockCGIter::setStateSize: LinearProblem lacks "
-             "multivectors from which to clone.");
-          R_ = MVT::Clone (*tmp, blockSize_);
-          Z_ = MVT::Clone (*tmp, blockSize_);
-          P_ = MVT::Clone (*tmp, blockSize_);
-          AP_ = MVT::Clone (*tmp, blockSize_);
-        }
-
-        // State storage has now been initialized.
-        stateStorageInitialized_ = true;
-      }
-    }
-  }
-
-  template <class ScalarType, class MV, class OP>
   void BlockCGIter<ScalarType,MV,OP,true>::setBlockSize (int blockSize)
   {
     // This routine only allocates space; it doesn't not perform any computation
@@ -398,45 +402,40 @@ public:
     }
     blockSize_ = blockSize;
     initialized_ = false;
-    // Use the current blockSize_ to initialize the state storage.
-    setStateSize ();
   }
 
   template <class ScalarType, class MV, class OP>
   void BlockCGIter<ScalarType,MV,OP,true>::
-  initializeCG (CGIterationState<ScalarType,MV>& newstate)
+  initializeCG (Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > newstate, Teuchos::RCP<MV> R_0)
   {
     const char prefix[] = "Belos::BlockCGIter::initialize: ";
 
     // Initialize the state storage if it isn't already.
-    if (! stateStorageInitialized_) {
-      setStateSize();
-    }
-
-    TEUCHOS_TEST_FOR_EXCEPTION
-      (! stateStorageInitialized_, std::invalid_argument,
-       prefix << "Cannot initialize state storage!");
+    Teuchos::RCP<const MV> lhsMV = lp_->getLHS();
+    Teuchos::RCP<const MV> rhsMV = lp_->getRHS();
+    Teuchos::RCP<const MV> tmp = ( (rhsMV!=Teuchos::null)? rhsMV: lhsMV );
+    TEUCHOS_ASSERT(!newstate.is_null());
+    if (!Teuchos::rcp_dynamic_cast<BlockCGIterationState<ScalarType,MV> >(newstate, true)->matches(tmp, blockSize_))
+      newstate->initialize(tmp, blockSize_);
+    setState(newstate);
 
     // NOTE:  In BlockCGIter R_, the initial residual, is required!!!
     const char errstr[] = "Specified multivectors must have a consistent "
       "length and width.";
 
-    // Create convenience variables for zero and one.
-    //const MagnitudeType zero = Teuchos::ScalarTraits<MagnitudeType>::zero(); // unused
-
-    if (newstate.R != Teuchos::null) {
+    {
 
       TEUCHOS_TEST_FOR_EXCEPTION
-        (MVT::GetGlobalLength(*newstate.R) != MVT::GetGlobalLength(*R_),
+        (MVT::GetGlobalLength(*R_0) != MVT::GetGlobalLength(*R_),
          std::invalid_argument, prefix << errstr );
       TEUCHOS_TEST_FOR_EXCEPTION
-        (MVT::GetNumberVecs(*newstate.R) != blockSize_,
+        (MVT::GetNumberVecs(*R_0) != blockSize_,
          std::invalid_argument, prefix << errstr );
 
       // Copy basis vectors from newstate into V
-      if (newstate.R != R_) {
+      if (R_0 != R_) {
         // copy over the initial residual (unpreconditioned).
-        MVT::Assign( *newstate.R, *R_ );
+        MVT::Assign( *R_0, *R_ );
       }
       // Compute initial direction vectors
       // Initially, they are set to the preconditioned residuals
@@ -444,9 +443,9 @@ public:
       if ( lp_->getLeftPrec() != Teuchos::null ) {
         lp_->applyLeftPrec( *R_, *Z_ );
         if ( lp_->getRightPrec() != Teuchos::null ) {
-          Teuchos::RCP<MV> tmp = MVT::Clone( *Z_, blockSize_ );
-          lp_->applyRightPrec( *Z_, *tmp );
-          Z_ = tmp;
+          Teuchos::RCP<MV> tmp2 = MVT::Clone( *Z_, blockSize_ );
+          lp_->applyRightPrec( *Z_, *tmp2 );
+          Z_ = tmp2;
         }
       }
       else if ( lp_->getRightPrec() != Teuchos::null ) {
@@ -456,11 +455,6 @@ public:
         Z_ = R_;
       }
       MVT::Assign( *Z_, *P_ );
-    }
-    else {
-      TEUCHOS_TEST_FOR_EXCEPTION
-        (newstate.R == Teuchos::null, std::invalid_argument,
-         prefix << "BlockCGStateIterState does not have initial residual.");
     }
 
     // The solver is initialized

--- a/packages/belos/src/BelosBlockCGIter.hpp
+++ b/packages/belos/src/BelosBlockCGIter.hpp
@@ -55,18 +55,18 @@ namespace Belos {
 
     virtual ~BlockCGIterationState() = default;
 
-    void initialize(Teuchos::RCP<const MV> tmp, int _numRHS) {
+    void initialize(Teuchos::RCP<const MV> tmp, int _numVectors) {
       using MVT = MultiVecTraits<ScalarType, MV>;
-      this->R = MVT::Clone( *tmp, _numRHS );
-      this->Z = MVT::Clone( *tmp, _numRHS );
-      this->P = MVT::Clone( *tmp, _numRHS );
-      this->AP = MVT::Clone(*tmp, _numRHS );
+      this->R = MVT::Clone( *tmp, _numVectors );
+      this->Z = MVT::Clone( *tmp, _numVectors );
+      this->P = MVT::Clone( *tmp, _numVectors );
+      this->AP = MVT::Clone(*tmp, _numVectors );
 
-      CGIterationStateBase<ScalarType, MV>::initialize(tmp, _numRHS);
+      CGIterationStateBase<ScalarType, MV>::initialize(tmp, _numVectors);
     }
 
-    bool matches(Teuchos::RCP<const MV> tmp, int _numRHS=1) const {
-      return CGIterationStateBase<ScalarType, MV>::matches(tmp, _numRHS);
+    bool matches(Teuchos::RCP<const MV> tmp, int _numVectors=1) const {
+      return CGIterationStateBase<ScalarType, MV>::matches(tmp, _numVectors);
     }
 
 };

--- a/packages/belos/src/BelosCGIter.hpp
+++ b/packages/belos/src/BelosCGIter.hpp
@@ -62,9 +62,9 @@ namespace Belos {
 
     virtual ~CGIterationState() = default;
 
-    void initialize(Teuchos::RCP<const MV> tmp, int _numRHS) {
+    void initialize(Teuchos::RCP<const MV> tmp, int _numVectors) {
       using MVT = MultiVecTraits<ScalarType, MV>;
-      TEUCHOS_ASSERT(_numRHS == 1);
+      TEUCHOS_ASSERT(_numVectors == 1);
 
       // S = (R, Z)
       // This allows to compute the inner products (R, S) = ((R, R), (R, Z)) using a single reduction.
@@ -78,11 +78,11 @@ namespace Belos {
       this->P = MVT::Clone( *tmp, 1 );
       this->AP = MVT::Clone(*tmp, 1);
 
-      CGIterationStateBase<ScalarType, MV>::initialize(tmp, _numRHS);
+      CGIterationStateBase<ScalarType, MV>::initialize(tmp, _numVectors);
     }
 
-    bool matches(Teuchos::RCP<const MV> tmp, int _numRHS=1) const {
-      return (CGIterationStateBase<ScalarType, MV>::matches(tmp, _numRHS) &&
+    bool matches(Teuchos::RCP<const MV> tmp, int _numVectors=1) const {
+      return (CGIterationStateBase<ScalarType, MV>::matches(tmp, _numVectors) &&
               !S.is_null());
     }
 

--- a/packages/belos/src/BelosCGIter.hpp
+++ b/packages/belos/src/BelosCGIter.hpp
@@ -31,53 +31,100 @@
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
 
-/*!	
+/*!
   \class Belos::CGIter
-  
+
   \brief This class implements the preconditioned Conjugate Gradient (CG) iteration.
 
   \ingroup belos_solver_framework
- 
+
   \author Teri Barth and Heidi Thornquist
 */
 
 namespace Belos {
-  
+
+  //! @name CGIteration Structures
+  //@{
+
+  /** \brief Structure to contain pointers to CGIteration state variables.
+   *
+   * This struct is utilized by CGIteration::initialize() and CGIteration::getState().
+   */
+  template <class ScalarType, class MV>
+  class CGIterationState : public CGIterationStateBase<ScalarType, MV> {
+
+  public:
+    CGIterationState() = default;
+
+    CGIterationState(Teuchos::RCP<const MV> tmp) {
+      initialize(tmp);
+    }
+
+    virtual ~CGIterationState() = default;
+
+    void initialize(Teuchos::RCP<const MV> tmp, int _numRHS) {
+      using MVT = MultiVecTraits<ScalarType, MV>;
+      TEUCHOS_ASSERT(_numRHS == 1);
+
+      // S = (R, Z)
+      // This allows to compute the inner products (R, S) = ((R, R), (R, Z)) using a single reduction.
+      S = MVT::Clone( *tmp, 2 );
+      std::vector<int> index(1,0);
+      index[0] = 0;
+      this->R = MVT::CloneViewNonConst( *S, index );
+      index[0] = 1;
+      this->Z = MVT::CloneViewNonConst( *S, index );
+
+      this->P = MVT::Clone( *tmp, 1 );
+      this->AP = MVT::Clone(*tmp, 1);
+
+      CGIterationStateBase<ScalarType, MV>::initialize(tmp, _numRHS);
+    }
+
+    bool matches(Teuchos::RCP<const MV> tmp, int _numRHS=1) const {
+      return (CGIterationStateBase<ScalarType, MV>::matches(tmp, _numRHS) &&
+              !S.is_null());
+    }
+
+    Teuchos::RCP<MV> S;
+
+};
+
 template<class ScalarType, class MV, class OP>
 class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
 
   public:
-    
+
   //
   // Convenience typedefs
   //
-  typedef MultiVecTraits<ScalarType,MV> MVT;
-  typedef OperatorTraits<ScalarType,MV,OP> OPT;
-  typedef Teuchos::ScalarTraits<ScalarType> SCT;
-  typedef typename SCT::magnitudeType MagnitudeType;
+  using MVT = MultiVecTraits<ScalarType, MV>;
+  using OPT = OperatorTraits<ScalarType, MV, OP>;
+  using SCT = Teuchos::ScalarTraits<ScalarType>;
+  using MagnitudeType = typename SCT::magnitudeType;
 
   //! @name Constructors/Destructor
-  //@{ 
+  //@{
 
   /*! \brief %CGIter constructor with linear problem, solver utilities, and parameter list of solver options.
    *
    * This constructor takes pointers required by the linear solver iteration, in addition
    * to a parameter list of options for the linear solver.
    */
-  CGIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
+  CGIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 		  const Teuchos::RCP<OutputManager<ScalarType> > &printer,
 		  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
                   const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > &convTester,
 		  Teuchos::ParameterList &params );
 
   //! Destructor.
-  virtual ~CGIter() {};
+  virtual ~CGIter() = default;
   //@}
 
 
   //! @name Solver methods
-  //@{ 
-  
+  //@{
+
   /*! \brief This method performs CG iterations until the status
    * test indicates the need to stop or an error occurs (in which case, an
    * std::exception is thrown).
@@ -86,7 +133,7 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
    * not, it will call initialize() using default arguments. After
    * initialization, the solver performs CG iterations until the
    * status test evaluates as ::Passed, at which point the method returns to
-   * the caller. 
+   * the caller.
    *
    * The status test is queried at the beginning of the iteration.
    */
@@ -94,53 +141,62 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
 
   /*! \brief Initialize the solver to an iterate, providing a complete state.
    *
-   * The %CGIter contains a certain amount of state, consisting of the current 
+   * The %CGIter contains a certain amount of state, consisting of the current
    * residual, preconditioned residual, and decent direction.
    *
    * initialize() gives the user the opportunity to manually set these,
    * although only the current unpreconditioned residual is required.
    *
-   * \post 
+   * \post
    * <li>isInitialized() == \c true (see post-conditions of isInitialize())
    *
-   * \note For any pointer in \c newstate which directly points to the multivectors in 
+   * \note For any pointer in \c newstate which directly points to the multivectors in
    * the solver, the data is not copied.
    */
-  void initializeCG(CGIterationState<ScalarType,MV>& newstate);
+  void initializeCG(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > newstate, Teuchos::RCP<MV> R_0);
 
   /*! \brief Initialize the solver with the initial vectors from the linear problem
    *  or random data.
    */
   void initialize()
   {
-    CGIterationState<ScalarType,MV> empty;
-    initializeCG(empty);
+    initializeCG(Teuchos::null, Teuchos::null);
   }
-  
+
   /*! \brief Get the current state of the linear solver.
    *
    * The data is only valid if isInitialized() == \c true.
    *
    * \returns A CGIterationState object containing const pointers to the current solver state.
    */
-  CGIterationState<ScalarType,MV> getState() const {
-    CGIterationState<ScalarType,MV> state;
-    state.R = R_;
-    state.P = P_;
-    state.AP = AP_;
-    state.Z = Z_;
+  Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > getState() const {
+    auto state = Teuchos::rcp(new CGIterationState<ScalarType,MV>());
+    state->R = R_;
+    state->P = P_;
+    state->AP = AP_;
+    state->Z = Z_;
+    state->S = S_;
     return state;
+  }
+
+  void setState(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > state) {
+    auto s = Teuchos::rcp_dynamic_cast<CGIterationState<ScalarType,MV> >(state, true);
+    R_ = s->R;
+    Z_ = s->Z;
+    P_ = s->P;
+    AP_ = s->AP;
+    S_ = s->S;
   }
 
   //@}
 
-  
+
   //! @name Status methods
-  //@{ 
+  //@{
 
   //! \brief Get the current iteration count.
   int getNumIters() const { return iter_; }
-  
+
   //! \brief Reset the iteration count.
   void resetNumIters( int iter = 0 ) { iter_ = iter; }
 
@@ -160,9 +216,9 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
   Teuchos::RCP<MV> getCurrentUpdate() const { return Teuchos::null; }
 
   //@}
-  
+
   //! @name Accessor methods
-  //@{ 
+  //@{
 
   //! Get a constant reference to the linear problem.
   const LinearProblem<ScalarType,MV,OP>& getProblem() const { return *lp_; }
@@ -178,26 +234,26 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
 
   //! States whether the solver has been initialized or not.
   bool isInitialized() { return initialized_; }
-  
+
 
   //! Sets whether or not to store the diagonal for condition estimation
   void setDoCondEst(bool val) {
-   if (numEntriesForCondEst_) doCondEst_=val;
+   if (numEntriesForCondEst_ != 0) doCondEst_=val;
   }
-  
+
   //! Gets the diagonal for condition estimation
   Teuchos::ArrayView<MagnitudeType> getDiag() {
     // NOTE (mfh 30 Jul 2015) See note on getOffDiag() below.
     // getDiag() didn't actually throw for me in that case, but why
     // not be cautious?
-    typedef typename Teuchos::ArrayView<MagnitudeType>::size_type size_type;
+    using size_type = typename Teuchos::ArrayView<MagnitudeType>::size_type;
     if (static_cast<size_type> (iter_) >= diag_.size ()) {
       return diag_ ();
     } else {
       return diag_ (0, iter_);
     }
     }
-  
+
   //! Gets the off-diagonal for condition estimation
   Teuchos::ArrayView<MagnitudeType> getOffDiag() {
     // NOTE (mfh 30 Jul 2015) The implementation as I found it
@@ -205,24 +261,20 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
     // debug mode) when the maximum number of iterations has been
     // reached, because iter_ == offdiag_.size() in that case.  The
     // new logic fixes this.
-    typedef typename Teuchos::ArrayView<MagnitudeType>::size_type size_type;
+    using size_type = typename Teuchos::ArrayView<MagnitudeType>::size_type;
     if (static_cast<size_type> (iter_) >= offdiag_.size ()) {
       return offdiag_ ();
     } else {
       return offdiag_ (0, iter_);
     }
   }
-  
+
   //@}
 
   private:
 
   //
   // Internal methods
-  //
-  //! Method for initalizing the state storage needed by CG.
-  void setStateSize();
-  
   //
   // Classes inputed through constructor that define the linear problem to be solved.
   //
@@ -231,18 +283,13 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
   const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
   const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> >       convTest_;
 
-  //  
+  //
   // Current solver state
   //
   // initialized_ specifies that the basis vectors have been initialized and the iterate() routine
   // is capable of running; _initialize is controlled  by the initialize() member method
   // For the implications of the state of initialized_, please see documentation for initialize()
   bool initialized_;
-
-  // stateStorageInitialized_ specifies that the state storage has been initialized.
-  // This initialization may be postponed if the linear problem was generated without 
-  // the right-hand side or solution vectors.
-  bool stateStorageInitialized_;
 
   // Current number of iterations performed.
   int iter_;
@@ -261,11 +308,11 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
   int numEntriesForCondEst_;
   bool doCondEst_;
 
- 
-  
-  // 
+
+
+  //
   // State Storage
-  // 
+  //
   // Residual
   Teuchos::RCP<MV> R_;
   //
@@ -285,7 +332,7 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
   template<class ScalarType, class MV, class OP>
-  CGIter<ScalarType,MV,OP>::CGIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
+  CGIter<ScalarType,MV,OP>::CGIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 						   const Teuchos::RCP<OutputManager<ScalarType> > &printer,
 						   const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
                                                    const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > &convTester,
@@ -295,7 +342,6 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
     stest_(tester),
     convTest_(convTester),
     initialized_(false),
-    stateStorageInitialized_(false),
     iter_(0),
     assertPositiveDefiniteness_( params.get("Assert Positive Definiteness", true) ),
     numEntriesForCondEst_(params.get("Max Size For Condest",0) ),
@@ -304,80 +350,39 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
     foldConvergenceDetectionIntoAllreduce_ = params.get<bool>("Fold Convergence Detection Into Allreduce",false);
   }
 
-  //////////////////////////////////////////////////////////////////////////////////////////////////
-  // Setup the state storage.
-  template <class ScalarType, class MV, class OP>
-  void CGIter<ScalarType,MV,OP>::setStateSize ()
-  {
-    if (!stateStorageInitialized_) {
-
-      // Check if there is any multivector to clone from.
-      Teuchos::RCP<const MV> lhsMV = lp_->getLHS();
-      Teuchos::RCP<const MV> rhsMV = lp_->getRHS();
-      if (lhsMV == Teuchos::null && rhsMV == Teuchos::null) {
-	stateStorageInitialized_ = false;
-	return;
-      }
-      else {
-	
-	// Initialize the state storage
-	// If the subspace has not be initialized before, generate it using the LHS or RHS from lp_.
-	if (R_ == Teuchos::null) {
-	  // Get the multivector that is not null.
-	  Teuchos::RCP<const MV> tmp = ( (rhsMV!=Teuchos::null)? rhsMV: lhsMV );
-	  TEUCHOS_TEST_FOR_EXCEPTION(tmp == Teuchos::null,std::invalid_argument,
-			     "Belos::CGIter::setStateSize(): linear problem does not specify multivectors to clone from.");
-          S_ = MVT::Clone( *tmp, 2 );
-          std::vector<int> index(1,0);
-          index[0] = 0;
-          R_ = MVT::CloneViewNonConst( *S_, index );
-          index[0] = 1;
-          Z_ = MVT::CloneViewNonConst( *S_, index );
-	  P_ = MVT::Clone( *tmp, 1 );
-	  AP_ = MVT::Clone( *tmp, 1 );
-
-        }
-
-        // Tracking information for condition number estimation
-        if(numEntriesForCondEst_ > 0) {
-          diag_.resize(numEntriesForCondEst_);
-          offdiag_.resize(numEntriesForCondEst_-1);
-        }
-        	
-	// State storage has now been initialized.
-	stateStorageInitialized_ = true;
-      }
-    }
-  }
-
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Initialize this iteration object
   template <class ScalarType, class MV, class OP>
-  void CGIter<ScalarType,MV,OP>::initializeCG(CGIterationState<ScalarType,MV>& newstate)
+  void CGIter<ScalarType,MV,OP>::initializeCG(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > newstate, Teuchos::RCP<MV> R_0)
   {
     // Initialize the state storage if it isn't already.
-    if (!stateStorageInitialized_) 
-      setStateSize();
+    Teuchos::RCP<const MV> lhsMV = lp_->getLHS();
+    Teuchos::RCP<const MV> rhsMV = lp_->getRHS();
+    Teuchos::RCP<const MV> tmp = ( (rhsMV!=Teuchos::null)? rhsMV: lhsMV );
+    TEUCHOS_ASSERT(!newstate.is_null());
+    if (!Teuchos::rcp_dynamic_cast<CGIterationState<ScalarType,MV> >(newstate, true)->matches(tmp, 1))
+      newstate->initialize(tmp, 1);
+    setState(newstate);
 
-    TEUCHOS_TEST_FOR_EXCEPTION(!stateStorageInitialized_,std::invalid_argument,
-		       "Belos::CGIter::initialize(): Cannot initialize state storage!");
-    
-    // NOTE:  In CGIter R_, the initial residual, is required!!!  
-    //
+    // Tracking information for condition number estimation
+    if(numEntriesForCondEst_ > 0) {
+      diag_.resize(numEntriesForCondEst_);
+      offdiag_.resize(numEntriesForCondEst_-1);
+    }
+
     std::string errstr("Belos::CGIter::initialize(): Specified multivectors must have a consistent length and width.");
+    {
 
-    if (newstate.R != Teuchos::null) {
-
-      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetGlobalLength(*newstate.R) != MVT::GetGlobalLength(*R_),
+      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetGlobalLength(*R_0) != MVT::GetGlobalLength(*R_),
                           std::invalid_argument, errstr );
-      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetNumberVecs(*newstate.R) != 1,
+      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetNumberVecs(*R_0) != 1,
                           std::invalid_argument, errstr );
 
       // Copy basis vectors from newstate into V
-      if (newstate.R != R_) {
+      if (R_0 != R_) {
         // copy over the initial residual (unpreconditioned).
-	MVT::Assign( *newstate.R, *R_ );
+	MVT::Assign( *R_0, *R_ );
       }
 
       // Compute initial direction vectors
@@ -386,22 +391,17 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
       if ( lp_->getLeftPrec() != Teuchos::null ) {
         lp_->applyLeftPrec( *R_, *Z_ );
         if ( lp_->getRightPrec() != Teuchos::null ) {
-          Teuchos::RCP<MV> tmp = MVT::CloneCopy( *Z_ );
-          lp_->applyRightPrec( *tmp, *Z_ );
+          Teuchos::RCP<MV> tmp2 = MVT::CloneCopy( *Z_ );
+          lp_->applyRightPrec( *tmp2, *Z_ );
         }
       }
       else if ( lp_->getRightPrec() != Teuchos::null ) {
         lp_->applyRightPrec( *R_, *Z_ );
-      } 
+      }
       else {
         MVT::Assign( *R_, *Z_ );
       }
       MVT::Assign( *Z_, *P_ );
-    }
-    else {
-
-      TEUCHOS_TEST_FOR_EXCEPTION(newstate.R == Teuchos::null,std::invalid_argument,
-                         "Belos::CGIter::initialize(): CGIterationState does not have initial residual.");
     }
 
     // The solver is initialized
@@ -417,14 +417,16 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
     //
     // Allocate/initialize data structures
     //
-    if (initialized_ == false) {
+    if (!initialized_) {
       initialize();
     }
 
     // Allocate memory for scalars.
     std::vector<ScalarType> alpha(1);
     std::vector<ScalarType> beta(1);
-    std::vector<ScalarType> rHz(1), rHz_old(1), pAp(1);
+    std::vector<ScalarType> rHz(1);
+    std::vector<ScalarType> rHz_old(1);
+    std::vector<ScalarType> pAp(1);
     Teuchos::SerialDenseMatrix<int,ScalarType> rHs( 1, 2 );
 
     // Create convenience variables for zero and one.
@@ -432,12 +434,14 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
     const MagnitudeType zero = Teuchos::ScalarTraits<MagnitudeType>::zero();
 
     // Scalars for condition estimation (if needed) - These will always use entry zero, for convenience
-    ScalarType pAp_old = one, beta_old = one, rHz_old2 = one;
-             
+    ScalarType pAp_old = one;
+    ScalarType beta_old = one;
+    ScalarType rHz_old2 = one;
+
     // Get the current solution vector.
     Teuchos::RCP<MV> cur_soln_vec = lp_->getCurrLHSVec();
 
-    // Check that the current solution vector only has one column. 
+    // Check that the current solution vector only has one column.
     TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetNumberVecs(*cur_soln_vec) != 1, CGIterateFailure,
                         "Belos::CGIter::iterate(): current linear system has more than one vector!" );
 
@@ -453,17 +457,17 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
     // Iterate until the status test tells us to stop.
     //
     while (stest_->checkStatus(this) != Passed) {
-      
+
       // Increment the iteration
       iter_++;
 
       // Multiply the current direction vector by A and store in AP_
       lp_->applyOp( *P_, *AP_ );
-      
+
       // Compute alpha := <R_,Z_> / <P_,AP_>
       MVT::MvDot( *P_, *AP_, pAp );
       alpha[0] = rHz[0] / pAp[0];
-      
+
       // Check that alpha is a positive number!
       if(assertPositiveDefiniteness_) {
         TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(alpha[0]) <= zero, CGPositiveDefiniteFailure,
@@ -484,7 +488,7 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
       //
       MVT::MvAddMv( one, *R_, -alpha[0], *AP_, *R_ );
       //
-      // Compute beta := [ new <R_, Z_> ] / [ old <R_, Z_> ], 
+      // Compute beta := [ new <R_, Z_> ] / [ old <R_, Z_> ],
       // and the new direction vector p.
       //
       if ( lp_->getLeftPrec() != Teuchos::null ) {
@@ -496,7 +500,7 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
       }
       else if ( lp_->getRightPrec() != Teuchos::null ) {
         lp_->applyRightPrec( *R_, *Z_ );
-      } 
+      }
       else {
         MVT::Assign( *R_, *Z_ );
       }
@@ -511,7 +515,7 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
       beta[0] = rHz[0] / rHz_old[0];
       //
       MVT::MvAddMv( one, *Z_, beta[0], *P_, *P_ );
-     
+
       // Condition estimate (if needed)
       if (doCondEst_) {
         if (iter_ > 1) {
@@ -525,7 +529,7 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
         beta_old = beta[0];
         pAp_old = pAp[0];
       }
- 
+
     } // end while (sTest_->checkStatus(this) != Passed)
   }
 

--- a/packages/belos/src/BelosCGIteration.hpp
+++ b/packages/belos/src/BelosCGIteration.hpp
@@ -33,27 +33,27 @@ namespace Belos {
   class CGIterationStateBase {
 
   public:
-    virtual void initialize(Teuchos::RCP<const MV> tmp, int _numRHS) {
+    virtual void initialize(Teuchos::RCP<const MV> tmp, int _numVectors) {
       TEUCHOS_ASSERT(!R.is_null());
       TEUCHOS_ASSERT(!Z.is_null());
       TEUCHOS_ASSERT(!P.is_null());
       TEUCHOS_ASSERT(!AP.is_null());
       isInitialized_ = true;
-      numRHS_ = _numRHS;
+      numVectors_ = _numVectors;
     }
 
     bool isInitialized() const { return isInitialized_; }
 
-    int numRHS() const { return numRHS_; }
+    int numVectors() const { return numVectors_; }
 
-    virtual bool matches(Teuchos::RCP<const MV> tmp, int _numRHS=1) const {
+    virtual bool matches(Teuchos::RCP<const MV> tmp, int _numVectors=1) const {
       using MVT = MultiVecTraits<ScalarType, MV>;
       return (isInitialized() &&
               !R.is_null() &&
               !Z.is_null() &&
               !P.is_null() &&
               !AP.is_null() &&
-              (numRHS() == _numRHS) &&
+              (numVectors() == _numVectors) &&
               (MVT::GetGlobalLength(*tmp) == MVT::GetGlobalLength(*R)));
     }
 
@@ -72,7 +72,7 @@ namespace Belos {
   private:
 
     bool isInitialized_;
-    int numRHS_;
+    int numVectors_;
 
   };
 

--- a/packages/belos/src/BelosCGIteration.hpp
+++ b/packages/belos/src/BelosCGIteration.hpp
@@ -17,47 +17,76 @@
 #include "BelosConfigDefs.hpp"
 #include "BelosTypes.hpp"
 #include "BelosIteration.hpp"
+#include "BelosMultiVecTraits.hpp"
+#include "Teuchos_Assert.hpp"
 
 namespace Belos {
 
-  //! @name CGIteration Structures 
-  //@{ 
-  
+  //! @name CGIteration Structures
+  //@{
+
   /** \brief Structure to contain pointers to CGIteration state variables.
    *
    * This struct is utilized by CGIteration::initialize() and CGIteration::getState().
    */
   template <class ScalarType, class MV>
-  struct CGIterationState {
+  class CGIterationStateBase {
+
+  public:
+    virtual void initialize(Teuchos::RCP<const MV> tmp, int _numRHS) {
+      TEUCHOS_ASSERT(!R.is_null());
+      TEUCHOS_ASSERT(!Z.is_null());
+      TEUCHOS_ASSERT(!P.is_null());
+      TEUCHOS_ASSERT(!AP.is_null());
+      isInitialized_ = true;
+      numRHS_ = _numRHS;
+    }
+
+    bool isInitialized() const { return isInitialized_; }
+
+    int numRHS() const { return numRHS_; }
+
+    virtual bool matches(Teuchos::RCP<const MV> tmp, int _numRHS=1) const {
+      using MVT = MultiVecTraits<ScalarType, MV>;
+      return (isInitialized() &&
+              !R.is_null() &&
+              !Z.is_null() &&
+              !P.is_null() &&
+              !AP.is_null() &&
+              (numRHS() == _numRHS) &&
+              (MVT::GetGlobalLength(*tmp) == MVT::GetGlobalLength(*R)));
+    }
 
     /*! \brief The current residual. */
-    Teuchos::RCP<const MV> R;
+    Teuchos::RCP<MV> R;
 
     /*! \brief The current preconditioned residual. */
-    Teuchos::RCP<const MV> Z;
+    Teuchos::RCP<MV> Z;
 
     /*! \brief The current decent direction vector */
-    Teuchos::RCP<const MV> P;
+    Teuchos::RCP<MV> P;
 
     /*! \brief The matrix A applied to current decent direction vector */
-    Teuchos::RCP<const MV> AP;
-    
-    CGIterationState() : R(Teuchos::null), Z(Teuchos::null), 
-		    P(Teuchos::null), AP(Teuchos::null)
-    {}
+    Teuchos::RCP<MV> AP;
+
+  private:
+
+    bool isInitialized_;
+    int numRHS_;
+
   };
 
   //! @name CGIteration Exceptions
-  //@{ 
-  
+  //@{
+
   /** \brief CGIterationInitFailure is thrown when the CGIteration object is unable to
-   * generate an initial iterate in the CGIteration::initialize() routine. 
+   * generate an initial iterate in the CGIteration::initialize() routine.
    *
    * This std::exception is thrown from the CGIteration::initialize() method, which is
    * called by the user or from the CGIteration::iterate() method if isInitialized()
    * == \c false.
    *
-   * In the case that this std::exception is thrown, 
+   * In the case that this std::exception is thrown,
    * CGIteration::isInitialized() will be \c false and the user will need to provide
    * a new initial iterate to the iteration.
    */
@@ -66,7 +95,7 @@ namespace Belos {
     {}};
 
   /** \brief CGIterateFailure is thrown when the CGIteration object is unable to
-   * compute the next iterate in the CGIteration::iterate() routine. 
+   * compute the next iterate in the CGIteration::iterate() routine.
    *
    * This std::exception is thrown from the CGIteration::iterate() method.
    *
@@ -85,7 +114,7 @@ namespace Belos {
     {}};
 
   /** \brief CGIterationOrthoFailure is thrown when the CGIteration object is unable to
-   * compute independent direction vectors in the CGIteration::iterate() routine. 
+   * compute independent direction vectors in the CGIteration::iterate() routine.
    *
    * This std::exception is thrown from the CGIteration::iterate() method.
    *
@@ -103,7 +132,7 @@ namespace Belos {
   class CGIterationLAPACKFailure : public BelosError {public:
     CGIterationLAPACKFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
-  
+
   //@}
 
 
@@ -113,22 +142,22 @@ class CGIteration : virtual public Iteration<ScalarType,MV,OP> {
   public:
 
   //! @name State methods
-  //@{ 
+  //@{
   /*! \brief Initialize the solver to an iterate, providing a complete state.
    *
-   * The %CGIteration contains a certain amount of state, consisting of the current 
+   * The %CGIteration contains a certain amount of state, consisting of the current
    * residual, preconditioned residual, and decent direction.
    *
    * initialize() gives the user the opportunity to manually set these,
    * although only the current unpreconditioned residual is required.
    *
-   * \post 
+   * \post
    * <li>isInitialized() == \c true (see post-conditions of isInitialize())
    *
-   * \note For any pointer in \c newstate which directly points to the multivectors in 
+   * \note For any pointer in \c newstate which directly points to the multivectors in
    * the solver, the data is not copied.
    */
-  virtual void initializeCG(CGIterationState<ScalarType,MV>& newstate) = 0;
+  virtual void initializeCG(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > newstate, Teuchos::RCP<MV> R_0) = 0;
 
   /*! \brief Get the current state of the linear solver.
    *
@@ -136,7 +165,9 @@ class CGIteration : virtual public Iteration<ScalarType,MV,OP> {
    *
    * \returns A CGIterationState object containing const pointers to the current solver state.
    */
-  virtual CGIterationState<ScalarType,MV> getState() const = 0;
+  virtual Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > getState() const = 0;
+
+  virtual void setState(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > state) = 0;
   //@}
 
 
@@ -146,7 +177,7 @@ class CGIteration : virtual public Iteration<ScalarType,MV,OP> {
   //! Gets the diagonal for condition estimation
   virtual Teuchos::ArrayView<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType> getDiag() = 0;
 
-  //! Gets the off-diagonal for condition estimation 
+  //! Gets the off-diagonal for condition estimation
   virtual Teuchos::ArrayView<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType> getOffDiag() = 0;
 
 };

--- a/packages/belos/src/BelosCGSingleRedIter.hpp
+++ b/packages/belos/src/BelosCGSingleRedIter.hpp
@@ -62,10 +62,10 @@ namespace Belos {
 
     virtual ~CGSingleRedIterationState() = default;
 
-    void initialize(Teuchos::RCP<const MV> tmp, int _numRHS) {
+    void initialize(Teuchos::RCP<const MV> tmp, int _numVectors) {
       using MVT = MultiVecTraits<ScalarType, MV>;
 
-      TEUCHOS_ASSERT(_numRHS == 1);
+      TEUCHOS_ASSERT(_numVectors == 1);
 
       // W = (AZ, R, Z)
       W = MVT::Clone( *tmp, 3 );
@@ -101,11 +101,11 @@ namespace Belos {
       index[0] = 1;
       this->P = MVT::CloneViewNonConst( *V, index );
 
-      CGIterationStateBase<ScalarType, MV>::initialize(tmp, _numRHS);
+      CGIterationStateBase<ScalarType, MV>::initialize(tmp, _numVectors);
     }
 
-    bool matches(Teuchos::RCP<const MV> tmp, int _numRHS=1) const {
-      return (CGIterationStateBase<ScalarType, MV>::matches(tmp, _numRHS) &&
+    bool matches(Teuchos::RCP<const MV> tmp, int _numVectors=1) const {
+      return (CGIterationStateBase<ScalarType, MV>::matches(tmp, _numVectors) &&
               !W.is_null() &&
               !V.is_null() &&
               !U.is_null() &&

--- a/packages/belos/src/BelosCGSingleRedIter.hpp
+++ b/packages/belos/src/BelosCGSingleRedIter.hpp
@@ -31,53 +31,133 @@
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
 
-/*!	
+/*!
   \class Belos::CGSingleRedIter
-  
+
   \brief This class implements the preconditioned single-reduction Conjugate Gradient (CG) iteration.
 
   \ingroup belos_solver_framework
- 
+
   \author Heidi Thornquist
 */
 
 namespace Belos {
-  
+
+//! @name CGSingleRedIteration Structures
+  //@{
+
+  /** \brief Structure to contain pointers to CGSingleRedIteration state variables.
+   *
+   * This struct is utilized by CGSingleRedIteration::initialize() and CGSingleRedIteration::getState().
+   */
+  template <class ScalarType, class MV>
+  class CGSingleRedIterationState : public CGIterationStateBase<ScalarType, MV> {
+
+  public:
+    CGSingleRedIterationState() = default;
+
+    CGSingleRedIterationState(Teuchos::RCP<const MV> tmp) {
+      initialize(tmp);
+    }
+
+    virtual ~CGSingleRedIterationState() = default;
+
+    void initialize(Teuchos::RCP<const MV> tmp, int _numRHS) {
+      using MVT = MultiVecTraits<ScalarType, MV>;
+
+      TEUCHOS_ASSERT(_numRHS == 1);
+
+      // W = (AZ, R, Z)
+      W = MVT::Clone( *tmp, 3 );
+      std::vector<int> index2(2,0);
+      std::vector<int> index(1,0);
+
+      // S = (AZ, R)
+      index2[0] = 0;
+      index2[1] = 1;
+      S = MVT::CloneViewNonConst( *W, index2 );
+
+      // U = (AZ, Z)
+      index2[0] = 0;
+      index2[1] = 2;
+      U = MVT::CloneViewNonConst( *W, index2 );
+
+      index[0] = 1;
+      this->R = MVT::CloneViewNonConst( *W, index );
+      index[0] = 0;
+      AZ = MVT::CloneViewNonConst( *W, index );
+      index[0] = 2;
+      this->Z = MVT::CloneViewNonConst( *W, index );
+
+      // T = (R, Z)
+      index2[0] = 1;
+      index2[1] = 2;
+      T = MVT::CloneViewNonConst( *W, index2 );
+
+      // V = (AP, P)
+      V = MVT::Clone( *tmp, 2 );
+      index[0] = 0;
+      this->AP = MVT::CloneViewNonConst( *V, index );
+      index[0] = 1;
+      this->P = MVT::CloneViewNonConst( *V, index );
+
+      CGIterationStateBase<ScalarType, MV>::initialize(tmp, _numRHS);
+    }
+
+    bool matches(Teuchos::RCP<const MV> tmp, int _numRHS=1) const {
+      return (CGIterationStateBase<ScalarType, MV>::matches(tmp, _numRHS) &&
+              !W.is_null() &&
+              !V.is_null() &&
+              !U.is_null() &&
+              !S.is_null() &&
+              !T.is_null() &&
+              !AZ.is_null());
+    }
+
+    Teuchos::RCP<MV> W;
+    Teuchos::RCP<MV> V;
+    Teuchos::RCP<MV> U;
+    Teuchos::RCP<MV> S;
+    Teuchos::RCP<MV> T;
+    Teuchos::RCP<MV> AZ;
+
+  };
+
 template<class ScalarType, class MV, class OP>
 class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
 
   public:
-    
+
   //
   // Convenience typedefs
   //
-  typedef MultiVecTraits<ScalarType,MV> MVT;
-  typedef OperatorTraits<ScalarType,MV,OP> OPT;
-  typedef Teuchos::ScalarTraits<ScalarType> SCT;
-  typedef typename SCT::magnitudeType MagnitudeType;
+  using MVT = MultiVecTraits<ScalarType, MV>;
+  using OPT = OperatorTraits<ScalarType, MV, OP>;
+  using SCT = Teuchos::ScalarTraits<ScalarType>;
+  using MagnitudeType = typename SCT::magnitudeType;
 
   //! @name Constructors/Destructor
-  //@{ 
+  //@{
 
   /*! \brief %CGSingleRedIter constructor with linear problem, solver utilities, and parameter list of solver options.
    *
    * This constructor takes pointers required by the linear solver iteration, in addition
    * to a parameter list of options for the linear solver.
    */
-  CGSingleRedIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
+  CGSingleRedIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                    const Teuchos::RCP<OutputManager<ScalarType> > &printer,
                    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
                    const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > &convTester,
                    Teuchos::ParameterList &params );
 
   //! Destructor.
-  virtual ~CGSingleRedIter() {};
+  virtual ~CGSingleRedIter() = default;
   //@}
 
 
   //! @name Solver methods
-  //@{ 
-  
+  //@{
+
   /*! \brief This method performs CG iterations until the status
    * test indicates the need to stop or an error occurs (in which case, an
    * std::exception is thrown).
@@ -86,7 +166,7 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
    * not, it will call initialize() using default arguments. After
    * initialization, the solver performs CG iterations until the
    * status test evaluates as ::Passed, at which point the method returns to
-   * the caller. 
+   * the caller.
    *
    * The status test is queried at the beginning of the iteration.
    */
@@ -94,53 +174,72 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
 
   /*! \brief Initialize the solver to an iterate, providing a complete state.
    *
-   * The %CGSingleRedIter contains a certain amount of state, consisting of the current 
+   * The %CGSingleRedIter contains a certain amount of state, consisting of the current
    * residual, preconditioned residual, and decent direction.
    *
    * initialize() gives the user the opportunity to manually set these,
    * although only the current unpreconditioned residual is required.
    *
-   * \post 
+   * \post
    * <li>isInitialized() == \c true (see post-conditions of isInitialize())
    *
-   * \note For any pointer in \c newstate which directly points to the multivectors in 
+   * \note For any pointer in \c newstate which directly points to the multivectors in
    * the solver, the data is not copied.
    */
-  void initializeCG(CGIterationState<ScalarType,MV>& newstate);
+  void initializeCG(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > newstate, Teuchos::RCP<MV> R_0);
 
   /*! \brief Initialize the solver with the initial vectors from the linear problem
    *  or random data.
    */
   void initialize()
   {
-    CGIterationState<ScalarType,MV> empty;
-    initializeCG(empty);
+    initializeCG(Teuchos::null, Teuchos::null);
   }
-  
+
   /*! \brief Get the current state of the linear solver.
    *
    * The data is only valid if isInitialized() == \c true.
    *
-   * \returns A CGIterationState object containing const pointers to the current solver state.
+   * \returns A CGSingleRedIterationState object containing const pointers to the current solver state.
    */
-  CGIterationState<ScalarType,MV> getState() const {
-    CGIterationState<ScalarType,MV> state;
-    state.R = R_;
-    state.P = P_;
-    state.AP = AP_;
-    state.Z = Z_;
+  Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > getState() const {
+    auto state = Teuchos::rcp(new CGSingleRedIterationState<ScalarType,MV>());
+    state->W = W_;
+    state->V = V_;
+    state->U = U_;
+    state->S = S_;
+    state->T = T_;
+    state->R = R_;
+    state->Z = Z_;
+    state->P = P_;
+    state->AP = AP_;
+    state->AZ = AZ_;
     return state;
+  }
+
+  void setState(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> >  state) {
+    auto s = Teuchos::rcp_dynamic_cast<CGSingleRedIterationState<ScalarType,MV> >(state, true);
+    W_ = s->W;
+    V_ = s->V;
+    U_ = s->U;
+    S_ = s->S;
+    T_ = s->T;
+    R_ = s->R;
+    Z_ = s->Z;
+    P_ = s->P;
+    AP_ = s->AP;
+    AZ_ = s->AZ;
   }
 
   //@}
 
-  
+
   //! @name Status methods
-  //@{ 
+  //@{
 
   //! \brief Get the current iteration count.
   int getNumIters() const { return iter_; }
-  
+
   //! \brief Reset the iteration count.
   void resetNumIters( int iter = 0 ) { iter_ = iter; }
 
@@ -154,9 +253,9 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
   Teuchos::RCP<MV> getCurrentUpdate() const { return Teuchos::null; }
 
   //@}
-  
+
   //! @name Accessor methods
-  //@{ 
+  //@{
 
   //! Get a constant reference to the linear problem.
   const LinearProblem<ScalarType,MV,OP>& getProblem() const { return *lp_; }
@@ -177,7 +276,7 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
   void setDoCondEst(bool /* val */){/*ignored*/}
 
   //! Gets the diagonal for condition estimation (NOT_IMPLEMENTED)
-  Teuchos::ArrayView<MagnitudeType> getDiag() { 
+  Teuchos::ArrayView<MagnitudeType> getDiag() {
     Teuchos::ArrayView<MagnitudeType> temp;
     return temp;
   }
@@ -195,10 +294,7 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
   //
   // Internal methods
   //
-  //! Method for initalizing the state storage needed by CG.
-  void setStateSize();
-  
-  //
+
   // Classes inputed through constructor that define the linear problem to be solved.
   //
   const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
@@ -206,18 +302,13 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
   const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
   const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> >       convTest_;
 
-  //  
+  //
   // Current solver state
   //
   // initialized_ specifies that the basis vectors have been initialized and the iterate() routine
   // is capable of running; _initialize is controlled  by the initialize() member method
   // For the implications of the state of initialized_, please see documentation for initialize()
   bool initialized_;
-
-  // stateStorageInitialized_ specifies that the state storage has been initialized.
-  // This initialization may be postponed if the linear problem was generated without 
-  // the right-hand side or solution vectors.
-  bool stateStorageInitialized_;
 
   // Current number of iterations performed.
   int iter_;
@@ -229,8 +320,8 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
   ScalarType rHz_;
   // <r,r>
   ScalarType rHr_;
-  
-  // 
+
+  //
   // State Storage
   //
   // Residual
@@ -260,7 +351,7 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
   template<class ScalarType, class MV, class OP>
-  CGSingleRedIter<ScalarType,MV,OP>::CGSingleRedIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
+  CGSingleRedIter<ScalarType,MV,OP>::CGSingleRedIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 						     const Teuchos::RCP<OutputManager<ScalarType> > &printer,
 						     const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
                                                      const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > &convTester,
@@ -270,106 +361,38 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
     stest_(tester),
     convTest_(convTester),
     initialized_(false),
-    stateStorageInitialized_(false),
     iter_(0)
   {
     foldConvergenceDetectionIntoAllreduce_ = params.get<bool>("Fold Convergence Detection Into Allreduce",false);
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
-  // Setup the state storage.
-  template <class ScalarType, class MV, class OP>
-  void CGSingleRedIter<ScalarType,MV,OP>::setStateSize ()
-  {
-    if (!stateStorageInitialized_) {
-
-      // Check if there is any multivector to clone from.
-      Teuchos::RCP<const MV> lhsMV = lp_->getLHS();
-      Teuchos::RCP<const MV> rhsMV = lp_->getRHS();
-      if (lhsMV == Teuchos::null && rhsMV == Teuchos::null) {
-	stateStorageInitialized_ = false;
-	return;
-      }
-      else {
-	
-	// Initialize the state storage
-	// If the subspace has not be initialized before, generate it using the LHS or RHS from lp_.
-	if (R_ == Teuchos::null) {
-	  // Get the multivector that is not null.
-	  Teuchos::RCP<const MV> tmp = ( (rhsMV!=Teuchos::null)? rhsMV: lhsMV );
-	  TEUCHOS_TEST_FOR_EXCEPTION(tmp == Teuchos::null,std::invalid_argument,
-			     "Belos::CGSingleRedIter::setStateSize(): linear problem does not specify multivectors to clone from.");
-
-          // W_ = (AZ_, R_, Z_)
-          W_ = MVT::Clone( *tmp, 3 );
-          std::vector<int> index2(2,0);
-          std::vector<int> index(1,0);
-
-          // S_ = (AZ_, R_)
-          index2[0] = 0;
-          index2[1] = 1;
-          S_ = MVT::CloneViewNonConst( *W_, index2 );
-
-          // U_ = (AZ_, Z_)
-          index2[0] = 0;
-          index2[1] = 2;
-          U_ = MVT::CloneViewNonConst( *W_, index2 );
-
-          index[0] = 1;
-          R_ = MVT::CloneViewNonConst( *W_, index );
-          index[0] = 0;
-          AZ_ = MVT::CloneViewNonConst( *W_, index );
-          index[0] = 2;
-          Z_ = MVT::CloneViewNonConst( *W_, index );
-
-          // T_ = (R_, Z_)
-          index2[0] = 1;
-          index2[1] = 2;
-          T_ = MVT::CloneViewNonConst( *W_, index2 );
-
-          // V_ = (AP_, P_)
-          V_ = MVT::Clone( *tmp, 2 );
-          index[0] = 0;
-          AP_ = MVT::CloneViewNonConst( *V_, index );
-          index[0] = 1;
-	  P_ = MVT::CloneViewNonConst( *V_, index );
-
-	}
-	
-	// State storage has now been initialized.
-	stateStorageInitialized_ = true;
-      }
-    }
-  }
-
-
-  //////////////////////////////////////////////////////////////////////////////////////////////////
   // Initialize this iteration object
   template <class ScalarType, class MV, class OP>
-  void CGSingleRedIter<ScalarType,MV,OP>::initializeCG(CGIterationState<ScalarType,MV>& newstate)
+  void CGSingleRedIter<ScalarType,MV,OP>::initializeCG(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > newstate, Teuchos::RCP<MV> R_0)
   {
     // Initialize the state storage if it isn't already.
-    if (!stateStorageInitialized_) 
-      setStateSize();
+    Teuchos::RCP<const MV> lhsMV = lp_->getLHS();
+    Teuchos::RCP<const MV> rhsMV = lp_->getRHS();
+    Teuchos::RCP<const MV> tmp = ( (rhsMV!=Teuchos::null)? rhsMV: lhsMV );
+    TEUCHOS_ASSERT(!newstate.is_null());
+    if (!Teuchos::rcp_dynamic_cast<CGSingleRedIterationState<ScalarType,MV> >(newstate, true)->matches(tmp, 1))
+      newstate->initialize(tmp, 1);
+    setState(newstate);
 
-    TEUCHOS_TEST_FOR_EXCEPTION(!stateStorageInitialized_,std::invalid_argument,
-		       "Belos::CGSingleRedIter::initialize(): Cannot initialize state storage!");
-    
-    // NOTE:  In CGSingleRedIter R_, the initial residual, is required!!!  
-    //
     std::string errstr("Belos::CGSingleRedIter::initialize(): Specified multivectors must have a consistent length and width.");
 
-    if (newstate.R != Teuchos::null) {
+    {
 
-      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetGlobalLength(*newstate.R) != MVT::GetGlobalLength(*R_),
+      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetGlobalLength(*newstate->R) != MVT::GetGlobalLength(*R_),
                           std::invalid_argument, errstr );
-      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetNumberVecs(*newstate.R) != 1,
+      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetNumberVecs(*newstate->R) != 1,
                           std::invalid_argument, errstr );
 
       // Copy basis vectors from newstate into V
-      if (newstate.R != R_) {
+      if (R_0 != R_) {
         // copy over the initial residual (unpreconditioned).
-	MVT::Assign( *newstate.R, *R_ );
+	MVT::Assign( *R_0, *R_ );
       }
 
       // Compute initial direction vectors
@@ -378,14 +401,14 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
       if ( lp_->getLeftPrec() != Teuchos::null ) {
         lp_->applyLeftPrec( *R_, *Z_ );
         if ( lp_->getRightPrec() != Teuchos::null ) {
-          Teuchos::RCP<MV> tmp = MVT::Clone( *Z_, 1 );
-          lp_->applyRightPrec( *Z_, *tmp );
-          MVT::Assign( *tmp, *Z_ );
+          Teuchos::RCP<MV> tmp2 = MVT::Clone( *Z_, 1 );
+          lp_->applyRightPrec( *Z_, *tmp2 );
+          MVT::Assign( *tmp2, *Z_ );
         }
       }
       else if ( lp_->getRightPrec() != Teuchos::null ) {
         lp_->applyRightPrec( *R_, *Z_ );
-      } 
+      }
       else {
         MVT::Assign( *R_, *Z_ );
       }
@@ -396,11 +419,6 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
       // P_ := Z_
       // Logically, AP_ := AZ_
       MVT::Assign( *U_, *V_);
-    }
-    else {
-
-      TEUCHOS_TEST_FOR_EXCEPTION(newstate.R == Teuchos::null,std::invalid_argument,
-                         "Belos::CGSingleRedIter::initialize(): CGIterationState does not have initial residual.");
     }
 
     // The solver is initialized
@@ -432,23 +450,26 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
     //
     // Allocate/initialize data structures
     //
-    if (initialized_ == false) {
+    if (!initialized_) {
       initialize();
     }
 
     // Allocate memory for scalars.
     Teuchos::SerialDenseMatrix<int,ScalarType> sHz( 2, 1 );
     Teuchos::SerialDenseMatrix<int,ScalarType> sHt( 2, 2 );
-    ScalarType rHz_old, alpha, beta, delta;
+    ScalarType rHz_old;
+    ScalarType alpha;
+    ScalarType beta;
+    ScalarType delta;
 
     // Create convenience variables for zero and one.
     const ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
     const MagnitudeType zero = Teuchos::ScalarTraits<MagnitudeType>::zero();
-    
+
     // Get the current solution vector.
     Teuchos::RCP<MV> cur_soln_vec = lp_->getCurrLHSVec();
 
-    // Check that the current solution vector only has one column. 
+    // Check that the current solution vector only has one column.
     TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetNumberVecs(*cur_soln_vec) != 1, CGIterateFailure,
                         "Belos::CGSingleRedIter::iterate(): current linear system has more than one vector!" );
 
@@ -472,7 +493,7 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
     // Check that alpha is a positive number!
     TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(alpha) <= zero, CGPositiveDefiniteFailure,
       "Belos::CGSingleRedIter::iterate(): non-positive value for p^H*A*p encountered!" );
- 
+
     ////////////////////////////////////////////////////////////////
     // Iterate until the status test tells us to stop.
     //
@@ -480,7 +501,7 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
       ////////////////////////////////////////////////////////////////
       // Iterate until the status test tells us to stop.
       //
-      while (1) {
+      while (true) {
 
         // Update the solution vector x := x + alpha * P_
         //
@@ -546,8 +567,8 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
       ////////////////////////////////////////////////////////////////
       // Iterate until the status test tells us to stop.
       //
-      while (1) {
-      
+      while (true) {
+
         // Update the solution vector x := x + alpha * P_
         //
         MVT::MvAddMv( one, *cur_soln_vec, alpha, *P_, *cur_soln_vec );

--- a/packages/belos/src/BelosPseudoBlockCGIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockCGIter.hpp
@@ -64,18 +64,18 @@ namespace Belos {
 
     virtual ~PseudoBlockCGIterationState() = default;
 
-    void initialize(Teuchos::RCP<const MV> tmp, int _numRHS) {
+    void initialize(Teuchos::RCP<const MV> tmp, int _numVectors) {
       using MVT = MultiVecTraits<ScalarType, MV>;
-      this->R = MVT::Clone( *tmp, _numRHS );
-      this->Z = MVT::Clone( *tmp, _numRHS );
-      this->P = MVT::Clone( *tmp, _numRHS );
-      this->AP = MVT::Clone(*tmp, _numRHS );
+      this->R = MVT::Clone( *tmp, _numVectors );
+      this->Z = MVT::Clone( *tmp, _numVectors );
+      this->P = MVT::Clone( *tmp, _numVectors );
+      this->AP = MVT::Clone(*tmp, _numVectors );
 
-      CGIterationStateBase<ScalarType, MV>::initialize(tmp, _numRHS);
+      CGIterationStateBase<ScalarType, MV>::initialize(tmp, _numVectors);
     }
 
-    bool matches(Teuchos::RCP<const MV> tmp, int _numRHS=1) const {
-      return CGIterationStateBase<ScalarType, MV>::matches(tmp, _numRHS);
+    bool matches(Teuchos::RCP<const MV> tmp, int _numVectors=1) const {
+      return CGIterationStateBase<ScalarType, MV>::matches(tmp, _numVectors);
     }
 };
 

--- a/packages/belos/src/BelosPseudoBlockCGIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockCGIter.hpp
@@ -25,6 +25,7 @@
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
 
+#include "Teuchos_Assert.hpp"
 #include "Teuchos_SerialDenseMatrix.hpp"
 #include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"
@@ -44,6 +45,40 @@
 
 namespace Belos {
 
+  //! @name PseudoBlockCGIteration Structures
+  //@{
+
+  /** \brief Structure to contain pointers to PseudoBlockCGIteration state variables.
+   *
+   * This struct is utilized by PseudoBlockCGIteration::initialize() and PseudoBlockCGIteration::getState().
+   */
+  template <class ScalarType, class MV>
+  class PseudoBlockCGIterationState : public CGIterationStateBase<ScalarType, MV> {
+
+  public:
+    PseudoBlockCGIterationState() = default;
+
+    PseudoBlockCGIterationState(Teuchos::RCP<const MV> tmp) {
+      initialize(tmp);
+    }
+
+    virtual ~PseudoBlockCGIterationState() = default;
+
+    void initialize(Teuchos::RCP<const MV> tmp, int _numRHS) {
+      using MVT = MultiVecTraits<ScalarType, MV>;
+      this->R = MVT::Clone( *tmp, _numRHS );
+      this->Z = MVT::Clone( *tmp, _numRHS );
+      this->P = MVT::Clone( *tmp, _numRHS );
+      this->AP = MVT::Clone(*tmp, _numRHS );
+
+      CGIterationStateBase<ScalarType, MV>::initialize(tmp, _numRHS);
+    }
+
+    bool matches(Teuchos::RCP<const MV> tmp, int _numRHS=1) const {
+      return CGIterationStateBase<ScalarType, MV>::matches(tmp, _numRHS);
+    }
+};
+
   template<class ScalarType, class MV, class OP>
   class PseudoBlockCGIter : virtual public CGIteration<ScalarType,MV,OP> {
 
@@ -52,10 +87,10 @@ namespace Belos {
     //
     // Convenience typedefs
     //
-    typedef MultiVecTraits<ScalarType,MV> MVT;
-    typedef OperatorTraits<ScalarType,MV,OP> OPT;
-    typedef Teuchos::ScalarTraits<ScalarType> SCT;
-    typedef typename SCT::magnitudeType MagnitudeType;
+    using MVT = MultiVecTraits<ScalarType, MV>;
+    using OPT = OperatorTraits<ScalarType, MV, OP>;
+    using SCT = Teuchos::ScalarTraits<ScalarType>;
+    using MagnitudeType = typename SCT::magnitudeType;
 
     //! @name Constructors/Destructor
     //@{
@@ -71,7 +106,7 @@ namespace Belos {
                           Teuchos::ParameterList &params );
 
     //! Destructor.
-    virtual ~PseudoBlockCGIter() {};
+    virtual ~PseudoBlockCGIter() = default;
     //@}
 
 
@@ -113,15 +148,14 @@ namespace Belos {
      * \note For any pointer in \c newstate which directly points to the multivectors in
      * the solver, the data is not copied.
      */
-    void initializeCG(CGIterationState<ScalarType,MV>& newstate);
+    void initializeCG(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > newstate, Teuchos::RCP<MV> R_0);
 
     /*! \brief Initialize the solver with the initial vectors from the linear problem
      *  or random data.
      */
     void initialize()
     {
-      CGIterationState<ScalarType,MV> empty;
-      initializeCG(empty);
+      initializeCG(Teuchos::null, Teuchos::null);
     }
 
     /*! \brief Get the current state of the linear solver.
@@ -131,13 +165,21 @@ namespace Belos {
      * \returns A CGIterationState object containing const pointers to the current
      * solver state.
      */
-    CGIterationState<ScalarType,MV> getState() const {
-      CGIterationState<ScalarType,MV> state;
-      state.R = R_;
-      state.P = P_;
-      state.AP = AP_;
-      state.Z = Z_;
+    Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > getState() const {
+      auto state = Teuchos::rcp(new PseudoBlockCGIterationState<ScalarType,MV>());
+      state->R = R_;
+      state->P = P_;
+      state->AP = AP_;
+      state->Z = Z_;
       return state;
+    }
+
+    void setState(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > state) {
+      auto s = Teuchos::rcp_dynamic_cast<PseudoBlockCGIterationState<ScalarType,MV> >(state, true);
+      R_ = s->R;
+      Z_ = s->Z;
+      P_ = s->P;
+      AP_ = s->AP;
     }
 
     //@}
@@ -185,7 +227,7 @@ namespace Belos {
 
     //! Sets whether or not to store the diagonal for condition estimation
     void setDoCondEst(bool val) {
-     if (numEntriesForCondEst_) doCondEst_=val;
+     if (numEntriesForCondEst_ != 0) doCondEst_=val;
     }
 
     //! Gets the diagonal for condition estimation
@@ -193,7 +235,7 @@ namespace Belos {
       // NOTE (mfh 30 Jul 2015) See note on getOffDiag() below.
       // getDiag() didn't actually throw for me in that case, but why
       // not be cautious?
-      typedef typename Teuchos::ArrayView<MagnitudeType>::size_type size_type;
+      using size_type = typename Teuchos::ArrayView<MagnitudeType>::size_type;
       if (static_cast<size_type> (iter_) >= diag_.size ()) {
         return diag_ ();
       } else {
@@ -208,7 +250,7 @@ namespace Belos {
       // debug mode) when the maximum number of iterations has been
       // reached, because iter_ == offdiag_.size() in that case.  The
       // new logic fixes this.
-      typedef typename Teuchos::ArrayView<MagnitudeType>::size_type size_type;
+      using size_type = typename Teuchos::ArrayView<MagnitudeType>::size_type;
       if (static_cast<size_type> (iter_) >= offdiag_.size ()) {
         return offdiag_ ();
       } else {
@@ -291,8 +333,8 @@ namespace Belos {
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Initialize this iteration object
   template <class ScalarType, class MV, class OP>
-  void PseudoBlockCGIter<ScalarType,MV,OP>::initializeCG(CGIterationState<ScalarType,MV>& newstate)
-  {
+  void PseudoBlockCGIter<ScalarType, MV, OP>::initializeCG(Teuchos::RCP<CGIterationStateBase<ScalarType, MV> > newstate, Teuchos::RCP<MV> R_0) {
+
     // Check if there is any mltivector to clone from.
     Teuchos::RCP<const MV> lhsMV = lp_->getCurrLHSVec();
     Teuchos::RCP<const MV> rhsMV = lp_->getCurrRHSVec();
@@ -306,14 +348,11 @@ namespace Belos {
     int numRHS = MVT::GetNumberVecs(*tmp);
     numRHS_ = numRHS;
 
-    // Initialize the state storage
-    // If the subspace has not be initialized before or has changed sizes, generate it using the LHS or RHS from lp_.
-    if (Teuchos::is_null(R_) || MVT::GetNumberVecs(*R_)!=numRHS_) {
-      R_ = MVT::Clone( *tmp, numRHS_ );
-      Z_ = MVT::Clone( *tmp, numRHS_ );
-      P_ = MVT::Clone( *tmp, numRHS_ );
-      AP_ = MVT::Clone( *tmp, numRHS_ );
-    }
+    // Initialize the state storage if it isn't already.
+    TEUCHOS_ASSERT(!newstate.is_null());
+    if (!Teuchos::rcp_dynamic_cast<PseudoBlockCGIterationState<ScalarType,MV> >(newstate, true)->matches(tmp, numRHS_))
+      newstate->initialize(tmp, numRHS_);
+    setState(newstate);
 
     // Tracking information for condition number estimation
     if(numEntriesForCondEst_ > 0) {
@@ -321,25 +360,19 @@ namespace Belos {
       offdiag_.resize(numEntriesForCondEst_-1);
     }
 
-    // NOTE:  In CGIter R_, the initial residual, is required!!!
-    //
     std::string errstr("Belos::BlockPseudoCGIter::initialize(): Specified multivectors must have a consistent length and width.");
 
-    // Create convenience variables for zero and one.
-    const ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
-    const MagnitudeType zero = Teuchos::ScalarTraits<MagnitudeType>::zero();
+    {
 
-    if (!Teuchos::is_null(newstate.R)) {
-
-      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetGlobalLength(*newstate.R) != MVT::GetGlobalLength(*R_),
+      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetGlobalLength(*R_0) != MVT::GetGlobalLength(*R_),
                           std::invalid_argument, errstr );
-      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetNumberVecs(*newstate.R) != numRHS_,
+      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetNumberVecs(*R_0) != numRHS_,
                           std::invalid_argument, errstr );
 
       // Copy basis vectors from newstate into V
-      if (newstate.R != R_) {
+      if (R_0 != R_) {
         // copy over the initial residual (unpreconditioned).
-        MVT::MvAddMv( one, *newstate.R, zero, *newstate.R, *R_ );
+        MVT::Assign( *R_0, *R_ );
       }
 
       // Compute initial direction vectors
@@ -357,14 +390,9 @@ namespace Belos {
         lp_->applyRightPrec( *R_, *Z_ );
       }
       else {
-        Z_ = R_;
+        MVT::Assign( *R_, *Z_ );
       }
-      MVT::MvAddMv( one, *Z_, zero, *Z_, *P_ );
-    }
-    else {
-
-      TEUCHOS_TEST_FOR_EXCEPTION(Teuchos::is_null(newstate.R),std::invalid_argument,
-                         "Belos::CGIter::initialize(): CGStateIterState does not have initial residual.");
+      MVT::Assign( *Z_, *P_ );
     }
 
     // The solver is initialized
@@ -380,14 +408,17 @@ namespace Belos {
     //
     // Allocate/initialize data structures
     //
-    if (initialized_ == false) {
+    if (!initialized_) {
       initialize();
     }
 
     // Allocate memory for scalars.
     int i=0;
     std::vector<int> index(1);
-    std::vector<ScalarType> rHz( numRHS_ ), rHz_old( numRHS_ ), pAp( numRHS_ ), beta( numRHS_ );
+    std::vector<ScalarType> rHz( numRHS_ );
+    std::vector<ScalarType> rHz_old( numRHS_ );
+    std::vector<ScalarType> pAp( numRHS_ );
+    std::vector<ScalarType> beta( numRHS_ );
     Teuchos::SerialDenseMatrix<int, ScalarType> alpha( numRHS_,numRHS_ );
 
     // Create convenience variables for zero and one.
@@ -477,7 +508,7 @@ namespace Belos {
         index[0] = i;
         Teuchos::RCP<const MV> Z_i = MVT::CloneView( *Z_, index );
         Teuchos::RCP<MV> P_i = MVT::CloneViewNonConst( *P_, index );
-        MVT::MvAddMv( one, *Z_i, beta[i], *P_i, *P_i );       
+        MVT::MvAddMv( one, *Z_i, beta[i], *P_i, *P_i );
       }
 
       // Condition estimate (if needed)


### PR DESCRIPTION
@trilinos/belos

## Motivation
Before this change the CG variants set only the initial residual vector from the problem in the `CGIterationState` structure.
The `Z`, `P` and `AP` member variables were not set. All auxiliary vectors were reallocated on every solve in the `CGIteration` class. 

With this change, all auxiliary vectors are members of the state and are reused or reallocated on subsequent solves.
