### PR TITLE
 Framework: Add containerized clang-openmpi config

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1822,6 +1822,34 @@ use PACKAGE-ENABLES|ALL
 use rhel8_aue-gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
+[rhel8_clang-openmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+use COMMON_SPACK_TPLS
+use NODE-TYPE|SERIAL
+use BUILD-TYPE|RELEASE-DEBUG
+use LIB-TYPE|SHARED
+use KOKKOS-ARCH|NO-KOKKOS-ARCH
+use USE-ASAN|NO
+use USE-COMPLEX|NO
+use USE-FPIC|NO
+use USE-MPI-NO-EXPLICIT-COMPILERS|YES
+use USE-PT|NO
+use USE-RDC|NO
+use USE-UVM|NO
+use USE-DEPRECATED|YES
+use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
+
+USE SPACK_NETLIB_BLAS_LAPACK
+use TEST_DISABLES|CLANG
+
+opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS STRING : --bind-to;none --mca btl vader,self
+
+opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE BOOL : ON
+opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE BOOL : ON
+
+[rhel8_clang-openmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+use rhel8_clang-openmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use PACKAGE-ENABLES|ALL
+
 [rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use COMMON_SPACK_TPLS
 use COMPILER|INTEL

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1112,6 +1112,8 @@ opt-set-cmake-var ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_rgdsw_MPI_4_DIS
 opt-set-cmake-var ShyLU_DDFROSch_test_frosch_interfacesets_2D_MPI_4_DISABLE BOOL : ON
 # Disable for clang
 opt-set-cmake-var ROL_example_PinT_parabolic-control_example_01_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE BOOL : ON
+opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE BOOL : ON
 
 [COMPILER|GNU]
 opt-set-cmake-var MPI_EXEC FILEPATH : mpirun
@@ -1838,13 +1840,13 @@ use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
-USE SPACK_NETLIB_BLAS_LAPACK
-use TEST_DISABLES|CLANG
+opt-set-cmake-var TPL_BLAS_LIBRARIES STRING FORCE : ${BLAS_ROOT|ENV}/lib/libopenblas.so;-lgfortran;-lm
+opt-set-cmake-var TPL_LAPACK_LIBRARIES STRING FORCE : ${BLAS_ROOT|ENV}/lib/libopenblas.so;-lgfortran;-lm
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS STRING : --bind-to;none --mca btl vader,self
+opt-set-cmake-var CMAKE_Fortran_FLAGS STRING : -fPIE
 
-opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE BOOL : ON
-opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE BOOL : ON
+use TEST_DISABLES|CLANG
 
 [rhel8_clang-openmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel8_clang-openmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables

--- a/packages/framework/ini-files/environment-specs.ini
+++ b/packages/framework/ini-files/environment-specs.ini
@@ -171,6 +171,8 @@ use rhel8_cuda-gcc-openmpi
 
 [rhel8_aue-gcc-openmpi]
 
+[rhel8_clang-openmpi]
+
 [rhel8_python]
 envvar-find-in-path PYTHON_EXECUTABLE : python3
 

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -181,6 +181,7 @@ cuda-11-gcc-openmpi
 gcc-openmpi
 gcc-serial
 aue-gcc-openmpi
+clang-openmpi
 sems-gnu-8.5.0-serial
 sems-cuda-11.4.2-sems-gnu-10.1.0-sems-openmpi-4.1.4
 sems-cuda-11.4.2-gnu-10.1.0-openmpi-4.1.6


### PR DESCRIPTION
@trilinos/framework cc: @bartlettroscoe @jwillenbring @rmmilewi 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
As part of the AT1 -> AT2 transition, we want to add a clang-openmpi container supported with an accompanying GenConfig configuration.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->
- trilinos/containers#17


## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
- Built the above clang-openmpi container with clang@19.1.6 and openmpi@4.1.6 and used this configuration to build Trilinos
  - able to build all of Trilinos
  - able to run and pass all tests 

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
