### PR TITLE
Framework: Add ccache stats output to AT2 jobs

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -70,7 +70,7 @@ jobs:
           git branch -a
       - name: Output ccache stats
         run: |
-          ccache --show-stats --verbose
+          bash -l -c "ccache --show-stats --verbose"
       - name: get dependencies
         working-directory: ./packages/framework
         run: |
@@ -175,7 +175,7 @@ jobs:
           git branch -a
       - name: Output ccache stats
         run: |
-          ccache --show-stats --verbose
+          bash -l -c "ccache --show-stats --verbose"
       - name: get dependencies
         working-directory: ./packages/framework
         run: |
@@ -281,7 +281,7 @@ jobs:
           git branch -a
       - name: Output ccache stats
         run: |
-          ccache --show-stats --verbose
+          bash -l -c "ccache --show-stats --verbose"
       - name: get dependencies
         working-directory: ./packages/framework
         run: |
@@ -386,7 +386,7 @@ jobs:
           git branch -a
       - name: Output ccache stats
         run: |
-          ccache --show-stats --verbose
+          bash -l -c "ccache --show-stats --verbose"
       - name: get dependencies
         working-directory: ./packages/framework
         run: |

--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -68,6 +68,9 @@ jobs:
           git status
           git branch -vv
           git branch -a
+      - name: Output ccache stats
+        run: |
+          ccache --show-stats --verbose
       - name: get dependencies
         working-directory: ./packages/framework
         run: |
@@ -170,6 +173,9 @@ jobs:
           git status
           git branch -vv
           git branch -a
+      - name: Output ccache stats
+        run: |
+          ccache --show-stats --verbose
       - name: get dependencies
         working-directory: ./packages/framework
         run: |
@@ -273,6 +279,9 @@ jobs:
           git status
           git branch -vv
           git branch -a
+      - name: Output ccache stats
+        run: |
+          ccache --show-stats --verbose
       - name: get dependencies
         working-directory: ./packages/framework
         run: |
@@ -375,6 +384,9 @@ jobs:
           git status
           git branch -vv
           git branch -a
+      - name: Output ccache stats
+        run: |
+          ccache --show-stats --verbose
       - name: get dependencies
         working-directory: ./packages/framework
         run: |

--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -384,9 +384,6 @@ jobs:
           git status
           git branch -vv
           git branch -a
-      - name: Output ccache stats
-        run: |
-          bash -l -c "ccache --show-stats --verbose"
       - name: get dependencies
         working-directory: ./packages/framework
         run: |


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
As a Trilinos Framework member, I want to output ccache stats for each AT2 job to monitor ccache usage for each build.


## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

- [TRILFRAME-692](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-692)