### PR TITLE
MueLu: Fix filtered emin multigrid parameter hookup

### DIFF
--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -81,7 +81,7 @@ IF (${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK OR ${PACKAGE_NAME}_HAVE_EPETRA_SOLV
     ) 
 
   TRIBITS_COPY_FILES_TO_BINARY_DIR(Driver_cp
-    SOURCE_FILES scaling.xml scaling.yaml scaling-complex.xml scaling_apex.xml scaling-withglobalconstants.xml scaling-complex-withglobalconstants.xml circ_nsp_dependency.xml isorropia.xml iso_poisson.xml conchas_milestone_zoltan.xml conchas_milestone_zoltan2.xml conchas_milestone_zoltan2_complex.xml sa_with_ilu.xml sa_with_Ifpack2_line_detection.xml rap.xml smoother.xml smoother_complex.xml tripleMatrixProduct.xml scaling-ml.xml elasticity3D.xml amgx.json amgx.xml scaling-with-rerun.xml scaling_distance2_agg.xml smooVec.mm smooVecCoalesce.xml pairwise.xml sa_enforce_constraints.xml recurMG.xml anisotropic.xml  comp_rotations.xml generalBlkSmoothing.xml GblkMap.dat GblkAmat.dat GblkRhs.dat Gblks.dat blkSmooEquivOlapSchwarz.xml oLapSchwarzEquivBlkSmoo.xml regularOverLap.dat zeroAggTest.xml blkDiag3x3And6x6.mat  coords2.mm aux1.mat aux2.mat  coords1.mat  coords2.mat  multiPhys4x4.mat multiPhys4x4.mat  null1.mat null2.mat comboP.xml material.xml material.mm
+    SOURCE_FILES scaling.xml scaling.yaml scaling-complex.xml scaling_apex.xml scaling-withglobalconstants.xml scaling-complex-withglobalconstants.xml circ_nsp_dependency.xml isorropia.xml iso_poisson.xml conchas_milestone_zoltan.xml conchas_milestone_zoltan2.xml conchas_milestone_zoltan2_complex.xml sa_with_ilu.xml sa_with_Ifpack2_line_detection.xml rap.xml smoother.xml smoother_complex.xml tripleMatrixProduct.xml scaling-ml.xml elasticity3D.xml emin_with_dl_elasticity3D.xml amgx.json amgx.xml scaling-with-rerun.xml scaling_distance2_agg.xml smooVec.mm smooVecCoalesce.xml pairwise.xml sa_enforce_constraints.xml recurMG.xml anisotropic.xml  comp_rotations.xml generalBlkSmoothing.xml GblkMap.dat GblkAmat.dat GblkRhs.dat Gblks.dat blkSmooEquivOlapSchwarz.xml oLapSchwarzEquivBlkSmoo.xml regularOverLap.dat zeroAggTest.xml blkDiag3x3And6x6.mat  coords2.mm aux1.mat aux2.mat  coords1.mat  coords2.mat  multiPhys4x4.mat multiPhys4x4.mat  null1.mat null2.mat comboP.xml material.xml material.mm
     CATEGORIES BASIC PERFORMANCE
    )
 
@@ -546,6 +546,14 @@ IF (${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK)
       Driver
       NAME "CalcRotations"
       ARGS "--linAlgebra=Tpetra --xml=comp_rotations.xml  --matrixType=Elasticity3D --nx=40 --ny=40 --nz=4 --its=26 --belosType=gmres --tol=1.0e-8  --muelu-computed-nullspace"
+      NUM_MPI_PROCS 4
+      COMM serial mpi
+      PASS_REGULAR_EXPRESSION "Belos converged"
+      )
+  MUELU_ADD_SERIAL_AND_MPI_TEST(
+      Driver
+      NAME "AnisotropicElasticityEmin"
+      ARGS "--linAlgebra=Tpetra --xml=emin_with_dl_elasticity3D.xml  --matrixType=Elasticity3D --nx=20 --ny=20 --stretchx=3. --its=25 --belosType=cg --tol=1.0e-8  --muelu-computed-nullspace"
       NUM_MPI_PROCS 4
       COMM serial mpi
       PASS_REGULAR_EXPRESSION "Belos converged"

--- a/packages/muelu/test/scaling/emin_with_dl_elasticity3D.xml
+++ b/packages/muelu/test/scaling/emin_with_dl_elasticity3D.xml
@@ -1,0 +1,52 @@
+<ParameterList name="MueLu">
+
+  <!--
+    For 3D elasticity, these are the recommended settings for MueLu.
+  -->
+
+  <!-- ===========  GENERAL ================ -->
+    <Parameter        name="problem: type"                        type="string"   value="Elasticity-3D"/>
+
+    <Parameter        name="verbosity"                            type="string"   value="high"/>
+
+    <Parameter        name="coarse: max size"                     type="int"      value="1000"/>
+
+    <Parameter        name="multigrid algorithm"                  type="string"   value="emin"/>
+
+    <!-- reduces setup cost for symmetric problems -->
+    <Parameter        name="transpose: use implicit"              type="bool"     value="true"/>
+
+    <!-- start of default values for general options (can be omitted) -->
+    <Parameter        name="max levels"                	          type="int"      value="10"/>
+    <Parameter        name="number of equations"                  type="int"      value="3"/>
+
+  <!-- ===========  AGGREGATION  =========== -->
+    <Parameter        name="aggregation: type"                    type="string"   value="uncoupled"/>
+    <Parameter        name="aggregation: drop scheme"             type="string"   value="distance laplacian"/>
+    <Parameter        name="aggregation: drop tol"                type="double"   value="0.04"/>
+
+  <!-- ===========  SMOOTHING  =========== -->
+    <Parameter        name="smoother: type"                       type="string"   value="CHEBYSHEV"/>
+    <ParameterList    name="smoother: params">
+      <Parameter      name="chebyshev: degree"                    type="int"      value="2"/>>
+      <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="7"/>
+      <Parameter      name="chebyshev: min eigenvalue"            type="double"   value="1.0"/>
+      <Parameter      name="chebyshev: zero starting solution"    type="bool"     value="true"/>
+    </ParameterList>
+
+  <!-- ===========  REPARTITIONING  =========== -->
+    <Parameter        name="repartition: enable"                  type="bool"     value="true"/>
+    <Parameter        name="repartition: partitioner"             type="string"   value="zoltan2"/>
+    <Parameter        name="repartition: start level"             type="int"      value="2"/>
+    <Parameter        name="repartition: min rows per proc"       type="int"      value="800"/>
+    <Parameter        name="repartition: max imbalance"           type="double"   value="1.1"/>
+    <Parameter        name="repartition: remap parts"             type="bool"     value="false"/>
+    <!-- start of default values for repartitioning (can be omitted) -->
+    <Parameter name="repartition: remap parts"                type="bool"     value="true"/>
+    <Parameter name="repartition: rebalance P and R"          type="bool"     value="false"/>
+    <ParameterList name="repartition: params">
+       <Parameter name="algorithm" type="string" value="multijagged"/>
+    </ParameterList>
+    <!-- end of default values -->
+
+</ParameterList>


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
The emin multigrid parameter and factory hookup seems to have a slight conceptual error regarding matrix filtering. Thus, changing the factory and parameter hookup in case of a filtered matrix to make things right and avoid duplicated factory calls.

With the changes made the filtered matrix is now used for the prolongator pattern creation and the full operator for the actual minimization procedure (before it was the other way round).

@aprokop I was told you used this multigrid option at some point. Do you mind having a look at the changes? At least from a conceptual standpoint. Thanks! :smile: 

Might also be interesting for @mayrmt @alinaescher