### PR TITLE
Teko: Add adaptive sub-block solver option

### DIFF
--- a/packages/teko/src/Teko_AdaptivePreconditionerFactory.cpp
+++ b/packages/teko/src/Teko_AdaptivePreconditionerFactory.cpp
@@ -1,0 +1,277 @@
+// @HEADER
+// *****************************************************************************
+//      Teko: A package for block and physics based preconditioning
+//
+// Copyright 2010 NTESS and the Teko contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#include <ios>
+#include <utility>
+#include "Teko_AdaptivePreconditionerFactory.hpp"
+#include "Teko_ImplicitLinearOp.hpp"
+#include "Teko_PreconditionerState.hpp"
+#include "Teko_Utilities.hpp"
+#include "Teuchos_ENull.hpp"
+
+namespace Teko {
+
+using SizeOrdinalType = AdaptivePreconditionerFactory::SizeOrdinalType;
+
+namespace {
+
+LinearOp buildInverse(const InverseFactory &invFact, const Teuchos::RCP<InverseFactory> &precFact,
+                      const LinearOp &matrix, PreconditionerState &state,
+                      const std::string &opPrefix, size_t i) {
+  std::stringstream ss;
+  ss << opPrefix << "_" << i;
+
+  ModifiableLinearOp &invOp  = state.getModifiableOp(ss.str());
+  ModifiableLinearOp &precOp = state.getModifiableOp("prec_" + ss.str());
+
+  if (precFact != Teuchos::null) {
+    if (precOp == Teuchos::null) {
+      precOp = precFact->buildInverse(matrix);
+      state.addModifiableOp("prec_" + ss.str(), precOp);
+    } else {
+      rebuildInverse(*precFact, matrix, precOp);
+    }
+  }
+
+  if (invOp == Teuchos::null) {
+    if (precOp.is_null()) {
+      invOp = buildInverse(invFact, matrix);
+    } else {
+      invOp = buildInverse(invFact, matrix, precOp);
+    }
+  } else {
+    if (precOp.is_null()) {
+      rebuildInverse(invFact, matrix, invOp);
+    } else {
+      rebuildInverse(invFact, matrix, precOp, invOp);
+    }
+  }
+
+  return invOp;
+}
+
+class AdaptiveLinearOp : public ImplicitLinearOp {
+ public:
+  AdaptiveLinearOp(LinearOp A_, const std::vector<Teuchos::RCP<InverseFactory>> &inverses_,
+                   const std::vector<Teuchos::RCP<InverseFactory>> &preconditioners_,
+                   const std::vector<SizeOrdinalType> &maximumSizes_, PreconditionerState &state_,
+                   AdaptiveSolverSettings settings_)
+      : A(std::move(A_)),
+        inverses(inverses_),
+        preconditioners(preconditioners_),
+        maximumSizes(maximumSizes_),
+        state(state_),
+        settings(settings_) {
+    subblockSize = A->range()->dim();
+  }
+
+  ~AdaptiveLinearOp() override = default;
+
+  VectorSpace range() const override { return A->range(); }
+  VectorSpace domain() const override { return A->domain(); }
+
+  void implicitApply(const MultiVector &x, MultiVector &y, const double alpha = 1.0,
+                     const double beta = 0.0) const override {
+    bool converged                    = true;
+    bool additionalIterationsRequired = false;
+    double residualReduction          = 0.0;
+    bool try_next_solver              = true;
+
+    do {
+      applyOp(A_inv, x, y, alpha, beta);
+
+      residualReduction = computeMaxRelativeNorm(x, y);
+
+      converged = residualReduction <= settings.targetResidualReduction;
+      if (converged) continue;
+
+      if (!has_another_solver()) break;
+
+      try_next_solver = setup_next_solver();
+
+      additionalIterationsRequired = true;
+
+    } while (!converged && try_next_solver);
+
+    successfulApplications++;
+    if (additionalIterationsRequired || !converged) successfulApplications = 0;
+
+    // revert back to initial solver in chain
+    if (successfulApplications >= settings.numAppliesCycle && index != 0) {
+      index                  = 0;
+      successfulApplications = 0;
+      setup_solver();
+    }
+  }
+
+  void describe(Teuchos::FancyOStream &out_arg,
+                const Teuchos::EVerbosityLevel verbLevel) const override {
+    A->describe(out_arg, verbLevel);
+  }
+
+  void initialize_step() const { setup_solver(); }
+
+ private:
+  bool has_another_solver() const { return (index + 1) < inverses.size(); }
+
+  bool setup_solver() const {
+    if (subblockSize > maximumSizes.at(index)) {
+      return false;
+    }
+
+    try {
+      A_inv = buildInverse(*inverses.at(index), preconditioners.at(index), A, state, prefix, index);
+      return true;
+    } catch (std::exception &exc) {
+      return false;
+    }
+  }
+
+  bool setup_next_solver() const {
+    if (!has_another_solver()) return false;
+
+    const auto currentSolverIndex = index;
+    while (has_another_solver()) {
+      index++;
+      const auto success = setup_solver();
+      if (success) return true;
+    }
+
+    index = currentSolverIndex;
+    return false;
+  }
+
+  double computeMaxRelativeNorm(const MultiVector &x, MultiVector &y) const {
+    const double alpha = 1.0;
+    std::vector<double> norms(y->domain()->dim());
+    std::vector<double> rhsNorms(x->domain()->dim());
+
+    auto residual = deepcopy(x);
+    applyOp(A, y, residual, -1.0, alpha);
+
+    Thyra::norms_2<double>(*residual, Teuchos::arrayViewFromVector(norms));
+    Thyra::norms_2<double>(*x, Teuchos::arrayViewFromVector(rhsNorms));
+
+    double maxRelRes = 0.0;
+    for (auto i = 0U; i < norms.size(); ++i) {
+      const auto relRes = rhsNorms[i] == 0 ? norms[i] : norms[i] / rhsNorms[i];
+      maxRelRes         = std::max(relRes, maxRelRes);
+    }
+
+    return maxRelRes;
+  }
+
+  LinearOp A;
+  std::vector<Teuchos::RCP<InverseFactory>> inverses;
+  std::vector<Teuchos::RCP<InverseFactory>> preconditioners;
+  std::vector<SizeOrdinalType> maximumSizes;
+  PreconditionerState &state;
+  AdaptiveSolverSettings settings;
+  SizeOrdinalType subblockSize;
+  mutable size_t index               = 0;
+  mutable int successfulApplications = 0;
+  mutable LinearOp A_inv;
+
+  const std::string prefix = "adaptive";
+};
+
+LinearOp create_adaptive_linear_operator(
+    const LinearOp &A, const std::vector<Teuchos::RCP<InverseFactory>> &inverses,
+    const std::vector<Teuchos::RCP<InverseFactory>> &preconditioners,
+    const std::vector<SizeOrdinalType> &maximumSizes, PreconditionerState &state,
+    const AdaptiveSolverSettings &settings) {
+  ModifiableLinearOp &adaptiveOp = state.getModifiableOp("adaptive_linear_op");
+  if (adaptiveOp == Teuchos::null) {
+    adaptiveOp = Teuchos::rcp(
+        new AdaptiveLinearOp(A, inverses, preconditioners, maximumSizes, state, settings));
+  }
+
+  {
+    auto adaptiveSolver = Teuchos::rcp_dynamic_cast<AdaptiveLinearOp>(adaptiveOp);
+    adaptiveSolver->initialize_step();
+  }
+
+  return adaptiveOp;
+}
+
+}  // namespace
+
+LinearOp AdaptivePreconditionerFactory::buildPreconditionerOperator(
+    LinearOp &lo, PreconditionerState &state) const {
+  return create_adaptive_linear_operator(lo, inverses, preconditioners, maximumSizes, state,
+                                         settings);
+}
+
+void AdaptivePreconditionerFactory::initializeFromParameterList(const Teuchos::ParameterList &pl) {
+  settings.numAppliesCycle         = 100;
+  settings.targetResidualReduction = 0.1;
+
+  if (pl.isParameter("Target Residual Reduction")) {
+    settings.targetResidualReduction = pl.get<double>("Target Residual Reduction");
+  }
+
+  if (pl.isParameter("Number of Successful Applications Before Resetting")) {
+    settings.numAppliesCycle = pl.get<int>("Number of Successful Applications Before Resetting");
+  }
+
+  const std::string inverse_type          = "Inverse Type";
+  const std::string preconditioner_type   = "Preconditioner Type";
+  const std::string maximum_size_subblock = "Maximum Size";
+  auto invLib                             = getInverseLibrary();
+
+  std::set<int> positions;
+  for (const auto &entry : pl) {
+    auto fieldName = entry.first;
+
+    // figure out what the integer is
+    bool isInverse = fieldName.find(inverse_type) != std::string::npos;
+    if (!isInverse) continue;
+
+    int position = -1;
+    std::string inverse, type;
+
+    // figure out position
+    std::stringstream ss(fieldName);
+    ss >> inverse >> type >> position;
+
+    if (position <= 0) {
+      Teko_DEBUG_MSG("Adaptive \"Inverse Type\" must be a (strictly) positive integer", 1);
+    }
+
+    positions.insert(position);
+  }
+
+  inverses.resize(positions.size());
+  preconditioners.resize(positions.size());
+  maximumSizes.resize(positions.size());
+  std::fill(maximumSizes.begin(), maximumSizes.end(), std::numeric_limits<SizeOrdinalType>::max());
+
+  // check for individual solvers
+  for (const auto &position : positions) {
+    auto inverseName        = inverse_type + std::string(" ") + std::to_string(position);
+    auto preconditionerName = preconditioner_type + std::string(" ") + std::to_string(position);
+    auto maximumSizeName    = maximum_size_subblock + std::string(" ") + std::to_string(position);
+
+    // inverse or preconditioner
+    const auto &invStr     = pl.get<std::string>(inverseName);
+    inverses[position - 1] = invLib->getInverseFactory(invStr);
+
+    if (pl.isParameter(preconditionerName)) {
+      const auto &precStr           = pl.get<std::string>(preconditionerName);
+      preconditioners[position - 1] = invLib->getInverseFactory(precStr);
+    }
+
+    if (pl.isParameter(maximumSizeName)) {
+      const auto maxSizeSubblock = pl.get<SizeOrdinalType>(maximumSizeName);
+      maximumSizes[position - 1] = maxSizeSubblock;
+    }
+  }
+}
+
+}  // end namespace Teko

