### PR TITLE
Tpetra: Fix assignment to DualView::view_[host|device]

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -3708,22 +3708,20 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
     {
       const size_t newSize = X.imports_.extent (0) / numCols;
       const size_t offset = jj*newSize;
-      auto newImports = X.imports_;
-      newImports.view_device() = subview (X.imports_.view_device(),
+      auto device_view = subview (X.imports_.view_device(),
                                    range_type (offset, offset+newSize));
-      newImports.view_host() = subview (X.imports_.view_host(),
+      auto host_view = subview (X.imports_.view_host(),
                                    range_type (offset, offset+newSize));
-      this->imports_ = newImports;
+      this->imports_ = decltype(X.imports_)(device_view, host_view);
     }
     {
       const size_t newSize = X.exports_.extent (0) / numCols;
       const size_t offset = jj*newSize;
-      auto newExports = X.exports_;
-      newExports.view_device() = subview (X.exports_.view_device(),
+      auto device_view = subview (X.exports_.view_device(),
                                    range_type (offset, offset+newSize));
-      newExports.view_host() = subview (X.exports_.view_host(),
+      auto host_view = subview (X.exports_.view_host(),
                                    range_type (offset, offset+newSize));
-      this->exports_ = newExports;
+      this->exports_ = decltype(X.exports_)(device_view, host_view);
     }
     // These two DualViews already either have the right number of
     // entries, or zero entries.  This means that we don't need to


### PR DESCRIPTION
@trilinos/tpetra

## Motivation
https://github.com/trilinos/Trilinos/pull/13823 didn't inlcude the patch in https://github.com/trilinos/Trilinos/pull/13820#issuecomment-2667128984. Since `view_[host|device]` will return by `const&` in the future and returns by value right now, assigning to it isn't intended. Instead you would create a new `DualView` from existing Views.

## Testing
@jhux2 tested this in https://github.com/trilinos/Trilinos/pull/13820#issuecomment-2667217874.