### PR TITLE
Change default CDash site to internal trilinos-cdash[-qual].sandia.gov

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -14,15 +14,15 @@ IF (NOT DEFINED CTEST_DROP_METHOD)
   SET_DEFAULT_AND_FROM_ENV(CTEST_DROP_METHOD "https")
 ENDIF()
 
-IF (CTEST_DROP_METHOD STREQUAL "http" OR CTEST_DROP_METHOD STREQUAL "https")
-  SET_DEFAULT_AND_FROM_ENV(CTEST_DROP_SITE "testing.sandia.gov")
+IF (CTEST_DROP_METHOD STREQUAL "https")
+  SET_DEFAULT_AND_FROM_ENV(CTEST_DROP_SITE "trilinos-cdash.sandia.gov")
   SET_DEFAULT_AND_FROM_ENV(CTEST_PROJECT_NAME "Trilinos")
-  SET_DEFAULT_AND_FROM_ENV(CTEST_DROP_LOCATION "/cdash/submit.php?project=Trilinos")
+  SET_DEFAULT_AND_FROM_ENV(CTEST_DROP_LOCATION "/submit.php?project=Trilinos")
   SET_DEFAULT_AND_FROM_ENV(CTEST_TRIGGER_SITE "")
   SET_DEFAULT_AND_FROM_ENV(CTEST_DROP_SITE_CDASH TRUE)
   # Secondary submit to development CDash site
   SET_DEFAULT_AND_FROM_ENV(TRIBITS_2ND_CTEST_DROP_SITE
-    "testing-dev.sandia.gov")
+    "trilinos-cdash-qual.sandia.gov")
   SET_DEFAULT_AND_FROM_ENV(TRIBITS_2ND_CTEST_DROP_LOCATION
-    "/cdash/submit.php?project=Trilinos")
+    "/submit.php?project=Trilinos")
 ENDIF()


### PR DESCRIPTION
This allows SNL Trilinos devs to submit to the internal Trilinos CDash site by default.  It is easy to configure to submit to a different CDash stie.

You need to set the SNL proxy env vars for this to work.  (Don't know that I can post those here.)

I tested his on an internal SNL machine and submitted to this CDash site as described [here](https://github.com/trilinos/Trilinos/issues/13731#issuecomment-2727621109) and shown on `trilinos-cdash.sandia.gov` [here](https://trilinos-cdash.sandia.gov/index.php?project=Trilinos&filtercount=3&showfilters=1&filtercombine=and&field1=site&compare1=61&value1=cee-build030&field2=buildname&compare2=61&value2=Linux-SERIAL_RELEASE&field3=buildstamp&compare3=61&value3=20250316-2010-Experimental) showing:

![image](https://github.com/user-attachments/assets/897e8e36-9c0a-4fa5-8275-9fa58265a13c)

and on `https://trilinos-cdash-qual.sandia.gov/` [here](https://trilinos-cdash-qual.sandia.gov/index.php?project=Trilinos&filtercount=3&showfilters=1&filtercombine=and&field1=site&compare1=61&value1=cee-build030&field2=buildname&compare2=61&value2=Linux-SERIAL_RELEASE&field3=buildstamp&compare3=61&value3=20250316-2010-Experimental) showing:

![image](https://github.com/user-attachments/assets/3a03aedb-3ed0-4ec3-8435-443cf9b6734d)


