### PR TITLE
Tpetra: updates for disabled kokkos deprecated code

### DIFF
--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
@@ -562,7 +562,7 @@ namespace Tpetra {
     dev_row_view_t new_rowmap("new_rowmap", nrows+1);
     const auto blocks_per_row = nrows / blockSize; // assumes square matrix
     dev_row_view_t active_block_row_map("active_block_row_map", blocks_per_row + 1);
-    const int max_threads = execution_space::concurrency();
+    const int max_threads = execution_space().concurrency();
     assert(blockSize > 1);
     assert(nrows % blockSize == 0);
     const int mem_level = 1;

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -59,7 +59,7 @@ namespace Tpetra {
 namespace { // (anonymous)
 
   template<class T, class BinaryFunction>
-  T atomic_binary_function_update (volatile T* const dest,
+  T atomic_binary_function_update (T* const dest,
                                    const T& inputVal,
                                    BinaryFunction f)
   {
@@ -2772,7 +2772,7 @@ namespace Tpetra {
             //const ST newVal = f (rowVals[offset], newVals[j]);
             //Kokkos::atomic_assign (&rowVals[offset], newVal);
 
-            volatile ST* const dest = &rowVals[offset];
+            ST* const dest = &rowVals[offset];
             (void) atomic_binary_function_update (dest, newVals[j], f);
           }
           else {
@@ -2816,7 +2816,7 @@ namespace Tpetra {
               //const ST newVal = f (rowVals[offset], newVals[j]);
               //Kokkos::atomic_assign (&rowVals[offset], newVal);
 
-              volatile ST* const dest = &rowVals[offset];
+              ST* const dest = &rowVals[offset];
               (void) atomic_binary_function_update (dest, newVals[j], f);
             }
             else {
@@ -2881,7 +2881,7 @@ namespace Tpetra {
             //const ST newVal = f (rowVals[offset], newVals[j]);
             //Kokkos::atomic_assign (&rowVals[offset], newVal);
 
-            volatile ST* const dest = &rowVals[offset];
+            ST* const dest = &rowVals[offset];
             (void) atomic_binary_function_update (dest, newVals[j], f);
           }
           else {
@@ -2924,7 +2924,7 @@ namespace Tpetra {
               //const ST newVal = f (rowVals[offset], newVals[j]);
               //Kokkos::atomic_assign (&rowVals[offset], newVal);
 
-              volatile ST* const dest = &rowVals[offset];
+              ST* const dest = &rowVals[offset];
               (void) atomic_binary_function_update (dest, newVals[j], f);
             }
             else {
@@ -8513,7 +8513,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       auto PermuteFromLIDs_d = PermuteFromLIDs.view_device();
 
       Details::unpackAndCombineIntoCrsArrays(
-                                     *this, 
+                                     *this,
                                      RemoteLIDs_d,
                                      destMat->imports_.view_device(),                //hostImports
                                      destMat->numImportPacketsPerLID_.view_device(), //numImportPacketsPerLID
@@ -8717,7 +8717,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       Kokkos::View<int*,device_type>    TargetPids_d;
   
       Details::unpackAndCombineIntoCrsArrays(
-                                     *this, 
+                                     *this,
                                      RemoteLIDs_d,
                                      destMat->imports_.view_device(),                //hostImports
                                      destMat->numImportPacketsPerLID_.view_device(), //numImportPacketsPerLID

--- a/packages/tpetra/core/src/Tpetra_Details_checkLaunchBlocking.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_checkLaunchBlocking.hpp
@@ -17,7 +17,7 @@
 
 namespace Tpetra {
 namespace Details {
-#ifdef HAVE_TPETRACORE_CUDA
+#if defined(HAVE_TPETRACORE_CUDA) && defined(KOKKOS_ENABLE_DEPRECATED_CODE_4)
   //Verify that for pre-Pascal CUDA architectures, $CUDA_LAUNCH_BLOCKING == 1
   inline void checkOldCudaLaunchBlocking()
   {

--- a/packages/tpetra/core/src/Tpetra_Details_crsMatrixAssembleElement.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_crsMatrixAssembleElement.hpp
@@ -242,7 +242,7 @@ crsMatrixReplaceValues_sortedSortedLinear (const SparseMatrixType& A,
         // compiler might not need to insert a branch here.  This
         // could help vectorization, if vectorization is possible.
         if (forceAtomic) {
-          Kokkos::atomic_assign (&(row_view.value(offset)), vals[perm_index]);
+          Kokkos::atomic_store (&(row_view.value(offset)), vals[perm_index]);
         }
         else {
           row_view.value(offset) += vals[perm_index];

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_decl.hpp
@@ -195,7 +195,7 @@ unpackAndCombineWithOwningPIDsCount (
 ///
 /// Note: This method does the work previously done in unpackAndCombineWithOwningPIDsCount,
 /// namely, calculating the local number of nonzeros, and allocates CRS
-/// arrays of the correct sizes.
+/// arrays of the correct sizes
 
 template<typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
 void
@@ -203,25 +203,40 @@ unpackAndCombineIntoCrsArrays (
     const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> & sourceMatrix,
     const Kokkos::View<LocalOrdinal const *, 
           Kokkos::Device<typename Node::device_type::execution_space,
-                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void>,
+                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          >,
     const Kokkos::View<const char*, 
           Kokkos::Device<typename Node::device_type::execution_space,
                          Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
-          ,void, void >,
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          >,
     const Kokkos::View<const size_t*, 
           Kokkos::Device<typename Node::device_type::execution_space,
                          Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
-          ,void, void >,
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          >,
     const size_t numSameIDs,
     const Kokkos::View<LocalOrdinal const *, 
           Kokkos::Device<typename Node::device_type::execution_space,
-                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void>,
+                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          >,
     const Kokkos::View<LocalOrdinal const *, 
           Kokkos::Device<typename Node::device_type::execution_space,
-                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void>,
+                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          >,
     size_t TargetNumRows,
     const int MyTargetPID,
     Teuchos::ArrayRCP<size_t>& CRS_rowptr,
@@ -236,25 +251,40 @@ unpackAndCombineIntoCrsArrays (
     const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> & sourceMatrix,
     const Kokkos::View<LocalOrdinal const *, 
           Kokkos::Device<typename Node::device_type::execution_space,
-                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void>,
+                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          >,
     const Kokkos::View<const char*, 
           Kokkos::Device<typename Node::device_type::execution_space,
                          Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
-          ,void, void >,
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          >,
     const Kokkos::View<const size_t*, 
           Kokkos::Device<typename Node::device_type::execution_space,
                          Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
-          ,void, void >,
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          >,
     const size_t numSameIDs,
     const Kokkos::View<LocalOrdinal const *, 
           Kokkos::Device<typename Node::device_type::execution_space,
-                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void>,
+                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          >,
     const Kokkos::View<LocalOrdinal const *, 
           Kokkos::Device<typename Node::device_type::execution_space,
-                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void>,
+                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          >,
     size_t TargetNumRows,
     const int MyTargetPID,
     Kokkos::View<size_t*,typename Node::device_type>& /*crs_rowptr_d*/,

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
@@ -714,8 +714,13 @@ size_t
 unpackAndCombineWithOwningPIDsCount(
   const LocalMatrix& local_matrix,
   const typename PackTraits<typename LocalMatrix::ordinal_type>::input_array_type permute_from_lids,
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   const Kokkos::View<const char*, BufferDeviceType, void, void>& imports,
   const Kokkos::View<const size_t*, BufferDeviceType, void, void>& num_packets_per_lid,
+#else
+  const Kokkos::View<const char*, BufferDeviceType>& imports,
+  const Kokkos::View<const size_t*, BufferDeviceType>& num_packets_per_lid,
+#endif
   const size_t num_same_ids)
 {
   using Kokkos::parallel_reduce;
@@ -928,8 +933,13 @@ unpackAndCombineIntoCrsArrays2(
     const Kokkos::View<size_t*,typename LocalMap::device_type>& new_start_row,
     const typename PackTraits<size_t>::input_array_type& offsets,
     const typename PackTraits<typename LocalMap::local_ordinal_type>::input_array_type& import_lids,
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
     const Kokkos::View<const char*, BufferDeviceType, void, void>& imports,
     const Kokkos::View<const size_t*, BufferDeviceType, void, void>& num_packets_per_lid,
+#else
+    const Kokkos::View<const char*, BufferDeviceType>& imports,
+    const Kokkos::View<const size_t*, BufferDeviceType>& num_packets_per_lid,
+#endif
     const LocalMatrix& /* local_matrix */,
     const LocalMap /*& local_col_map*/,
     const int my_pid,
@@ -1003,8 +1013,13 @@ unpackAndCombineIntoCrsArrays(
     const LocalMatrix & local_matrix,
     const LocalMap & local_col_map,
     const typename PackTraits<typename LocalMap::local_ordinal_type>::input_array_type& import_lids,
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
     const Kokkos::View<const char*, BufferDeviceType, void, void>& imports,
     const Kokkos::View<const size_t*, BufferDeviceType, void, void>& num_packets_per_lid,
+#else
+    const Kokkos::View<const char*, BufferDeviceType>& imports,
+    const Kokkos::View<const size_t*, BufferDeviceType>& num_packets_per_lid,
+#endif
     const typename PackTraits<typename LocalMap::local_ordinal_type>::input_array_type& permute_to_lids,
     const typename PackTraits<typename LocalMap::local_ordinal_type>::input_array_type& permute_from_lids,
     const typename PackTraits<size_t>::output_array_type& tgt_rowptr,
@@ -1357,19 +1372,31 @@ unpackAndCombineWithOwningPIDsCount (
   using kokkos_device_type = Kokkos::Device<typename Node::device_type::execution_space,
                          Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>;
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   Kokkos::View<LocalOrdinal const *, kokkos_device_type, void, void > permute_from_lids_d =
+#else
+  Kokkos::View<LocalOrdinal const *, kokkos_device_type> permute_from_lids_d =
+#endif
     create_mirror_view_from_raw_host_array (DT (),
                                             permuteFromLIDs.getRawPtr (),
                                             permuteFromLIDs.size (), true,
                                             "permute_from_lids");
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   Kokkos::View<const char*, kokkos_device_type, void, void > imports_d =
+#else
+  Kokkos::View<const char*, kokkos_device_type> imports_d =
+#endif
     create_mirror_view_from_raw_host_array (DT (),
                                             imports.getRawPtr (),
                                             imports.size (), true,
                                             "imports");
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   Kokkos::View<const size_t*, kokkos_device_type, void, void > num_packets_per_lid_d =
+#else
+  Kokkos::View<const size_t*, kokkos_device_type> num_packets_per_lid_d =
+#endif
     create_mirror_view_from_raw_host_array (DT (),
                                             numPacketsPerLID.getRawPtr (),
                                             numPacketsPerLID.size (), true,
@@ -1401,25 +1428,40 @@ unpackAndCombineIntoCrsArrays (
     const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> & sourceMatrix,
     const Kokkos::View<LocalOrdinal const *,
           Kokkos::Device<typename Node::device_type::execution_space,
-                        Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void > import_lids_d,
+                        Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          > import_lids_d,
     const Kokkos::View<const char*,
           Kokkos::Device<typename Node::device_type::execution_space,
-                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void > imports_d,
+                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          > imports_d,
     const Kokkos::View<const size_t*,
           Kokkos::Device<typename Node::device_type::execution_space,
-                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void > num_packets_per_lid_d,
+                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          > num_packets_per_lid_d,
     const size_t numSameIDs,
     const Kokkos::View<LocalOrdinal const *,
           Kokkos::Device<typename Node::device_type::execution_space,
-                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void > permute_to_lids_d,
+                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          > permute_to_lids_d,
     const Kokkos::View<LocalOrdinal const *,
           Kokkos::Device<typename Node::device_type::execution_space,
-                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void > permute_from_lids_d,
+                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          > permute_from_lids_d,
     size_t TargetNumRows,
     const int MyTargetPID,
     Kokkos::View<size_t*,typename Node::device_type> &crs_rowptr_d,
@@ -1576,25 +1618,40 @@ unpackAndCombineIntoCrsArrays (
     const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> & sourceMatrix,
     const Kokkos::View<LocalOrdinal const *,
           Kokkos::Device<typename Node::device_type::execution_space,
-                        Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void > import_lids_d,
+                        Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          > import_lids_d,
     const Kokkos::View<const char*,
           Kokkos::Device<typename Node::device_type::execution_space,
-                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void > imports_d,
+                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          > imports_d,
     const Kokkos::View<const size_t*,
           Kokkos::Device<typename Node::device_type::execution_space,
-                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void > num_packets_per_lid_d,
+                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          > num_packets_per_lid_d,
     const size_t numSameIDs,
     const Kokkos::View<LocalOrdinal const *,
           Kokkos::Device<typename Node::device_type::execution_space,
-                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void > permute_to_lids_d,
+                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          > permute_to_lids_d,
     const Kokkos::View<LocalOrdinal const *,
           Kokkos::Device<typename Node::device_type::execution_space,
-                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>,
-          void, void > permute_from_lids_d,
+                         Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename Node::device_type>>
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+          , void, void
+#endif
+          > permute_from_lids_d,
     size_t TargetNumRows,
     const int MyTargetPID,
     Teuchos::ArrayRCP<size_t>& CRS_rowptr,
@@ -1809,7 +1866,7 @@ unpackAndCombineIntoCrsArrays (
 } // namespace Details
 } // namespace Tpetra
 
-#define TPETRA_DETAILS_UNPACKCRSMATRIXANDCOMBINE_INSTANT( ST, LO, GO, NT ) \
+#define TPETRA_DETAILS_UNPACKCRSMATRIXANDCOMBINE_INSTANT_KOKKOS_DEPRECATED_CODE_4_ON( ST, LO, GO, NT ) \
   template void \
   Details::unpackCrsMatrixAndCombine<ST, LO, GO, NT> ( \
     const CrsMatrix<ST, LO, GO, NT>&, \
@@ -1899,5 +1956,94 @@ unpackAndCombineIntoCrsArrays (
     Teuchos::ArrayRCP<ST>&, \
     const Teuchos::ArrayView<const int>&, \
     Teuchos::Array<int>&);
+
+#define TPETRA_DETAILS_UNPACKCRSMATRIXANDCOMBINE_INSTANT_KOKKOS_DEPRECATED_CODE_4_OFF( ST, LO, GO, NT ) \
+  template void \
+  Details::unpackCrsMatrixAndCombine<ST, LO, GO, NT> ( \
+    const CrsMatrix<ST, LO, GO, NT>&, \
+    const Teuchos::ArrayView<const char>&, \
+    const Teuchos::ArrayView<const size_t>&, \
+    const Teuchos::ArrayView<const LO>&, \
+    size_t, \
+    CombineMode); \
+  template size_t \
+  Details::unpackAndCombineWithOwningPIDsCount<ST, LO, GO, NT> ( \
+    const CrsMatrix<ST, LO, GO, NT> &, \
+    const Teuchos::ArrayView<const LO> &, \
+    const Teuchos::ArrayView<const char> &, \
+    const Teuchos::ArrayView<const size_t>&, \
+    size_t, \
+    CombineMode, \
+    size_t, \
+    const Teuchos::ArrayView<const LO>&, \
+    const Teuchos::ArrayView<const LO>&); \
+  template void \
+  Details::unpackCrsMatrixAndCombineNew<ST, LO, GO, NT> ( \
+    const CrsMatrix<ST, LO, GO, NT>&, \
+    Kokkos::DualView<char*, typename DistObject<char, LO, GO, NT>::buffer_device_type>, \
+    Kokkos::DualView<size_t*, typename DistObject<char, LO, GO, NT>::buffer_device_type>, \
+    const Kokkos::DualView<const LO*, typename DistObject<char, LO, GO, NT>::buffer_device_type>&, \
+    const size_t, \
+    const CombineMode); \
+  template void \
+  Details::unpackAndCombineIntoCrsArrays<ST, LO, GO, NT> ( \
+    const CrsMatrix<ST, LO, GO, NT> &, \
+    const Kokkos::View<LO const *, \
+                       Kokkos::Device<typename NT::device_type::execution_space, \
+                                      Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename NT::device_type>>>, \
+    const Kokkos::View<const char*, \
+                       Kokkos::Device<typename NT::device_type::execution_space, \
+                                      Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename NT::device_type>>>, \
+    const Kokkos::View<const size_t*, \
+                       Kokkos::Device<typename NT::device_type::execution_space, \
+                                      Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename NT::device_type>>>, \
+    const size_t, \
+    const Kokkos::View<LO const *, \
+                       Kokkos::Device<typename NT::device_type::execution_space, \
+                                      Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename NT::device_type>>>, \
+    const Kokkos::View<LO const *, \
+                       Kokkos::Device<typename NT::device_type::execution_space, \
+                                      Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename NT::device_type>>>, \
+    size_t, \
+    const int, \
+    Kokkos::View<size_t*,typename NT::device_type>&, \
+    Kokkos::View<GO*,typename NT::device_type>&, \
+    Kokkos::View<typename CrsMatrix<ST, LO, GO, NT>::impl_scalar_type*,typename NT::device_type>&, \
+    const Teuchos::ArrayView<const int>&, \
+    Kokkos::View<int*,typename NT::device_type>&); \
+  template void \
+  Details::unpackAndCombineIntoCrsArrays<ST, LO, GO, NT> ( \
+    const CrsMatrix<ST, LO, GO, NT> &, \
+    const Kokkos::View<LO const *, \
+                       Kokkos::Device<typename NT::device_type::execution_space, \
+                                      Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename NT::device_type>>>, \
+    const Kokkos::View<const char*, \
+                       Kokkos::Device<typename NT::device_type::execution_space, \
+                                      Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename NT::device_type>>>, \
+    const Kokkos::View<const size_t*, \
+                       Kokkos::Device<typename NT::device_type::execution_space, \
+                                      Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename NT::device_type>>>, \
+    const size_t, \
+    const Kokkos::View<LO const *, \
+                       Kokkos::Device<typename NT::device_type::execution_space, \
+                                      Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename NT::device_type>>>, \
+    const Kokkos::View<LO const *, \
+                       Kokkos::Device<typename NT::device_type::execution_space, \
+                                      Tpetra::Details::DefaultTypes::comm_buffer_memory_space<typename NT::device_type>>>, \
+    size_t, \
+    const int, \
+    Teuchos::ArrayRCP<size_t>&, \
+    Teuchos::ArrayRCP<GO>&, \
+    Teuchos::ArrayRCP<ST>&, \
+    const Teuchos::ArrayView<const int>&, \
+    Teuchos::Array<int>&);
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+#define TPETRA_DETAILS_UNPACKCRSMATRIXANDCOMBINE_INSTANT( ST, LO, GO, NT ) \
+  TPETRA_DETAILS_UNPACKCRSMATRIXANDCOMBINE_INSTANT_KOKKOS_DEPRECATED_CODE_4_ON( ST, LO, GO, NT )
+#else
+#define TPETRA_DETAILS_UNPACKCRSMATRIXANDCOMBINE_INSTANT( ST, LO, GO, NT ) \
+  TPETRA_DETAILS_UNPACKCRSMATRIXANDCOMBINE_INSTANT_KOKKOS_DEPRECATED_CODE_4_OFF( ST, LO, GO, NT )
+#endif
 
 #endif // TPETRA_DETAILS_UNPACKCRSMATRIXANDCOMBINE_DEF_HPP


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Compatibility updates to resolve compilation errors when setting `Kokkos_ENABLE_DEPRECATED_CODE_4=OFF`

### Summary of changes
* call `concurrency()` as non-static member function , see https://github.com/kokkos/kokkos/issues/5655
* replace `Kokkos::atomic_assign` with `Kokkos::atomic_store` , see https://github.com/kokkos/kokkos/pull/7458
* drop `volatile` qualifier , no longer needed see https://github.com/kokkos/kokkos/pull/5412
  * also see https://github.com/kokkos/kokkos/issues/4077, https://github.com/kokkos/kokkos/pull/4931, https://github.com/kokkos/kokkos/issues/1554, https://github.com/kokkos/kokkos/issues/5194, https://github.com/kokkos/kokkos/pull/5215
* update DualView interface (type) used in `unpackAndCombineIntoCrsArrays` function input args , see https://github.com/kokkos/kokkos/issues/6154 and https://github.com/kokkos/kokkos/pull/6120
* guard `checkOldCudaLaunchBlocking()` with `KOKKOS_ENABLE_DEPRECATED_CODE_4` , internal use of `Kokkos::Cuda::device_arch()` deprecated in https://github.com/kokkos/kokkos/pull/6710

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
Confirmed compilation successful and tests pass in gcc/12 build with Serial+OpenMP backends enabled

Configuration snip:
```bash
export TRILINOS_DIR=<path-to-source>
cmake \
-G"Ninja" \
-D CMAKE_CXX_FLAGS:STRING="-g" \
-D CMAKE_BUILD_TYPE:STRING=RELEASE \
-D BUILD_SHARED_LIBS:BOOL=OFF \
\
-D TPL_ENABLE_MPI:BOOL=ON \
  -D CMAKE_CXX_COMPILER:FILEPATH="`which mpicxx`" \
  -D CMAKE_C_COMPILER:FILEPATH="`which mpicc`" \
  -D CMAKE_Fortran_COMPILER:FILEPATH="`which mpifort`" \
\
-D TPL_ENABLE_BLAS:STRING=ON \
  -D BLAS_LIBRARY_DIRS:FILEPATH=${BLAS_PATH}/lib \
  -D BLAS_LIBRARY_NAMES:STRING="openblas" \
  -D TPL_BLAS_LIBRARIES:PATH="${BLAS_LIBRARIES}" \
-D TPL_ENABLE_LAPACK:STRING=ON \
  -D LAPACK_INCLUDE_DIRS:FILEPATH="${LAPACK_PATH}/include" \
  -D LAPACK_LIBRARY_DIRS:FILEPATH=${LAPACK_PATH}/lib \
  -D LAPACK_LIBRARY_NAMES:STRING="openblas" \
  -D TPL_LAPACK_LIBRARIES:PATH="${LAPACK_LIBRARIES}" \
\
-D TPL_ENABLE_METIS:BOOL=ON \
  -D METIS_INCLUDE_DIRS:PATH="${METIS_PATH}/include" \
  -D METIS_LIBRARY_DIRS:PATH="${METIS_PATH}/lib" \
  -D METIS_LIBRARY_NAMES:STRING="metis" \
-D TPL_ENABLE_ParMETIS:BOOL=ON \
  -D ParMETIS_INCLUDE_DIRS:PATH="${PARMETIS_PATH}/include;${METIS_PATH}/include" \
  -D ParMETIS_LIBRARY_DIRS:PATH="${PARMETIS_PATH}/lib" \
  -D ParMETIS_LIBRARY_NAMES:STRING="parmetis" \
-D TPL_ENABLE_Scotch:BOOL=OFF \
  -D Scotch_INCLUDE_DIRS:PATH="${SCOTCH_PATH}/include" \
  -D Scotch_LIBRARY_DIRS:PATH="${SCOTCH_PATH}/lib" \
  -D Scotch_LIBRARY_NAMES:STRING="scotch;scotcherr" \
-D TPL_ENABLE_SuperLU:BOOL=ON \
  -D SuperLU_INCLUDE_DIRS:FILEPATH="${SUPERLU_PATH}/include" \
  -D SuperLU_LIBRARY_DIRS:FILEPATH="${SUPERLU_PATH}/lib" \
  -D SuperLU_LIBRARY_NAMES:STRING="superlu" \
-D TPL_ENABLE_UMFPACK:STRING=ON \
  -D UMFPACK_INCLUDE_DIRS:PATH="${SS_PATH}/include" \
  -D UMFPACK_LIBRARY_DIRS:PATH="${SS_PATH}/lib" \
  -D UMFPACK_LIBRARY_NAMES:STRING="umfpack;suitesparseconfig;amd" \
\
-D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
-D Trilinos_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_COMPLEX_DOUBLE:BOOL=ON \
-D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
-D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
\
-D Trilinos_ENABLE_OpenMP:BOOL=ON \
-D Trilinos_ENABLE_Kokkos:BOOL=ON \
  -D Kokkos_ENABLE_OPENMP:BOOL=ON \
  -D Kokkos_ENABLE_SERIAL:BOOL=ON \
  -D Kokkos_ENABLE_EXAMPLES:BOOL=OFF \
  -D Kokkos_ENABLE_TESTS:BOOL=OFF \
  -D Kokkos_ENABLE_DEPRECATED_CODE_4:BOOL=OFF \
  -D KokkosKernels_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_Epetra:BOOL=OFF \
-D Trilinos_ENABLE_Tpetra:BOOL=ON \
  -D Tpetra_INST_INT_INT:BOOL=ON \
  -D Tpetra_INST_SERIAL:BOOL=ON \
  -D Tpetra_INST_OPENMP:BOOL=ON \
  -D Tpetra_ENABLE_TESTS:BOOL=ON \
${TRILINOS_DIR}
```

<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
