### PR TITLE
Framework: Ignore ctest submit errors

### DIFF
--- a/cmake/SimpleTesting/README.md
+++ b/cmake/SimpleTesting/README.md
@@ -33,7 +33,6 @@ from being include more than once in an include chain.
 | `skip_clean_build_dir`     | BOOL   |    NO     | ON                                            | Skip cleaning the build directory (`ctest_empty_binary_directory`) |
 | `skip_update_step`         | BOOL   |    NO     | OFF                                           | Skip the update step (`ctest_update()`) of the repository.         |
 | `skip_by_parts_submit`     | BOOL   |    NO     | ON                                            | Skip submission to CDash after each phase.                         |
-| `skip_single_submit`       | BOOL   |    NO     | ON                                            | Skip single submission                                             |
 | `skip_upload_config_files` | BOOL   |    NO     | OFF                                           | Skip upload config files (???)                                     |
 | `build_root`               | STRING |    NO     | `${source_dir}/nightly_testing`               | Used to generate `build_dir` if `build_dir` is not defined.        |
 | `build_dir`                | STRING |    NO     | `${build_root}/${CTEST_BUILD_NAME}`           | Path to the build directory.                                       |

--- a/cmake/SimpleTesting/cmake/ctest-common.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-common.cmake
@@ -64,10 +64,6 @@ if( NOT DEFINED skip_clean_build_dir )
     set( skip_clean_build_dir ON )
 endif()
 
-if( NOT DEFINED skip_single_submit )
-    set( skip_single_submit ON )
-endif()
-
 if( NOT DEFINED skip_update_step )
     set( skip_update_step OFF )
 endif()

--- a/cmake/SimpleTesting/cmake/ctest-functions.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-functions.cmake
@@ -51,36 +51,10 @@ endmacro()
 
 
 
-macro(submit_single_submit)
-    banner("submit_single_submit() START")
-    if(NOT skip_single_submit)
-        message(">>> ctest_submit(RETRY_COUNT  ${ctest_submit_retry_count}")
-        message("                 RETRY_DELAY  ${ctest_submit_retry_delay}")
-        message("                 RETURN_VALUE error_code)")
-
-        ctest_submit(RETRY_COUNT ${ctest_submit_retry_count}
-                     RETRY_DELAY ${ctest_submit_retry_delay}
-                     RETURN_VALUE error_code)
-
-        if(error_code EQUAL 0)
-            message(">>> Single submit: OK")
-        else()
-            message(">>> Single submit: FAILED")
-            message(">>> - The ERROR code is ${error_code}")
-        endif()
-    else()
-        message(">>> SKIPPED")
-        message(">>> skip_single_submit : ${skip_single_submit}")
-    endif()
-    banner("submit_single_submit() FINISH")
-endmacro()
-
-
-
 macro(submit_upload_config_files)
     banner("submit_upload_config_files() START")
     if( NOT skip_upload_config_files )
-        if( NOT (skip_single_submit AND skip_by_parts_submit) )
+        if( NOT (skip_by_parts_submit) )
             message(">>> ctest_upload(FILES ${configure_command_file}")
             message("                 ${configure_file}")
             message("                 ${package_enables_file}")
@@ -111,7 +85,6 @@ macro(submit_upload_config_files)
             endif()
         else()
             message(">>> SKIPPED")
-            message(">>> skip_single_submit   : ${skip_single_submit}")
             message(">>> skip_by_parts_submit : ${skip_by_parts_submit}")
         endif()
     else()
@@ -129,7 +102,6 @@ macro(print_options_list)
     message(">>> PARALLEL_LEVEL           = ${PARALLEL_LEVEL}")
     message(">>> TEST_PARALLEL_LEVEL      = ${TEST_PARALLEL_LEVEL}")
     message(">>> skip_by_parts_submit     = ${skip_by_parts_submit}")
-    message(">>> skip_single_submit       = ${skip_single_submit}")
     message(">>> skip_update_step         = ${skip_update_step}")
     message(">>> skip_upload_config_files = ${skip_upload_config_files}")
     message(">>> skip_clean_build_dir     = ${skip_clean_build_dir}")

