### PR TITLE
MueLu: Fix aggregate material visualization

### DIFF
--- a/packages/muelu/src/Utils/MueLu_AggregationExportFactory_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_AggregationExportFactory_def.hpp
@@ -668,7 +668,7 @@ void AggregationExportFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::writeF
     fout << indent;
     for (size_t i = 0; i < uniqueFine.size(); i++) {
       for (size_t k = 0; k < dim; k++) {
-        fout << material[k][vertex2AggIds[uniqueFine[i]]] << " ";
+        fout << material[k][uniqueFine[i]] << " ";
       }
       fout << endl
            << indent;


### PR DESCRIPTION
@trilinos/muelu

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Small fix to properly visualize the material tensor for aggregates in .vtu format.

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Need to recreate .gold files for visualization testing.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
@cgcgcg 