### PR TITLE
Tpetra: Don't test need_sync_[host|device]

### DIFF
--- a/packages/tpetra/core/test/MultiVector/MultiVector_LocalViewTests.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_LocalViewTests.cpp
@@ -303,22 +303,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, TemplatedGetLocalView, LO, GO, S
     bool correctType = std::is_same<typename decltype(deviceView)::device_type, device_t>::value;
     TEST_ASSERT(correctType);
   }
-  constexpr bool needsSyncPath = !std::is_same<Kokkos::HostSpace, typename device_t::memory_space>::value;
-  if(needsSyncPath)
-  {
-    TEST_ASSERT(x.need_sync_host());
-    TEST_ASSERT(!x.need_sync_device());
-  }
   // Assuming device/host device types aren't the same, make sure getting the host view also works
   {
     auto hostView = x.template getLocalView<host_t>(Tpetra::Access::ReadWrite);
     bool correctType = std::is_same<typename decltype(hostView)::device_type, host_t>::value;
     TEST_ASSERT(correctType);
-    if(needsSyncPath)
-    {
-      TEST_ASSERT(!x.need_sync_host());
-      TEST_ASSERT(x.need_sync_device());
-    }
   }
 }
 


### PR DESCRIPTION
@trilinos/tpetra

## Motivation
https://github.com/kokkos/kokkos/pull/7775 proposes to skip `modify` and `sync` if `DualView` only references one `View`, i.e., if the memory space is host-accessible. This changes the behavior of `DualView::need_sync_[host|device]` and thus
`Tpetra::MultiVector::need_sync_[host|device]` which just calls the respective `DualView` function, see https://github.com/trilinos/Trilinos/blob/74d6091476be50a2e5c10f3f9f4020045038b822/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp#L4494-L4506. One of the `Tpetra` unit tests checks this behavior explicitly and therefore breaks with https://github.com/kokkos/kokkos/pull/7775.
This pull request proposes to just remove this particular check since the `MultiVector` function only forwards anyway.
An alternative would be to use 
```
constexpr bool needsSyncPath = !Kokkos::SpaceAccessibility<Kokkos::HostSpace, typename device_t::memory_space>::accessible;
```
once `Kokkos` is updated in `Trilinos`. 

## Testing
Running all `Tpetra` unit tests with a configuration that has `Kokkos_ENABLE_CUDA_UVM=ON`.