### PR TITLE
Set MPI_ALLOW_PACKAGE_PREFIND=FALSE by default (#13839)

### DIFF
--- a/cmake/tribits/core/std_tpls/FindTPLMPI.cmake
+++ b/cmake/tribits/core/std_tpls/FindTPLMPI.cmake
@@ -20,6 +20,12 @@ if(WIN32 AND TPL_ENABLE_MPI)
   global_set(TPL_MPI_LIBRARIES ${MPI_LIBRARIES})
 endif()
 
+# Don't allow calling find_package(MPI) by default.  Force the user to set
+# MPI_ALLOW_PACKAGE_PREFIND=TRUE or even MPI_FORCE_PRE_FIND_PACKAGE if then
+# want to force the finding of MPI using find_package(MPI).
+set(MPI_ALLOW_PACKAGE_PREFIND  FALSE  CACHE  BOOL
+  "Allow calling find_package(MPI) by default (default is FALSE)")
+
 tribits_tpl_allow_pre_find_package(MPI MPI_ALLOW_PREFIND)
 if(MPI_ALLOW_PREFIND)
 

--- a/cmake/tribits/core/std_tpls/FindTPLMPI.cmake
+++ b/cmake/tribits/core/std_tpls/FindTPLMPI.cmake
@@ -28,9 +28,7 @@ set(MPI_ALLOW_PACKAGE_PREFIND  FALSE  CACHE  BOOL
 
 tribits_tpl_allow_pre_find_package(MPI MPI_ALLOW_PREFIND)
 if(MPI_ALLOW_PREFIND)
-
   find_package(MPI)
-
   if(MPI_C_FOUND AND MPI_CXX_FOUND)
     tribits_extpkg_create_imported_all_libs_target_and_config_file(
       MPI
@@ -41,7 +39,6 @@ endif()
 
 if(NOT TARGET MPI::all_libs)
   tribits_tpl_find_include_dirs_and_libraries(MPI)
+  # NOTE: Above, we need to generate the MPI::all_libs target and the
+  # MPIConfig.cmake file that will also provide the MPI::all_libs target.
 endif()
-
-# NOTE: Above, we need to generate the MPI::all_libs target and the
-# MPIConfig.cmake file that will also provide the MPI::all_libs target.


### PR DESCRIPTION
This returns backwards compatibility for how MPI is found (see #13839) that was caused by #13840.  If you want to use `find_package(MPI)` by default, you can configure Trilinos is with `-D MPI_ALLOW_PACKAGE_PREFIND=TRUE`.

See commit log messages for more details.

Addresses #13839 


