### PR TITLE
Intrepid2: use "access" for accessing DynRankView

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
@@ -1951,7 +1951,7 @@ struct OperatorTensorDecomposition
               {
                 for (int d=0; d<spaceDim; d++)
                 {
-                  output_(fieldOrdinal,pointOrdinal,d) = weight_ * input1_(fieldOrdinal1,pointOrdinal,d) * input2_(fieldOrdinal2,pointOrdinal) * input3_(fieldOrdinal3,pointOrdinal);
+                  output_.access(fieldOrdinal,pointOrdinal,d) = weight_ * input1_(fieldOrdinal1,pointOrdinal,d) * input2_(fieldOrdinal2,pointOrdinal) * input3_(fieldOrdinal3,pointOrdinal);
                 }
               }
             }
@@ -1968,7 +1968,7 @@ struct OperatorTensorDecomposition
               {
                 for (int d=0; d<spaceDim; d++)
                 {
-                  output_(fieldOrdinal,pointOrdinal,d) = weight_ * input1_(fieldOrdinal1,pointOrdinal) * input2_(fieldOrdinal2,pointOrdinal,d) * input3_(fieldOrdinal3,pointOrdinal);
+                  output_.access(fieldOrdinal,pointOrdinal,d) = weight_ * input1_(fieldOrdinal1,pointOrdinal) * input2_(fieldOrdinal2,pointOrdinal,d) * input3_(fieldOrdinal3,pointOrdinal);
                 }
               }
             }
@@ -1985,7 +1985,7 @@ struct OperatorTensorDecomposition
               {
                 for (int d=0; d<spaceDim; d++)
                 {
-                  output_(fieldOrdinal,pointOrdinal,d) = weight_ * input1_(fieldOrdinal1,pointOrdinal) * input2_(fieldOrdinal2,pointOrdinal) * input3_(fieldOrdinal3,pointOrdinal,d);
+                  output_.access(fieldOrdinal,pointOrdinal,d) = weight_ * input1_(fieldOrdinal1,pointOrdinal) * input2_(fieldOrdinal2,pointOrdinal) * input3_(fieldOrdinal3,pointOrdinal,d);
                 }
               }
             }

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefModifyBasis.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefModifyBasis.hpp
@@ -130,11 +130,11 @@ namespace Intrepid2 {
                   input_value_type temp = 0.0;
                   for (ordinal_type l=0;l<ndofEdge;++l) {
                     const ordinal_type ll = tagToOrdinal(1, edgeId, l);
-                    auto & input_ = leftMultiply ? in(ll, j, k) : in(j, ll, k);
+                    auto & input_ = leftMultiply ? in.access(ll, j, k) : in.access(j, ll, k);
                     auto & mat_il = transpose ? mat(l,i) : mat(i,l);
                     temp += mat_il*input_;
                   }
-                  auto & output_ = leftMultiply ? out(ii, j, k) : out(j, ii, k);
+                  auto & output_ = leftMultiply ? out.access(ii, j, k) : out.access(j, ii, k);
                   output_ = temp;
                 }
               }
@@ -165,12 +165,12 @@ namespace Intrepid2 {
                   input_value_type temp = 0.0;
                   for (ordinal_type l=0;l<ndofFace;++l) {
                     const ordinal_type ll = tagToOrdinal(2, faceId, l);
-                    auto & input_ = leftMultiply ? in(ll, j, k) : in(j, ll, k);
+                    auto & input_ = leftMultiply ? in.access(ll, j, k) : in.access(j, ll, k);
                     auto & mat_il = transpose ? mat(l,i) : mat(i,l);
                     temp += mat_il*input_;
                   }
                   
-                  auto & output_ = leftMultiply ? out(ii, j, k) : out(j, ii, k);
+                  auto & output_ = leftMultiply ? out.access(ii, j, k) : out.access(j, ii, k);
                   output_ = temp;
                 }
               }
@@ -198,11 +198,11 @@ namespace Intrepid2 {
                 input_value_type temp = 0.0;
                 for (ordinal_type l=0;l<ndofFace;++l) {
                   const ordinal_type ll = tagToOrdinal(2, 0, l);
-                  auto & input_ = leftMultiply ? in(ll, j, k) : in(j, ll, k);
+                  auto & input_ = leftMultiply ? in.access(ll, j, k) : in.access(j, ll, k);
                   auto & mat_il = transpose ? mat(l,i) : mat(i,l);
                   temp += mat_il*input_;
                 }
-                auto & output_ = leftMultiply ? out(ii, j, k) : out(j, ii, k);
+                auto & output_ = leftMultiply ? out.access(ii, j, k) : out.access(j, ii, k);
                 output_ = temp;
               }
             }
