### PR TITLE
Framework: Always copy ci artifacts

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -111,6 +111,7 @@ jobs:
             --max-cores-allowed=29 \
             --num-concurrent-tests=16
       - name: Copy artifacts
+        if: success() || failure()
         shell: bash -l {0}
         working-directory: /home/Trilinos/build
         run: |
@@ -226,6 +227,7 @@ jobs:
             --max-cores-allowed=29 \
             --num-concurrent-tests=16
       - name: Copy artifacts
+        if: success() || failure()
         shell: bash -l {0}
         working-directory: /home/Trilinos/build
         run: |
@@ -340,6 +342,7 @@ jobs:
             --num-concurrent-tests=112 \
             --slots-per-gpu=8
       - name: Copy artifacts
+        if: success() || failure()
         shell: bash -l {0}
         working-directory: /home/Trilinos/build
         run: |
@@ -450,9 +453,17 @@ jobs:
             --filename-packageenables ./packageEnables.cmake \
             --max-cores-allowed=29 \
             --num-concurrent-tests=16
+      - name: Copy artifacts
+        if: success() || failure()
+        shell: bash -l {0}
+        working-directory: /home/Trilinos/build
+        run: |
+          cp ./packageEnables.cmake /home/runner/artifacts/
+          cp ./configure_command.txt /home/runner/artifacts/
+          cp ./genconfig_build_name.txt /home/runner/artifacts/
       - name: Upload artifacts
         if: success() || failure()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         env:
           NODE_TLS_REJECT_UNAUTHORIZED: 0
         with:
@@ -550,6 +561,7 @@ jobs:
             --filename-subprojects ./package_subproject_list.cmake \
             --skip-create-packageenables
       - name: Copy artifacts
+        if: success() || failure()
         shell: bash -l {0}
         working-directory: /home/Trilinos/build
         run: |


### PR DESCRIPTION
@trilinos/framework 

## Motivation
@rppawlo noticed when trying to reproduce some CI failures that `packageEnables.cmake` was not included in the artifacts.  Remedy that by running the copy artifacts step even if the previous step fails.