### PR TITLE
Framework: Remove target branch limitations for AT2 workflows

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -5,9 +5,6 @@ on:
     types:
       - opened
       - synchronize
-    branches:
-      - master
-      - develop
   workflow_dispatch:
 
 # Cancels any in progress 'workflows' associated with this PR

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,8 +2,6 @@ name: "CodeQL Security Scan"
 
 on:
   pull_request:
-    branches:
-      - develop
     types:
       - opened
       - synchronize

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -4,9 +4,6 @@ on:
     types:
       - opened
       - synchronize
-    branches:
-      - master
-      - develop
   workflow_dispatch:
 
 # Cancels any in progress 'workflow' associated with this PR


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

Branch specifications limited the scope that these workflows could run on. (i.e. Release branch PR testing) This results in an inconsistent testing environment for PR targeting a non-master/develop branch.

## Related Issues
Noticed in the following PR
- #13889

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->