@@ -227,11 +227,11 @@ namespace Intrepid2 {
                 input_value_type temp = 0.0;
                 for (ordinal_type l=0;l<ndofEdge;++l) {
                   const ordinal_type ll = tagToOrdinal(1, 0, l);
-                  auto & input_ = leftMultiply ? in(ll, j, k) : in(j, ll, k);
+                  auto & input_ = leftMultiply ? in.access(ll, j, k) : in.access(j, ll, k);
                   auto & mat_il = transpose ? mat(l,i) : mat(i,l);
                   temp += mat_il*input_;
                 }
-                auto & output_ = leftMultiply ? out(ii, j, k) : out(j, ii, k);
+                auto & output_ = leftMultiply ? out.access(ii, j, k) : out.access(j, ii, k);
                 output_ = temp;
               }
             }

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHCURL.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHCURL.hpp
@@ -369,18 +369,18 @@ struct ComputeBasisCoeffsOnCell_HCurl {
 
       for(ordinal_type d=0; d <derDim_; ++d) {
         for(ordinal_type iq=0; iq <numBasisCurlPoints; ++iq) {
-          cellBasisCurlAtBasisCurlEPoints_(0,j,iq,d)=basisCurlAtBasisCurlEPoints_(idof,offsetBasisCurl_+iq,d);
+          cellBasisCurlAtBasisCurlEPoints_(0,j,iq,d)=basisCurlAtBasisCurlEPoints_.access(idof,offsetBasisCurl_+iq,d);
           wBasisCurlAtBasisCurlEPoints_(ic,j,iq,d)=cellBasisCurlAtBasisCurlEPoints_(0,j,iq,d)*basisCurlEWeights_(iq);
         }
         for(ordinal_type iq=0; iq <numTargetCurlPoints; ++iq)
-          wBasisCurlAtTargetCurlEPoints_(ic,j,iq,d) = basisCurlAtTargetCurlEPoints_(idof,offsetTargetCurl_+iq,d)*targetCurlEWeights_(iq);
+          wBasisCurlAtTargetCurlEPoints_(ic,j,iq,d) = basisCurlAtTargetCurlEPoints_.access(idof,offsetTargetCurl_+iq,d)*targetCurlEWeights_(iq);
       }
     }
     for(ordinal_type j=0; j < numEdgeFaceDofs_; ++j) {
       ordinal_type jdof = computedDofs_(j);
       for(ordinal_type d=0; d <derDim_; ++d)
         for(ordinal_type iq=0; iq <numBasisCurlPoints; ++iq)
-          negPartialProjCurl_(ic,iq,d) -=  basisCoeffs_(ic,jdof)*basisCurlAtBasisCurlEPoints_(jdof,offsetBasisCurl_+iq,d);
+          negPartialProjCurl_(ic,iq,d) -=  basisCoeffs_(ic,jdof)*basisCurlAtBasisCurlEPoints_.access(jdof,offsetBasisCurl_+iq,d);
       for(ordinal_type d=0; d <dim_; ++d)
         for(ordinal_type iq=0; iq <numBasisPoints; ++iq)
           negPartialProj_(ic,iq,d) -=  basisCoeffs_(ic,jdof)*basisAtBasisEPoints_(jdof,offsetBasis_+iq,d);

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHGRAD.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHGRAD.hpp
@@ -51,7 +51,7 @@ struct ComputeBasisCoeffsOnVertices_HGRAD {
       ordinal_type idof = tagToOrdinal_(0, iv, 0);
       ordinal_type pt = targetEPointsRange_(0,iv).first;
       //the value of the basis at the vertex might be different than 1; HGrad basis, so the function is scalar
-      basisCoeffs_(ic,idof) = targetAtTargetEPoints_(ic,pt)/basisAtTargetEPoints_(idof,pt,0);
+      basisCoeffs_(ic,idof) = targetAtTargetEPoints_(ic,pt)/basisAtTargetEPoints_(idof,pt);
     }
   }
 };

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefL2.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefL2.hpp
@@ -114,7 +114,7 @@ struct ComputeBasisCoeffsOnEdges_L2 {
 
     for(ordinal_type iq=0; iq <ordinal_type(targetEWeights_.extent(0)); ++iq)
       for(ordinal_type d=0; d <fieldDim_; ++d)
-        targetTanAtTargetEPoints_(ic,iq) += targetAtTargetEPoints_(ic,offsetTarget_+iq,d)*refEdgesVec_(iedge_,d);
+        targetTanAtTargetEPoints_(ic,iq) += targetAtTargetEPoints_.access(ic,offsetTarget_+iq,d)*refEdgesVec_(iedge_,d);
 
     for(ordinal_type j=0; j <numVertexDofs_; ++j) {
       ordinal_type jdof = computedDofs_(j);
@@ -243,7 +243,7 @@ struct ComputeBasisCoeffsOnFaces_L2 {
 
       for(ordinal_type d=0; d <fieldDim_; ++d)
         for(ordinal_type iq=0; iq <ordinal_type(targetEWeights_.extent(0)); ++iq)
-          targetDofAtTargetEPoints_(ic,iq,0) += coeff[d]*targetAtTargetEPoints_(ic,offsetTarget_+iq,d);
+          targetDofAtTargetEPoints_(ic,iq,0) += coeff[d]*targetAtTargetEPoints_.access(ic,offsetTarget_+iq,d);
 
       for(ordinal_type j=0; j <numVertexEdgeDofs_; ++j) {
         ordinal_type jdof = computedDofs_(j);

--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefContractions.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefContractions.hpp
@@ -127,12 +127,12 @@ namespace Intrepid2 {
           for (size_type qp = 0; qp < npts; ++qp)
             for (ordinal_type i = 0; i < iend; ++i)
               for (ordinal_type j = 0; j < jend; ++j)
-                result() += field(qp, i, j) * data(qp, i, j);
+                result() += field.access(qp, i, j) * data.access(qp, i, j);
         else
           for (size_type qp = 0; qp < npts; ++qp)
             for (ordinal_type i = 0; i < iend; ++i)
               for (ordinal_type j = 0; j < jend; ++j)
-                result() += field(qp, i, j) * data(0, i, j);
+                result() += field.access(qp, i, j) * data.access(0, i, j);
       }
     };
     } //namespace
@@ -197,7 +197,7 @@ namespace Intrepid2 {
         for (size_type qp = 0; qp < npts; ++qp) 
           for (ordinal_type i = 0; i < iend; ++i) 
             for (ordinal_type j = 0; j < jend; ++j) 
-              result() += left(qp, i, j)*right(qp, i, j);
+              result() += left.access(qp, i, j)*right.access(qp, i, j);
       }
     };
     } //namespace