--- a/packages/teko/src/Teko_AdaptivePreconditionerFactory.hpp
+++ b/packages/teko/src/Teko_AdaptivePreconditionerFactory.hpp
@@ -1,0 +1,77 @@
+// @HEADER
+// *****************************************************************************
+//      Teko: A package for block and physics based preconditioning
+//
+// Copyright 2010 NTESS and the Teko contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef __Teko_AdaptivePreconditionerFactory_hpp__
+#define __Teko_AdaptivePreconditionerFactory_hpp__
+
+#include "Teuchos_RCP.hpp"
+#include "Teko_PreconditionerFactory.hpp"
+#include "Teko_Utilities.hpp"
+
+namespace Teko {
+
+struct AdaptiveSolverSettings {
+  int numAppliesCycle            = 100;
+  double targetResidualReduction = 0.1;
+};
+
+/** Adaptive sub-block solver.
+  * Given a user-provided schedule of sub-block solvers, progressively try more sub-block solvers
+  * until sufficient residual reduction has been reached.
+  *
+  \code
+       <Parameter name="Type" type="string" value="Adaptive"/>
+
+       <!-- Target relative residual reduction. Default: 1e-1. -->
+       <Parameter name="Target Residual Reduction" type="double" value="1e-2"/>
+
+       <!-- Specify schedule of inverses:
+         Robustness/cost should increase, with, e.g., 3 more expensive and robust than 2, 2 more
+  expensive and robust than 1, etc.
+       -->
+       <Parameter name="Inverse Type 1" type="string" value="GMRES"/>
+       <Parameter name="Preconditioner Type 1" type="string" value="Jacobi"/>
+       <Parameter name="Inverse Type 2" type="string" value="GMRES"/>
+       <Parameter name="Preconditioner Type 2" type="string" value="MueLu"/>
+       <Parameter name="Inverse Type 3" type="string" value="Amesos2"/>
+
+       <!--
+         If a system has more rows than the given maximum size, avoid constructing the
+  preconditioner/solver at this position. For example, this can be used to prevent a direct solver
+  from being used on a sufficiently large sub-block. Default:
+  std::numeric_limits<SizeOrdinalType>::max().
+       -->
+       <Parameter name="Maximum Size 3" type="long long int" value="10000"/>
+
+       <!-- Number of times to try a solver before resetting to the first solver. Default: 100.-->
+       <Parameter name="Number of Successful Applications Before Resetting" type="int" value="100"/>
+  \endcode
+  */
+class AdaptivePreconditionerFactory : public PreconditionerFactory {
+ public:
+  using SizeOrdinalType = Thyra::Ordinal;
+
+  AdaptivePreconditionerFactory() = default;
+
+  ~AdaptivePreconditionerFactory() override = default;
+
+  LinearOp buildPreconditionerOperator(LinearOp& lo, PreconditionerState& state) const override;
+
+  void initializeFromParameterList(const Teuchos::ParameterList& pl) override;
+
+ private:
+  std::vector<Teuchos::RCP<InverseFactory>> inverses;
+  std::vector<Teuchos::RCP<InverseFactory>> preconditioners;
+  std::vector<SizeOrdinalType> maximumSizes;
+  AdaptiveSolverSettings settings{};
+};
+
+}  // end namespace Teko
+
+#endif