--- a/cmake/SimpleTesting/cmake/ctest-functions.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-functions.cmake
@@ -32,7 +32,8 @@ macro(submit_by_parts arg_parts_value)
                      RETRY_COUNT ${ctest_submit_retry_count}
                      RETRY_DELAY ${ctest_submit_retry_delay}
                      BUILD_ID    cdash_build_id
-                     RETURN_VALUE ctest_submit_error)
+                     RETURN_VALUE ctest_submit_error
+                     CAPTURE_CMAKE_ERROR ctest_submit_error)
 
         if(ctest_submit_error EQUAL 0)
             message(">>> ${arg_parts_value} submit: OK")
@@ -88,7 +89,8 @@ macro(submit_upload_config_files)
             ctest_upload(FILES ${configure_command_file}
                                ${configure_file}
                                ${package_enables_file}
-                               ${genconfig_build_name_file})
+                               ${genconfig_build_name_file}
+                         CAPTURE_CMAKE_ERROR file_upload_error)
 
             message(">>> ctest_submit(PARTS upload")
             message("                 RETRY_COUNT  ${ctest_submit_retry_count}")
@@ -98,7 +100,8 @@ macro(submit_upload_config_files)
             ctest_submit(PARTS Upload
                          RETRY_COUNT ${ctest_submit_retry_count}
                          RETRY_DELAY ${ctest_submit_retry_delay}
-                         RETURN_VALUE file_upload_error)
+                         RETURN_VALUE file_upload_error
+                         CAPTURE_CMAKE_ERROR file_upload_error)
 
             if(file_upload_error EQUAL 0)
                 message(">>> Config Files Upload: OK")

--- a/cmake/SimpleTesting/cmake/ctest-stage-configure.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-stage-configure.cmake
@@ -37,11 +37,6 @@ endif()
 
 submit_by_parts("Configure")
 
-if((NOT ${configure_error} EQUAL 0) OR (NOT ${tmp_cmake_error} EQUAL 0))
-    submit_single_submit()
-    message(WARNING "Configure failed with error ${configure_error}")
-endif()
-
 message("+--------------------------------------+")
 message("| ctest-stage-configure.cmake FINISH   |")
 message("+--------------------------------------+")

--- a/cmake/SimpleTesting/cmake/ctest-stage-test.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-stage-test.cmake
@@ -42,9 +42,6 @@ else()
     banner("END test step - FAILURE")
 endif()
 
-# Single submit
-submit_single_submit()
-
 # Upload configure files
 submit_upload_config_files()
 

--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -255,7 +255,6 @@ test_cmd_options=(
     --filename-subprojects=${WORKSPACE:?}/package_subproject_list.cmake
     --source-dir=${WORKSPACE}/Trilinos
     --build-dir=${TRILINOS_BUILD_DIR:?}
-    --ctest-driver=${WORKSPACE:?}/Trilinos/cmake/SimpleTesting/cmake/ctest-driver.cmake
     --ctest-drop-site=${TRILINOS_CTEST_DROP_SITE:?}
 )
 

--- a/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
@@ -66,30 +66,11 @@ def parse_args():
     default_filename_packageenables = os.path.join("..", "packageEnables.cmake")
     default_filename_subprojects = os.path.join("..", "package_subproject_list.cmake")
 
-
-    required.add_argument('--source-repo-url',
-                          dest="source_repo_url",
-                          action='store',
-                          help='Repo with the new changes',
-                          required=False)
-
-    required.add_argument('--target-repo-url',
-                          dest="target_repo_url",
-                          action='store',
-                          help='Repo to merge into',
-                          required=False)
-
     required.add_argument('--target-branch-name',
                           dest="target_branch_name",
                           action='store',
                           help='Branch to merge into',
                           required=True)
-
-    required.add_argument('--pullrequest-build-name',
-                          dest="pullrequest_build_name",
-                          action='store',
-                          help='The Jenkins job base name',
-                          required=False)
 
     required.add_argument('--genconfig-build-name',
                           dest="genconfig_build_name",
@@ -103,7 +84,13 @@ def parse_args():
                           help='The github PR number',
                           required=True)
 
