### PR TITLE
MueLu: Add optional OmitSubblockSmoother argument to MultiPhys class

### DIFF
--- a/packages/muelu/src/Operators/MueLu_MultiPhys_decl.hpp
+++ b/packages/muelu/src/Operators/MueLu_MultiPhys_decl.hpp
@@ -69,6 +69,7 @@ class MultiPhys : public VerboseObject, public Xpetra::Operator<Scalar, LocalOrd
    * \param[in] List Parameter list
    * \param[in] ComputePrec If true, compute the preconditioner immediately
    * \param[in] arrayOfMaterials      Material multivectors used to generate subblock prolongators for multiphysics system
+   * \param[in] OmitSubblockSmoother If true, omit construction of subblock-level smoothers
    */
   MultiPhys(const Teuchos::RCP<Matrix>& AmatMultiPhysics,
             const Teuchos::ArrayRCP<RCP<Matrix>> arrayOfAuxMatrices,
@@ -77,12 +78,14 @@ class MultiPhys : public VerboseObject, public Xpetra::Operator<Scalar, LocalOrd
             const int nBlks,
             Teuchos::ParameterList& List,
             bool ComputePrec                                                    = true,
-            const Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfMaterials = Teuchos::null)
+            const Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfMaterials = Teuchos::null,
+            bool OmitSubblockSmoother                                           = true)
     : AmatMultiphysics_(AmatMultiPhysics)
     , arrayOfAuxMatrices_(arrayOfAuxMatrices)
     , arrayOfNullspaces_(arrayOfNullspaces)
     , arrayOfCoords_(arrayOfCoords)
     , arrayOfMaterials_(arrayOfMaterials)
+    , OmitSubblockSmoother_(OmitSubblockSmoother)
     , nBlks_(nBlks) {
     initialize(AmatMultiPhysics, arrayOfAuxMatrices, arrayOfNullspaces, arrayOfCoords, nBlks, List, arrayOfMaterials);
     compute(false);
@@ -181,6 +184,8 @@ class MultiPhys : public VerboseObject, public Xpetra::Operator<Scalar, LocalOrd
   Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfNullspaces_;        // array of nullspaces for smoothed aggregation.
   Teuchos::ArrayRCP<Teuchos::RCP<RealValuedMultiVector>> arrayOfCoords_;  // array of coordinates for smoothed aggregation/rebalancing.
   Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfMaterials_;         // array of materials for smoothed aggregation.
+
+  bool OmitSubblockSmoother_;
 
   int nBlks_;  // number of PDE sub-systems within multiphysics system
   bool useKokkos_, enable_reuse_, syncTimers_;

--- a/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
@@ -69,7 +69,7 @@ void MultiPhys<Scalar, LocalOrdinal, GlobalOrdinal, Node>::setParameters(Teuchos
       TEUCHOS_TEST_FOR_EXCEPTION(true, Exceptions::RuntimeError, "Must provide sublist " + listName);
 
     arrayOfParamLists_[i]->set("verbosity", arrayOfParamLists_[i]->get("verbosity", verbosity));
-    if(OmitSubblockSmoother_){
+    if (OmitSubblockSmoother_) {
       arrayOfParamLists_[i]->set("smoother: pre or post", "none");
       arrayOfParamLists_[i]->set("smoother: type", "none");
     }

--- a/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
@@ -69,8 +69,10 @@ void MultiPhys<Scalar, LocalOrdinal, GlobalOrdinal, Node>::setParameters(Teuchos
       TEUCHOS_TEST_FOR_EXCEPTION(true, Exceptions::RuntimeError, "Must provide sublist " + listName);
 
     arrayOfParamLists_[i]->set("verbosity", arrayOfParamLists_[i]->get("verbosity", verbosity));
-    arrayOfParamLists_[i]->set("smoother: pre or post", "none");
-    arrayOfParamLists_[i]->set("smoother: type", "none");
+    if(OmitSubblockSmoother_){
+      arrayOfParamLists_[i]->set("smoother: pre or post", "none");
+      arrayOfParamLists_[i]->set("smoother: type", "none");
+    }
   }
 
   // Are we using Kokkos?


### PR DESCRIPTION
Motivation:

I have a use-case where I construct a custom block Jacobi smoother where, for each diagonal subblock, I use the smoother from the subblock level AMG setup.