### PR TITLE
Framework: Add a new check to prevent changing deprecated packages

### DIFF
--- a/.github/workflows/per-commit.yml
+++ b/.github/workflows/per-commit.yml
@@ -21,3 +21,18 @@ jobs:
         $GITHUB_WORKSPACE/commonTools/test/utilities/check-commit-signoffs.sh \
         origin/${{ github.event.pull_request.base.ref }} \
         ${{ github.event.pull_request.head.sha }}
+
+  no-modifying-deprecated-packages:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        fetch-depth: 0
+
+    - name: Search for signoff statements in commit messages
+      run: |
+        $GITHUB_WORKSPACE/commonTools/test/utilities/check-not-modify-legacy-packages.sh \
+        origin/${{ github.event.pull_request.base.ref }} \
+        ${{ github.event.pull_request.head.sha }}

--- a/commonTools/test/utilities/check-not-modify-legacy-packages.sh
+++ b/commonTools/test/utilities/check-not-modify-legacy-packages.sh
@@ -1,0 +1,35 @@
+#!/bin/bash    
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+target_branch=${1}
+source_branch=${2}
+
+deprecated_packages=$(cat $(git rev-parse --show-toplevel)/CMakeLists.txt | grep "set(DEPRECATED_PACKAGES" | sed 's/set(DEPRECATED_PACKAGES //g' | sed 's/)//g' | tr '[:upper:]' '[:lower:]')
+paths=
+for package in ${deprecated_packages}
+do
+    paths="packages/${package} ${paths}"
+done
+
+estat=0
+for commit in $(git log --format=%H ${source_branch} --not ${target_branch})
+do
+    echo "Processing commit ${commit}"
+    git diff --quiet ${commit}^ ${commit} -- ${paths} || \
+    {
+        diff_output=$(git diff --name-only ${commit}^ ${commit} -- ${paths})
+        for path in ${paths}
+        do
+            if [[ "${diff_output}" == *"${path}"* ]]
+            then
+                echo -e "  This commit modified a legacy package (${path}), which is deprecated and will be deleted soon."
+            fi
+        done
+        estat=1
+    }
+done
+
+exit ${estat}


### PR DESCRIPTION
## Motivation
Discussed with operational leadership yesterday and a desire to prohibit changes to deprecated packages was expressed.  Commits that change deprecated (soon to-be deleted packages) should be flagged for additional scrutiny, and prohibited by default.