### PR TITLE
Teko: Perform as much of the sub-block reassembly operation on the device as possible

### DIFF
--- a/packages/teko/src/Tpetra/Teko_BlockingTpetra.cpp
+++ b/packages/teko/src/Tpetra/Teko_BlockingTpetra.cpp
@@ -264,7 +264,8 @@ RCP<Tpetra::CrsMatrix<ST, LO, GO, NT>> buildSubBlock(
   TEUCHOS_ASSERT(prefixSumHost(numMyRows) == totalNumOwnedCols)
   Kokkos::deep_copy(prefixSumEntriesPerRow, prefixSumHost);
 
-  auto uniqueColumnIndices = Kokkos::View<GO*>(
+  using device_type        = typename NT::device_type;
+  auto uniqueColumnIndices = Kokkos::View<GO*, device_type>(
       Kokkos::ViewAllocateWithoutInitializing("uniqueColumnIndices"), totalNumOwnedCols);
   auto columnIndices = Kokkos::View<GO*>(Kokkos::ViewAllocateWithoutInitializing("columnIndices"),
                                          totalNumOwnedCols);


### PR DESCRIPTION
On GPU platforms, https://github.com/trilinos/Trilinos/pull/13843 is still not sufficient to get good sub-block reassembly times.

Using the same benchmarking code, but now also measuring the initial sub-block assembly times:

```cpp
  auto dof_block_gids = ...;
  auto dof_blocked_matrix =
      Teuchos::rcp(new Teko::TpetraHelpers::BlockedTpetraOperator(dof_block_gids, A));
  
  {
    constexpr int ntrials = 10;
    const auto tStart = MPI_Wtime();
    for (int i = 0; i < ntrials; ++i)
    {
      dof_blocked_matrix = Teuchos::rcp(new Teko::TpetraHelpers::BlockedTpetraOperator(dof_block_gids, A));
    }
    const auto tElapsed = MPI_Wtime() - tStart;
    std::cout << "time per trial, assembly: " << tElapsed / ntrials << "\n";
    EXPECT_TRUE(dof_blocked_matrix->testAgainstFullOperator(100, tol));
  }

  {
    constexpr int ntrials = 10;
    const auto tStart = MPI_Wtime();
    for (int i = 0; i < ntrials; ++i)
    {
      dof_blocked_matrix->RebuildOps();
    }
    const auto tElapsed = MPI_Wtime() - tStart;
    std::cout << "time per trial, reassembly: " << tElapsed / ntrials << "\n";
    EXPECT_TRUE(dof_blocked_matrix->testAgainstFullOperator(100, tol));
  }
```

For a 57,640 DOF system with 4,135,524 nnz and 15 subblocks on a single rank takes 0.65s per RebuildOps call and 1.996s per `BlockedTpetraOperator` construction (i.e., the original sub-block assembly).

This PR reduces that time to 0.026s per `RebuildOps` call on a V100, and 0.459s per `BlockedTpetraOperator` construction.

Another nice benefit, as pointed out by @cgcgcg, is that the entire sub-block reassembly can be done locally.