--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefDot.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefDot.hpp
@@ -74,7 +74,7 @@ namespace Intrepid2 {
         value_type tmp(0);
         for(ordinal_type i = 0; i < iend; ++i)
           for(ordinal_type j = 0; j < jend; ++j)
-            tmp += left(i, j)*right(i, j);
+            tmp += left.access(i, j)*right.access(i, j);
         result() = tmp;
       }
     };

--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefTensor.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefTensor.hpp
@@ -55,8 +55,6 @@ namespace Intrepid2 {
                              _output.extent(1), 
                              iter );
 
-        auto result = ( _hasField ? Kokkos::subview(_output, cell, field, point, Kokkos::ALL()) :
-                                    Kokkos::subview(_output, cell,        point, Kokkos::ALL()));
 
         auto left   = Kokkos::subview(_leftInput, cell, point, Kokkos::ALL());
 
@@ -68,11 +66,14 @@ namespace Intrepid2 {
 
         // branch prediction is possible
         if (_isCrossProd3D) {
+          auto result = ( _hasField ? Kokkos::subview(_output, cell, field, point, Kokkos::ALL()) :
+                                      Kokkos::subview(_output, cell,        point, Kokkos::ALL()));
           result(0) = left(1)*right(2) - left(2)*right(1);
           result(1) = left(2)*right(0) - left(0)*right(2);
           result(2) = left(0)*right(1) - left(1)*right(0);
         } else {
-          result(0) = left(0)*right(1) - left(1)*right(0);
+          typename OutputViewType::reference_type result = _hasField ? _output(cell, field, point) : _output(cell, point);
+          result = left(0)*right(1) - left(1)*right(0);
         }
       }
     };

--- a/packages/intrepid2/src/Shared/Intrepid2_Kernels.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Kernels.hpp
@@ -429,7 +429,7 @@ namespace Intrepid2 {
 
       for (ordinal_type i=0;i<iend;++i)
         for (ordinal_type j=0;j<jend;++j)
-          A(i,j) *= alpha;
+          A.access(i,j) *= alpha;
     }
 
     template<typename AViewType,
@@ -444,7 +444,7 @@ namespace Intrepid2 {
       
       for (ordinal_type i=0;i<iend;++i)
         for (ordinal_type j=0;j<jend;++j)
-          A(i,j) /= alpha;
+          A.access(i,j) /= alpha;
     }
 
     template<typename AViewType,
@@ -461,7 +461,7 @@ namespace Intrepid2 {
 
       for (ordinal_type i=0;i<iend;++i)
         for (ordinal_type j=0;j<jend;++j)
-          A(i,j) = alpha*B(i,j);
+          A.access(i,j) = alpha*B.access(i,j);
     }
 
     template<typename AViewType,
@@ -478,7 +478,7 @@ namespace Intrepid2 {
       
       for (ordinal_type i=0;i<iend;++i)
         for (ordinal_type j=0;j<jend;++j)
-          A(i,j) = B(i,j)/alpha;
+          A.access(i,j) = B.access(i,j)/alpha;
     }
 
   }