--- a/packages/teko/src/Teko_AdaptivePreconditionerFactory.hpp
+++ b/packages/teko/src/Teko_AdaptivePreconditionerFactory.hpp
@@ -65,6 +65,12 @@ class AdaptivePreconditionerFactory : public PreconditionerFactory {
 
   void initializeFromParameterList(const Teuchos::ParameterList& pl) override;
 
+  const std::vector<Teuchos::RCP<InverseFactory>>& get_inverses() const { return inverses; }
+
+  const std::vector<Teuchos::RCP<InverseFactory>>& get_preconditioners() const {
+    return preconditioners;
+  }
+
  private:
   std::vector<Teuchos::RCP<InverseFactory>> inverses;
   std::vector<Teuchos::RCP<InverseFactory>> preconditioners;

--- a/packages/teko/src/Teko_PreconditionerFactory.cpp
+++ b/packages/teko/src/Teko_PreconditionerFactory.cpp
@@ -24,6 +24,7 @@
 #include "Teko_DiagnosticPreconditionerFactory.hpp"
 #include "Teko_DiagonallyScaledPreconditionerFactory.hpp"
 #include "Teko_DiagonalPreconditionerFactory.hpp"
+#include "Teko_AdaptivePreconditionerFactory.hpp"
 #ifdef TEKO_HAVE_EPETRA
 #include "Teko_ProbingPreconditionerFactory.hpp"
 #endif
@@ -274,6 +275,9 @@ void PreconditionerFactory::initializePrecFactoryBuilder() {
 
   clone = rcp(new AutoClone<IdentityPreconditionerFactory>());
   precFactoryBuilder_.addClone("Identity", clone);
+
+  clone = rcp(new AutoClone<AdaptivePreconditionerFactory>());
+  precFactoryBuilder_.addClone("Adaptive", clone);
 
 #if defined(Teko_ENABLE_Isorropia) && defined(TEKO_HAVE_EPETRA)
   clone = rcp(new AutoClone<ProbingPreconditionerFactory>());

--- a/packages/teko/tests/CMakeLists.txt
+++ b/packages/teko/tests/CMakeLists.txt
@@ -220,6 +220,16 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   NUM_MPI_PROCS 1
   )
 
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  AdaptiveLinearOp_test
+  SOURCES
+    unit_tests/tAdaptivePreconditionerFactory.cpp
+    ${UNIT_TEST_DRIVER}
+  COMM serial mpi
+  ARGS ${SERIAL_ARGS_STRING}
+  NUM_MPI_PROCS 1
+  )
+
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   DiagonallyScaledPreconditioner
   SOURCES

