### PR TITLE
Zoltan2: Don't access DualView's [h|d]_view directly 

### DIFF
--- a/packages/zoltan2/core/src/input/Zoltan2_BasicKokkosIdentifierAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_BasicKokkosIdentifierAdapter.hpp
@@ -122,12 +122,12 @@ BasicKokkosIdentifierAdapter<User>::BasicKokkosIdentifierAdapter(
     Kokkos::View<scalar_t **, device_t> &weights)
 {
   idsView_ = Kokkos::DualView<gno_t *, device_t>("idsView_", ids.extent(0));
-  Kokkos::deep_copy(idsView_.h_view, ids);
+  Kokkos::deep_copy(idsView_.view_host(), ids);
 
   weightsView_ = Kokkos::DualView<scalar_t **, device_t>("weightsView_",
                                                          weights.extent(0),
                                                          weights.extent(1));
-  Kokkos::deep_copy(weightsView_.h_view, weights);
+  Kokkos::deep_copy(weightsView_.view_host(), weights);
 
   weightsView_.modify_host();
   weightsView_.sync_host();

--- a/packages/zoltan2/sphynx/src/Zoltan2_Sphynx.hpp
+++ b/packages/zoltan2/sphynx/src/Zoltan2_Sphynx.hpp
@@ -441,7 +441,7 @@ namespace Zoltan2 {
 
         // D^{-1/2}
         dual_view_t dv ("MV::DualView", numRows, 1);
-        auto deginvsqrt = dv.d_view;
+        auto deginvsqrt = dv.view_device();
 
         // Get the diagonal offsets
         offset_view_t diagOffsets(Kokkos::view_alloc("Diag Offsets", Kokkos::WithoutInitializing), numRows);

--- a/packages/zoltan2/test/core/partition/mj_backwardcompat.cpp
+++ b/packages/zoltan2/test/core/partition/mj_backwardcompat.cpp
@@ -134,7 +134,7 @@ public:
       kokkos_gids = view_ids_t(
         Kokkos::ViewAllocateWithoutInitializing("gids"), nids);
 
-      auto host_gids = kokkos_gids.h_view;
+      auto host_gids = kokkos_gids.view_host();
       for(size_t n = 0; n < nids; ++n) {
         host_gids(n) = gids_[n];
       }
@@ -150,7 +150,7 @@ public:
       typedef Kokkos::DualView<scalar_t **, device_t> view_weights_t;
       kokkos_weights = view_weights_t(
         Kokkos::ViewAllocateWithoutInitializing("weights"), nids, 0);
-      auto host_kokkos_weights = kokkos_weights.h_view;
+      auto host_kokkos_weights = kokkos_weights.view_host();
       for(size_t n = 0; n < nids; ++n) {
         host_kokkos_weights(n,0) = weights_[n];
       }
@@ -165,7 +165,7 @@ public:
       typedef Kokkos::DualView<scalar_t **, Kokkos::LayoutLeft, device_t> kokkos_coords_t;
       kokkos_coords = kokkos_coords_t(
         Kokkos::ViewAllocateWithoutInitializing("coords"), nids, dim);
-      auto host_kokkos_coords = kokkos_coords.h_view;
+      auto host_kokkos_coords = kokkos_coords.view_host();
 
       for(size_t n = 0; n < nids; ++n) {
         for(int idx = 0; idx < dim; ++idx) {
@@ -190,7 +190,7 @@ public:
     ids = kokkos_gids.template view<device_t>();
   }
 
-  int getNumWeightsPerID() const { return (kokkos_weights.h_view.size() != 0); }
+  int getNumWeightsPerID() const { return (kokkos_weights.view_host().size() != 0); }
 
   void getWeightsView(const scalar_t *&wgt, int &stride,
                       int idx = 0) const override


### PR DESCRIPTION
@trilinos/zoltan2

## Motivation
https://github.com/kokkos/kokkos/pull/7716 proposes to deprecate the ability to access `DualView`'s `h_view` and `d_view` members directly since modifying the allocations can get perturbed the `DualView`'s internal status. This pull request replaces all places in `Zoltan2` that use these members directly, in most places, verbatim with `view_device` resp. `view_host`.

## Related Issues
Related to https://github.com/kokkos/kokkos/pull/7716.

Signed-off-by: Daniel Arndt <arndtd@ornl.gov>