### PR TITLE
Tpetra DistributorActor: Split Recvs and Sends

### DIFF
--- a/packages/tpetra/core/CMakeLists.txt
+++ b/packages/tpetra/core/CMakeLists.txt
@@ -177,13 +177,6 @@ TRIBITS_ADD_OPTION_AND_DEFINE(
 )
 
 TRIBITS_ADD_OPTION_AND_DEFINE(
-  Tpetra_ENABLE_Distributor_Timings
-  HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-  "Enable the timings for the Distributor"
-  OFF
-)
-
-TRIBITS_ADD_OPTION_AND_DEFINE(
   Tpetra_ENABLE_MMM_Statistics
   HAVE_TPETRA_MMM_STATISTICS
   "Enable statistics for the MMM kernels.  Warning: This involves extra communication and should only be enabled for diagnostic purposes."

--- a/packages/tpetra/core/cmake/TpetraCore_config.h.in
+++ b/packages/tpetra/core/cmake/TpetraCore_config.h.in
@@ -77,7 +77,6 @@
 
 /* Tpetra timers */
 #cmakedefine HAVE_TPETRA_MMM_TIMINGS
-#cmakedefine HAVE_TPETRA_DISTRIBUTOR_TIMINGS
 
 /* Define when enabling Kokkos in Tpetra */
 #cmakedefine HAVE_TPETRACORE_KOKKOS

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
@@ -8,35 +8,21 @@
 // @HEADER
 
 #include "Tpetra_Details_DistributorActor.hpp"
-#include "Teuchos_TimeMonitor.hpp"
 
-namespace Tpetra {
-namespace Details {
+namespace Tpetra::Details {
 
   DistributorActor::DistributorActor()
-    : mpiTag_(DEFAULT_MPI_TAG)
-  {
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    makeTimers();
-#endif // HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-  }
+    : mpiTag_(DEFAULT_MPI_TAG) {}
 
   DistributorActor::DistributorActor(const DistributorActor& otherActor)
     : mpiTag_(otherActor.mpiTag_),
     requestsRecv_(otherActor.requestsRecv_),
-    requestsSend_(otherActor.requestsSend_)
-  {
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    makeTimers();
-#endif // HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-  }
+    requestsSend_(otherActor.requestsSend_) {}
 
   void DistributorActor::doWaits(const DistributorPlan& plan) {
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor timeMon (*timer_doWaitsRecv_);
-#endif // HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-
     if (requestsRecv_.size() > 0) {
+      ProfilingRegion wr("Tpetra::Distributor: doWaitsRecv");
+
       Teuchos::waitAll(*plan.getComm(), requestsRecv_());
 
       // Restore the invariant that requests_.size() is the number of
@@ -44,11 +30,9 @@ namespace Details {
       requestsRecv_.resize(0);
     }
 
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor timeMon (*timer_doWaitsSend_);
-#endif // HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-
     if (requestsSend_.size() > 0) {
+      ProfilingRegion ws("Tpetra::Distributor: doWaitsSend");
+
       Teuchos::waitAll(*plan.getComm(), requestsSend_());
 
       // Restore the invariant that requests_.size() is the number of
@@ -58,11 +42,9 @@ namespace Details {
   }
 
   void DistributorActor::doWaitsRecv(const DistributorPlan& plan) {
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor timeMon (*timer_doWaitsRecv_);
-#endif // HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-
     if (requestsRecv_.size() > 0) {
+      ProfilingRegion wr("Tpetra::Distributor: doWaitsRecv");
+
       Teuchos::waitAll(*plan.getComm(), requestsRecv_());
 
       // Restore the invariant that requests_.size() is the number of
@@ -72,11 +54,9 @@ namespace Details {
   }
 
   void DistributorActor::doWaitsSend(const DistributorPlan& plan) {
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor timeMon (*timer_doWaitsSend_);
-#endif // HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-
     if (requestsSend_.size() > 0) {
+      ProfilingRegion ws("Tpetra::Distributor: doWaitsSend");
+
       Teuchos::waitAll(*plan.getComm(), requestsSend_());
 
       // Restore the invariant that requests_.size() is the number of
@@ -95,43 +75,4 @@ namespace Details {
     }
     return result;
   }
-
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-  void DistributorActor::makeTimers () {
-    timer_doWaitsRecv_ = Teuchos::TimeMonitor::getNewTimer (
-                           "Tpetra::Distributor: doWaitsRecv");
-
-    timer_doWaitsSend_ = Teuchos::TimeMonitor::getNewTimer (
-                           "Tpetra::Distributor: doWaitsSend");
-
-    timer_doPosts3KV_ = Teuchos::TimeMonitor::getNewTimer (
-                           "Tpetra::Distributor: doPosts(3) KV");
-    timer_doPosts4KV_ = Teuchos::TimeMonitor::getNewTimer (
-                           "Tpetra::Distributor: doPosts(4) KV");
-
-    timer_doPosts3KV_recvs_ = Teuchos::TimeMonitor::getNewTimer (
-                           "Tpetra::Distributor: doPosts(3): recvs KV");
-    timer_doPosts4KV_recvs_ = Teuchos::TimeMonitor::getNewTimer (
-                           "Tpetra::Distributor: doPosts(4): recvs KV");
-
-    timer_doPosts3KV_barrier_ = Teuchos::TimeMonitor::getNewTimer (
-                           "Tpetra::Distributor: doPosts(3): barrier KV");
-    timer_doPosts4KV_barrier_ = Teuchos::TimeMonitor::getNewTimer (
-                           "Tpetra::Distributor: doPosts(4): barrier KV");
-
-    timer_doPosts3KV_sends_ = Teuchos::TimeMonitor::getNewTimer (
-                           "Tpetra::Distributor: doPosts(3): sends KV");
-    timer_doPosts4KV_sends_ = Teuchos::TimeMonitor::getNewTimer (
-                           "Tpetra::Distributor: doPosts(4): sends KV");
-    timer_doPosts3KV_sends_slow_ = Teuchos::TimeMonitor::getNewTimer (
-                           "Tpetra::Distributor: doPosts(3): sends KV SLOW");
-    timer_doPosts4KV_sends_slow_ = Teuchos::TimeMonitor::getNewTimer (
-                           "Tpetra::Distributor: doPosts(4): sends KV SLOW");
-    timer_doPosts3KV_sends_fast_ = Teuchos::TimeMonitor::getNewTimer (
-                           "Tpetra::Distributor: doPosts(3): sends KV FAST");
-    timer_doPosts4KV_sends_fast_ = Teuchos::TimeMonitor::getNewTimer (
-                           "Tpetra::Distributor: doPosts(4): sends KV FAST");
-  }
-#endif // HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-}
 }

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -7,13 +7,11 @@
 // *****************************************************************************
 // @HEADER
 
-// clang-format off
-
 #ifndef TPETRA_DETAILS_DISTRIBUTOR_ACTOR_HPP
 #define TPETRA_DETAILS_DISTRIBUTOR_ACTOR_HPP
 
+#include "Teuchos_Assert.hpp"
 #include "Tpetra_Details_DistributorPlan.hpp"
-#include "Tpetra_Details_Profiling.hpp"
 #include "Tpetra_Util.hpp"
 
 #include "Teuchos_Array.hpp"
@@ -39,6 +37,9 @@ constexpr bool areKokkosViews = Kokkos::is_view<View1>::value && Kokkos::is_view
 class DistributorActor {
   static constexpr int DEFAULT_MPI_TAG = 1;
 
+  using IndexView = DistributorPlan::IndexView;
+  using SubViewLimits = DistributorPlan::SubViewLimits;
+
 public:
   DistributorActor();
   DistributorActor(const DistributorActor& otherActor);
@@ -61,18 +62,6 @@ public:
                    size_t numPackets,
                    const ImpView& imports);
 
-  template <class ExpView, class ImpView>
-  void doPostSends(const DistributorPlan& plan,
-                   const ExpView& exports,
-                   size_t numPackets,
-                   const ImpView& imports);
-
-  template <class ExpView, class ImpView>
-  void doPosts(const DistributorPlan& plan,
-               const ExpView& exports,
-               size_t numPackets,
-               const ImpView& imports);
-
   template <class ImpView>
   void doPostRecvs(const DistributorPlan& plan,
                    const ImpView &imports,
@@ -80,10 +69,22 @@ public:
 
   template <class ExpView, class ImpView>
   void doPostSends(const DistributorPlan& plan,
+                   const ExpView& exports,
+                   size_t numPackets,
+                   const ImpView& imports);
+
+  template <class ExpView, class ImpView>
+  void doPostSends(const DistributorPlan& plan,
                    const ExpView &exports,
                    const Teuchos::ArrayView<const size_t>& numExportPacketsPerLID,
                    const ImpView &imports,
                    const Teuchos::ArrayView<const size_t>& numImportPacketsPerLID);
+
+  template <class ExpView, class ImpView>
+  void doPosts(const DistributorPlan& plan,
+               const ExpView& exports,
+               size_t numPackets,
+               const ImpView& imports);
 
   template <class ExpView, class ImpView>
   void doPosts(const DistributorPlan& plan,
@@ -101,33 +102,37 @@ public:
   bool isReady() const;
 
 private:
-// clang-format on
-#ifdef HAVE_TPETRA_MPI
-  template <class ExpView, class ImpView>
-  void doPostsAllToAll(const DistributorPlan &plan, const ExpView &exports,
-                       size_t numPackets, const ImpView &imports);
+
+  template <class ImpView>
+  void doPostRecvsImpl(const DistributorPlan& plan,
+                       const ImpView& imports,
+                       const SubViewLimits& totalPacketsFrom);
 
   template <class ExpView, class ImpView>
-  void doPostsAllToAll(
-      const DistributorPlan &plan, const ExpView &exports,
-      const Teuchos::ArrayView<const size_t> &numExportPacketsPerLID,
-      const ImpView &imports,
-      const Teuchos::ArrayView<const size_t> &numImportPacketsPerLID);
+  void doPostSendsImpl(const DistributorPlan& plan,
+                       const ExpView& exports,
+                       const SubViewLimits& exportSubViewLimits,
+                       const ImpView& imports,
+                       const SubViewLimits& importSubViewLimits);
+
+#ifdef HAVE_TPETRA_MPI
+  template <class ExpView, class ImpView>
+  void doPostsAllToAllImpl(const DistributorPlan &plan,
+                           const ExpView &exports,
+                           const SubViewLimits& exportSubViewLimits,
+                           const ImpView &imports,
+                           const SubViewLimits& importSubViewLimits);
 
 #if defined(HAVE_TPETRACORE_MPI_ADVANCE)
   template <class ExpView, class ImpView>
-  void doPostsNbrAllToAllV(const DistributorPlan &plan, const ExpView &exports,
-                           size_t numPackets, const ImpView &imports);
-
-  template <class ExpView, class ImpView>
-  void doPostsNbrAllToAllV(
-      const DistributorPlan &plan, const ExpView &exports,
-      const Teuchos::ArrayView<const size_t> &numExportPacketsPerLID,
-      const ImpView &imports,
-      const Teuchos::ArrayView<const size_t> &numImportPacketsPerLID);
+  void doPostsNbrAllToAllVImpl(const DistributorPlan &plan,
+                               const ExpView &exports,
+                               const SubViewLimits& exportSubViewLimits,
+                               const ImpView &imports,
+                               const SubViewLimits& importSubViewLimits);
 #endif // HAVE_TPETRACORE_MPI_ADVANCE
 #endif // HAVE_TPETRA_CORE
-  // clang-format off
+
   int mpiTag_;
 
   Teuchos::Array<Teuchos::RCP<Teuchos::CommRequest<int>>> requestsRecv_;
@@ -213,567 +218,13 @@ packOffset(const DstViewType& dst,
   Kokkos::Compat::deep_copy_offset(dst, src, dst_offset, src_offset, size);
 }
 
-// clang-format on
 #ifdef HAVE_TPETRA_MPI
 template <class ExpView, class ImpView>
-void DistributorActor::doPostsAllToAll(const DistributorPlan &plan,
-                                       const ExpView &exports,
-                                       size_t numPackets,
-                                       const ImpView &imports) {
-  using size_type = Teuchos::Array<size_t>::size_type;
-
-  TEUCHOS_TEST_FOR_EXCEPTION(
-      !plan.getIndicesTo().is_null(), std::runtime_error,
-      "Send Type=\"Alltoall\" only works for fast-path communication.");
-
-  auto comm = plan.getComm();
-  const int myRank = comm->getRank();
-  std::vector<int> sendcounts(comm->getSize(), 0);
-  std::vector<int> sdispls(comm->getSize(), 0);
-  std::vector<int> recvcounts(comm->getSize(), 0);
-  std::vector<int> rdispls(comm->getSize(), 0);
-
-  size_t numBlocks = plan.getNumSends() + plan.hasSelfMessage();
-  for (size_t p = 0; p < numBlocks; ++p) {
-    sdispls[plan.getProcsTo()[p]] = plan.getStartsTo()[p] * numPackets;
-    size_t sendcount = plan.getLengthsTo()[p] * numPackets;
-    // sendcount is converted down to int, so make sure it can be represented
-    TEUCHOS_TEST_FOR_EXCEPTION(sendcount > size_t(INT_MAX), std::logic_error,
-                               "Tpetra::Distributor::doPostsAllToAll(3 args): "
-                               "Send count for block "
-                                   << p << " (" << sendcount
-                                   << ") is too large "
-                                      "to be represented as int.");
-    sendcounts[plan.getProcsTo()[p]] = static_cast<int>(sendcount);
-  }
-
-  const size_type actualNumReceives =
-      Teuchos::as<size_type>(plan.getNumReceives()) +
-      Teuchos::as<size_type>(plan.hasSelfMessage() ? 1 : 0);
-  size_t curBufferOffset = 0;
-  for (size_type i = 0; i < actualNumReceives; ++i) {
-    const size_t curBufLen = plan.getLengthsFrom()[i] * numPackets;
-    TEUCHOS_TEST_FOR_EXCEPTION(
-        curBufferOffset + curBufLen > static_cast<size_t>(imports.size()),
-        std::logic_error,
-        "Tpetra::Distributor::doPostsAllToAll(3 args): "
-        "Exceeded size of 'imports' array in packing loop on Process "
-            << myRank << ".  imports.size() = " << imports.size()
-            << " < "
-               "curBufferOffset("
-            << curBufferOffset << ") + curBufLen(" << curBufLen << ").");
-    rdispls[plan.getProcsFrom()[i]] = curBufferOffset;
-    // curBufLen is converted down to int, so make sure it can be represented
-    TEUCHOS_TEST_FOR_EXCEPTION(curBufLen > size_t(INT_MAX), std::logic_error,
-                               "Tpetra::Distributor::doPostsAllToAll(3 args): "
-                               "Recv count for receive "
-                                   << i << " (" << curBufLen
-                                   << ") is too large "
-                                      "to be represented as int.");
-    recvcounts[plan.getProcsFrom()[i]] = static_cast<int>(curBufLen);
-    curBufferOffset += curBufLen;
-  }
-
-  using T = typename ExpView::non_const_value_type;
-  MPI_Datatype rawType = ::Tpetra::Details::MpiTypeTraits<T>::getType(T());
-
-#if defined(HAVE_TPETRACORE_MPI_ADVANCE)
-  if (Details::DISTRIBUTOR_MPIADVANCE_ALLTOALL == plan.getSendType()) {
-    MPIX_Comm *mpixComm = *plan.getMPIXComm();
-    TEUCHOS_TEST_FOR_EXCEPTION(
-        !mpixComm, std::runtime_error,
-        "plan's MPIX_Comm null in doPostsAllToAll, but "
-        "DISTRIBUTOR_MPIADVANCE_ALLTOALL set: plan.howInitialized()="
-            << DistributorHowInitializedEnumToString(plan.howInitialized()));
-
-    const int err = MPIX_Alltoallv(
-        exports.data(), sendcounts.data(), sdispls.data(), rawType,
-        imports.data(), recvcounts.data(), rdispls.data(), rawType, mpixComm);
-
-    TEUCHOS_TEST_FOR_EXCEPTION(err != MPI_SUCCESS, std::runtime_error,
-                               "MPIX_Alltoallv failed with error \""
-                                   << Teuchos::mpiErrorCodeToString(err)
-                                   << "\".");
-
-    return;
-  }
-#endif
-  Teuchos::RCP<const Teuchos::MpiComm<int>> mpiComm =
-      Teuchos::rcp_dynamic_cast<const Teuchos::MpiComm<int>>(comm);
-  Teuchos::RCP<const Teuchos::OpaqueWrapper<MPI_Comm>> rawComm =
-      mpiComm->getRawMpiComm();
-
-  const int err = MPI_Alltoallv(
-      exports.data(), sendcounts.data(), sdispls.data(), rawType,
-      imports.data(), recvcounts.data(), rdispls.data(), rawType, (*rawComm)());
-
-  TEUCHOS_TEST_FOR_EXCEPTION(err != MPI_SUCCESS, std::runtime_error,
-                             "MPI_Alltoallv failed with error \""
-                                 << Teuchos::mpiErrorCodeToString(err)
-                                 << "\".");
-
-  return;
-}
-
-#if defined(HAVE_TPETRACORE_MPI_ADVANCE)
-template <class ExpView, class ImpView>
-void DistributorActor::doPostsNbrAllToAllV(const DistributorPlan &plan,
+void DistributorActor::doPostsAllToAllImpl(const DistributorPlan &plan,
                                            const ExpView &exports,
-                                           size_t numPackets,
-                                           const ImpView &imports) {
-  TEUCHOS_TEST_FOR_EXCEPTION(
-      !plan.getIndicesTo().is_null(), std::runtime_error,
-      "Send Type=\"Alltoall\" only works for fast-path communication.");
-
-  const int myRank = plan.getComm()->getRank();
-  MPIX_Comm *mpixComm = *plan.getMPIXComm();
-
-  const size_t numSends = plan.getNumSends() + plan.hasSelfMessage();
-  const size_t numRecvs = plan.getNumReceives() + plan.hasSelfMessage();
-  std::vector<int> sendcounts(numSends, 0);
-  std::vector<int> sdispls(numSends, 0);
-  std::vector<int> recvcounts(numRecvs, 0);
-  std::vector<int> rdispls(numRecvs, 0);
-
-  for (size_t p = 0; p < numSends; ++p) {
-    sdispls[p] = plan.getStartsTo()[p] * numPackets;
-    const size_t sendcount = plan.getLengthsTo()[p] * numPackets;
-    // sendcount is converted down to int, so make sure it can be represented
-    TEUCHOS_TEST_FOR_EXCEPTION(sendcount > size_t(INT_MAX), std::logic_error,
-                               "Tpetra::Distributor::doPostsNbrAllToAllV(3 args): "
-                               "Send count for block "
-                                   << p << " (" << sendcount
-                                   << ") is too large "
-                                      "to be represented as int.");
-    sendcounts[p] = static_cast<int>(sendcount);
-  }
-
-  size_t curBufferOffset = 0;
-  for (size_t i = 0; i < numRecvs; ++i) {
-    const size_t curBufLen = plan.getLengthsFrom()[i] * numPackets;
-    TEUCHOS_TEST_FOR_EXCEPTION(
-        curBufferOffset + curBufLen > static_cast<size_t>(imports.size()),
-        std::logic_error,
-        "Tpetra::Distributor::doPostsNbrAllToAllV(3 args): "
-        "Exceeded size of 'imports' array in packing loop on Process "
-            << myRank << ".  imports.size() = " << imports.size()
-            << " < "
-               "curBufferOffset("
-            << curBufferOffset << ") + curBufLen(" << curBufLen << ").");
-    rdispls[i] = curBufferOffset;
-    // curBufLen is converted down to int, so make sure it can be represented
-    TEUCHOS_TEST_FOR_EXCEPTION(curBufLen > size_t(INT_MAX), std::logic_error,
-                               "Tpetra::Distributor::doPostsNbrAllToAllV(3 args): "
-                               "Recv count for receive "
-                                   << i << " (" << curBufLen
-                                   << ") is too large "
-                                      "to be represented as int.");
-    recvcounts[i] = static_cast<int>(curBufLen);
-    curBufferOffset += curBufLen;
-  }
-
-  using T = typename ExpView::non_const_value_type;
-  MPI_Datatype rawType = ::Tpetra::Details::MpiTypeTraits<T>::getType(T());
-
-  const int err = MPIX_Neighbor_alltoallv(
-      exports.data(), sendcounts.data(), sdispls.data(), rawType,
-      imports.data(), recvcounts.data(), rdispls.data(), rawType, mpixComm);
-
-  TEUCHOS_TEST_FOR_EXCEPTION(err != MPI_SUCCESS, std::runtime_error,
-                             "MPIX_Neighbor_alltoallv failed with error \""
-                                 << Teuchos::mpiErrorCodeToString(err)
-                                 << "\".");
-}
-#endif // HAVE_TPETRACORE_MPI_ADVANCE
-#endif // HAVE_TPETRA_MPI
-// clang-format off
-
-template <class ImpView>
-void DistributorActor::doPostRecvs(const DistributorPlan& plan,
-                                   size_t numPackets,
-                                   const ImpView& imports)
-{
-  static_assert(isKokkosView<ImpView>,
-      "Data arrays for DistributorActor::doPostRecvs must be Kokkos::Views");
-  using Teuchos::Array;
-  using Teuchos::as;
-  using Teuchos::FancyOStream;
-  using Teuchos::includesVerbLevel;
-  using Teuchos::ireceive;
-  using Teuchos::isend;
-  using Teuchos::send;
-  using Teuchos::TypeNameTraits;
-  using Teuchos::typeName;
-  using std::endl;
-  using Kokkos::Compat::create_const_view;
-  using Kokkos::Compat::create_view;
-  using Kokkos::Compat::subview_offset;
-  using Kokkos::Compat::deep_copy_offset;
-  using size_type = Array<size_t>::size_type;
-  using imports_view_type = ImpView;
-
-#ifdef KOKKOS_ENABLE_CUDA
-  static_assert
-    (! std::is_same<typename ImpView::memory_space, Kokkos::CudaUVMSpace>::value,
-     "Please do not use Tpetra::Distributor with UVM allocations.  "
-     "See Trilinos GitHub issue #1088.");
-#endif // KOKKOS_ENABLE_CUDA
-
-#ifdef KOKKOS_ENABLE_SYCL
-    static_assert
-      (! std::is_same<typename ImpView::memory_space, Kokkos::Experimental::SYCLSharedUSMSpace>::value,
-       "Please do not use Tpetra::Distributor with SharedUSM allocations.  "
-       "See Trilinos GitHub issue #1088 (corresponding to CUDA).");
-#endif // KOKKOS_ENABLE_SYCL
-
-#if defined(HAVE_TPETRA_MPI)
-  // All-to-all communication layout is quite different from
-  // point-to-point, so we handle it separately.
-  // These send options require no matching receives, so we just return.
-  const Details::EDistributorSendType sendType = plan.getSendType();
-  if ((sendType == Details::DISTRIBUTOR_ALLTOALL)
-#ifdef HAVE_TPETRACORE_MPI_ADVANCE
-      || (sendType == Details::DISTRIBUTOR_MPIADVANCE_ALLTOALL)
-      || (sendType == Details::DISTRIBUTOR_MPIADVANCE_NBRALLTOALLV)
-#endif
-      ) {
-    return;
-  }
-#endif // HAVE_TPETRA_MPI
-
-  ProfilingRegion pr3("Tpetra::Distributor: doPostRecvs(3)");
-
-  const int myRank = plan.getComm()->getRank ();
-
-#ifdef HAVE_TPETRA_DEBUG
-  TEUCHOS_TEST_FOR_EXCEPTION
-    (requestsRecv_.size () != 0,
-     std::logic_error,
-     "Tpetra::Distributor::doPostRecvs(3 args): Process "
-     << myRank << ": requestsRecv_.size() = " << requestsRecv_.size () << " != 0.");
-#endif // HAVE_TPETRA_DEBUG
-
-  // Distributor uses requestsRecv_.size() and requestsSend_.size()
-  // as the number of outstanding nonblocking message requests, so
-  // we resize to zero to maintain this invariant.
-  //
-  // getNumReceives() does _not_ include the self message, if there is
-  // one.  Here, we do actually send a message to ourselves, so we
-  // include any self message in the "actual" number of receives to
-  // post.
-  //
-  // NOTE (mfh 19 Mar 2012): Epetra_MpiDistributor::DoPosts()
-  // doesn't (re)allocate its array of requests.  That happens in
-  // CreateFromSends(), ComputeRecvs_(), DoReversePosts() (on
-  // demand), or Resize_().
-  const size_type actualNumReceives = as<size_type> (plan.getNumReceives()) +
-    as<size_type> (plan.hasSelfMessage() ? 1 : 0);
-  requestsRecv_.resize (0);
-
-  // Post the nonblocking receives.  It's common MPI wisdom to post
-  // receives before sends.  In MPI terms, this means favoring
-  // adding to the "posted queue" (of receive requests) over adding
-  // to the "unexpected queue" (of arrived messages not yet matched
-  // with a receive).
-  {
-    ProfilingRegion pr3r("Tpetra::Distributor: doPostRecvs(3) irecvs");
-
-    size_t curBufferOffset = 0;
-    for (size_type i = 0; i < actualNumReceives; ++i) {
-      const size_t curBufLen = plan.getLengthsFrom()[i] * numPackets;
-      if (plan.getProcsFrom()[i] != myRank) {
-        // If my process is receiving these packet(s) from another
-        // process (not a self-receive):
-        //
-        // 1. Set up the persisting view (recvBuf) of the imports
-        //    array, given the offset and size (total number of
-        //    packets from process getProcsFrom()[i]).
-        // 2. Start the Irecv and save the resulting request.
-        TEUCHOS_TEST_FOR_EXCEPTION(
-            curBufferOffset + curBufLen > static_cast<size_t> (imports.size ()),
-            std::logic_error, "Tpetra::Distributor::doPostRecvs(3 args): "
-            "Exceeded size of 'imports' array in packing loop on Process " <<
-            myRank << ".  imports.size() = " << imports.size () << " < "
-            "curBufferOffset(" << curBufferOffset << ") + curBufLen(" <<
-            curBufLen << ").");
-        imports_view_type recvBuf =
-          subview_offset (imports, curBufferOffset, curBufLen);
-        requestsRecv_.push_back (ireceive<int> (recvBuf, plan.getProcsFrom()[i],
-              mpiTag_, *plan.getComm()));
-      }
-      curBufferOffset += curBufLen;
-    }
-  }
-}
-
-template <class ExpView, class ImpView>
-void DistributorActor::doPostSends(const DistributorPlan& plan,
-                                   const ExpView& exports,
-                                   size_t numPackets,
-                                   const ImpView& imports)
-{
-  static_assert(areKokkosViews<ExpView, ImpView>,
-      "Data arrays for DistributorActor::doPostSends must be Kokkos::Views");
-  using Teuchos::Array;
-  using Teuchos::as;
-  using Teuchos::FancyOStream;
-  using Teuchos::includesVerbLevel;
-  using Teuchos::ireceive;
-  using Teuchos::isend;
-  using Teuchos::send;
-  using Teuchos::TypeNameTraits;
-  using Teuchos::typeName;
-  using std::endl;
-  using Kokkos::Compat::create_const_view;
-  using Kokkos::Compat::create_view;
-  using Kokkos::Compat::subview_offset;
-  using Kokkos::Compat::deep_copy_offset;
-  using size_type = Array<size_t>::size_type;
-  using exports_view_type = ExpView;
-
-#ifdef KOKKOS_ENABLE_CUDA
-  static_assert
-    (! std::is_same<typename ExpView::memory_space, Kokkos::CudaUVMSpace>::value &&
-     ! std::is_same<typename ImpView::memory_space, Kokkos::CudaUVMSpace>::value,
-     "Please do not use Tpetra::Distributor with UVM allocations.  "
-     "See Trilinos GitHub issue #1088.");
-#endif // KOKKOS_ENABLE_CUDA
-
-#ifdef KOKKOS_ENABLE_SYCL
-    static_assert
-      (! std::is_same<typename ExpView::memory_space, Kokkos::Experimental::SYCLSharedUSMSpace>::value &&
-       ! std::is_same<typename ImpView::memory_space, Kokkos::Experimental::SYCLSharedUSMSpace>::value,
-       "Please do not use Tpetra::Distributor with SharedUSM allocations.  "
-       "See Trilinos GitHub issue #1088 (corresponding to CUDA).");
-#endif // KOKKOS_ENABLE_SYCL
-
-  ProfilingRegion ps3("Tpetra::Distributor: doPostSends(3)");
-
-  const int myRank = plan.getComm()->getRank ();
-  // Run-time configurable parameters that come from the input
-  // ParameterList set by setParameterList().
-  const Details::EDistributorSendType sendType = plan.getSendType();
-
-#if defined(HAVE_TPETRA_MPI)
-  //  All-to-all communication layout is quite different from
-  //  point-to-point, so we handle it separately.
-
-  if (sendType == Details::DISTRIBUTOR_ALLTOALL) {
-    doPostsAllToAll(plan, exports,numPackets, imports);
-    return;
-  }
-#ifdef HAVE_TPETRACORE_MPI_ADVANCE
-  else if (sendType == Details::DISTRIBUTOR_MPIADVANCE_ALLTOALL) {
-    doPostsAllToAll(plan, exports,numPackets, imports);
-    return;
-  } else if (sendType == Details::DISTRIBUTOR_MPIADVANCE_NBRALLTOALLV) {
-    doPostsNbrAllToAllV(plan, exports,numPackets, imports);
-    return;
-  }
-#endif // defined(HAVE_TPETRACORE_MPI_ADVANCE)
-
-#else // HAVE_TPETRA_MPI
-    if (plan.hasSelfMessage()) {
-      // This is how we "send a message to ourself": we copy from
-      // the export buffer to the import buffer.  That saves
-      // Teuchos::Comm implementations other than MpiComm (in
-      // particular, SerialComm) the trouble of implementing self
-      // messages correctly.  (To do this right, SerialComm would
-      // need internal buffer space for messages, keyed on the
-      // message's tag.)
-      size_t selfReceiveOffset = 0;
-      deep_copy_offset(imports, exports, selfReceiveOffset,
-                       plan.getStartsTo()[0]*numPackets,
-                       plan.getLengthsTo()[0]*numPackets);
-    }
-    // should we just return here?
-    // likely not as comm could be a serial comm
-#endif // HAVE_TPETRA_MPI
-
-  size_t selfReceiveOffset = 0;
-
-#ifdef HAVE_TPETRA_DEBUG
-  TEUCHOS_TEST_FOR_EXCEPTION
-    (requestsSend_.size () != 0,
-     std::logic_error,
-     "Tpetra::Distributor::doPostSends(3 args): Process "
-     << myRank << ": requestsSend_.size() = " << requestsSend_.size () << " != 0.");
-#endif // HAVE_TPETRA_DEBUG
-
-  // Distributor uses requestsRecv_.size() and requestsSend_.size()
-  // as the number of outstanding nonblocking message requests, so
-  // we resize to zero to maintain this invariant.
-  //
-  // getNumReceives() does _not_ include the self message, if there is
-  // one.  Here, we do actually send a message to ourselves, so we
-  // include any self message in the "actual" number of receives to
-  // post.
-  //
-  // NOTE (mfh 19 Mar 2012): Epetra_MpiDistributor::DoPosts()
-  // doesn't (re)allocate its array of requests.  That happens in
-  // CreateFromSends(), ComputeRecvs_(), DoReversePosts() (on
-  // demand), or Resize_().
-  const size_type actualNumReceives = as<size_type> (plan.getNumReceives()) +
-    as<size_type> (plan.hasSelfMessage() ? 1 : 0);
-  requestsSend_.resize (0);
-
-  {
-    size_t curBufferOffset = 0;
-    for (size_type i = 0; i < actualNumReceives; ++i) {
-      const size_t curBufLen = plan.getLengthsFrom()[i] * numPackets;
-      if (plan.getProcsFrom()[i] == myRank) { // Receiving from myself
-        selfReceiveOffset = curBufferOffset; // Remember the self-recv offset
-      }
-      curBufferOffset += curBufLen;
-    }
-  }
-
-  ProfilingRegion ps3s("Tpetra::Distributor: doPostSends(3) sends");
-
-  // setup scan through getProcsTo() list starting with higher numbered procs
-  // (should help balance message traffic)
-  //
-  // FIXME (mfh 20 Feb 2013) Why haven't we precomputed this?
-  // It doesn't depend on the input at all.
-  size_t numBlocks = plan.getNumSends() + plan.hasSelfMessage();
-  size_t procIndex = 0;
-  while ((procIndex < numBlocks) && (plan.getProcsTo()[procIndex] < myRank)) {
-    ++procIndex;
-  }
-  if (procIndex == numBlocks) {
-    procIndex = 0;
-  }
-
-  size_t selfNum = 0;
-  size_t selfIndex = 0;
-
-  if (plan.getIndicesTo().is_null()) {
-    ProfilingRegion ps3sf("Tpetra::Distributor: doPostSends(3) sends FAST");
-
-    // Data are already blocked (laid out) by process, so we don't
-    // need a separate send buffer (besides the exports array).
-    for (size_t i = 0; i < numBlocks; ++i) {
-      size_t p = i + procIndex;
-      if (p > (numBlocks - 1)) {
-        p -= numBlocks;
-      }
-
-      if (plan.getProcsTo()[p] != myRank) {
-        exports_view_type tmpSend = subview_offset(
-            exports, plan.getStartsTo()[p]*numPackets, plan.getLengthsTo()[p]*numPackets);
-
-        if (sendType == Details::DISTRIBUTOR_ISEND) {
-          // NOTE: This looks very similar to the tmpSend above, but removing
-          // tmpSendBuf and uses tmpSend leads to a performance hit on Arm
-          // SerialNode builds
-          exports_view_type tmpSendBuf =
-            subview_offset (exports, plan.getStartsTo()[p] * numPackets,
-                plan.getLengthsTo()[p] * numPackets);
-          requestsSend_.push_back (isend<int> (tmpSendBuf, plan.getProcsTo()[p],
-                mpiTag_, *plan.getComm()));
-        }
-        else {  // DISTRIBUTOR_SEND
-          send<int> (tmpSend,
-              as<int> (tmpSend.size ()),
-              plan.getProcsTo()[p], mpiTag_, *plan.getComm());
-        }
-      }
-      else { // "Sending" the message to myself
-        selfNum = p;
-      }
-    }
-
-    if (plan.hasSelfMessage()) {
-      // This is how we "send a message to ourself": we copy from
-      // the export buffer to the import buffer.  That saves
-      // Teuchos::Comm implementations other than MpiComm (in
-      // particular, SerialComm) the trouble of implementing self
-      // messages correctly.  (To do this right, SerialComm would
-      // need internal buffer space for messages, keyed on the
-      // message's tag.)
-      deep_copy_offset(imports, exports, selfReceiveOffset,
-          plan.getStartsTo()[selfNum]*numPackets,
-          plan.getLengthsTo()[selfNum]*numPackets);
-    }
-
-  }
-  else { // data are not blocked by proc, use send buffer
-    ProfilingRegion ps3ss("Tpetra::Distributor: doPostSends(3): sends SLOW");
-
-    using Packet = typename ExpView::non_const_value_type;
-    using Layout = typename ExpView::array_layout;
-    using Device = typename ExpView::device_type;
-    using Mem = typename ExpView::memory_traits;
-
-    // This buffer is long enough for only one message at a time.
-    // Thus, we use DISTRIBUTOR_SEND always in this case, regardless
-    // of sendType requested by user.
-    // This code path formerly errored out with message:
-    //     Tpetra::Distributor::doPosts(3 args):
-    //     The "send buffer" code path
-    //     doesn't currently work with nonblocking sends.
-    // Now, we opt to just do the communication in a way that works.
-#ifdef HAVE_TPETRA_DEBUG
-    if (sendType != Details::DISTRIBUTOR_SEND) {
-      if (plan.getComm()->getRank() == 0)
-        std::cout << "The requested Tpetra send type "
-                  << DistributorSendTypeEnumToString(sendType)
-                  << " requires Distributor data to be ordered by"
-                  << " the receiving processor rank.  Since these"
-                  << " data are not ordered, Tpetra will use Send"
-                  << " instead." << std::endl;
-    }
-#endif
-
-    Kokkos::View<Packet*,Layout,Device,Mem> sendArray ("sendArray",
-        plan.getMaxSendLength() * numPackets);
-
-    for (size_t i = 0; i < numBlocks; ++i) {
-      size_t p = i + procIndex;
-      if (p > (numBlocks - 1)) {
-        p -= numBlocks;
-      }
-
-      if (plan.getProcsTo()[p] != myRank) {
-        size_t sendArrayOffset = 0;
-        size_t j = plan.getStartsTo()[p];
-        for (size_t k = 0; k < plan.getLengthsTo()[p]; ++k, ++j) {
-          packOffset(sendArray, exports, sendArrayOffset, plan.getIndicesTo()[j]*numPackets, numPackets);
-          sendArrayOffset += numPackets;
-        }
-        typename ExpView::execution_space().fence();
-
-        ImpView tmpSend =
-          subview_offset(sendArray, size_t(0), plan.getLengthsTo()[p]*numPackets);
-
-        send<int> (tmpSend,
-            as<int> (tmpSend.size ()),
-            plan.getProcsTo()[p], mpiTag_, *plan.getComm());
-      }
-      else { // "Sending" the message to myself
-        selfNum = p;
-        selfIndex = plan.getStartsTo()[p];
-      }
-    }
-
-    if (plan.hasSelfMessage()) {
-      for (size_t k = 0; k < plan.getLengthsTo()[selfNum]; ++k) {
-        packOffset(imports, exports, selfReceiveOffset, plan.getIndicesTo()[selfIndex]*numPackets, numPackets);
-        ++selfIndex;
-        selfReceiveOffset += numPackets;
-      }
-    }
-  }
-}
-
-// clang-format on
-#ifdef HAVE_TPETRA_MPI
-template <class ExpView, class ImpView>
-void DistributorActor::doPostsAllToAll(
-    const DistributorPlan &plan, const ExpView &exports,
-    const Teuchos::ArrayView<const size_t> &numExportPacketsPerLID,
-    const ImpView &imports,
-    const Teuchos::ArrayView<const size_t> &numImportPacketsPerLID) {
+                                           const SubViewLimits& exportSubViewLimits,
+                                           const ImpView &imports,
+                                           const SubViewLimits& importSubViewLimits) {
   TEUCHOS_TEST_FOR_EXCEPTION(
       !plan.getIndicesTo().is_null(), std::runtime_error,
       "Send Type=\"Alltoall\" only works for fast-path communication.");
@@ -786,50 +237,39 @@ void DistributorActor::doPostsAllToAll(
   std::vector<int> recvcounts(comm->getSize(), 0);
   std::vector<int> rdispls(comm->getSize(), 0);
 
-  size_t curPKToffset = 0;
+  auto& [importStarts, importLengths] = importSubViewLimits;
+  auto& [exportStarts, exportLengths] = exportSubViewLimits;
+
   for (size_t pp = 0; pp < plan.getNumSends(); ++pp) {
-    sdispls[plan.getProcsTo()[pp]] = curPKToffset;
-    size_t numPackets = 0;
-    for (size_t j = plan.getStartsTo()[pp];
-         j < plan.getStartsTo()[pp] + plan.getLengthsTo()[pp]; ++j) {
-      numPackets += numExportPacketsPerLID[j];
-    }
+    sdispls[plan.getProcsTo()[pp]] = exportStarts[pp];
+    size_t numPackets = exportLengths[pp];
     // numPackets is converted down to int, so make sure it can be represented
     TEUCHOS_TEST_FOR_EXCEPTION(numPackets > size_t(INT_MAX), std::logic_error,
-                               "Tpetra::Distributor::doPostsAllToAll(4 args): "
+                               "Tpetra::Distributor::doPostsAllToAll: "
                                "Send count for send "
                                    << pp << " (" << numPackets
                                    << ") is too large "
                                       "to be represented as int.");
     sendcounts[plan.getProcsTo()[pp]] = static_cast<int>(numPackets);
-    curPKToffset += numPackets;
   }
 
   const size_type actualNumReceives =
       Teuchos::as<size_type>(plan.getNumReceives()) +
       Teuchos::as<size_type>(plan.hasSelfMessage() ? 1 : 0);
 
-  size_t curBufferOffset = 0;
-  size_t curLIDoffset = 0;
   for (size_type i = 0; i < actualNumReceives; ++i) {
-    size_t totalPacketsFrom_i = 0;
-    for (size_t j = 0; j < plan.getLengthsFrom()[i]; ++j) {
-      totalPacketsFrom_i += numImportPacketsPerLID[curLIDoffset + j];
-    }
-    curLIDoffset += plan.getLengthsFrom()[i];
-
-    rdispls[plan.getProcsFrom()[i]] = curBufferOffset;
+    rdispls[plan.getProcsFrom()[i]] = importStarts[i];
+    size_t totalPacketsFrom_i = importLengths[i];
     // totalPacketsFrom_i is converted down to int, so make sure it can be
     // represented
     TEUCHOS_TEST_FOR_EXCEPTION(totalPacketsFrom_i > size_t(INT_MAX),
                                std::logic_error,
-                               "Tpetra::Distributor::doPostsAllToAll(3 args): "
+                               "Tpetra::Distributor::doPostsAllToAll: "
                                "Recv count for receive "
                                    << i << " (" << totalPacketsFrom_i
                                    << ") is too large "
                                       "to be represented as int.");
     recvcounts[plan.getProcsFrom()[i]] = static_cast<int>(totalPacketsFrom_i);
-    curBufferOffset += totalPacketsFrom_i;
   }
 
   Teuchos::RCP<const Teuchos::MpiComm<int>> mpiComm =
@@ -871,75 +311,63 @@ void DistributorActor::doPostsAllToAll(
 
 #if defined(HAVE_TPETRACORE_MPI_ADVANCE)
 template <class ExpView, class ImpView>
-void DistributorActor::doPostsNbrAllToAllV(
-    const DistributorPlan &plan, const ExpView &exports,
-    const Teuchos::ArrayView<const size_t> &numExportPacketsPerLID,
-    const ImpView &imports,
-    const Teuchos::ArrayView<const size_t> &numImportPacketsPerLID) {
+void DistributorActor::doPostsNbrAllToAllVImpl(const DistributorPlan &plan,
+                                               const ExpView &exports,
+                                               const SubViewLimits& exportSubViewLimits,
+                                               const ImpView &imports,
+                                               const SubViewLimits& importSubViewLimits) {
   TEUCHOS_TEST_FOR_EXCEPTION(
       !plan.getIndicesTo().is_null(), std::runtime_error,
       "Send Type=\"Alltoall\" only works for fast-path communication.");
 
-  const Teuchos_Ordinal numSends = plan.getProcsTo().size();
-  const Teuchos_Ordinal numRecvs = plan.getProcsFrom().size();
+  const int myRank = plan.getComm()->getRank();
+  MPIX_Comm *mpixComm = *plan.getMPIXComm();
 
-  auto comm = plan.getComm();
+  const size_t numSends = plan.getNumSends() + plan.hasSelfMessage();
+  const size_t numRecvs = plan.getNumReceives() + plan.hasSelfMessage();
   std::vector<int> sendcounts(numSends, 0);
   std::vector<int> sdispls(numSends, 0);
   std::vector<int> recvcounts(numRecvs, 0);
   std::vector<int> rdispls(numRecvs, 0);
 
-  Teuchos::RCP<const Teuchos::MpiComm<int>> mpiComm =
-      Teuchos::rcp_dynamic_cast<const Teuchos::MpiComm<int>>(comm);
-  Teuchos::RCP<const Teuchos::OpaqueWrapper<MPI_Comm>> rawComm =
-      mpiComm->getRawMpiComm();
-  using T = typename ExpView::non_const_value_type;
-  MPI_Datatype rawType = ::Tpetra::Details::MpiTypeTraits<T>::getType(T());
+  auto& [importStarts, importLengths] = importSubViewLimits;
+  auto& [exportStarts, exportLengths] = exportSubViewLimits;
 
-  // unlike standard alltoall, entry `i` in sdispls and sendcounts
-  // refer to the ith participating rank, rather than rank i
-  size_t curPKToffset = 0;
-  for (Teuchos_Ordinal pp = 0; pp < numSends; ++pp) {
-    sdispls[pp] = curPKToffset;
-    size_t numPackets = 0;
-    for (size_t j = plan.getStartsTo()[pp];
-         j < plan.getStartsTo()[pp] + plan.getLengthsTo()[pp]; ++j) {
-      numPackets += numExportPacketsPerLID[j];
-    }
+  for (size_t pp = 0; pp < plan.getNumSends(); ++pp) {
+    sdispls[plan.getProcsTo()[pp]] = exportStarts[pp];
+    size_t numPackets = exportLengths[pp];
     // numPackets is converted down to int, so make sure it can be represented
     TEUCHOS_TEST_FOR_EXCEPTION(numPackets > size_t(INT_MAX), std::logic_error,
-                               "Tpetra::Distributor::doPostsNbrAllToAllV(4 args): "
+                               "Tpetra::Distributor::doPostsNbrAllToAllV: "
                                "Send count for send "
                                    << pp << " (" << numPackets
                                    << ") is too large "
                                       "to be represented as int.");
-    sendcounts[pp] = static_cast<int>(numPackets);
-    curPKToffset += numPackets;
+    sendcounts[plan.getProcsTo()[pp]] = static_cast<int>(numPackets);
   }
-  size_t curBufferOffset = 0;
-  size_t curLIDoffset = 0;
-  for (Teuchos_Ordinal i = 0; i < numRecvs; ++i) {
-    size_t totalPacketsFrom_i = 0;
-    for (size_t j = 0; j < plan.getLengthsFrom()[i]; ++j) {
-      totalPacketsFrom_i += numImportPacketsPerLID[curLIDoffset + j];
-    }
-    curLIDoffset += plan.getLengthsFrom()[i];
 
-    rdispls[i] = curBufferOffset;
+  const size_type actualNumReceives =
+      Teuchos::as<size_type>(plan.getNumReceives()) +
+      Teuchos::as<size_type>(plan.hasSelfMessage() ? 1 : 0);
+
+  for (size_type i = 0; i < actualNumReceives; ++i) {
+    rdispls[plan.getProcsFrom()[i]] = importStarts(i);
+    size_t totalPacketsFrom_i = importLengths(i);
     // totalPacketsFrom_i is converted down to int, so make sure it can be
     // represented
     TEUCHOS_TEST_FOR_EXCEPTION(totalPacketsFrom_i > size_t(INT_MAX),
                                std::logic_error,
-                               "Tpetra::Distributor::doPostsNbrAllToAllV(3 args): "
+                               "Tpetra::Distributor::doPostsNbrAllToAllV: "
                                "Recv count for receive "
                                    << i << " (" << totalPacketsFrom_i
                                    << ") is too large "
                                       "to be represented as int.");
-    recvcounts[i] = static_cast<int>(totalPacketsFrom_i);
-    curBufferOffset += totalPacketsFrom_i;
+    recvcounts[plan.getProcsFrom()[i]] = static_cast<int>(totalPacketsFrom_i);
   }
 
-  MPIX_Comm *mpixComm = *plan.getMPIXComm();
+  using T = typename ExpView::non_const_value_type;
+  MPI_Datatype rawType = ::Tpetra::Details::MpiTypeTraits<T>::getType(T());
+
   const int err = MPIX_Neighbor_alltoallv(
       exports.data(), sendcounts.data(), sdispls.data(), rawType,
       imports.data(), recvcounts.data(), rdispls.data(), rawType, mpixComm);
@@ -951,24 +379,36 @@ void DistributorActor::doPostsNbrAllToAllV(
 }
 #endif // HAVE_TPETRACORE_MPI_ADVANCE
 #endif // HAVE_TPETRA_MPI
-       // clang-format off
+
+template <class ImpView>
+void DistributorActor::doPostRecvs(const DistributorPlan& plan,
+                                   size_t numPackets,
+                                   const ImpView& imports)
+{
+  auto importSubViewLimits = plan.getImportViewLimits(numPackets);
+  doPostRecvsImpl(plan, imports, importSubViewLimits);
+}
 
 template <class ImpView>
 void DistributorActor::doPostRecvs(const DistributorPlan& plan,
                                    const ImpView &imports,
                                    const Teuchos::ArrayView<const size_t>& numImportPacketsPerLID)
 {
+  auto importSubViewLimits = plan.getImportViewLimits(numImportPacketsPerLID);
+  doPostRecvsImpl(plan, imports, importSubViewLimits);
+}
+
+template <class ImpView>
+void DistributorActor::doPostRecvsImpl(const DistributorPlan& plan,
+                                       const ImpView &imports,
+                                       const SubViewLimits& importSubViewLimits)
+{
   static_assert(isKokkosView<ImpView>,
       "Data arrays for DistributorActor::doPostRecvs must be Kokkos::Views");
   using Teuchos::Array;
   using Teuchos::as;
   using Teuchos::ireceive;
-  using Teuchos::TypeNameTraits;
-  using std::endl;
-  using Kokkos::Compat::create_const_view;
-  using Kokkos::Compat::create_view;
   using Kokkos::Compat::subview_offset;
-  using Kokkos::Compat::deep_copy_offset;
   using size_type = Array<size_t>::size_type;
   using imports_view_type = ImpView;
 
@@ -988,6 +428,7 @@ void DistributorActor::doPostRecvs(const DistributorPlan& plan,
 #if defined(HAVE_TPETRA_MPI)
   // All-to-all communication layout is quite different from
   // point-to-point, so we handle it separately.
+
   // These send options require no matching receives, so we just return.
   const Details::EDistributorSendType sendType = plan.getSendType();
   if ((sendType == Details::DISTRIBUTOR_ALLTOALL)
@@ -1000,27 +441,12 @@ void DistributorActor::doPostRecvs(const DistributorPlan& plan,
   }
 #endif // HAVE_TPETRA_MPI
 
-  ProfilingRegion pr4("Tpetra::Distributor: doPostRecvs(4)");
+  ProfilingRegion pr("Tpetra::Distributor: doPostRecvs");
 
   const int myProcID = plan.getComm()->getRank ();
 
-#ifdef HAVE_TPETRA_DEBUG
-  // Different messages may have different numbers of packets.
-  size_t totalNumImportPackets = 0;
-  for (size_type ii = 0; ii < numImportPacketsPerLID.size (); ++ii) {
-    totalNumImportPackets += numImportPacketsPerLID[ii];
-  }
-  TEUCHOS_TEST_FOR_EXCEPTION(
-      imports.extent (0) < totalNumImportPackets, std::runtime_error,
-      "Tpetra::Distributor::doPostRecvs(4 args): The 'imports' array must have "
-      "enough entries to hold the expected number of import packets.  "
-      "imports.extent(0) = " << imports.extent (0) << " < "
-      "totalNumImportPackets = " << totalNumImportPackets << ".");
-  TEUCHOS_TEST_FOR_EXCEPTION
-    (requestsRecv_.size () != 0, std::logic_error, "Tpetra::Distributor::"
-     "doPostRecvs(4 args): Process " << myProcID << ": requestsRecv_.size () = "
-     << requestsRecv_.size () << " != 0.");
-#endif // HAVE_TPETRA_DEBUG
+  auto& [importStarts, importLengths] = importSubViewLimits;
+
   // Distributor uses requestsRecv_.size() and requestsSend_.size()
   // as the number of outstanding nonblocking message requests, so
   // we resize to zero to maintain this invariant.
@@ -1036,6 +462,24 @@ void DistributorActor::doPostRecvs(const DistributorPlan& plan,
   // demand), or Resize_().
   const size_type actualNumReceives = as<size_type> (plan.getNumReceives()) +
     as<size_type> (plan.hasSelfMessage() ? 1 : 0);
+
+#ifdef HAVE_TPETRA_DEBUG
+  size_t totalNumImportPackets = 0;
+  for (size_t i = 0; i < Teuchos::as<size_t>(actualNumReceives); ++i) {
+    totalNumImportPackets += importLengths[i];
+  }
+  TEUCHOS_TEST_FOR_EXCEPTION(
+      imports.extent (0) < totalNumImportPackets, std::runtime_error,
+      "Tpetra::Distributor::doPostRecvs: The 'imports' array must have "
+      "enough entries to hold the expected number of import packets.  "
+      "imports.extent(0) = " << imports.extent (0) << " < "
+      "totalNumImportPackets = " << totalNumImportPackets << ".");
+  TEUCHOS_TEST_FOR_EXCEPTION
+    (!requestsRecv_.empty(), std::logic_error, "Tpetra::Distributor::"
+     "doPostRecvs: Process " << myProcID << ": requestsRecv_.size () = "
+     << requestsRecv_.size () << " != 0.");
+#endif // HAVE_TPETRA_DEBUG
+
   requestsRecv_.resize (0);
 
   // Post the nonblocking receives.  It's common MPI wisdom to post
@@ -1044,21 +488,14 @@ void DistributorActor::doPostRecvs(const DistributorPlan& plan,
   // to the "unexpected queue" (of arrived messages not yet matched
   // with a receive).
   {
-    ProfilingRegion pr4r("Tpetra::Distributor: doPostRecvs(4) recvs");
+    ProfilingRegion prr("Tpetra::Distributor: doPostRecvs recvs");
 
-    size_t curBufferOffset = 0;
-    size_t curLIDoffset = 0;
     for (size_type i = 0; i < actualNumReceives; ++i) {
-      size_t totalPacketsFrom_i = 0;
-      for (size_t j = 0; j < plan.getLengthsFrom()[i]; ++j) {
-        totalPacketsFrom_i += numImportPacketsPerLID[curLIDoffset+j];
-      }
-      // totalPacketsFrom_i is converted down to int, so make sure it can be represented
+      size_t totalPacketsFrom_i = importLengths[Teuchos::as<size_t>(i)];
       TEUCHOS_TEST_FOR_EXCEPTION(totalPacketsFrom_i > size_t(INT_MAX),
-                                 std::logic_error, "Tpetra::Distributor::doPostRecvs(3 args): "
+                                 std::logic_error, "Tpetra::Distributor::doPostRecvs: "
                                  "Recv count for receive " << i << " (" << totalPacketsFrom_i << ") is too large "
                                  "to be represented as int.");
-      curLIDoffset += plan.getLengthsFrom()[i];
       if (plan.getProcsFrom()[i] != myProcID && totalPacketsFrom_i) {
         // If my process is receiving these packet(s) from another
         // process (not a self-receive), and if there is at least
@@ -1069,13 +506,23 @@ void DistributorActor::doPostRecvs(const DistributorPlan& plan,
         //    packets from process getProcsFrom()[i]).
         // 2. Start the Irecv and save the resulting request.
         imports_view_type recvBuf =
-          subview_offset (imports, curBufferOffset, totalPacketsFrom_i);
+          subview_offset (imports, importStarts[i], totalPacketsFrom_i);
         requestsRecv_.push_back (ireceive<int> (recvBuf, plan.getProcsFrom()[i],
               mpiTag_, *plan.getComm()));
       }
-      curBufferOffset += totalPacketsFrom_i;
     }
   }
+}
+
+template <class ExpView, class ImpView>
+void DistributorActor::doPostSends(const DistributorPlan& plan,
+                                   const ExpView& exports,
+                                   size_t numPackets,
+                                   const ImpView& imports)
+{
+  auto exportSubViewLimits = plan.getExportViewLimits(numPackets);
+  auto importSubViewLimits = plan.getImportViewLimits(numPackets);
+  doPostSendsImpl(plan, exports, exportSubViewLimits, imports, importSubViewLimits);
 }
 
 template <class ExpView, class ImpView>
@@ -1085,106 +532,102 @@ void DistributorActor::doPostSends(const DistributorPlan& plan,
                                    const ImpView &imports,
                                    const Teuchos::ArrayView<const size_t>& numImportPacketsPerLID)
 {
+  auto exportSubViewLimits = plan.getExportViewLimits(numExportPacketsPerLID);
+  auto importSubViewLimits = plan.getImportViewLimits(numImportPacketsPerLID);
+  doPostSendsImpl(plan, exports, exportSubViewLimits, imports, importSubViewLimits);
+}
+
+template <class ExpView, class ImpView>
+void DistributorActor::doPostSendsImpl(const DistributorPlan& plan,
+                                       const ExpView& exports,
+                                       const SubViewLimits& exportSubViewLimits,
+                                       const ImpView& imports,
+                                       const SubViewLimits& importSubViewLimits)
+{
   static_assert(areKokkosViews<ExpView, ImpView>,
       "Data arrays for DistributorActor::doPostSends must be Kokkos::Views");
   using Teuchos::Array;
   using Teuchos::as;
-  using Teuchos::ireceive;
   using Teuchos::isend;
   using Teuchos::send;
-  using Teuchos::TypeNameTraits;
-  using std::endl;
-  using Kokkos::Compat::create_const_view;
-  using Kokkos::Compat::create_view;
   using Kokkos::Compat::subview_offset;
   using Kokkos::Compat::deep_copy_offset;
   using size_type = Array<size_t>::size_type;
   using exports_view_type = ExpView;
 
 #ifdef KOKKOS_ENABLE_CUDA
-  static_assert (! std::is_same<typename ExpView::memory_space, Kokkos::CudaUVMSpace>::value &&
-                 ! std::is_same<typename ImpView::memory_space, Kokkos::CudaUVMSpace>::value,
-                 "Please do not use Tpetra::Distributor with UVM "
-                 "allocations.  See GitHub issue #1088.");
+  static_assert
+    (! std::is_same<typename ExpView::memory_space, Kokkos::CudaUVMSpace>::value &&
+     ! std::is_same<typename ImpView::memory_space, Kokkos::CudaUVMSpace>::value,
+     "Please do not use Tpetra::Distributor with UVM allocations.  "
+     "See Trilinos GitHub issue #1088.");
 #endif // KOKKOS_ENABLE_CUDA
 
 #ifdef KOKKOS_ENABLE_SYCL
-    static_assert (! std::is_same<typename ExpView::memory_space, Kokkos::Experimental::SYCLSharedUSMSpace>::value &&
-                   ! std::is_same<typename ImpView::memory_space, Kokkos::Experimental::SYCLSharedUSMSpace>::value,
-                   "Please do not use Tpetra::Distributor with SharedUSM "
-                   "allocations.  See GitHub issue #1088 (corresponding to CUDA).");
+    static_assert
+      (! std::is_same<typename ExpView::memory_space, Kokkos::Experimental::SYCLSharedUSMSpace>::value &&
+       ! std::is_same<typename ImpView::memory_space, Kokkos::Experimental::SYCLSharedUSMSpace>::value,
+       "Please do not use Tpetra::Distributor with SharedUSM allocations.  "
+       "See Trilinos GitHub issue #1088 (corresponding to CUDA).");
 #endif // KOKKOS_ENABLE_SYCL
 
-  ProfilingRegion ps4("Tpetra::Distributor: doPostSends(4)");
+  ProfilingRegion ps("Tpetra::Distributor: doPostSends");
 
+  const int myRank = plan.getComm()->getRank ();
   // Run-time configurable parameters that come from the input
   // ParameterList set by setParameterList().
   const Details::EDistributorSendType sendType = plan.getSendType();
 
-#ifdef HAVE_TPETRA_MPI
+  auto& [exportStarts, exportLengths] = exportSubViewLimits;
+  auto& [importStarts, importLengths] = importSubViewLimits;
+
+#if defined(HAVE_TPETRA_MPI)
   //  All-to-all communication layout is quite different from
   //  point-to-point, so we handle it separately.
+
   if (sendType == Details::DISTRIBUTOR_ALLTOALL) {
-    doPostsAllToAll(plan, exports, numExportPacketsPerLID, imports, numImportPacketsPerLID);
+    doPostsAllToAllImpl(plan, exports, exportSubViewLimits, imports, importSubViewLimits);
     return;
   }
 #ifdef HAVE_TPETRACORE_MPI_ADVANCE
-  else if (sendType == Details::DISTRIBUTOR_MPIADVANCE_ALLTOALL)
-  {
-    doPostsAllToAll(plan, exports, numExportPacketsPerLID, imports, numImportPacketsPerLID);
+  else if (sendType == Details::DISTRIBUTOR_MPIADVANCE_ALLTOALL) {
+    doPostsAllToAllImpl(plan, exports, exportSubViewLimits, imports, importSubViewLimits);
     return;
   } else if (sendType == Details::DISTRIBUTOR_MPIADVANCE_NBRALLTOALLV) {
-    doPostsNbrAllToAllV(plan, exports, numExportPacketsPerLID, imports, numImportPacketsPerLID);
+    doPostsNbrAllToAllVImpl(plan, exports,numPackets, imports);
     return;
   }
-#endif
+#endif // defined(HAVE_TPETRACORE_MPI_ADVANCE)
+
 
 #else // HAVE_TPETRA_MPI
     if (plan.hasSelfMessage()) {
-
+      // This is how we "send a message to ourself": we copy from
+      // the export buffer to the import buffer.  That saves
+      // Teuchos::Comm implementations other than MpiComm (in
+      // particular, SerialComm) the trouble of implementing self
+      // messages correctly.  (To do this right, SerialComm would
+      // need internal buffer space for messages, keyed on the
+      // message's tag.)
       size_t selfReceiveOffset = 0;
-
-      // setup arrays containing starting-offsets into exports for each send,
-      // and num-packets-to-send for each send.
-      Array<size_t> sendPacketOffsets(plan.getNumSends(),0), packetsPerSend(plan.getNumSends(),0);
-      size_t maxNumPackets = 0;
-      size_t curPKToffset = 0;
-      for (size_t pp=0; pp<plan.getNumSends(); ++pp) {
-        sendPacketOffsets[pp] = curPKToffset;
-        size_t numPackets = 0;
-        for (size_t j=plan.getStartsTo()[pp]; j<plan.getStartsTo()[pp]+plan.getLengthsTo()[pp]; ++j) {
-          numPackets += numExportPacketsPerLID[j];
-        }
-        if (numPackets > maxNumPackets) maxNumPackets = numPackets;
-        packetsPerSend[pp] = numPackets;
-        curPKToffset += numPackets;
-      }
-
       deep_copy_offset(imports, exports, selfReceiveOffset,
-          sendPacketOffsets[0], packetsPerSend[0]);
+                       exportStarts[0],
+                       exportLengths[0]);
     }
+    // should we just return here?
+    // likely not as comm could be a serial comm
 #endif // HAVE_TPETRA_MPI
 
-  const int myProcID = plan.getComm()->getRank ();
   size_t selfReceiveOffset = 0;
 
 #ifdef HAVE_TPETRA_DEBUG
-  // Different messages may have different numbers of packets.
-  size_t totalNumImportPackets = 0;
-  for (size_type ii = 0; ii < numImportPacketsPerLID.size (); ++ii) {
-    totalNumImportPackets += numImportPacketsPerLID[ii];
-  }
-  TEUCHOS_TEST_FOR_EXCEPTION(
-      imports.extent (0) < totalNumImportPackets, std::runtime_error,
-      "Tpetra::Distributor::doPostSends(4 args): The 'imports' array must have "
-      "enough entries to hold the expected number of import packets.  "
-      "imports.extent(0) = " << imports.extent (0) << " < "
-      "totalNumImportPackets = " << totalNumImportPackets << ".");
   TEUCHOS_TEST_FOR_EXCEPTION
-    (requestsSend_.size () != 0, std::logic_error, "Tpetra::Distributor::"
-     "doPostSends(4 args): Process " << myProcID << ": requestsSend_.size () = "
-     << requestsSend_.size () << " != 0.");
+    (requestsSend_.size () != 0,
+     std::logic_error,
+     "Tpetra::Distributor::doPostSends: Process "
+     << myRank << ": requestsSend_.size() = " << requestsSend_.size () << " != 0.");
 #endif // HAVE_TPETRA_DEBUG
+
   // Distributor uses requestsRecv_.size() and requestsSend_.size()
   // as the number of outstanding nonblocking message requests, so
   // we resize to zero to maintain this invariant.
@@ -1203,55 +646,23 @@ void DistributorActor::doPostSends(const DistributorPlan& plan,
   requestsSend_.resize (0);
 
   {
-    size_t curBufferOffset = 0;
-    size_t curLIDoffset = 0;
     for (size_type i = 0; i < actualNumReceives; ++i) {
-      size_t totalPacketsFrom_i = 0;
-      for (size_t j = 0; j < plan.getLengthsFrom()[i]; ++j) {
-        totalPacketsFrom_i += numImportPacketsPerLID[curLIDoffset+j];
+      if (plan.getProcsFrom()[i] == myRank) { // Receiving from myself
+        selfReceiveOffset = importStarts[i];  // Remember the self-recv offset
       }
-      // totalPacketsFrom_i is converted down to int, so make sure it can be represented
-      TEUCHOS_TEST_FOR_EXCEPTION(totalPacketsFrom_i > size_t(INT_MAX),
-                                 std::logic_error, "Tpetra::Distributor::doPostSends(4 args): "
-                                 "Recv count for receive " << i << " (" << totalPacketsFrom_i << ") is too large "
-                                 "to be represented as int.");
-      curLIDoffset += plan.getLengthsFrom()[i];
-      if (plan.getProcsFrom()[i] == myProcID && totalPacketsFrom_i) {
-        // Receiving these packet(s) from myself
-        selfReceiveOffset = curBufferOffset; // Remember the offset
-      }
-      curBufferOffset += totalPacketsFrom_i;
     }
   }
 
-  ProfilingRegion ps4s("Tpetra::Distributor: doPostSends(4) sends");
-
-  // setup arrays containing starting-offsets into exports for each send,
-  // and num-packets-to-send for each send.
-  Array<size_t> sendPacketOffsets(plan.getNumSends(),0), packetsPerSend(plan.getNumSends(),0);
-  size_t maxNumPackets = 0;
-  size_t curPKToffset = 0;
-  for (size_t pp=0; pp<plan.getNumSends(); ++pp) {
-    sendPacketOffsets[pp] = curPKToffset;
-    size_t numPackets = 0;
-    for (size_t j=plan.getStartsTo()[pp]; j<plan.getStartsTo()[pp]+plan.getLengthsTo()[pp]; ++j) {
-      numPackets += numExportPacketsPerLID[j];
-    }
-    if (numPackets > maxNumPackets) maxNumPackets = numPackets;
-    // numPackets will be used as a message length, so make sure it can be represented as int
-    TEUCHOS_TEST_FOR_EXCEPTION(numPackets > size_t(INT_MAX),
-                               std::logic_error, "Tpetra::Distributor::doPostSends(4 args): "
-                               "packetsPerSend[" << pp << "] = " << numPackets << " is too large "
-                               "to be represented as int.");
-    packetsPerSend[pp] = numPackets;
-    curPKToffset += numPackets;
-  }
+  ProfilingRegion pss("Tpetra::Distributor: doPostSends sends");
 
   // setup scan through getProcsTo() list starting with higher numbered procs
   // (should help balance message traffic)
+  //
+  // FIXME (mfh 20 Feb 2013) Why haven't we precomputed this?
+  // It doesn't depend on the input at all.
   size_t numBlocks = plan.getNumSends() + plan.hasSelfMessage();
   size_t procIndex = 0;
-  while ((procIndex < numBlocks) && (plan.getProcsTo()[procIndex] < myProcID)) {
+  while ((procIndex < numBlocks) && (plan.getProcsTo()[procIndex] < myRank)) {
     ++procIndex;
   }
   if (procIndex == numBlocks) {
@@ -1260,9 +671,9 @@ void DistributorActor::doPostSends(const DistributorPlan& plan,
 
   size_t selfNum = 0;
   size_t selfIndex = 0;
-  if (plan.getIndicesTo().is_null()) {
 
-    ProfilingRegion ps4sf("Tpetra::Distributor: doPostSends(4) sends FAST");
+  if (plan.getIndicesTo().is_null()) {
+    ProfilingRegion pssf("Tpetra::Distributor: doPostSends sends FAST");
 
     // Data are already blocked (laid out) by process, so we don't
     // need a separate send buffer (besides the exports array).
@@ -1272,17 +683,24 @@ void DistributorActor::doPostSends(const DistributorPlan& plan,
         p -= numBlocks;
       }
 
-      if (plan.getProcsTo()[p] != myProcID && packetsPerSend[p] > 0) {
-        exports_view_type tmpSend =
-          subview_offset(exports, sendPacketOffsets[p], packetsPerSend[p]);
+      if (plan.getProcsTo()[p] != myRank) {
+        if (exportLengths[p] == 0) {
+          // Do not attempt to send messages of length 0.
+          continue;
+        }
+
+        exports_view_type tmpSend = subview_offset(exports, exportStarts[p], exportLengths[p]);
 
         if (sendType == Details::DISTRIBUTOR_ISEND) {
+          // NOTE: This looks very similar to the tmpSend above, but removing
+          // tmpSendBuf and uses tmpSend leads to a performance hit on Arm
+          // SerialNode builds
           exports_view_type tmpSendBuf =
-            subview_offset (exports, sendPacketOffsets[p], packetsPerSend[p]);
+            subview_offset (exports, exportStarts[p], exportLengths[p]);
           requestsSend_.push_back (isend<int> (tmpSendBuf, plan.getProcsTo()[p],
                 mpiTag_, *plan.getComm()));
         }
-        else { // DISTRIBUTOR_SEND
+        else {  // DISTRIBUTOR_SEND
           send<int> (tmpSend,
               as<int> (tmpSend.size ()),
               plan.getProcsTo()[p], mpiTag_, *plan.getComm());
@@ -1294,14 +712,21 @@ void DistributorActor::doPostSends(const DistributorPlan& plan,
     }
 
     if (plan.hasSelfMessage()) {
+      // This is how we "send a message to ourself": we copy from
+      // the export buffer to the import buffer.  That saves
+      // Teuchos::Comm implementations other than MpiComm (in
+      // particular, SerialComm) the trouble of implementing self
+      // messages correctly.  (To do this right, SerialComm would
+      // need internal buffer space for messages, keyed on the
+      // message's tag.)
       deep_copy_offset(imports, exports, selfReceiveOffset,
-          sendPacketOffsets[selfNum], packetsPerSend[selfNum]);
+                       exportStarts[selfNum], exportLengths[selfNum]);
     }
+
   }
   else { // data are not blocked by proc, use send buffer
-    ProfilingRegion ps4ss("Tpetra::Distributor: doPostSends(4) sends SLOW");
+    ProfilingRegion psss("Tpetra::Distributor: doPostSends: sends SLOW");
 
-    // FIXME (mfh 05 Mar 2013) This may be broken for Isend.
     using Packet = typename ExpView::non_const_value_type;
     using Layout = typename ExpView::array_layout;
     using Device = typename ExpView::device_type;
@@ -1311,7 +736,7 @@ void DistributorActor::doPostSends(const DistributorPlan& plan,
     // Thus, we use DISTRIBUTOR_SEND always in this case, regardless
     // of sendType requested by user.
     // This code path formerly errored out with message:
-    //     Tpetra::Distributor::doPostSends(4-arg):
+    //     Tpetra::Distributor::doPosts(3 args):
     //     The "send buffer" code path
     //     doesn't currently work with nonblocking sends.
     // Now, we opt to just do the communication in a way that works.
@@ -1327,15 +752,21 @@ void DistributorActor::doPostSends(const DistributorPlan& plan,
     }
 #endif
 
-    Kokkos::View<Packet*,Layout,Device,Mem> sendArray ("sendArray",
-                                                        maxNumPackets);
+    size_t maxSendLength = 0;
+    for (size_t i = 0; i < numBlocks; ++i) {
+      size_t p = i + procIndex;
+      if (p > (numBlocks - 1)) {
+        p -= numBlocks;
+      }
 
-    Array<size_t> indicesOffsets (numExportPacketsPerLID.size(), 0);
-    size_t ioffset = 0;
-    for (int j=0; j<numExportPacketsPerLID.size(); ++j) {
-      indicesOffsets[j] = ioffset;
-      ioffset += numExportPacketsPerLID[j];
+      size_t sendArrayOffset = 0;
+        size_t j = plan.getStartsTo()[p];
+        for (size_t k = 0; k < plan.getLengthsTo()[p]; ++k, ++j) {
+        sendArrayOffset += exportLengths[j];
+      }
+      maxSendLength = std::max(maxSendLength, sendArrayOffset);
     }
+    Kokkos::View<Packet*,Layout,Device,Mem> sendArray ("sendArray", maxSendLength);
 
     for (size_t i = 0; i < numBlocks; ++i) {
       size_t p = i + procIndex;
@@ -1343,8 +774,23 @@ void DistributorActor::doPostSends(const DistributorPlan& plan,
         p -= numBlocks;
       }
 
-      if (plan.getProcsTo()[p] == myProcID) {
-        // "Sending" the message to myself
+      if (plan.getProcsTo()[p] != myRank) {
+        size_t sendArrayOffset = 0;
+        size_t j = plan.getStartsTo()[p];
+        for (size_t k = 0; k < plan.getLengthsTo()[p]; ++k, ++j) {
+          packOffset(sendArray, exports, sendArrayOffset, exportStarts[j], exportLengths[j]);
+          sendArrayOffset += exportLengths[j];
+        }
+        typename ExpView::execution_space().fence();
+
+        ImpView tmpSend =
+          subview_offset(sendArray, size_t(0), sendArrayOffset);
+
+        send<int> (tmpSend,
+            as<int> (tmpSend.size ()),
+            plan.getProcsTo()[p], mpiTag_, *plan.getComm());
+      }
+      else { // "Sending" the message to myself
         selfNum = p;
         selfIndex = plan.getStartsTo()[p];
       }
@@ -1352,10 +798,8 @@ void DistributorActor::doPostSends(const DistributorPlan& plan,
 
     if (plan.hasSelfMessage()) {
       for (size_t k = 0; k < plan.getLengthsTo()[selfNum]; ++k) {
-        deep_copy_offset(imports, exports, selfReceiveOffset,
-            indicesOffsets[selfIndex],
-            numExportPacketsPerLID[selfIndex]);
-        selfReceiveOffset += numExportPacketsPerLID[selfIndex];
+        packOffset(imports, exports, selfReceiveOffset, exportStarts[selfIndex], exportLengths[selfIndex]);
+        selfReceiveOffset += exportLengths[selfIndex];
         ++selfIndex;
       }
     }

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -391,7 +391,6 @@ size_t DistributorPlan::createFromSends(const Teuchos::ArrayView<const int>& exp
 
 void DistributorPlan::createFromRecvs(const Teuchos::ArrayView<const int>& remoteProcIDs)
 {
-  createFromSends(remoteProcIDs);
   *this = *getReversePlan();
   howInitialized_ = Details::DISTRIBUTOR_INITIALIZED_BY_CREATE_FROM_RECVS;
 }

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp
@@ -7,7 +7,7 @@
 // *****************************************************************************
 // @HEADER
 
-/*! \file 
+/*! \file
 
    How we communicate (Send, ISend).
    How / whether a Distributor is initialized.
@@ -91,6 +91,10 @@ class DistributorPlan : public Teuchos::ParameterListAcceptorDefaultBase {
   static constexpr int DEFAULT_MPI_TAG = 0;
 
 public:
+
+  using IndexView = std::vector<size_t>;
+  using SubViewLimits = std::pair<IndexView, IndexView>;
+
   DistributorPlan(Teuchos::RCP<const Teuchos::Comm<int>> comm);
   DistributorPlan(const DistributorPlan& otherPlan);
 
@@ -121,6 +125,11 @@ public:
   Teuchos::ArrayView<const size_t> getIndicesTo() const { return indicesTo_; }
   Details::EDistributorHowInitialized howInitialized() const { return howInitialized_; }
 
+  SubViewLimits getImportViewLimits(size_t numPackets) const;
+  SubViewLimits getImportViewLimits(const Teuchos::ArrayView<const size_t> &numImportPacketsPerLID) const;
+  SubViewLimits getExportViewLimits(size_t numPackets) const;
+  SubViewLimits getExportViewLimits(const Teuchos::ArrayView<const size_t> &numExportPacketsPerLID) const;
+
 private:
 
   // after the plan has been created we have the info we need to initialize the MPI advance communicator
@@ -137,7 +146,7 @@ private:
   /// This method computes numReceives_, lengthsFrom_, procsFrom_,
   /// totalReceiveLength_, indicesFrom_, and startsFrom_.
   ///
-  /// \note This method currently ignores the sendType_ 
+  /// \note This method currently ignores the sendType_
   ///   parameter, and always uses ireceive() /
   ///   send() for communication of the process IDs from which our
   ///   process is receiving and their corresponding receive packet

--- a/packages/tpetra/core/src/Tpetra_Distributor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.hpp
@@ -815,6 +815,9 @@ namespace Tpetra {
       exportGIDs[i] = static_cast<OrdinalType> (exportObjs[2*i]);
       exportProcIDs[i] = static_cast<int> (exportObjs[2*i+1]);
     }
+
+    // Store tempPlan instead of recreating it later
+    plan_ = tempPlan.plan_;
   }
 
   template <class OrdinalType>

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -394,7 +394,6 @@ namespace { // (anonymous)
     if constexpr(!ST::isOrdinal) {
       typedef Tpetra::CrsMatrix<Scalar,LO,GO,Node> MAT;
       typedef Tpetra::MultiVector<Scalar,LO,GO,Node> MV;
-      typedef Tpetra::Vector<Scalar,LO,GO,Node> V;
       typedef typename ST::magnitudeType Mag;
       typedef Teuchos::ScalarTraits<Mag> MT;
       const GST INVALID = Teuchos::OrdinalTraits<GST>::invalid();

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_getLocalDiagCopy.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_getLocalDiagCopy.cpp
@@ -24,7 +24,6 @@ namespace { // (anonymous)
     using map_type = Tpetra::Map<LO, GO, Node>;
     using vec_type = Tpetra::Vector<Scalar, LO, GO, Node>;
     using crs_matrix_type = Tpetra::CrsMatrix<Scalar, LO, GO, Node>;
-    using row_matrix_type = Tpetra::RowMatrix<Scalar, LO, GO, Node>;
 
     using STS = Teuchos::ScalarTraits<Scalar>;
     using MT = typename STS::magnitudeType;

--- a/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
+++ b/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
@@ -145,10 +145,6 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor::summarize(std::cout);
-    Teuchos::TimeMonitor::zeroOutTimers();
-#endif
   }
 
   TEUCHOS_UNIT_TEST( Distributor, badArgsFromSends)
@@ -186,10 +182,6 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor::summarize(std::cout);
-    Teuchos::TimeMonitor::zeroOutTimers();
-#endif
   }
 
   ////
@@ -281,10 +273,6 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor::summarize(std::cout);
-    Teuchos::TimeMonitor::zeroOutTimers();
-#endif
   }
 
 
@@ -375,10 +363,6 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor::summarize(std::cout);
-    Teuchos::TimeMonitor::zeroOutTimers();
-#endif
   }
 
 
@@ -461,10 +445,6 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor::summarize(std::cout);
-    Teuchos::TimeMonitor::zeroOutTimers();
-#endif
   }
 
 
@@ -552,10 +532,6 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor::summarize(std::cout);
-    Teuchos::TimeMonitor::zeroOutTimers();
-#endif
   }
 
 
@@ -638,10 +614,6 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor::summarize(std::cout);
-    Teuchos::TimeMonitor::zeroOutTimers();
-#endif
   }
 
 
@@ -761,10 +733,6 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor::summarize(std::cout);
-    Teuchos::TimeMonitor::zeroOutTimers();
-#endif
   }
 
 
@@ -867,10 +835,6 @@ namespace {
       reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
       TEST_EQUALITY_CONST( globalSuccess_int, 0 );
     }
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor::summarize(std::cout);
-    Teuchos::TimeMonitor::zeroOutTimers();
-#endif
   }
 
   TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( Distributor, badArgsFromRecvs, Ordinal )
@@ -920,10 +884,6 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor::summarize(std::cout);
-    Teuchos::TimeMonitor::zeroOutTimers();
-#endif
   }
 
   TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( Distributor, createFromRecvs, Ordinal )
@@ -966,10 +926,6 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
-#ifdef HAVE_TPETRA_DISTRIBUTOR_TIMINGS
-    Teuchos::TimeMonitor::summarize(std::cout);
-    Teuchos::TimeMonitor::zeroOutTimers();
-#endif
   }
 
 

--- a/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
+++ b/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
@@ -11,6 +11,7 @@
 #include "Tpetra_Core.hpp"
 #include "Tpetra_Distributor.hpp"
 #include "Tpetra_Details_Behavior.hpp"
+#include "Tpetra_Details_DistributorActor.hpp"
 #include "Teuchos_Array.hpp"
 #include "Teuchos_as.hpp"
 
@@ -729,6 +730,23 @@ namespace {
     }
     // check the values
     TEST_COMPARE_ARRAYS(expectedImports,imports);
+
+    // reset imports
+    Kokkos::deep_copy(imports, 0);
+    // get DistributorPlan
+    auto& plan = distributor.getPlan();
+
+    // Set up a fresh DistributorActor
+    Tpetra::Details::DistributorActor actor;
+
+    // Perform communication steps
+    actor.doPostRecvs(plan, 1, imports);
+    actor.doPostSends(plan, myExportsConst, 1, imports);
+    actor.doWaitsRecv(plan);
+    actor.doWaitsSend(plan);
+
+    // check the values
+    TEST_COMPARE_ARRAYS(expectedImports,imports);
     // All procs fail if any proc fails
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
@@ -830,6 +848,24 @@ namespace {
       }
       // check the values
       TEST_COMPARE_ARRAYS(expectedImports,imports);
+
+      // reset imports
+      Kokkos::deep_copy(imports, 0);
+      // get DistributorPlan
+      auto& plan = distributor.getPlan();
+
+      // Set up a fresh DistributorActor
+      Tpetra::Details::DistributorActor actor;
+
+      // Perform communication steps
+      actor.doPostRecvs(plan, 1, imports);
+      actor.doPostSends(plan, myExportsConst, 1, imports);
+      actor.doWaitsRecv(plan);
+      actor.doWaitsSend(plan);
+
+      // check the values
+      TEST_COMPARE_ARRAYS(expectedImports,imports);
+
       // All procs fail if any proc fails
       int globalSuccess_int = -1;
       reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Start work on splitting the posting of recvs and sends. The goal is to post recvs, then launch packing kernels and then post sends. This should result in less copies within MPI since the likelihood of unexpected messages is decreased.

What this PR does:
- Remove the duplication between 3 argument and 4-argument variants of `doPosts`. The difference between the code paths was how the offsets are computed, but everything else is the same. The offset computation is now in the overloaded `getImportViewLimits`, `getExportViewLimits` methods.
- Split into `doPostRecvs` and `doPostSends`. Currently nothing outside of the `DistributorActor` calls these methods, but rather the now trivial `doPosts`.
- Remove `Tpetra_ENABLE_Distributor_Timings` and replace the corresponding timers with profiling regions. 

I do not expect this PR to impact performance. It will enable subsequent changes to transfers that are supposed to improve communication. It also simplifies the code.