### PR TITLE
Ifpack2: Fused block jacobi

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockComputeResidualAndSolve.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockComputeResidualAndSolve.hpp
@@ -1,0 +1,684 @@
+// @HEADER
+// *****************************************************************************
+//       Ifpack2: Templated Object-Oriented Algebraic Preconditioner Package
+//
+// Copyright 2009 NTESS and the Ifpack2 contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef IFPACK2_BLOCKCOMPUTERESAND_SOLVE_IMPL_HPP
+#define IFPACK2_BLOCKCOMPUTERESAND_SOLVE_IMPL_HPP
+
+#include "Ifpack2_BlockHelper.hpp"
+#include "Ifpack2_BlockComputeResidualVector.hpp"
+
+namespace Ifpack2::BlockHelperDetails {
+
+template <typename ExecSpace, typename DiagOffsets, typename Rowptrs,
+          typename Entries>
+DiagOffsets findDiagOffsets(const Rowptrs& rowptrs, const Entries& entries,
+                            size_t nrows, int blocksize) {
+  DiagOffsets diag_offsets(do_not_initialize_tag("btdm.diag_offsets"), nrows);
+  int err = 0;
+  Kokkos::parallel_reduce(
+      Kokkos::RangePolicy<ExecSpace>(0, nrows),
+      KOKKOS_LAMBDA(size_t row, int& err) {
+        auto rowBegin = rowptrs(row);
+        auto rowEnd   = rowptrs(row + 1);
+        for (size_t j = rowBegin; j < rowEnd; j++) {
+          if (size_t(entries(j)) == row) {
+            diag_offsets(row) = j * blocksize * blocksize;
+            return;
+          }
+        }
+        err++;
+      },
+      err);
+  TEUCHOS_TEST_FOR_EXCEPT_MSG(
+      err, "Ifpack2 BTD: at least one row has no diagonal entry");
+  return diag_offsets;
+}
+
+template <typename MatrixType, int B>
+struct ComputeResidualAndSolve_1Pass {
+  using impl_type        = BlockHelperDetails::ImplType<MatrixType>;
+  using node_device_type = typename impl_type::node_device_type;
+  using execution_space  = typename impl_type::execution_space;
+  using memory_space     = typename impl_type::memory_space;
+
+  using local_ordinal_type = typename impl_type::local_ordinal_type;
+  using size_type          = typename impl_type::size_type;
+  using impl_scalar_type   = typename impl_type::impl_scalar_type;
+  using magnitude_type     = typename impl_type::magnitude_type;
+  /// views
+  using local_ordinal_type_1d_view =
+      typename impl_type::local_ordinal_type_1d_view;
+  using size_type_1d_view = typename impl_type::size_type_1d_view;
+  using tpetra_block_access_view_type =
+      typename impl_type::tpetra_block_access_view_type;  // block crs (layout
+                                                          // right)
+  using impl_scalar_type_1d_view = typename impl_type::impl_scalar_type_1d_view;
+  using impl_scalar_type_2d_view_tpetra =
+      typename impl_type::impl_scalar_type_2d_view_tpetra;  // block multivector
+                                                            // (layout left)
+  using btdm_scalar_type_3d_view = typename impl_type::btdm_scalar_type_3d_view;
+  using btdm_scalar_type_4d_view = typename impl_type::btdm_scalar_type_4d_view;
+  using i64_3d_view              = typename impl_type::i64_3d_view;
+
+  /// team policy member type (used in cuda)
+  using member_type = typename Kokkos::TeamPolicy<execution_space>::member_type;
+
+  // enum for max blocksize and vector length
+  enum : int { max_blocksize = 32 };
+
+ private:
+  ConstUnmanaged<impl_scalar_type_2d_view_tpetra> b;
+  ConstUnmanaged<impl_scalar_type_2d_view_tpetra> x;  // x_owned
+  ConstUnmanaged<impl_scalar_type_2d_view_tpetra> x_remote;
+  Unmanaged<impl_scalar_type_2d_view_tpetra> y;
+
+  // AmD information
+  const ConstUnmanaged<impl_scalar_type_1d_view> tpetra_values;
+
+  // blocksize
+  const local_ordinal_type blocksize_requested;
+
+  // block offsets
+  const ConstUnmanaged<i64_3d_view> A_x_offsets;
+  const ConstUnmanaged<i64_3d_view> A_x_offsets_remote;
+
+  // diagonal block inverses
+  const ConstUnmanaged<btdm_scalar_type_3d_view> d_inv;
+
+  // squared update norms
+  const Unmanaged<impl_scalar_type_1d_view> W;
+
+  impl_scalar_type damping_factor;
+
+ public:
+  ComputeResidualAndSolve_1Pass(const AmD<MatrixType>& amd,
+                                const btdm_scalar_type_3d_view& d_inv_,
+                                const impl_scalar_type_1d_view& W_,
+                                const local_ordinal_type& blocksize_requested_,
+                                const impl_scalar_type& damping_factor_)
+      : tpetra_values(amd.tpetra_values),
+        blocksize_requested(blocksize_requested_),
+        A_x_offsets(amd.A_x_offsets),
+        A_x_offsets_remote(amd.A_x_offsets_remote),
+        d_inv(d_inv_),
+        W(W_),
+        damping_factor(damping_factor_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const member_type& member) const {
+    const local_ordinal_type blocksize   = (B == 0 ? blocksize_requested : B);
+    const local_ordinal_type rowidx      = member.league_rank();
+    const local_ordinal_type row         = rowidx * blocksize;
+    const local_ordinal_type num_vectors = b.extent(1);
+    const local_ordinal_type num_local_rows = d_inv.extent(0);
+
+    const impl_scalar_type* xx;
+    auto A_block_cst = ConstUnmanaged<tpetra_block_access_view_type>(
+        NULL, blocksize, blocksize);
+
+    // Get shared allocation for a local copy of x, Ax, and A
+    impl_scalar_type* local_Ax = reinterpret_cast<impl_scalar_type*>(
+        member.team_scratch(0).get_shmem(blocksize * sizeof(impl_scalar_type)));
+    impl_scalar_type* local_DinvAx = reinterpret_cast<impl_scalar_type*>(
+        member.team_scratch(0).get_shmem(blocksize * sizeof(impl_scalar_type)));
+    impl_scalar_type* local_x =
+        reinterpret_cast<impl_scalar_type*>(member.thread_scratch(0).get_shmem(
+            blocksize * sizeof(impl_scalar_type)));
+
+    magnitude_type norm = 0;
+    for (local_ordinal_type col = 0; col < num_vectors; ++col) {
+      if (col) member.team_barrier();
+      // y -= Rx
+      // Initialize accumulation arrays
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(member, blocksize),
+                           [&](const local_ordinal_type& i) {
+                             local_DinvAx[i] = 0;
+                             local_Ax[i]     = b(row + i, col);
+                           });
+      member.team_barrier();
+
+      int numEntries = A_x_offsets.extent(2);
+
+      Kokkos::parallel_for(
+          Kokkos::TeamThreadRange(member, 0, numEntries), [&](const int k) {
+            int64_t A_offset = A_x_offsets(rowidx, 0, k);
+            int64_t x_offset = A_x_offsets(rowidx, 1, k);
+            if (A_offset != Kokkos::ArithTraits<int64_t>::min()) {
+              A_block_cst.assign_data(tpetra_values.data() + A_offset);
+              // Pull x into local memory
+              int64_t remote_cutoff = blocksize * num_local_rows;
+              if (x_offset >= remote_cutoff)
+                xx = &x_remote(x_offset - remote_cutoff, col);
+              else
+                xx = &x(x_offset, col);
+
+              Kokkos::parallel_for(
+                  Kokkos::ThreadVectorRange(member, blocksize),
+                  [&](const local_ordinal_type& i) { local_x[i] = xx[i]; });
+
+              // matvec on block: local_Ax -= A_block_cst * local_x
+              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, blocksize),
+                                   [&](const int k0) {
+                                     impl_scalar_type val = 0;
+                                     for (int k1 = 0; k1 < blocksize; k1++)
+                                       val += A_block_cst(k0, k1) * local_x[k1];
+                                     Kokkos::atomic_add(local_Ax + k0, -val);
+                                   });
+            }
+          });
+      member.team_barrier();
+      // Compute local_DinvAx = D^-1 * local_Ax
+      Kokkos::parallel_for(
+          Kokkos::TeamThreadRange(member, blocksize),
+          [&](const local_ordinal_type& k0) {
+            Kokkos::parallel_reduce(
+                Kokkos::ThreadVectorRange(member, blocksize),
+                [&](const local_ordinal_type& k1, impl_scalar_type& update) {
+                  update += d_inv(rowidx, k0, k1) * local_Ax[k1];
+                },
+                local_DinvAx[k0]);
+          });
+      member.team_barrier();
+      // local_DinvAx is fully computed. Now compute the
+      // squared y update norm and update y (using damping factor).
+      magnitude_type colNorm;
+      Kokkos::parallel_reduce(
+          Kokkos::TeamVectorRange(member, blocksize),
+          [&](const local_ordinal_type& k, magnitude_type& update) {
+            // Compute the change in y (assuming damping_factor == 1) for this
+            // entry.
+            impl_scalar_type old_y    = x(row + k, col);
+            impl_scalar_type y_update = local_DinvAx[k] - old_y;
+            magnitude_type ydiff =
+                Kokkos::ArithTraits<impl_scalar_type>::abs(y_update);
+            update += ydiff * ydiff;
+            y(row + k, col) = old_y + damping_factor * y_update;
+          },
+          colNorm);
+      norm += colNorm;
+    }
+    Kokkos::single(Kokkos::PerTeam(member), [&]() { W(rowidx) = norm; });
+  }
+
+  // Launch SinglePass version (owned + nonowned residual, plus Dinv in a single
+  // kernel)
+  void run(const ConstUnmanaged<impl_scalar_type_2d_view_tpetra>& b_,
+           const ConstUnmanaged<impl_scalar_type_2d_view_tpetra>& x_,
+           const ConstUnmanaged<impl_scalar_type_2d_view_tpetra>& x_remote_,
+           const Unmanaged<impl_scalar_type_2d_view_tpetra>& y_) {
+    IFPACK2_BLOCKHELPER_PROFILER_REGION_BEGIN;
+    IFPACK2_BLOCKHELPER_TIMER_WITH_FENCE(
+        "BlockTriDi::ComputeResidualAndSolve::RunSinglePass",
+        ComputeResidualAndSolve0, execution_space);
+
+    y        = y_;
+    b        = b_;
+    x        = x_;
+    x_remote = x_remote_;
+
+    const local_ordinal_type blocksize = blocksize_requested;
+    const local_ordinal_type nrows     = d_inv.extent(0);
+
+    const local_ordinal_type team_size   = 8;
+    const local_ordinal_type vector_size = 8;
+    // team: local_Ax, local_DinvAx
+    const size_t shmem_team_size = 2 * blocksize * sizeof(impl_scalar_type);
+    // thread: local_x
+    const size_t shmem_thread_size = blocksize * sizeof(impl_scalar_type);
+    Kokkos::TeamPolicy<execution_space> policy(nrows, team_size, vector_size);
+    policy.set_scratch_size(0, Kokkos::PerTeam(shmem_team_size),
+                            Kokkos::PerThread(shmem_thread_size));
+    Kokkos::parallel_for("ComputeResidualAndSolve::TeamPolicy::SinglePass",
+                         policy, *this);
+    IFPACK2_BLOCKHELPER_PROFILER_REGION_END;
+    IFPACK2_BLOCKHELPER_TIMER_FENCE(execution_space)
+  }
+};
+
+template <typename MatrixType, int B>
+struct ComputeResidualAndSolve_2Pass {
+  using impl_type        = BlockHelperDetails::ImplType<MatrixType>;
+  using node_device_type = typename impl_type::node_device_type;
+  using execution_space  = typename impl_type::execution_space;
+  using memory_space     = typename impl_type::memory_space;
+
+  using local_ordinal_type = typename impl_type::local_ordinal_type;
+  using size_type          = typename impl_type::size_type;
+  using impl_scalar_type   = typename impl_type::impl_scalar_type;
+  using magnitude_type     = typename impl_type::magnitude_type;
+  /// views
+  using local_ordinal_type_1d_view =
+      typename impl_type::local_ordinal_type_1d_view;
+  using size_type_1d_view = typename impl_type::size_type_1d_view;
+  using tpetra_block_access_view_type =
+      typename impl_type::tpetra_block_access_view_type;  // block crs (layout
+                                                          // right)
+  using impl_scalar_type_1d_view = typename impl_type::impl_scalar_type_1d_view;
+  using impl_scalar_type_2d_view_tpetra =
+      typename impl_type::impl_scalar_type_2d_view_tpetra;  // block multivector
+                                                            // (layout left)
+  using btdm_scalar_type_3d_view = typename impl_type::btdm_scalar_type_3d_view;
+  using btdm_scalar_type_4d_view = typename impl_type::btdm_scalar_type_4d_view;
+  using i64_3d_view              = typename impl_type::i64_3d_view;
+
+  /// team policy member type (used in cuda)
+  using member_type = typename Kokkos::TeamPolicy<execution_space>::member_type;
+
+  // enum for max blocksize and vector length
+  enum : int { max_blocksize = 32 };
+
+  // Tag for computing residual with owned columns only (pass 1)
+  struct OwnedTag {};
+
+  // Tag for finishing the residual with nonowned columns, and solving/norming
+  // (pass 2)
+  struct NonownedTag {};
+
+ private:
+  ConstUnmanaged<impl_scalar_type_2d_view_tpetra> b;
+  ConstUnmanaged<impl_scalar_type_2d_view_tpetra> x;  // x_owned
+  ConstUnmanaged<impl_scalar_type_2d_view_tpetra> x_remote;
+  Unmanaged<impl_scalar_type_2d_view_tpetra> y;
+
+  // AmD information
+  const ConstUnmanaged<impl_scalar_type_1d_view> tpetra_values;
+
+  // blocksize
+  const local_ordinal_type blocksize_requested;
+
+  // block offsets
+  const ConstUnmanaged<i64_3d_view> A_x_offsets;
+  const ConstUnmanaged<i64_3d_view> A_x_offsets_remote;
+
+  // diagonal block inverses
+  const ConstUnmanaged<btdm_scalar_type_3d_view> d_inv;
+
+  // squared update norms
+  const Unmanaged<impl_scalar_type_1d_view> W;
+
+  impl_scalar_type damping_factor;
+
+ public:
+  ComputeResidualAndSolve_2Pass(const AmD<MatrixType>& amd,
+                                const btdm_scalar_type_3d_view& d_inv_,
+                                const impl_scalar_type_1d_view& W_,
+                                const local_ordinal_type& blocksize_requested_,
+                                const impl_scalar_type& damping_factor_)
+      : tpetra_values(amd.tpetra_values),
+        blocksize_requested(blocksize_requested_),
+        A_x_offsets(amd.A_x_offsets),
+        A_x_offsets_remote(amd.A_x_offsets_remote),
+        d_inv(d_inv_),
+        W(W_),
+        damping_factor(damping_factor_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const OwnedTag, const member_type& member) const {
+    const local_ordinal_type blocksize   = (B == 0 ? blocksize_requested : B);
+    const local_ordinal_type rowidx      = member.league_rank();
+    const local_ordinal_type row         = rowidx * blocksize;
+    const local_ordinal_type num_vectors = b.extent(1);
+
+    auto A_block_cst = ConstUnmanaged<tpetra_block_access_view_type>(
+        NULL, blocksize, blocksize);
+
+    // Get shared allocation for a local copy of x, Ax, and A
+    impl_scalar_type* local_Ax = reinterpret_cast<impl_scalar_type*>(
+        member.team_scratch(0).get_shmem(blocksize * sizeof(impl_scalar_type)));
+    impl_scalar_type* local_x =
+        reinterpret_cast<impl_scalar_type*>(member.thread_scratch(0).get_shmem(
+            blocksize * sizeof(impl_scalar_type)));
+
+    for (local_ordinal_type col = 0; col < num_vectors; ++col) {
+      if (col) member.team_barrier();
+      // y -= Rx
+      // Initialize accumulation arrays
+      Kokkos::parallel_for(
+          Kokkos::TeamVectorRange(member, blocksize),
+          [&](const local_ordinal_type& i) { local_Ax[i] = b(row + i, col); });
+      member.team_barrier();
+
+      int numEntries = A_x_offsets.extent(2);
+
+      Kokkos::parallel_for(
+          Kokkos::TeamThreadRange(member, 0, numEntries), [&](const int k) {
+            int64_t A_offset = A_x_offsets(rowidx, 0, k);
+            int64_t x_offset = A_x_offsets(rowidx, 1, k);
+            if (A_offset != Kokkos::ArithTraits<int64_t>::min()) {
+              A_block_cst.assign_data(tpetra_values.data() + A_offset);
+              // Pull x into local memory
+              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, blocksize),
+                                   [&](const local_ordinal_type& i) {
+                                     local_x[i] = x(x_offset + i, col);
+                                   });
+
+              // MatVec op Ax += A*x
+              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, blocksize),
+                                   [&](const local_ordinal_type& k0) {
+                                     impl_scalar_type val = 0;
+                                     for (int k1 = 0; k1 < blocksize; k1++)
+                                       val += A_block_cst(k0, k1) * local_x[k1];
+                                     Kokkos::atomic_add(local_Ax + k0, -val);
+                                   });
+            }
+          });
+      member.team_barrier();
+      // Write back the partial residual to y
+      if (member.team_rank() == 0) {
+        Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, blocksize),
+                             [&](const local_ordinal_type& k) {
+                               y(row + k, col) = local_Ax[k];
+                             });
+      }
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const NonownedTag, const member_type& member) const {
+    const local_ordinal_type blocksize   = (B == 0 ? blocksize_requested : B);
+    const local_ordinal_type rowidx      = member.league_rank();
+    const local_ordinal_type row         = rowidx * blocksize;
+    const local_ordinal_type num_vectors = b.extent(1);
+
+    auto A_block_cst = ConstUnmanaged<tpetra_block_access_view_type>(
+        NULL, blocksize, blocksize);
+
+    // Get shared allocation for a local copy of x, Ax, and A
+    impl_scalar_type* local_Ax = reinterpret_cast<impl_scalar_type*>(
+        member.team_scratch(0).get_shmem(blocksize * sizeof(impl_scalar_type)));
+    impl_scalar_type* local_DinvAx = reinterpret_cast<impl_scalar_type*>(
+        member.team_scratch(0).get_shmem(blocksize * sizeof(impl_scalar_type)));
+    impl_scalar_type* local_x =
+        reinterpret_cast<impl_scalar_type*>(member.thread_scratch(0).get_shmem(
+            blocksize * sizeof(impl_scalar_type)));
+
+    magnitude_type norm = 0;
+    for (local_ordinal_type col = 0; col < num_vectors; ++col) {
+      if (col) member.team_barrier();
+      // y -= Rx
+      // Initialize accumulation arrays.
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(member, blocksize),
+                           [&](const local_ordinal_type& i) {
+                             local_DinvAx[i] = 0;
+                             local_Ax[i]     = y(row + i, col);
+                           });
+      member.team_barrier();
+
+      int numEntries = A_x_offsets_remote.extent(2);
+
+      Kokkos::parallel_for(
+          Kokkos::TeamThreadRange(member, 0, numEntries), [&](const int k) {
+            int64_t A_offset = A_x_offsets_remote(rowidx, 0, k);
+            int64_t x_offset = A_x_offsets_remote(rowidx, 1, k);
+            if (A_offset != Kokkos::ArithTraits<int64_t>::min()) {
+              A_block_cst.assign_data(tpetra_values.data() + A_offset);
+              // Pull x into local memory
+              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, blocksize),
+                                   [&](const local_ordinal_type& i) {
+                                     local_x[i] = x_remote(x_offset + i, col);
+                                   });
+
+              // matvec on block: local_Ax -= A_block_cst * local_x
+              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, blocksize),
+                                   [&](const int k0) {
+                                     impl_scalar_type val = 0;
+                                     for (int k1 = 0; k1 < blocksize; k1++)
+                                       val += A_block_cst(k0, k1) * local_x[k1];
+                                     Kokkos::atomic_add(local_Ax + k0, -val);
+                                   });
+            }
+          });
+      member.team_barrier();
+      // Compute local_DinvAx = D^-1 * local_Ax
+      Kokkos::parallel_for(
+          Kokkos::TeamThreadRange(member, blocksize),
+          [&](const local_ordinal_type& k0) {
+            Kokkos::parallel_reduce(
+                Kokkos::ThreadVectorRange(member, blocksize),
+                [&](const local_ordinal_type& k1, impl_scalar_type& update) {
+                  update += d_inv(rowidx, k0, k1) * local_Ax[k1];
+                },
+                local_DinvAx[k0]);
+          });
+      member.team_barrier();
+      // local_DinvAx is fully computed. Now compute the
+      // squared y update norm and update y (using damping factor).
+      magnitude_type colNorm;
+      Kokkos::parallel_reduce(
+          Kokkos::TeamVectorRange(member, blocksize),
+          [&](const local_ordinal_type& k, magnitude_type& update) {
+            // Compute the change in y (assuming damping_factor == 1) for this
+            // entry.
+            impl_scalar_type old_y    = x(row + k, col);
+            impl_scalar_type y_update = local_DinvAx[k] - old_y;
+            magnitude_type ydiff =
+                Kokkos::ArithTraits<impl_scalar_type>::abs(y_update);
+            update += ydiff * ydiff;
+            y(row + k, col) = old_y + damping_factor * y_update;
+          },
+          colNorm);
+      norm += colNorm;
+    }
+    Kokkos::single(Kokkos::PerTeam(member), [&]() { W(rowidx) = norm; });
+  }
+
+  // Launch pass 1 of the 2-pass version.
+  // This computes just the owned part of residual and writes that back to y.
+  void run_pass1(const ConstUnmanaged<impl_scalar_type_2d_view_tpetra>& b_,
+                 const ConstUnmanaged<impl_scalar_type_2d_view_tpetra>& x_,
+                 const Unmanaged<impl_scalar_type_2d_view_tpetra>& y_) {
+    IFPACK2_BLOCKHELPER_PROFILER_REGION_BEGIN;
+    IFPACK2_BLOCKHELPER_TIMER_WITH_FENCE(
+        "BlockTriDi::ComputeResidualAndSolve::RunPass1",
+        ComputeResidualAndSolve0, execution_space);
+
+    b = b_;
+    x = x_;
+    y = y_;
+
+    const local_ordinal_type blocksize = blocksize_requested;
+    const local_ordinal_type nrows     = d_inv.extent(0);
+
+    const local_ordinal_type team_size   = 8;
+    const local_ordinal_type vector_size = 8;
+    const size_t shmem_team_size         = blocksize * sizeof(impl_scalar_type);
+    const size_t shmem_thread_size       = blocksize * sizeof(impl_scalar_type);
+    Kokkos::TeamPolicy<execution_space, OwnedTag> policy(nrows, team_size,
+                                                         vector_size);
+    policy.set_scratch_size(0, Kokkos::PerTeam(shmem_team_size),
+                            Kokkos::PerThread(shmem_thread_size));
+    Kokkos::parallel_for("ComputeResidualAndSolve::TeamPolicy::Pass1", policy,
+                         *this);
+    IFPACK2_BLOCKHELPER_PROFILER_REGION_END;
+    IFPACK2_BLOCKHELPER_TIMER_FENCE(execution_space)
+  }
+
+  // Launch pass 2 of the 2-pass version.
+  // This finishes computing residual with x_remote,
+  // and then applies Dinv and computes norm.
+  void run_pass2(
+      const ConstUnmanaged<impl_scalar_type_2d_view_tpetra>& x_,
+      const ConstUnmanaged<impl_scalar_type_2d_view_tpetra>& x_remote_,
+      const Unmanaged<impl_scalar_type_2d_view_tpetra>& y_) {
+    IFPACK2_BLOCKHELPER_PROFILER_REGION_BEGIN;
+    IFPACK2_BLOCKHELPER_TIMER_WITH_FENCE(
+        "BlockTriDi::ComputeResidualAndSolve::RunPass2",
+        ComputeResidualAndSolve0, execution_space);
+
+    x        = x_;
+    x_remote = x_remote_;
+    y        = y_;
+
+    const local_ordinal_type blocksize = blocksize_requested;
+    const local_ordinal_type nrows     = d_inv.extent(0);
+
+    const local_ordinal_type team_size   = 8;
+    const local_ordinal_type vector_size = 8;
+    const size_t shmem_team_size   = 2 * blocksize * sizeof(impl_scalar_type);
+    const size_t shmem_thread_size = blocksize * sizeof(impl_scalar_type);
+    Kokkos::TeamPolicy<execution_space, NonownedTag> policy(nrows, team_size,
+                                                            vector_size);
+    policy.set_scratch_size(0, Kokkos::PerTeam(shmem_team_size),
+                            Kokkos::PerThread(shmem_thread_size));
+    Kokkos::parallel_for("ComputeResidualAndSolve::TeamPolicy::Pass2", policy,
+                         *this);
+    IFPACK2_BLOCKHELPER_PROFILER_REGION_END;
+    IFPACK2_BLOCKHELPER_TIMER_FENCE(execution_space)
+  }
+};
+
+template <typename MatrixType, int B>
+struct ComputeResidualAndSolve_SolveOnly {
+  using impl_type        = BlockHelperDetails::ImplType<MatrixType>;
+  using node_device_type = typename impl_type::node_device_type;
+  using execution_space  = typename impl_type::execution_space;
+  using memory_space     = typename impl_type::memory_space;
+
+  using local_ordinal_type = typename impl_type::local_ordinal_type;
+  using size_type          = typename impl_type::size_type;
+  using impl_scalar_type   = typename impl_type::impl_scalar_type;
+  using magnitude_type     = typename impl_type::magnitude_type;
+  /// views
+  using local_ordinal_type_1d_view =
+      typename impl_type::local_ordinal_type_1d_view;
+  using size_type_1d_view = typename impl_type::size_type_1d_view;
+  using tpetra_block_access_view_type =
+      typename impl_type::tpetra_block_access_view_type;  // block crs (layout
+                                                          // right)
+  using impl_scalar_type_1d_view = typename impl_type::impl_scalar_type_1d_view;
+  using impl_scalar_type_2d_view_tpetra =
+      typename impl_type::impl_scalar_type_2d_view_tpetra;  // block multivector
+                                                            // (layout left)
+  using btdm_scalar_type_3d_view = typename impl_type::btdm_scalar_type_3d_view;
+  using btdm_scalar_type_4d_view = typename impl_type::btdm_scalar_type_4d_view;
+  using i64_3d_view              = typename impl_type::i64_3d_view;
+
+  /// team policy member type (used in cuda)
+  using member_type = typename Kokkos::TeamPolicy<execution_space>::member_type;
+
+  // enum for max blocksize and vector length
+  enum : int { max_blocksize = 32 };
+
+ private:
+  ConstUnmanaged<impl_scalar_type_2d_view_tpetra> b;
+  ConstUnmanaged<impl_scalar_type_2d_view_tpetra> x;  // x_owned
+  ConstUnmanaged<impl_scalar_type_2d_view_tpetra> x_remote;
+  Unmanaged<impl_scalar_type_2d_view_tpetra> y;
+
+  // AmD information
+  const ConstUnmanaged<impl_scalar_type_1d_view> tpetra_values;
+
+  // blocksize
+  const local_ordinal_type blocksize_requested;
+
+  // block offsets
+  const ConstUnmanaged<i64_3d_view> A_x_offsets;
+  const ConstUnmanaged<i64_3d_view> A_x_offsets_remote;
+
+  // diagonal block inverses
+  const ConstUnmanaged<btdm_scalar_type_3d_view> d_inv;
+
+  // squared update norms
+  const Unmanaged<impl_scalar_type_1d_view> W;
+
+  impl_scalar_type damping_factor;
+
+ public:
+  ComputeResidualAndSolve_SolveOnly(
+      const AmD<MatrixType>& amd, const btdm_scalar_type_3d_view& d_inv_,
+      const impl_scalar_type_1d_view& W_,
+      const local_ordinal_type& blocksize_requested_,
+      const impl_scalar_type& damping_factor_)
+      : tpetra_values(amd.tpetra_values),
+        blocksize_requested(blocksize_requested_),
+        A_x_offsets(amd.A_x_offsets),
+        A_x_offsets_remote(amd.A_x_offsets_remote),
+        d_inv(d_inv_),
+        W(W_),
+        damping_factor(damping_factor_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const member_type& member) const {
+    const local_ordinal_type blocksize = (B == 0 ? blocksize_requested : B);
+    const local_ordinal_type rowidx =
+        member.league_rank() * member.team_size() + member.team_rank();
+    const local_ordinal_type row         = rowidx * blocksize;
+    const local_ordinal_type num_vectors = b.extent(1);
+
+    // Get shared allocation for a local copy of x, Ax, and A
+    impl_scalar_type* local_DinvAx =
+        reinterpret_cast<impl_scalar_type*>(member.thread_scratch(0).get_shmem(
+            blocksize * sizeof(impl_scalar_type)));
+
+    if (rowidx >= (local_ordinal_type)d_inv.extent(0)) return;
+
+    magnitude_type norm = 0;
+    for (local_ordinal_type col = 0; col < num_vectors; ++col) {
+      // Compute local_DinvAx = D^-1 * local_Ax
+      Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, blocksize),
+                           [&](const local_ordinal_type& k0) {
+                             impl_scalar_type val = 0;
+                             for (local_ordinal_type k1 = 0; k1 < blocksize;
+                                  k1++) {
+                               val += d_inv(rowidx, k0, k1) * b(row + k1, col);
+                             }
+                             local_DinvAx[k0] = val;
+                           });
+
+      magnitude_type colNorm;
+      Kokkos::parallel_reduce(
+          Kokkos::ThreadVectorRange(member, blocksize),
+          [&](const local_ordinal_type& k, magnitude_type& update) {
+            // Compute the change in y (assuming damping_factor == 1) for this
+            // entry.
+            impl_scalar_type y_update = local_DinvAx[k];
+            magnitude_type ydiff =
+                Kokkos::ArithTraits<impl_scalar_type>::abs(y_update);
+            update += ydiff * ydiff;
+            y(row + k, col) = damping_factor * y_update;
+          },
+          colNorm);
+      norm += colNorm;
+    }
+    Kokkos::single(Kokkos::PerThread(member), [&]() { W(rowidx) = norm; });
+  }
+
+  // ComputeResidualAndSolve_SolveOnly::run does the solve for the first
+  // iteration, when the initial guess for y is zero. This means the residual
+  // vector is just b. The kernel applies the inverse diags to b to find y, and
+  // also puts the partial squared update norms (1 per row) into W.
+  void run(const ConstUnmanaged<impl_scalar_type_2d_view_tpetra>& b_,
+           const Unmanaged<impl_scalar_type_2d_view_tpetra>& y_) {
+    IFPACK2_BLOCKHELPER_PROFILER_REGION_BEGIN;
+    IFPACK2_BLOCKHELPER_TIMER_WITH_FENCE(
+        "BlockTriDi::ComputeResidualAndSolve::Run_Y_Zero",
+        ComputeResidualAndSolve0, execution_space);
+
+    y = y_;
+    b = b_;
+
+    const local_ordinal_type blocksize = blocksize_requested;
+    const local_ordinal_type nrows     = d_inv.extent(0);
+
+    const local_ordinal_type team_size   = 8;
+    const local_ordinal_type vector_size = 8;
+    const size_t shmem_thread_size       = blocksize * sizeof(impl_scalar_type);
+    Kokkos::TeamPolicy<execution_space> policy(
+        (nrows + team_size - 1) / team_size, team_size, vector_size);
+    policy.set_scratch_size(0, Kokkos::PerThread(shmem_thread_size));
+    Kokkos::parallel_for("ComputeResidualAndSolve::TeamPolicy::y_zero", policy,
+                         *this);
+    IFPACK2_BLOCKHELPER_PROFILER_REGION_END;
+    IFPACK2_BLOCKHELPER_TIMER_FENCE(execution_space)
+  }
+};
+
+}  // namespace Ifpack2::BlockHelperDetails
+
+#endif

