### PR TITLE
Panzer: improve mpi communication in mesh initialization

### DIFF
--- a/packages/panzer/adapters-stk/cmake/Dependencies.cmake
+++ b/packages/panzer/adapters-stk/cmake/Dependencies.cmake
@@ -4,7 +4,7 @@
 # Pamgen enabled to run, so Pamgen is only declared an optional test
 # dependency.
 
-SET(LIB_REQUIRED_DEP_PACKAGES TeuchosCore STKUtil STKTopology STKMesh STKIO Zoltan Stratimikos Piro NOX PanzerCore PanzerDiscFE)
+SET(LIB_REQUIRED_DEP_PACKAGES TeuchosCore STKUtil STKTools STKTopology STKMesh STKIO Zoltan Stratimikos Piro NOX PanzerCore PanzerDiscFE)
 SET(LIB_OPTIONAL_DEP_PACKAGES STKSearch SEACASIoss SEACASExodus UMR Percept Teko MueLu Ifpack2 Tempus)
 SET(TEST_REQUIRED_DEP_PACKAGES SEACASIoss SEACASExodus Teko MueLu Ifpack2)
 SET(TEST_OPTIONAL_DEP_PACKAGES Pamgen STKSearch ROL)

--- a/packages/panzer/adapters-stk/src/Panzer_STKConnManager.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STKConnManager.cpp
@@ -221,11 +221,8 @@ STKConnManager::modifySubcellConnectivities(const panzer::FieldPattern & fp, stk
 
 void STKConnManager::buildConnectivity(const panzer::FieldPattern & fp)
 {
-#ifdef HAVE_EXTRA_TIMERS
-  using Teuchos::TimeMonitor;
-  RCP<Teuchos::TimeMonitor> tM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(std::string("panzer_stk::STKConnManager::buildConnectivity"))));
-#endif
-
+   PANZER_FUNC_TIME_MONITOR_DIFF("panzer_stk::STKConnManager::buildConnectivity", build_connectivity);
+  
    stk::mesh::BulkData& bulkData = *stkMeshDB_->getBulkData();
 
    // get element info from STK_Interface
@@ -302,10 +299,7 @@ void STKConnManager::applyPeriodicBCs(const panzer::FieldPattern & fp, GlobalOrd
    using Teuchos::RCP;
    using Teuchos::rcp;
 
-#ifdef HAVE_EXTRA_TIMERS
-  using Teuchos::TimeMonitor;
-  RCP<Teuchos::TimeMonitor> tM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(std::string("panzer_stk::STKConnManager::applyPeriodicBCs"))));
-#endif
+   PANZER_FUNC_TIME_MONITOR_DIFF("panzer_stk::STKConnManager::applyPeriodicBCs", apply_periodic_bcs);
 
    std::pair<Teuchos::RCP<std::vector<std::pair<std::size_t,std::size_t> > >, Teuchos::RCP<std::vector<unsigned int> > > matchedValues
             = stkMeshDB_->getPeriodicNodePairing();

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
@@ -244,8 +244,12 @@ void STK_ExodusReaderFactory::completeMeshConstruction(STK_Interface & mesh,stk:
       mesh.buildLocalFaceIDs();
       addFaceBlocks(mesh);
    }
-   mesh.endModification();
 
