### PR TITLE
MueLu: Avoid altering coordinate map in `VariableDofLaplacianFactory`

### DIFF
--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_VariableDofLaplacianFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_VariableDofLaplacianFactory_def.hpp
@@ -294,8 +294,10 @@ void VariableDofLaplacianFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Bui
   // We need the ghosted Coordinates in the buildLaplacian routine. But we access the data
   // through getData only, i.e., the global ids are not interesting as long as we do not change
   // the ordering of the entries
-  Coords->replaceMap(amalgRowMap);
-  ghostedCoords->doImport(*Coords, *nodeImporter, Xpetra::INSERT);
+  RCP<dxMV> CoordsCopy = dxMVf::Build(amalgColMap, Coords->getNumVectors());
+  *CoordsCopy          = *Coords;
+  CoordsCopy->replaceMap(amalgRowMap);
+  ghostedCoords->doImport(*CoordsCopy, *nodeImporter, Xpetra::INSERT);
 
   Teuchos::ArrayRCP<Scalar> lapVals(amalgRowPtr[nLocalNodes]);
   this->buildLaplacian(amalgRowPtr, amalgCols, lapVals, Coords->getNumVectors(), ghostedCoords);


### PR DESCRIPTION
Motivation: our user app actually relies on the map in the coordinate MV.