### PR TITLE
Tpetra: Fix typo in CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::isIdenticalTo()

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -7465,7 +7465,7 @@ namespace Tpetra {
     output = this->haveLocalConstants_ == graph.haveLocalConstants_ ? output : false;
     output = this->haveGlobalConstants_ == graph.haveGlobalConstants_ ? output : false;
     output = this->haveLocalOffRankOffsets_ == graph.haveLocalOffRankOffsets_ ? output : false;
-    output = this->sortGhostsAssociatedWithEachProcessor_ == this->sortGhostsAssociatedWithEachProcessor_ ? output : false;
+    output = this->sortGhostsAssociatedWithEachProcessor_ == graph.sortGhostsAssociatedWithEachProcessor_ ? output : false;
 
     // Compare nonlocals_ -- std::map<GlobalOrdinal, std::vector<GlobalOrdinal> >
     // nonlocals_ isa std::map<GO, std::vector<GO> >


### PR DESCRIPTION
@trilinos/tpetra

## Motivation
The comparison fixed here was always true. The context makes it clear that the code meant to compare the current object with `graph`.

## Testing
The `Tpetra` unit tests passed with this change.

Signed-off-by: Daniel Arndt <arndtd@ornl.gov>