### PR TITLE
Tpetra: Use memory pool for imports & exports

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -7081,8 +7081,8 @@ namespace Tpetra {
           // Reallocation MUST go before setting the modified flag,
           // because it may clear out the flags.
           destGraph->reallocImportsIfNeeded(totalImportPackets, false, nullptr);
-          destGraph->imports_.modify_host();
-          auto hostImports = destGraph->imports_.view_host();
+          destGraph->imports_->modify_host();
+          auto hostImports = destGraph->imports_->view_host();
           // This is a legacy host pack/unpack path, so use the host
           // version of exports_.
           destGraph->exports_.sync_host();
@@ -7093,8 +7093,8 @@ namespace Tpetra {
                                          numImportPacketsPerLID);
         }
         else { // constant number of packets per LI
-          destGraph->imports_.modify_host();
-          auto hostImports = destGraph->imports_.view_host();
+          destGraph->imports_->modify_host();
+          auto hostImports = destGraph->imports_->view_host();
           // This is a legacy host pack/unpack path, so use the host
           // version of exports_.
           destGraph->exports_.sync_host();
@@ -7124,8 +7124,8 @@ namespace Tpetra {
           // Reallocation MUST go before setting the modified flag,
           // because it may clear out the flags.
           destGraph->reallocImportsIfNeeded(totalImportPackets, false, nullptr);
-          destGraph->imports_.modify_host();
-          auto hostImports = destGraph->imports_.view_host();
+          destGraph->imports_->modify_host();
+          auto hostImports = destGraph->imports_->view_host();
           // This is a legacy host pack/unpack path, so use the host
           // version of exports_.
           destGraph->exports_.sync_host();
@@ -7135,8 +7135,8 @@ namespace Tpetra {
           Distor.doPostsAndWaits(hostExports, numExportPacketsPerLID, hostImports, numImportPacketsPerLID);
         }
         else { // constant number of packets per LID
-          destGraph->imports_.modify_host();
-          auto hostImports = destGraph->imports_.view_host();
+          destGraph->imports_->modify_host();
+          auto hostImports = destGraph->imports_->view_host();
           // This is a legacy host pack/unpack path, so use the host
           // version of exports_.
           destGraph->exports_.sync_host();
@@ -7159,9 +7159,9 @@ namespace Tpetra {
     destGraph->numImportPacketsPerLID_.sync_host();
     Teuchos::ArrayView<const size_t> numImportPacketsPerLID =
       getArrayViewFromDualView(destGraph->numImportPacketsPerLID_);
-    destGraph->imports_.sync_host();
+    destGraph->imports_->sync_host();
     Teuchos::ArrayView<const packet_type> hostImports =
-      getArrayViewFromDualView(destGraph->imports_);
+      getArrayViewFromDualView(*destGraph->imports_);
     size_t mynnz =
       unpackAndCombineWithOwningPIDsCount(*this, RemoteLIDs, hostImports,
                                            numImportPacketsPerLID,
@@ -7195,6 +7195,7 @@ namespace Tpetra {
                                   PermuteFromLIDs, N, mynnz, MyPID,
                                   CSR_rowptr(), CSR_colind_GID(),
                                   SourcePids(), TargetPids);
+    destGraph->imports_.reset();
 
     /**************************************************************/
     /**** 4) Call Optimized MakeColMap w/ no Directory Lookups ****/

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -7159,9 +7159,11 @@ namespace Tpetra {
     destGraph->numImportPacketsPerLID_.sync_host();
     Teuchos::ArrayView<const size_t> numImportPacketsPerLID =
       getArrayViewFromDualView(destGraph->numImportPacketsPerLID_);
-    destGraph->imports_->sync_host();
+    if(destGraph->imports_) destGraph->imports_->sync_host();
+    using imports_dv_t = typename DistObject<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node>::imports_dv_t;
+    auto destImports = destGraph->imports_ ? *destGraph->imports_ : imports_dv_t{};
     Teuchos::ArrayView<const packet_type> hostImports =
-      getArrayViewFromDualView(*destGraph->imports_);
+      getArrayViewFromDualView(destImports);
     size_t mynnz =
       unpackAndCombineWithOwningPIDsCount(*this, RemoteLIDs, hostImports,
                                            numImportPacketsPerLID,

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -8329,8 +8329,8 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
           // because it may clear out the flags.
           destMat->reallocImportsIfNeeded (totalImportPackets, verbose,
                                            verbosePrefix.get ());
-          destMat->imports_.modify_host ();
-          auto hostImports = destMat->imports_.view_host();
+          destMat->imports_->modify_host ();
+          auto hostImports = destMat->imports_->view_host();
           // This is a legacy host pack/unpack path, so use the host
           // version of exports_.
           destMat->exports_.sync_host ();
@@ -8359,8 +8359,8 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
                << std::endl;
             std::cerr << os.str ();
           }
-          destMat->imports_.modify_host ();
-          auto hostImports = destMat->imports_.view_host();
+          destMat->imports_->modify_host ();
+          auto hostImports = destMat->imports_->view_host();
           // This is a legacy host pack/unpack path, so use the host
           // version of exports_.
           destMat->exports_.sync_host ();
@@ -8423,8 +8423,8 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
           // because it may clear out the flags.
           destMat->reallocImportsIfNeeded (totalImportPackets, verbose,
                                            verbosePrefix.get ());
-          destMat->imports_.modify_host ();
-          auto hostImports = destMat->imports_.view_host();
+          destMat->imports_->modify_host ();
+          auto hostImports = destMat->imports_->view_host();
           // This is a legacy host pack/unpack path, so use the host
           // version of exports_.
           destMat->exports_.sync_host ();
@@ -8453,8 +8453,8 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
                << std::endl;
             std::cerr << os.str ();
           }
-          destMat->imports_.modify_host ();
-          auto hostImports = destMat->imports_.view_host();
+          destMat->imports_->modify_host ();
+          auto hostImports = destMat->imports_->view_host();
           // This is a legacy host pack/unpack path, so use the host
           // version of exports_.
           destMat->exports_.sync_host ();
@@ -8503,7 +8503,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       ArrayRCP<LO> CSR_colind_LID;
       ArrayRCP<Scalar> CSR_vals;
   
-      destMat->imports_.sync_device ();
+      destMat->imports_->sync_device ();
       destMat->numImportPacketsPerLID_.sync_device ();
   
       size_t N = BaseRowMap->getLocalNumElements ();
@@ -8515,7 +8515,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       Details::unpackAndCombineIntoCrsArrays(
                                      *this, 
                                      RemoteLIDs_d,
-                                     destMat->imports_.view_device(),                //hostImports
+                                     destMat->imports_->view_device(),                //hostImports
                                      destMat->numImportPacketsPerLID_.view_device(), //numImportPacketsPerLID
                                      NumSameIDs,
                                      PermuteToLIDs_d,
@@ -8701,7 +8701,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       ArrayRCP<LO> CSR_colind_LID;
       ArrayRCP<Scalar> CSR_vals;
   
-      destMat->imports_.sync_device ();
+      destMat->imports_->sync_device ();
       destMat->numImportPacketsPerLID_.sync_device ();
   
       size_t N = BaseRowMap->getLocalNumElements ();
@@ -8719,7 +8719,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       Details::unpackAndCombineIntoCrsArrays(
                                      *this, 
                                      RemoteLIDs_d,
-                                     destMat->imports_.view_device(),                //hostImports
+                                     destMat->imports_->view_device(),                //hostImports
                                      destMat->numImportPacketsPerLID_.view_device(), //numImportPacketsPerLID
                                      NumSameIDs,
                                      PermuteToLIDs_d,
@@ -8865,6 +8865,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       }
   
     } //if (runOnHost) .. else ..
+    destMat->imports_.reset();
 
     /***************************************************/
     /**** 7) Build Importer & Call ESFC             ****/

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -8503,7 +8503,9 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       ArrayRCP<LO> CSR_colind_LID;
       ArrayRCP<Scalar> CSR_vals;
   
-      destMat->imports_->sync_device ();
+      if(destMat->imports_) destMat->imports_->sync_device ();
+      using imports_v_t = typename DistObject<char, LocalOrdinal, GlobalOrdinal, Node>::imports_dv_t::t_dev;
+      auto destMat_imports = destMat->imports_ ? destMat->imports_->view_device() : imports_v_t{};
       destMat->numImportPacketsPerLID_.sync_device ();
   
       size_t N = BaseRowMap->getLocalNumElements ();
@@ -8515,7 +8517,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       Details::unpackAndCombineIntoCrsArrays(
                                      *this, 
                                      RemoteLIDs_d,
-                                     destMat->imports_->view_device(),                //hostImports
+                                     destMat_imports,
                                      destMat->numImportPacketsPerLID_.view_device(), //numImportPacketsPerLID
                                      NumSameIDs,
                                      PermuteToLIDs_d,
@@ -8701,7 +8703,9 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       ArrayRCP<LO> CSR_colind_LID;
       ArrayRCP<Scalar> CSR_vals;
   
-      destMat->imports_->sync_device ();
+      if(destMat->imports_) destMat->imports_->sync_device ();
+      using imports_v_t = typename DistObject<char, LocalOrdinal, GlobalOrdinal, Node>::imports_dv_t::t_dev;
+      auto destMat_imports = destMat->imports_ ? destMat->imports_->view_device() : imports_v_t{};
       destMat->numImportPacketsPerLID_.sync_device ();
   
       size_t N = BaseRowMap->getLocalNumElements ();
@@ -8719,7 +8723,7 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       Details::unpackAndCombineIntoCrsArrays(
                                      *this, 
                                      RemoteLIDs_d,
-                                     destMat->imports_->view_device(),                //hostImports
+                                     destMat_imports,
                                      destMat->numImportPacketsPerLID_.view_device(), //numImportPacketsPerLID
                                      NumSameIDs,
                                      PermuteToLIDs_d,

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -978,7 +978,8 @@ namespace Tpetra {
     /// Unfortunately, I had to declare these protected, because
     /// CrsMatrix uses them at one point.  Please, nobody else use
     /// them.
-    Kokkos::DualView<packet_type*, buffer_device_type> imports_;
+    using imports_dv_t = Kokkos::DualView<packet_type*, buffer_device_type>;
+    Teuchos::RCP<imports_dv_t> imports_;
 
     /// \brief Reallocate imports_ if needed.
     ///

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -2343,6 +2343,10 @@ namespace Tpetra {
      size_t& constantNumPackets,
      const execution_space &space) override;
 
+    Teuchos::RCP<Kokkos::DualView<
+       impl_scalar_type*,
+       buffer_device_type>> exports_from_pool;
+
     virtual void
     packAndPrepare
     (const SrcDistObject& sourceObj,

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -2422,10 +2422,6 @@ namespace Tpetra {
   public:
     bool importsAreAliased();
 
-  protected:
-    Kokkos::DualView<impl_scalar_type*, buffer_device_type> unaliased_imports_;
-
-    //@}
   }; // class MultiVector
 
   template<class SC, class LO, class GO, class NT>

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -20,6 +20,7 @@
 /// Tpetra::MultiVector, include "Tpetra_MultiVector_decl.hpp".
 
 #include "Tpetra_Core.hpp"
+#include "Tpetra_Pool.hpp"
 #include "Tpetra_Util.hpp"
 #include "Tpetra_Vector.hpp"
 #include "Tpetra_Details_allReduceView.hpp"
@@ -1569,7 +1570,10 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
          << ", newExportsSize: " << newExportsSize << std::endl;
       std::cerr << os.str ();
     }
-    reallocDualViewIfNeeded (exports, newExportsSize, "exports");
+    exports_from_pool.reset();
+    exports_from_pool = getDualViewFromPool<Kokkos::DualView< impl_scalar_type*, buffer_device_type>>(newExportsSize);
+    exports = *exports_from_pool;
+    //reallocDualViewIfNeeded (exports, newExportsSize, "exports");
 
     // mfh 04 Feb 2019: sourceMV doesn't belong to us, so we can't
     // sync it.  Pack it where it's currently sync'd.

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -1776,14 +1776,14 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
     if (verbose) {
       std::ostringstream os;
       os << *prefix << "Realloc (if needed) imports_ from "
-         << this->imports_.extent (0) << " to " << newSize << std::endl;
+         << this->imports_->extent (0) << " to " << newSize << std::endl;
       std::cerr << os.str ();
     }
 
     bool reallocated = false;
 
     using IST = impl_scalar_type;
-    using DV = Kokkos::DualView<IST*, Kokkos::LayoutLeft, buffer_device_type>;
+    using DV = Kokkos::DualView<IST*, buffer_device_type>;
 
     // Conditions for aliasing memory:
     // - When both sides of the dual view are in the same memory
@@ -1804,12 +1804,12 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
         (newSize > 0)) {
 
       size_t offset = getLocalLength () - newSize;
-      reallocated = this->imports_.view_device().data() != view_.getDualView().view_device().data() + offset;
+      reallocated = !this->imports_ || (this->imports_->view_device().data() != view_.getDualView().view_device().data() + offset);
       if (reallocated) {
         typedef std::pair<size_t, size_t> range_type;
-        this->imports_ = DV(view_.getDualView(),
+        this->imports_ = Teuchos::rcp(new DV(view_.getDualView(),
                             range_type (offset, getLocalLength () ),
-                            0);
+                            0));
 
         if (verbose) {
           std::ostringstream os;
@@ -1820,15 +1820,7 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
       return reallocated;
     }
     {
-      using ::Tpetra::Details::reallocDualViewIfNeeded;
-      reallocated =
-        reallocDualViewIfNeeded (this->unaliased_imports_, newSize, "imports");
-      if (verbose) {
-        std::ostringstream os;
-        os << *prefix << "Finished realloc'ing unaliased_imports_" << std::endl;
-        std::cerr << os.str ();
-      }
-      this->imports_ = this->unaliased_imports_;
+      DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>::reallocImportsIfNeeded(newSize, verbose, prefix, areRemoteLIDsContiguous, CM);
     }
     return reallocated;
   }
@@ -1864,7 +1856,7 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
   bool
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   importsAreAliased() {
-    return (this->imports_.view_device().data() + this->imports_.view_device().extent(0) ==
+    return (this->imports_->view_device().data() + this->imports_->view_device().extent(0) ==
             view_.getDualView().view_device().data() + view_.getDualView().view_device().extent(0));
   }
 
@@ -1964,10 +1956,10 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
     // DistObject::doTransferNew decides where it was last modified (based on
     // whether communication buffers used were on host or device).
     if (unpackOnHost) {
-      if (this->imports_.need_sync_host()) this->imports_.sync_host();
+      if (imports.need_sync_host()) imports.sync_host();
     }
     else {
-      if (this->imports_.need_sync_device()) this->imports_.sync_device();
+      if (imports.need_sync_device()) imports.sync_device();
     }
 
     if (printDebugOutput) {
@@ -3702,18 +3694,9 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
     // MultiVector.  Thus, it is safe to reuse communication buffers.
     // See #1560 discussion.
     //
-    // We only need one column's worth of buffer for imports_ and
+    // We only need one column's worth of buffer for
     // exports_.  Taking subviews now ensures that their lengths will
     // be exactly what we need, so we won't have to resize them later.
-    {
-      const size_t newSize = X.imports_.extent (0) / numCols;
-      const size_t offset = jj*newSize;
-      auto device_view = subview (X.imports_.view_device(),
-                                   range_type (offset, offset+newSize));
-      auto host_view = subview (X.imports_.view_host(),
-                                   range_type (offset, offset+newSize));
-      this->imports_ = decltype(X.imports_)(device_view, host_view);
-    }
     {
       const size_t newSize = X.exports_.extent (0) / numCols;
       const size_t offset = jj*newSize;

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -1856,8 +1856,8 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::copyAndPermute(
   bool
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   importsAreAliased() {
-    return (this->imports_->view_device().data() + this->imports_->view_device().extent(0) ==
-            view_.getDualView().view_device().data() + view_.getDualView().view_device().extent(0));
+    return this->imports_ ? (this->imports_->view_device().data() + this->imports_->view_device().extent(0) ==
+            view_.getDualView().view_device().data() + view_.getDualView().view_device().extent(0)) : false;
   }
 
 

--- a/packages/tpetra/core/src/Tpetra_Pool.hpp
+++ b/packages/tpetra/core/src/Tpetra_Pool.hpp
@@ -1,0 +1,145 @@
+// @HEADER
+// *****************************************************************************
+//          Tpetra: Templated Linear Algebra Services Package
+//
+// Copyright 2008 NTESS and the Tpetra contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+// clang-format off
+
+#ifndef TPETRA_POOL_HPP
+#define TPETRA_POOL_HPP
+
+#include "Kokkos_Core.hpp"
+#include "Tpetra_MultiVector.hpp"
+
+namespace Tpetra
+{
+
+namespace impl
+{
+template<class DualViewType>
+class DualViewPool
+{
+public:
+  using dv_t = DualViewType;
+
+  DualViewPool() {
+    Kokkos::push_finalize_hook([this]() { this->availableDVs.clear(); });
+  }
+
+  template <typename... Sizes>
+  Teuchos::RCP<dv_t> getDV(const Sizes & ...sizes){
+    size_t total_size = dv_t::t_dev::required_allocation_size(sizes...);
+
+    // Use lower_bound so that we can re-use a slightly larger allocation if it is available
+    auto available_it = availableDVs.lower_bound(total_size);
+    while(available_it != availableDVs.end() && available_it->second.empty()) {
+      ++available_it;
+    }
+    if(available_it != availableDVs.end()) {
+      auto & available = available_it->second;
+      auto full_size_dv = available.back();
+      available.pop_back();
+
+      typename dv_t::t_dev mv_dev(full_size_dv.view_device().data(), sizes...);
+      typename dv_t::t_host mv_host(full_size_dv.view_host().data(), sizes...);
+
+      return Teuchos::rcpWithDealloc(new dv_t(mv_dev, mv_host), RCPDeleter{available, full_size_dv});
+    }
+
+    // No sufficiently large allocations were found so we need to create a new one.
+    // Also remove the largest currently available allocation if there is one because it would be able
+    // to use the allocation we are adding instead.
+    auto available_rit = availableDVs.rbegin();
+    while(available_rit != availableDVs.rend() && available_rit->second.empty()) {
+      ++available_rit;
+    }
+    if(available_rit != availableDVs.rend()) {
+      available_rit->second.pop_back();
+    }
+    dv_t dv("Tpetra::DualViewPool", sizes...);
+    auto & available = availableDVs[total_size];
+    return Teuchos::rcpWithDealloc(new dv_t(dv), RCPDeleter{available, dv});
+  }
+
+private:
+  struct RCPDeleter
+  {
+    void free(dv_t * dv_ptr) {
+      if(dv_ptr) {
+        dv_pool.push_back(dv);
+        delete dv_ptr;
+      }
+    }
+    std::vector<dv_t> & dv_pool;
+    dv_t dv;
+  };
+  std::map<size_t, std::vector<dv_t>> availableDVs;
+};
+}
+
+template<class DualViewType>
+inline impl::DualViewPool<DualViewType> & getPool()
+{
+  static impl::DualViewPool<DualViewType> static_pool;
+  return static_pool;
+}
+
+template<class DualViewType, class... Sizes>
+inline Teuchos::RCP<DualViewType> getDualViewFromPool(const Sizes & ...sizes)
+{
+  return getPool<DualViewType>().getDV(sizes...);
+}
+
+namespace impl
+{
+template<class Scalar, class LO, class GO, class Node>
+class MultiVecPool
+{
+public:
+  MultiVecPool() = default;
+
+  using MV = ::Tpetra::MultiVector<Scalar, LO, GO, Node>;
+
+  Teuchos::RCP<MV> getMV(const Teuchos::RCP<const ::Tpetra::Map<LO, GO, Node>> & map, const int numVecs) {
+    const auto num_local_elems = map->getLocalNumElements();
+    auto dv_rcp = getDualViewFromPool<dv_t>(num_local_elems, numVecs);
+
+    return Teuchos::rcpWithDealloc(new MV(map, *dv_rcp), RCPDeleter{dv_rcp});
+  }
+
+private:
+  using dv_t = typename MV::dual_view_type;
+  struct RCPDeleter
+  {
+    void free(MV * mv_ptr) {
+      if(mv_ptr) {
+        delete mv_ptr;
+        dv_rcp.reset();
+      }
+    }
+    Teuchos::RCP<dv_t> dv_rcp;
+  };
+  std::map<size_t, std::vector<dv_t>> availableDVs;
+};
+}
+
+template<class Scalar, class LO, class GO, class Node>
+inline impl::MultiVecPool<Scalar, LO, GO, Node> & getPool()
+{
+  static impl::MultiVecPool<Scalar, LO, GO, Node> static_pool;
+  return static_pool;
+}
+
+template<class Scalar, class LO, class GO, class Node>
+inline Teuchos::RCP<::Tpetra::MultiVector<Scalar, LO, GO, Node>> getMultiVectorFromPool(const Teuchos::RCP<const ::Tpetra::Map<LO, GO, Node>> & map, const int numVecs)
+{
+  return getPool<Scalar, LO, GO, Node>().getMV(map, numVecs);
+}
+
+}
+
+#endif

--- a/packages/tpetra/core/src/Tpetra_Pool.hpp
+++ b/packages/tpetra/core/src/Tpetra_Pool.hpp
@@ -13,7 +13,7 @@
 #define TPETRA_POOL_HPP
 
 #include "Kokkos_Core.hpp"
-#include "Tpetra_MultiVector.hpp"
+#include "Tpetra_MultiVector_decl.hpp"
 
 namespace Tpetra
 {

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -726,26 +726,11 @@ namespace {
           TEUCHOS_ASSERT(!importer.areRemoteLIDsContiguous());
         }
 
-        // When there are remote LIDs and they are contiguous, and
-        // MV::imports_ and MV::view_ have the same memory space, the
-        // imports_ view is aliased to the data view of the target MV.
-        if ((myImageID == collectRank) && (myImageID == 0)) {
-          if (std::is_same_v<typename mv_type::dual_view_type::t_dev::device_type, typename mv_type::dual_view_type::t_host::device_type>)
-            TEUCHOS_ASSERT(tgt_mv->importsAreAliased());
-          // else {
-          //   We do not know if copyAndPermute was run on host or device.
-          // }
-        }
-        else {
-          TEUCHOS_ASSERT(!tgt_mv->importsAreAliased());
-        }
-
         // produce a reference solution that uses the classical code path
         expertSetRemoteLIDsContiguous(importer, false);
         // Do the import
         tgt_mv_reference->doImport (*src_mv, importer, INSERT);
         TEUCHOS_ASSERT(!importer.areRemoteLIDsContiguous());
-        TEUCHOS_ASSERT(!tgt_mv_reference->importsAreAliased());
 
         // Loop through tgt_mv and make sure the import worked.
         if (tgt_num_local_elements != 0) {
@@ -796,26 +781,11 @@ namespace {
           TEUCHOS_ASSERT(!exporter.areExportLIDsContiguous());
         }
 
-        // When there are export LIDs and they are contiguous, and
-        // MV::imports_ and MV::view_ have the same memory space, the
-        // imports_ view is aliased to the data view of the target MV.
-        if ((myImageID == collectRank) && (myImageID == 0)) {
-          if (std::is_same_v<typename mv_type::dual_view_type::t_dev::device_type, typename mv_type::dual_view_type::t_host::device_type>)
-            TEUCHOS_ASSERT(tgt_mv->importsAreAliased());
-          // else {
-          //   We do not know if copyAndPermute was run on host or device.
-          // }
-        }
-        else {
-          TEUCHOS_ASSERT(!tgt_mv->importsAreAliased());
-        }
-
         // produce a reference solution that uses the classical code path
         expertSetExportLIDsContiguous(exporter, false);
         // Do the import
         tgt_mv_reference->doImport (*src_mv, exporter, INSERT);
         TEUCHOS_ASSERT(!exporter.areExportLIDsContiguous());
-        TEUCHOS_ASSERT(!tgt_mv_reference->importsAreAliased());
 
         // Loop through tgt_mv and make sure the import worked.
         if (tgt_num_local_elements != 0) {


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra

## Motivation
@japlews @crdohrm and I have been looking at some performance issues on AMD GPUs for Sierra/SD's GDSW solver and tracked it down to HIP allocations for the imports & exports DualViews used by DistObject happening during Tpetra export operations. For reasons we haven't determined the DualView allocations are very slow on one rank and progressively get slower over the course of a run.

Prior to these changes DistObject attempts to avoid reallocations via `reallocDualViewIfNeeded`, but the way that is currently implemented if there is a repeated pattern of Import/Export operations on the same DistObject where the source DistObject changes each time so that the required size of the imports_/exports_ DualViews alternates between larger and smaller sizes then reallocations will happen. See at https://github.com/trilinos/Trilinos/blob/618c4742e39bce83fbea98c1f930f51a389f71e9/packages/tpetra/core/src/Tpetra_Details_reallocDualViewIfNeeded.hpp#L102 in the case where the incoming DualView is larger than the requested size then the DualView is shrunk via subview. This prevents a reallocation that time, but loses track of the original larger size of the DualView so on the following Import/Export operation where the original larger size is needed the branch that reallocates is taken.

I started on an approach to avoid this by leveraging some of the memory pool approach I added for temporary MultiVector's in belos in #13469 to get the DualView's for the imports_ from a pool, but that's a bit awkward for the exports_ given that they are passed by non-const reference to `packAndPrepare` for the child classes to resize rather than having `DistObject` handle the resizing. I have just hacked in having MultiVector use the pool in `packAndPrepare` for now. I see #13947 is also modifying DistObject right now so I thought it would be useful to have a discussion before taking this farther.