### PR TITLE
[NOX] Check for a zero denominator when computing relative norm in `NOX::Solver::SingleStep`

### DIFF
--- a/packages/nox/src/NOX_Solver_SingleStep.C
+++ b/packages/nox/src/NOX_Solver_SingleStep.C
@@ -251,7 +251,8 @@ void NOX::Solver::SingleStep::printUpdate()
       double normDx = dirVecPtr->norm();
       utilsPtr->out() << "||F||=" << normF << ", ||dx||=" << normDx;
       if (computeRelativeNorm) {
-        utilsPtr->out() << ", ||F|| / ||F_0||=" << normF/normF_0;
+        utilsPtr->out() << ", ||F|| / ||F_0||=";
+        utilsPtr->out() << (normF_0 ? normF / normF_0 : std::numeric_limits<double>::quiet_NaN());
       }
     }
     if (status == NOX::StatusTest::Converged)


### PR DESCRIPTION
@trilinos/nox @rppawlo

## Motivation
This division results in UB if `normF_0=0`. Normally, if that happens, this means that the user has made a mistake setting up his numerical model. A particular user code that uses `NOX::Solver::SingleStep` could probably provide a meaningful output on this, but it may have no chance to do so since the program may silently die when trying to be the output inside `NOX::Solver::SingleStep::printUpdate()`.
