### PR TITLE
Framework: Increase warning limit

### DIFF
--- a/cmake/SimpleTesting/cmake/ctest-common.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-common.cmake
@@ -170,6 +170,8 @@ cmake_host_system_information(RESULT HOSTNAME QUERY HOSTNAME)
 
 set(CTEST_SITE "${HOSTNAME}")
 
+set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 500)
+
 # See: https://cmake.org/cmake/help/latest/command/site_name.html#command:site_name
 site_name(${CTEST_SITE})
 


### PR DESCRIPTION
Want to have a more comprehensive look at how many warnings are in Trilinos packages.

@trilinos/framework 

## Motivation
This will allow for a better overall view as to the state of current warnings work (e.g. how many packages have shadow warnings).

## Related Issues
https://github.com/trilinos/Trilinos/issues/11497