--- a/packages/teko/tests/unit_tests/tAdaptivePreconditionerFactory.cpp
+++ b/packages/teko/tests/unit_tests/tAdaptivePreconditionerFactory.cpp
@@ -1,0 +1,131 @@
+// @HEADER
+// *****************************************************************************
+//      Teko: A package for block and physics based preconditioning
+//
+// Copyright 2010 NTESS and the Teko contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#include "Teko_Config.h"
+
+#include <Teuchos_ConfigDefs.hpp>
+#include <Teuchos_UnitTestHarness.hpp>
+#include <Teuchos_RCP.hpp>
+#include <Teuchos_TimeMonitor.hpp>
+
+#include <string>
+#include <iostream>
+
+#include "Teko_StratimikosFactory.hpp"
+#include "Tpetra_Map.hpp"
+#include "Tpetra_CrsMatrix.hpp"
+
+// Teko-Package includes
+#include "Teko_ConfigDefs.hpp"
+#include "Teko_Utilities.hpp"
+#include "Teko_DiagnosticLinearOp.hpp"
+#include "Teko_AdaptivePreconditionerFactory.hpp"
+#include "Teko_PreconditionerInverseFactory.hpp"
+#include "Teko_PreconditionerLinearOp.hpp"
+
+#include "Thyra_TpetraLinearOp.hpp"
+
+#include "Teuchos_AbstractFactoryStd.hpp"
+
+#include "Stratimikos_DefaultLinearSolverBuilder.hpp"
+
+// Test-rig
+
+typedef Teko::ST ST;
+typedef Teko::LO LO;
+typedef Teko::GO GO;
+typedef Teko::NT NT;
+
+using Teuchos::ParameterList;
+using Teuchos::rcp;
+using Teuchos::RCP;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::rcpFromRef;
+
+const RCP<Thyra::LinearOpBase<ST> > buildSystem(const Teuchos::RCP<const Teuchos::Comm<int> > comm,
+                                                GO size) {
+  RCP<Tpetra::Map<LO, GO, NT> > map = rcp(new Tpetra::Map<LO, GO, NT>(size, 0, comm));
+
+  RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > mat = Tpetra::createCrsMatrix<ST, LO, GO, NT>(map, 3);
+
+  ST values[] = {-1.0, 2.0, -1.0};
+  GO iTemp[]  = {-1, 0, 1}, indices[3];
+  ST* vPtr;
+  GO* iPtr;
+  for (size_t i = 0; i < map->getLocalNumElements(); i++) {
+    int count = 3;
+    GO gid    = map->getGlobalElement(i);
+
+    vPtr = values;
+    iPtr = indices;
+
+    indices[0] = gid + iTemp[0];
+    indices[1] = gid + iTemp[1];
+    indices[2] = gid + iTemp[2];
+
+    if (gid == 0) {
+      vPtr  = &values[1];
+      iPtr  = &indices[1];
+      count = 2;
+    } else if (gid == map->getMaxAllGlobalIndex())
+      count = 2;
+
+    mat->insertGlobalValues(gid, Teuchos::ArrayView<GO>(iPtr, count),
+                            Teuchos::ArrayView<ST>(vPtr, count));
+  }
+
+  mat->fillComplete();
+
+  return Thyra::tpetraLinearOp<ST, LO, GO, NT>(
+      Thyra::tpetraVectorSpace<ST, LO, GO, NT>(mat->getRangeMap()),
+      Thyra::tpetraVectorSpace<ST, LO, GO, NT>(mat->getDomainMap()), mat);
+}
+
+TEUCHOS_UNIT_TEST(tAdaptivePreconditionerFactory, relative_residual_test) {
+  // build global (or serial communicator)
+  RCP<const Teuchos::Comm<int> > Comm = Tpetra::getDefaultComm();
+
+  // build stratimikos factory, adding Teko's version
+  Stratimikos::DefaultLinearSolverBuilder stratFactory;
+  stratFactory.setPreconditioningStrategyFactory(
+      Teuchos::abstractFactoryStd<Thyra::PreconditionerFactoryBase<double>,
+                                  Teko::StratimikosFactory>(),
+      "Teko");
+  RCP<ParameterList> params = Teuchos::rcp(new ParameterList(*stratFactory.getValidParameters()));
+  ParameterList& tekoList   = params->sublist("Preconditioner Types").sublist("Teko");
+  tekoList.set("Write Block Operator", false);
+  tekoList.set("Test Block Operator", false);
+  tekoList.set("Strided Blocking", "1 1");
+  ParameterList& ifl = tekoList.sublist("Inverse Factory Library");
+
+  double targetReduction = 1e-4;
+  ifl.sublist("adapt").set("Type", "Adaptive");
+  ifl.sublist("adapt").set("Inverse Type 1", "Ifpack2");
+  ifl.sublist("adapt").set("Inverse Type 2", "Amesos2");
+
+  RCP<Teko::InverseLibrary> invLibrary = Teko::InverseLibrary::buildFromParameterList(ifl);
+  RCP<Teko::InverseFactory> invFact    = invLibrary->getInverseFactory("adapt");
+  Teko::LinearOp A                     = buildSystem(Comm, 1000);
+  Teko::ModifiableLinearOp invA        = Teko::buildInverse(*invFact, A);
+
+  Teko::MultiVector b = Thyra::createMember(A->domain());
+  Teko::MultiVector x = Thyra::createMember(A->range());
+  Thyra::randomize(-1.0, 1.0, b.ptr());
+
+  Teko::MultiVector residual = Teko::deepcopy(b);
+
+  Teko::applyOp(invA, b, x);
+  Teko::applyOp(A, x, residual, -1.0, 1.0);
+
+  const auto resNorm    = Teko::norm_2(residual, 0);
+  const auto rhsNorm    = Teko::norm_2(b, 0);
+  const auto relResNorm = resNorm / rhsNorm;
+
+  success = relResNorm <= targetReduction;
+}


