### PR TITLE
Tacho : variant-3 solve with OpenMP

### DIFF
--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Driver_Impl.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Driver_Impl.hpp
@@ -142,11 +142,6 @@ void Driver<VT, DT>::setLevelSetOptionDeviceFunctionThreshold(const ordinal_type
 }
 
 template <typename VT, typename DT> void Driver<VT, DT>::setLevelSetOptionAlgorithmVariant(const ordinal_type variant) {
-#if !defined(TACHO_HAVE_CUSPARSE) && !defined(KOKKOS_ENABLE_HIP)
-  if (variant == 3) {
-    TACHO_TEST_FOR_EXCEPTION(true, std::logic_error, "variant 3 requires CuSparse or rocSparce");
-  }
-#endif
   if (variant > 3 || variant < 0) {
    TACHO_TEST_FOR_EXCEPTION(true, std::logic_error, "levelset algorithm variants range from 0 to 3");
   }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_Factory.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_Factory.hpp
@@ -219,6 +219,10 @@ public:
       TACHO_NUMERIC_TOOLS_FACTORY_LEVELSET_BODY(numeric_tools_levelset_var2_type);
       break;
     }
+    case 3: {
+      TACHO_NUMERIC_TOOLS_FACTORY_LEVELSET_BODY(numeric_tools_levelset_var3_type);
+      break;
+    }
     default: {
       TACHO_TEST_FOR_EXCEPTION(true, std::logic_error, "Invalid variant input");
     }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -2412,8 +2412,10 @@ public:
     const ordinal_type m = t.extent(0);
     const ordinal_type nrhs = t.extent(1);
     const ordinal_type ldt = t.stride(1);
+    const ordinal_type old_nrhs = _w_vec.extent(1);
+
     auto &s0 = _h_supernodes(_h_level_sids(pbeg));
-    if (_w_vec.extent(1) != size_t(nrhs)) {
+    if (old_nrhs != nrhs) {
       // expand workspace
       Kokkos::resize(_w_vec, m, nrhs);
     }
@@ -2440,7 +2442,7 @@ public:
     // compute t = L^{-1}*w
     const value_type alpha (1);
     const value_type beta  (0);
-    if (_w_vec.extent(1) != size_t(nrhs)) {
+    if (old_nrhs != nrhs) {
       // attach to Cusparse/Rocsparse data struct
       int ldw = _w_vec.stride(1);
 #if defined(KOKKOS_ENABLE_CUDA)


### PR DESCRIPTION
@trilinos/shylu 

## Motivation

This PR enables `variant 3` solve with OpenMP


## Testing

Tested `variant 3` of chol & lu with Cuda (V100), Hip (Mi250), and OpenMP.

## Additional Information

It is based on a simple sequential SpMV.
