### PR TITLE
Belos: Don't access DualView's [h|d]_view directly

### DIFF
--- a/packages/belos/tpetra/src/BelosMultiVecTraits_Tpetra.hpp
+++ b/packages/belos/tpetra/src/BelosMultiVecTraits_Tpetra.hpp
@@ -85,8 +85,8 @@ makeStaticLocalMultiVector (const MultiVectorType& gblMv,
     // even if the scalar type doesn't define it; it just returns some
     // undefined value in the latter case.
     const IST nan = Kokkos::ArithTraits<IST>::nan ();
-    Kokkos::deep_copy (dv.d_view, nan);
-    Kokkos::deep_copy (dv.h_view, nan);
+    Kokkos::deep_copy (dv.view_device(), nan);
+    Kokkos::deep_copy (dv.view_host(), nan);
   }
   return MultiVectorType (lclMap, dv);
 }


### PR DESCRIPTION
@trilinos/belos

## Motivation
https://github.com/kokkos/kokkos/pull/7716 proposes to deprecate the ability to access `DualView`'s `h_view` and `d_view` members directly since modifying the allocations can get perturbed the `DualView`'s internal status. This pull request replaces all places in `Belos` that use these members directly, in most places, verbatim with `view_device` resp. `view_host`.

## Related Issues
Related to https://github.com/kokkos/kokkos/pull/7716.

Signed-off-by: Daniel Arndt <arndtd@ornl.gov>