### PR DESCRIPTION
This adds a feature in Teko to use an adaptive sub-block solver.

If the relative residual is larger than a user-specified constant, $`\dfrac{\vert\vert b - A M_A^{-1} b\vert\vert}{\vert\vert b\vert\vert} > \varepsilon`$, then the next preconditioner/solver in the sequence is used. After a user specified number of steps, the adaptive sub-block solver transitions back to the initial solver.

Example input:
```xml
  <ParameterList name="temperature_solver">
    <Parameter name="Type" type="string" value="Adaptive"/>
    <Parameter name="Target Residual Reduction" type="double" value="0.1"/>

    <!-- GMRES + DD(0)-ILU(0) -->
    <Parameter name="Inverse Type 1" type="string" value="gmres"/>
    <Parameter name="Preconditioner Type 1" type="string" value="dd_0_ilu_0_pc"/>

    <!-- GMRES + DD(1)-ILU(1) -->
    <Parameter name="Inverse Type 2" type="string" value="gmres"/>
    <Parameter name="Preconditioner Type 2" type="string" value="dd_1_ilu_1_pc"/>

    <!-- GMRES + DD(2)-ILU(2) -->
    <Parameter name="Inverse Type 3" type="string" value="gmres"/>
    <Parameter name="Preconditioner Type 3" type="string" value="dd_2_ilu_2_pc"/>
  </ParameterList>
```