### PR TITLE
Ifpack2: BlockTriDi/Block Jacobi residual improvements

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockComputeResidualVector.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockComputeResidualVector.hpp
@@ -566,42 +566,67 @@ namespace Ifpack2 {
         using subview_1D_stride_t = decltype(Kokkos::subview(y_packed_scalar, 0, block_range, 0, 0));
         subview_1D_right_t bb(nullptr, blocksize);
         subview_1D_right_t xx(nullptr, blocksize);
-        subview_1D_right_t xx_remote(nullptr, blocksize);
         subview_1D_stride_t yy(nullptr, Kokkos::LayoutStride(blocksize, y_packed_scalar.stride_1()));
         auto A_block_cst = ConstUnmanaged<tpetra_block_access_view_type>(NULL, blocksize, blocksize);
         auto colindsub_used = overlap ? colindsub_remote : colindsub;
         auto rowptr_used = overlap ? rowptr_remote : rowptr;
 
+        // Get shared allocation for a local copy of x, Ax, and A
+        impl_scalar_type * local_Ax = reinterpret_cast<impl_scalar_type *>(member.team_scratch(0).get_shmem(blocksize*sizeof(impl_scalar_type)));
+        impl_scalar_type * local_x = reinterpret_cast<impl_scalar_type *>(member.thread_scratch(0).get_shmem(blocksize*sizeof(impl_scalar_type)));
+
         const local_ordinal_type lr = lclrow(rowidx);
         const local_ordinal_type row = lr*blocksize;
         for (local_ordinal_type col = 0; col < num_vectors; ++col) {
-          yy.assign_data(&y_packed_scalar(pri, 0, col, v));
-          if (!overlap) {
-            // y := b
-            bb.assign_data(&b(row, col));
-            if (member.team_rank() == 0)
-              VectorCopy(member, blocksize, bb, yy);
+          if(col)
             member.team_barrier();
-          }
-
           // y -= Rx
+          // Initialize accumulation array
+          Kokkos::parallel_for(Kokkos::TeamVectorRange(member, blocksize),[&](const local_ordinal_type & i){
+            local_Ax[i] = 0;
+          });
+          member.team_barrier();
+
           const size_type A_k0 = A_block_rowptr[lr];
           Kokkos::parallel_for
             (Kokkos::TeamThreadRange(member, rowptr_used[lr], rowptr_used[lr+1]),
-            [&](const local_ordinal_type &k) {
+            [&](const size_type& k) {
               const size_type j = A_k0 + colindsub_used[k];
-              A_block_cst.assign_data( &tpetra_values(j*blocksize_square) );
               const local_ordinal_type A_colind_at_j = A_colind[j];
+              // Pull x into local memory
               if ((async && A_colind_at_j < num_local_rows) || (!async && !overlap)) {
                 const auto loc = is_dm2cm_active ? dm2cm[A_colind_at_j] : A_colind_at_j;
                 xx.assign_data( &x(loc*blocksize, col) );
-                VectorGemv(member, blocksize, A_block_cst, xx, yy);
               } else {
                 const auto loc = A_colind_at_j - num_local_rows;
-                xx_remote.assign_data( &x_remote(loc*blocksize, col) );
-                VectorGemv(member, blocksize, A_block_cst, xx_remote, yy);
+                xx.assign_data( &x_remote(loc*blocksize, col) );
               }
+
+              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, blocksize),[&](const local_ordinal_type & i){
+                local_x[i] = xx(i);
+              });
+            
+              // MatVec op Ax += A*x
+              A_block_cst.assign_data( &tpetra_values(j*blocksize_square) );
+              Kokkos::parallel_for(
+                Kokkos::ThreadVectorRange(member, blocksize),
+                [&](const local_ordinal_type &k0) {
+                  impl_scalar_type val = 0;
+                  for(int k1=0; k1<blocksize; k1++)
+                    val += A_block_cst(k0,k1)*local_x[k1];
+                  Kokkos::atomic_add(local_Ax+k0, val);
+              });
             });
+          member.team_barrier();
+          // Update y = b - local_Ax
+          yy.assign_data(&y_packed_scalar(pri, 0, col, v));
+          bb.assign_data(&b(row, col));
+          Kokkos::parallel_for(Kokkos::TeamVectorRange(member, blocksize),[&](const local_ordinal_type & i){
+            if (!overlap)
+              yy(i) = bb(i) - local_Ax[i];
+            else
+              yy(i) -= local_Ax[i];
+          });
         }
       }
 
