### PR TITLE
ROL: Fix missing switch-case compilation error in OptimizationSolver

### DIFF
--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -76,6 +76,7 @@ set(promoted_warnings
     sequence-point
     sign-compare
     strict-aliasing
+    switch
     type-limits
     uninitialized
     unused-function

--- a/packages/rol/adapters/sacado/test/test_01.cpp
+++ b/packages/rol/adapters/sacado/test/test_01.cpp
@@ -117,6 +117,7 @@ int main(int argc, char *argv[]) {
         break;
 
         case TYPE_LAST:
+        default:
           ROL_TEST_FOR_EXCEPTION(true,std::invalid_argument,"Error: Unsupported problem type!");
         break;
       }

--- a/packages/rol/src/algorithm/ROL_OptimizationSolver.hpp
+++ b/packages/rol/src/algorithm/ROL_OptimizationSolver.hpp
@@ -219,6 +219,7 @@ public:
         output_ = algo_->run(*x_,*g_,*l_,*c_,*obj_,*con_,*bnd_,true,outStream);
       break;
       case TYPE_LAST:
+      default:
         ROL_TEST_FOR_EXCEPTION(true,std::invalid_argument,
           "Error in OptimizationSolver::solve() : Unsupported problem type");
     }


### PR DESCRIPTION
@trilinos/rol 

Add in missing default in switch-case to report that `TYPE_P` is not supported in `OptimizationSolver`.

This closes https://github.com/trilinos/Trilinos/issues/13765.

I should clarify that there's still the issue of hooking up `TYPE_P` in the `OptimizationSolver`, which I have added as https://github.com/trilinos/Trilinos/issues/13767.

