### PR TITLE
Tpetra: Kokkos::StaticCrsGraph -> KokkosSparse::StaticCrsGraph

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -25,12 +25,13 @@
 
 #include "KokkosSparse_findRelOffset.hpp"
 #include "Kokkos_DualView.hpp"
-#include "Kokkos_StaticCrsGraph.hpp"
 
 #include "Teuchos_CommHelpers.hpp"
 #include "Teuchos_Describable.hpp"
 #include "Teuchos_OrdinalTraits.hpp"
 #include "Teuchos_ParameterListAcceptorDefaultBase.hpp"
+
+#include "KokkosSparse_StaticCrsGraph.hpp"
 
 #include <functional> // std::function
 #include <memory>
@@ -222,7 +223,7 @@ namespace Tpetra {
 
     //! The type of the part of the sparse graph on each MPI process.
     using local_graph_device_type =
-           Kokkos::StaticCrsGraph<local_ordinal_type, Kokkos::LayoutLeft,
+           KokkosSparse::StaticCrsGraph<local_ordinal_type, Kokkos::LayoutLeft,
                                   device_type, void, size_t>;
 
     //! The type of the part of the sparse graph on each MPI process.

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -3353,7 +3353,7 @@ namespace Tpetra {
     // that process to avoid communiation in the Import setup.
     this->makeImportExport (remotePIDs, mustBuildColMap);
 
-    // Create the Kokkos::StaticCrsGraph, if it doesn't already exist.
+    // Create the KokkosSparse::StaticCrsGraph, if it doesn't already exist.
     this->fillLocalGraph (params);
 
     const bool callComputeGlobalConstants = params.get () == nullptr ||
@@ -7519,15 +7519,15 @@ namespace Tpetra {
     }
 
     // Check lclGraph_ isa
-    // Kokkos::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, execution_space>
-    // Kokkos::StaticCrsGraph has 3 data members in it:
+    // KokkosSparse::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, execution_space>
+    // KokkosSparse::StaticCrsGraph has 3 data members in it:
     //   Kokkos::View<size_type*, ...> row_map            
     //           (local_graph_device_type::row_map_type)
     //   Kokkos::View<data_type*, ...> entries            
     //           (local_graph_device_type::entries_type)
     //   Kokkos::View<size_type*, ...> row_block_offsets  
     //           (local_graph_device_type::row_block_type)
-    // There is currently no Kokkos::StaticCrsGraph comparison function 
+    // There is currently no KokkosSparse::StaticCrsGraph comparison function 
     // that's built-in, so we will just compare
     // the three data items here. This can be replaced if Kokkos ever 
     // puts in its own comparison routine.

--- a/packages/tpetra/core/src/Tpetra_Details_determineLocalTriangularStructure.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_determineLocalTriangularStructure.hpp
@@ -50,7 +50,7 @@ namespace Impl {
   /// number of diagonal entries in a sparse graph, and determining
   /// whether the graph is lower or upper triangular (or neither).
   ///
-  /// \tparam LocalGraphType Kokkos::StaticCrsGraph specialization
+  /// \tparam LocalGraphType KokkosSparse::StaticCrsGraph specialization
   /// \tparam LocalMapType Result of Tpetra::Map::getLocalGraph()
   template<class LocalGraphType, class LocalMapType>
   class DetermineLocalTriangularStructure {
@@ -192,7 +192,7 @@ namespace Impl {
 /// \warning This is an implementation detail of Tpetra.  It may
 ///   change or disappear at any time.
 ///
-/// \tparam LocalGraphType Kokkos::StaticCrsGraph specialization
+/// \tparam LocalGraphType KokkosSparse::StaticCrsGraph specialization
 /// \tparam LocalMapType Result of Tpetra::Map::getLocalGraph()
 ///
 /// \param G [in] The local sparse graph

--- a/packages/tpetra/core/src/Tpetra_Details_getGraphDiagOffsets_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getGraphDiagOffsets_decl.hpp
@@ -17,7 +17,7 @@
 
 #include "TpetraCore_config.h"
 #include "Kokkos_Core.hpp"
-#include "Kokkos_StaticCrsGraph.hpp"
+#include "KokkosSparse_StaticCrsGraph.hpp"
 #include "Tpetra_Details_LocalMap.hpp"
 #include <type_traits>
 
@@ -30,7 +30,7 @@ namespace Impl {
 ///   implementation detail of Tpetra::CrsGraph.
 ///
 /// FIXME (mfh 12 Mar 2016) There's currently no way to make a
-/// MemoryUnmanaged Kokkos::StaticCrsGraph.  Thus, we have to do this
+/// MemoryUnmanaged KokkosSparse::StaticCrsGraph.  Thus, we have to do this
 /// separately for its column indices.  We want the column indices to
 /// be unmanaged because we need to take subviews in this kernel.
 /// Taking a subview of a managed View updates the reference count,
@@ -49,10 +49,9 @@ public:
   typedef ::Kokkos::View<diag_offset_type*,
                          device_type,
                          ::Kokkos::MemoryUnmanaged> diag_offsets_type;
-  typedef ::Kokkos::StaticCrsGraph<LO,
-                                   ::Kokkos::LayoutLeft,
-                                   device_type,
-                                   void, size_t> local_graph_device_type;
+  using local_graph_device_type = ::KokkosSparse::StaticCrsGraph<LO,
+                                  ::Kokkos::LayoutLeft,
+                                  device_type, void, size_t>;
   typedef ::Tpetra::Details::LocalMap<LO, GO, device_type> local_map_type;
   typedef ::Kokkos::View<const typename local_graph_device_type::size_type*,
                          ::Kokkos::LayoutLeft,

--- a/packages/tpetra/core/src/Tpetra_Details_getGraphDiagOffsets_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getGraphDiagOffsets_def.hpp
@@ -28,7 +28,7 @@ namespace Impl {
 ///   implementation detail of Tpetra::CrsGraph.
 ///
 /// FIXME (mfh 12 Mar 2016) There's currently no way to make a
-/// MemoryUnmanaged Kokkos::StaticCrsGraph.  Thus, we have to do this
+/// MemoryUnmanaged KokkosSparse::StaticCrsGraph.  Thus, we have to do this
 /// separately for its column indices.  We want the column indices to
 /// be unmanaged because we need to take subviews in this kernel.
 /// Taking a subview of a managed View updates the reference count,

--- a/packages/tpetra/core/src/Tpetra_Details_getGraphOffRankOffsets_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getGraphOffRankOffsets_decl.hpp
@@ -17,7 +17,7 @@
 
 #include "TpetraCore_config.h"
 #include "Kokkos_Core.hpp"
-#include "Kokkos_StaticCrsGraph.hpp"
+#include "KokkosSparse_StaticCrsGraph.hpp"
 #include "Tpetra_Details_LocalMap.hpp"
 #include <type_traits>
 
@@ -30,7 +30,7 @@ namespace Impl {
 ///   implementation detail of Tpetra::CrsGraph.
 ///
 /// FIXME (mfh 12 Mar 2016) There's currently no way to make a
-/// MemoryUnmanaged Kokkos::StaticCrsGraph.  Thus, we have to do this
+/// MemoryUnmanaged KokkosSparse::StaticCrsGraph.  Thus, we have to do this
 /// separately for its column indices.  We want the column indices to
 /// be unmanaged because we need to take subviews in this kernel.
 /// Taking a subview of a managed View updates the reference count,
@@ -49,10 +49,9 @@ public:
   typedef ::Kokkos::View<offset_type*,
                          device_type,
                          ::Kokkos::MemoryUnmanaged> offsets_type;
-  typedef ::Kokkos::StaticCrsGraph<LO,
+  using local_graph_type = ::KokkosSparse::StaticCrsGraph<LO,
                                    ::Kokkos::LayoutLeft,
-                                   device_type,
-                                   void, size_t> local_graph_type;
+                                   device_type, void, size_t>;
   typedef ::Tpetra::Details::LocalMap<LO, GO, device_type> local_map_type;
   typedef ::Kokkos::View<const typename local_graph_type::size_type*,
                          ::Kokkos::LayoutLeft,

--- a/packages/tpetra/core/src/Tpetra_Details_getGraphOffRankOffsets_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getGraphOffRankOffsets_def.hpp
@@ -28,7 +28,7 @@ namespace Impl {
 ///   implementation detail of Tpetra::CrsGraph.
 ///
 /// FIXME (mfh 12 Mar 2016) There's currently no way to make a
-/// MemoryUnmanaged Kokkos::StaticCrsGraph.  Thus, we have to do this
+/// MemoryUnmanaged KokkosSparse::StaticCrsGraph.  Thus, we have to do this
 /// separately for its column indices.  We want the column indices to
 /// be unmanaged because we need to take subviews in this kernel.
 /// Taking a subview of a managed View updates the reference count,

--- a/packages/tpetra/core/src/Tpetra_Details_getNumDiags.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getNumDiags.hpp
@@ -28,7 +28,7 @@ namespace Impl {
   /// \brief Kokkos::parallel_reduce functor for counting the local
   ///   number of diagonal entries in a sparse graph.
   ///
-  /// \tparam LocalGraphType Kokkos::StaticCrsGraph specialization
+  /// \tparam LocalGraphType KokkosSparse::StaticCrsGraph specialization
   /// \tparam LocalMapType Result of Tpetra::CrsGraph::getLocalGraph*()
   template<class LocalGraphType, class LocalMapType>
   class CountLocalNumDiags {

--- a/packages/tpetra/core/test/CrsGraph/DetermineLocalTriangularStructure.cpp
+++ b/packages/tpetra/core/test/CrsGraph/DetermineLocalTriangularStructure.cpp
@@ -20,7 +20,7 @@
 namespace { // (anonymous)
 
 template<class LocalOrdinalType, class DeviceType>
-using LocalCrsGraph = Kokkos::StaticCrsGraph<LocalOrdinalType, Kokkos::LayoutLeft, DeviceType>;
+using LocalCrsGraph = KokkosSparse::StaticCrsGraph<LocalOrdinalType, Kokkos::LayoutLeft, DeviceType>;
 
 // template<class ScalarType, class LocalOrdinalType, class DeviceType>
 // using LocalCrsMatrix =

--- a/packages/tpetra/core/test/Utils/TpetraUtils_WrappedDualView.cpp
+++ b/packages/tpetra/core/test/Utils/TpetraUtils_WrappedDualView.cpp
@@ -7,7 +7,7 @@
 // *****************************************************************************
 // @HEADER
 
-#include "Kokkos_StaticCrsGraph.hpp"
+#include "KokkosSparse_StaticCrsGraph.hpp"
 
 #include "TpetraUtils_WrappedDualViewFixture.hpp"
 

--- a/packages/tpetra/core/test/Utils/TpetraUtils_WrappedDualViewFixture.hpp
+++ b/packages/tpetra/core/test/Utils/TpetraUtils_WrappedDualViewFixture.hpp
@@ -7,7 +7,7 @@
 // *****************************************************************************
 // @HEADER
 
-#include "Kokkos_StaticCrsGraph.hpp"
+#include "KokkosSparse_StaticCrsGraph.hpp"
 
 #include <Tpetra_Details_WrappedDualView.hpp>
 #include <Tpetra_Map.hpp>

--- a/packages/tpetra/core/test/Utils/TpetraUtils_WrappedDualViewMicrobench.cpp
+++ b/packages/tpetra/core/test/Utils/TpetraUtils_WrappedDualViewMicrobench.cpp
@@ -7,7 +7,7 @@
 // *****************************************************************************
 // @HEADER
 
-#include "Kokkos_StaticCrsGraph.hpp"
+#include "KokkosSparse_StaticCrsGraph.hpp"
 
 #include "TpetraUtils_WrappedDualViewFixture.hpp"
 


### PR DESCRIPTION
It's deprecated in Kokkos and adopted by Kokkos Kernels