@@ -719,21 +744,26 @@ namespace Ifpack2 {
 
         if constexpr(is_device<execution_space>::value) {
           const local_ordinal_type blocksize = blocksize_requested;
-          const local_ordinal_type team_size = 8;
-          const local_ordinal_type vector_size = ComputeResidualVectorRecommendedVectorSize<execution_space>(blocksize, team_size);
           // local_ordinal_type vl_power_of_two = 1;
           // for (;vl_power_of_two<=blocksize_requested;vl_power_of_two*=2);
           // vl_power_of_two *= (vl_power_of_two < blocksize_requested ? 2 : 1);
           // const local_ordinal_type vl = vl_power_of_two > vector_length ? vector_length : vl_power_of_two;
 #define BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(B) {                \
             if(this->hasBlockCrsMatrix) { \
-              const Kokkos::TeamPolicy<execution_space,AsyncTag<B, true> >      \
+              const local_ordinal_type team_size = 8; \
+              const local_ordinal_type vector_size = 8; \
+              const size_t shmem_team_size = blocksize*sizeof(btdm_scalar_type); \
+              const size_t shmem_thread_size = blocksize*sizeof(btdm_scalar_type); \
+              Kokkos::TeamPolicy<execution_space,AsyncTag<B, true> >      \
                 policy(rowidx2part.extent(0), team_size, vector_size);    \
+              policy.set_scratch_size(0,Kokkos::PerTeam(shmem_team_size),Kokkos::PerThread(shmem_thread_size)); \
               Kokkos::parallel_for                                        \
                 ("ComputeResidual::TeamPolicy::run<AsyncTag>",            \
                  policy, *this); \
             } \
             else { \
+              const local_ordinal_type team_size = 8; \
+              const local_ordinal_type vector_size = ComputeResidualVectorRecommendedVectorSize<execution_space>(blocksize, team_size); \
               const Kokkos::TeamPolicy<execution_space,AsyncTag<B, false> >      \
                 policy(rowidx2part.extent(0), team_size, vector_size);    \
               Kokkos::parallel_for                                        \
@@ -813,27 +843,33 @@ namespace Ifpack2 {
 
         if constexpr (is_device<execution_space>::value) {
           const local_ordinal_type blocksize = blocksize_requested;
-          const local_ordinal_type team_size = 8;
-          const local_ordinal_type vector_size = ComputeResidualVectorRecommendedVectorSize<execution_space>(blocksize, team_size);
           // local_ordinal_type vl_power_of_two = 1;
           // for (;vl_power_of_two<=blocksize_requested;vl_power_of_two*=2);
           // vl_power_of_two *= (vl_power_of_two < blocksize_requested ? 2 : 1);
           // const local_ordinal_type vl = vl_power_of_two > vector_length ? vector_length : vl_power_of_two;
 #define BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(B)  \
           if(this->hasBlockCrsMatrix) { \
+            const local_ordinal_type team_size = 8; \
+            const local_ordinal_type vector_size = 8; \
+            const size_t shmem_team_size = blocksize*sizeof(btdm_scalar_type); \
+            const size_t shmem_thread_size = blocksize*sizeof(btdm_scalar_type); \
             if (compute_owned) {                                          \
-              const Kokkos::TeamPolicy<execution_space,OverlapTag<0, B, true> > \
+              Kokkos::TeamPolicy<execution_space,OverlapTag<0, B, true> > \
                 policy(rowidx2part.extent(0), team_size, vector_size);    \
+              policy.set_scratch_size(0,Kokkos::PerTeam(shmem_team_size),Kokkos::PerThread(shmem_thread_size)); \
               Kokkos::parallel_for                                        \
                 ("ComputeResidual::TeamPolicy::run<OverlapTag<0> >", policy, *this); \
             } else {                                                      \
-              const Kokkos::TeamPolicy<execution_space,OverlapTag<1, B, true> > \
+              Kokkos::TeamPolicy<execution_space,OverlapTag<1, B, true> > \
                 policy(rowidx2part.extent(0), team_size, vector_size);    \
+              policy.set_scratch_size(0,Kokkos::PerTeam(shmem_team_size),Kokkos::PerThread(shmem_thread_size)); \
               Kokkos::parallel_for                                        \
                 ("ComputeResidual::TeamPolicy::run<OverlapTag<1> >", policy, *this); \
             } \
           } \
           else { \
+            const local_ordinal_type team_size = 8; \
+            const local_ordinal_type vector_size = ComputeResidualVectorRecommendedVectorSize<execution_space>(blocksize, team_size); \
             if (compute_owned) {                                          \
               const Kokkos::TeamPolicy<execution_space,OverlapTag<0, B, false> > \
                 policy(rowidx2part.extent(0), team_size, vector_size);    \

--- a/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
@@ -319,6 +319,7 @@ namespace Ifpack2 {
       ///
       typedef Kokkos::View<size_type*,device_type> size_type_1d_view;
       typedef Kokkos::View<size_type**,device_type> size_type_2d_view;
+      typedef Kokkos::View<int64_t***,Kokkos::LayoutRight,device_type> i64_3d_view;
       typedef Kokkos::View<local_ordinal_type*,device_type> local_ordinal_type_1d_view;
       typedef Kokkos::View<local_ordinal_type**,device_type> local_ordinal_type_2d_view;
       // tpetra block crs values

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_def.hpp
@@ -246,13 +246,15 @@ namespace Ifpack2 {
     this->IsComputed_ = false;
     TEUCHOS_ASSERT(!impl_->A.is_null()); // when initInternal is called, A_ must be set
     {
+      bool useSeqMethod = !impl_->tpetra_importer.is_null();
       BlockTriDiContainerDetails::performSymbolicPhase<MatrixType>
-        (impl_->A, 
-         impl_->blockGraph, 
-         impl_->part_interface, 
-         impl_->block_tridiags, 
-         impl_->a_minus_d, 
-         impl_->overlap_communication_and_computation);    
+        (impl_->A,
+         impl_->blockGraph,
+         impl_->part_interface,
+         impl_->block_tridiags,
+         impl_->a_minus_d,
+         impl_->overlap_communication_and_computation,
+         impl_->async_importer, useSeqMethod);
     }
     IFPACK2_BLOCKHELPER_TIMER_FENCE(typename BlockHelperDetails::ImplType<MatrixType>::execution_space)
   }


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

Improve GPU performance of BlockTriDi residual kernel, especially on AMD MI300A.
- Separately instantiate the BlockCrs and non-BlockCrs kernel implementations on GPU, instead of having a runtime branch inside the kernel.
- Merge the Async and Overlap tagged kernels since they are almost the same (only difference is how to decide whether to load LHS from ``x`` or ``x_remote``). This reduces code but also means any optimization only needs to be written in one place (#13610 only added optimizations for the Overlap tag and would have needed to be duplicated to the Async version).
- Incorporate changes by @seanofthemillers in #13610
- Precompute A, x entry offsets to reduce levels of indirection and cache pressure
- Remove unnecessary team barriers

Also fixed some invalid Kokkos thread-level parallel_fors which were modifying captured variables (though these weren't used in the final BlockCrs GPU kernel).

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->
Supersedes PR #13610 by @seanofthemillers 
<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->

## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->