### PR TITLE
Framework: AT2 name update

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -35,7 +35,7 @@ jobs:
           with:
             skip_after_successful_duplicate: 'true'
 
-  gcc10-openmpi416-EXPERIMENTAL:
+  gcc10-openmpi4:
     needs: pre-checks
     runs-on: [self-hosted, gcc-10.3.0_openmpi-4.1.6]
     if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}
@@ -221,7 +221,7 @@ jobs:
           echo "https://github.com/trilinos/Trilinos/wiki/Containers" >> $GITHUB_STEP_SUMMARY
           echo "https://gitlab-ex.sandia.gov/trilinos-project/trilinos-containers/-/wikis/Containers-at-Sandia" >> $GITHUB_STEP_SUMMARY
 
-  cuda11-EXPERIMENTAL:
+  cuda11:
     needs: pre-checks
     runs-on: [self-hosted, cuda-11.4.2_gcc-10.3.0_openmpi-4.1.6]
     if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}

--- a/commonTools/framework/github_issue_creator/create_trilinos_github_test_failure_issue_unit_tests.py
+++ b/commonTools/framework/github_issue_creator/create_trilinos_github_test_failure_issue_unit_tests.py
@@ -7,7 +7,6 @@
 
 
 import sys
-import imp
 import shutil
 import unittest
 


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Want the names to be up-to-date as early as possible so that users will have the correct checks on their branches _before_ the check is required.
