### PR TITLE
Framework: Update list of tests to run serially with CUDA

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1253,9 +1253,11 @@ opt-set-cmake-var TPL_BLAS_LIBRARIES STRING FORCE : /lib64/libblas.so.3
 opt-set-cmake-var TPL_LAPACK_LIBRARIES STRING FORCE : /lib64/liblapack.so.3
 
 [CUDA-RUN-SERIAL-TESTS]
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Integration_test_01_CUDA_DOUBLE_MPI_1_RUN_SERIAL BOOL FORCE : ON
 opt-set-cmake-var Kokkos_CoreUnitTest_Cuda1_SET_RUN_SERIAL BOOL FORCE : ON
 opt-set-cmake-var Kokkos_CoreUnitTest_CudaTimingBased_SET_RUN_SERIAL BOOL FORCE : ON
 opt-set-cmake-var Kokkos_CoreUnitTest_Default_SET_RUN_SERIAL BOOL FORCE : ON
+opt-set-cmake-var Kokkos_IncrementalTest_CUDA_SET_RUN_SERIAL BOOL FORCE : ON
 opt-set-cmake-var KokkosKernels_sparse_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
 opt-set-cmake-var KokkosKernels_batched_dla_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
 

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1036,6 +1036,8 @@ opt-set-cmake-var TpetraCore_CrsMatrix_2DRandomDist_MPI_4_RUN_SERIAL BOOL FORCE 
 opt-set-cmake-var TpetraCore_MatrixMatrix_UnitTests_MPI_4_RUN_SERIAL BOOL FORCE : ON
 opt-set-cmake-var Zoltan2_TaskMappingTest3_MPI_1_RUN_SERIAL BOOL FORCE : ON
 opt-set-cmake-var KokkosKernels_batched_dla_cuda_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
+opt-set-cmake-var Kokkos_CoreUnitTest_CudaInterOpStreams_SET_RUN_SERIAL BOOL FORCE : ON
+opt-set-cmake-var Kokkos_CoreUnitTest_CudaInterOpInit_SET_RUN_SERIAL BOOL FORCE : ON
 
 [ATS2-ENABLE-OVERRIDES]
 opt-set-cmake-var TPL_ENABLE_DLlib BOOL FORCE : ON
@@ -1068,9 +1070,6 @@ opt-set-cmake-var TPL_TENTATIVE_ENABLE_DLlib BOOL FORCE : ON
 opt-set-cmake-var Xpetra_ENABLE_DEPRECATED_CODE BOOL FORCE : ON
 opt-set-cmake-var Xpetra_ENABLE_EXPLICIT_INSTANTIATION BOOL FORCE : ON
 opt-set-cmake-var Xpetra_ENABLE_Kokkos_Refactor BOOL FORCE : ON
-
-opt-set-cmake-var Kokkos_CoreUnitTest_CudaInterOpStreams_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
-opt-set-cmake-var Kokkos_CoreUnitTest_CudaInterOpInit_MPI_1_SET_RUN_SERIAL BOOL FORCE : ON
 
 [ATS2-TEST-DISABLES]
 opt-set-cmake-var Adelus_vector_random_MPI_1_DISABLE BOOL : ON


### PR DESCRIPTION
@trilinos/framework 
@trilinos/intrepid2 
@trilinos/kokkos 

## Motivation
Want to avoid test timeouts in CI.

[Here](https://sems-cdash-son.sandia.gov/cdash/index.php?project=Trilinos&date=2025-04-01&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=cuda&field2=groupname&compare2=63&value2=Pull) are the relevant failures that I've seen recently in the new AT2-based CUDA builds:
