### PR TITLE
Xpetra: Use Kokkos-Kernels include instead of deprecated Kokkos header

### DIFF
--- a/packages/xpetra/src/CrsGraph/Xpetra_CrsGraph.hpp
+++ b/packages/xpetra/src/CrsGraph/Xpetra_CrsGraph.hpp
@@ -21,7 +21,7 @@
 #include "Xpetra_Map.hpp"
 
 #ifdef HAVE_XPETRA_TPETRA
-#include <Kokkos_StaticCrsGraph.hpp>
+#include <KokkosSparse_StaticCrsGraph.hpp>
 #endif
 
 namespace Xpetra {
@@ -194,7 +194,7 @@ class CrsGraph
 #ifdef HAVE_XPETRA_TPETRA
   typedef typename node_type::execution_space execution_space;
   typedef typename node_type::device_type device_type;
-  typedef Kokkos::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, device_type, void, size_t> local_graph_type;
+  typedef KokkosSparse::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, device_type, void, size_t> local_graph_type;
 
   /// \brief Get the local graph.
   ///

--- a/packages/xpetra/src/CrsMatrix/Xpetra_CrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_CrsMatrix.hpp
@@ -20,7 +20,7 @@
 #include "Xpetra_Vector.hpp"
 
 #ifdef HAVE_XPETRA_TPETRA
-#include <Kokkos_StaticCrsGraph.hpp>
+#include <KokkosSparse_StaticCrsGraph.hpp>
 #include <KokkosSparse_CrsMatrix.hpp>
 #endif
 
@@ -277,11 +277,11 @@ class CrsMatrix
   using execution_space  = typename node_type::device_type;
 
   // that is the local_graph_type in Tpetra::CrsGraph...
-  using local_graph_type = Kokkos::StaticCrsGraph<LocalOrdinal,
-                                                  Kokkos::LayoutLeft,
-                                                  execution_space,
-                                                  void,
-                                                  size_t>;
+  using local_graph_type = KokkosSparse::StaticCrsGraph<LocalOrdinal,
+                                                        Kokkos::LayoutLeft,
+                                                        execution_space,
+                                                        void,
+                                                        size_t>;
   /// \brief The specialization of Kokkos::CrsMatrix that represents
   ///   the part of the sparse matrix on each MPI process.
   ///  The same as for Tpetra


### PR DESCRIPTION
@trilinos/xpetra 