### PR TITLE
Fixes

### DIFF
--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_MatrixConstruction.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_MatrixConstruction.hpp
@@ -64,7 +64,7 @@ class PointwiseCountingFunctor {
     std::string mangledFunctorName = typeid(decltype(functor)).name();
     int status                     = 0;
     char* demangledFunctorName     = 0;
-    demangledFunctorName           = abi::__cxa_demangle(functorName.c_str(), 0, 0, &status);
+    demangledFunctorName           = abi::__cxa_demangle(mangledFunctorName.c_str(), 0, 0, &status);
     functorName                    = demangledFunctorName;
 #endif
   }
@@ -80,7 +80,7 @@ class PointwiseCountingFunctor {
     std::string mangledFunctorName = typeid(decltype(functor)).name();
     int status                     = 0;
     char* demangledFunctorName     = 0;
-    demangledFunctorName           = abi::__cxa_demangle(functorName.c_str(), 0, 0, &status);
+    demangledFunctorName           = abi::__cxa_demangle(mangledFunctorName.c_str(), 0, 0, &status);
     functorName                    = demangledFunctorName;
 #endif
   }
@@ -161,7 +161,7 @@ class PointwiseCountingFunctor<local_matrix_type, functor_type> {
     std::string mangledFunctorName = typeid(decltype(functor)).name();
     int status                     = 0;
     char* demangledFunctorName     = 0;
-    demangledFunctorName           = abi::__cxa_demangle(functorName.c_str(), 0, 0, &status);
+    demangledFunctorName           = abi::__cxa_demangle(mangledFunctorName.c_str(), 0, 0, &status);
     functorName                    = demangledFunctorName;
 #endif
   }
@@ -176,7 +176,7 @@ class PointwiseCountingFunctor<local_matrix_type, functor_type> {
     std::string mangledFunctorName = typeid(decltype(functor)).name();
     int status                     = 0;
     char* demangledFunctorName     = 0;
-    demangledFunctorName           = abi::__cxa_demangle(functorName.c_str(), 0, 0, &status);
+    demangledFunctorName           = abi::__cxa_demangle(mangledFunctorName.c_str(), 0, 0, &status);
     functorName                    = demangledFunctorName;
 #endif
   }
@@ -460,7 +460,9 @@ class VectorCountingFunctor {
 
   VectorCountingFunctor<local_matrix_type, remaining_functor_types...> remainingFunctors;
 
-  std::vector<std::string> functorNames;
+#ifdef MUELU_COALESCE_DROP_DEBUG
+  std::string functorName;
+#endif
 
  public:
   VectorCountingFunctor(local_matrix_type& A_, local_ordinal_type blockSize_, block_indices_view_type ghosted_point_to_block_, results_view& results_, rowptr_type& filtered_rowptr_, rowptr_type& graph_rowptr_, functor_type& functor_, remaining_functor_types&... remainingFunctors_)
@@ -631,7 +633,9 @@ class VectorCountingFunctor<local_matrix_type, functor_type> {
   bool firstFunctor;
   functor_type functor;
 
-  std::vector<std::string> functorNames;
+#ifdef MUELU_COALESCE_DROP_DEBUG
+  std::string functorName;
+#endif
 
   BlockRowComparison<local_matrix_type> comparison;
   permutation_type permutation;

--- a/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
@@ -1740,8 +1740,7 @@ void RefMaxwell<Scalar, LocalOrdinal, GlobalOrdinal, Node>::buildNodalProlongato
     std::string distLaplAlgo = parameterList_.get<std::string>("aggregation: distance laplacian algo");
     dropFact->SetParameter("aggregation: drop tol", Teuchos::ParameterEntry(dropTol));
     dropFact->SetParameter("aggregation: drop scheme", Teuchos::ParameterEntry(dropScheme));
-    if (!useKokkos_)
-      dropFact->SetParameter("aggregation: distance laplacian algo", Teuchos::ParameterEntry(distLaplAlgo));
+    dropFact->SetParameter("aggregation: distance laplacian algo", Teuchos::ParameterEntry(distLaplAlgo));
 
     UncoupledAggFact->SetFactory("Graph", dropFact);
     int minAggSize = parameterList_.get<int>("aggregation: min agg size");

--- a/packages/muelu/test/meshtying/MeshTyingBlocked_NodeBased.cpp
+++ b/packages/muelu/test/meshtying/MeshTyingBlocked_NodeBased.cpp
@@ -158,7 +158,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
   H->IsPreconditioner(true);
 
   // Create the preconditioned GMRES solver
-  typedef typename tpetra_mvector_type::dot_type belos_scalar;
+  using belos_scalar = Scalar;
   typedef Belos::OperatorT<MultiVector> OP;
 
   typedef Belos::StatusTestGenResSubNorm<belos_scalar, MultiVector, OP> blockStatusTestClass;

--- a/packages/muelu/test/scaling/Driver.cpp
+++ b/packages/muelu/test/scaling/Driver.cpp
@@ -452,14 +452,14 @@ int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib& lib, int ar
         for (size_t i = 0; i < dim; ++i)
           for (size_t j = 0; j < dim; ++j) {
             if (i == j)
-              material->getVectorNonConst(k)->putScalar(2 * Teuchos::ScalarTraits<SC>::one());
+              material->getVectorNonConst(k)->putScalar(2.0 * Teuchos::ScalarTraits<SC>::one());
             else
               material->getVectorNonConst(k)->putScalar(Teuchos::ScalarTraits<SC>::zero());
             ++k;
           }
       } else {
         material = MultiVectorFactory::Build(map, 1);
-        material->putScalar(2 * Teuchos::ScalarTraits<SC>::one());
+        material->putScalar(2.0 * Teuchos::ScalarTraits<SC>::one());
       }
     }
 


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
- Two fixes for builds with `Scalar=std::complex<double>`.
- CoalesceDrop: Fix the commented out (because hyper verbose) debug code.
- RefMaxwell: Use "aggregation: distance laplacian algo" option for non-Kokkos and Kokkos code path, since that's now available in both.