+   {
+     const bool find_and_set_shared_nodes_in_stk = false;
+     mesh.endModification(find_and_set_shared_nodes_in_stk);
+   }
+   
    if (userMeshScaling_) {
      stk::mesh::Field<double>* coord_field = metaData.get_field<double>(stk::topology::NODE_RANK, "coordinates");
      std::vector< const stk::mesh::FieldBase *> fields;

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
@@ -618,7 +618,10 @@ void STK_ExodusReaderFactory::addEdgeBlocks(STK_Interface & mesh) const
 
    /* For each element block, iterate over it's edge topologies.
     * For each edge topology, get the matching edge block and
-    * add all edges of that topology to the edge block.
+    * add all edges of that topology to the edge block. Make sure to include
+    * aura values - when they are marked shared, the part membership
+    * gets updated, if only ghosted the part memberships are not
+    * automatically updated.
     */
    for (auto iter : elemBlockUniqueEdgeTopologies_) {
       std::string elemBlockName = iter.first;
@@ -631,7 +634,6 @@ void STK_ExodusReaderFactory::addEdgeBlocks(STK_Interface & mesh) const
          stk::mesh::Selector owned_block;
          owned_block  = *elemBlockPart;
          owned_block &= edgeTopoPart;
-         owned_block &= metaData->locally_owned_part();
 
          std::string edge_block_name = mkBlockName(panzer_stk::STK_Interface::edgeBlockString, topo.name());
          stk::mesh::Part * edge_block = mesh.getEdgeBlock(edge_block_name);
@@ -648,9 +650,12 @@ void STK_ExodusReaderFactory::addFaceBlocks(STK_Interface & mesh) const
    Teuchos::RCP<stk::mesh::BulkData> bulkData = mesh.getBulkData();
    Teuchos::RCP<stk::mesh::MetaData> metaData = mesh.getMetaData();
 
-   /* For each element block, iterate over it's face topologies.
-    * For each face topology, get the matching face block and
-    * add all faces of that topology to the face block.
+   /* For each element block, iterate over it's face topologies.  For
+    * each face topology, get the matching face block and add all
+    * faces of that topology to the face block. Make sure to include
+    * aura values - when they are marked shared, the part membership
+    * gets updated, if only ghosted the part memberships are not
+    * automatically updated.
     */
    for (auto iter : elemBlockUniqueFaceTopologies_) {
       std::string elemBlockName = iter.first;
@@ -663,7 +668,6 @@ void STK_ExodusReaderFactory::addFaceBlocks(STK_Interface & mesh) const
          stk::mesh::Selector owned_block;
          owned_block  = *elemBlockPart;
          owned_block &= faceTopoPart;
-         owned_block &= metaData->locally_owned_part();
 
          std::string face_block_name = mkBlockName(panzer_stk::STK_Interface::faceBlockString, topo.name());
          stk::mesh::Part * face_block = mesh.getFaceBlock(face_block_name);

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
@@ -32,6 +32,8 @@
 #include <stk_util/parallel/ParallelReduce.hpp>
 #include <stk_util/parallel/CommSparse.hpp>
 
+#include <stk_tools/mesh_tools/FixNodeSharingViaSearch.hpp>
+
 #ifdef PANZER_HAVE_IOSS
 #include <Ionit_Initializer.h>
 #include <stk_io/IossBridge.hpp>
@@ -405,60 +407,27 @@ void STK_Interface::beginModification()
    bulkData_->modification_begin();
 }
 
-void STK_Interface::endModification()
+void STK_Interface::endModification(const bool find_and_set_shared_nodes_in_stk)
 {
-   TEUCHOS_TEST_FOR_EXCEPTION(bulkData_==Teuchos::null,std::logic_error,
-                      "STK_Interface: Must call \"initialized\" or \"instantiateBulkData\" before \"endModification\"");
+  TEUCHOS_TEST_FOR_EXCEPTION(bulkData_==Teuchos::null,std::logic_error,
+                             "STK_Interface: Must call \"initialized\" or \"instantiateBulkData\" before \"endModification\"");
 
-   // TODO: Resolving sharing this way comes at a cost in performance. The STK
-   // team has decided that users need to declare their own sharing. We should
-   // find where shared entities are being created in Panzer and declare it.
-   // Once this is done, the extra code below can be deleted.
+   // Resolving sharing this way comes at a cost in performance. The
+   // STK mesh database requires users to declare their own node
+   // sharing. We should find where shared entities are being created
+   // in Panzer (the inline mesh factories) and declare it.  Once this
+   // is done, the extra code below can be deleted. Note that the
+   // exodus reader already has shared nodes set up properly, so only
+   // the inline mesh factories need this.
+   if (find_and_set_shared_nodes_in_stk) {
+     const double radius = 10.0 * std::numeric_limits<double>::epsilon();
+     stk::tools::fix_node_sharing_via_search(*bulkData_,radius);
+   }
 
-    stk::CommSparse comm(bulkData_->parallel());
-
-    for (int phase=0;phase<2;++phase) {
-      for (int i=0;i<bulkData_->parallel_size();++i) {
-        if ( i != bulkData_->parallel_rank() ) {
-          const stk::mesh::BucketVector& buckets = bulkData_->buckets(stk::topology::NODE_RANK);
-          for (size_t j=0;j<buckets.size();++j) {
-            const stk::mesh::Bucket& bucket = *buckets[j];
-            if ( bucket.owned() ) {
-              for (size_t k=0;k<bucket.size();++k) {
-                stk::mesh::EntityKey key = bulkData_->entity_key(bucket[k]);
-                comm.send_buffer(i).pack<stk::mesh::EntityKey>(key);
-              }
-            }
-          }
-        }
-      }
-
-      if (phase == 0 ) {
-        comm.allocate_buffers();
-      }
-      else {
-        comm.communicate();
-      }
-    }
-
-    for (int i=0;i<bulkData_->parallel_size();++i) {
-      if ( i != bulkData_->parallel_rank() ) {
-        while(comm.recv_buffer(i).remaining()) {
-          stk::mesh::EntityKey key;
-          comm.recv_buffer(i).unpack<stk::mesh::EntityKey>(key);
-          stk::mesh::Entity node = bulkData_->get_entity(key);
-          if ( bulkData_->is_valid(node) ) {
-            bulkData_->add_node_sharing(node, i);
-          }
-        }
-      }
-    }
-
-
-    bulkData_->modification_end();
-
-    buildEntityCounts();
-    buildMaxEntityIds();
+   bulkData_->modification_end();
+   
+   buildEntityCounts();
+   buildMaxEntityIds();
 }
 
 void STK_Interface::addNode(stk::mesh::EntityId gid, const std::vector<double> & coord)

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
@@ -194,8 +194,18 @@ public:
    void beginModification();
 
    /** Take the bulk data manager out of modification mode.
+
+       @param find_and_set_shared_nodes_in_stk (bool) If set to true,
+       this performs a geometric search to figure out which nodes are
+       shared entities and marks them as shared in stk. This is very
+       inefficient and communication intensive. Set this to false for
+       exodus as the sharing is already known. Must be true for inline
+       meshes. We should fix the inline mesh factories to mark sharing
+       at node construction time to eliminate the need for searching
+       for shared nodes. Defaults to true to maintain backwards
+       compatibility.
      */
-   void endModification();
+   void endModification(const bool find_and_set_shared_nodes_in_stk=true);
 
    /** Add a node to the mesh with a specific set of coordinates to the mesh.
      *

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tLineMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tLineMeshFactory.cpp
@@ -21,6 +21,8 @@
 
 #include "Shards_BasicTopologies.hpp"
 
+#include "stk_mesh/base/DumpMeshInfo.hpp"
+
 namespace panzer_stk {
 
 TEUCHOS_UNIT_TEST(tLineMeshFactory, defaults)
@@ -37,6 +39,9 @@ TEUCHOS_UNIT_TEST(tLineMeshFactory, defaults)
 
    if(mesh->isWritable())
       mesh->writeToExodus("Line.exo");
+
+   // Example of dumping mesh info files per mpi process for debugging
+   stk::mesh::impl::dump_mesh_per_proc(*mesh->getBulkData(),"Line.stk_mesh_info");
 
    // minimal requirements
    TEST_ASSERT(not mesh->isModifiable());


### PR DESCRIPTION
@trilinos/panzer 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Large scale runs were seeing excessive communication during mesh construction.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
All functions are exercised in the adapters-stk tests.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
