### PR TITLE
Intrepid2 fix #13915

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometry.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometry.hpp
@@ -46,6 +46,8 @@ namespace Intrepid2
   class CellGeometry
   {
     public:
+    using value_type = PointScalar;
+    
     /*! Supported types for CellGeometry */
     enum CellGeometryType {
         UNIFORM_GRID   /// each grid division has the same dimensions

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_BasisValues.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_BasisValues.hpp
@@ -34,6 +34,9 @@ namespace Intrepid2
   template<class Scalar, typename DeviceType>
   class BasisValues
   {
+  public:
+    using value_type = Scalar;
+  private:
     using TensorDataType = TensorData<Scalar,DeviceType>;
     using VectorDataType = VectorData<Scalar,DeviceType>;
     

--- a/packages/intrepid2/src/Shared/Intrepid2_TransformedBasisValues.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TransformedBasisValues.hpp
@@ -33,6 +33,8 @@ namespace Intrepid2 {
   class TransformedBasisValues
   {
   public:
+    using value_type = Scalar;
+    
     ordinal_type numCells_;
     
     Data<Scalar,DeviceType> transform_; // vector case: (C,P,D,D) jacobian or jacobian inverse; can also be unset for identity transform.  Scalar case: (C,P), or unset for identity.  Contracted vector case: (C,P,D) transform, to be contracted with a vector field to produce a scalar result.

--- a/packages/intrepid2/src/Shared/Intrepid2_VectorData.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_VectorData.hpp
@@ -31,6 +31,7 @@ namespace Intrepid2 {
   class VectorData
   {
   public:
+    using value_type = Scalar;
     using VectorArray = Kokkos::Array< TensorData<Scalar,DeviceType>, Parameters::MaxVectorComponents >; // for axis-aligned case, these correspond entry-wise to the axis with which the vector values align
     using FamilyVectorArray = Kokkos::Array< VectorArray, Parameters::MaxTensorComponents>;
 

--- a/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
@@ -971,8 +971,8 @@ namespace
     shards::CellTopology hexTopo = shards::CellTopology(shards::getCellTopologyData<shards::Hexahedron<> >() );
     
     std::vector<EOperator> operators_dk = {OPERATOR_D1,OPERATOR_D2,OPERATOR_D3,OPERATOR_D4,OPERATOR_D5,OPERATOR_D6,OPERATOR_D7,OPERATOR_D8,OPERATOR_D9,OPERATOR_D10};
-    // for Fad types under CUDA, we sometimes run into allocation errors with the highest-k dk operators in 3D.  Not sure why (are we actually running out of memory? It seems possible, but still surprises me a little), but for now we don't test beyond D8.
-    std::vector<EOperator> operators_dk_3D = {OPERATOR_D1,OPERATOR_D2,OPERATOR_D3,OPERATOR_D4,OPERATOR_D5,OPERATOR_D6,OPERATOR_D7,OPERATOR_D8};
+    // for Fad types under CUDA, we sometimes run into allocation errors with the highest-k dk operators in 3D.  Not sure why (are we actually running out of memory? It seems possible, but still surprises me a little), but for now we don't test beyond D4.
+    std::vector<EOperator> operators_dk_3D = {OPERATOR_D1,OPERATOR_D2,OPERATOR_D3,OPERATOR_D4};
     
     // "harder" test is probably higher-order, but it's more expensive in higher dimensions.
     // the below are compromises according to spatial dimension.


### PR DESCRIPTION
@trilinos/intrepid2

## Motivation
As documented in #13915, some CUDA runs of Intrepid2 CI tests fail randomly with allocation errors.  Investigation has led us to believe (though the evidence gathered is circumstantial) that there is a legitimate out-of-memory condition occurring for some of the more intensive test cases.  This PR fixes it by reducing the intensity of the covered test cases, specifically by omitting tests against `OPERATOR_D5` through `OPERATOR_D8` for the 3D bases in `HierarchicalNodalComparisons`.

While I was in there, I also added a few missing `value_type` typedef declarations for some of Intrepid2's View-like containers.

## Related Issues
Closes #13915.
