### PR TITLE
STK: Don't access DualView's [h|d]_view directly

### DIFF
--- a/packages/stk/stk_unit_tests/stk_mesh/ngp/NgpUnitTestUtils.hpp
+++ b/packages/stk/stk_unit_tests/stk_mesh/ngp/NgpUnitTestUtils.hpp
@@ -29,7 +29,7 @@ DualViewType create_dualview(const std::string& name, unsigned size)
 {
   DualViewType result(name, size);
 
-  Kokkos::deep_copy(result.h_view, 0);
+  Kokkos::deep_copy(result.view_host(), 0);
   result.template modify<typename DualViewType::host_mirror_space>();
   result.template sync<typename DualViewType::execution_space>();
 

--- a/packages/stk/stk_unit_tests/stk_mesh/ngp/UnitTestNgp.cpp
+++ b/packages/stk/stk_unit_tests/stk_mesh/ngp/UnitTestNgp.cpp
@@ -44,14 +44,14 @@ void test_view_of_fields(const stk::mesh::BulkData& bulk,
   Kokkos::parallel_for(stk::ngp::DeviceRangePolicy(0, 2),
                        KOKKOS_LAMBDA(const unsigned& i)
                        {
-                         result.d_view(i) = fields(i).get_ordinal();
+                         result.view_device()(i) = fields(i).get_ordinal();
                        });
 
   result.modify<UnsignedDualViewType::execution_space>();
   result.sync<UnsignedDualViewType::host_mirror_space>();
 
-  EXPECT_EQ(hostFields(0).get_ordinal(), result.h_view(0));
-  EXPECT_EQ(hostFields(1).get_ordinal(), result.h_view(1));
+  EXPECT_EQ(hostFields(0).get_ordinal(), result.view_host()(0));
+  EXPECT_EQ(hostFields(1).get_ordinal(), result.view_host()(1));
 
 #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP)
   for (unsigned i = 0; i < 2; ++i) {


### PR DESCRIPTION
@trilinos/stk

## Motivation
https://github.com/kokkos/kokkos/pull/7716 proposes to deprecate the ability to access `DualView`'s `h_view` and `d_view` members directly since modifying the allocations can get perturbed the `DualView`'s internal status. This pull request replaces all places in `STK` that use these members directly, in most places, verbatim with `view_device` resp. `view_host`.

## Related Issues
Related to https://github.com/kokkos/kokkos/pull/7716.

Signed-off-by: Daniel Arndt <arndtd@ornl.gov>