### PR TITLE
Epetra: Missing Tutorial Code

### DIFF
--- a/packages/epetra/doc/Doxyfile.options
+++ b/packages/epetra/doc/Doxyfile.options
@@ -2,7 +2,7 @@
 # Include the global look and feel options
 #
 @INCLUDE_PATH          = $(TRILINOS_HOME)/packages
-@INCLUDE               = common/Doxyfile
+@INCLUDE               = ../../common/Doxyfile
 #
 # Package options
 #

--- a/packages/epetra/doc/DoxyfileWeb
+++ b/packages/epetra/doc/DoxyfileWeb
@@ -51,6 +51,12 @@ INPUT                  = ../src ../../aztecoo/src index.doc \
 
 FILE_PATTERNS          = E*.h
 
-EXAMPLE_PATH           = ../example/petra_power_method
+EXAMPLE_PATH           = ../example/petra_power_method/cxx_main.cpp \
+                         ../example/Lessons/Lesson01-Init \
+                         ../example/Lessons/Lesson02-Map-Vector \
+                         ../example/Lessons/Lesson03-Power-Method \
+                         ../example/Lessons/Lesson04-Sparse-Matrix-Fill \
+                         ../example/Lessons/Lesson05-Redistribution
+
 
 GENERATE_TAGFILE       = ../../common/tag_files/epetra.tag

--- a/packages/epetra/doc/build_docs
+++ b/packages/epetra/doc/build_docs
@@ -13,14 +13,10 @@ echo
 
 doxygen DoxyfileWeb
 
-echo
-echo "Generating epetra/thyra doxygen documentation ..."
-echo
+# --  Uncomment below if you want 
+# --  "Epetra Package Browser (Single Doxygen Collection)"
+#echo
+#echo "Generating doxygen browser documentation for all of epetra ..."
+#echo
 
-doxygen ../thyra/doc/Doxyfile
-
-echo
-echo "Generating doxygen browser documentation for all of epetra ..."
-echo
-
-doxygen ../browser/doc/Doxyfile
+#doxygen ../browser/doc/Doxyfile

--- a/packages/epetra/src/Epetra_BasicRowMatrix.h
+++ b/packages/epetra/src/Epetra_BasicRowMatrix.h
@@ -323,7 +323,7 @@ class EPETRA_LIB_DLL_EXPORT Epetra_BasicRowMatrix: public Epetra_CompObject, pub
     /*! @brief Returns the infinity norm of the global matrix.
 
        Returns the quantity \f$ \| A \|_\infty\f$ such that
-       \f[\| A \|_\infty = \max_{1\lei\lem} \sum_{j=1}^n |a_{ij}| \f].
+       \f[\| A \|_\infty = \max_{1\leq i\leq m} \sum_{j=1}^n |a_{ij}| \f].
 
      @warning This method is supported if and only if the Epetra_RowMatrix Object that was used to create this supports this method.
 
@@ -333,7 +333,7 @@ class EPETRA_LIB_DLL_EXPORT Epetra_BasicRowMatrix: public Epetra_CompObject, pub
     /*! @brief Returns the one norm of the global matrix.
 
        Returns the quantity \f$ \| A \|_1\f$ such that
-       \f[\| A \|_1= \max_{1\lej\len} \sum_{i=1}^m |a_{ij}| \f].
+       \f[\| A \|_1= \max_{1\leq j\leq n} \sum_{i=1}^m |a_{ij}| \f].
 
      @warning This method is supported if and only if the Epetra_RowMatrix Object that was used to create this supports this method.
 

--- a/packages/epetra/src/Epetra_CrsMatrix.h
+++ b/packages/epetra/src/Epetra_CrsMatrix.h
@@ -1042,14 +1042,14 @@ or if the number of entries in this row exceed the Length parameter.
 
   //! Returns the infinity norm of the global matrix.
   /* Returns the quantity \f$ \| A \|_\infty\f$ such that
-     \f[\| A \|_\infty = \max_{1\lei\lem} \sum_{j=1}^n |a_{ij}| \f]
+     \f[\| A \|_\infty = \max_{1\leq i\leq m} \sum_{j=1}^n |a_{ij}| \f]
      \warning The NormInf() method will not properly calculate the infinity norm for a matrix that has entries that are
      replicated on multiple processors.  */
   double NormInf() const;
 
   //! Returns the one norm of the global matrix.
   /* Returns the quantity \f$ \| A \|_1\f$ such that
-     \f[\| A \|_1= \max_{1\lej\len} \sum_{i=1}^m |a_{ij}| \f].
+     \f[\| A \|_1= \max_{1\leq j\leq n} \sum_{i=1}^m |a_{ij}| \f].
      \warning The NormOne() method will not properly calculate the one norm for a matrix that has entries that are
      replicated on multiple processors.
   */

--- a/packages/epetra/src/Epetra_FastCrsMatrix.h
+++ b/packages/epetra/src/Epetra_FastCrsMatrix.h
@@ -106,7 +106,7 @@ class Epetra_FastCrsOperator: public Epetra_CompObject, public virtual Epetra_Op
 
   //! Returns the infinity norm of the global matrix.
   /* Returns the quantity \f$ \| A \|_\infty\f$ such that
-     \f[\| A \|_\infty = \max_{1\lei\lem} \sum_{j=1}^n |a_{ij}| \f].
+     \f[\| A \|_\infty = \max_{1\leq i\leq m} \sum_{j=1}^n |a_{ij}| \f].
   */
   double NormInf() const {return(CrsMatrix_.NormInf());};
 