--- a/packages/ifpack2/src/Ifpack2_BlockComputeResidualAndSolve.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockComputeResidualAndSolve.hpp
@@ -195,9 +195,14 @@ struct ComputeResidualAndSolve_1Pass {
             // entry.
             impl_scalar_type old_y    = x(row + k, col);
             impl_scalar_type y_update = local_Dinv_residual[k] - old_y;
-            magnitude_type ydiff =
-                Kokkos::ArithTraits<impl_scalar_type>::abs(y_update);
-            update += ydiff * ydiff;
+            if constexpr(Kokkos::ArithTraits<impl_scalar_type>::is_complex) {
+              magnitude_type ydiff =
+                  Kokkos::ArithTraits<impl_scalar_type>::abs(y_update);
+              update += ydiff * ydiff;
+            }
+            else {
+              update += y_update * y_update;
+            }
             y(row + k, col) = old_y + damping_factor * y_update;
           },
           colNorm);
@@ -457,9 +462,14 @@ struct ComputeResidualAndSolve_2Pass {
             // entry.
             impl_scalar_type old_y    = x(row + k, col);
             impl_scalar_type y_update = local_Dinv_residual[k] - old_y;
-            magnitude_type ydiff =
-                Kokkos::ArithTraits<impl_scalar_type>::abs(y_update);
-            update += ydiff * ydiff;
+            if constexpr(Kokkos::ArithTraits<impl_scalar_type>::is_complex) {
+              magnitude_type ydiff =
+                  Kokkos::ArithTraits<impl_scalar_type>::abs(y_update);
+              update += ydiff * ydiff;
+            }
+            else {
+              update += y_update * y_update;
+            }
             y(row + k, col) = old_y + damping_factor * y_update;
           },
           colNorm);
