### PR TITLE
Tpetra: Remove unusued data structure MueLu::LinkedList

### DIFF
--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -2074,7 +2074,7 @@ void BlockCrsMatrix<Scalar, LO, GO, Node>::localApplyBlockNoTrans(
     // then all their owning process ranks, and then the values.
     if(exports.extent(0) != totalNumBytes)
     {
-      const std::string oldLabel = exports.d_view.label ();
+      const std::string oldLabel = exports.view_device().label ();
       const std::string newLabel = (oldLabel == "") ? "exports" : oldLabel;
       exports = Kokkos::DualView<packet_type*, buffer_device_type>(newLabel, totalNumBytes);
     }

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -365,7 +365,7 @@ namespace Tpetra {
             const Teuchos::RCP<Teuchos::ParameterList>& params) :
     dist_object_type (rowMap)
     , rowMap_ (rowMap)
-    , k_numAllocPerRow_ (numEntPerRow.h_view)
+    , k_numAllocPerRow_ (numEntPerRow.view_host())
     , numAllocForAllRows_ (0)
   {
     const char tfecfFuncName[] =
@@ -382,7 +382,7 @@ namespace Tpetra {
 
     if (debug_) {
       for (size_t r = 0; r < lclNumRows; ++r) {
-        const size_t curRowCount = numEntPerRow.h_view(r);
+        const size_t curRowCount = numEntPerRow.view_host()(r);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (curRowCount == Teuchos::OrdinalTraits<size_t>::invalid (),
            std::invalid_argument, "numEntPerRow(" << r << ") "
@@ -405,7 +405,7 @@ namespace Tpetra {
     dist_object_type (rowMap)
     , rowMap_ (rowMap)
     , colMap_ (colMap)
-    , k_numAllocPerRow_ (numEntPerRow.h_view)
+    , k_numAllocPerRow_ (numEntPerRow.view_host())
     , numAllocForAllRows_ (0)
   {
     const char tfecfFuncName[] =
@@ -422,7 +422,7 @@ namespace Tpetra {
 
     if (debug_) {
       for (size_t r = 0; r < lclNumRows; ++r) {
-        const size_t curRowCount = numEntPerRow.h_view(r);
+        const size_t curRowCount = numEntPerRow.view_host()(r);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (curRowCount == Teuchos::OrdinalTraits<size_t>::invalid (),
            std::invalid_argument, "numEntPerRow(" << r << ") "

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -6269,7 +6269,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       // Allocate 'exports', and copy exports_a back into it.
       const size_t newAllocSize = static_cast<size_t> (exports_a.size ());
       if (static_cast<size_t> (exports.extent (0)) < newAllocSize) {
-        const std::string oldLabel = exports.d_view.label ();
+        const std::string oldLabel = exports.view_device().label ();
         const std::string newLabel = (oldLabel == "") ? "exports" : oldLabel;
         exports = exports_type (newLabel, newAllocSize);
       }
@@ -6572,7 +6572,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     if (static_cast<size_t> (exports.extent (0)) < allocSize) {
       using exports_type = Kokkos::DualView<char*, buffer_device_type>;
 
-      const std::string oldLabel = exports.d_view.label ();
+      const std::string oldLabel = exports.view_device().label ();
       const std::string newLabel = (oldLabel == "") ? "exports" : oldLabel;
       exports = exports_type (newLabel, allocSize);
     }

--- a/packages/tpetra/core/src/Tpetra_Details_DualViewUtil.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DualViewUtil.hpp
@@ -42,19 +42,15 @@ makeDualViewFromOwningHostView
   using execution_space = typename DeviceType::execution_space;
   using dual_view_type = Kokkos::DualView<ElementType*, DeviceType>;
 
-  if (dv.extent (0) == hostView.extent (0)) {
-    // We don't need to reallocate the device View.
-    dv.clear_sync_state ();
-    dv.modify_host ();
-    dv.h_view = hostView;
-    dv.sync_device ();
-  }
-  else {
-    auto devView = Kokkos::create_mirror_view (DeviceType (), hostView);
-    // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
-    Kokkos::deep_copy (execution_space(), devView, hostView);
-    dv = dual_view_type (devView, hostView);
-  }
+  typename Kokkos::DualView<ElementType*, DeviceType>::t_dev devView;
+  if (dv.extent (0) == hostView.extent (0))
+    devView = dv.view_device();
+  else
+    devView = Kokkos::create_mirror_view (DeviceType (), hostView);
+  // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+  Kokkos::deep_copy (execution_space(), devView, hostView);
+  dv = dual_view_type (devView, hostView);
+  execution_space().fence();
 }
 
 template<class ElementType, class DeviceType>

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
@@ -820,7 +820,7 @@ packCrsGraph (const CrsGraph<LO, GO, NT>& sourceGraph,
   View<packet_type*, HostSpace, MemoryUnmanaged>
     exports_h (exports.getRawPtr (), exports.size ());
   // DEEP_COPY REVIEW - DEVICE-TO-HOST
-  Kokkos::deep_copy (execution_space(), exports_h, exports_dv.d_view);
+  Kokkos::deep_copy (execution_space(), exports_h, exports_dv.view_device());
   execution_space().fence();
 }
 

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
@@ -889,7 +889,7 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
   Kokkos::View<char*, host_dev_type> exports_h (exports.getRawPtr (),
                                                 exports.size ());
   // DEEP_COPY REVIEW - DEVICE-TO-HOST
-  Kokkos::deep_copy (device_exec_space(), exports_h, exports_dv.d_view);
+  Kokkos::deep_copy (device_exec_space(), exports_h, exports_dv.view_device());
 }
 
 template<typename ST, typename LO, typename GO, typename NT>

--- a/packages/tpetra/core/src/Tpetra_Details_reallocDualViewIfNeeded.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_reallocDualViewIfNeeded.hpp
@@ -72,7 +72,7 @@ reallocDualViewIfNeeded (Kokkos::DualView<ValueType*, DeviceType>& dv,
     }
     dv = dual_view_type (); // free first, in order to save memory
     // If current size is 0, the DualView's Views likely lack a label.
-    dv = dual_view_type (curSize == 0 ? newLabel : dv.d_view.label (), newSize);
+    dv = dual_view_type (curSize == 0 ? newLabel : dv.view_device().label (), newSize);
     return true; // we did reallocate
   }
   else {
@@ -81,7 +81,7 @@ reallocDualViewIfNeeded (Kokkos::DualView<ValueType*, DeviceType>& dv,
         execution_space().fence (); // keep this fence to respect needFenceBeforeRealloc
       }
       // If current size is 0, the DualView's Views likely lack a label.
-      dv = dual_view_type (curSize == 0 ? newLabel : dv.d_view.label (), 0);
+      dv = dual_view_type (curSize == 0 ? newLabel : dv.view_device().label (), 0);
       return true; // we did reallocate
     }
     // Instead of writing curSize >= tooBigFactor * newSize, express
@@ -95,12 +95,13 @@ reallocDualViewIfNeeded (Kokkos::DualView<ValueType*, DeviceType>& dv,
       }
       dv = dual_view_type (); // free first, in order to save memory
       // If current size is 0, the DualView's Views likely lack a label.
-      dv = dual_view_type (curSize == 0 ? newLabel : dv.d_view.label (), newSize);
+      dv = dual_view_type (curSize == 0 ? newLabel : dv.view_device().label (), newSize);
       return true; // we did reallocate
     }
     else {
-      dv.d_view = Kokkos::subview (dv.d_view, range_type (0, newSize));
-      dv.h_view = Kokkos::subview (dv.h_view, range_type (0, newSize));
+      auto d_view = Kokkos::subview (dv.view_device(), range_type (0, newSize));
+      auto h_view = Kokkos::subview (dv.view_host(), range_type (0, newSize));
+      dv = Kokkos::DualView<ValueType*, DeviceType>(d_view, h_view);
       return false; // we did not reallocate
     }
   }

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -863,7 +863,7 @@ namespace Tpetra {
       (LDA < lclNumRows, std::invalid_argument, "Map and DualView origView "
        "do not match.  LDA = " << LDA << " < this->getLocalLength() = " <<
        lclNumRows << ".  origView.extent(0) = " << origView.extent(0)
-       << ", origView.stride(1) = " << origView.d_view.stride(1) << ".");
+       << ", origView.stride(1) = " << origView.view_device().stride(1) << ".");
 
     if (whichVectors.size () == 1) {
       // If whichVectors has only one entry, we don't need to bother
@@ -1049,10 +1049,10 @@ namespace Tpetra {
   aliases(const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& other) const
   {
     //Don't actually get a view, just get pointers.
-    auto thisData = view_.getDualView().h_view.data();
-    auto otherData = other.view_.getDualView().h_view.data();
-    size_t thisSpan = view_.getDualView().h_view.span();
-    size_t otherSpan = other.view_.getDualView().h_view.span();
+    auto thisData = view_.getDualView().view_host().data();
+    auto otherData = other.view_.getDualView().view_host().data();
+    size_t thisSpan = view_.getDualView().view_host().span();
+    size_t otherSpan = other.view_.getDualView().view_host().span();
     return (otherData <= thisData && thisData < otherData + otherSpan)
       || (thisData <= otherData && otherData < thisData + thisSpan);
   }
@@ -1286,7 +1286,7 @@ namespace Tpetra {
         Kokkos::DualView<size_t*, device_type> tmpTgt ("tgtWhichVecs", numCols);
         tmpTgt.modify_host ();
         for (size_t j = 0; j < numCols; ++j) {
-          tmpTgt.h_view(j) = j;
+          tmpTgt.view_host()(j) = j;
         }
         if (! copyOnHost) {
           tmpTgt.sync_device ();
@@ -1311,7 +1311,7 @@ namespace Tpetra {
         Kokkos::DualView<size_t*, device_type> tmpSrc ("srcWhichVecs", numCols);
         tmpSrc.modify_host ();
         for (size_t j = 0; j < numCols; ++j) {
-          tmpSrc.h_view(j) = j;
+          tmpSrc.view_host()(j) = j;
         }
         if (! copyOnHost) {
           tmpSrc.sync_device ();
@@ -1804,7 +1804,7 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
         (newSize > 0)) {
 
       size_t offset = getLocalLength () - newSize;
-      reallocated = this->imports_.d_view.data() != view_.getDualView().d_view.data() + offset;
+      reallocated = this->imports_.view_device().data() != view_.getDualView().view_device().data() + offset;
       if (reallocated) {
         typedef std::pair<size_t, size_t> range_type;
         this->imports_ = DV(view_.getDualView(),
@@ -1864,8 +1864,8 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
   bool
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   importsAreAliased() {
-    return (this->imports_.d_view.data() + this->imports_.d_view.extent(0) ==
-            view_.getDualView().d_view.data() + view_.getDualView().d_view.extent(0));
+    return (this->imports_.view_device().data() + this->imports_.view_device().extent(0) ==
+            view_.getDualView().view_device().data() + view_.getDualView().view_device().extent(0));
   }
 
 
@@ -2885,7 +2885,7 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
     k_alphas_type k_alphas ("alphas::tmp", numAlphas);
     k_alphas.modify_host ();
     for (size_t i = 0; i < numAlphas; ++i) {
-      k_alphas.h_view(i) = static_cast<impl_scalar_type> (alphas[i]);
+      k_alphas.view_host()(i) = static_cast<impl_scalar_type> (alphas[i]);
     }
     k_alphas.sync_device ();
     // Invoke the scale() overload that takes a device View of coefficients.
@@ -3709,9 +3709,9 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
       const size_t newSize = X.imports_.extent (0) / numCols;
       const size_t offset = jj*newSize;
       auto newImports = X.imports_;
-      newImports.d_view = subview (X.imports_.d_view,
+      newImports.view_device() = subview (X.imports_.view_device(),
                                    range_type (offset, offset+newSize));
-      newImports.h_view = subview (X.imports_.h_view,
+      newImports.view_host() = subview (X.imports_.view_host(),
                                    range_type (offset, offset+newSize));
       this->imports_ = newImports;
     }
@@ -3719,9 +3719,9 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
       const size_t newSize = X.exports_.extent (0) / numCols;
       const size_t offset = jj*newSize;
       auto newExports = X.exports_;
-      newExports.d_view = subview (X.exports_.d_view,
+      newExports.view_device() = subview (X.exports_.view_device(),
                                    range_type (offset, offset+newSize));
-      newExports.h_view = subview (X.exports_.h_view,
+      newExports.view_host() = subview (X.exports_.view_host(),
                                    range_type (offset, offset+newSize));
       this->exports_ = newExports;
     }
@@ -4488,7 +4488,7 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
     const size_t col = isConstantStride () ? j : whichVectors_[j];
     col_dual_view_type X_col =
       Kokkos::subview (view_, Kokkos::ALL (), col);
-    return Kokkos::Compat::persistingView (X_col.d_view);
+    return Kokkos::Compat::persistingView (X_col.view_device());
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/tpetra/core/test/Map/Map_LocalMap.cpp
+++ b/packages/tpetra/core/test/Map/Map_LocalMap.cpp
@@ -304,7 +304,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( LocalMap, KokkosView, LO, GO, NT )
 
     dual_view_t my_dual_view("test view with local maps",1);
 
-    my_dual_view.h_view(0) = local_map_t();
+    my_dual_view.view_host()(0) = local_map_t();
 
     my_dual_view.sync_device();
 }

--- a/packages/tpetra/core/test/MultiVector/MV_Kokkos_DualView_subview.cpp
+++ b/packages/tpetra/core/test/MultiVector/MV_Kokkos_DualView_subview.cpp
@@ -72,10 +72,10 @@ namespace { // (anonymous)
 
     TEST_EQUALITY_CONST( X.extent (0), numRows );
     TEST_EQUALITY_CONST( X.extent (1), numCols );
-    TEST_EQUALITY_CONST( X.d_view.extent (0), numRows );
-    TEST_EQUALITY_CONST( X.d_view.extent (1), numCols );
-    TEST_EQUALITY_CONST( X.h_view.extent (0), numRows );
-    TEST_EQUALITY_CONST( X.h_view.extent (1), numCols );
+    TEST_EQUALITY_CONST( X.view_device().extent (0), numRows );
+    TEST_EQUALITY_CONST( X.view_device().extent (1), numCols );
+    TEST_EQUALITY_CONST( X.view_host().extent (0), numRows );
+    TEST_EQUALITY_CONST( X.view_host().extent (1), numCols );
     out << endl;
 
     newNumRows = numRows;
@@ -91,10 +91,10 @@ namespace { // (anonymous)
 
     TEST_EQUALITY_CONST( X_sub.extent (0), newNumRows );
     TEST_EQUALITY_CONST( X_sub.extent (1), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.d_view.extent (0), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.d_view.extent (1), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.h_view.extent (0), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.h_view.extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.view_device().extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.view_device().extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.view_host().extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.view_host().extent (1), newNumCols );
     out << endl;
 
     newNumRows = numRows;
@@ -110,10 +110,10 @@ namespace { // (anonymous)
 
     TEST_EQUALITY_CONST( X_sub.extent (0), newNumRows );
     TEST_EQUALITY_CONST( X_sub.extent (1), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.d_view.extent (0), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.d_view.extent (1), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.h_view.extent (0), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.h_view.extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.view_device().extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.view_device().extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.view_host().extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.view_host().extent (1), newNumCols );
     out << endl;
 
     newNumRows = 0;
@@ -129,10 +129,10 @@ namespace { // (anonymous)
 
     TEST_EQUALITY_CONST( X_sub.extent (0), newNumRows );
     TEST_EQUALITY_CONST( X_sub.extent (1), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.d_view.extent (0), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.d_view.extent (1), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.h_view.extent (0), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.h_view.extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.view_device().extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.view_device().extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.view_host().extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.view_host().extent (1), newNumCols );
     out << endl;
 
     newNumRows = 0;
@@ -150,10 +150,10 @@ namespace { // (anonymous)
 
     TEST_EQUALITY_CONST( X_sub.extent (0), newNumRows );
     TEST_EQUALITY_CONST( X_sub.extent (1), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.d_view.extent (0), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.d_view.extent (1), newNumCols );
-    TEST_EQUALITY_CONST( X_sub.h_view.extent (0), newNumRows );
-    TEST_EQUALITY_CONST( X_sub.h_view.extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.view_device().extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.view_device().extent (1), newNumCols );
+    TEST_EQUALITY_CONST( X_sub.view_host().extent (0), newNumRows );
+    TEST_EQUALITY_CONST( X_sub.view_host().extent (1), newNumCols );
     out << endl;
   }
 

--- a/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
@@ -4185,7 +4185,7 @@ namespace {
       X->normInf (norms.template view<device_type> ());
       norms.sync_host ();
       for (size_t k = 0; k < numVecs; ++k) {
-        TEST_EQUALITY_CONST( norms.h_view(k), ONE );
+        TEST_EQUALITY_CONST( norms.view_host()(k), ONE );
       }
     }
   }
@@ -4252,7 +4252,7 @@ namespace {
     X_gbl.normInf (norms.template view<device_type> ());
     norms.sync_host ();
     for (size_t k = 0; k < numVecs; ++k) {
-      TEST_EQUALITY_CONST( norms.h_view(k), ONE );
+      TEST_EQUALITY_CONST( norms.view_host()(k), ONE );
     }
 
     // Now change the values in X_lcl.  X_gbl should see them.  Just
@@ -4269,7 +4269,7 @@ namespace {
     X_gbl.normInf (norms.template view<device_type> ());
     norms.sync_host ();
     for (size_t k = 0; k < numVecs; ++k) {
-      TEST_EQUALITY_CONST( norms.h_view(k), TWO );
+      TEST_EQUALITY_CONST( norms.view_host()(k), TWO );
     }
   }
 
@@ -4375,7 +4375,7 @@ namespace {
     X_gbl.normInf (norms.template view<device_type> ());
     norms.sync_host ();
     for (size_t k = 0; k < numVecs; ++k) {
-      TEST_EQUALITY_CONST( norms.h_view(k), ONE );
+      TEST_EQUALITY_CONST( norms.view_host()(k), ONE );
     }
 
     {
@@ -4405,7 +4405,7 @@ namespace {
     X_gbl.normInf (norms.template view<device_type> ());
     norms.sync_host ();
     for (size_t k = 0; k < numVecs; ++k) {
-      TEST_EQUALITY_CONST( norms.h_view(k), TWO );
+      TEST_EQUALITY_CONST( norms.view_host()(k), TWO );
     }
 
     {

--- a/packages/tpetra/core/test/Utils/StaticView.cpp
+++ b/packages/tpetra/core/test/Utils/StaticView.cpp
@@ -507,19 +507,19 @@ namespace { // (anonymous)
           (row_size, col_size);
         TEST_ASSERT( size_t (view.extent (0)) == row_size );
         TEST_ASSERT( size_t (view.extent (1)) == col_size );
-        TEST_ASSERT( size_t (view.d_view.extent (0)) == row_size );
-        TEST_ASSERT( size_t (view.d_view.extent (1)) == col_size );
-        TEST_ASSERT( size_t (view.h_view.extent (0)) == row_size );
-        TEST_ASSERT( size_t (view.h_view.extent (1)) == col_size );
+        TEST_ASSERT( size_t (view.view_device().extent (0)) == row_size );
+        TEST_ASSERT( size_t (view.view_device().extent (1)) == col_size );
+        TEST_ASSERT( size_t (view.view_host().extent (0)) == row_size );
+        TEST_ASSERT( size_t (view.view_host().extent (1)) == col_size );
         TEST_ASSERT( ! (view.need_sync_device () && view.need_sync_host ()) );
 
         if (row_size != 0 && col_size != 0) {
-          const ValueType* rawPtr_d = view.d_view.data ();
+          const ValueType* rawPtr_d = view.view_device().data ();
           TEST_ASSERT( rawPtr_d != nullptr );
           TEST_ASSERT( reinterpret_cast<size_t> (rawPtr_d) %
                        sizeof (ValueType) == 0 );
 
-          const ValueType* rawPtr_h = view.h_view.data ();
+          const ValueType* rawPtr_h = view.view_host().data ();
           TEST_ASSERT( rawPtr_h != nullptr );
           TEST_ASSERT( reinterpret_cast<size_t> (rawPtr_h) %
                        sizeof (ValueType) == 0 );
@@ -536,8 +536,8 @@ namespace { // (anonymous)
             Kokkos::subview (referenceView,
                              std::pair<size_t, size_t> (0, row_size),
                              std::pair<size_t, size_t> (0, col_size));
-          TEST_ASSERT( refView.d_view.data () != rawPtr_d );
-          TEST_ASSERT( refView.h_view.data () != rawPtr_h );
+          TEST_ASSERT( refView.view_device().data () != rawPtr_d );
+          TEST_ASSERT( refView.view_host().data () != rawPtr_h );
 
           refView.clear_sync_state ();
           view.clear_sync_state ();
@@ -555,30 +555,30 @@ namespace { // (anonymous)
           if (ok_to_test_sync) {
             refView.modify_host ();
             view.modify_host ();
-            view2dIota (view.h_view, initVal);
-            view2dIota (refView.h_view, initVal);
-            TEST_ASSERT( view2dSame (view.h_view, refView.h_view) );
+            view2dIota (view.view_host(), initVal);
+            view2dIota (refView.view_host(), initVal);
+            TEST_ASSERT( view2dSame (view.view_host(), refView.view_host()) );
 
             refView.sync_device ();
             view.sync_device ();
 
             refView.modify_device ();
             view.modify_device ();
-            view2dIota (view.d_view, initVal);
-            view2dIota (refView.d_view, initVal);
-            TEST_ASSERT( view2dSame (view.d_view, refView.d_view) );
+            view2dIota (view.view_device(), initVal);
+            view2dIota (refView.view_device(), initVal);
+            TEST_ASSERT( view2dSame (view.view_device(), refView.view_device()) );
           }
           else {
             refView.modify_device ();
             view.modify_device ();
-            view2dIota (view.d_view, initVal);
-            view2dIota (refView.d_view, initVal);
-            TEST_ASSERT( view2dSame (view.d_view, refView.d_view) );
+            view2dIota (view.view_device(), initVal);
+            view2dIota (refView.view_device(), initVal);
+            TEST_ASSERT( view2dSame (view.view_device(), refView.view_device()) );
           }
         }
 
-        TEST_NOTHROW( out << "Device View label: " << view.d_view.label () );
-        TEST_NOTHROW( out << "Host View label: " << view.h_view.label () );
+        TEST_NOTHROW( out << "Device View label: " << view.view_device().label () );
+        TEST_NOTHROW( out << "Host View label: " << view.view_host().label () );
       }
     }
   }

--- a/packages/tpetra/core/test/Utils/TpetraUtils_WrappedDualViewNull.cpp
+++ b/packages/tpetra/core/test/Utils/TpetraUtils_WrappedDualViewNull.cpp
@@ -44,8 +44,8 @@ TEUCHOS_UNIT_TEST(WrappedDualView, InitFromNull) {
                                    viewNull);
 
     dualview_t dvNull(viewNull, viewNull_mirror);
-    size_t use_h = dvNull.h_view.use_count();
-    size_t use_d = dvNull.d_view.use_count();
+    size_t use_h = dvNull.view_host().use_count();
+    size_t use_d = dvNull.view_device().use_count();
 
     std::cout << "Null DualView:     "
               << "host.use_count = " << use_h << ";  "


### PR DESCRIPTION
@trilinos/tpetra

## Motivation
https://github.com/kokkos/kokkos/pull/7716 proposes to deprecate the ability to access `DualView`'s `h_view` and `d_view` members directly since modifying the allocations can get perturbed the `DualView`'s internal status. This pull request replaces all places in `Tpetra` that use these members directly, in most places, verbatim with `view_device` resp. `view_host`.

## Related Issues
Related to https://github.com/kokkos/kokkos/pull/7716.

## Stakeholder Feedback

## Testing
Compiling Trilinos with `Tpetra` enabled with the OpenMP backend and running the `Tpetra` tests.