### PR TITLE
Ifpack2: Change namespace for symbols that Kokkos-Kernels moved out of Experimental

### DIFF
--- a/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_def.hpp
@@ -22,6 +22,7 @@
 #include <type_traits>
 #include "Amesos2_TpetraMultiVecAdapter_decl.hpp"
 #include "Amesos2_Kokkos_View_Copy_Assign.hpp"
+#include "Teuchos_CompilerCodeTweakMacros.hpp"
 
 
 namespace Amesos2 {
@@ -76,7 +77,7 @@ namespace Amesos2 {
     return contig_local_view_1d.data();
   }
 
-  // TODO Proper type handling: 
+  // TODO Proper type handling:
   // Consider a MultiVectorTraits class
   // typedef Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> multivector_type
   // NOTE: In this class, above already has a typedef multivec_t
@@ -145,7 +146,7 @@ namespace Amesos2 {
         // needs to keep the distribution Map, we have to make a copy of
         // the latter in order to ensure that it will stick around past
         // the scope of this function call.  (Ptr is not reference
-        // counted.)  
+        // counted.)
         distMap = rcp(new map_type(*distribution_map));
         // (Re)create the Export object.
         exporter_ = rcp (new export_type (this->getMap (), distMap));
@@ -248,6 +249,7 @@ namespace Amesos2 {
       }
       else {
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "Resolve handling for non-constant stride.");
+        TEUCHOS_UNREACHABLE_RETURN(false);
       }
     }
     else {
@@ -292,6 +294,7 @@ namespace Amesos2 {
         }
         else {
           TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "Kokkos adapter non-constant stride not imlemented.");
+          TEUCHOS_UNREACHABLE_RETURN(false);
         }
       }
     }

--- a/packages/belos/tpetra/example/BlockGmres/BlockGmresTpetraGaleriEx.cpp
+++ b/packages/belos/tpetra/example/BlockGmres/BlockGmresTpetraGaleriEx.cpp
@@ -60,8 +60,6 @@ int run(int argc, char *argv[]) {
   using MT = typename Teuchos::ScalarTraits<ST>::magnitudeType;
 
   using tmap_t       = Tpetra::Map<LO,GO,NT>;
-  using tvector_t    = Tpetra::Vector<ST,LO,GO,NT>;
-  using trowmatrix_t = Tpetra::RowMatrix<ST,LO,GO,NT>;
   using tcrsmatrix_t = Tpetra::CrsMatrix<ST,LO,GO,NT>;
 
   using MVT = typename Belos::MultiVecTraits<ST,MV>;

--- a/packages/belos/tpetra/example/SolverFactory/SolverFactoryTpetraGaleriEx.cpp
+++ b/packages/belos/tpetra/example/SolverFactory/SolverFactoryTpetraGaleriEx.cpp
@@ -59,8 +59,6 @@ int run(int argc, char *argv[]) {
   using MT = typename Teuchos::ScalarTraits<ST>::magnitudeType;
 
   using tmap_t       = Tpetra::Map<LO,GO,NT>;
-  using tvector_t    = Tpetra::Vector<ST,LO,GO,NT>;
-  using trowmatrix_t = Tpetra::RowMatrix<ST,LO,GO,NT>;
   using tcrsmatrix_t = Tpetra::CrsMatrix<ST,LO,GO,NT>;
 
   using MVT = typename Belos::MultiVecTraits<ST,MV>;

--- a/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
@@ -925,13 +925,13 @@ void RBILUK<MatrixType>::compute ()
       auto U_entries = lclU.graph.entries;
       auto U_values  = lclU.values;
 
-      KokkosSparse::Experimental::spiluk_numeric( KernelHandle_.getRawPtr(), this->LevelOfFill_,
-                                                  A_local_rowmap, A_local_entries, A_local_values,
-                                                  L_rowmap, L_entries, L_values, U_rowmap, U_entries, U_values );
+      KokkosSparse::spiluk_numeric( KernelHandle_.getRawPtr(), this->LevelOfFill_,
+                                   A_local_rowmap, A_local_entries, A_local_values,
+                                   L_rowmap, L_entries, L_values, U_rowmap, U_entries, U_values );
 
       // Now call symbolic for sptrsvs
-      KokkosSparse::Experimental::sptrsv_symbolic(L_Sptrsv_KernelHandle_.getRawPtr(), L_rowmap, L_entries, L_values);
-      KokkosSparse::Experimental::sptrsv_symbolic(U_Sptrsv_KernelHandle_.getRawPtr(), U_rowmap, U_entries, U_values);
+      KokkosSparse::sptrsv_symbolic(L_Sptrsv_KernelHandle_.getRawPtr(), L_rowmap, L_entries, L_values);
+      KokkosSparse::sptrsv_symbolic(U_Sptrsv_KernelHandle_.getRawPtr(), U_rowmap, U_entries, U_values);
     }
   } // Stop timing
 
