### PR TITLE
Panzer: fix interior bc issue

### DIFF
--- a/packages/panzer/adapters-stk/src/Panzer_STK_SetupUtilities.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_SetupUtilities.cpp
@@ -260,7 +260,7 @@ buildBCWorksets(const panzer_stk::STK_Interface & mesh,
   try {
      // grab local entities on this side
      // ...catch any failure...primarily wrong side set and element block info
-     mesh.getMySides(sidesetID,eblockID,sideEntities);
+     mesh.getAllSides(sidesetID,eblockID,sideEntities);
   } 
   catch(STK_Interface::SidesetException & e) {
      std::stringstream ss;
@@ -296,8 +296,7 @@ buildBCWorksets(const panzer_stk::STK_Interface & mesh,
   std::vector<stk::mesh::Entity> elements;
   std::vector<std::size_t> local_cell_ids;
   std::vector<std::size_t> local_side_ids;
-  getSideElements(mesh, eblockID,
-		      sideEntities,local_side_ids,elements);
+  getSideElements(mesh, eblockID,sideEntities,local_side_ids,elements);
 
   // loop over elements of this block
   for(std::size_t elm=0;elm<elements.size();++elm) {
@@ -316,7 +315,7 @@ buildBCWorksets(const panzer_stk::STK_Interface & mesh,
 
       Kokkos::DynRankView<double,PHX::Device> nodes;
       mesh.getElementNodes(local_cell_ids,eblockID,nodes);
-  
+
       return panzer::buildBCWorkset(needs, eblockID, local_cell_ids, local_side_ids, nodes);
   }
   


### PR DESCRIPTION
@trilinos/panzer 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
ORNL team was seeing issues with internal sidesets.

The workset builder was failing to collect all elements/sides for an interior bc if the face/edge was owned by a different mpi process than the cell.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

Closes #13717 

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
ORNL team verified this change fixes their issue.

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
A unit test is under development and will be added this week in a separate PR.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
