### PR TITLE
Framework: Uniformize container configs

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1895,25 +1895,25 @@ opt-set-cmake-var Trilinos_ENABLE_Teuchos BOOL : ON
 opt-set-cmake-var Trilinos_ENABLE_ALL_PACKAGES BOOL FORCE : OFF
 
 [rhel8_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+use COMMON_SPACK_TPLS
+use COMPILER|GNU
 use NODE-TYPE|CUDA
 use BUILD-TYPE|RELEASE
-opt-set-cmake-var BUILD_SHARED_LIBS      BOOL   : OFF
-opt-set-cmake-var TPL_FIND_SHARED_LIBS   BOOL   : OFF
+use LIB-TYPE|STATIC
 use KOKKOS-ARCH|AMPERE80
 use USE-ASAN|NO
+use USE-COMPLEX|YES
 use USE-FPIC|NO
 use USE-MPI-NO-EXPLICIT-COMPILERS|YES
 use USE-PT|NO
-use USE-COMPLEX|YES
 use USE-RDC|NO
 use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-EPETRA
+
 use CUDA
 use SPACK_NETLIB_BLAS_LAPACK
 
-opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL : ON
-opt-set-cmake-var TPL_ENABLE_X11 BOOL : OFF
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS STRING FORCE : --bind-to;none --mca btl ^smcuda
 opt-set-cmake-var Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC BOOL : OFF
 
@@ -1923,20 +1923,22 @@ opt-set-cmake-var ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE BOOL : ON
 opt-set-cmake-var PanzerMiniEM_Maxwell_MueLu_order1_tpl_MPI_4_DISABLE BOOL : ON
 
 [rhel8_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables]
+use COMMON_SPACK_TPLS
+use COMPILER|GNU
 use NODE-TYPE|CUDA
 use BUILD-TYPE|RELEASE
-opt-set-cmake-var BUILD_SHARED_LIBS      BOOL   : OFF
-opt-set-cmake-var TPL_FIND_SHARED_LIBS   BOOL   : OFF
+use LIB-TYPE|STATIC
 use KOKKOS-ARCH|AMPERE80
 use USE-ASAN|NO
+use USE-COMPLEX|YES
 use USE-FPIC|NO
 use USE-MPI-NO-EXPLICIT-COMPILERS|YES
 use USE-PT|NO
-use USE-COMPLEX|YES
 use USE-RDC|NO
 use USE-UVM|YES
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-EPETRA
+
 use CUDA
 use SPACK_NETLIB_BLAS_LAPACK
 

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1870,30 +1870,6 @@ opt-set-cmake-var MueLu_Structured_Interp_SA_Laplace2D_kokkos_MPI_4_DISABLE BOOL
 use rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
-[ubuntu_gnu_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
-use BUILD-TYPE|RELEASE-DEBUG
-use KOKKOS-ARCH|NO-KOKKOS-ARCH
-use USE-ASAN|NO
-use USE-COMPLEX|NO
-use USE-FPIC|YES
-
-opt-set-cmake-var BUILD_SHARED_LIBS      BOOL   : ON
-
-opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL : ON
-
-opt-set-cmake-var CMAKE_C_COMPILER       FILEPATH : ${CC|ENV}
-opt-set-cmake-var CMAKE_CXX_COMPILER     FILEPATH : ${CXX|ENV}
-opt-set-cmake-var CMAKE_Fortran_COMPILER FILEPATH : ${FC|ENV}
-opt-set-cmake-var TPL_ENABLE_MPI         BOOL     : OFF
-
-use USE-PT|NO
-use USE-RDC|NO
-use USE-UVM|NO
-use USE-DEPRECATED|YES
-
-opt-set-cmake-var Trilinos_ENABLE_Teuchos BOOL : ON
-opt-set-cmake-var Trilinos_ENABLE_ALL_PACKAGES BOOL FORCE : OFF
-
 [rhel8_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use COMMON_SPACK_TPLS
 use COMPILER|GNU

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -686,6 +686,8 @@ opt-set-cmake-var Tpetra_INST_CUDA                BOOL   : ON
 opt-set-cmake-var Sacado_ENABLE_HIERARCHICAL_DFAD BOOL   : ON
 opt-set-cmake-var TPL_ENABLE_CUDA                 BOOL   : ON
 opt-set-cmake-var TPL_ENABLE_CUSPARSE             BOOL   : ON
+# FIXME: This really should be somewhere else (like CUDA+OpenMPI?)
+opt-set-cmake-var MPI_EXEC FILEPATH : mpiexec
 
 [NODE-TYPE|OPENMP]
 opt-set-cmake-var Trilinos_ENABLE_OpenMP          BOOL   : ON
@@ -1111,10 +1113,6 @@ opt-set-cmake-var ShyLU_DDFROSch_test_frosch_interfacesets_2D_MPI_4_DISABLE BOOL
 # Disable for clang
 opt-set-cmake-var ROL_example_PinT_parabolic-control_example_01_MPI_1_DISABLE BOOL : ON
 
-[RHEL_COMPILER|CUDA]
-use NODE-TYPE|CUDA
-opt-set-cmake-var MPI_EXEC FILEPATH : mpiexec
-
 [COMPILER|GNU]
 opt-set-cmake-var MPI_EXEC FILEPATH : mpirun
 opt-set-cmake-var Trilinos_WARNINGS_MODE STRING : WARN
@@ -1373,7 +1371,7 @@ use PACKAGE-ENABLES|ALL
 
 [rhel8_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.1.4_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 # uses sems-v2 modules
-use RHEL_COMPILER|CUDA
+use COMPILER|GNU
 use NODE-TYPE|CUDA
 use BUILD-TYPE|RELEASE
 use LIB-TYPE|STATIC
@@ -1428,7 +1426,7 @@ use PACKAGE-ENABLES|ALL-NO-EPETRA
 [rhel8_sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables]
 # uses sems-v2 modules
 use RHEL8
-use RHEL_COMPILER|CUDA
+use COMPILER|GNU
 use NODE-TYPE|CUDA
 use BUILD-TYPE|RELEASE
 use LIB-TYPE|STATIC
@@ -1478,7 +1476,7 @@ opt-set-cmake-var TrilinosCouplings_ENABLE_TESTS BOOL FORCE : ON
 [rhel8_sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 # uses sems-v2 modules
 use RHEL8
-use RHEL_COMPILER|CUDA
+use COMPILER|GNU
 use NODE-TYPE|CUDA
 use BUILD-TYPE|RELEASE
 use LIB-TYPE|STATIC

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1694,6 +1694,43 @@ opt-set-cmake-var Trilinos_ENABLE_COMPLEX_FLOAT                          BOOL FO
 use rhel8_sems-gnu-8.5.0-openmpi-4.1.6-serial_debug_shared_no-kokkos-arch_no-asan_complex-float_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
+[rhel8_aue-gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+use COMPILER|GNU
+use NODE-TYPE|SERIAL
+use BUILD-TYPE|DEBUG
+
+use LIB-TYPE|SHARED
+use KOKKOS-ARCH|NO-KOKKOS-ARCH
+
+use USE-ASAN|NO
+use USE-FPIC|NO
+use USE-MPI|YES
+use USE-PT|NO
+use USE-COMPLEX|YES
+use USE-RDC|NO
+use USE-UVM|NO
+use USE-DEPRECATED|YES
+use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
+
+use COMMON_AUE_SPACK
+
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                                STRING       : --bind-to;none --mca btl vader,self
+opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D              BOOL         : ON
+opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                    BOOL         : ON
+opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE     BOOL         : ON
+opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL         : ON
+opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE                         BOOL         : ON
+opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE                         BOOL         : ON
+opt-set-cmake-var CMAKE_CXX_FLAGS                                            STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare
+
+opt-set-cmake-var TPL_ENABLE_SuperLUDist BOOL FORCE: OFF
+
+# Turn off Framework tests due to issues in AUE container
+opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL FORCE : OFF
+opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats     BOOL FORCE : OFF
+
+use RHEL8_POST
+
 [rhel8_gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 #uses a containerized environment
 use COMPILER|GNU
@@ -1771,43 +1808,6 @@ opt-set-cmake-var TPL_Netcdf_LIBRARIES      STRING FORCE : ""
 opt-set-cmake-var TPL_ENABLE_ParMETIS       BOOL FORCE   : OFF
 opt-set-cmake-var TPL_ENABLE_Pnetcdf        BOOL FORCE   : OFF
 
-opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL FORCE : OFF
-opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats     BOOL FORCE : OFF
-
-use RHEL8_POST
-
-[rhel8_aue-gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
-use COMPILER|GNU
-use NODE-TYPE|SERIAL
-use BUILD-TYPE|DEBUG
-
-use LIB-TYPE|SHARED
-use KOKKOS-ARCH|NO-KOKKOS-ARCH
-
-use USE-ASAN|NO
-use USE-FPIC|NO
-use USE-MPI|YES
-use USE-PT|NO
-use USE-COMPLEX|YES
-use USE-RDC|NO
-use USE-UVM|NO
-use USE-DEPRECATED|YES
-use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
-
-use COMMON_AUE_SPACK
-
-opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                                STRING       : --bind-to;none --mca btl vader,self
-opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D              BOOL         : ON
-opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                    BOOL         : ON
-opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE     BOOL         : ON
-opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL         : ON
-opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE                         BOOL         : ON
-opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE                         BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                                            STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare
-
-opt-set-cmake-var TPL_ENABLE_SuperLUDist BOOL FORCE: OFF
-
-# Turn off Framework tests due to issues in AUE container
 opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats     BOOL FORCE : OFF
 

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1371,7 +1371,8 @@ use PACKAGE-ENABLES|ALL
 
 [rhel8_sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.1.4_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 # uses sems-v2 modules
-use COMPILER|GNU
+# Not using currently to prevent warning overload
+#use COMPILER|GNU
 use NODE-TYPE|CUDA
 use BUILD-TYPE|RELEASE
 use LIB-TYPE|STATIC
@@ -1426,7 +1427,8 @@ use PACKAGE-ENABLES|ALL-NO-EPETRA
 [rhel8_sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables]
 # uses sems-v2 modules
 use RHEL8
-use COMPILER|GNU
+# Not using currently to prevent warning overload
+#use COMPILER|GNU
 use NODE-TYPE|CUDA
 use BUILD-TYPE|RELEASE
 use LIB-TYPE|STATIC
@@ -1476,7 +1478,8 @@ opt-set-cmake-var TrilinosCouplings_ENABLE_TESTS BOOL FORCE : ON
 [rhel8_sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6_release_static_Volta70_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 # uses sems-v2 modules
 use RHEL8
-use COMPILER|GNU
+# Not using currently to prevent warning overload
+#use COMPILER|GNU
 use NODE-TYPE|CUDA
 use BUILD-TYPE|RELEASE
 use LIB-TYPE|STATIC
@@ -1857,7 +1860,8 @@ use PACKAGE-ENABLES|ALL
 
 [rhel8_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use COMMON_SPACK_TPLS
-use COMPILER|GNU
+# Not using currently to prevent warning overload
+#use COMPILER|GNU
 use NODE-TYPE|CUDA
 use BUILD-TYPE|RELEASE
 use LIB-TYPE|STATIC
@@ -1885,7 +1889,8 @@ opt-set-cmake-var PanzerMiniEM_Maxwell_MueLu_order1_tpl_MPI_4_DISABLE BOOL : ON
 
 [rhel8_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables]
 use COMMON_SPACK_TPLS
-use COMPILER|GNU
+# Not using currently to prevent warning overload
+#use COMPILER|GNU
 use NODE-TYPE|CUDA
 use BUILD-TYPE|RELEASE
 use LIB-TYPE|STATIC

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1729,28 +1729,22 @@ opt-set-cmake-var TPL_ENABLE_SuperLUDist BOOL FORCE: OFF
 opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats     BOOL FORCE : OFF
 
-use RHEL8_POST
-
 [rhel8_gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
-#uses a containerized environment
+use COMMON_SPACK_TPLS
 use COMPILER|GNU
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|DEBUG
-
 use LIB-TYPE|SHARED
 use KOKKOS-ARCH|NO-KOKKOS-ARCH
-
 use USE-ASAN|NO
+use USE-COMPLEX|YES
 use USE-FPIC|NO
 use USE-MPI-NO-EXPLICIT-COMPILERS|YES
 use USE-PT|NO
-use USE-COMPLEX|YES
 use USE-RDC|NO
 use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
-
-use COMMON_SPACK_TPLS
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                                STRING       : --bind-to;none --mca btl vader,self
 opt-set-cmake-var CMAKE_CXX_FLAGS                                            STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare
@@ -1768,7 +1762,6 @@ opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE        
 opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE     BOOL : ON
 opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE                             BOOL : ON
 opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE                             BOOL : ON
-
 opt-set-cmake-var Zoltan_ch_7944_parmetis_parallel_DISABLE                       BOOL : ON
 opt-set-cmake-var Zoltan_ch_simple_parmetis_parallel_DISABLE                     BOOL : ON
 opt-set-cmake-var Belos_bl_gmres_complex_hb_3_MPI_4_DISABLE                      BOOL : ON
@@ -1778,17 +1771,13 @@ opt-set-cmake-var Belos_gcrodr_complex_hb_MPI_4_DISABLE                         
 opt-set-cmake-var Belos_Tpetra_gcrodr_complex_hb_MPI_4_DISABLE                   BOOL : ON
 opt-set-cmake-var Stratimikos_Galeri_xpetra_complex_double_Jacobi_MPI_4_DISABLE  BOOL : ON
 
-use RHEL8_POST
-
 [rhel8_gcc-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
-# gcc-serial containerized environment
+use COMMON_SPACK_TPLS
 use COMPILER|GNU
 use NODE-TYPE|SERIAL
 use BUILD-TYPE|RELEASE-DEBUG
-
 use LIB-TYPE|SHARED
 use KOKKOS-ARCH|NO-KOKKOS-ARCH
-
 use USE-ASAN|NO
 use USE-COMPLEX|NO
 use USE-FPIC|NO
@@ -1799,8 +1788,6 @@ use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
-use COMMON_SPACK_TPLS
-
 opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-unused-but-set-variable
 
 opt-set-cmake-var TPL_Netcdf_LIBRARIES      STRING FORCE : ""
@@ -1810,8 +1797,6 @@ opt-set-cmake-var TPL_ENABLE_Pnetcdf        BOOL FORCE   : OFF
 
 opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats     BOOL FORCE : OFF
-
-use RHEL8_POST
 
 [rhel8_gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel8_gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables


### PR DESCRIPTION
@trilinos/framework 

## Motivation
When looking at CI failures in #13985, @gsjaardema observed the following configure error with the cuda11 check:
```
CMake Error at cmake/tribits/core/package_arch/TribitsAdjustPackageEnables.cmake:1010 (message):
   ***
   *** ERROR: Setting Trilinos_ENABLE_SEACASExo2mat=OFF which was 'ON' because SEACASExo2mat has a required library dependence on disabled package Matio!
   ***
```
This error should not have happened with our current configuration, because we set `Trilinos_DISABLE_ENABLED_FORWARD_DEP_PACKAGES` to `ON` in `config-specs.ini`.  However, that config block was not getting included in this particular configuration.  Much like I did with the Intel check configuration, this change makes the rest of our container config blocks adopt a "common" ish syntax, which hopefully prevents this type of thing in the future.

Side note: Whether or not we should be setting that option is a matter for future work (I posture that we should NOT be setting it given that Trilinos wants it set to `OFF`, and that the error was informative and desired, but that would force us to enable MATIO everywhere right now, which seems out-of-scope).

I also did some light refactoring and rearranging where it made sense to increase overall readability.

## Related Issues
#13985

## Stakeholder Feedback
Framework team is the stakeholder.

## Testing
I did not test this manually.  As it applies to many of the CI configurations, using the CI to test it directly makes sense here.