@@ -1126,7 +1126,7 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
           for (LO vec = 0; vec < numVecs; ++vec) {
             auto X_view = Kokkos::subview(X_views, Kokkos::ALL(), vec);
             auto Y_view = Kokkos::subview(Y_views, Kokkos::ALL(), vec);
-            KokkosSparse::Experimental::sptrsv_solve(L_Sptrsv_KernelHandle_.getRawPtr(), L_rowmap, L_entries, L_values, X_view, tmp_);
+            KokkosSparse::sptrsv_solve(L_Sptrsv_KernelHandle_.getRawPtr(), L_rowmap, L_entries, L_values, X_view, tmp_);
           }
         }
 
@@ -1134,7 +1134,7 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
           const LO numVecs = X.getNumVectors();
           for (LO vec = 0; vec < numVecs; ++vec) {
             auto Y_view = Kokkos::subview(Y_views, Kokkos::ALL(), vec);
-            KokkosSparse::Experimental::sptrsv_solve(U_Sptrsv_KernelHandle_.getRawPtr(), U_rowmap, U_entries, U_values, tmp_, Y_view);
+            KokkosSparse::sptrsv_solve(U_Sptrsv_KernelHandle_.getRawPtr(), U_rowmap, U_entries, U_values, tmp_, Y_view);
           }
         }
 

