### PR TITLE
Tpetra: Reorder operations in transfer

### DIFF
--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_def.hpp
@@ -135,7 +135,7 @@ BlockMultiVector (const mv_type& X_mv,
 
   // At this point, mv_ has been assigned, so we can ignore X_mv.
   Teuchos::RCP<const map_type> pointMap = mv_.getMap ();
-  pointMap_ = pointMap; 
+  pointMap_ = pointMap;
 
 }
 
@@ -267,7 +267,7 @@ void
 BlockMultiVector<Scalar, LO, GO, Node>::
 replaceLocalValuesImpl (const LO localRowIndex,
                         const LO colIndex,
-                        const Scalar vals[]) 
+                        const Scalar vals[])
 {
   auto X_dst = getLocalBlockHost (localRowIndex, colIndex, Access::ReadWrite);
   typename const_little_vec_type::HostMirror::const_type X_src (reinterpret_cast<const impl_scalar_type*> (vals),
@@ -406,7 +406,7 @@ getLocalBlockHost (const LO localRowIndex,
     auto hostView = mv_.getLocalViewHost(Access::ReadWrite);
     LO startRow = localRowIndex*blockSize;
     LO endRow = startRow + blockSize;
-    return Kokkos::subview(hostView, Kokkos::make_pair(startRow, endRow), 
+    return Kokkos::subview(hostView, Kokkos::make_pair(startRow, endRow),
                            colIndex);
   }
 }
@@ -478,7 +478,7 @@ packAndPrepare
 {
   TEUCHOS_TEST_FOR_EXCEPTION
     (true, std::logic_error,
-     "Tpetra::BlockMultiVector::copyAndPermute: Do NOT use this; "
+     "Tpetra::BlockMultiVector::packAndPrepare: Do NOT use this; "
      "instead, create a point importer using makePointMap function.");
 }
 
@@ -496,7 +496,7 @@ unpackAndCombine
 {
   TEUCHOS_TEST_FOR_EXCEPTION
     (true, std::logic_error,
-     "Tpetra::BlockMultiVector::copyAndPermute: Do NOT use this; "
+     "Tpetra::BlockMultiVector::unpackAndCombine: Do NOT use this; "
      "instead, create a point importer using makePointMap function.");
 }
 

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -101,6 +101,8 @@ constexpr const std::string_view SKIP_COPY_AND_PERMUTE =
     "TPETRA_SKIP_COPY_AND_PERMUTE";
 constexpr const std::string_view FUSED_RESIDUAL = "TPETRA_FUSED_RESIDUAL";
 constexpr const std::string_view OVERLAP = "TPETRA_OVERLAP";
+  constexpr const std::string_view DEFAULT_SEND_TYPE = "TPETRA_DEFAULT_SEND_TYPE";
+constexpr const std::string_view GRANULAR_TRANSFERS = "TPETRA_GRANULAR_TRANSFERS";
 constexpr const std::string_view SPACES_ID_WARN_LIMIT =
     "TPETRA_SPACES_ID_WARN_LIMIT";
 constexpr const std::string_view TIME_KOKKOS_DEEP_COPY =
@@ -128,6 +130,7 @@ constexpr const auto RECOGNIZED_VARS = make_array(
     HIERARCHICAL_UNPACK_BATCH_SIZE, HIERARCHICAL_UNPACK_TEAM_SIZE,
     USE_TEUCHOS_TIMERS, USE_KOKKOS_PROFILING, DEBUG, VERBOSE, TIMING,
     HIERARCHICAL_UNPACK, SKIP_COPY_AND_PERMUTE, FUSED_RESIDUAL, OVERLAP,
+    DEFAULT_SEND_TYPE, GRANULAR_TRANSFERS,
     SPACES_ID_WARN_LIMIT, TIME_KOKKOS_DEEP_COPY, TIME_KOKKOS_DEEP_COPY_VERBOSE1,
     TIME_KOKKOS_DEEP_COPY_VERBOSE2, TIME_KOKKOS_FENCE, TIME_KOKKOS_FUNCTIONS);
 
@@ -672,6 +675,24 @@ bool Behavior::overlapCommunicationAndComputation() {
   static bool initialized_ = false;
   return idempotentlyGetEnvironmentVariable(
       value_, initialized_, BehaviorDetails::OVERLAP, defaultValue);
+}
+
+int Behavior::defaultSendType() {
+  constexpr int defaultValue(1);
+
+  static int value_ = defaultValue;
+  static bool initialized_ = false;
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::DEFAULT_SEND_TYPE, defaultValue);
+}
+
+bool Behavior::enableGranularTransfers() {
+  constexpr bool defaultValue(false);
+
+  static bool value_ = defaultValue;
+  static bool initialized_ = false;
+  return idempotentlyGetEnvironmentVariable(
+      value_, initialized_, BehaviorDetails::GRANULAR_TRANSFERS, defaultValue);
 }
 
 size_t Behavior::spacesIdWarnLimit() {

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
@@ -182,7 +182,7 @@ public:
   /// average (it is not a proportion between max and average).
   ///
   /// If the "imbalance" of a local matrix is greater than this threshold,
-  /// a different algorithm may be used for some operations like 
+  /// a different algorithm may be used for some operations like
   /// sparse matrix-vector multiply, packAndPrepare, and
   /// unpackAndCombine.  You may control this at run time via the
   /// <tt>TPETRA_ROW_IMBALANCE_THRESHOLD</tt> environment variable.
@@ -212,7 +212,7 @@ public:
 
   /// \brief the threshold for transitioning from device to host
   ///
-  /// If the number of elements in the multivector does not exceed this 
+  /// If the number of elements in the multivector does not exceed this
   /// threshold and the data is on host, then run the calculation on
   /// host.  Otherwise, run on device.
   /// By default this is 10000, but may be altered by the environment
@@ -251,13 +251,25 @@ public:
   /// <tt>TPETRA_OVERLAP</tt> environment variable.
   static bool overlapCommunicationAndComputation();
 
+  /// \brief Speed up transfers by overlapping computation and communication.
+  ///
+  /// This is enabled by default.  You may control this at run time via the
+  /// <tt>TPETRA_GRANULAR_TRANSFERS</tt> environment variable.
+  static bool enableGranularTransfers();
+
+  /// \brief Default send type
+  ///
+  /// This is defaults to "Send".  You may control this at run time via the
+  /// <tt>TPETRA_DEFAULT_SEND_TYPE</tt> environment variable.
+  static int defaultSendType();
+
   /// \brief Add Teuchos timers for all host calls to Kokkos::deep_copy().
   /// This is especially useful for identifying host/device data transfers
   ///
   /// This is disabled by default.  You may control this at run time via the
   /// <tt>TPETRA_TIME_KOKKOS_DEEP_COPY</tt> environment variable.
   static bool timeKokkosDeepCopy();
-  
+
   /// \brief Adds verbose output to Kokkos deep_copy timers
   /// by appending source and destination.
   /// This is especially useful for identifying host/device data transfers
@@ -266,7 +278,7 @@ public:
   /// <tt>TPETRA_TIME_KOKKOS_DEEP_COPY_VERBOSE1</tt> environment variable.
   static bool timeKokkosDeepCopyVerbose1();
 
-  
+
   /// \brief Adds verbose output to Kokkos deep_copy timers
   /// by appending source, destination, and size.
   /// This is especially useful for identifying host/device data transfers
@@ -279,14 +291,14 @@ public:
   ///
   /// This is disabled by default.  You may control this at run time via the
   /// <tt>TPETRA_TIME_KOKKOS_FENCE</tt> environment variable.
-  static bool timeKokkosFence();  
+  static bool timeKokkosFence();
 
-  /// \brief Add Teuchos timers for all host calls to Kokkos::parallel_for(), 
+  /// \brief Add Teuchos timers for all host calls to Kokkos::parallel_for(),
   /// Kokkos::parallel_reduce() and Kokkos::parallel_scan().
   ///
   /// This is disabled by default.  You may control this at run time via the
   /// <tt>TPETRA_TIME_KOKKOS_FUNCTIONS</tt> environment variable.
-  static bool timeKokkosFunctions();  
+  static bool timeKokkosFunctions();
 
   /// \brief Warn if more than this many Kokkos spaces are accessed.
   ///

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
@@ -20,30 +20,13 @@ namespace Tpetra::Details {
     requestsSend_(otherActor.requestsSend_) {}
 
   void DistributorActor::doWaits(const DistributorPlan& plan) {
-    if (requestsRecv_.size() > 0) {
-      ProfilingRegion wr("Tpetra::Distributor: doWaitsRecv");
-
-      Teuchos::waitAll(*plan.getComm(), requestsRecv_());
-
-      // Restore the invariant that requests_.size() is the number of
-      // outstanding nonblocking communication requests.
-      requestsRecv_.resize(0);
-    }
-
-    if (requestsSend_.size() > 0) {
-      ProfilingRegion ws("Tpetra::Distributor: doWaitsSend");
-
-      Teuchos::waitAll(*plan.getComm(), requestsSend_());
-
-      // Restore the invariant that requests_.size() is the number of
-      // outstanding nonblocking communication requests.
-      requestsSend_.resize(0);
-    }
+    doWaitsRecv(plan);
+    doWaitsSend(plan);
   }
 
   void DistributorActor::doWaitsRecv(const DistributorPlan& plan) {
     if (requestsRecv_.size() > 0) {
-      ProfilingRegion wr("Tpetra::Distributor: doWaitsRecv");
+      ProfilingRegion wr("Tpetra::Distributor::doWaitsRecv");
 
       Teuchos::waitAll(*plan.getComm(), requestsRecv_());
 
@@ -55,7 +38,7 @@ namespace Tpetra::Details {
 
   void DistributorActor::doWaitsSend(const DistributorPlan& plan) {
     if (requestsSend_.size() > 0) {
-      ProfilingRegion ws("Tpetra::Distributor: doWaitsSend");
+      ProfilingRegion ws("Tpetra::Distributor::doWaitsSend");
 
       Teuchos::waitAll(*plan.getComm(), requestsSend_());
 

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -488,7 +488,7 @@ void DistributorActor::doPostRecvsImpl(const DistributorPlan& plan,
   // to the "unexpected queue" (of arrived messages not yet matched
   // with a receive).
   {
-    ProfilingRegion prr("Tpetra::Distributor::doPostRecvs recvs");
+    ProfilingRegion prr("Tpetra::Distributor::doPostRecvs MPI_Irecv");
 
     for (size_type i = 0; i < actualNumReceives; ++i) {
       size_t totalPacketsFrom_i = importLengths[Teuchos::as<size_t>(i)];
@@ -673,7 +673,9 @@ void DistributorActor::doPostSendsImpl(const DistributorPlan& plan,
   size_t selfIndex = 0;
 
   if (plan.getIndicesTo().is_null()) {
-    ProfilingRegion pssf("Tpetra::Distributor::doPostSends sends FAST");
+    const char isend_region[] = "Tpetra::Distributor::doPostSends MPI_Isend FAST";
+    const char send_region[] = "Tpetra::Distributor::doPostSends MPI_Send FAST";
+    ProfilingRegion pssf((sendType == Details::DISTRIBUTOR_ISEND) ? isend_region : send_region);
 
     // Data are already blocked (laid out) by process, so we don't
     // need a separate send buffer (besides the exports array).
@@ -725,7 +727,7 @@ void DistributorActor::doPostSendsImpl(const DistributorPlan& plan,
 
   }
   else { // data are not blocked by proc, use send buffer
-    ProfilingRegion psss("Tpetra::Distributor::doPostSends: sends SLOW");
+    ProfilingRegion psss("Tpetra::Distributor::doPostSends: MPI_Send SLOW");
 
     using Packet = typename ExpView::non_const_value_type;
     using Layout = typename ExpView::array_layout;

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -441,7 +441,7 @@ void DistributorActor::doPostRecvsImpl(const DistributorPlan& plan,
   }
 #endif // HAVE_TPETRA_MPI
 
-  ProfilingRegion pr("Tpetra::Distributor: doPostRecvs");
+  ProfilingRegion pr("Tpetra::Distributor::doPostRecvs");
 
   const int myProcID = plan.getComm()->getRank ();
 
@@ -488,7 +488,7 @@ void DistributorActor::doPostRecvsImpl(const DistributorPlan& plan,
   // to the "unexpected queue" (of arrived messages not yet matched
   // with a receive).
   {
-    ProfilingRegion prr("Tpetra::Distributor: doPostRecvs recvs");
+    ProfilingRegion prr("Tpetra::Distributor::doPostRecvs recvs");
 
     for (size_type i = 0; i < actualNumReceives; ++i) {
       size_t totalPacketsFrom_i = importLengths[Teuchos::as<size_t>(i)];
@@ -571,7 +571,7 @@ void DistributorActor::doPostSendsImpl(const DistributorPlan& plan,
        "See Trilinos GitHub issue #1088 (corresponding to CUDA).");
 #endif // KOKKOS_ENABLE_SYCL
 
-  ProfilingRegion ps("Tpetra::Distributor: doPostSends");
+  ProfilingRegion ps("Tpetra::Distributor::doPostSends");
 
   const int myRank = plan.getComm()->getRank ();
   // Run-time configurable parameters that come from the input
@@ -653,7 +653,7 @@ void DistributorActor::doPostSendsImpl(const DistributorPlan& plan,
     }
   }
 
-  ProfilingRegion pss("Tpetra::Distributor: doPostSends sends");
+  ProfilingRegion pss("Tpetra::Distributor::doPostSends sends");
 
   // setup scan through getProcsTo() list starting with higher numbered procs
   // (should help balance message traffic)
@@ -673,7 +673,7 @@ void DistributorActor::doPostSendsImpl(const DistributorPlan& plan,
   size_t selfIndex = 0;
 
   if (plan.getIndicesTo().is_null()) {
-    ProfilingRegion pssf("Tpetra::Distributor: doPostSends sends FAST");
+    ProfilingRegion pssf("Tpetra::Distributor::doPostSends sends FAST");
 
     // Data are already blocked (laid out) by process, so we don't
     // need a separate send buffer (besides the exports array).
@@ -725,7 +725,7 @@ void DistributorActor::doPostSendsImpl(const DistributorPlan& plan,
 
   }
   else { // data are not blocked by proc, use send buffer
-    ProfilingRegion psss("Tpetra::Distributor: doPostSends: sends SLOW");
+    ProfilingRegion psss("Tpetra::Distributor::doPostSends: sends SLOW");
 
     using Packet = typename ExpView::non_const_value_type;
     using Layout = typename ExpView::array_layout;

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -71,7 +71,7 @@ DistributorPlan::DistributorPlan(Teuchos::RCP<const Teuchos::Comm<int>> comm)
 #endif
     howInitialized_(DISTRIBUTOR_NOT_INITIALIZED),
     reversePlan_(Teuchos::null),
-    sendType_(DISTRIBUTOR_SEND),
+    sendType_(static_cast<EDistributorSendType>(Behavior::defaultSendType())),
     sendMessageToSelf_(false),
     numSendsToOtherProcs_(0),
     maxSendLength_(0),
@@ -909,7 +909,7 @@ DistributorPlan::getValidParameters() const
   using Teuchos::setStringToIntegralParameter;
 
   Array<std::string> sendTypes = distributorSendTypes ();
-  const std::string defaultSendType ("Send");
+  const std::string defaultSendType (DistributorSendTypeEnumToString(static_cast<EDistributorSendType>(Behavior::defaultSendType())));
   Array<Details::EDistributorSendType> sendTypeEnums;
   sendTypeEnums.push_back (Details::DISTRIBUTOR_ISEND);
   sendTypeEnums.push_back (Details::DISTRIBUTOR_SEND);

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -24,13 +24,6 @@
 #include <memory>
 #include <type_traits>
 
-// #ifndef HAVE_TPETRA_TRANSFER_TIMERS
-// #  define HAVE_TPETRA_TRANSFER_TIMERS 1
-// #endif // HAVE_TPETRA_TRANSFER_TIMERS
-
-#ifdef HAVE_TPETRA_TRANSFER_TIMERS
-#  undef HAVE_TPETRA_TRANSFER_TIMERS
-#endif // HAVE_TPETRA_TRANSFER_TIMERS
 
 namespace KokkosClassic {
   /// \brief Read/write options for non-const views.
@@ -759,12 +752,17 @@ namespace Tpetra {
                      const CombineMode CM,
                      const bool restrictedMode);
 
-    void doPosts(const Details::DistributorPlan& distributorPlan,
-                 size_t constantNumPackets,
-                 bool commOnHost,
-                 std::shared_ptr<std::string> prefix,
-                 const bool canTryAliasing,
-                 const CombineMode CM);
+    void doPostRecvs(const Details::DistributorPlan& distributorPlan,
+                     size_t constantNumPackets,
+                     bool commOnHost,
+                     std::shared_ptr<std::string> prefix,
+                     const bool canTryAliasing,
+                     const CombineMode CM);
+
+    void doPostSends(const Details::DistributorPlan& distributorPlan,
+                     size_t constantNumPackets,
+                     bool commOnHost,
+                     std::shared_ptr<std::string> prefix);
 
     void doPackAndPrepare(const SrcDistObject& src,
                           const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
@@ -820,7 +818,7 @@ namespace Tpetra {
     /// \param permuteFromLIDs [in] List of the elements that are
     ///   permuted.  They are listed by their local index (LID) in the
     ///   source object.
-    /// \param CM [in] CombineMode to be used during copyAndPermute; 
+    /// \param CM [in] CombineMode to be used during copyAndPermute;
     ///   may or may not be used by the particular object being called;
     ///   behavior with respect to CombineMode may differ by object.
     virtual void
@@ -1047,13 +1045,6 @@ namespace Tpetra {
 
     Details::DistributorActor distributorActor_;
 
-#ifdef HAVE_TPETRA_TRANSFER_TIMERS
-    Teuchos::RCP<Teuchos::Time> doXferTimer_;
-    Teuchos::RCP<Teuchos::Time> copyAndPermuteTimer_;
-    Teuchos::RCP<Teuchos::Time> packAndPrepareTimer_;
-    Teuchos::RCP<Teuchos::Time> doPostsAndWaitsTimer_;
-    Teuchos::RCP<Teuchos::Time> unpackAndCombineTimer_;
-#endif // HAVE_TPETRA_TRANSFER_TIMERS
   }; // class DistObject
 } // namespace Tpetra
 

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -993,7 +993,7 @@ namespace Tpetra {
     // the overlapping of communication and computation in the "fast"
     // transfer case, i.e. when constantNumPackets > 0.
 
-    const bool overlapTransferSteps = (constantNumPackets != 0);
+    const bool overlapTransferSteps = (constantNumPackets != 0) && Behavior::fastTransfers();
 
     if (verbose) {
       std::ostringstream os;

--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -166,7 +166,7 @@ namespace Tpetra {
     const bool debug = tpetraDistributorDebugDefault;
 
     Array<std::string> sendTypes = distributorSendTypes ();
-    const std::string defaultSendType ("Send");
+    const std::string defaultSendType (Details::DistributorSendTypeEnumToString(static_cast<Details::EDistributorSendType>(Details::Behavior::defaultSendType())));
     Array<Details::EDistributorSendType> sendTypeEnums;
     sendTypeEnums.push_back (Details::DISTRIBUTOR_ISEND);
     sendTypeEnums.push_back (Details::DISTRIBUTOR_SEND);

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -1112,7 +1112,7 @@ namespace Tpetra {
     MV& sourceMV = const_cast<MV &>(dynamic_cast<const MV&> (sourceObj));
 
     bool copyOnHost;
-    if (importsAreAliased () && (this->constantNumberOfPackets () != 0)) {
+    if (importsAreAliased () && (this->constantNumberOfPackets () != 0) && Behavior::enableGranularTransfers()) {
       // imports are aliased to the target. We already posted Irecvs
       // into imports using a memory space that depends on GPU
       // awareness. Therefore we want to modify target in the same

--- a/packages/tpetra/core/test/CrsMatrix/Bug8794.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Bug8794.cpp
@@ -27,9 +27,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Bug8794, InsertDenseRows,
 // Multiply the matrix time a vector of global IDs and compare the result
 // to expected values.
 
-  using map_t = Tpetra::Map<>;
-  using matrix_t = Tpetra::CrsMatrix<Scalar>;
-  using vector_t = Tpetra::Vector<Scalar>;
+  using map_t = Tpetra::Map<LO, GO, Node>;
+  using matrix_t = Tpetra::CrsMatrix<Scalar, LO, GO, Node>;
+  using vector_t = Tpetra::Vector<Scalar, LO, GO, Node>;
   using magnitude_t = typename Teuchos::ScalarTraits<Scalar>::magnitudeType;
 
   auto comm = Tpetra::getDefaultComm();


### PR DESCRIPTION
## Motivation
The order of steps for `beginTransfer` and `endTransfer` is:
- `copyAndPermute`
- `packAndPrepare`
- `doPost`
- `doWaitsRecvs`
- `unpackAndCombine`
- `doWaitsSend`

After splitting `DistributorActor::doPosts` into `doPostRecvs` and `doPostSends` in PR #13934, this PR allows to reorder the steps as follows:
- `doPostRecvs`
- `packAndPrepare`
- `doPostSends`
- `copyAndPermute`
- `doWaitsRecvs`
- `unpackAndCombine`
- `doWaitsSend`

The motivation for this is to decrease the number of unexpected messages that MPI sees by separating receives and sends and to allows MPI to make progress while local work is performed. The new behavior can be enabled by setting the environment variable `TPETRA_GRANULAR_TRANSFERS=ON`. By default this behavior is off.