### PR TITLE
Phalanx: fix use of deprecated kokkos 4 code

### DIFF
--- a/packages/phalanx/example/FiniteElementAssembly/LinearObjectFactory.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/LinearObjectFactory.hpp
@@ -14,7 +14,7 @@
 #include <utility>
 #include "Mesh.hpp"
 #include "Phalanx_KokkosDeviceTypes.hpp"
-#include "Kokkos_StaticCrsGraph.hpp"
+#include "KokkosSparse_StaticCrsGraph.hpp"
 #include "Kokkos_UnorderedMap.hpp"
 #include "KokkosSparse_CrsMatrix.hpp"
 

--- a/packages/phalanx/example/FiniteElementAssembly/PrintValues.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/PrintValues.hpp
@@ -56,7 +56,7 @@ namespace phx_example {
   {
     auto host_f = Kokkos::create_mirror_view(f);
     auto host_J_vals = Kokkos::create_mirror_view(J.values);
-    auto host_graph = Kokkos::create_mirror(J.graph); // deep_copies automagically
+    auto host_graph = KokkosSparse::create_mirror(J.graph); // deep_copies automagically
     Kokkos::deep_copy(host_f,f);
     Kokkos::deep_copy(host_J_vals,J.values);
     typename PHX::exec_space().fence();

--- a/packages/phalanx/example/FiniteElementAssembly/auxiliary_tests/Example_FEM_LinearObjectFactory_AuxTest.cpp
+++ b/packages/phalanx/example/FiniteElementAssembly/auxiliary_tests/Example_FEM_LinearObjectFactory_AuxTest.cpp
@@ -45,7 +45,7 @@ TEUCHOS_UNIT_TEST(mesh, coord_gids)
 
   // Mirror calls deep_copy on underlying obejcts so host copy is up
   // to date.
-  auto graph = Kokkos::create_mirror(J.graph);
+  auto graph = KokkosSparse::create_mirror(J.graph);
   
   const int max_entries_per_row = 27*num_equations;
   const int min_entries_per_row = 8*num_equations;


### PR DESCRIPTION
- This removes use of bracket operator in DynRankView for rank greater than 1. See https://github.com/kokkos/kokkos/pull/7457. Phalanx implemented this due to requirements in intrepid2.

- Fix for moving CrsGraph and CrsMatrix from Kokkos to KokkosSparse.

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/phalanx 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Multiple tests covered the deprecations and are updated for changes. 

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
