### PR TITLE
Add comment with CDash urls to PRs

### DIFF
--- a/.github/workflows/cdash_urls.yml
+++ b/.github/workflows/cdash_urls.yml
@@ -1,0 +1,22 @@
+name: CDash
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  pre-checks:
+        runs-on: ubuntu-latest
+        permissions:
+          pull-requests: write
+        steps:
+        - name: Post CDash URLs
+          uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            message-id: cdash
+            message: |
+              [CDash for AT1 results](https://trilinos-cdash.sandia.gov/index.php?project=Trilinos&filtercombine=and&filtercombine=and&filtercombine=and&filtercombine=and&filtercombine=and&filtercombine=and&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=PR-${{ github.event.number }}-test&field2=buildstarttime&compare2=84&value2=NOW) [Only accessible from Sandia networks]
+              [CDash for AT2 results](https://sems-cdash-son.sandia.gov/cdash/index.php?project=Trilinos&display=project&begin=2024-01-01&end=now&filtercount=1&showfilters=1&field1=buildname&compare1=65&value1=PR-${{ github.event.number }}) [Currently only accessible from Sandia networks]


### PR DESCRIPTION
@trilinos/framework @sebrowne @achauphan 

## Motivation
The URL to the CDash with build results is somewhat hidden and only becomes available once the first build finishes.

With this change a comment is added to newly opened PRs with the link to the results.

It seems to be somewhat tricky to get the comment to work for PRs from forks when the trigger is `pull_request`. Instead, I now use `pull_request_target`. This means that the action will only run if the workflow file is in the target of the PR (i.e. usually `develop`).

I tested this by opening a dummy PR against the branch of this PR: https://github.com/trilinos/Trilinos/pull/13981