-    required.add_argument('--jenkins-job-number',
+    optional.add_argument('--pullrequest-build-name',
+                          dest="pullrequest_build_name",
+                          action='store',
+                          help='The Jenkins job base name',
+                          required=False)
+
+    optional.add_argument('--jenkins-job-number',
                           dest="jenkins_job_number",
                           action='store',
                           help='The Jenkins build number',
@@ -285,8 +272,6 @@ def parse_args():
     print("+" + "="*78 + "+")
     print("| PullRequestLinuxDriverTest Parameters")
     print("+" + "="*78 + "+")
-    print("| - [R] source-repo-url             : {source_repo_url}".format(**vars(arguments)))
-    print("| - [R] target_repo_url             : {target_repo_url}".format(**vars(arguments)))
     print("| - [R] target_branch_name          : {target_branch_name}".format(**vars(arguments)))
     print("| - [R] pullrequest-build-name      : {pullrequest_build_name}".format(**vars(arguments)))
     print("| - [R] genconfig-build-name        : {genconfig_build_name}".format(**vars(arguments)))

--- a/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
@@ -84,6 +84,18 @@ def parse_args():
                           help='The github PR number',
                           required=True)
 
+    required.add_argument('--source-dir',
+                          dest="source_dir",
+                          action='store',
+                          help="Directory containing the source code to compile/test.",
+                          required=True)
+
+    required.add_argument('--build-dir',
+                          dest="build_dir",
+                          action='store',
+                          help="Path to the build directory.",
+                          required=True)
+
     optional.add_argument('--pullrequest-build-name',
                           dest="pullrequest_build_name",
                           action='store',
@@ -100,18 +112,6 @@ def parse_args():
                           dest="dashboard_build_name",
                           action='store',
                           help='The build name posted by ctest to a dashboard',
-                          required=False)
-
-    optional.add_argument('--source-dir',
-                          dest="source_dir",
-                          action='store',
-                          help="Directory containing the source code to compile/test.",
-                          required=False)
-
-    optional.add_argument('--build-dir',
-                          dest="build_dir",
-                          action='store',
-                          help="Path to the build directory.",
                           required=False)
 
     optional.add_argument('--use-explicit-cachefile',

--- a/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
@@ -272,6 +272,9 @@ def parse_args():
 
     arguments = parser.parse_args()
 
+    if not arguments.ctest_driver:
+        arguments.ctest_driver = os.path.join(arguments.source_dir, 'cmake', 'SimpleTesting', 'cmake', 'ctest-driver.cmake')
+
     # Type conversions
     arguments.max_cores_allowed    = int(arguments.max_cores_allowed)
     arguments.num_concurrent_tests = int(arguments.num_concurrent_tests)

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -207,8 +207,6 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         Generate dummy command line arguments
         """
         output = argparse.Namespace(
-            source_repo_url="https://github.com/trilinos/Trilinos",
-            target_repo_url="https://github.com/trilinos/Trilinos",
             target_branch_name="develop",
             pullrequest_build_name="Trilinos-pullrequest-gcc",
             genconfig_build_name="rhel8_sems-gnu-openmpi_release_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-package-enables",

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationInstallation.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationInstallation.py
@@ -150,8 +150,6 @@ class TrilinosPRConfigurationInstallationTest(TestCase):
         Generate dummy command line arguments
         """
         output = argparse.Namespace(
-            source_repo_url="https://github.com/trilinos/Trilinos",
-            target_repo_url="https://github.com/trilinos/Trilinos",
             target_branch_name="develop",
             pullrequest_build_name="Trilinos-pullrequest-gcc-installation-testing",
             genconfig_build_name="rhel8_sems-gnu-openmpi_release_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-package-enables",

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationStandard.py
@@ -149,8 +149,6 @@ class TrilinosPRConfigurationStandardTest(TestCase):
         Generate dummy command line arguments
         """
         output = argparse.Namespace(
-            source_repo_url="https://github.com/trilinos/Trilinos",
-            target_repo_url="https://github.com/trilinos/Trilinos",
             target_branch_name="develop",
             pullrequest_build_name="Trilinos-pullrequest-gcc",
             genconfig_build_name="rhel8_sems-gnu-openmpi_release_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-package-enables",

--- a/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/unittests/test_PullRequestLinuxDriverTest.py
@@ -44,35 +44,25 @@ class Test_parse_args(unittest.TestCase):
         self.stderrRedirect = mock.patch('sys.stderr', new_callable=StringIO)
 
         self.m_argv = mock.patch.object(sys, 'argv', ['programName',
-                                                      '--source-repo-url',
-                                                      os.path.join(os.path.sep,
-                                                                   'dev',
-                                                                   'null',
-                                                                   'source_repo'),
-                                                      '--target-repo-url',
-                                                      os.path.join(os.path.sep,
-                                                                   'dev',
-                                                                   'null',
-                                                                   'target_repo'),
                                                       '--target-branch-name', 'real_trash',
                                                       '--pullrequest-build-name',
                                                       'Some_odd_compiler',
                                                       '--genconfig-build-name',
                                                       'Some_odd_compiler_and_options',
                                                       '--pullrequest-number', '4242',
-                                                      '--jenkins-job-number', '2424'])
+                                                      '--jenkins-job-number', '2424',
+                                                      '--source-dir=/some/source/dir',
+                                                      '--build-dir=/some/build/dir'])
 
-        self.default_options = Namespace(source_repo_url='/dev/null/source_repo',
-                                         target_repo_url='/dev/null/target_repo',
-                                         target_branch_name='real_trash',
+        self.default_options = Namespace(target_branch_name='real_trash',
                                          pullrequest_build_name='Some_odd_compiler',
                                          genconfig_build_name='Some_odd_compiler_and_options',
                                          dashboard_build_name=None,
                                          pullrequest_number='4242',
                                          jenkins_job_number='2424',
-                                         source_dir=None,
-                                         build_dir=None,
-                                         ctest_driver=None,
+                                         source_dir='/some/source/dir',
+                                         build_dir='/some/build/dir',
+                                         ctest_driver='/some/source/dir/cmake/SimpleTesting/cmake/ctest-driver.cmake',
                                          ctest_drop_site='testing.sandia.gov',
                                          pullrequest_cdash_track='Pull Request',
                                          pullrequest_env_config_file='/dev/null/Trilinos_clone/pr_config/pullrequest.ini',
@@ -93,16 +83,14 @@ class Test_parse_args(unittest.TestCase):
                                          extra_configure_args="")
 
         self.default_stdout = dedent('''\
-                | - [R] source-repo-url             : /dev/null/source_repo
-                | - [R] target_repo_url             : /dev/null/target_repo
                 | - [R] target_branch_name          : real_trash
                 | - [R] pullrequest-build-name      : Some_odd_compiler
                 | - [R] genconfig-build-name        : Some_odd_compiler_and_options
                 | - [R] pullrequest-number          : 4242
                 | - [R] jenkins-job-number          : 2424
-                | - [R] source-dir                  : None
-                | - [R] build-dir                   : None
-                | - [R] ctest-driver                : None
+                | - [R] source-dir                  : /some/source/dir
+                | - [R] build-dir                   : /some/build/dir
+                | - [R] ctest-driver                : /some/source/dir/cmake/SimpleTesting/cmake/ctest-driver.cmake
                 | - [R] ctest-drop-site             : testing.sandia.gov
                 |
                 | - [O] dry-run                     : False


### PR DESCRIPTION
@trilinos/framework 

Note that I also did some misc. cleanup on the PR script option handling (having to run it manually for this process pointed out some issues) and cleaned up an unused code path in the SimpleTesting logic.

## Motivation
If a submission to CDash fails, that's a bummer, but it does not on its own need to halt the ability to merge a PR.  That can be handled by the exit status of the configure/build/test.

## Related Issues
Affected https://github.com/trilinos/Trilinos/pull/13804
JIRA issue: https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-704


## Testing
I set the CDash upload URL to something invalid in an attempt to induce a submission error, and was successful.  The old code propagated a bad exit value, the new code is zero.
