### PR TITLE
Xpetra: Rename view access methods

### DIFF
--- a/packages/muelu/research/caglusa/auxiliaryOperators.hpp
+++ b/packages/muelu/research/caglusa/auxiliaryOperators.hpp
@@ -45,8 +45,8 @@ buildDistanceLaplacian(RCP<const Xpetra::CrsGraph<LocalOrdinal, GlobalOrdinal, N
   ghosted_coords->doImport(*coords, *graph->getImporter(), Xpetra::INSERT);
 
   {
-    auto lcl_coords         = coords->getHostLocalView(Xpetra::Access::ReadOnly);
-    auto lcl_ghosted_coords = ghosted_coords->getHostLocalView(Xpetra::Access::ReadOnly);
+    auto lcl_coords         = coords->getLocalViewHost(Xpetra::Access::ReadOnly);
+    auto lcl_ghosted_coords = ghosted_coords->getLocalViewHost(Xpetra::Access::ReadOnly);
     auto lcl_distLapl       = distLapl->getLocalMatrixHost();
 
     // TODO: parallel_for

--- a/packages/muelu/research/graham/mf_example_01.cpp
+++ b/packages/muelu/research/graham/mf_example_01.cpp
@@ -186,8 +186,8 @@ class TridiagonalOperator : public Xpetra::Operator<Scalar, LocalOrdinal, Global
     redistDataX->doImport(X, *importer_, Xpetra::INSERT);
 
     // Get a view of the multivector
-    auto KokkosViewX = redistDataX->getDeviceLocalView(Xpetra::Access::ReadOnly);
-    auto KokkosViewY = Y.getDeviceLocalView(Xpetra::Access::ReadWrite);
+    auto KokkosViewX = redistDataX->getLocalViewDevice(Xpetra::Access::ReadOnly);
+    auto KokkosViewY = Y.getLocalViewDevice(Xpetra::Access::ReadWrite);
 
     // Perform the matvec with the locally owned data
     // For each column
@@ -473,7 +473,7 @@ int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib lib, int arg
       const SC h           = (x_right - x_left) / (n_local - 1);
 
       // fill the RHS appropriately
-      auto rhs_2d = rhs->getHostLocalView(Xpetra::Access::OverwriteAll);
+      auto rhs_2d = rhs->getLocalViewHost(Xpetra::Access::OverwriteAll);
       auto rhs_1d = Kokkos::subview(rhs_2d, Kokkos::ALL(), 0);
       SC x        = x_left;
       for (size_t i = 0; i < n_local; ++i) {
@@ -577,9 +577,9 @@ int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib lib, int arg
     // (sleep my_rank is very hacky here, but keeps prints contiguous)
     if (print_RHS_and_solution) {
       sleep(my_rank);
-      auto rhs_2d = rhs->getHostLocalView(Xpetra::Access::ReadOnly);
+      auto rhs_2d = rhs->getLocalViewHost(Xpetra::Access::ReadOnly);
       PRINT_VIEW2_LINEAR(rhs_2d)
-      auto solution_2d = solution->getHostLocalView(Xpetra::Access::ReadOnly);
+      auto solution_2d = solution->getLocalViewHost(Xpetra::Access::ReadOnly);
       PRINT_VIEW2_LINEAR(solution_2d)
     }
 

--- a/packages/muelu/src/Graph/Containers/MueLu_Aggregates_def.hpp
+++ b/packages/muelu/src/Graph/Containers/MueLu_Aggregates_def.hpp
@@ -88,8 +88,8 @@ Aggregates<LocalOrdinal, GlobalOrdinal, Node>::ComputeAggregateSizes(bool forceR
 
     int myPID = GetMap()->getComm()->getRank();
 
-    auto vertex2AggId = vertex2AggId_->getDeviceLocalView(Xpetra::Access::ReadOnly);
-    auto procWinner   = procWinner_->getDeviceLocalView(Xpetra::Access::ReadOnly);
+    auto vertex2AggId = vertex2AggId_->getLocalViewDevice(Xpetra::Access::ReadOnly);
+    auto procWinner   = procWinner_->getLocalViewDevice(Xpetra::Access::ReadOnly);
 
     typename AppendTrait<decltype(aggregateSizes_), Kokkos::Atomic>::type aggregateSizesAtomic = aggregateSizes;
     Kokkos::parallel_for(
@@ -139,8 +139,8 @@ Aggregates<LocalOrdinal, GlobalOrdinal, Node>::GetGraph() const {
   if (static_cast<LO>(graph_.numRows()) == numAggregates)
     return graph_;
 
-  auto vertex2AggId = vertex2AggId_->getDeviceLocalView(Xpetra::Access::ReadOnly);
-  auto procWinner   = procWinner_->getDeviceLocalView(Xpetra::Access::ReadOnly);
+  auto vertex2AggId = vertex2AggId_->getLocalViewDevice(Xpetra::Access::ReadOnly);
+  auto procWinner   = procWinner_->getLocalViewDevice(Xpetra::Access::ReadOnly);
   auto sizes        = ComputeAggregateSizes();
 
   // FIXME_KOKKOS: replace by ViewAllocateWithoutInitializing + rows(0) = 0.
@@ -192,7 +192,7 @@ template <class LocalOrdinal, class GlobalOrdinal, class Node>
 void Aggregates<LocalOrdinal, GlobalOrdinal, Node>::ComputeNodesInAggregate(LO_view& aggPtr, LO_view& aggNodes, LO_view& unaggregated) const {
   LO numAggs                                          = GetNumAggregates();
   LO numNodes                                         = vertex2AggId_->getLocalLength();
-  auto vertex2AggId                                   = vertex2AggId_->getDeviceLocalView(Xpetra::Access::ReadOnly);
+  auto vertex2AggId                                   = vertex2AggId_->getLocalViewDevice(Xpetra::Access::ReadOnly);
   typename aggregates_sizes_type::const_type aggSizes = ComputeAggregateSizes(true);
   LO INVALID                                          = Teuchos::OrdinalTraits<LO>::invalid();
 

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_ClassicalDropping.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_ClassicalDropping.hpp
@@ -56,7 +56,7 @@ class SAFunctor {
     , eps(threshold)
     , results(results_) {
     diagVec        = Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetMatrixOverlappedDiagonal(A_);
-    auto lclDiag2d = diagVec->getDeviceLocalView(Xpetra::Access::ReadOnly);
+    auto lclDiag2d = diagVec->getLocalViewDevice(Xpetra::Access::ReadOnly);
     diag           = Kokkos::subview(lclDiag2d, Kokkos::ALL(), 0);
   }
 
@@ -116,7 +116,7 @@ class SignedRSFunctor {
     , eps(threshold)
     , results(results_) {
     max_offdiagVec = Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetMatrixMaxMinusOffDiagonal(A_);
-    auto lcl2d     = max_offdiagVec->getDeviceLocalView(Xpetra::Access::ReadOnly);
+    auto lcl2d     = max_offdiagVec->getLocalViewDevice(Xpetra::Access::ReadOnly);
     max_offdiag    = Kokkos::subview(lcl2d, Kokkos::ALL(), 0);
   }
 
@@ -174,7 +174,7 @@ class SignedSAFunctor {
     , results(results_) {
     // Construct ghosted matrix diagonal
     diagVec        = Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetMatrixOverlappedDiagonal(A_);
-    auto lclDiag2d = diagVec->getDeviceLocalView(Xpetra::Access::ReadOnly);
+    auto lclDiag2d = diagVec->getLocalViewDevice(Xpetra::Access::ReadOnly);
     diag           = Kokkos::subview(lclDiag2d, Kokkos::ALL(), 0);
   }
 

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp
@@ -561,7 +561,7 @@ void CoalesceDropFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level
           using implATS          = Kokkos::ArithTraits<impl_scalar_type>;
 
           // move from host to device
-          auto ghostedDiagValsView = Kokkos::subview(ghostedDiag->getDeviceLocalView(Xpetra::Access::ReadOnly), Kokkos::ALL(), 0);
+          auto ghostedDiagValsView = Kokkos::subview(ghostedDiag->getLocalViewDevice(Xpetra::Access::ReadOnly), Kokkos::ALL(), 0);
           auto thresholdKokkos     = static_cast<impl_scalar_type>(threshold);
           auto realThresholdKokkos = implATS::magnitude(thresholdKokkos);
           auto columnsDevice       = Kokkos::create_mirror_view(ExecSpace(), columns);
@@ -580,7 +580,7 @@ void CoalesceDropFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level
           } else {
             boundaryColumnVector = boundaryNodesVector;
           }
-          auto boundaryColumn = boundaryColumnVector->getDeviceLocalView(Xpetra::Access::ReadOnly);
+          auto boundaryColumn = boundaryColumnVector->getLocalViewDevice(Xpetra::Access::ReadOnly);
           auto boundary       = Kokkos::subview(boundaryColumn, Kokkos::ALL(), 0);
 
           Kokkos::View<LO*, ExecSpace> rownnzView("rownnzView", A_device.numRows());

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CutDrop.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CutDrop.hpp
@@ -140,7 +140,7 @@ class ScaledComparison {
     : A(A_.getLocalMatrixDevice())
     , results(results_) {
     diagVec        = Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetMatrixOverlappedDiagonal(A_);
-    auto lclDiag2d = diagVec->getDeviceLocalView(Xpetra::Access::ReadOnly);
+    auto lclDiag2d = diagVec->getLocalViewDevice(Xpetra::Access::ReadOnly);
     diag           = Kokkos::subview(lclDiag2d, Kokkos::ALL(), 0);
   }
 
@@ -236,7 +236,7 @@ class UnscaledDistanceLaplacianComparison {
     , dist2(dist2_) {
     // Construct ghosted distance Laplacian diagonal
     diagVec        = DistanceLaplacian::getDiagonal(A_, dist2);
-    auto lclDiag2d = diagVec->getDeviceLocalView(Xpetra::Access::ReadOnly);
+    auto lclDiag2d = diagVec->getLocalViewDevice(Xpetra::Access::ReadOnly);
     diag           = Kokkos::subview(lclDiag2d, Kokkos::ALL(), 0);
   }
 
@@ -346,7 +346,7 @@ class ScaledDistanceLaplacianComparison {
     , dist2(dist2_) {
     // Construct ghosted distance Laplacian diagonal
     diagVec        = DistanceLaplacian::getDiagonal(A_, dist2);
-    auto lclDiag2d = diagVec->getDeviceLocalView(Xpetra::Access::ReadOnly);
+    auto lclDiag2d = diagVec->getLocalViewDevice(Xpetra::Access::ReadOnly);
     diag           = Kokkos::subview(lclDiag2d, Kokkos::ALL(), 0);
   }
 

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_DistanceLaplacianDropping.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_DistanceLaplacianDropping.hpp
@@ -57,10 +57,10 @@ class UnweightedDistanceFunctor {
     if (!importer.is_null()) {
       ghostedCoordsMV = Xpetra::MultiVectorFactory<magnitudeType, LocalOrdinal, GlobalOrdinal, Node>::Build(importer->getTargetMap(), coordsMV->getNumVectors());
       ghostedCoordsMV->doImport(*coordsMV, *importer, Xpetra::INSERT);
-      coords        = coordsMV->getDeviceLocalView(Xpetra::Access::ReadOnly);
-      ghostedCoords = ghostedCoordsMV->getDeviceLocalView(Xpetra::Access::ReadOnly);
+      coords        = coordsMV->getLocalViewDevice(Xpetra::Access::ReadOnly);
+      ghostedCoords = ghostedCoordsMV->getLocalViewDevice(Xpetra::Access::ReadOnly);
     } else {
-      coords        = coordsMV->getDeviceLocalView(Xpetra::Access::ReadOnly);
+      coords        = coordsMV->getLocalViewDevice(Xpetra::Access::ReadOnly);
       ghostedCoords = coords;
     }
   }
@@ -114,18 +114,18 @@ class ScalarMaterialDistanceFunctor {
     if (!importer.is_null()) {
       ghostedCoordsMV = Xpetra::MultiVectorFactory<magnitudeType, LocalOrdinal, GlobalOrdinal, Node>::Build(importer->getTargetMap(), coordsMV->getNumVectors());
       ghostedCoordsMV->doImport(*coordsMV, *importer, Xpetra::INSERT);
-      coords        = coordsMV->getDeviceLocalView(Xpetra::Access::ReadOnly);
-      ghostedCoords = ghostedCoordsMV->getDeviceLocalView(Xpetra::Access::ReadOnly);
+      coords        = coordsMV->getLocalViewDevice(Xpetra::Access::ReadOnly);
+      ghostedCoords = ghostedCoordsMV->getLocalViewDevice(Xpetra::Access::ReadOnly);
 
       ghostedMaterialMV = Xpetra::MultiVectorFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(importer->getTargetMap(), materialMV->getNumVectors());
       ghostedMaterialMV->doImport(*materialMV, *importer, Xpetra::INSERT);
-      material        = materialMV->getDeviceLocalView(Xpetra::Access::ReadOnly);
-      ghostedMaterial = ghostedMaterialMV->getDeviceLocalView(Xpetra::Access::ReadOnly);
+      material        = materialMV->getLocalViewDevice(Xpetra::Access::ReadOnly);
+      ghostedMaterial = ghostedMaterialMV->getLocalViewDevice(Xpetra::Access::ReadOnly);
     } else {
-      coords        = coordsMV->getDeviceLocalView(Xpetra::Access::ReadOnly);
+      coords        = coordsMV->getLocalViewDevice(Xpetra::Access::ReadOnly);
       ghostedCoords = coords;
 
-      material        = materialMV->getDeviceLocalView(Xpetra::Access::ReadOnly);
+      material        = materialMV->getLocalViewDevice(Xpetra::Access::ReadOnly);
       ghostedMaterial = material;
     }
   }
@@ -215,10 +215,10 @@ class TensorMaterialDistanceFunctor {
     if (!importer.is_null()) {
       ghostedCoordsMV = Xpetra::MultiVectorFactory<magnitudeType, LocalOrdinal, GlobalOrdinal, Node>::Build(importer->getTargetMap(), coordsMV->getNumVectors());
       ghostedCoordsMV->doImport(*coordsMV, *importer, Xpetra::INSERT);
-      coords        = coordsMV->getDeviceLocalView(Xpetra::Access::ReadOnly);
-      ghostedCoords = ghostedCoordsMV->getDeviceLocalView(Xpetra::Access::ReadOnly);
+      coords        = coordsMV->getLocalViewDevice(Xpetra::Access::ReadOnly);
+      ghostedCoords = ghostedCoordsMV->getLocalViewDevice(Xpetra::Access::ReadOnly);
     } else {
-      coords        = coordsMV->getDeviceLocalView(Xpetra::Access::ReadOnly);
+      coords        = coordsMV->getLocalViewDevice(Xpetra::Access::ReadOnly);
       ghostedCoords = coords;
     }
 
@@ -235,7 +235,7 @@ class TensorMaterialDistanceFunctor {
       using range_type      = Kokkos::RangePolicy<LocalOrdinal, execution_space>;
 
       local_ordinal_type dim = std::sqrt(material_->getNumVectors());
-      auto lclMaterial       = ghostedMaterial->getDeviceLocalView(Xpetra::Access::ReadOnly);
+      auto lclMaterial       = ghostedMaterial->getLocalViewDevice(Xpetra::Access::ReadOnly);
       material               = local_material_type("material", lclMaterial.extent(0), dim, dim);
       lcl_dist               = local_dist_type("material", lclMaterial.extent(0), dim);
       TensorInversion<local_ordinal_type, typename material_type::dual_view_type::t_dev_const_um, local_material_type> functor(lclMaterial, material);
@@ -310,7 +310,7 @@ getDiagonal(Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A,
   auto diag = Xpetra::MultiVectorFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(A.getRowMap(), 1);
   {
     auto lclA    = A.getLocalMatrixDevice();
-    auto lclDiag = diag->getDeviceLocalView(Xpetra::Access::OverwriteAll);
+    auto lclDiag = diag->getLocalViewDevice(Xpetra::Access::OverwriteAll);
 
     Kokkos::parallel_for(
         "MueLu:CoalesceDropF:Build:scalar_filter:laplacian_diag",
@@ -383,7 +383,7 @@ class DropFunctor {
     , dist2(dist2_)
     , results(results_) {
     diagVec        = getDiagonal(A_, dist2);
-    auto lclDiag2d = diagVec->getDeviceLocalView(Xpetra::Access::ReadOnly);
+    auto lclDiag2d = diagVec->getLocalViewDevice(Xpetra::Access::ReadOnly);
     diag           = Kokkos::subview(lclDiag2d, Kokkos::ALL(), 0);
   }
 

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_DroppingCommon.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_DroppingCommon.hpp
@@ -304,8 +304,8 @@ class BlockDiagonalizeFunctor {
  public:
   BlockDiagonalizeFunctor(matrix_type& A_, block_indices_type& point_to_block_, block_indices_type& ghosted_point_to_block_, results_view& results_)
     : A(A_.getLocalMatrixDevice())
-    , point_to_block(point_to_block_.getDeviceLocalView(Xpetra::Access::ReadOnly))
-    , ghosted_point_to_block(ghosted_point_to_block_.getDeviceLocalView(Xpetra::Access::ReadOnly))
+    , point_to_block(point_to_block_.getLocalViewDevice(Xpetra::Access::ReadOnly))
+    , ghosted_point_to_block(ghosted_point_to_block_.getLocalViewDevice(Xpetra::Access::ReadOnly))
     , results(results_) {}
 
   KOKKOS_FORCEINLINE_FUNCTION

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_decl.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_decl.hpp
@@ -58,7 +58,7 @@ class AggregationStructuredAlgorithm : public MueLu::AggregationAlgorithmBase<Lo
   using execution_space        = typename local_graph_type::device_type::execution_space;
   using memory_space           = typename local_graph_type::device_type::memory_space;
 
-  using LOVectorView      = decltype(std::declval<LOVector>().getDeviceLocalView(Xpetra::Access::ReadWrite));
+  using LOVectorView      = decltype(std::declval<LOVector>().getLocalViewDevice(Xpetra::Access::ReadWrite));
   using constIntTupleView = typename Kokkos::View<const int[3], device_type>;
   using constLOTupleView  = typename Kokkos::View<const LO[3], device_type>;
   //! @name Constructors/Destructors.

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_def.hpp
@@ -405,8 +405,8 @@ void AggregationStructuredAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::
   RCP<IndexManager_kokkos> geoData = aggregates.GetIndexManagerKokkos();
   const LO numLocalFineNodes       = geoData->getNumLocalFineNodes();
   const LO numCoarseNodes          = geoData->getNumCoarseNodes();
-  LOVectorView vertex2AggId        = aggregates.GetVertex2AggId()->getDeviceLocalView(Xpetra::Access::ReadWrite);
-  LOVectorView procWinner          = aggregates.GetProcWinner()->getDeviceLocalView(Xpetra::Access::ReadWrite);
+  LOVectorView vertex2AggId        = aggregates.GetVertex2AggId()->getLocalViewDevice(Xpetra::Access::ReadWrite);
+  LOVectorView procWinner          = aggregates.GetProcWinner()->getLocalViewDevice(Xpetra::Access::ReadWrite);
 
   *out << "Loop over fine nodes and assign them to an aggregate and a rank" << std::endl;
   LO numAggregatedNodes;

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_def.hpp
@@ -256,8 +256,8 @@ void AggregationPhase1Algorithm<LocalOrdinal, GlobalOrdinal, Node>::
   const int myRank = graph.GetComm()->getRank();
 
   // Extract data from aggregates
-  auto vertex2AggId = aggregates.GetVertex2AggId()->getDeviceLocalView(Xpetra::Access::ReadWrite);
-  auto procWinner   = aggregates.GetProcWinner()->getDeviceLocalView(Xpetra::Access::ReadWrite);
+  auto vertex2AggId = aggregates.GetVertex2AggId()->getLocalViewDevice(Xpetra::Access::ReadWrite);
+  auto procWinner   = aggregates.GetProcWinner()->getLocalViewDevice(Xpetra::Access::ReadWrite);
   auto colors       = aggregates.GetGraphColors();
 
   auto lclLWGraph = graph;
@@ -363,8 +363,8 @@ void AggregationPhase1Algorithm<LocalOrdinal, GlobalOrdinal, Node>::
   const LO numRows = graph.GetNodeNumVertices();
   const int myRank = graph.GetComm()->getRank();
 
-  auto vertex2AggId = aggregates.GetVertex2AggId()->getDeviceLocalView(Xpetra::Access::ReadWrite);
-  auto procWinner   = aggregates.GetProcWinner()->getDeviceLocalView(Xpetra::Access::ReadWrite);
+  auto vertex2AggId = aggregates.GetVertex2AggId()->getLocalViewDevice(Xpetra::Access::ReadWrite);
+  auto procWinner   = aggregates.GetProcWinner()->getLocalViewDevice(Xpetra::Access::ReadWrite);
   auto colors       = aggregates.GetGraphColors();
 
   auto lclLWGraph = graph;

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_def.hpp
@@ -187,8 +187,8 @@ void AggregationPhase2aAlgorithm<LO, GO, Node>::
   const LO numRows = graph.GetNodeNumVertices();
   const int myRank = graph.GetComm()->getRank();
 
-  auto vertex2AggId  = aggregates.GetVertex2AggId()->getDeviceLocalView(Xpetra::Access::ReadWrite);
-  auto procWinner    = aggregates.GetProcWinner()->getDeviceLocalView(Xpetra::Access::ReadWrite);
+  auto vertex2AggId  = aggregates.GetVertex2AggId()->getLocalViewDevice(Xpetra::Access::ReadWrite);
+  auto procWinner    = aggregates.GetProcWinner()->getLocalViewDevice(Xpetra::Access::ReadWrite);
   auto colors        = aggregates.GetGraphColors();
   const LO numColors = aggregates.GetGraphNumColors();
 
@@ -307,8 +307,8 @@ void AggregationPhase2aAlgorithm<LO, GO, Node>::
   const LO numRows = graph.GetNodeNumVertices();
   const int myRank = graph.GetComm()->getRank();
 
-  auto vertex2AggId  = aggregates.GetVertex2AggId()->getDeviceLocalView(Xpetra::Access::ReadWrite);
-  auto procWinner    = aggregates.GetProcWinner()->getDeviceLocalView(Xpetra::Access::ReadWrite);
+  auto vertex2AggId  = aggregates.GetVertex2AggId()->getLocalViewDevice(Xpetra::Access::ReadWrite);
+  auto procWinner    = aggregates.GetProcWinner()->getLocalViewDevice(Xpetra::Access::ReadWrite);
   auto colors        = aggregates.GetGraphColors();
   const LO numColors = aggregates.GetGraphNumColors();
 

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_def.hpp
@@ -241,8 +241,8 @@ void AggregationPhase2bAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::
   const LO numRows = graph.GetNodeNumVertices();
   const int myRank = graph.GetComm()->getRank();
 
-  auto vertex2AggId           = aggregates.GetVertex2AggId()->getDeviceLocalView(Xpetra::Access::ReadWrite);
-  auto procWinner             = aggregates.GetProcWinner()->getDeviceLocalView(Xpetra::Access::ReadWrite);
+  auto vertex2AggId           = aggregates.GetVertex2AggId()->getLocalViewDevice(Xpetra::Access::ReadWrite);
+  auto procWinner             = aggregates.GetProcWinner()->getLocalViewDevice(Xpetra::Access::ReadWrite);
   auto colors                 = aggregates.GetGraphColors();
   const LO numColors          = aggregates.GetGraphNumColors();
   const LO numLocalAggregates = aggregates.GetNumAggregates();

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_def.hpp
@@ -202,8 +202,8 @@ void AggregationPhase3Algorithm<LocalOrdinal, GlobalOrdinal, Node>::
   const LO numRows = graph.GetNodeNumVertices();
   const int myRank = graph.GetComm()->getRank();
 
-  auto vertex2AggId  = aggregates.GetVertex2AggId()->getDeviceLocalView(Xpetra::Access::ReadWrite);
-  auto procWinner    = aggregates.GetProcWinner()->getDeviceLocalView(Xpetra::Access::ReadWrite);
+  auto vertex2AggId  = aggregates.GetVertex2AggId()->getLocalViewDevice(Xpetra::Access::ReadWrite);
+  auto procWinner    = aggregates.GetProcWinner()->getLocalViewDevice(Xpetra::Access::ReadWrite);
   auto colors        = aggregates.GetGraphColors();
   const LO numColors = aggregates.GetGraphNumColors();
 

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_PreserveDirichletAggregationAlgorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_PreserveDirichletAggregationAlgorithm_def.hpp
@@ -77,8 +77,8 @@ void PreserveDirichletAggregationAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::
   const int myRank  = graph.GetComm()->getRank();
 
   // 3) the aggregates
-  auto vertex2AggId = aggregates.GetVertex2AggId()->getDeviceLocalView(Xpetra::Access::ReadWrite);
-  auto procWinner   = aggregates.GetProcWinner()->getDeviceLocalView(Xpetra::Access::ReadWrite);
+  auto vertex2AggId = aggregates.GetVertex2AggId()->getLocalViewDevice(Xpetra::Access::ReadWrite);
+  auto procWinner   = aggregates.GetProcWinner()->getLocalViewDevice(Xpetra::Access::ReadWrite);
 
   // A view is needed to count on the fly the current number of local aggregates
   Kokkos::View<LO, device_type> aggCount("aggCount");

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_def.hpp
@@ -336,8 +336,8 @@ void UncoupledAggregationFactory<LocalOrdinal, GlobalOrdinal, Node>::Build(Level
       if (IsPrint(Statistics1)) GetOStream(Statistics1) << "  algorithm: MIS-2 aggregation" << std::endl;
       labels = KokkosGraph::graph_mis2_aggregate<device_t, rowmap_t, colinds_t>(aRowptrs, aColinds, numAggs);
     }
-    auto vertex2AggId = aggregates->GetVertex2AggId()->getDeviceLocalView(Xpetra::Access::ReadWrite);
-    auto procWinner   = aggregates->GetProcWinner()->getDeviceLocalView(Xpetra::Access::OverwriteAll);
+    auto vertex2AggId = aggregates->GetVertex2AggId()->getLocalViewDevice(Xpetra::Access::ReadWrite);
+    auto procWinner   = aggregates->GetProcWinner()->getLocalViewDevice(Xpetra::Access::OverwriteAll);
     int rank          = comm->getRank();
     Kokkos::parallel_for(
         Kokkos::RangePolicy<exec_space>(0, numRows),

--- a/packages/muelu/src/Misc/MueLu_CoordinatesTransferFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_CoordinatesTransferFactory_def.hpp
@@ -195,8 +195,8 @@ void CoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Buil
     auto aggGraph = aggregates->GetGraph();
     auto numAggs  = aggGraph.numRows();
 
-    auto fineCoordsView   = ghostedCoords->getDeviceLocalView(Xpetra::Access::ReadOnly);
-    auto coarseCoordsView = coarseCoords->getDeviceLocalView(Xpetra::Access::OverwriteAll);
+    auto fineCoordsView   = ghostedCoords->getLocalViewDevice(Xpetra::Access::ReadOnly);
+    auto coarseCoordsView = coarseCoords->getLocalViewDevice(Xpetra::Access::OverwriteAll);
 
     // Fill in coarse coordinates
     {

--- a/packages/muelu/src/Misc/MueLu_MultiVectorTransferFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_MultiVectorTransferFactory_def.hpp
@@ -134,8 +134,8 @@ void MultiVectorTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Buil
 
     coarseVector = MultiVectorFactory::Build(coarseVectorMap, fineVector->getNumVectors());
 
-    auto lcl_fineVector   = fineVector->getDeviceLocalView(Xpetra::Access::ReadOnly);
-    auto lcl_coarseVector = coarseVector->getDeviceLocalView(Xpetra::Access::OverwriteAll);
+    auto lcl_fineVector   = fineVector->getLocalViewDevice(Xpetra::Access::ReadOnly);
+    auto lcl_coarseVector = coarseVector->getLocalViewDevice(Xpetra::Access::OverwriteAll);
 
     Kokkos::parallel_for(
         "MueLu:MultiVectorTransferFactory",

--- a/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
@@ -1519,8 +1519,8 @@ RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>> RefMaxwell<S
     RCP<MultiVector> Nullspace = Xpetra::MultiVectorFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(facesToNodes->getRangeMap(), dim_);
     {
       auto facesToNodesLocal     = facesToNodes->getLocalMatrixDevice();
-      auto localNodalCoordinates = ghostedNodalCoordinates->getDeviceLocalView(Xpetra::Access::ReadOnly);
-      auto localFaceNullspace    = Nullspace->getDeviceLocalView(Xpetra::Access::ReadWrite);
+      auto localNodalCoordinates = ghostedNodalCoordinates->getLocalViewDevice(Xpetra::Access::ReadOnly);
+      auto localFaceNullspace    = Nullspace->getLocalViewDevice(Xpetra::Access::ReadWrite);
 
       // enter values
       Kokkos::parallel_for(
@@ -1654,7 +1654,7 @@ RefMaxwell<Scalar, LocalOrdinal, GlobalOrdinal, Node>::buildProjection(const int
         rowptr(i) = dim * localIncidence.graph.row_map(i);
       });
 
-  auto localNullspace = Nullspace->getDeviceLocalView(Xpetra::Access::ReadOnly);
+  auto localNullspace = Nullspace->getLocalViewDevice(Xpetra::Access::ReadOnly);
 
   // set column indices and values
   magnitudeType tol = 1e-5;
@@ -1944,7 +1944,7 @@ void RefMaxwell<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
     //   auto localP = Prolongator->getLocalMatrixDevice();
     //   auto localAggsToFaces = aggsToFaces->getLocalMatrixDevice();
-    //   auto localNullspace = Nullspace->getDeviceLocalView(Xpetra::Access::ReadOnly);
+    //   auto localNullspace = Nullspace->getLocalViewDevice(Xpetra::Access::ReadOnly);
 
     //   size_t dim = dim_;
     //   Kokkos::parallel_for(solverName_+"::buildVectorNodalProlongator_adjustRowptr",
@@ -1967,8 +1967,8 @@ void RefMaxwell<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     size_t dim      = dim_;
     coarseNullspace = MultiVectorFactory::Build(vectorP_nodal->getDomainMap(), dim);
 
-    auto localNullspace_nodal  = coarseNodalNullspace->getDeviceLocalView(Xpetra::Access::ReadOnly);
-    auto localNullspace_coarse = coarseNullspace->getDeviceLocalView(Xpetra::Access::ReadWrite);
+    auto localNullspace_nodal  = coarseNodalNullspace->getLocalViewDevice(Xpetra::Access::ReadOnly);
+    auto localNullspace_coarse = coarseNullspace->getLocalViewDevice(Xpetra::Access::ReadWrite);
     Kokkos::parallel_for(
         solverName_ + "::buildProlongator_nullspace_" + typeStr,
         range_type(0, coarseNodalNullspace->getLocalLength()),
@@ -1987,7 +1987,7 @@ void RefMaxwell<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     } else if (spaceNumber >= 1) {
       size_t dim                 = dim_;
       coarseNullspace            = MultiVectorFactory::Build(projection->getDomainMap(), dim);
-      auto localNullspace_coarse = coarseNullspace->getDeviceLocalView(Xpetra::Access::ReadWrite);
+      auto localNullspace_coarse = coarseNullspace->getLocalViewDevice(Xpetra::Access::ReadWrite);
       Kokkos::parallel_for(
           solverName_ + "::buildProlongator_nullspace_" + typeStr,
           range_type(0, coarseNullspace->getLocalLength() / dim),

--- a/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
@@ -44,7 +44,7 @@ Projection<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   Kokkos::View<Scalar**, Kokkos::LayoutLeft, Kokkos::HostSpace> Q("Q", Nullspace->getNumVectors(), Nullspace->getNumVectors());
   int LDQ;
   {
-    auto dots = tempMV->getHostLocalView(Xpetra::Access::ReadOnly);
+    auto dots = tempMV->getLocalViewHost(Xpetra::Access::ReadOnly);
     Kokkos::deep_copy(Q, dots);
     LDQ = Q.stride(1);
   }
@@ -75,7 +75,7 @@ void Projection<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   // Nullspace_ ^T * X
   Teuchos::RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > tempMV = Xpetra::MultiVectorFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(localMap_, X.getNumVectors());
   tempMV->multiply(Teuchos::CONJ_TRANS, Teuchos::NO_TRANS, ONE, *Nullspace_, X, ZERO);
-  auto dots      = tempMV->getHostLocalView(Xpetra::Access::ReadOnly);
+  auto dots      = tempMV->getLocalViewHost(Xpetra::Access::ReadOnly);
   bool doProject = true;
   for (size_t i = 0; i < X.getNumVectors(); i++) {
     for (size_t j = 0; j < Nullspace_->getNumVectors(); j++) {
@@ -231,8 +231,8 @@ void Amesos2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Setup(Level& cu
 
     // form normalization * nullspace * nullspace^T
     {
-      auto lclNullspace        = Nullspace->getDeviceLocalView(Xpetra::Access::ReadOnly);
-      auto lclGhostedNullspace = ghostedNullspace->getDeviceLocalView(Xpetra::Access::ReadOnly);
+      auto lclNullspace        = Nullspace->getLocalViewDevice(Xpetra::Access::ReadOnly);
+      auto lclGhostedNullspace = ghostedNullspace->getLocalViewDevice(Xpetra::Access::ReadOnly);
       Kokkos::parallel_for(
           "MueLu:Amesos2Smoother::fixNullspace_1", range_type(0, lclNumRows + 1),
           KOKKOS_LAMBDA(const size_t i) {

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_kokkos_def.hpp
@@ -127,8 +127,8 @@ void GeometricInterpolationPFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, 
     // Construct and launch functor to fill coarse coordinates values
     // function should take a const view really
     coarseCoordinatesBuilderFunctor myCoarseCoordinatesBuilder(geoData,
-                                                               fineCoordinates->getDeviceLocalView(Xpetra::Access::ReadWrite),
-                                                               coarseCoordinates->getDeviceLocalView(Xpetra::Access::OverwriteAll));
+                                                               fineCoordinates->getLocalViewDevice(Xpetra::Access::ReadWrite),
+                                                               coarseCoordinates->getLocalViewDevice(Xpetra::Access::OverwriteAll));
     Kokkos::parallel_for("GeometricInterpolation: build coarse coordinates",
                          Kokkos::RangePolicy<execution_space>(0, geoData->getNumCoarseNodes()),
                          myCoarseCoordinatesBuilder);

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_RegionRFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_RegionRFactory_kokkos_def.hpp
@@ -211,8 +211,8 @@ void RegionRFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
                                                                                numDimensions);
 
   // Get device views of coordinates
-  auto fineCoordsView   = fineCoordinates->getDeviceLocalView(Xpetra::Access::ReadOnly);
-  auto coarseCoordsView = coarseCoordinates->getDeviceLocalView(Xpetra::Access::OverwriteAll);
+  auto fineCoordsView   = fineCoordinates->getLocalViewDevice(Xpetra::Access::ReadOnly);
+  auto coarseCoordsView = coarseCoordinates->getLocalViewDevice(Xpetra::Access::OverwriteAll);
 
   Array<ArrayRCP<const real_type> > fineCoordData(numDimensions);
   Array<ArrayRCP<real_type> > coarseCoordData(numDimensions);

--- a/packages/muelu/src/Transfers/Matrix-Free/MueLu_MatrixFreeTentativeP_def.hpp
+++ b/packages/muelu/src/Transfers/Matrix-Free/MueLu_MatrixFreeTentativeP_def.hpp
@@ -41,13 +41,13 @@ void MatrixFreeTentativeP<Scalar, LocalOrdinal, GlobalOrdinal, Node>::apply(cons
   // TODO: probably smarter to sqrt the whole aggSizes once, but may be slower if it's done in a separate kernel launch?
   typename Aggregates::aggregates_sizes_type::const_type aggSizes = aggregates_->ComputeAggregateSizes();
 
-  auto kokkos_view_X = X.getDeviceLocalView(Xpetra::Access::ReadOnly);
-  auto kokkos_view_Y = Y.getDeviceLocalView(Xpetra::Access::ReadWrite);
+  auto kokkos_view_X = X.getLocalViewDevice(Xpetra::Access::ReadOnly);
+  auto kokkos_view_Y = Y.getLocalViewDevice(Xpetra::Access::ReadWrite);
   LO numCols         = kokkos_view_X.extent(1);
 
   if (mode == Teuchos::TRANS) {  // if we're in restrictor mode
     auto vertex2AggId     = aggregates_->GetVertex2AggId();
-    auto vertex2AggIdView = vertex2AggId->getDeviceLocalView(Xpetra::Access::ReadOnly);
+    auto vertex2AggIdView = vertex2AggId->getLocalViewDevice(Xpetra::Access::ReadOnly);
     LO numNodes           = kokkos_view_X.extent(0);
 
     // Step 2: Compute Y=Y+alpha*R*X
@@ -62,7 +62,7 @@ void MatrixFreeTentativeP<Scalar, LocalOrdinal, GlobalOrdinal, Node>::apply(cons
         });
   } else {  // if we're in prolongator mode
     const auto vertex2Agg = aggregates_->GetVertex2AggId();
-    auto vertex2AggView   = vertex2Agg->getDeviceLocalView(Xpetra::Access::ReadOnly);
+    auto vertex2AggView   = vertex2Agg->getLocalViewDevice(Xpetra::Access::ReadOnly);
     LO numNodes           = kokkos_view_Y.extent(0);
 
     // Step 2: Compute Y=Y+alpha*P*X

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_kokkos_def.hpp
@@ -318,14 +318,14 @@ void SemiCoarsenPFactory_kokkos<
     importer = ImportFactory::Build(Amat->getDomainMap(), Amat->getColMap());
   {
     // Fill local temp with layer ids and fill ghost nodes
-    const auto localTempHost = localTemp->getHostLocalView(Xpetra::Access::ReadWrite);
+    const auto localTempHost = localTemp->getLocalViewHost(Xpetra::Access::ReadWrite);
     for (int row = 0; row < NFRows; row++)
       localTempHost(row, 0) = LayerId[row / DofsPerNode];
-    const auto localTempView = localTemp->getDeviceLocalView(Xpetra::Access::ReadWrite);
+    const auto localTempView = localTemp->getLocalViewDevice(Xpetra::Access::ReadWrite);
     Kokkos::deep_copy(localTempView, localTempHost);
     FCol2LayerVector->doImport(*localTemp, *(importer), Xpetra::INSERT);
   }
-  const auto FCol2LayerView = FCol2LayerVector->getDeviceLocalView(Xpetra::Access::ReadOnly);
+  const auto FCol2LayerView = FCol2LayerVector->getLocalViewDevice(Xpetra::Access::ReadOnly);
   const auto FCol2Layer     = Kokkos::subview(FCol2LayerView, Kokkos::ALL(), 0);
 
   // Construct a map from fine level column to local dof per node id (including
@@ -334,14 +334,14 @@ void SemiCoarsenPFactory_kokkos<
       Xpetra::VectorFactory<LO, LO, GO, NO>::Build(Amat->getColMap());
   {
     // Fill local temp with local dof per node ids and fill ghost nodes
-    const auto localTempHost = localTemp->getHostLocalView(Xpetra::Access::ReadWrite);
+    const auto localTempHost = localTemp->getLocalViewHost(Xpetra::Access::ReadWrite);
     for (int row = 0; row < NFRows; row++)
       localTempHost(row, 0) = row % DofsPerNode;
-    const auto localTempView = localTemp->getDeviceLocalView(Xpetra::Access::ReadWrite);
+    const auto localTempView = localTemp->getLocalViewDevice(Xpetra::Access::ReadWrite);
     Kokkos::deep_copy(localTempView, localTempHost);
     FCol2DofVector->doImport(*localTemp, *(importer), Xpetra::INSERT);
   }
-  const auto FCol2DofView = FCol2DofVector->getDeviceLocalView(Xpetra::Access::ReadOnly);
+  const auto FCol2DofView = FCol2DofVector->getLocalViewDevice(Xpetra::Access::ReadOnly);
   const auto FCol2Dof     = Kokkos::subview(FCol2DofView, Kokkos::ALL(), 0);
 
   // Compute NVertLines
@@ -627,8 +627,8 @@ void SemiCoarsenPFactory_kokkos<
   coarseNullspace =
       MultiVectorFactory::Build(coarseMap, fineNullspace->getNumVectors());
   const int numVectors           = fineNullspace->getNumVectors();
-  const auto fineNullspaceView   = fineNullspace->getDeviceLocalView(Xpetra::Access::ReadOnly);
-  const auto coarseNullspaceView = coarseNullspace->getDeviceLocalView(Xpetra::Access::ReadWrite);
+  const auto fineNullspaceView   = fineNullspace->getLocalViewDevice(Xpetra::Access::ReadOnly);
+  const auto coarseNullspaceView = coarseNullspace->getLocalViewDevice(Xpetra::Access::ReadWrite);
   using range_policy             = Kokkos::RangePolicy<execution_space>;
   Kokkos::parallel_for(
       "MueLu::SemiCoarsenPFactory_kokkos::BuildSemiCoarsenP Inject Nullspace",

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_NullspaceFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_NullspaceFactory_def.hpp
@@ -178,7 +178,7 @@ void NullspaceFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level& c
         Coords->meanValue(hostMeans);
         Kokkos::View<typename RealValuedMultiVector::impl_scalar_type*, Kokkos::HostSpace> hostMeanView(hostMeans.getRawPtr(), hostMeans.size());
         Kokkos::deep_copy(meanView, hostMeanView);
-        coordsView = Coords->getDeviceLocalView(Xpetra::Access::ReadOnly);
+        coordsView = Coords->getLocalViewDevice(Xpetra::Access::ReadOnly);
         GetOStream(Runtime1) << "Generating nullspace with rotations: dimension = " << nullspaceDim << std::endl;
       } else
         GetOStream(Runtime1) << "Generating canonical nullspace: dimension = " << numPDEs << std::endl;
@@ -203,7 +203,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void NullspaceFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::fillNullspaceVector(const RCP<MultiVector>& nullspace, LocalOrdinal numPDEs, LocalOrdinal nullspaceDim, CoordsType coordsView, MeanCoordsType meanView) const {
   RCP<BlockedMultiVector> bnsp = Teuchos::rcp_dynamic_cast<BlockedMultiVector>(nullspace);
   if (bnsp.is_null() == true) {
-    auto nullspaceView = nullspace->getDeviceLocalView(Xpetra::Access::OverwriteAll);
+    auto nullspaceView = nullspace->getLocalViewDevice(Xpetra::Access::OverwriteAll);
 
     int numBlocks = nullspace->getLocalLength() / numPDEs;
     if (nullspaceDim > numPDEs)

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
@@ -458,8 +458,8 @@ void TentativePFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP
     auto aggGraph = aggregates->GetGraph();
     auto numAggs  = aggGraph.numRows();
 
-    auto fineCoordsView   = fineCoords->getDeviceLocalView(Xpetra::Access::ReadOnly);
-    auto coarseCoordsView = coarseCoords->getDeviceLocalView(Xpetra::Access::OverwriteAll);
+    auto fineCoordsView   = fineCoords->getLocalViewDevice(Xpetra::Access::ReadOnly);
+    auto coarseCoordsView = coarseCoords->getLocalViewDevice(Xpetra::Access::OverwriteAll);
 
     // Fill in coarse coordinates
     {
@@ -583,8 +583,8 @@ void TentativePFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   GO globalOffset = amalgInfo->GlobalOffset();
 
   // Extract aggregation info (already in Kokkos host views)
-  auto procWinner            = aggregates->GetProcWinner()->getDeviceLocalView(Xpetra::Access::ReadOnly);
-  auto vertex2AggId          = aggregates->GetVertex2AggId()->getDeviceLocalView(Xpetra::Access::ReadOnly);
+  auto procWinner            = aggregates->GetProcWinner()->getLocalViewDevice(Xpetra::Access::ReadOnly);
+  auto vertex2AggId          = aggregates->GetVertex2AggId()->getLocalViewDevice(Xpetra::Access::ReadOnly);
   const size_t numAggregates = aggregates->GetNumAggregates();
 
   int myPID = aggregates->GetMap()->getComm()->getRank();
@@ -680,8 +680,8 @@ void TentativePFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   coarseNullspace = MultiVectorFactory::Build(coarseMap, NSDim);
 
   // Pull out the nullspace vectors so that we can have random access (on the device)
-  auto fineNS   = fineNullspace->getDeviceLocalView(Xpetra::Access::ReadWrite);
-  auto coarseNS = coarseNullspace->getDeviceLocalView(Xpetra::Access::OverwriteAll);
+  auto fineNS   = fineNullspace->getLocalViewDevice(Xpetra::Access::ReadWrite);
+  auto coarseNS = coarseNullspace->getLocalViewDevice(Xpetra::Access::OverwriteAll);
 
   size_t nnz = 0;  // actual number of nnz
 
@@ -1021,8 +1021,8 @@ void TentativePFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   // GO globalOffset = amalgInfo->GlobalOffset();
 
   // Extract aggregation info (already in Kokkos host views)
-  auto procWinner            = aggregates->GetProcWinner()->getDeviceLocalView(Xpetra::Access::ReadOnly);
-  auto vertex2AggId          = aggregates->GetVertex2AggId()->getDeviceLocalView(Xpetra::Access::ReadOnly);
+  auto procWinner            = aggregates->GetProcWinner()->getLocalViewDevice(Xpetra::Access::ReadOnly);
+  auto vertex2AggId          = aggregates->GetVertex2AggId()->getLocalViewDevice(Xpetra::Access::ReadOnly);
   const size_t numAggregates = aggregates->GetNumAggregates();
 
   int myPID = aggregates->GetMap()->getComm()->getRank();
@@ -1089,8 +1089,8 @@ void TentativePFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   coarseNullspace = MultiVectorFactory::Build(coarsePointMap, NSDim);
 
   // Pull out the nullspace vectors so that we can have random access (on the device)
-  auto fineNS   = fineNullspace->getDeviceLocalView(Xpetra::Access::ReadWrite);
-  auto coarseNS = coarseNullspace->getDeviceLocalView(Xpetra::Access::OverwriteAll);
+  auto fineNS   = fineNullspace->getLocalViewDevice(Xpetra::Access::ReadWrite);
+  auto coarseNS = coarseNullspace->getLocalViewDevice(Xpetra::Access::OverwriteAll);
 
   typedef typename Xpetra::Matrix<SC, LO, GO, NO>::local_matrix_type local_matrix_type;
   typedef typename local_matrix_type::row_map_type::non_const_type rows_type;

--- a/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
@@ -345,7 +345,7 @@ UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
   // Now generate local objects
   local_matrix_type localMatrix = A.getLocalMatrixDevice();
-  auto diagVals                 = diag->getDeviceLocalView(Xpetra::Access::ReadWrite);
+  auto diagVals                 = diag->getLocalViewDevice(Xpetra::Access::ReadWrite);
 
   ordinal_type numRows = localMatrix.graph.numRows();
 
@@ -434,7 +434,7 @@ UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       using KAT_M       = typename Kokkos::ArithTraits<mag_type>;
       using size_type   = typename local_matrix_type::non_const_size_type;
 
-      local_vector_type diag_dev      = diag->getDeviceLocalView(Xpetra::Access::OverwriteAll);
+      local_vector_type diag_dev      = diag->getLocalViewDevice(Xpetra::Access::OverwriteAll);
       local_matrix_type local_mat_dev = rcpA->getLocalMatrixDevice();
       Kokkos::RangePolicy<execution_space, int> my_policy(0, static_cast<int>(diag_dev.extent(0)));
       scalar_type valReplacement_dev = valReplacement;
@@ -599,7 +599,7 @@ UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   using scalar_type       = typename values_type::non_const_value_type;
   using KAT_S             = typename Kokkos::ArithTraits<scalar_type>;
 
-  auto diag_dev      = diag->getDeviceLocalView(Xpetra::Access::OverwriteAll);
+  auto diag_dev      = diag->getLocalViewDevice(Xpetra::Access::OverwriteAll);
   auto local_mat_dev = A.getLocalMatrixDevice();
   Kokkos::RangePolicy<execution_space, int> my_policy(0, static_cast<int>(diag_dev.extent(0)));
 
@@ -638,9 +638,9 @@ UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   using scalar_type       = typename values_type::non_const_value_type;
   using KAT_S             = typename Kokkos::ArithTraits<scalar_type>;
 
-  auto diag_dev        = diag->getDeviceLocalView(Xpetra::Access::OverwriteAll);
+  auto diag_dev        = diag->getLocalViewDevice(Xpetra::Access::OverwriteAll);
   auto local_mat_dev   = A.getLocalMatrixDevice();
-  auto local_block_dev = BlockNumber.getDeviceLocalView(Xpetra::Access::ReadOnly);
+  auto local_block_dev = BlockNumber.getLocalViewDevice(Xpetra::Access::ReadOnly);
   Kokkos::RangePolicy<execution_space, int> my_policy(0, static_cast<int>(diag_dev.extent(0)));
 
   Kokkos::parallel_for(
@@ -1194,8 +1194,8 @@ void UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   TEUCHOS_ASSERT(RHS.getMap()->isCompatible(InitialGuess.getMap()));
 #endif
 
-  auto lclRHS          = RHS.getDeviceLocalView(Xpetra::Access::ReadOnly);
-  auto lclInitialGuess = InitialGuess.getDeviceLocalView(Xpetra::Access::ReadWrite);
+  auto lclRHS          = RHS.getLocalViewDevice(Xpetra::Access::ReadOnly);
+  auto lclInitialGuess = InitialGuess.getLocalViewDevice(Xpetra::Access::ReadWrite);
 
   Kokkos::parallel_for(
       "MueLu:Utils::EnforceInitialCondition", range_type(0, numRows),
@@ -1294,7 +1294,7 @@ void UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   TEUCHOS_ASSERT(dirichletDomain.extent(0) == domMap->getLocalNumElements());
   RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>> myColsToZero = Xpetra::VectorFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(colMap, /*zeroOut=*/true);
   // Find all local column indices that are in Dirichlet rows, record in myColsToZero as 1.0
-  auto myColsToZeroView = myColsToZero->getDeviceLocalView(Xpetra::Access::ReadWrite);
+  auto myColsToZeroView = myColsToZero->getLocalViewDevice(Xpetra::Access::ReadWrite);
   auto localMatrix      = A.getLocalMatrixDevice();
   Kokkos::parallel_for(
       "MueLu:Maxwell1::DetectDirichletCols", range_type(0, rowMap->getLocalNumElements()),
@@ -1318,8 +1318,8 @@ void UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     myColsToZero->doImport(*globalColsToZero, *importer, Xpetra::INSERT);
   } else
     globalColsToZero = myColsToZero;
-  UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::FindNonZeros(globalColsToZero->getDeviceLocalView(Xpetra::Access::ReadOnly), dirichletDomain);
-  UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::FindNonZeros(myColsToZero->getDeviceLocalView(Xpetra::Access::ReadOnly), dirichletCols);
+  UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::FindNonZeros(globalColsToZero->getLocalViewDevice(Xpetra::Access::ReadOnly), dirichletDomain);
+  UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::FindNonZeros(myColsToZero->getLocalViewDevice(Xpetra::Access::ReadOnly), dirichletCols);
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -1546,7 +1546,7 @@ UtilitiesBase<SC, LO, GO, NO>::
   Teuchos::RCP<const Xpetra::Map<LO, GO, NO>> colMap             = A.getColMap();
   Teuchos::RCP<Xpetra::MultiVector<SC, LO, GO, NO>> myColsToZero = Xpetra::MultiVectorFactory<SC, LO, GO, NO>::Build(colMap, 1);
   myColsToZero->putScalar(zero);
-  auto myColsToZeroView = myColsToZero->getDeviceLocalView(Xpetra::Access::ReadWrite);
+  auto myColsToZeroView = myColsToZero->getLocalViewDevice(Xpetra::Access::ReadWrite);
   // Find all local column indices that are in Dirichlet rows, record in myColsToZero as 1.0
   Kokkos::parallel_for(
       "MueLu:Utils::DetectDirichletCols1", range_type(0, numRows),
@@ -1568,7 +1568,7 @@ UtilitiesBase<SC, LO, GO, NO>::
   // import to column map
   myColsToZero->doImport(*globalColsToZero, *exporter, Xpetra::INSERT);
 
-  auto myCols          = myColsToZero->getDeviceLocalView(Xpetra::Access::ReadOnly);
+  auto myCols          = myColsToZero->getLocalViewDevice(Xpetra::Access::ReadOnly);
   size_t numColEntries = colMap->getLocalNumElements();
   Kokkos::View<bool*, typename NO::device_type> dirichletCols(Kokkos::ViewAllocateWithoutInitializing("dirichletCols"), numColEntries);
   const typename ATS::magnitudeType eps = 2.0 * ATS::eps();
@@ -1870,7 +1870,7 @@ void UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
   typename ATS::val_type impl_replaceWith = replaceWith;
 
-  auto myCols    = X->getDeviceLocalView(Xpetra::Access::ReadWrite);
+  auto myCols    = X->getLocalViewDevice(Xpetra::Access::ReadWrite);
   size_t numVecs = X->getNumVectors();
   Kokkos::parallel_for(
       "MueLu:Utils::ZeroDirichletRows_MV", range_type(0, dirichletRows.size()),
@@ -2092,7 +2092,7 @@ UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       Xpetra::VectorFactory<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node>::Build(Op.getRowMap());
 
   // Copy out and reorder data
-  auto view1D = Kokkos::subview(retval->getDeviceLocalView(Xpetra::Access::ReadWrite), Kokkos::ALL(), 0);
+  auto view1D = Kokkos::subview(retval->getLocalViewDevice(Xpetra::Access::ReadWrite), Kokkos::ALL(), 0);
   Kokkos::parallel_for(
       "Utilities::ReverseCuthillMcKee",
       Kokkos::RangePolicy<ordinal_type, execution_space>(0, localGraph.numRows()),
@@ -2122,7 +2122,7 @@ UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       Xpetra::VectorFactory<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node>::Build(Op.getRowMap());
 
   // Copy out data
-  auto view1D = Kokkos::subview(retval->getDeviceLocalView(Xpetra::Access::ReadWrite), Kokkos::ALL(), 0);
+  auto view1D = Kokkos::subview(retval->getLocalViewDevice(Xpetra::Access::ReadWrite), Kokkos::ALL(), 0);
   // Since KokkosKernels produced RCM, also reverse the order of the view to get CM
   Kokkos::parallel_for(
       "Utilities::ReverseCuthillMcKee",

--- a/packages/muelu/src/Utils/MueLu_Utilities_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_decl.hpp
@@ -946,7 +946,7 @@ Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> importOffRank
   finalVec->doImport(*toggleVec, *importer, Xpetra::ABSMAX);
 
   std::vector<GO> finalDropMapEntries = {};
-  auto finalVec_h_2D                  = finalVec->getHostLocalView(Xpetra::Access::ReadOnly);
+  auto finalVec_h_2D                  = finalVec->getLocalViewHost(Xpetra::Access::ReadOnly);
   auto finalVec_h_1D                  = Kokkos::subview(finalVec_h_2D, Kokkos::ALL(), 0);
   const size_t localLength            = finalVec->getLocalLength();
 

--- a/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
@@ -433,8 +433,8 @@ Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       (typeid(Scalar).name() == typeid(std::complex<float>).name())) {
     size_t numVecs  = X->getNumVectors();
     Xscalar         = Xpetra::MultiVectorFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(X->getMap(), numVecs);
-    auto XVec       = X->getDeviceLocalView(Xpetra::Access::ReadOnly);
-    auto XVecScalar = Xscalar->getDeviceLocalView(Xpetra::Access::ReadWrite);
+    auto XVec       = X->getLocalViewDevice(Xpetra::Access::ReadOnly);
+    auto XVecScalar = Xscalar->getLocalViewDevice(Xpetra::Access::ReadWrite);
 
     Kokkos::parallel_for(
         "MueLu:Utils::RealValuedToScalarMultiVector", range_type(0, X->getLocalLength()),

--- a/packages/muelu/test/unit_tests/Utilities.cpp
+++ b/packages/muelu/test/unit_tests/Utilities.cpp
@@ -70,8 +70,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Utilities, MatMatMult_EpetraVsTpetra, Scalar, 
   result                    = MultiVectorFactory::Build(OpOp->getRangeMap(), 1);
   RCP<MultiVector> X_tpetra = MultiVectorFactory::Build(OpOp->getDomainMap(), 1);
   {
-    auto lcl_X_epetra = X_epetra->getHostLocalView(Xpetra::Access::ReadOnly);
-    auto lcl_X_tpetra = X_tpetra->getHostLocalView(Xpetra::Access::OverwriteAll);
+    auto lcl_X_epetra = X_epetra->getLocalViewHost(Xpetra::Access::ReadOnly);
+    auto lcl_X_tpetra = X_tpetra->getLocalViewHost(Xpetra::Access::OverwriteAll);
     Kokkos::deep_copy(lcl_X_tpetra, lcl_X_epetra);
   }
   X_tpetra->norm2(xnorm);
@@ -172,8 +172,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Utilities, EnforceInitialCondition, Scalar, Lo
   X->putScalar(666. * TST::one());
   Utilities::EnforceInitialCondition(*A, *RHS, *X, TST::magnitude(0.26));
 
-  auto lclRHS = RHS->getHostLocalView(Xpetra::Access::ReadOnly);
-  auto lclX   = X->getHostLocalView(Xpetra::Access::ReadOnly);
+  auto lclRHS = RHS->getLocalViewHost(Xpetra::Access::ReadOnly);
+  auto lclX   = X->getLocalViewHost(Xpetra::Access::ReadOnly);
 
   // row 5 is Dirichlet
   for (size_t row = 0; row < A->getLocalNumRows(); ++row) {

--- a/packages/muelu/test/unit_tests_kokkos/Aggregates_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/Aggregates_kokkos.cpp
@@ -153,7 +153,7 @@ LocalOrdinal checkAggregatesContiguous(MueLu::LWGraph_kokkos<LocalOrdinal, Globa
   using device_type     = typename LWGraph_kokkos::device_type;
 
   const LO numNodes = graph.GetNodeNumVertices();
-  auto vertex2AggId = aggregates.GetVertex2AggId()->getDeviceLocalView(Xpetra::Access::ReadOnly);
+  auto vertex2AggId = aggregates.GetVertex2AggId()->getLocalViewDevice(Xpetra::Access::ReadOnly);
   auto aggSizes     = aggregates.ComputeAggregateSizes(true);
 
   auto lclLWGraph = graph;
@@ -452,8 +452,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Aggregates_kokkos, DiscontiguousAggregates, Sc
   Kokkos::deep_copy(aggStat, MueLu::READY);
 
   // Performing fake aggregates to generate a discontiguous aggregate
-  Kokkos::View<LO**, Kokkos::LayoutLeft, device_type> vertex2AggId = aggregates->GetVertex2AggId()->getDeviceLocalView(Xpetra::Access::ReadWrite);
-  Kokkos::View<LO**, Kokkos::LayoutLeft, device_type> procWinner   = aggregates->GetProcWinner()->getDeviceLocalView(Xpetra::Access::ReadWrite);
+  Kokkos::View<LO**, Kokkos::LayoutLeft, device_type> vertex2AggId = aggregates->GetVertex2AggId()->getLocalViewDevice(Xpetra::Access::ReadWrite);
+  Kokkos::View<LO**, Kokkos::LayoutLeft, device_type> procWinner   = aggregates->GetProcWinner()->getLocalViewDevice(Xpetra::Access::ReadWrite);
 
   typename Kokkos::View<LO**, Kokkos::LayoutLeft, device_type>::HostMirror vertex2AggId_h = Kokkos::create_mirror_view(vertex2AggId);
   Kokkos::deep_copy(vertex2AggId_h, vertex2AggId);
@@ -762,7 +762,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Aggregates_kokkos, GreedyDirichlet, Scalar, Lo
 
   typename Aggregates::aggregates_sizes_type::const_type aggSizes = aggregates->ComputeAggregateSizes(true);
 
-  auto vertex2AggId = aggregates->GetVertex2AggId()->getHostLocalView(Xpetra::Access::ReadOnly);
+  auto vertex2AggId = aggregates->GetVertex2AggId()->getLocalViewHost(Xpetra::Access::ReadOnly);
   for (auto i = 0; i < (nx / 2 * ny / 2); i++) {
     TEST_EQUALITY(vertex2AggId(i, 0) != MUELU_UNAGGREGATED, true);  // check that all nodes are aggregated
   }
@@ -794,7 +794,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Aggregates_kokkos, GreedyDirichlet, Scalar, Lo
   // This may not be true for all problem setups, but is true for the setup in this test case.
   TEST_EQUALITY(aggSizesGreedy.extent(0) == aggSizes.extent(0), true)
 
-  vertex2AggId = aggregates->GetVertex2AggId()->getHostLocalView(Xpetra::Access::ReadOnly);
+  vertex2AggId = aggregates->GetVertex2AggId()->getLocalViewHost(Xpetra::Access::ReadOnly);
   TEST_EQUALITY(vertex2AggId(2, 0) == MUELU_UNAGGREGATED, true);  // check that the node with the Dof flagged as dirichlet is unaggregated
 
   // Repeat with greedy Dirichlet and preserve Dirichlet points
@@ -825,7 +825,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Aggregates_kokkos, GreedyDirichlet, Scalar, Lo
   // This will always be true.
   TEST_EQUALITY(aggSizesGreedyPreserve.extent(0) > aggSizesGreedy.extent(0), true)
 
-  vertex2AggId = aggregates->GetVertex2AggId()->getHostLocalView(Xpetra::Access::ReadOnly);
+  vertex2AggId = aggregates->GetVertex2AggId()->getLocalViewHost(Xpetra::Access::ReadOnly);
   for (auto i = 0; i < (nx / 2 * ny / 2); i++) {
     TEST_EQUALITY(vertex2AggId(i, 0) != MUELU_UNAGGREGATED, true);  // check that all nodes are aggregated
   }

--- a/packages/muelu/test/unit_tests_kokkos/CoalesceDropFactory_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/CoalesceDropFactory_kokkos.cpp
@@ -436,7 +436,7 @@ materialTestCase<Scalar, LocalOrdinal, GlobalOrdinal, Node> constructVariableMat
   {
     magnitudeType data[27][3] = {{0.0, 0.0, 2.0}, {0.0, 0.0, 1.0}, {0.0, 1.0, 1.0}, {0.0, 1.0, 2.0}, {1.0, 0.0, 2.0}, {1.0, 0.0, 1.0}, {1.0, 1.0, 1.0}, {1.0, 1.0, 2.0}, {0.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {1.0, 0.0, 0.0}, {1.0, 1.0, 0.0}, {0.0, 2.0, 1.0}, {0.0, 2.0, 2.0}, {1.0, 2.0, 1.0}, {1.0, 2.0, 2.0}, {0.0, 2.0, 0.0}, {1.0, 2.0, 0.0}, {2.0, 0.0, 2.0}, {2.0, 0.0, 1.0}, {2.0, 1.0, 1.0}, {2.0, 1.0, 2.0}, {2.0, 0.0, 0.0}, {2.0, 1.0, 0.0}, {2.0, 2.0, 1.0}, {2.0, 2.0, 2.0}, {2.0, 2.0, 0.0}};
     Kokkos::View<magnitudeType **, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> kv(&data[0][0], 27, 3);
-    auto lclMV = coords->getHostLocalView(Xpetra::Access::OverwriteAll);
+    auto lclMV = coords->getLocalViewHost(Xpetra::Access::OverwriteAll);
     Kokkos::deep_copy(lclMV, kv);
   }
 
@@ -444,7 +444,7 @@ materialTestCase<Scalar, LocalOrdinal, GlobalOrdinal, Node> constructVariableMat
   {
     impl_scalar_type data[27][9] = {{128.0, 0.0, 0.0, 0.0, 128.0, 0.0, 0.0, 0.0, 128.0}, {128.0, 0.0, 0.0, 0.0, 128.0, 0.0, 0.0, 0.0, 128.0}, {128.0, 0.0, 0.0, 0.0, 128.0, 0.0, 0.0, 0.0, 128.0}, {128.0, 0.0, 0.0, 0.0, 128.0, 0.0, 0.0, 0.0, 128.0}, {64.5, 0.0, 0.0, 0.0, 64.5, 0.0, 0.0, 0.0, 64.5}, {64.5, 0.0, 0.0, 0.0, 64.5, 0.0, 0.0, 0.0, 64.5}, {64.5, 0.0, 0.0, 0.0, 64.5, 0.0, 0.0, 0.0, 64.5}, {64.5, 0.0, 0.0, 0.0, 64.5, 0.0, 0.0, 0.0, 64.5}, {128.0, 0.0, 0.0, 0.0, 128.0, 0.0, 0.0, 0.0, 128.0}, {128.0, 0.0, 0.0, 0.0, 128.0, 0.0, 0.0, 0.0, 128.0}, {64.5, 0.0, 0.0, 0.0, 64.5, 0.0, 0.0, 0.0, 64.5}, {64.5, 0.0, 0.0, 0.0, 64.5, 0.0, 0.0, 0.0, 64.5}, {128.0, 0.0, 0.0, 0.0, 128.0, 0.0, 0.0, 0.0, 128.0}, {128.0, 0.0, 0.0, 0.0, 128.0, 0.0, 0.0, 0.0, 128.0}, {64.5, 0.0, 0.0, 0.0, 64.5, 0.0, 0.0, 0.0, 64.5}, {64.5, 0.0, 0.0, 0.0, 64.5, 0.0, 0.0, 0.0, 64.5}, {128.0, 0.0, 0.0, 0.0, 128.0, 0.0, 0.0, 0.0, 128.0}, {64.5, 0.0, 0.0, 0.0, 64.5, 0.0, 0.0, 0.0, 64.5}, {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0}, {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0}, {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0}, {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0}, {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0}, {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0}, {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0}, {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0}, {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0}};
     Kokkos::View<impl_scalar_type **, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> kv(&data[0][0], 27, 9);
-    auto lclMV = material->getHostLocalView(Xpetra::Access::OverwriteAll);
+    auto lclMV = material->getLocalViewHost(Xpetra::Access::OverwriteAll);
     Kokkos::deep_copy(lclMV, kv);
   }
   return std::make_tuple(A, droppedA, coords, material);
@@ -2238,7 +2238,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CoalesceDropFactory_kokkos, 2x2, Scalar, Local
   Teuchos::RCP<Xpetra::MultiVector<magnitudeType, LocalOrdinal, GlobalOrdinal, Node>> coords;
   coords = Xpetra::MultiVectorFactory<magnitudeType, LocalOrdinal, GlobalOrdinal, Node>::Build(mtx->getRowMap(), 1);
   {
-    auto lclCoords  = coords->getHostLocalView(Xpetra::Access::OverwriteAll);
+    auto lclCoords  = coords->getLocalViewHost(Xpetra::Access::OverwriteAll);
     auto rank       = comm->getRank();
     lclCoords(0, 0) = 2 * rank;
     lclCoords(1, 0) = 2 * rank + 1;

--- a/packages/muelu/test/unit_tests_kokkos/SemiCoarsenPFactory_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/SemiCoarsenPFactory_kokkos.cpp
@@ -108,7 +108,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(SemiCoarsenPFactory_kokkos, TestSemiCoarsenP, 
   // in this special case, the third layer will have the correct coordinates
   using impl_SC                 = typename Kokkos::ArithTraits<SC>::val_type;
   using impl_ATS                = Kokkos::ArithTraits<impl_SC>;
-  const auto fineCoordsDiffView = fineCoordsDiff->getDeviceLocalView(Xpetra::Access::ReadOnly);
+  const auto fineCoordsDiffView = fineCoordsDiff->getLocalViewDevice(Xpetra::Access::ReadOnly);
   const int numNodes            = fineCoordsDiff->getLocalLength();
   const int numVectors          = fineCoordsDiff->getNumVectors();
   const auto fineMap            = fineCoordsDiff->getMap()->getLocalMap();

--- a/packages/muelu/test/unit_tests_kokkos/Utilities_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/Utilities_kokkos.cpp
@@ -145,7 +145,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Utilities_kokkos, GetMatrixDiagonal, Scalar, L
 
   auto A        = MueLu_TestHelper_Factory::Build1DPoisson(100);
   auto diag     = Utils::GetMatrixDiagonal(*A);
-  auto diagView = diag->getHostLocalView(Xpetra::Access::ReadOnly);
+  auto diagView = diag->getLocalViewHost(Xpetra::Access::ReadOnly);
 
   TEST_EQUALITY(diagView.extent(0), A->getLocalNumRows());
 
@@ -166,7 +166,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Utilities_kokkos, GetMatrixDiagonalInverse, Sc
 
   auto A        = MueLu_TestHelper_Factory::Build1DPoisson(100);
   auto diag     = Utils::GetMatrixDiagonalInverse(*A);
-  auto diagView = diag->getHostLocalView(Xpetra::Access::ReadOnly);
+  auto diagView = diag->getLocalViewHost(Xpetra::Access::ReadOnly);
 
   TEST_EQUALITY(diagView.extent(0), A->getLocalNumRows());
 
@@ -186,7 +186,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Utilities_kokkos, GetMatrixOverlappedDiagonal,
 
   auto A        = MueLu_TestHelper_Factory::Build1DPoisson(100);
   auto diag     = Utils::GetMatrixOverlappedDiagonal(*A);
-  auto diagView = diag->getHostLocalView(Xpetra::Access::ReadOnly);
+  auto diagView = diag->getLocalViewHost(Xpetra::Access::ReadOnly);
 
   for (size_t idx = 0; idx < diagView.extent(0); ++idx) {
     TEST_EQUALITY(diagView(idx, 0), Scalar(2));
@@ -206,14 +206,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Utilities_kokkos, FindNonZeros, Scalar, LocalO
   auto A          = MueLu_TestHelper_Factory::Build1DPoisson(100);
   auto map        = A->getMap();
   auto vector     = Xpetra::MultiVectorFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(map, 1);
-  auto vectorView = vector->getDeviceLocalView(Xpetra::Access::ReadOnly);
+  auto vectorView = vector->getLocalViewDevice(Xpetra::Access::ReadOnly);
 
   Kokkos::View<bool *, typename Node::device_type> nonZeros("", vectorView.extent(0));
   unsigned int result = 0;
 
   // Zero-ed out Vector
   {
-    Utils::FindNonZeros(vector->getDeviceLocalView(Xpetra::Access::ReadOnly), nonZeros);
+    Utils::FindNonZeros(vector->getLocalViewDevice(Xpetra::Access::ReadOnly), nonZeros);
 
     Kokkos::parallel_reduce(
         "", RangeType(0, nonZeros.extent(0)),
@@ -226,7 +226,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Utilities_kokkos, FindNonZeros, Scalar, LocalO
   {
     vector->putScalar(TST::one());
 
-    Utils::FindNonZeros(vector->getDeviceLocalView(Xpetra::Access::ReadOnly), nonZeros);
+    Utils::FindNonZeros(vector->getLocalViewDevice(Xpetra::Access::ReadOnly), nonZeros);
 
     Kokkos::parallel_reduce(
         "", RangeType(0, nonZeros.extent(0)),
@@ -306,7 +306,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Utilities_kokkos, ZeroDirichletRows, Scalar, L
     const auto zeroVal = Scalar(0.25);
     Utils::ZeroDirichletRows(vector, dcols, zeroVal);
 
-    auto vecView = vector->getHostLocalView(Xpetra::Access::ReadOnly);
+    auto vecView = vector->getLocalViewHost(Xpetra::Access::ReadOnly);
 
     for (size_t idx = 0; idx < vecView.extent(0); ++idx) {
       TEST_EQUALITY(vecView(localRowToZero, idx), zeroVal);

--- a/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
@@ -202,7 +202,7 @@ namespace FROSch {
 
             auto repeatedLocalMap = repeatedMap->getLocalMap();
             auto rowLocalMap = rowMap->getLocalMap();
-            auto AssembledBasisView = AssembledBasis_->getDeviceLocalView(Access::ReadOnly);
+            auto AssembledBasisView = AssembledBasis_->getLocalViewDevice(Access::ReadOnly);
 
             // count number of nonzeros per row
             UN numLocalRows = rowMap->getLocalNumElements();

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_def.hpp
@@ -498,7 +498,7 @@ namespace FROSch {
                 auto localRepeatedMap = repeatedMap->getLocalMap();
                 auto localBasisMap = basisMap->getLocalMap();
 
-                auto localMVBasis = asembledBasis->getDeviceLocalView(Xpetra::Access::ReadOnly);
+                auto localMVBasis = asembledBasis->getLocalViewDevice(Xpetra::Access::ReadOnly);
 
                 // Array for scaling the columns of PhiGamma (1/norm(PhiGamma(:,i)))
                 using execution_space = typename Map<LO,GO,NO>::local_map_type::execution_space;
@@ -1186,7 +1186,7 @@ namespace FROSch {
             ExtensionSolver_->initialize();
         }
     }
-    
+
 }
 
 #endif

--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.hpp
@@ -398,15 +398,15 @@ class EpetraIntMultiVectorT<int, EpetraNode>
 
   typedef typename Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type dual_view_type;
 
-  typename dual_view_type::t_host_const_um getHostLocalView(Access::ReadOnlyStruct) const override { return getHostLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_host_const_um getLocalViewHost(Access::ReadOnlyStruct) const override { return getLocalViewHost(Access::ReadWrite); }
 
-  typename dual_view_type::t_dev_const_um getDeviceLocalView(Access::ReadOnlyStruct) const override { return getDeviceLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_dev_const_um getLocalViewDevice(Access::ReadOnlyStruct) const override { return getLocalViewDevice(Access::ReadWrite); }
 
-  typename dual_view_type::t_host_um getHostLocalView(Access::OverwriteAllStruct) const override { return getHostLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_host_um getLocalViewHost(Access::OverwriteAllStruct) const override { return getLocalViewHost(Access::ReadWrite); }
 
-  typename dual_view_type::t_dev_um getDeviceLocalView(Access::OverwriteAllStruct) const override { return getDeviceLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_dev_um getLocalViewDevice(Access::OverwriteAllStruct) const override { return getLocalViewDevice(Access::ReadWrite); }
 
-  typename dual_view_type::t_host_um getHostLocalView(Access::ReadWriteStruct) const override {
+  typename dual_view_type::t_host_um getLocalViewHost(Access::ReadWriteStruct) const override {
     typedef Kokkos::View<typename dual_view_type::t_host::data_type,
                          Kokkos::LayoutLeft,
                          typename dual_view_type::t_host::device_type,
@@ -426,7 +426,7 @@ class EpetraIntMultiVectorT<int, EpetraNode>
     return ret;
   }
 
-  typename dual_view_type::t_dev_um getDeviceLocalView(Access::ReadWriteStruct) const override { return getHostLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_dev_um getLocalViewDevice(Access::ReadWriteStruct) const override { return getLocalViewHost(Access::ReadWrite); }
 
   //@}
 

--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraMultiVector.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraMultiVector.hpp
@@ -665,15 +665,15 @@ class EpetraMultiVectorT<int, EpetraNode>
 
   typedef typename Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type dual_view_type;
 
-  typename dual_view_type::t_host_const_um getHostLocalView(Access::ReadOnlyStruct) const override { return getHostLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_host_const_um getLocalViewHost(Access::ReadOnlyStruct) const override { return getLocalViewHost(Access::ReadWrite); }
 
-  typename dual_view_type::t_dev_const_um getDeviceLocalView(Access::ReadOnlyStruct) const override { return getDeviceLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_dev_const_um getLocalViewDevice(Access::ReadOnlyStruct) const override { return getLocalViewDevice(Access::ReadWrite); }
 
-  typename dual_view_type::t_host_um getHostLocalView(Access::OverwriteAllStruct) const override { return getHostLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_host_um getLocalViewHost(Access::OverwriteAllStruct) const override { return getLocalViewHost(Access::ReadWrite); }
 
-  typename dual_view_type::t_dev_um getDeviceLocalView(Access::OverwriteAllStruct) const override { return getDeviceLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_dev_um getLocalViewDevice(Access::OverwriteAllStruct) const override { return getLocalViewDevice(Access::ReadWrite); }
 
-  typename dual_view_type::t_host_um getHostLocalView(Access::ReadWriteStruct) const override {
+  typename dual_view_type::t_host_um getLocalViewHost(Access::ReadWriteStruct) const override {
     typedef Kokkos::View<typename dual_view_type::t_host::data_type,
                          Kokkos::LayoutLeft,
                          typename dual_view_type::t_host::device_type,
@@ -694,7 +694,7 @@ class EpetraMultiVectorT<int, EpetraNode>
     return ret;
   }
 
-  typename dual_view_type::t_dev_um getDeviceLocalView(Access::ReadWriteStruct) const override { return getHostLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_dev_um getLocalViewDevice(Access::ReadWriteStruct) const override { return getLocalViewHost(Access::ReadWrite); }
 
   //@}
 

--- a/packages/xpetra/src/MultiVector/Xpetra_MultiVector_decl.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_MultiVector_decl.hpp
@@ -237,48 +237,48 @@ class MultiVector
   using host_execution_space = typename dual_view_type::host_mirror_space;
   using dev_execution_space  = typename dual_view_type::t_dev::execution_space;
 
-  virtual typename dual_view_type::t_host_const_um getHostLocalView(Access::ReadOnlyStruct) const {
-    throw std::runtime_error("Dummy function getHostLocalView(Access::ReadOnlyStruct), should be overwritten at" + std::string(__FILE__) + ":" + std::to_string(__LINE__));
+  virtual typename dual_view_type::t_host_const_um getLocalViewHost(Access::ReadOnlyStruct) const {
+    throw std::runtime_error("Dummy function getLocalViewHost(Access::ReadOnlyStruct), should be overwritten at" + std::string(__FILE__) + ":" + std::to_string(__LINE__));
 #ifndef __NVCC__
     typename dual_view_type::t_host_um test;
 #endif
     TEUCHOS_UNREACHABLE_RETURN(test);
   }
 
-  virtual typename dual_view_type::t_dev_const_um getDeviceLocalView(Access::ReadOnlyStruct) const {
-    throw std::runtime_error("Dummy function getDeviceLocalView(Access::ReadOnlyStruct), should be overwritten at" + std::string(__FILE__) + ":" + std::to_string(__LINE__));
+  virtual typename dual_view_type::t_dev_const_um getLocalViewDevice(Access::ReadOnlyStruct) const {
+    throw std::runtime_error("Dummy function getLocalViewDevice(Access::ReadOnlyStruct), should be overwritten at" + std::string(__FILE__) + ":" + std::to_string(__LINE__));
 #ifndef __NVCC__
     typename dual_view_type::t_dev_um test;
 #endif
     TEUCHOS_UNREACHABLE_RETURN(test);
   }
 
-  virtual typename dual_view_type::t_host_um getHostLocalView(Access::OverwriteAllStruct) const {
-    throw std::runtime_error("Dummy function getHostLocalView(Access::OverwriteAllStruct), should be overwritten at" + std::string(__FILE__) + ":" + std::to_string(__LINE__));
+  virtual typename dual_view_type::t_host_um getLocalViewHost(Access::OverwriteAllStruct) const {
+    throw std::runtime_error("Dummy function getLocalViewHost(Access::OverwriteAllStruct), should be overwritten at" + std::string(__FILE__) + ":" + std::to_string(__LINE__));
 #ifndef __NVCC__
     typename dual_view_type::t_host_um test;
 #endif
     TEUCHOS_UNREACHABLE_RETURN(test);
   }
 
-  virtual typename dual_view_type::t_dev_um getDeviceLocalView(Access::OverwriteAllStruct) const {
-    throw std::runtime_error("Dummy function getDeviceLocalView(Access::OverwriteAllStruct), should be overwritten at" + std::string(__FILE__) + ":" + std::to_string(__LINE__));
+  virtual typename dual_view_type::t_dev_um getLocalViewDevice(Access::OverwriteAllStruct) const {
+    throw std::runtime_error("Dummy function getLocalViewDevice(Access::OverwriteAllStruct), should be overwritten at" + std::string(__FILE__) + ":" + std::to_string(__LINE__));
 #ifndef __NVCC__
     typename dual_view_type::t_dev_um test;
 #endif
     TEUCHOS_UNREACHABLE_RETURN(test);
   }
 
-  virtual typename dual_view_type::t_host_um getHostLocalView(Access::ReadWriteStruct) const {
-    throw std::runtime_error("Dummy function getHostLocalView(Access::ReadWriteStruct), should be overwritten at" + std::string(__FILE__) + ":" + std::to_string(__LINE__));
+  virtual typename dual_view_type::t_host_um getLocalViewHost(Access::ReadWriteStruct) const {
+    throw std::runtime_error("Dummy function getLocalViewHost(Access::ReadWriteStruct), should be overwritten at" + std::string(__FILE__) + ":" + std::to_string(__LINE__));
 #ifndef __NVCC__
     typename dual_view_type::t_host_um test;
 #endif
     TEUCHOS_UNREACHABLE_RETURN(test);
   }
 
-  virtual typename dual_view_type::t_dev_um getDeviceLocalView(Access::ReadWriteStruct) const {
-    throw std::runtime_error("Dummy function getDeviceLocalView(Access::ReadWriteStruct), should be overwritten at" + std::string(__FILE__) + ":" + std::to_string(__LINE__));
+  virtual typename dual_view_type::t_dev_um getLocalViewDevice(Access::ReadWriteStruct) const {
+    throw std::runtime_error("Dummy function getLocalViewDevice(Access::ReadWriteStruct), should be overwritten at" + std::string(__FILE__) + ":" + std::to_string(__LINE__));
 #ifndef __NVCC__
     typename dual_view_type::t_dev_um test;
 #endif

--- a/packages/xpetra/src/MultiVector/Xpetra_TpetraMultiVector_decl.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_TpetraMultiVector_decl.hpp
@@ -253,17 +253,17 @@ class TpetraMultiVector
 
   typedef typename Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type dual_view_type;
 
-  virtual typename dual_view_type::t_host_const_um getHostLocalView(Access::ReadOnlyStruct) const;
+  virtual typename dual_view_type::t_host_const_um getLocalViewHost(Access::ReadOnlyStruct) const;
 
-  virtual typename dual_view_type::t_dev_const_um getDeviceLocalView(Access::ReadOnlyStruct) const;
+  virtual typename dual_view_type::t_dev_const_um getLocalViewDevice(Access::ReadOnlyStruct) const;
 
-  virtual typename dual_view_type::t_host_um getHostLocalView(Access::OverwriteAllStruct) const;
+  virtual typename dual_view_type::t_host_um getLocalViewHost(Access::OverwriteAllStruct) const;
 
-  virtual typename dual_view_type::t_dev_um getDeviceLocalView(Access::OverwriteAllStruct) const;
+  virtual typename dual_view_type::t_dev_um getLocalViewDevice(Access::OverwriteAllStruct) const;
 
-  virtual typename dual_view_type::t_host_um getHostLocalView(Access::ReadWriteStruct) const;
+  virtual typename dual_view_type::t_host_um getLocalViewHost(Access::ReadWriteStruct) const;
 
-  virtual typename dual_view_type::t_dev_um getDeviceLocalView(Access::ReadWriteStruct) const;
+  virtual typename dual_view_type::t_dev_um getLocalViewDevice(Access::ReadWriteStruct) const;
 
  protected:
   /// \brief Implementation of the assignment operator (operator=);

--- a/packages/xpetra/src/MultiVector/Xpetra_TpetraMultiVector_def.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_TpetraMultiVector_def.hpp
@@ -531,42 +531,42 @@ void TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 typename TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type::t_host_const_um
 TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-    getHostLocalView(Access::ReadOnlyStruct) const {
+    getLocalViewHost(Access::ReadOnlyStruct) const {
   return subview(vec_->getLocalViewHost(Tpetra::Access::ReadOnly), Kokkos::ALL(), Kokkos::ALL());
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 typename TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type::t_dev_const_um
 TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-    getDeviceLocalView(Access::ReadOnlyStruct) const {
+    getLocalViewDevice(Access::ReadOnlyStruct) const {
   return subview(vec_->getLocalViewDevice(Tpetra::Access::ReadOnly), Kokkos::ALL(), Kokkos::ALL());
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 typename TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type::t_host_um
 TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-    getHostLocalView(Access::OverwriteAllStruct) const {
+    getLocalViewHost(Access::OverwriteAllStruct) const {
   return subview(vec_->getLocalViewHost(Tpetra::Access::OverwriteAll), Kokkos::ALL(), Kokkos::ALL());
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 typename TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type::t_dev_um
 TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-    getDeviceLocalView(Access::OverwriteAllStruct) const {
+    getLocalViewDevice(Access::OverwriteAllStruct) const {
   return subview(vec_->getLocalViewDevice(Tpetra::Access::OverwriteAll), Kokkos::ALL(), Kokkos::ALL());
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 typename TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type::t_host_um
 TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-    getHostLocalView(Access::ReadWriteStruct) const {
+    getLocalViewHost(Access::ReadWriteStruct) const {
   return subview(vec_->getLocalViewHost(Tpetra::Access::ReadWrite), Kokkos::ALL(), Kokkos::ALL());
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 typename TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type::t_dev_um
 TpetraMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-    getDeviceLocalView(Access::ReadWriteStruct) const {
+    getLocalViewDevice(Access::ReadWriteStruct) const {
   return subview(vec_->getLocalViewDevice(Tpetra::Access::ReadWrite), Kokkos::ALL(), Kokkos::ALL());
 }
 

--- a/packages/xpetra/src/Vector/Xpetra_EpetraIntVector.hpp
+++ b/packages/xpetra/src/Vector/Xpetra_EpetraIntVector.hpp
@@ -485,15 +485,15 @@ class EpetraIntVectorT<int, EpetraNode>
 
   typedef typename Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type dual_view_type;
 
-  typename dual_view_type::t_host_const_um getHostLocalView(Access::ReadOnlyStruct) const override { return getHostLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_host_const_um getLocalViewHost(Access::ReadOnlyStruct) const override { return getLocalViewHost(Access::ReadWrite); }
 
-  typename dual_view_type::t_dev_const_um getDeviceLocalView(Access::ReadOnlyStruct) const override { return getDeviceLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_dev_const_um getLocalViewDevice(Access::ReadOnlyStruct) const override { return getLocalViewDevice(Access::ReadWrite); }
 
-  typename dual_view_type::t_host_um getHostLocalView(Access::OverwriteAllStruct) const override { return getHostLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_host_um getLocalViewHost(Access::OverwriteAllStruct) const override { return getLocalViewHost(Access::ReadWrite); }
 
-  typename dual_view_type::t_dev_um getDeviceLocalView(Access::OverwriteAllStruct) const override { return getDeviceLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_dev_um getLocalViewDevice(Access::OverwriteAllStruct) const override { return getLocalViewDevice(Access::ReadWrite); }
 
-  typename dual_view_type::t_host_um getHostLocalView(Access::ReadWriteStruct) const override {
+  typename dual_view_type::t_host_um getLocalViewHost(Access::ReadWriteStruct) const override {
     typedef Kokkos::View<typename dual_view_type::t_host::data_type,
                          Kokkos::LayoutLeft,
                          typename dual_view_type::t_host::device_type,
@@ -510,7 +510,7 @@ class EpetraIntVectorT<int, EpetraNode>
     return ret;
   }
 
-  typename dual_view_type::t_dev_um getDeviceLocalView(Access::ReadWriteStruct) const override { return getHostLocalView(Access::ReadWrite); }
+  typename dual_view_type::t_dev_um getLocalViewDevice(Access::ReadWriteStruct) const override { return getLocalViewHost(Access::ReadWrite); }
 
   //@}
 

--- a/packages/xpetra/test/MultiVector/MultiVector_UnitTestsXpetraSpecific.cpp
+++ b/packages/xpetra/test/MultiVector/MultiVector_UnitTestsXpetraSpecific.cpp
@@ -111,7 +111,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_7_DECL(MultiVector, XpetraSpecific_GetHostLocalView, 
   }
 
   // get a view of the multivector data on the host memory
-  typename dual_view_type::t_host_um hostView = mv->getHostLocalView(Xpetra::Access::ReadWrite);
+  typename dual_view_type::t_host_um hostView = mv->getLocalViewHost(Xpetra::Access::ReadWrite);
 
   TEST_EQUALITY(hostView.extent(0), numLocal);
   TEST_EQUALITY(hostView.extent(1), 3);


### PR DESCRIPTION
@trilinos/xpetra @trilinos/muelu @trilinos/shylu 

## Motivation
Tpetra uses
https://github.com/trilinos/Trilinos/blob/26c09fcb338d45ad0895da1f044baac688548c2f/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp#L1423
Xpetra uses
https://github.com/trilinos/Trilinos/blob/26c09fcb338d45ad0895da1f044baac688548c2f/packages/xpetra/src/MultiVector/Xpetra_MultiVector_decl.hpp#L240
That seems silly.