@@ -638,9 +648,14 @@ struct ComputeResidualAndSolve_SolveOnly {
             // Compute the change in y (assuming damping_factor == 1) for this
             // entry.
             impl_scalar_type y_update = local_Dinv_residual[k];
-            magnitude_type ydiff =
-                Kokkos::ArithTraits<impl_scalar_type>::abs(y_update);
-            update += ydiff * ydiff;
+            if constexpr(Kokkos::ArithTraits<impl_scalar_type>::is_complex) {
+              magnitude_type ydiff =
+                  Kokkos::ArithTraits<impl_scalar_type>::abs(y_update);
+              update += ydiff * ydiff;
+            }
+            else {
+              update += y_update * y_update;
+            }
             y(row + k, col) = damping_factor * y_update;
           },
           colNorm);

--- a/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
@@ -311,6 +311,7 @@ namespace Ifpack2 {
 
       static constexpr int vector_length = DefaultVectorLength<btdm_scalar_type,memory_space>::value;
       static constexpr int internal_vector_length = DefaultInternalVectorLength<btdm_scalar_type,memory_space>::value;
+      static constexpr int half_vector_length = (vector_length > 1) ? (vector_length / 2) : 1;
       typedef Vector<SIMD<btdm_scalar_type>,vector_length> vector_type;
       typedef Vector<SIMD<btdm_scalar_type>,internal_vector_length> internal_vector_type;
 
@@ -329,6 +330,7 @@ namespace Ifpack2 {
       // tpetra multivector values (layout left): may need to change the typename more explicitly
       typedef Kokkos::View<impl_scalar_type**,Kokkos::LayoutLeft,device_type> impl_scalar_type_2d_view;
       typedef Kokkos::View<impl_scalar_type**,Kokkos::LayoutLeft,node_device_type> impl_scalar_type_2d_view_tpetra;
+      typedef Kokkos::View<const impl_scalar_type**,Kokkos::LayoutLeft,node_device_type> const_impl_scalar_type_2d_view_tpetra;
 
       // packed data always use layout right
       typedef Kokkos::View<vector_type*,device_type> vector_type_1d_view;

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_decl.hpp
@@ -376,6 +376,12 @@ namespace Ifpack2 {
                        const bool explicitConversion = false);
 
     void clearInternal();
+
+    // Decide whether the fused block Jacobi path can and should be used.
+    bool shouldUseFusedBlockJacobi(
+        const Teuchos::RCP<const row_matrix_type>& matrix,
+        const Teuchos::Array<Teuchos::Array<local_ordinal_type> >& partitions,
+        bool useSeqMethod);
   };
   
   ///

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -3273,14 +3273,14 @@ namespace Ifpack2 {
         using default_algo_type = typename default_mode_and_algo_type::algo_type;
         // When fused block Jacobi can be used, the mapping between local rows and parts is trivial (i <-> i)
         // We can simply pull the diagonal entry from A into d_inv
-        btdm_scalar_scratch_type_3d_view WW1(member.team_scratch(ScratchLevel), vector_length / 2, blocksize, blocksize);
-        btdm_scalar_scratch_type_3d_view WW2(member.team_scratch(ScratchLevel), vector_length / 2, blocksize, blocksize);
+        btdm_scalar_scratch_type_3d_view WW1(member.team_scratch(ScratchLevel), half_vector_length, blocksize, blocksize);
+        btdm_scalar_scratch_type_3d_view WW2(member.team_scratch(ScratchLevel), half_vector_length, blocksize, blocksize);
         const auto one = Kokkos::ArithTraits<btdm_magnitude_type>::one();
         const local_ordinal_type nrows = lclrow.extent(0);
         Kokkos::parallel_for
-          (Kokkos::ThreadVectorRange(member, vector_length / 2),
+          (Kokkos::ThreadVectorRange(member, half_vector_length),
 	   [&](const local_ordinal_type &v) {
-            local_ordinal_type row = member.league_rank() * vector_length / 2 + v;
+            local_ordinal_type row = member.league_rank() * half_vector_length + v;
             // diagEntry has index of diagonal within row
             auto W1 = Kokkos::subview(WW1, v, Kokkos::ALL(), Kokkos::ALL());
             auto W2 = Kokkos::subview(WW2, v, Kokkos::ALL(), Kokkos::ALL());


### PR DESCRIPTION
More performant paths for block Jacobi case inside BTDS (GPU only, BlockCrs only).
- Fuses residual and diagonal solve into one kernel
- Inverts diagonal blocks completely in shared memory before writing them back out. This would double the shared mem requirement per team, so to compensate the vector length is halved.

Compared to #13805, this gives between 9% (bs = 7) and 33% (bs = 11) speedup on the overall solve and about 1.9x speedup in numeric setup for both block sizes. **Note:** this was measured on a single GPU run, so the speedup only applies to local computation. Multi-rank runs will speed up less due to time spent doing communication.

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

Follows #13805

## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Will ask SPARC team to evaluate.

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".=
-->
Tested in Ifpack2_BlockTriDiContainerUnitAndPerfTests, and ran this on OpenMP, Cuda and HIP. For Cuda tested double, float and complex_double.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
