### PR TITLE
Make Pliris compatible with C23.

### DIFF
--- a/packages/pliris/src/x_factor.c
+++ b/packages/pliris/src/x_factor.c
@@ -80,7 +80,7 @@ void X_FACTOR_ (DATA_TYPE *matrix,int *matrixsize,
   DATA_TYPE *mat;
   int *permutations;
   double run_secs;              /* time (in secs) during which the prog ran */
-  double seconds();             /* function to generate timings */
+  double seconds(double);       /* function to generate timings */
   double tsecs;                 /* intermediate storage of timing info */
 
   int totmem1;

--- a/packages/pliris/src/xlu_solve_new.c
+++ b/packages/pliris/src/xlu_solve_new.c
@@ -80,7 +80,7 @@ void XLU_SOLVE_ (DATA_TYPE *matrix, int *matrix_size, int *num_procsr,
 
   int begin_rhs;                /* Beginning index for the RHS   */
   double run_secs;              /* time (in secs) during which the prog ran */
-  double seconds();             /* function to generate timings */
+  double seconds(double);       /* function to generate timings */
   double tsecs;                 /* intermediate storage of timing info */
 
   int totmem;


### PR DESCRIPTION
@trilinos/pliris

## Motivation
This is the default C standard for GCC 15 - see also

https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters

## Related Issues
* N/A

## Stakeholder Feedback
N/A

## Testing
Not sure how to do this in this context.

