### PR TITLE
Framework: Only disable GCC warnings for GCC

### DIFF
--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -95,4 +95,6 @@ elseif("${Trilinos_WARNINGS_MODE}" STREQUAL "ERROR")
     disable_warnings_for_deprecated_packages()
 endif()
 
-disable_warnings("${explicitly_disabled_warnings}")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    disable_warnings("${explicitly_disabled_warnings}")
+endif()


### PR DESCRIPTION
@trilinos/framework 

## Motivation
If the compiler in use is not GCC, disabling GCC warnings can cause compile errors.

## Related Issues
#13744 


## Testing
I configured with and without the GCC compiler and the output looked as expected.