### PR TITLE
Thyra: Comment out fence in Tpetra operator apply

### DIFF
--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraLinearOp_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraLinearOp_def.hpp
@@ -264,7 +264,9 @@ void TpetraLinearOp<Scalar,LocalOrdinal,GlobalOrdinal,Node>::applyImpl(
   // Apply the operator
 
   tpetraOperator_->apply(*tX, *tY, tTransp, alpha, beta);
-  Kokkos::fence();
+  // CAG: Commented out since the purpose seems unclear.
+  //      Tpetra apply should do all the necessary fencing.
+  // Kokkos::fence();
 }
 
 // Protected member functions overridden from ScaledLinearOpBase


### PR DESCRIPTION
@trilinos/thyra

## Motivation
I commented out a fence in the Thyra-Tpetra adapter since it doesn't make sense to me. Let's see if the AT thinks that it was actually necessary.