### PR TITLE
Ifpack2: Ifpack2: local trsv cusparse spec selector missing impl_scalar_type (fixes #13970)

### DIFF
--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_decl.hpp
@@ -54,8 +54,10 @@ class LocalSparseTriangularSolver :
                                                                        typename MatrixType::node_type> >
 {
 public:
-  //! Type of the entries of the input matrix.
+  //! Scalar type of the entries of the input matrix.
   typedef typename MatrixType::scalar_type scalar_type;
+  //! Implementation scalar type of the entries of the input matrix.
+  typedef typename MatrixType::impl_scalar_type impl_scalar_type;
   //! Type of the local indices of the input matrix.
   typedef typename MatrixType::local_ordinal_type local_ordinal_type;
   //! Type of the global indices of the input matrix.

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -637,8 +637,8 @@ LocalSparseTriangularSolver<MatrixType>::kokkosKernelsAlgorithm() const
       std::is_same<int, local_ordinal_type>::value &&
     (std::is_same<scalar_type, float>::value ||
       std::is_same<scalar_type, double>::value ||
-      std::is_same<scalar_type, Kokkos::complex<float>>::value ||
-      std::is_same<scalar_type, Kokkos::complex<double>>::value))
+      std::is_same<impl_scalar_type, Kokkos::complex<float>>::value ||
+      std::is_same<impl_scalar_type, Kokkos::complex<double>>::value))
   {
     return KokkosSparse::Experimental::SPTRSVAlgorithm::SPTRSV_CUSPARSE;
   }


### PR DESCRIPTION
@trilinos/ifpack2 @vdq8a @GaleAxiom @romintomasetti 

Fixes #13970.