--- a/packages/intrepid2/src/Shared/Intrepid2_RealSpaceToolsDef.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_RealSpaceToolsDef.hpp
@@ -454,7 +454,7 @@ namespace Intrepid2 {
         auto vec = ( _inVecs.rank() == 2 ? Kokkos::subview(_inVecs, i,    Kokkos::ALL()) :
                                            Kokkos::subview(_inVecs, i, j, Kokkos::ALL()) );
 
-        _normArray(i, j) = RealSpaceTools<>::Serial::vectorNorm(vec, _normType);
+        _normArray.access(i, j) = RealSpaceTools<>::Serial::vectorNorm(vec, _normType);
       }
     };
   }
@@ -1190,7 +1190,7 @@ det( DeterminantArrayViewType detArray, const MatrixViewType inMats );
         auto vec2 = ( r == 2 ? Kokkos::subview(_inVecs2, i,    Kokkos::ALL()) :
                                Kokkos::subview(_inVecs2, i, j, Kokkos::ALL()) );
 
-        _dotArray(i,j) = RealSpaceTools<>::Serial::dot(vec1, vec2);
+        _dotArray.access(i,j) = RealSpaceTools<>::Serial::dot(vec1, vec2);
       }
     };
   }

--- a/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/AnalyticPolynomialsMatchTests.cpp
@@ -689,7 +689,7 @@ namespace
         // relationship between our H^1 basis and our L^2 (see the "Analytic" tests above for explicit polynomial expressions)
         // - nth derivative of H^1 fieldOrdinal i is one half of the (n-1)th derivative of L^2 fieldOrdinal i-1 (for i>=2)
         OutputScalar hgradValue = hgradOutputViewHost(fieldOrdinal,  pointOrdinal,0);
-        OutputScalar hvolValue  =  hvolOutputViewHost(fieldOrdinal-1,pointOrdinal,0);
+        OutputScalar hvolValue  =  hvolOutputViewHost.access(fieldOrdinal-1,pointOrdinal,0);
         
         OutputScalar actual = hgradValue;
         OutputScalar expected = OutputScalar(0.5 * hvolValue);

--- a/packages/intrepid2/unit-test/MonolithicExecutable/TensorViewFunctorTests.cpp
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/TensorViewFunctorTests.cpp
@@ -109,10 +109,10 @@ namespace
     view2_host(0,0,1) = 0.5;
     view2_host(0,0,2) = 3.0;
     
-    tensor_expected_host(0,0,0) = 0;
+    tensor_expected_host.access(0,0,0) = 0;
     for (int d=0; d<space_dim; d++)
     {
-      tensor_expected_host(0,0,0) += view1_host(0,0,d) * view2_host(0,0,d);
+      tensor_expected_host.access(0,0,0) += view1_host(0,0,d) * view2_host(0,0,d);
     }
     Kokkos::deep_copy(view1,           view1_host);
     Kokkos::deep_copy(view2,           view2_host);

--- a/packages/intrepid2/unit-test/Shared/RealSpaceTools/test_01.hpp
+++ b/packages/intrepid2/unit-test/Shared/RealSpaceTools/test_01.hpp
@@ -464,23 +464,19 @@ namespace Intrepid2 {
             const auto iend = ma_x_d_d.extent(0);
             const auto jend = ma_x_d_d.extent(1);
             const auto kend = ma_x_d_d.extent(2);
-            const auto lend = ma_x_d_d.extent(3);
             
             for (size_type i=0;i<iend;++i)
               for (size_type j=0;j<jend;++j)
                 for (size_type k=0;k<kend;++k)
-                  for (size_type l=0;l<lend;++l)
-                    ma_x_d_d_host(i,j,k,l) = Teuchos::ScalarTraits<value_type>::random();
+                  ma_x_d_d_host(i,j,k) = Teuchos::ScalarTraits<value_type>::random();
           }
           {
             const auto iend = va_x_d.extent(0);
             const auto jend = va_x_d.extent(1);
-            const auto kend = va_x_d.extent(2);
             
             for (size_type i=0;i<iend;++i)
               for (size_type j=0;j<jend;++j)
-                for (size_type k=0;k<kend;++k)
-                  va_x_d_host(i,j,k) = Teuchos::ScalarTraits<value_type>::random();
+                va_x_d_host(i,j) = Teuchos::ScalarTraits<value_type>::random();
           }
 
           Kokkos::deep_copy(ma_x_d_d, ma_x_d_d_host);


### PR DESCRIPTION
This PR uses the `access` method to access Dynamic Rank Views with more indices than the view rank.


<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/Intrepid2

## Motivation
Accessing views using the `operator()` with more indices than the view rank will soon result in a runtime error in debug mode

<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->


<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
