### PR TITLE
Tpetra: Fix makeDualViewFromOwningHostView if the device View is host-accessible

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_DualViewUtil.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DualViewUtil.hpp
@@ -42,15 +42,20 @@ makeDualViewFromOwningHostView
   using execution_space = typename DeviceType::execution_space;
   using dual_view_type = Kokkos::DualView<ElementType*, DeviceType>;
 
-  typename Kokkos::DualView<ElementType*, DeviceType>::t_dev devView;
-  if (dv.extent (0) == hostView.extent (0))
-    devView = dv.view_device();
-  else
-    devView = Kokkos::create_mirror_view (DeviceType (), hostView);
-  // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
-  Kokkos::deep_copy (execution_space(), devView, hostView);
-  dv = dual_view_type (devView, hostView);
-  execution_space().fence();
+  if constexpr(Kokkos::SpaceAccessibility<Kokkos::HostSpace, typename DeviceType::memory_space>::accessible) {
+    // DualView only references one View, so we pass in the same View twice
+    dv = dual_view_type (hostView, hostView);
+  } else {
+    typename Kokkos::DualView<ElementType*, DeviceType>::t_dev devView;
+    if (dv.extent (0) == hostView.extent (0))
+      devView = dv.view_device();
+    else
+      devView = Kokkos::create_mirror_view (DeviceType (), hostView);
+    // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+    Kokkos::deep_copy (execution_space(), devView, hostView);
+    dv = dual_view_type (devView, hostView);
+    execution_space().fence();
+  }
 }
 
 template<class ElementType, class DeviceType>


### PR DESCRIPTION
@trilinos/tpetra

## Motivation
Fixes https://github.com/trilinos/Trilinos/pull/13778#issuecomment-2663872617. The code preceding #13778 had
```
dv.clear_sync_state ();
dv.modify_host ();
dv.h_view = hostView;
dv.sync_device ();
```
to create a `Kokkos::DualView` using a shallow copy of `hostView` as the host `View`. In case the `DualView` assumes to reference only one `View`, i.e., the device memory space is host-accessible, and `modify` and `skip` are no-ops, this is problematic. #13778 didn't fix this issue but made it detectable by using the `DeviceView` constructor instead of assigning the host `View` directly. The check for the allocations to be the same has been implemented in https://github.com/kokkos/kokkos/pull/7712.
This pull request addresses the problem by not trying to preserve the device `View` in this case but to construct the DualView using `hostView` for both arguments. Note that this (implicitly) requires that device memory space is assignable from the host memory space. Otherwise, there is no way to create the `DualView` from a shallow copy of `hostView`.

## Testing
Running all `Tpetra` tests with a `Kokkos` development version using the `Serial` backend only and with `Kokkos_ENABLE_CUDA_UVM=ON` ina different configuration.