### PR TITLE
Port Trilinos to CMake 4.0.0 (#13731)

### DIFF
--- a/cmake/get-tribits-mainline-merge-commits.sh
+++ b/cmake/get-tribits-mainline-merge-commits.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# This script gets the merge commits from TriBITS on the mainline branch since
+# the last snaphsot.
+
+# Get the SHA1 of the commit from TriBITS for most recent snapshot
+lastTribitsSnapshotSha1=$(git log --pretty='%s' -1 --grep="Automatic snapshot commit from tribits" -- cmake/tribits | awk '{print $NF}')
+#echo "lastTribitsSnapshotSha1 = '${lastTribitsSnapshotSha1}'"
+
+# Get the merge commit on the TriBITS mainline branch for ${lastTribitsSnapshotSha1}
+tribitsMergeCommitForLastSnapshot=$(cd TriBITS ; git log --pretty="%H" --reverse master --not ${lastTribitsSnapshotSha1} | head -n 1)
+#echo "tribitsMergeCommitForLastSnapshot = '${tribitsMergeCommitForLastSnapshot}'"
+# NOTE: ${tribitsMergeCommitForLastSnapshot} was the merge commit that pulled
+# the TriBITS topic branch containing ${lastTribitsSnapshotSha1} into the
+# TriBITS 'master' branch.  Therefore, we only want to report merge commits
+# (i.e. TriBITS PRs) that were merged after that.
+
+# Get the merge commits since ${tribitsMergeCommitForLastSnapshot}
+cd TriBITS 2>&1 >> /dev/null
+git log --first-parent --pretty=format:'%Cgreen%h%Creset "%s"%nAuthor: %an <%ae>%nDate:   %ad (%cr)%n' master --not ${tribitsMergeCommitForLastSnapshot}
+cd -  2>&1 >> /dev/null

--- a/cmake/tribits/CHANGELOG.md
+++ b/cmake/tribits/CHANGELOG.md
@@ -2,6 +2,15 @@
 ChangeLog for TriBITS
 ----------------------------------------
 
+## 2025-03-22:
+
+* **Changed:** Set CMake policy
+  [CMP0144](https://cmake.org/cmake/help/latest/policy/CMP0144.html) to `NEW`
+  (for versions of CMake 3.27+) so that `find_package(<PackageName> ...)` will
+  use upper case env var `<PACKAGENAME>_ROOT`.  Now, systems that are setting
+  uppercase env var names for standard packages will get picked in CMake
+  configures.
+
 ## 2025-02-17:
 
 * **Added:** Added support for header-only libraries with

--- a/cmake/tribits/core/common/TribitsCMakePolicies.cmake
+++ b/cmake/tribits/core/common/TribitsCMakePolicies.cmake
@@ -7,11 +7,17 @@
 # *****************************************************************************
 # @HEADER
 
+macro(tribits_set_cmake_policy_if_exists  policyName  oldOrNew)
+  if (POLICY ${policyName})
+    cmake_policy(SET ${policyName} ${oldOrNew})
+  endif()
+endmacro()
+
 # Define policies for CMake
-# It is assumed that the project has already called CMAKE_MINIMUM_REQUIRED.
-cmake_policy(SET CMP0003 NEW) # Don't split up full lib paths to linker args
-cmake_policy(SET CMP0007 NEW) # Don't ignore empty list items
-cmake_policy(SET CMP0053 NEW) # Make var references much faster
-cmake_policy(SET CMP0054 NEW) # Avoid quoted strings lookup variables
-cmake_policy(SET CMP0057 NEW) # Support if ( ... IN_LIST ... )
-cmake_policy(SET CMP0082 NEW) # Install rules follow order install() called in subdirs
+tribits_set_cmake_policy_if_exists(CMP0003 NEW) # Don't split up full lib paths to linker args
+tribits_set_cmake_policy_if_exists(CMP0007 NEW) # Don't ignore empty list items
+tribits_set_cmake_policy_if_exists(CMP0053 NEW) # Make var references much faster
+tribits_set_cmake_policy_if_exists(CMP0054 NEW) # Avoid quoted strings lookup variables
+tribits_set_cmake_policy_if_exists(CMP0057 NEW) # Support if ( ... IN_LIST ... )
+tribits_set_cmake_policy_if_exists(CMP0082 NEW) # Install rules follow order install() called in subdirs
+tribits_set_cmake_policy_if_exists(CMP0144 NEW) # find_package() use <PACKAGENAME>_ROOT env var

--- a/cmake/tribits/examples/RawHelloWorld/CMakeLists.txt
+++ b/cmake/tribits/examples/RawHelloWorld/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Example of a simple project that uses raw CMake
-cmake_minimum_required(VERSION 2.8.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(RawHelloWorld)
 enable_testing()
 add_subdirectory(hello_world)

--- a/cmake/update-tribits-snapshot.sh
+++ b/cmake/update-tribits-snapshot.sh
@@ -21,6 +21,40 @@ _SCRIPT_DIR=`echo $0 | sed "s/\(.*\)\/.*\.sh/\1/g"`
 echo "_SCRIPT_DIR = '${_SCRIPT_DIR}'"
 _TRILINOS_HOME=$_SCRIPT_DIR/..
 
-# Update the snapshot
+# Get the merge commits being pulled in and amend the commit message
+newTribitsMergeCommits=$(./cmake/get-tribits-mainline-merge-commits.sh)
+#echo "newTribitsMergeCommits:
+#
+#${newTribitsMergeCommits}"
+
+# Create the snapshot commit
 cd $_TRILINOS_HOME/cmake/tribits/
-../../TriBITS/tribits/snapshot_tribits.py --clean-ignored-files-orig-dir "$@"
+../../TriBITS/tribits/snapshot_tribits.py --clean-ignored-files-orig-dir "$@" \
+  || echo "snapshot_tribits.py failed but it worked okay?"
+cd - 2>&1 >> /dev/null
+
+# Get the current commit message created by the snapshotting script
+currentCommitMsg=$(git log -1 --pretty="%B")
+#echo "currentCommitMsg:
+#
+#${currentCommitMsg}"
+
+# Amend the commit message
+
+echo
+echo "Amending the snapshot commit message with the new first-parent commits from TriBITS repo:"
+echo
+echo "${newTribitsMergeCommits}"
+echo
+
+newCommitMsg="${currentCommitMsg}
+
+New first-parent commits in TriBITS snapshot:
+
+${newTribitsMergeCommits}\n"
+
+#echo "CommitMsg:
+#
+#${newCommitMsg}"
+
+git commit -s --amend -m "${newCommitMsg}"

--- a/demos/simpleBuildAgainstTrilinos/CMakeLists.by_package.cmake
+++ b/demos/simpleBuildAgainstTrilinos/CMakeLists.by_package.cmake
@@ -1,6 +1,6 @@
 # CMAKE File for "MyApp" application building against an installed Trilinos
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Define the project and the compilers
 #

--- a/demos/simpleBuildAgainstTrilinos/CMakeLists.txt
+++ b/demos/simpleBuildAgainstTrilinos/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMAKE File for "MyApp" application building against an installed Trilinos
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Define the project and the compilers
 #

--- a/packages/TrilinosInstallTests/find_package_Trilinos/CMakeLists.txt
+++ b/packages/TrilinosInstallTests/find_package_Trilinos/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Disable Kokkos warning about not supporting C++ extensions
 set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
CC: @sebrowne 

## Description

Addresses:

* #13731

This PR contains some commits that allow Trilinos to configure, build, and pass (all but 3) tests for the a recent version of CMake 4.0 on the 4.0 release branch (after the merge of [CMake MR 10489](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10489)).

I installed CMake `v4.0.0-rc4-34-g68475b77d2` (called `v4.0.0-rc4-g68475b77d2` by `cmake --version`) by locally (see details below on how that was installed) and did a configure and `make dashboard` to submit to:

* https://trilinos-cdash-qual.sandia.gov/index.php?project=Trilinos&filtercount=3&showfilters=1&filtercombine=and&field1=site&compare1=61&value1=cee-build030&field2=buildname&compare2=61&value2=clang-instru-coverage&field3=buildstamp&compare3=61&value3=20250321-1930-Experimental

showing:

![image](https://github.com/user-attachments/assets/3f1ea688-3056-4316-a265-2834f8496936)

NOTE: I did this build as part of work with new CMake build instrumentation, coverage, and metrics work, see [cmake#26247](https://gitlab.kitware.com/cmake/cmake/-/issues/26247), [cdash#2395](https://github.com/Kitware/CDash/issues/2395), [snl-kitware#265](https://gitlab.kitware.com/snl/project-1/-/issues/265) (private), and [peso#27](https://github.com/pesoproject/pesoproject/issues/27) (private), which is why this build is called `clang-instru-coverage`.

The 3 failing tests are shown at:

* https://trilinos-cdash-qual.sandia.gov/queryTests.php?project=Trilinos&filtercount=3&showfilters=1&filtercombine=and&field1=buildname&compare1=61&value1=clang-instru-coverage&field2=buildstarttime&compare2=81&value2=2025-03-21T13%3A30%3A53%20MDT&field3=status&compare3=61&value3=failed

and are:

| Site | Build Name | Test Name | Status | Time Status | Time | Proc Time | Details | Labels | Build Time | Processors |
| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
| cee-build030 | clang-instru-coverage | TrilinosCouplings_Example_Maxwell_Tpetra_MueLu_MPI_1 | Failed | Passed | 11s 340ms | 11s 340ms | Completed (Failed) | TrilinosCouplings | 2025-03-21T13:30:53 MDT | 1 |
| cee-build030 | clang-instru-coverage | TrilinosCouplings_Example_Poisson2D_p2_tpetra_MPI_1 | Failed | Passed | 10s 840ms | 10s 840ms | Completed (Failed) | TrilinosCouplings | 2025-03-21T13:30:53 MDT | 1 |
| cee-build030 | clang-instru-coverage | TrilinosCouplings_Poisson2D_pn=4_tpetra_MPI_1 | Failed | Passed | 11s 260ms | 11s 260ms | Completed (Failed) | TrilinosCouplings | 2025-03-21T13:30:53 MDT | 1 |

The details of these failing tests will be given in a later comment.

<details>

<summary><b>REPRODUCIBILITY DETAILS</b> (click to expand)</summary>

<br>

A recent version of CMake 4.0 release branch (after the tag `v4.0.0-rc4` and  [CMake MR 10489](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10489) was merged) was installed on 'cee-build030' with:

```
$ cd /scratch/rabartl/CMake.base/scratch/cmake-instrumentation_cdash/cmake-instrumentation_cdash/

$ git fetch glkw-cmake

$ git checkout --track glkw-cmake/release

$ git log-short --name-status -1
68475b77d2 "Merge topic 'pkgc-variable-docs' into release-4.0"
Author: Brad King <brad.king@kitware.com>
Date:   Thu Mar 20 12:53:55 2025 +0000 (9 hours ago)

$ git describe
v4.0.0-rc4-34-g68475b77d2

$ cd /scratch/rabartl/CMake.base/scratch/cmake-instrumentation_cdash/cmake-build/

$ env CXXFLAGS=-O3 CFLAGS=-O3 cmake -DCMAKE_INSTALL_PREFIX=/home/rabartl/install/cmake-4.0.0-rc4-34-g68475b77d2 -DCMAKE_USE_OPENSSL=ON ../../../cmake && make -j32 && make -j32 install 
```

I then set up a modified GenConfig env on 'cee-build030' using:

```
$ cd /scratch/rabartl/Trilinos.base/BUILDS/GenConfig/clang-instru-coverage/

$ cat load-env.sh
if [[ "${SNLSYSTEM}" == "cee" ]] && [[ "${SEMS_TPLS_INTEL_LICENSE_FILE}" == "" ]] ; then
  echo "SEMS Modules not defined yet!  Defining ..."
  . /projects/sems/modulefiles/utils/sems-modules-init.sh ""
fi
export TRILINOS_DIR=/scratch/rabartl/Trilinos.base/Trilinos
source ${TRILINOS_DIR}/packages/framework/GenConfig/gen-config.sh \
--cmake-fragment GenConfigSettings.cmake \
rhel8_sems-clang-11.0.1-openmpi-4.0.5-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables \
--force -y \
"$@" \
${TRILINOS_DIR}

$ . load-env.sh

$ cat use-cmake-4.0.0-rc4.sh
export PATH=/home/rabartl/install/cmake-4.0.0-rc4-34-g68475b77d2/bin:${PATH}

$ . use-cmake-4.0.0-rc4.sh

$ which cmake
/home/rabartl/install/cmake-4.0.0-rc4-34-g68475b77d2/bin/cmake

$ cmake --version
cmake version 4.0.0-rc4-g68475b7

CMake suite maintained and supported by Kitware (kitware.com/cmake).

$ cat use-ctest-insturmentation.sh 
export CTEST_EXPERIMENTAL_INSTRUMENTATION=a37d1069-1972-4901-b9c9-f194aaf2b6e0
export CTEST_USE_INSTRUMENTATION=1

$ . use-ctest-insturmentation.sh

$ set | grep CTEST_
CTEST_EXPERIMENTAL_INSTRUMENTATION=a37d1069-1972-4901-b9c9-f194aaf2b6e0
CTEST_USE_INSTRUMENTATION=1

$ cat use-newer-llvm.sh
LLVM_BIN_PATH=/scratch/rabartl_shared/install/llvmorg-20-init-13761-g261a4026e8a3/bin
export PATH=${LLVM_BIN_PATH}:${PATH}
export OMPI_CC=${LLVM_BIN_PATH}/clang
export OMPI_CXX=${LLVM_BIN_PATH}/clang++
export RUN_CLANG_TIDY_PYTHON_EXEC=python3.12

$ . use-newer-llvm.sh

$ which clang++
/scratch/rabartl_shared/install/llvmorg-20-init-13761-g261a4026e8a3/bin/clang++

$ clang++ --version
clang version 20.0.0git (git@github.com:llvm/llvm-project.git 261a4026e8a367eda229879838709b92abaf445c)

$ cat do-configure.base
rm -rf CMakeCache.txt CMakeFiles
cmake \
-G Ninja \
-C GenConfigSettings.cmake \
-D CMAKE_EXPORT_COMPILE_COMMANDS=ON \
-D CTEST_BUILD_NAME=clang-instru-coverage \
-D CTEST_PROJECT_NAME="Trilinos" \
-D CTEST_DROP_SITE="cdash-test.apps.openshift.sandia.gov" \
-D CTEST_DROP_LOCATION="/submit.php?project=Trilinos" \
-D TRIBITS_2ND_CTEST_DROP_SITE="trilinos-cdash-qual.sandia.gov" \
-D TRIBITS_2ND_CTEST_DROP_LOCATION="/submit.php?project=Trilinos" \
-D CTEST_BUILD_FLAGS=-j32 \
-D CTEST_PARALLEL_LEVEL=32 \
-D Trilinos_ENABLE_Fortran=OFF \
-D Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES=OFF \
-D Trilinos_ENABLE_TESTS=ON \
"$@" \
${TRILINOS_DIR}

$ cat do-configure
./do-configure.base \
"$@"
```

With that setup, I think ran a configure of all Trilinos packages except Epetra and ML disabled with:

```
$ build_config=all_packages.no-epetra-ml; time ./do-configure -DTrilinos_ENABLE_ALL_PACKAGES=ON -DTrilinos_ENABLE_Epetra=OFF -DTrilinos_ENABLE_ML=OFF &> configure.${build_config}.out && time make dashboard &> make.dashboard.${build_config}.out 
 
real    2m56.637s
user    1m1.615s
sys     1m47.065s

real    73m17.025s
user    1226m38.583s
sys     122m19.536s
```

(NOTE: There was a partial build already in place.)

The set of enabled/disabled packages were:

* **Final set of enabled top-level packages:**  TrilinosFrameworkTests TrilinosATDMConfigTests Gtest Kokkos Teuchos KokkosKernels RTOp Sacado MiniTensor Zoltan Shards Triutils Tpetra TrilinosSS Thyra Xpetra Galeri Pamgen Zoltan2Core Belos ShyLU_Node Amesos2 SEACAS Anasazi Ifpack2 Stratimikos Teko Intrepid Intrepid2 Compadre STK Percept Krino Phalanx NOX MueLu Zoltan2Sphynx Zoltan2 ShyLU_DD Tempus Stokhos ROL Piro Panzer Adelus TrilinosCouplings TrilinosBuildStats TrilinosInstallTests 48

* **Final set of enabled packages:**  TrilinosFrameworkTests TrilinosATDMConfigTests Gtest Kokkos TeuchosCore TeuchosParser TeuchosParameterList TeuchosComm TeuchosNumerics TeuchosRemainder TeuchosKokkosCompat TeuchosKokkosComm Teuchos KokkosKernels RTOp Sacado MiniTensor Zoltan Shards Triutils TpetraTSQR TpetraCore Tpetra TrilinosSS ThyraCore ThyraTpetraAdapters Thyra Xpetra Galeri Pamgen Zoltan2Core Belos ShyLU_NodeHTS ShyLU_NodeTacho ShyLU_NodeFastILU ShyLU_Node Amesos2 SEACASExodus SEACASNemesis SEACASIoss SEACASChaco SEACASAprepro_lib SEACASSuplibC SEACASSuplibCpp SEACASAprepro SEACASConjoin SEACASEjoin SEACASEpu SEACASCpup SEACASExodiff SEACASExomatlab SEACASExo_format SEACASNas2exo SEACASZellij SEACASNemslice SEACASNemspread SEACASSlice SEACAS Anasazi Ifpack2 Stratimikos Teko Intrepid Intrepid2 Compadre STKUtil STKEmend STKCoupling STKMath STKSimd STKNGP_TEST STKExprEval STKTopology STKSearch STKTransfer STKMesh STKSearchUtil STKIO STKTools STKBalance STKUnit_test_utils STKUnit_tests STKDoc_tests STKIntegration_tests STKPerformance_tests STK Percept Krino Phalanx NOX MueLu Zoltan2Sphynx Zoltan2 ShyLU_DDFROSch ShyLU_DDCommon ShyLU_DD Tempus Stokhos ROL Piro PanzerCore PanzerDofMgr PanzerDiscFE PanzerAdaptersSTK PanzerMiniEM Panzer Adelus TrilinosCouplings TrilinosBuildStats TrilinosInstallTests 110

* **Final set of non-enabled top-level packages:**  Epetra EpetraExt Isorropia Pliris AztecOO Amesos Ifpack ML ShyLU PyTrilinos PyTrilinos2 NewPackage 12

* **Final set of non-enabled packages:**  Epetra EpetraExt ThyraEpetraAdapters ThyraEpetraExtAdapters Isorropia Pliris AztecOO Amesos Ifpack ML ShyLU_NodeBasker SEACASExodus_for SEACASExoIIv2for32 SEACASSupes SEACASSuplib SEACASSVDI SEACASPLT SEACASAlgebra SEACASBlot SEACASExo2mat SEACASExotxt SEACASEx1ex2v2 SEACASExotec2 SEACASFastq SEACASGjoin SEACASGen3D SEACASGenshell SEACASGrepos SEACASExplore SEACASMapvarlib SEACASMapvar SEACASMapvar-kd SEACASMat2exo SEACASNumbers SEACASTxtexo SEACASEx2ex1v2 STKMiddle_mesh STKTransferUtil STKMiddle_mesh_util ShyLU_DDCore ShyLU PanzerExprEval PyTrilinos PyTrilinos2 NewPackage 45

* **Final set of enabled top-level external packages/TPLs:**  Pthread MPI BLAS LAPACK Boost Zlib HDF5 Netcdf SuperLU BoostLib DLlib 11

* **Final set of enabled external packages/TPLs:**  Pthread MPI BLAS LAPACK Boost Zlib HDF5 Netcdf SuperLU BoostLib DLlib 11

* **Final set of non-enabled top-level external packages/TPLs:**  MKL yamlcpp Peano CUDA CUBLAS CUSOLVER CUSPARSE Thrust Cusp ROCBLAS ROCSPARSE ROCSOLVER TBB HWLOC QTHREAD BinUtils ARPREC QD Scotch OVIS gpcd DataWarp METIS MTMETIS ParMETIS PuLP TopoManager LibTopoMap PaToH CppUnit ADOLC ADIC TVMET MF ExodusII Nemesis XDMF CGNS Pnetcdf ADIOS2 Faodel Cereal Catalyst2 y12m SuperLUDist SuperLUMT Cholmod UMFPACK MA28 AMD CSparse HYPRE PETSC BLACS SCALAPACK MUMPS STRUMPACK CSS_MKL PARDISO_MKL PARDISO Oski TAUCS ForUQTK Dakota HIPS MATLAB CASK SPARSKIT QT gtest BoostAlbLib OpenNURBS Portals CrayPortals Gemini InfiniBand BGPDCMF BGQPAMI Pablo HPCToolkit Clp GLPK qpOASES Matio PAPI MATLABLib Eigen X11 Lemon GLM quadmath CAMAL RTlib AmgX VTune TASMANIAN ArrayFireCPU SimMesh SimModel SimParasolid SimAcis SimField Valgrind QUO ViennaCL Avatar mlpack pebbl MAGMASparse Check SARMA CDT mpi_advance 113

* **Final set of non-enabled external packages/TPLs:**  MKL yamlcpp Peano CUDA CUBLAS CUSOLVER CUSPARSE Thrust Cusp ROCBLAS ROCSPARSE ROCSOLVER TBB HWLOC QTHREAD BinUtils ARPREC QD Scotch OVIS gpcd DataWarp METIS MTMETIS ParMETIS PuLP TopoManager LibTopoMap PaToH CppUnit ADOLC ADIC TVMET MF ExodusII Nemesis XDMF CGNS Pnetcdf ADIOS2 Faodel Cereal Catalyst2 y12m SuperLUDist SuperLUMT Cholmod UMFPACK MA28 AMD CSparse HYPRE PETSC BLACS SCALAPACK MUMPS STRUMPACK CSS_MKL PARDISO_MKL PARDISO Oski TAUCS ForUQTK Dakota HIPS MATLAB CASK SPARSKIT QT gtest BoostAlbLib OpenNURBS Portals CrayPortals Gemini InfiniBand BGPDCMF BGQPAMI Pablo HPCToolkit Clp GLPK qpOASES Matio PAPI MATLABLib Eigen X11 Lemon GLM quadmath CAMAL RTlib AmgX VTune TASMANIAN ArrayFireCPU SimMesh SimModel SimParasolid SimAcis SimField Valgrind QUO ViennaCL Avatar mlpack pebbl MAGMASparse Check SARMA CDT mpi_advance 113

</details>

**NOTES:**

* This pulls in updated TriBITS snapshot that gets rid of a warning (see https://github.com/TriBITSPub/TriBITS/pull/630/commits/6ad8ceadb574c295832281a5780b5ed7dc3f2dc6)
* This PR also contains an update to the script `cmake/update-tribits-snapshot.sh` that provides the TriBITS first-parent commits (i.e. merge commits for PRs) in the TriBITS snapshot git commit message)
