### PR TITLE
Ifpack2: BlockTriDi fix for large blocks

### DIFF
--- a/packages/ifpack2/example/CMakeLists.txt
+++ b/packages/ifpack2/example/CMakeLists.txt
@@ -36,6 +36,38 @@ ASSERT_DEFINED (
 )
 
 IF(${PACKAGE_NAME}_ENABLE_Xpetra AND ${PACKAGE_NAME}_ENABLE_Galeri)
+# Correctness test with maximum block size (32)
+# Use a small grid so that GPU memory requirement isn't too large
+# Block TriDi
+TRIBITS_ADD_TEST(
+  BlockTriDiagonalSolver
+  NAME BlockTriDiLargeBlock
+  ARGS "--matrixType=Laplace3D --blockSize=32 --nx=20 --ny=20 --nz=20"
+  COMM serial mpi
+  NUM_MPI_PROCS 1-4
+  STANDARD_PASS_OUTPUT
+)
+# Block TriDi with Schur line splitting
+TRIBITS_ADD_TEST(
+  BlockTriDiagonalSolver
+  NAME BlockTriDiLargeBlockSchur
+  ARGS "--matrixType=Laplace3D --blockSize=32 --nx=20 --ny=20 --nz=20 --sublinesPerLine=1 --sublinesPerLineSchur=2"
+  COMM serial mpi
+  NUM_MPI_PROCS 1-4
+  STANDARD_PASS_OUTPUT
+)
+# Block Jacobi
+TRIBITS_ADD_TEST(
+  BlockTriDiagonalSolver
+  NAME BlockTriDiLargeBlockJacobi
+  ARGS "--matrixType=Laplace3D --blockSize=32 --nx=20 --ny=20 --nz=20 --sublinesPerLine=-1"
+  COMM serial mpi
+  NUM_MPI_PROCS 1-4
+  STANDARD_PASS_OUTPUT
+)
+ENDIF()
+
+IF(${PACKAGE_NAME}_ENABLE_Xpetra AND ${PACKAGE_NAME}_ENABLE_Galeri)
 
   set(blockSize 11)
   set(nx 256)


### PR DESCRIPTION
In BlockTriDi's ExtractAndFactorize kernels that use scratch, fall back to level 1 when there isn't sufficient level 0.

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Ifpack2's block TriDi and block Jacobi should work for block sizes to and including 32. For relatively large block sizes like 27, many GPUs didn't have enough shared memory per block for the numeric setup (extract+factorize). When there isn't enough shared, this PR falls back to level 1 scratch.

The level 0 and level 1 cases are instantiated separately to make sure there is no performance hit to the original level 0 case.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->
No issue for this, was reported by email

## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Issue reported directly by @jewatkins for SPARC.
## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Added testing with the maximum block size of 32. Verified that the level 1 scratch code path is taken on nvidia and amd gpus in this test.
<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
