### PR TITLE
NOX: Make `Solver::SingleStep` independent on the group's `getNewton()` implementation

### DIFF
--- a/packages/nox/src/NOX_Solver_SingleStep.C
+++ b/packages/nox/src/NOX_Solver_SingleStep.C
@@ -132,7 +132,6 @@ bool NOX::Solver::SingleStep::try_step()
   // Pick Jacobian matrix to use
   Teuchos::RCP<NOX::Abstract::Group> jacobian = updateJacobian ? solnPtr : frozenJacobianPtr;
 
-  // Reuse memory in group instead of new allocation for dir
   NOX::Abstract::Vector& dir = *dirVecPtr;
   const auto ls_status = jacobian->applyJacobianInverse(paramsPtr->sublist("Single Step Solver").sublist("Linear Solver"),
                                                         solnPtr->getF(),

--- a/packages/nox/src/NOX_Solver_SingleStep.C
+++ b/packages/nox/src/NOX_Solver_SingleStep.C
@@ -26,7 +26,8 @@ SingleStep(const Teuchos::RCP<NOX::Abstract::Group>& xGrp,
   updateJacobian(true),
   printNorms(false),
   computeRelativeNorm(false),
-  normF_0(0.0)
+  normF_0(0.0),
+  dirVecPtr(xGrp->getX().clone(ShapeCopy)) // stores the result of explicit call applyJacobianInverse()
 {
   Teuchos::ParameterList validParams;
   validParams.set("Ignore Linear Solver Failures",false,"Return the step as converged, ignoring the returned linear solver status.");
@@ -132,7 +133,7 @@ bool NOX::Solver::SingleStep::try_step()
   Teuchos::RCP<NOX::Abstract::Group> jacobian = updateJacobian ? solnPtr : frozenJacobianPtr;
 
   // Reuse memory in group instead of new allocation for dir
-  NOX::Abstract::Vector& dir = const_cast<NOX::Abstract::Vector&>(solnPtr->getNewton());
+  NOX::Abstract::Vector& dir = *dirVecPtr;
   const auto ls_status = jacobian->applyJacobianInverse(paramsPtr->sublist("Single Step Solver").sublist("Linear Solver"),
                                                         solnPtr->getF(),
                                                         dir);
@@ -248,7 +249,7 @@ void NOX::Solver::SingleStep::printUpdate()
       if (!solnPtr->isF())
         solnPtr->computeF();
       double normF = solnPtr->getF().norm();
-      double normDx = solnPtr->getNewtonPtr()->norm();
+      double normDx = dirVecPtr->norm();
       utilsPtr->out() << "||F||=" << normF << ", ||dx||=" << normDx;
       if (computeRelativeNorm) {
         utilsPtr->out() << ", ||F|| / ||F_0||=" << normF/normF_0;

--- a/packages/nox/src/NOX_Solver_SingleStep.H
+++ b/packages/nox/src/NOX_Solver_SingleStep.H
@@ -118,6 +118,9 @@ protected:
 
   //! Group that contains the "frozen Jacobian" if updateJacobian is false.
   Teuchos::RCP<NOX::Abstract::Group> frozenJacobianPtr;
+
+  //! Direction vector (pointer).
+  Teuchos::RCP<NOX::Abstract::Vector> dirVecPtr;
 };
 } // namespace Solver
 } // namespace NOX


### PR DESCRIPTION
@trilinos/nox @rppawlo 

## Motivation
The current implementation of `NOX::Solver::SingleStep` is dependent on the behavior of `getNewton()` method of a particular group. The call to `getNewton()` throws an exception for certain groups if they check that the Newton vector has been computed prior to the corresponding call. Surprisingly, not all groups do this: `NOX::Epetra::Group` and `NOX::Petsc::Group` have this check (i.e. may throw an exception), but `NOX::Thyra::Group` and `NOX::LAPACK::Group` simply return the vector with no checks performed. The proposed modification makes `NOX::Solver::SingleStep` independent from this implementation detail.

## Related Issues
* Closes #14016