--- a/packages/ifpack2/src/Ifpack2_IlukGraph.hpp
+++ b/packages/ifpack2/src/Ifpack2_IlukGraph.hpp
@@ -574,9 +574,9 @@ void IlukGraph<GraphType, KKHandleType>::initialize(const Teuchos::RCP<KKHandleT
   do {
     symbolicError = false;
     try {
-      KokkosSparse::Experimental::spiluk_symbolic( KernelHandle.getRawPtr(), LevelFill_,
-                                                   localOverlapGraph.row_map, localOverlapGraph.entries,
-                                                   L_row_map, L_entries, U_row_map, U_entries );
+      KokkosSparse::spiluk_symbolic( KernelHandle.getRawPtr(), LevelFill_,
+                                    localOverlapGraph.row_map, localOverlapGraph.entries,
+                                    L_row_map, L_entries, U_row_map, U_entries );
     }
     catch (std::runtime_error &e) {
       symbolicError = true;

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -1006,7 +1006,7 @@ void RILUK<MatrixType>::compute_kkspiluk()
   auto U_values  = lclU.values;
 
   auto lclMtx = A_local_crs_->getLocalMatrixDevice();
-  KokkosSparse::Experimental::spiluk_numeric( KernelHandle_.getRawPtr(), LevelOfFill_,
+  KokkosSparse::spiluk_numeric( KernelHandle_.getRawPtr(), LevelOfFill_,
                                               lclMtx.graph.row_map, lclMtx.graph.entries, lclMtx.values,
                                               L_rowmap, L_entries, L_values, U_rowmap, U_entries, U_values );
 

--- a/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
@@ -775,7 +775,7 @@ void Relaxation<MatrixType>::initialize ()
         mtKernelHandle_->set_gs_twostage_compact_form (CompactForm_);
       }
 
-      KokkosSparse::Experimental::gauss_seidel_symbolic(
+      KokkosSparse::gauss_seidel_symbolic(
           mtKernelHandle_.getRawPtr (),
           A_->getLocalNumRows (),
           A_->getLocalNumCols (),
@@ -1338,7 +1338,7 @@ void Relaxation<MatrixType>::compute ()
       //const-valued view for user-provided D^-1. OK for now, Diagonal_ is nonconst.
       auto diagView_2d = Diagonal_->getLocalViewDevice (Tpetra::Access::ReadWrite);
       scalar_view_t diagView_1d = Kokkos::subview (diagView_2d, Kokkos::ALL (), 0);
-      KokkosSparse::Experimental::gauss_seidel_numeric(
+      KokkosSparse::gauss_seidel_numeric(
           mtKernelHandle_.getRawPtr (),
           A_->getLocalNumRows (),
           A_->getLocalNumCols (),
@@ -2109,7 +2109,7 @@ ApplyInverseMTGS_CrsMatrix(
     }
 
     if (direction == Tpetra::Symmetric) {
-      KokkosSparse::Experimental::symmetric_gauss_seidel_apply
+      KokkosSparse::symmetric_gauss_seidel_apply
       (mtKernelHandle_.getRawPtr(), A_->getLocalNumRows(), A_->getLocalNumCols(),
           kcsr.graph.row_map, kcsr.graph.entries, kcsr.values,
           X_colMap->getLocalViewDevice(Tpetra::Access::ReadWrite),
@@ -2117,7 +2117,7 @@ ApplyInverseMTGS_CrsMatrix(
           zero_x_vector, update_y_vector, DampingFactor_, 1);
     }
     else if (direction == Tpetra::Forward) {
-      KokkosSparse::Experimental::forward_sweep_gauss_seidel_apply
+      KokkosSparse::forward_sweep_gauss_seidel_apply
       (mtKernelHandle_.getRawPtr(), A_->getLocalNumRows(), A_->getLocalNumCols(),
           kcsr.graph.row_map,kcsr.graph.entries, kcsr.values,
           X_colMap->getLocalViewDevice(Tpetra::Access::ReadWrite),
@@ -2125,7 +2125,7 @@ ApplyInverseMTGS_CrsMatrix(
           zero_x_vector, update_y_vector, DampingFactor_, 1);
     }
     else if (direction == Tpetra::Backward) {
-      KokkosSparse::Experimental::backward_sweep_gauss_seidel_apply
+      KokkosSparse::backward_sweep_gauss_seidel_apply
       (mtKernelHandle_.getRawPtr(), A_->getLocalNumRows(), A_->getLocalNumCols(),
           kcsr.graph.row_map,kcsr.graph.entries, kcsr.values,
           X_colMap->getLocalViewDevice(Tpetra::Access::ReadWrite),

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev2.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev2.cpp
@@ -264,6 +264,8 @@ private:
     if (computeResidualNorm) {
       computeResidual (r, b, A, x);
       return r.norm2 ();
+    } else {
+      return -Teuchos::ScalarTraits<MT>::one();
     }
   }
 };
@@ -580,7 +582,7 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   A->apply (x, r, Teuchos::NO_TRANS, -one, one);
   r.norm2 (norms ());
   maxResNormIfpack2 = *std::max_element (norms.begin (), norms.end ());
-  
+
   // Run Ifpack2's 4th-kind Chebyshev.
   x.putScalar (zero); // Reset the initial guess(es).
   params.set ("chebyshev: algorithm", "fourth");
@@ -833,5 +835,3 @@ TEUCHOS_UNIT_TEST(Ifpack2Chebyshev, Convergence)
   os2 << endl;
   myCheby.print (os2);
 }
-
-


### PR DESCRIPTION
@trilinos/ifpack2 

## Motivation
Avoid some deprecation warnings.