### PR TITLE
Panzer: Disable failing test

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2015,6 +2015,7 @@ opt-set-cmake-var Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC BOOL : OFF
 [rhel8_cuda-11-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use rhel8_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 opt-set-cmake-var ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var PanzerMiniEM_Maxwell_MueLu_order1_tpl_MPI_4_DISABLE BOOL : ON
 
 [rhel8_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables]
 use NODE-TYPE|CUDA


### PR DESCRIPTION
Discussed with @cgcgcg and @rppawlo.  Decided to disable this test for now, will reevaluate later.  It is failing reliably in our containerized CI runs on 2xA100 machines.

@trilinos/panzer 
@trilinos/framework 

## Motivation
This disables the single reliably-failing Panzer test for the new CI A100 configuration (required to move to AT2).