### PR TITLE
MueLu: Add material vector information into MueLu multiphysics class

### DIFF
--- a/packages/muelu/src/Operators/MueLu_MultiPhys_decl.hpp
+++ b/packages/muelu/src/Operators/MueLu_MultiPhys_decl.hpp
@@ -133,7 +133,7 @@ class MultiPhys : public VerboseObject, public Xpetra::Operator<Scalar, LocalOrd
     return hierarchyMultiphysics_;
   }
 
-  //! Return an array of hierarchies corresponding to each diagona subblock
+  //! Return an array of hierarchies corresponding to each diagonal subblock
   Teuchos::ArrayRCP<Teuchos::RCP<Hierarchy>> subblockHierarchies() {
     return arrayOfHierarchies_;
   }

--- a/packages/muelu/src/Operators/MueLu_MultiPhys_decl.hpp
+++ b/packages/muelu/src/Operators/MueLu_MultiPhys_decl.hpp
@@ -68,6 +68,7 @@ class MultiPhys : public VerboseObject, public Xpetra::Operator<Scalar, LocalOrd
    * \param[in] nBlks                 nBlks x nBlks gives the block dimensions of the multiphysics operator
    * \param[in] List Parameter list
    * \param[in] ComputePrec If true, compute the preconditioner immediately
+   * \param[in] arrayOfMaterials      Material multivectors used to generate subblock prolongators for multiphysics system
    */
   MultiPhys(const Teuchos::RCP<Matrix>& AmatMultiPhysics,
             const Teuchos::ArrayRCP<RCP<Matrix>> arrayOfAuxMatrices,
@@ -75,13 +76,15 @@ class MultiPhys : public VerboseObject, public Xpetra::Operator<Scalar, LocalOrd
             const Teuchos::ArrayRCP<Teuchos::RCP<RealValuedMultiVector>> arrayOfCoords,
             const int nBlks,
             Teuchos::ParameterList& List,
-            bool ComputePrec = true)
+            bool ComputePrec                                                    = true,
+            const Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfMaterials = Teuchos::null)
     : AmatMultiphysics_(AmatMultiPhysics)
     , arrayOfAuxMatrices_(arrayOfAuxMatrices)
     , arrayOfNullspaces_(arrayOfNullspaces)
     , arrayOfCoords_(arrayOfCoords)
+    , arrayOfMaterials_(arrayOfMaterials)
     , nBlks_(nBlks) {
-    initialize(AmatMultiPhysics, arrayOfAuxMatrices, arrayOfNullspaces, arrayOfCoords, nBlks, List);
+    initialize(AmatMultiPhysics, arrayOfAuxMatrices, arrayOfNullspaces, arrayOfCoords, nBlks, List, arrayOfMaterials);
     compute(false);
   }
 
@@ -125,6 +128,16 @@ class MultiPhys : public VerboseObject, public Xpetra::Operator<Scalar, LocalOrd
     this->apply(X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());
   }
 
+  //! Return the multiphysics hierarchy
+  Teuchos::RCP<Hierarchy> multiphysicsHierarchy() {
+    return hierarchyMultiphysics_;
+  }
+
+  //! Return an array of hierarchies corresponding to each diagona subblock
+  Teuchos::ArrayRCP<Teuchos::RCP<Hierarchy>> subblockHierarchies() {
+    return arrayOfHierarchies_;
+  }
+
  private:
   /** Initialize with matrices except the Jacobian (don't compute the preconditioner)
    *
@@ -134,13 +147,15 @@ class MultiPhys : public VerboseObject, public Xpetra::Operator<Scalar, LocalOrd
    * \param[in] arrayOfCoords         Array of coordinate multivectors used to generate subblock prolongators for multiphysics system
    * \param[in] nBlks                 nBlks x nBlks gives the block dimensions of the multiphysics operator
    * \param[in] List Parameter list
+   * \param[in] arrayOfMaterials      Array of material multivectors used to generate subblock prolongators for multiphysics system
    */
   void initialize(const Teuchos::RCP<Matrix>& AmatMultiPhysics,
                   const Teuchos::ArrayRCP<RCP<Matrix>> arrayOfAuxMatrices,
                   const Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfNullspaces,
                   const Teuchos::ArrayRCP<Teuchos::RCP<RealValuedMultiVector>> arrayOfCoords,
                   const int nBlks,
-                  Teuchos::ParameterList& List);
+                  Teuchos::ParameterList& List,
+                  const Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfMaterials);
 
   //! apply standard MultiPhys cycle
   void applyInverse(const MultiVector& RHS, MultiVector& X) const;
@@ -165,6 +180,7 @@ class MultiPhys : public VerboseObject, public Xpetra::Operator<Scalar, LocalOrd
   Teuchos::ArrayRCP<Teuchos::RCP<Matrix>> arrayOfAuxMatrices_;            // array of discretization/auxiliary matrices used to generate subblock prolongators
   Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfNullspaces_;        // array of nullspaces for smoothed aggregation.
   Teuchos::ArrayRCP<Teuchos::RCP<RealValuedMultiVector>> arrayOfCoords_;  // array of coordinates for smoothed aggregation/rebalancing.
+  Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfMaterials_;         // array of materials for smoothed aggregation.
 
   int nBlks_;  // number of PDE sub-systems within multiphysics system
   bool useKokkos_, enable_reuse_, syncTimers_;

--- a/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
@@ -105,7 +105,15 @@ void MultiPhys<Scalar, LocalOrdinal, GlobalOrdinal, Node>::compute(bool reuse) {
 
   for (int iii = 0; iii < nBlks_; iii++) {
     if (arrayOfCoords_ != Teuchos::null) {
-      arrayOfParamLists_[iii]->sublist("user data").set("Coordinates", arrayOfCoords_[iii]);
+      if (arrayOfCoords_[iii] != Teuchos::null) {
+        arrayOfParamLists_[iii]->sublist("user data").set("Coordinates", arrayOfCoords_[iii]);
+      }
+    }
+
+    if (arrayOfMaterials_ != Teuchos::null) {
+      if (arrayOfMaterials_[iii] != Teuchos::null) {
+        arrayOfParamLists_[iii]->sublist("user data").set("Material", arrayOfMaterials_[iii]);
+      }
     }
 
     bool wantToRepartition = false;
@@ -223,7 +231,8 @@ void MultiPhys<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
                const Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfNullspaces,
                const Teuchos::ArrayRCP<Teuchos::RCP<RealValuedMultiVector>> arrayOfCoords,
                const int nBlks,
-               Teuchos::ParameterList& List) {
+               Teuchos::ParameterList& List,
+               const Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfMaterials) {
   arrayOfHierarchies_.resize(nBlks_);
   for (int i = 0; i < nBlks_; i++) arrayOfHierarchies_[i] = Teuchos::null;
 


### PR DESCRIPTION
This adds material property information for the individual subblocks in the `MultiPhys` class.