### PR TITLE
MueLu: Add support for "Nullspace[1-9]" user data input

### DIFF
--- a/packages/muelu/src/MueCentral/MueLu_HierarchyUtils_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_HierarchyUtils_def.hpp
@@ -287,6 +287,9 @@ void HierarchyUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::AddNonSerializab
       const ParameterList& userList = nonSerialList.sublist(levelName);
       for (ParameterList::ConstIterator userListEntry = userList.begin(); userListEntry != userList.end(); userListEntry++) {
         const std::string& name = userListEntry->first;
+        // Check if the name starts with "Nullspace", has length > 9, and the last character is a digit
+        bool isNumberedNullspace = (name.rfind("Nullspace", 0) == 0 && name.length() > 9 && std::isdigit(name.back(), std::locale::classic()));
+
         TEUCHOS_TEST_FOR_EXCEPTION(name != "P" && name != "R" && name != "K" && name != "M" && name != "Mdiag" &&
                                        name != "D0" && name != "Dk_1" && name != "Dk_2" &&
                                        name != "Mk_one" && name != "Mk_1_one" && name != "M1_beta" && name != "M1_alpha" &&
@@ -298,6 +301,7 @@ void HierarchyUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::AddNonSerializab
                                        name != "Node Comm" && name != "DualNodeID2PrimalNodeID" && name != "Primal interface DOF map" &&
                                        name != "dropMap1" && name != "dropMap2" &&
                                        name != "output stream" &&
+                                       !isNumberedNullspace &&
                                        !IsParamValidVariable(name),
                                    Exceptions::InvalidArgument,
                                    std::string("MueLu::Utils::AddNonSerializableDataToHierarchy: user data parameter list contains unknown data type (") + name + ")");
@@ -312,7 +316,7 @@ void HierarchyUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::AddNonSerializab
         } else if (name == "Mdiag") {
           level->AddKeepFlag(name, NoFactory::get(), MueLu::UserData);
           level->Set(name, Teuchos::getValue<RCP<Vector>>(userListEntry->second), NoFactory::get());
-        } else if (name == "Nullspace") {
+        } else if (name == "Nullspace" || isNumberedNullspace) {
           level->AddKeepFlag(name, NoFactory::get(), MueLu::UserData);
           level->Set(name, Teuchos::getValue<RCP<MultiVector>>(userListEntry->second), NoFactory::get());
           // M->SetFactory(name, NoFactory::getRCP()); // TAW: generally it is a bad idea to overwrite the factory manager data here

--- a/packages/muelu/src/Utils/MueLu_Utilities.cpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities.cpp
@@ -55,11 +55,14 @@ long ExtractNonSerializableData(const Teuchos::ParameterList& inList, Teuchos::P
       const ParameterList& levelList = inList.sublist(levelName);
       for (ParameterList::ConstIterator levelListEntry = levelList.begin(); levelListEntry != levelList.end(); levelListEntry++) {
         const std::string& name = levelListEntry->first;
+        // Check if the name starts with "Nullspace", has length > 9, and the last character is a digit
+        bool isNumberedNullspace = (name.rfind("Nullspace", 0) == 0 && name.length() > 9 && std::isdigit(name.back(), std::locale::classic()));
+
         if (name == "A" || name == "P" || name == "R" || name == "M" || name == "Mdiag" || name == "K" || name == "Nullspace" || name == "Material" || name == "Coordinates" || name == "D0" || name == "Dk_1" || name == "Dk_2" || name == "Mk_one" || name == "Mk_1_one" || name == "M1_beta" || name == "M1_alpha" || name == "invMk_1_invBeta" || name == "invMk_2_invAlpha" || name == "M1" || name == "Ms" || name == "M0inv" || name == "Pnodal" || name == "NodeMatrix" || name == "NodeAggMatrix" || name == "Node Comm" || name == "DualNodeID2PrimalNodeID"
 #ifdef HAVE_MUELU_INTREPID2  // For the IntrepidPCoarsenFactory
             || name == "pcoarsen: element to node map"
 #endif
-            || name == "output stream") {
+            || name == "output stream" || isNumberedNullspace) {
           nonSerialList.sublist(levelName).setEntry(name, levelListEntry->second);
         }
 #ifdef HAVE_MUELU_MATLAB


### PR DESCRIPTION
@trilinos/muelu

## Motivation

When using blocked structure within MueLu it is convenient to pass the null space candidates as "user data" when using MueLu with Stratimikos.

## Related Issues

* #7929