### PR TITLE
Teko: Improve Tpetra subblock re-assembly performance

### DIFF
--- a/packages/teko/src/Tpetra/Teko_BlockingTpetra.cpp
+++ b/packages/teko/src/Tpetra/Teko_BlockingTpetra.cpp
@@ -205,7 +205,7 @@ RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
   const RCP<const Tpetra::Map<LO, GO, NT> > rowMap  = subMaps[i].second;  // contiguous GIDs
   const RCP<const Tpetra::Map<LO, GO, NT> > colMap  = subMaps[j].second;
 
-  if(!plocal2ContigGIDs){
+  if (!plocal2ContigGIDs) {
     plocal2ContigGIDs = Blocking::getSubBlockColumnGIDs(*A, subMaps[j]);
   }
   Tpetra::Vector<GO, LO, GO, NT>& local2ContigGIDs = *plocal2ContigGIDs;
@@ -240,7 +240,7 @@ RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
     A->getLocalRowCopy(lid, indices, values, numEntries);
 
     LO numOwnedCols = 0;
-    auto data = local2ContigGIDs.getLocalViewHost(Tpetra::Access::ReadOnly);
+    auto data       = local2ContigGIDs.getLocalViewHost(Tpetra::Access::ReadOnly);
     for (size_t localCol = 0; localCol < numEntries; localCol++) {
       TEUCHOS_ASSERT(indices(localCol) > -1);
 
@@ -268,7 +268,7 @@ RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
     A->getLocalRowCopy(lid, indices, values, numEntries);
 
     LO numOwnedCols = 0;
-    auto data = local2ContigGIDs.getLocalViewHost(Tpetra::Access::ReadOnly);
+    auto data       = local2ContigGIDs.getLocalViewHost(Tpetra::Access::ReadOnly);
     for (size_t localCol = 0; localCol < numEntries; localCol++) {
       TEUCHOS_ASSERT(indices(localCol) > -1);
 
@@ -307,7 +307,7 @@ void rebuildSubBlock(int i, int j, const RCP<const Tpetra::CrsMatrix<ST, LO, GO,
   const Tpetra::Map<LO, GO, NT>& rowMap  = *subMaps[i].second;  // contiguous GIDs
   const Tpetra::Map<LO, GO, NT>& colMap  = *subMaps[j].second;
 
-  if(!plocal2ContigGIDs){
+  if (!plocal2ContigGIDs) {
     plocal2ContigGIDs = Blocking::getSubBlockColumnGIDs(*A, subMaps[j]);
   }
   Tpetra::Vector<GO, LO, GO, NT>& local2ContigGIDs = *plocal2ContigGIDs;
@@ -344,7 +344,7 @@ void rebuildSubBlock(int i, int j, const RCP<const Tpetra::CrsMatrix<ST, LO, GO,
     A->getLocalRowCopy(lid, indices, values, numEntries);
 
     LO numOwnedCols = 0;
-    auto data = local2ContigGIDs.getLocalViewHost(Tpetra::Access::ReadOnly);
+    auto data       = local2ContigGIDs.getLocalViewHost(Tpetra::Access::ReadOnly);
     for (size_t localCol = 0; localCol < numEntries; localCol++) {
       TEUCHOS_ASSERT(indices(localCol) > -1);
 

--- a/packages/teko/src/Tpetra/Teko_BlockingTpetra.cpp
+++ b/packages/teko/src/Tpetra/Teko_BlockingTpetra.cpp
@@ -195,7 +195,7 @@ RCP<Tpetra::Vector<GO, LO, GO, NT> > getSubBlockColumnGIDs(
 RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
     int i, int j, const RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT> >& A,
     const std::vector<MapPair>& subMaps,
-    const Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> >& plocal2ContigGIDs) {
+    Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> > plocal2ContigGIDs) {
   // get the number of variables families
   int numVarFamily = subMaps.size();
 
@@ -205,6 +205,9 @@ RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
   const RCP<const Tpetra::Map<LO, GO, NT> > rowMap  = subMaps[i].second;  // contiguous GIDs
   const RCP<const Tpetra::Map<LO, GO, NT> > colMap  = subMaps[j].second;
 
+  if(!plocal2ContigGIDs){
+    plocal2ContigGIDs = Blocking::getSubBlockColumnGIDs(*A, subMaps[j]);
+  }
   Tpetra::Vector<GO, LO, GO, NT>& local2ContigGIDs = *plocal2ContigGIDs;
 
   // get entry information
@@ -293,7 +296,7 @@ RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
 // build a single subblock Epetra_CrsMatrix
 void rebuildSubBlock(int i, int j, const RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT> >& A,
                      const std::vector<MapPair>& subMaps, Tpetra::CrsMatrix<ST, LO, GO, NT>& mat,
-                     const Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> >& plocal2ContigGIDs) {
+                     Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> > plocal2ContigGIDs) {
   // get the number of variables families
   int numVarFamily = subMaps.size();
 
@@ -304,6 +307,9 @@ void rebuildSubBlock(int i, int j, const RCP<const Tpetra::CrsMatrix<ST, LO, GO,
   const Tpetra::Map<LO, GO, NT>& rowMap  = *subMaps[i].second;  // contiguous GIDs
   const Tpetra::Map<LO, GO, NT>& colMap  = *subMaps[j].second;
 
+  if(!plocal2ContigGIDs){
+    plocal2ContigGIDs = Blocking::getSubBlockColumnGIDs(*A, subMaps[j]);
+  }
   Tpetra::Vector<GO, LO, GO, NT>& local2ContigGIDs = *plocal2ContigGIDs;
 
   mat.resumeFill();

--- a/packages/teko/src/Tpetra/Teko_BlockingTpetra.cpp
+++ b/packages/teko/src/Tpetra/Teko_BlockingTpetra.cpp
@@ -195,7 +195,7 @@ RCP<Tpetra::Vector<GO, LO, GO, NT> > getSubBlockColumnGIDs(
 RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
     int i, int j, const RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT> >& A,
     const std::vector<MapPair>& subMaps,
-    const Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> > & plocal2ContigGIDs) {
+    const Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> >& plocal2ContigGIDs) {
   // get the number of variables families
   int numVarFamily = subMaps.size();
 
@@ -237,7 +237,7 @@ RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
     A->getLocalRowCopy(lid, indices, values, numEntries);
 
     LO numOwnedCols = 0;
-    auto data = local2ContigGIDs.getData();
+    auto data       = local2ContigGIDs.getData();
     for (size_t localCol = 0; localCol < numEntries; localCol++) {
       TEUCHOS_ASSERT(indices(localCol) > -1);
 
@@ -265,7 +265,7 @@ RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
     A->getLocalRowCopy(lid, indices, values, numEntries);
 
     LO numOwnedCols = 0;
-    auto data = local2ContigGIDs.getData();
+    auto data       = local2ContigGIDs.getData();
     for (size_t localCol = 0; localCol < numEntries; localCol++) {
       TEUCHOS_ASSERT(indices(localCol) > -1);
 
@@ -293,8 +293,7 @@ RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
 // build a single subblock Epetra_CrsMatrix
 void rebuildSubBlock(int i, int j, const RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT> >& A,
                      const std::vector<MapPair>& subMaps, Tpetra::CrsMatrix<ST, LO, GO, NT>& mat,
-                     const Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> > & plocal2ContigGIDs) {
-
+                     const Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> >& plocal2ContigGIDs) {
   // get the number of variables families
   int numVarFamily = subMaps.size();
 
@@ -339,7 +338,7 @@ void rebuildSubBlock(int i, int j, const RCP<const Tpetra::CrsMatrix<ST, LO, GO,
     A->getLocalRowCopy(lid, indices, values, numEntries);
 
     LO numOwnedCols = 0;
-    auto data = local2ContigGIDs.getData();
+    auto data       = local2ContigGIDs.getData();
     for (size_t localCol = 0; localCol < numEntries; localCol++) {
       TEUCHOS_ASSERT(indices(localCol) > -1);
 

--- a/packages/teko/src/Tpetra/Teko_BlockingTpetra.cpp
+++ b/packages/teko/src/Tpetra/Teko_BlockingTpetra.cpp
@@ -237,13 +237,13 @@ RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
     A->getLocalRowCopy(lid, indices, values, numEntries);
 
     LO numOwnedCols = 0;
-    auto data       = local2ContigGIDs.getData();
+    auto data = local2ContigGIDs.getLocalViewHost(Tpetra::Access::ReadOnly);
     for (size_t localCol = 0; localCol < numEntries; localCol++) {
       TEUCHOS_ASSERT(indices(localCol) > -1);
 
       // if global id is not owned by this column
 
-      GO gid = data[indices[localCol]];
+      GO gid = data(indices[localCol], 0);
       if (gid == -1) continue;  // in contiguous row
       numOwnedCols++;
     }
@@ -265,13 +265,13 @@ RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
     A->getLocalRowCopy(lid, indices, values, numEntries);
 
     LO numOwnedCols = 0;
-    auto data       = local2ContigGIDs.getData();
+    auto data = local2ContigGIDs.getLocalViewHost(Tpetra::Access::ReadOnly);
     for (size_t localCol = 0; localCol < numEntries; localCol++) {
       TEUCHOS_ASSERT(indices(localCol) > -1);
 
       // if global id is not owned by this column
 
-      GO gid = data[indices(localCol)];
+      GO gid = data(indices(localCol), 0);
       if (gid == -1) continue;  // in contiguous row
 
       colIndices[numOwnedCols] = gid;
@@ -338,12 +338,12 @@ void rebuildSubBlock(int i, int j, const RCP<const Tpetra::CrsMatrix<ST, LO, GO,
     A->getLocalRowCopy(lid, indices, values, numEntries);
 
     LO numOwnedCols = 0;
-    auto data       = local2ContigGIDs.getData();
+    auto data = local2ContigGIDs.getLocalViewHost(Tpetra::Access::ReadOnly);
     for (size_t localCol = 0; localCol < numEntries; localCol++) {
       TEUCHOS_ASSERT(indices(localCol) > -1);
 
       // if global id is not owned by this column
-      GO gid = data[indices(localCol)];
+      GO gid = data(indices(localCol), 0);
       if (gid == -1) continue;  // in contiguous row
 
       colIndices[numOwnedCols] = gid;

--- a/packages/teko/src/Tpetra/Teko_BlockingTpetra.hpp
+++ b/packages/teko/src/Tpetra/Teko_BlockingTpetra.hpp
@@ -119,7 +119,8 @@ Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> > getSubBlockColumnGIDs(
  */
 Teuchos::RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
     int i, int j, const Teuchos::RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT> >& A,
-    const std::vector<MapPair>& subMaps);
+    const std::vector<MapPair>& subMaps,
+    const Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> > & plocal2ContigGIDs);
 
 /** Extract the (i,j) sub block described by a vector of map pair objects from
  * a CRS matrix. The first of map in the ith pair describes the rows to be extracted,
@@ -135,7 +136,8 @@ Teuchos::RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
  *                    this operator would come from the <code>buildSubBlock</code> routine.
  */
 void rebuildSubBlock(int i, int j, const Teuchos::RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT> >& A,
-                     const std::vector<MapPair>& subMaps, Tpetra::CrsMatrix<ST, LO, GO, NT>& mat);
+                     const std::vector<MapPair>& subMaps, Tpetra::CrsMatrix<ST, LO, GO, NT>& mat,
+                     const Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> > & plocal2ContigGIDs);
 
 }  // namespace Blocking
 }  // namespace TpetraHelpers

--- a/packages/teko/src/Tpetra/Teko_BlockingTpetra.hpp
+++ b/packages/teko/src/Tpetra/Teko_BlockingTpetra.hpp
@@ -120,7 +120,7 @@ Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> > getSubBlockColumnGIDs(
 Teuchos::RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
     int i, int j, const Teuchos::RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT> >& A,
     const std::vector<MapPair>& subMaps,
-    const Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> >& plocal2ContigGIDs);
+    Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> > plocal2ContigGIDs = {});
 
 /** Extract the (i,j) sub block described by a vector of map pair objects from
  * a CRS matrix. The first of map in the ith pair describes the rows to be extracted,
@@ -137,7 +137,7 @@ Teuchos::RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
  */
 void rebuildSubBlock(int i, int j, const Teuchos::RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT> >& A,
                      const std::vector<MapPair>& subMaps, Tpetra::CrsMatrix<ST, LO, GO, NT>& mat,
-                     const Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> >& plocal2ContigGIDs);
+                     Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> > plocal2ContigGIDs = {});
 
 }  // namespace Blocking
 }  // namespace TpetraHelpers

--- a/packages/teko/src/Tpetra/Teko_BlockingTpetra.hpp
+++ b/packages/teko/src/Tpetra/Teko_BlockingTpetra.hpp
@@ -120,7 +120,7 @@ Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> > getSubBlockColumnGIDs(
 Teuchos::RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
     int i, int j, const Teuchos::RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT> >& A,
     const std::vector<MapPair>& subMaps,
-    const Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> > & plocal2ContigGIDs);
+    const Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> >& plocal2ContigGIDs);
 
 /** Extract the (i,j) sub block described by a vector of map pair objects from
  * a CRS matrix. The first of map in the ith pair describes the rows to be extracted,
@@ -137,7 +137,7 @@ Teuchos::RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > buildSubBlock(
  */
 void rebuildSubBlock(int i, int j, const Teuchos::RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT> >& A,
                      const std::vector<MapPair>& subMaps, Tpetra::CrsMatrix<ST, LO, GO, NT>& mat,
-                     const Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> > & plocal2ContigGIDs);
+                     const Teuchos::RCP<Tpetra::Vector<GO, LO, GO, NT> >& plocal2ContigGIDs);
 
 }  // namespace Blocking
 }  // namespace TpetraHelpers

--- a/packages/teko/src/Tpetra/Teko_TpetraBlockedMappingStrategy.hpp
+++ b/packages/teko/src/Tpetra/Teko_TpetraBlockedMappingStrategy.hpp
@@ -184,6 +184,8 @@ class TpetraBlockedMappingStrategy : public MappingStrategy {
   std::vector<Teuchos::RCP<Tpetra::Import<LO, GO, NT> > > blockImport_;
   std::vector<Teuchos::RCP<Tpetra::Export<LO, GO, NT> > > blockExport_;
   //@}
+
+  mutable std::vector<RCP<Tpetra::Vector<GO, LO, GO, NT> >> plocal2ContigGIDs;
 };
 
 }  // end namespace TpetraHelpers

--- a/packages/teko/src/Tpetra/Teko_TpetraBlockedMappingStrategy.hpp
+++ b/packages/teko/src/Tpetra/Teko_TpetraBlockedMappingStrategy.hpp
@@ -50,8 +50,8 @@ class TpetraBlockedMappingStrategy : public MappingStrategy {
    * \param[in]      baseMap    original Tpetra::Map<LO,GO,NT>  to be broken up
    * \param[in]      comm   Teuchos::RCP<Teuchos::Comm<int> > object related to the map
    */
-  TpetraBlockedMappingStrategy(const std::vector<std::vector<GO> >& vars,
-                               const Teuchos::RCP<const Tpetra::Map<LO, GO, NT> >& baseMap,
+  TpetraBlockedMappingStrategy(const std::vector<std::vector<GO>>& vars,
+                               const Teuchos::RCP<const Tpetra::Map<LO, GO, NT>>& baseMap,
                                const Teuchos::Comm<int>& comm);
   //@}
 
@@ -66,7 +66,7 @@ class TpetraBlockedMappingStrategy : public MappingStrategy {
    * \param[in,out]     thyra_X   destination Thyra::MultiVectorBase
    */
   virtual void copyTpetraIntoThyra(const Tpetra::MultiVector<ST, LO, GO, NT>& tpetra_X,
-                                   const Teuchos::Ptr<Thyra::MultiVectorBase<ST> >& thyra_X) const;
+                                   const Teuchos::Ptr<Thyra::MultiVectorBase<ST>>& thyra_X) const;
 
   /** Virtual function defined in MappingStrategy.  This copies
    * an Tpetra::MultiVector<ST,LO,GO,NT> into a Thyra::MultiVectorBase with
@@ -75,7 +75,7 @@ class TpetraBlockedMappingStrategy : public MappingStrategy {
    * \param[in]     thyra_Y  source Thyra::MultiVectorBase
    * \param[in,out]     tpetra_Y destination Tpetra::MultiVector<ST,LO,GO,NT>
    */
-  virtual void copyThyraIntoTpetra(const Teuchos::RCP<const Thyra::MultiVectorBase<ST> >& thyra_Y,
+  virtual void copyThyraIntoTpetra(const Teuchos::RCP<const Thyra::MultiVectorBase<ST>>& thyra_Y,
                                    Tpetra::MultiVector<ST, LO, GO, NT>& tpetra_Y) const;
 
   /** Returns the domain and range maps used by this class.
@@ -85,9 +85,7 @@ class TpetraBlockedMappingStrategy : public MappingStrategy {
    *
    * \returns Range map corresponding to this class
    */
-  virtual const Teuchos::RCP<const Tpetra::Map<LO, GO, NT> > domainMap() const {
-    return domainMap_;
-  }
+  virtual const Teuchos::RCP<const Tpetra::Map<LO, GO, NT>> domainMap() const { return domainMap_; }
 
   /** Returns the domain and range maps used by this class.
    * This faciliates building an Tpetra_Operator around this
@@ -96,7 +94,7 @@ class TpetraBlockedMappingStrategy : public MappingStrategy {
    *
    * \returns Range map corresponding to this class
    */
-  virtual const Teuchos::RCP<const Tpetra::Map<LO, GO, NT> > rangeMap() const { return rangeMap_; }
+  virtual const Teuchos::RCP<const Tpetra::Map<LO, GO, NT>> rangeMap() const { return rangeMap_; }
 
   /** A function for my sanity
    *
@@ -123,8 +121,8 @@ class TpetraBlockedMappingStrategy : public MappingStrategy {
    * \param[in]      baseMap   basic map to use in the transfers
    * \param[in]      comm      Teuchos::RCP<Teuchos::Comm<int> > object
    */
-  void buildBlockTransferData(const std::vector<std::vector<GO> >& vars,
-                              const Teuchos::RCP<const Tpetra::Map<LO, GO, NT> >& baseMap,
+  void buildBlockTransferData(const std::vector<std::vector<GO>>& vars,
+                              const Teuchos::RCP<const Tpetra::Map<LO, GO, NT>>& baseMap,
                               const Teuchos::Comm<int>& comm);
 
   /** \brief  Get the individual block maps underlying that
@@ -151,8 +149,8 @@ class TpetraBlockedMappingStrategy : public MappingStrategy {
    * \returns Blocked Thyra linear operator with sub blocks
    *          defined by this mapping strategy
    */
-  const Teuchos::RCP<Thyra::BlockedLinearOpBase<ST> > buildBlockedThyraOp(
-      const Teuchos::RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT> >& mat,
+  const Teuchos::RCP<Thyra::BlockedLinearOpBase<ST>> buildBlockedThyraOp(
+      const Teuchos::RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT>>& mat,
       const std::string& label = "<ANYM>") const;
 
   /** Rebuilds a block Thyra operator using the strided mapping
@@ -164,8 +162,8 @@ class TpetraBlockedMappingStrategy : public MappingStrategy {
    * \param[in] A Destination block linear op composed of blocks of
    *            Tpetra::CrsMatrix<ST,LO,GO,NT>  at all relevant locations
    */
-  void rebuildBlockedThyraOp(const RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT> >& mat,
-                             const RCP<Thyra::BlockedLinearOpBase<ST> >& A) const;
+  void rebuildBlockedThyraOp(const RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT>>& mat,
+                             const RCP<Thyra::BlockedLinearOpBase<ST>>& A) const;
 
   //@}
 
@@ -174,18 +172,18 @@ class TpetraBlockedMappingStrategy : public MappingStrategy {
 
   //! \name storage for sanity
   //@{
-  Teuchos::RCP<const Tpetra::Map<LO, GO, NT> > domainMap_;
-  Teuchos::RCP<const Tpetra::Map<LO, GO, NT> > rangeMap_;
+  Teuchos::RCP<const Tpetra::Map<LO, GO, NT>> domainMap_;
+  Teuchos::RCP<const Tpetra::Map<LO, GO, NT>> rangeMap_;
   //@}
 
   //! \name block transfer data
   //@{
   std::vector<Blocking::MapPair> blockMaps_;
-  std::vector<Teuchos::RCP<Tpetra::Import<LO, GO, NT> > > blockImport_;
-  std::vector<Teuchos::RCP<Tpetra::Export<LO, GO, NT> > > blockExport_;
+  std::vector<Teuchos::RCP<Tpetra::Import<LO, GO, NT>>> blockImport_;
+  std::vector<Teuchos::RCP<Tpetra::Export<LO, GO, NT>>> blockExport_;
   //@}
 
-  mutable std::vector<RCP<Tpetra::Vector<GO, LO, GO, NT> >> plocal2ContigGIDs;
+  mutable std::vector<RCP<Tpetra::Vector<GO, LO, GO, NT>>> plocal2ContigGIDs;
 };
 
 }  // end namespace TpetraHelpers


### PR DESCRIPTION
I've observed that `Teko::TpetraHelpers::BlockedTpetraOperator::RebuildOps` is slow in comparison to the other steps in a Teko preconditioner.

For example, consider the following benchmarking code.
```cpp
  auto dof_block_gids = ...;
  auto dof_blocked_matrix =
      Teuchos::rcp(new Teko::TpetraHelpers::BlockedTpetraOperator(dof_block_gids, A));

  constexpr int ntrials = 10;
  const auto tStart = MPI_Wtime();
  for (int i = 0; i < ntrials; ++i)
  {
    dof_blocked_matrix->RebuildOps();
  }
  const auto tElapsed = MPI_Wtime() - tStart;
  std::cout << "time per trial: " << tElapsed / ntrials << "\n";
```

For a 57,640 DOF system with 4,135,524 nnz and 15 subblocks takes 0.88s per `RebuildOps` call.

This PR reduces that time to 0.074s per call.
