### PR TITLE
Framework: Add OneAPI PR build

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -360,6 +360,108 @@ jobs:
           echo "https://github.com/trilinos/Trilinos/wiki/Containers" >> $GITHUB_STEP_SUMMARY
           echo "https://gitlab-ex.sandia.gov/trilinos-project/trilinos-containers/-/wikis/Containers-at-Sandia" >> $GITHUB_STEP_SUMMARY
 
+  oneapi2024:
+    needs: pre-checks
+    runs-on: [self-hosted, oneapi-2024.1.0]
+    if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}
+    steps:
+      - name: env
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          env
+      - name: module list
+        shell: bash
+        run: |
+          bash -l -c "module list"
+          printenv PATH
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
+        with:
+          access_token: ${{ github.token }}
+      - name: make dirs
+        working-directory: /
+        run: |
+          mkdir -p /home/Trilinos/src/Trilinos
+          mkdir -p /home/Trilinos/build
+      - name: Clone trilinos
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Repo status
+        run: |
+          git fetch --all
+          pwd
+          ls -lhat
+          git status
+          git branch -vv
+          git branch -a
+      - name: get dependencies
+        working-directory: ./packages/framework
+        run: |
+          bash -l -c "./get_dependencies.sh"
+      - name: PullRequestLinuxDriverTest.py
+        shell: bash -l {0}
+        working-directory: /home/Trilinos/build
+        run: |
+          # Set up python-is-python3 hackery
+          mkdir bin
+          pushd bin
+          ln -s $(type -p python3) python
+          export PATH=$(pwd):${PATH}
+          popd
+
+          export TRILINOS_DIR=${GITHUB_WORKSPACE:?}
+          export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/GenConfig
+          export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/pr_tools
+          export GENCONFIG_BUILD_NAME=rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+          printf "\n\n\n"
+
+          echo "image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}"
+
+          python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
+            --target-branch-name ${{ github.event.pull_request.base.ref }} \
+            --genconfig-build-name ${GENCONFIG_BUILD_NAME} \
+            --pullrequest-number ${{ github.event.pull_request.number }} \
+            --pullrequest-env-config-file ${GITHUB_WORKSPACE}/packages/framework/pr_tools/trilinos_pr.ini \
+            --pullrequest-gen-config-file ${GITHUB_WORKSPACE}/packages/framework/GenConfig/src/gen-config.ini \
+            --workspace-dir /home/runner/_work/Trilinos \
+            --source-dir ${GITHUB_WORKSPACE} \
+            --build-dir /home/Trilinos/build \
+            --dashboard-build-name=PR-${{ github.event.pull_request.number }}_${AT2_IMAGE}_debug_shared \
+            --ctest-driver /home/runner/_work/Trilinos/Trilinos/cmake/SimpleTesting/cmake/ctest-driver.cmake \
+            --ctest-drop-site sems-cdash-son.sandia.gov/cdash \
+            --filename-subprojects ./package_subproject_list.cmake \
+            --filename-packageenables ./packageEnables.cmake \
+            --max-cores-allowed=29 \
+            --num-concurrent-tests=16
+      - name: Upload artifacts
+        if: success() || failure()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        env:
+          NODE_TLS_REJECT_UNAUTHORIZED: 0
+        with:
+          name: ${{ github.job }}-artifacts
+          path: /home/runner/artifacts/*
+          retention-days: 90
+      - name: Summary
+        if: ${{ !cancelled() }}
+        shell: bash -l {0}
+        working-directory: /home/Trilinos/build
+        run: |
+          echo "## Image" >> $GITHUB_STEP_SUMMARY
+          echo "image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}" >> $GITHUB_STEP_SUMMARY
+          echo "## CDash Links" >> $GITHUB_STEP_SUMMARY
+          echo "### Current Build" >> $GITHUB_STEP_SUMMARY
+          AT2_URL=$(</home/runner/AT2_URL.txt)
+          echo $AT2_URL >> $GITHUB_STEP_SUMMARY
+          echo "### All Builds" >> $GITHUB_STEP_SUMMARY
+          AT2_ALL_BUILDS=$(</home/runner/AT2_ALL_BUILDS.txt)
+          echo $AT2_ALL_BUILDS >> $GITHUB_STEP_SUMMARY
+          echo "## Helpful Links" >> $GITHUB_STEP_SUMMARY
+          echo "https://github.com/trilinos/Trilinos/wiki/Containers" >> $GITHUB_STEP_SUMMARY
+          echo "https://gitlab-ex.sandia.gov/trilinos-project/trilinos-containers/-/wikis/Containers-at-Sandia" >> $GITHUB_STEP_SUMMARY
+
   framework-tests:
     needs: pre-checks
     runs-on: [self-hosted, python-3.9]

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -405,6 +405,11 @@ opt-set-cmake-var TPL_LAPACK_LIBRARY_DIRS STRING FORCE : ${BLAS_ROOT|ENV}/lib
 opt-set-cmake-var TPL_BLAS_LIBRARIES        STRING FORCE : ${OPENBLAS_ROOT|ENV}/lib/libopenblas.a;-lgfortran;-lm
 opt-set-cmake-var TPL_LAPACK_LIBRARIES      STRING FORCE : ${OPENBLAS_ROOT|ENV}/lib/libopenblas.a;-lgfortran;-lm
 
+[MKL_BLAS_LAPACK]
+opt-set-cmake-var TPL_BLAS_LIBRARIES   STRING : -qmkl=sequential
+opt-set-cmake-var TPL_LAPACK_LIBRARIES STRING : -qmkl=sequential
+
+
 [COMMON_SPACK_TPLS]
 use COMMON
 
@@ -448,7 +453,6 @@ opt-set-cmake-var SuperLU_LIBRARY_DIRS PATH FORCE : ${SUPERLU_LIB|ENV}
 opt-set-cmake-var SuperLU_LIBRARY_DIRS STRING FORCE : ${SUPERLU_LIB|ENV}
 # FIXME: Wouldn't need this if we used find_package(superlu)
 opt-set-cmake-var Trilinos_EXTRA_LINK_FLAGS STRING FORCE : -lm
-
 
 # Metis
 opt-set-cmake-var TPL_METIS_LIBRARIES STRING FORCE : ${METIS_LIB|ENV}/libmetis.so
@@ -1851,6 +1855,7 @@ use rhel8_aue-gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mp
 use PACKAGE-ENABLES|ALL
 
 [rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+use COMMON_SPACK_TPLS
 use COMPILER|INTEL
 use BUILD-TYPE|RELEASE-DEBUG
 use LIB-TYPE|SHARED
@@ -1865,38 +1870,7 @@ use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|ALL
 
-opt-set-cmake-var CMAKE_GENERATOR STRING : Ninja
-opt-set-cmake-var Trilinos_PARALLEL_LINK_JOBS_LIMIT STRING : 2
-
-opt-set-cmake-var Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES BOOL : ON
-opt-set-cmake-var Trilinos_ALLOW_NO_PACKAGES BOOL : ON
-opt-set-cmake-var Trilinos_DISABLE_ENABLED_FORWARD_DEP_PACKAGES BOOL : ON
-opt-set-cmake-var Trilinos_IGNORE_MISSING_EXTRA_REPOSITORIES BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL : ON
-opt-set-cmake-var Trilinos_TEST_CATEGORIES STRING : BASIC
-opt-set-cmake-var Trilinos_ENABLE_CONFIGURE_TIMING BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES BOOL : ON
-
-opt-set-cmake-var TPL_ENABLE_Matio BOOL : ON
-opt-set-cmake-var TPL_ENABLE_X11 BOOL : ON
-opt-set-cmake-var TPL_ENABLE_Pthread BOOL : ON
-opt-set-cmake-var TPL_ENABLE_BLAS BOOL : ON
-opt-set-cmake-var TPL_ENABLE_LAPACK BOOL : ON
-opt-set-cmake-var TPL_ENABLE_Boost BOOL : ON
-opt-set-cmake-var TPL_ENABLE_BoostLib BOOL : ON
-opt-set-cmake-var TPL_ENABLE_ParMETIS BOOL : ON
-opt-set-cmake-var TPL_ENABLE_Zlib BOOL : ON
-opt-set-cmake-var TPL_ENABLE_HDF5 BOOL : ON
-opt-set-cmake-var TPL_HDF5_LIBRARIES STRING : "${HDF5_LIB|ENV}/libhdf5_hl.so;${HDF5_LIB|ENV}/libhdf5.so;${ZLIB_LIB|ENV}/libz.so"
-opt-set-cmake-var TPL_ENABLE_Netcdf BOOL : ON
-opt-set-cmake-var TPL_ENABLE_SuperLU BOOL : ON
-opt-set-cmake-var ML_ENABLE_SuperLU BOOL FORCE : OFF
-opt-set-cmake-var TPL_ENABLE_Scotch BOOL : OFF
-
-opt-set-cmake-var TPL_BLAS_LIBRARIES   STRING : -qmkl=sequential
-opt-set-cmake-var TPL_LAPACK_LIBRARIES STRING : -qmkl=sequential
-
-opt-set-cmake-var Trilinos_ENABLE_PyTrilinos BOOL : OFF
+use MKL_BLAS_LAPACK
 
 [ubuntu_gnu_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use BUILD-TYPE|RELEASE-DEBUG

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1854,7 +1854,7 @@ use PACKAGE-ENABLES|ALL
 use rhel8_aue-gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
-[rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+[rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use COMMON_SPACK_TPLS
 use COMPILER|INTEL
 use BUILD-TYPE|RELEASE-DEBUG
@@ -1868,9 +1868,13 @@ use USE-PT|NO
 use USE-RDC|NO
 use USE-UVM|NO
 use USE-DEPRECATED|YES
-use PACKAGE-ENABLES|ALL
+use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use MKL_BLAS_LAPACK
+
+[rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+use rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use PACKAGE-ENABLES|ALL
 
 [ubuntu_gnu_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use BUILD-TYPE|RELEASE-DEBUG

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1853,6 +1853,20 @@ use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 use MKL_BLAS_LAPACK
 
+# Test disables as per discussion on https://github.com/trilinos/Trilinos/pull/13881
+#  Disabling these to get a OneAPI build into PR faster.  Try re-enabling them next time a toolchain is changed.
+opt-set-cmake-var Sacado_GTestSuite_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Zoltan_ch_simple_zoltan_parallel_DISABLE BOOL : ON
+opt-set-cmake-var Ifpack2_MTGS_belos_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Ifpack2_MTSGS_belos_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Ifpack2_MTGS_belos_muelu_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Ifpack2_SGSMT_compare_with_Jacobi_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Orientation_test_orientation_PYR_QuadFace_newBasis_Serial_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Intrepid2_unit-test_Orientation_test_orientation_PYR_TriFace_newBasis_Serial_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var MueLu_Structured_Interp_Laplace2D_kokkos_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var MueLu_Structured_Interp_SA_Laplace2D_kokkos_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var MueLu_Structured_Interp_SA_Laplace2D_kokkos_MPI_4_DISABLE BOOL : ON
+
 [rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1851,13 +1851,19 @@ use rhel8_aue-gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mp
 use PACKAGE-ENABLES|ALL
 
 [rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+use COMPILER|INTEL
 use BUILD-TYPE|RELEASE-DEBUG
+use LIB-TYPE|SHARED
 use KOKKOS-ARCH|NO-KOKKOS-ARCH
 use USE-ASAN|NO
 use USE-COMPLEX|NO
 use USE-FPIC|YES
-
-opt-set-cmake-var BUILD_SHARED_LIBS      BOOL   : ON
+use USE-MPI-NO-EXPLICIT-COMPILERS|YES
+use USE-PT|NO
+use USE-RDC|NO
+use USE-UVM|NO
+use USE-DEPRECATED|YES
+use PACKAGE-ENABLES|ALL
 
 opt-set-cmake-var CMAKE_GENERATOR STRING : Ninja
 opt-set-cmake-var Trilinos_PARALLEL_LINK_JOBS_LIMIT STRING : 2
@@ -1886,18 +1892,6 @@ opt-set-cmake-var TPL_ENABLE_Netcdf BOOL : ON
 opt-set-cmake-var TPL_ENABLE_SuperLU BOOL : ON
 opt-set-cmake-var ML_ENABLE_SuperLU BOOL FORCE : OFF
 opt-set-cmake-var TPL_ENABLE_Scotch BOOL : OFF
-
-opt-set-cmake-var CMAKE_C_COMPILER       FILEPATH : ${MPICC|ENV}
-opt-set-cmake-var CMAKE_CXX_COMPILER     FILEPATH : ${MPICXX|ENV}
-opt-set-cmake-var CMAKE_Fortran_COMPILER FILEPATH : ${MPIF90|ENV}
-opt-set-cmake-var TPL_ENABLE_MPI         BOOL     : ON
-opt-set-cmake-var MPI_EXEC FILEPATH : mpirun
-
-use USE-PT|NO
-use USE-RDC|NO
-use USE-UVM|NO
-use USE-DEPRECATED|YES
-use PACKAGE-ENABLES|ALL
 
 opt-set-cmake-var TPL_BLAS_LIBRARIES   STRING : -qmkl=sequential
 opt-set-cmake-var TPL_LAPACK_LIBRARIES STRING : -qmkl=sequential

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -868,54 +868,6 @@ opt-set-cmake-var Trilinos_ENABLE_ALL_PACKAGES BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL : ON
 opt-set-cmake-var TrilinosFrameworkTests_ENABLE_TESTS BOOL : ON
 
-[PACKAGE-ENABLES|RDC-MINIMAL]
-opt-set-cmake-var Trilinos_ENABLE_Amesos BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Amesos2 BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Anasazi BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_AztecOO BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Belos BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Epetra BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_EpetraExt BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Galeri BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Ifpack BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Ifpack2 BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Intrepid BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Intrepid2 BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Kokkos BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_KokkosKernels BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_MiniTensor BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_ML BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_MueLu BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_NOX BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Pamgen BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Panzer BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_PanzerExprEval BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Percept BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Phalanx BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Piro BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_ROL BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_RTOp BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Sacado BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_SEACAS BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Shards BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_ShyLU_NodeHTS BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_ShyLU_NodeTacho BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_STK BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Stratimikos BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_SuperLU5_API BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Teko BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Teuchos BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_ThreadPool BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Thyra BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_ThyraEpetraExtAdapters BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Tpetra BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_TrilinosSS BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Triutils BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Xpetra BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Zoltan BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Zoltan2 BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_Zoltan2Core BOOL : ON
-
 [PACKAGE-ENABLES|ALL-NO-EPETRA]
 opt-set-cmake-var Trilinos_ENABLE_ALL_PACKAGES BOOL FORCE : ON
 opt-set-cmake-var Trilinos_ENABLE_Amesos BOOL FORCE : OFF

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -473,25 +473,6 @@ use COMMON_SPACK_TPLS
 opt-set-cmake-var TPL_Netcdf_LIBRARIES STRING FORCE : ""
 opt-set-cmake-var TPL_HDF5_LIBRARIES   STRING FORCE : ""
 
-[COMMON_USE-MPI|NO]
-use COMMON
-opt-set-cmake-var TPL_ENABLE_ParMETIS BOOL FORCE : OFF
-opt-set-cmake-var TPL_ENABLE_Scotch   BOOL FORCE : OFF
-opt-set-cmake-var TPL_Netcdf_LIBRARIES STRING FORCE : ${SEMS_NETCDF_LIBRARY_PATH|ENV}/libnetcdf.so
-
-[COMMON_INTEL]
-use COMMON
-opt-set-cmake-var SuperLUDist_INCLUDE_DIRS PATH : ${SEMS_SUPERLU_DIST_INCLUDE_PATH|ENV}
-opt-set-cmake-var SuperLUDist_LIBRARY_DIRS PATH : ${SEMS_SUPERLU_DIST_LIBRARY_PATH|ENV}
-opt-set-cmake-var TPL_ENABLE_SuperLUDist BOOL : ON
-# Override TPL_ENABLE_SuperLU=ON from [COMMON]
-opt-set-cmake-var TPL_ENABLE_SuperLU BOOL FORCE : OFF
-
-opt-set-cmake-var Tpetra_INST_INT_INT BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_STKBalance BOOL FORCE : OFF
-#STK-TODO: try to remember to come back and remove this when stk-balance
-#is able to tolerate int as a global-index.
-
 
 #------------------------------------------------------------------------------
 # 2. Tweaks corresponding to flag-option pairs from


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Want to add a configuration and PR test for OneAPI-2024 (required for new Kokkos 4.6).

## Related Issues
#13878 

## Testing
Testing shows the following tests failing (mostly due to numerical tolerances, but the Intrepid2 ones may be because of Intel MKL):

```
The following tests FAILED:
        266 - Sacado_GTestSuite_MPI_1 (Failed)                  Sacado
        637 - Zoltan_ch_simple_zoltan_parallel (Failed)         Zoltan
        1541 - Ifpack2_MTGS_belos_MPI_1 (Failed)                 Ifpack2
        1542 - Ifpack2_MTSGS_belos_MPI_1 (Failed)                Ifpack2
        1544 - Ifpack2_MTGS_belos_muelu_MPI_4 (Failed)           Ifpack2
        1572 - Ifpack2_SGSMT_compare_with_Jacobi_MPI_4 (Failed)  Ifpack2
        2040 - Intrepid2_unit-test_Orientation_test_orientation_PYR_QuadFace_newBasis_Serial_DOUBLE_MPI_1 (Failed) Intrepid2
        2041 - Intrepid2_unit-test_Orientation_test_orientation_PYR_TriFace_newBasis_Serial_DOUBLE_MPI_1 (Failed) Intrepid2
        2415 - MueLu_Structured_Interp_Laplace2D_kokkos_MPI_4 (Failed) MueLu
        2416 - MueLu_Structured_Interp_SA_Laplace2D_kokkos_MPI_1 (Failed) MueLu
        2417 - MueLu_Structured_Interp_SA_Laplace2D_kokkos_MPI_4 (Failed) MueLu
```

Once the results are ready, I'll tag the respective teams to have them look at the CDash results and then we can iterate on how to handle each of the failures.

## Additional Information
I also cleaned up some other miscellany in the `config-specs.ini` file, and added the GenConfig build ID to the summary page for each action.