### PR TITLE
Tpetra: Fix leftover from switch to profiling regions

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -2815,44 +2815,48 @@ void jacobi_A_B_reuse(
   typedef Kokkos::RangePolicy<execution_space, size_t> range_type;
   typedef Kokkos::View<LO*, typename lno_view_t::array_layout, typename lno_view_t::device_type> lo_view_t;
 
-  Tpetra::Details::ProfilingRegion MM("TpetraExt: Jacobi: Reuse Cmap");
-
-  LO LO_INVALID = Teuchos::OrdinalTraits<LO>::invalid();
-
-  // Grab all the maps
   RCP<const import_type> Cimport = C.getGraph()->getImporter();
-  RCP<const map_type>    Ccolmap = C.getColMap();
-  local_map_type Acolmap_local = Aview.colMap->getLocalMap();
-  local_map_type Browmap_local = Bview.origMatrix->getRowMap()->getLocalMap();
-  local_map_type Irowmap_local;  if(!Bview.importMatrix.is_null()) Irowmap_local = Bview.importMatrix->getRowMap()->getLocalMap();
-  local_map_type Bcolmap_local = Bview.origMatrix->getColMap()->getLocalMap();
-  local_map_type Icolmap_local;  if(!Bview.importMatrix.is_null()) Icolmap_local = Bview.importMatrix->getColMap()->getLocalMap();
-  local_map_type Ccolmap_local = Ccolmap->getLocalMap();
-
-  // Build the final importer / column map, hash table lookups for C
-  lo_view_t Bcol2Ccol(Kokkos::ViewAllocateWithoutInitializing("Bcol2Ccol"),Bview.colMap->getLocalNumElements()), Icol2Ccol;
+  lo_view_t Bcol2Ccol, Icol2Ccol;
+  lo_view_t targetMapToOrigRow;
+  lo_view_t targetMapToImportRow;
   {
-    // Bcol2Col may not be trivial, as Ccolmap is compressed during fillComplete in newmatrix
-    // So, column map of C may be a strict subset of the column map of B
-    Kokkos::parallel_for(range_type(0,Bview.origMatrix->getColMap()->getLocalNumElements()),KOKKOS_LAMBDA(const LO i) {
+    Tpetra::Details::ProfilingRegion MM("TpetraExt: Jacobi: Reuse Cmap");
+
+    LO LO_INVALID = Teuchos::OrdinalTraits<LO>::invalid();
+
+    // Grab all the maps
+    RCP<const map_type>    Ccolmap = C.getColMap();
+    local_map_type Acolmap_local = Aview.colMap->getLocalMap();
+    local_map_type Browmap_local = Bview.origMatrix->getRowMap()->getLocalMap();
+    local_map_type Irowmap_local;  if(!Bview.importMatrix.is_null()) Irowmap_local = Bview.importMatrix->getRowMap()->getLocalMap();
+    local_map_type Bcolmap_local = Bview.origMatrix->getColMap()->getLocalMap();
+    local_map_type Icolmap_local;  if(!Bview.importMatrix.is_null()) Icolmap_local = Bview.importMatrix->getColMap()->getLocalMap();
+    local_map_type Ccolmap_local = Ccolmap->getLocalMap();
+
+    // Build the final importer / column map, hash table lookups for C
+    Bcol2Ccol = lo_view_t(Kokkos::ViewAllocateWithoutInitializing("Bcol2Ccol"),Bview.colMap->getLocalNumElements());
+    {
+      // Bcol2Col may not be trivial, as Ccolmap is compressed during fillComplete in newmatrix
+      // So, column map of C may be a strict subset of the column map of B
+      Kokkos::parallel_for(range_type(0,Bview.origMatrix->getColMap()->getLocalNumElements()),KOKKOS_LAMBDA(const LO i) {
         Bcol2Ccol(i) = Ccolmap_local.getLocalElement(Bcolmap_local.getGlobalElement(i));
       });
 
-    if (!Bview.importMatrix.is_null()) {
-      TEUCHOS_TEST_FOR_EXCEPTION(!Cimport->getSourceMap()->isSameAs(*Bview.origMatrix->getDomainMap()),
-                                 std::runtime_error, "Tpetra::Jacobi: Import setUnion messed with the DomainMap in an unfortunate way");
+      if (!Bview.importMatrix.is_null()) {
+        TEUCHOS_TEST_FOR_EXCEPTION(!Cimport->getSourceMap()->isSameAs(*Bview.origMatrix->getDomainMap()),
+                                   std::runtime_error, "Tpetra::Jacobi: Import setUnion messed with the DomainMap in an unfortunate way");
 
-      Kokkos::resize(Icol2Ccol,Bview.importMatrix->getColMap()->getLocalNumElements());
-      Kokkos::parallel_for(range_type(0,Bview.importMatrix->getColMap()->getLocalNumElements()),KOKKOS_LAMBDA(const LO i) {
+        Kokkos::resize(Icol2Ccol,Bview.importMatrix->getColMap()->getLocalNumElements());
+        Kokkos::parallel_for(range_type(0,Bview.importMatrix->getColMap()->getLocalNumElements()),KOKKOS_LAMBDA(const LO i) {
           Icol2Ccol(i) = Ccolmap_local.getLocalElement(Icolmap_local.getGlobalElement(i));
         });
+      }
     }
-  }
 
-  // Run through all the hash table lookups once and for all
-  lo_view_t targetMapToOrigRow(Kokkos::ViewAllocateWithoutInitializing("targetMapToOrigRow"),Aview.colMap->getLocalNumElements());
-  lo_view_t targetMapToImportRow(Kokkos::ViewAllocateWithoutInitializing("targetMapToImportRow"),Aview.colMap->getLocalNumElements());
-  Kokkos::parallel_for(range_type(Aview.colMap->getMinLocalIndex(), Aview.colMap->getMaxLocalIndex()+1),KOKKOS_LAMBDA(const LO i) {
+    // Run through all the hash table lookups once and for all
+    targetMapToOrigRow = lo_view_t(Kokkos::ViewAllocateWithoutInitializing("targetMapToOrigRow"),Aview.colMap->getLocalNumElements());
+    targetMapToImportRow = lo_view_t(Kokkos::ViewAllocateWithoutInitializing("targetMapToImportRow"),Aview.colMap->getLocalNumElements());
+    Kokkos::parallel_for(range_type(Aview.colMap->getMinLocalIndex(), Aview.colMap->getMaxLocalIndex()+1),KOKKOS_LAMBDA(const LO i) {
       GO aidx = Acolmap_local.getGlobalElement(i);
       LO B_LID = Browmap_local.getLocalElement(aidx);
       if (B_LID != LO_INVALID) {
@@ -2866,9 +2870,7 @@ void jacobi_A_B_reuse(
       }
     });
 
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-  MM = Teuchos::null;
-#endif
+  }
 
   // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
   // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Fixes a compile error when Tpetra is configured with `Tpetra_ENABLE_MMM_Timings=ON`.