--- a/packages/epetra/src/Epetra_InvOperator.h
+++ b/packages/epetra/src/Epetra_InvOperator.h
@@ -126,7 +126,7 @@ class Epetra_InvOperator: public virtual Epetra_Operator {
 
   //! Returns the infinity norm of the global matrix.
   /* Returns the quantity \f$ \| A \|_\infty\f$ such that
-     \f[\| A \|_\infty = \max_{1\lei\lem} \sum_{j=1}^n |a_{ij}| \f].
+     \f[\| A \|_\infty = \max_{1\leq i\leq m} \sum_{j=1}^n |a_{ij}| \f].
 
      \warning This method must not be called unless HasNormInf() returns true.
   */

--- a/packages/epetra/src/Epetra_Operator.h
+++ b/packages/epetra/src/Epetra_Operator.h
@@ -121,7 +121,7 @@ class EPETRA_LIB_DLL_EXPORT Epetra_Operator {
 
     //! Returns the infinity norm of the global matrix.
     /* Returns the quantity \f$ \| A \|_\infty\f$ such that
-       \f[\| A \|_\infty = \max_{1\lei\lem} \sum_{j=1}^n |a_{ij}| \f].
+       \f[\| A \|_\infty = \max_{1\leq i\leq m} \sum_{j=1}^n |a_{ij}| \f].
 
        \warning This method must not be called unless HasNormInf() returns true.
     */

--- a/packages/epetra/src/Epetra_RowMatrix.h
+++ b/packages/epetra/src/Epetra_RowMatrix.h
@@ -218,13 +218,13 @@ class EPETRA_LIB_DLL_EXPORT Epetra_RowMatrix: public virtual Epetra_Operator, pu
 
     //! Returns the infinity norm of the global matrix.
     /* Returns the quantity \f$ \| A \|_\infty\f$ such that
-       \f[\| A \|_\infty = \max_{1\lei\len} \sum_{i=1}^m |a_{ij}| \f].
+       \f[\| A \|_\infty = \max_{1\leq i\leq n} \sum_{i=1}^m |a_{ij}| \f].
     */
     virtual double NormInf() const = 0;
 
     //! Returns the one norm of the global matrix.
     /* Returns the quantity \f$ \| A \|_1\f$ such that
-       \f[\| A \|_1= \max_{1\lej\len} \sum_{j=1}^n |a_{ij}| \f].
+       \f[\| A \|_1= \max_{1\leq j\leq n} \sum_{j=1}^n |a_{ij}| \f].
     */
     virtual double NormOne() const = 0;
 

--- a/packages/epetra/src/Epetra_SerialDenseOperator.h
+++ b/packages/epetra/src/Epetra_SerialDenseOperator.h
@@ -117,7 +117,7 @@ class EPETRA_LIB_DLL_EXPORT Epetra_SerialDenseOperator {
 
     //! Returns the infinity norm of the global matrix.
     /* Returns the quantity \f$ \| A \|_\infty\f$ such that
-       \f[\| A \|_\infty = \max_{1\lei\lem} \sum_{j=1}^n |a_{ij}| \f].
+       \f[\| A \|_\infty = \max_{1\leq i\leq m} \sum_{j=1}^n |a_{ij}| \f].
 
        \warning This method must not be called unless HasNormInf() returns true.
     */

--- a/packages/epetra/src/Epetra_SerialDenseSVD.h
+++ b/packages/epetra/src/Epetra_SerialDenseSVD.h
@@ -433,7 +433,7 @@ class EPETRA_LIB_DLL_EXPORT Epetra_SerialDenseSVD : public virtual Epetra_Serial
 
     //! Returns the infinity norm of the global matrix.
     /* Returns the quantity \f$ \| A \|_\infty\f$ such that
-       \f[\| A \|_\infty = \max_{1\lei\lem} \sum_{j=1}^n |a_{ij}| \f].
+       \f[\| A \|_\infty = \max_{1\leq i\leq m} \sum_{j=1}^n |a_{ij}| \f].
 
        \warning This method must not be called unless HasNormInf() returns true.
     */

--- a/packages/epetra/src/Epetra_VbrMatrix.h
+++ b/packages/epetra/src/Epetra_VbrMatrix.h
@@ -890,14 +890,14 @@ class EPETRA_LIB_DLL_EXPORT Epetra_VbrMatrix : public Epetra_DistObject,
 
     //! Returns the infinity norm of the global matrix.
     /* Returns the quantity \f$ \| A \|_\infty\f$ such that
-       \f[\| A \|_\infty = \max_{1\lei\lem} \sum_{j=1}^n |a_{ij}| \f].
+       \f[\| A \|_\infty = \max_{1\leq i\leq m} \sum_{j=1}^n |a_{ij}| \f].
      \warning The NormInf() method will not properly calculate the infinity norm for a matrix that has entries that are
      replicated on multiple processors.  */
     double NormInf() const;
 
     //! Returns the one norm of the global matrix.
     /* Returns the quantity \f$ \| A \|_1\f$ such that
-       \f[\| A \|_1 = \max_{1\lej\len} \sum_{i=1}^m |a_{ij}| \f].
+       \f[\| A \|_1 = \max_{1\leq j\leq n} \sum_{i=1}^m |a_{ij}| \f].
      \warning The NormOne() method will not properly calculate the one norm for a matrix that has entries that are
     */
     double NormOne() const;


### PR DESCRIPTION
Fixes several doxygen build errors, along with the needed paths to EXAMPLE_PATH to find the missing
tutorial code.

Removed build of epetra/thyra since it no longer exists.

Commented out the build of "Epetra Package Browser (Single Doxygen Collection)", which is currently broken, but no one noticed/needed.

@trilinos/epetra 

## Motivation
Fix broken doxygen pages not including example code.

* Closes #13785 
