### PR TITLE
Framework: Add upload-artifact step to AT2 jobs

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -116,7 +116,7 @@ jobs:
           NODE_TLS_REJECT_UNAUTHORIZED: 0
         with:
           name: ${{ github.job }}-artifacts
-          path: $AT2_ARTIFACTS_DIR
+          path: /home/runner/artifacts/*
           retention-days: 90
       - name: Summary
         if: ${{ !cancelled() }}
@@ -217,7 +217,7 @@ jobs:
           NODE_TLS_REJECT_UNAUTHORIZED: 0
         with:
           name: ${{ github.job }}-artifacts
-          path: $AT2_ARTIFACTS_DIR
+          path: /home/runner/artifacts/*
           retention-days: 90
       - name: Summary
         if: ${{ !cancelled() }}
@@ -318,7 +318,7 @@ jobs:
           NODE_TLS_REJECT_UNAUTHORIZED: 0
         with:
           name: ${{ github.job }}-artifacts
-          path: $AT2_ARTIFACTS_DIR
+          path: /home/runner/artifacts/*
           retention-days: 90
       - name: Summary
         if: ${{ !cancelled() }}
@@ -416,7 +416,7 @@ jobs:
           NODE_TLS_REJECT_UNAUTHORIZED: 0
         with:
           name: ${{ github.job }}-artifacts
-          path: $AT2_ARTIFACTS_DIR
+          path: /home/runner/artifacts/*
           retention-days: 90
       - name: Summary
         if: ${{ !cancelled() }}

--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -110,6 +110,14 @@ jobs:
             --filename-packageenables ./packageEnables.cmake \
             --max-cores-allowed=29 \
             --num-concurrent-tests=16
+      - name: Upload artifacts
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        env:
+          NODE_TLS_REJECT_UNAUTHORIZED: 0
+        with:
+          name: ${{ github.job }}-artifacts
+          path: /home/runner/artifacts/*
+          retention-days: 90
       - name: Summary
         if: ${{ !cancelled() }}
         shell: bash -l {0}
@@ -203,6 +211,14 @@ jobs:
             --filename-packageenables ./packageEnables.cmake \
             --max-cores-allowed=29 \
             --num-concurrent-tests=16
+      - name: Upload artifacts
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        env:
+          NODE_TLS_REJECT_UNAUTHORIZED: 0
+        with:
+          name: ${{ github.job }}-artifacts
+          path: /home/runner/artifacts/*
+          retention-days: 90
       - name: Summary
         if: ${{ !cancelled() }}
         shell: bash -l {0}
@@ -296,6 +312,14 @@ jobs:
             --max-cores-allowed=56 \
             --num-concurrent-tests=112 \
             --slots-per-gpu=8
+      - name: Upload artifacts
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        env:
+          NODE_TLS_REJECT_UNAUTHORIZED: 0
+        with:
+          name: ${{ github.job }}-artifacts
+          path: /home/runner/artifacts/*
+          retention-days: 90
       - name: Summary
         if: ${{ !cancelled() }}
         shell: bash -l {0}
@@ -386,6 +410,14 @@ jobs:
             --ctest-drop-site sems-cdash-son.sandia.gov/cdash \
             --filename-subprojects ./package_subproject_list.cmake \
             --skip-create-packageenables \
+      - name: Upload artifacts
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        env:
+          NODE_TLS_REJECT_UNAUTHORIZED: 0
+        with:
+          name: ${{ github.job }}-artifacts
+          path: /home/runner/artifacts/*
+          retention-days: 90
       - name: Summary
         if: ${{ !cancelled() }}
         shell: bash -l {0}

--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -116,7 +116,7 @@ jobs:
           NODE_TLS_REJECT_UNAUTHORIZED: 0
         with:
           name: ${{ github.job }}-artifacts
-          path: /home/runner/artifacts/*
+          path: $AT2_ARTIFACTS_DIR
           retention-days: 90
       - name: Summary
         if: ${{ !cancelled() }}
@@ -217,7 +217,7 @@ jobs:
           NODE_TLS_REJECT_UNAUTHORIZED: 0
         with:
           name: ${{ github.job }}-artifacts
-          path: /home/runner/artifacts/*
+          path: $AT2_ARTIFACTS_DIR
           retention-days: 90
       - name: Summary
         if: ${{ !cancelled() }}
@@ -318,7 +318,7 @@ jobs:
           NODE_TLS_REJECT_UNAUTHORIZED: 0
         with:
           name: ${{ github.job }}-artifacts
-          path: /home/runner/artifacts/*
+          path: $AT2_ARTIFACTS_DIR
           retention-days: 90
       - name: Summary
         if: ${{ !cancelled() }}
@@ -416,7 +416,7 @@ jobs:
           NODE_TLS_REJECT_UNAUTHORIZED: 0
         with:
           name: ${{ github.job }}-artifacts
-          path: /home/runner/artifacts/*
+          path: $AT2_ARTIFACTS_DIR
           retention-days: 90
       - name: Summary
         if: ${{ !cancelled() }}

--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -111,6 +111,7 @@ jobs:
             --max-cores-allowed=29 \
             --num-concurrent-tests=16
       - name: Upload artifacts
+        if: success() || failure()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         env:
           NODE_TLS_REJECT_UNAUTHORIZED: 0
@@ -212,6 +213,7 @@ jobs:
             --max-cores-allowed=29 \
             --num-concurrent-tests=16
       - name: Upload artifacts
+        if: success() || failure()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         env:
           NODE_TLS_REJECT_UNAUTHORIZED: 0
@@ -313,6 +315,7 @@ jobs:
             --num-concurrent-tests=112 \
             --slots-per-gpu=8
       - name: Upload artifacts
+        if: success() || failure()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         env:
           NODE_TLS_REJECT_UNAUTHORIZED: 0
@@ -411,6 +414,7 @@ jobs:
             --filename-subprojects ./package_subproject_list.cmake \
             --skip-create-packageenables \
       - name: Upload artifacts
+        if: success() || failure()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         env:
           NODE_TLS_REJECT_UNAUTHORIZED: 0


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Want to directly provide the container recipe for the images used for each AutoTester2 job.

Adds a GitHub Actions Marketplace action for uploading artfiacts inside GitHub Runners to the GitHub Actions workflow interface. The added step uploads files from a specific directory inside the containers meant for generated artifacts.

https://github.com/actions/upload-artifact


## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->
- trilinos/containers#10
- trilinos/containers#11


<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
- [TRILFRAME-691](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-691)

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->

- Self-testing through AT2. Before merging, observe that the AT2 GitHub Actions jobs provides an artifact Dockerfile

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
