### PR TITLE
accept `TPETRA_DEFAULT_SEND_TYPE` behavior as string

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -677,10 +677,10 @@ bool Behavior::overlapCommunicationAndComputation() {
       value_, initialized_, BehaviorDetails::OVERLAP, defaultValue);
 }
 
-int Behavior::defaultSendType() {
-  constexpr int defaultValue(1);
+std::string Behavior::defaultSendType() {
+  const std::string defaultValue("Send");
 
-  static int value_ = defaultValue;
+  static std::string value_ = defaultValue;
   static bool initialized_ = false;
   return idempotentlyGetEnvironmentVariable(
       value_, initialized_, BehaviorDetails::DEFAULT_SEND_TYPE, defaultValue);

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
@@ -11,6 +11,7 @@
 #define TPETRA_DETAILS_BEHAVIOR_HPP
 
 #include <stddef.h>
+#include <string>
 
 /// \file Tpetra_Details_Behavior.hpp
 /// \brief Declaration of Tpetra::Details::Behavior, a class that
@@ -261,7 +262,7 @@ public:
   ///
   /// This is defaults to "Send".  You may control this at run time via the
   /// <tt>TPETRA_DEFAULT_SEND_TYPE</tt> environment variable.
-  static int defaultSendType();
+  static std::string defaultSendType();
 
   /// \brief Add Teuchos timers for all host calls to Kokkos::deep_copy().
   /// This is especially useful for identifying host/device data transfers

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -56,6 +56,15 @@ DistributorSendTypeStringToEnum (const std::string_view s)
   TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Invalid string to convert to EDistributorSendType enum value: " << s);
 }
 
+/// \brief Valid enum values of distributor send types.
+const std::string &validSendTypeOrThrow(const std::string &s) {
+  const auto valids = distributorSendTypes();
+  if (std::find(valids.begin(), valids.end(), s) == valids.end()) {
+    TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Invalid string for EDistributorSendType enum value: " << s);
+  }
+  return s;
+}
+
 std::string
 DistributorHowInitializedEnumToString (EDistributorHowInitialized how)
 {
@@ -936,10 +945,12 @@ DistributorPlan::getValidParameters() const
   Array<std::string> sendTypes = distributorSendTypes ();
   const Array<Details::EDistributorSendType> sendTypeEnums = distributorSendTypeEnums ();
 
+  const std::string validatedSendType = validSendTypeOrThrow(Behavior::defaultSendType());
+
   RCP<ParameterList> plist = parameterList ("Tpetra::Distributor");
 
   setStringToIntegralParameter<Details::EDistributorSendType> ("Send type",
-      Behavior::defaultSendType(), "When using MPI, the variant of send to use in "
+      validatedSendType, "When using MPI, the variant of send to use in "
       "do[Reverse]Posts()", sendTypes(), sendTypeEnums(), plist.getRawPtr());
   plist->set ("Timer Label","","Label for Time Monitor output");
 

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp
@@ -61,8 +61,17 @@ DistributorSendTypeEnumToString (EDistributorSendType sendType);
 EDistributorSendType
 DistributorSendTypeStringToEnum (const std::string_view s);
 
+/// \brief Valid string values for Distributor's "Send type" parameter.
+Teuchos::Array<std::string> distributorSendTypes ();
+
 /// \brief Valid enum values of distributor send types.
 Teuchos::Array<EDistributorSendType> distributorSendTypeEnums ();
+
+/// \brief Valid string values of distributor send types.
+Teuchos::Array<std::string> distributorSendTypes ();
+
+/// \brief Return the provided argument. Throw if it's not a valid send type.
+const std::string &validSendTypeOrThrow (const std::string &s);
 
 /// \brief Enum indicating how and whether a Distributor was initialized.
 ///

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp
@@ -57,6 +57,13 @@ enum EDistributorSendType {
 std::string
 DistributorSendTypeEnumToString (EDistributorSendType sendType);
 
+/// \brief Convert a string to an EDistributorSendType. Throw on error.
+EDistributorSendType
+DistributorSendTypeStringToEnum (const std::string_view s);
+
+/// \brief Valid enum values of distributor send types.
+Teuchos::Array<EDistributorSendType> distributorSendTypeEnums ();
+
 /// \brief Enum indicating how and whether a Distributor was initialized.
 ///
 /// This is an implementation detail of Distributor.  Please do

--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -166,19 +166,11 @@ namespace Tpetra {
     const bool debug = tpetraDistributorDebugDefault;
 
     Array<std::string> sendTypes = distributorSendTypes ();
-    const std::string defaultSendType (Details::DistributorSendTypeEnumToString(static_cast<Details::EDistributorSendType>(Details::Behavior::defaultSendType())));
-    Array<Details::EDistributorSendType> sendTypeEnums;
-    sendTypeEnums.push_back (Details::DISTRIBUTOR_ISEND);
-    sendTypeEnums.push_back (Details::DISTRIBUTOR_SEND);
-    sendTypeEnums.push_back (Details::DISTRIBUTOR_ALLTOALL);
-#if defined(HAVE_TPETRACORE_MPI_ADVANCE)
-    sendTypeEnums.push_back(Details::DISTRIBUTOR_MPIADVANCE_ALLTOALL);
-    sendTypeEnums.push_back(Details::DISTRIBUTOR_MPIADVANCE_NBRALLTOALLV);
-#endif
+    const Array<Details::EDistributorSendType> sendTypeEnums = Details::distributorSendTypeEnums ();
 
     RCP<ParameterList> plist = parameterList ("Tpetra::Distributor");
     setStringToIntegralParameter<Details::EDistributorSendType> ("Send type",
-      defaultSendType, "When using MPI, the variant of send to use in "
+      Details::Behavior::defaultSendType(), "When using MPI, the variant of send to use in "
       "do[Reverse]Posts()", sendTypes(), sendTypeEnums(), plist.getRawPtr());
     plist->set ("Debug", debug, "Whether to print copious debugging output on "
                 "all processes.");

--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -26,19 +26,13 @@ namespace Tpetra {
     const bool tpetraDistributorDebugDefault = false;
   } // namespace (anonymous)
 
+#if defined (TPETRA_ENABLE_DEPRECATED_CODE)
   Teuchos::Array<std::string>
   distributorSendTypes ()
   {
-    Teuchos::Array<std::string> sendTypes;
-    sendTypes.push_back ("Isend");
-    sendTypes.push_back ("Send");
-    sendTypes.push_back ("Alltoall");
-#if defined(HAVE_TPETRACORE_MPI_ADVANCE)
-    sendTypes.push_back ("MpiAdvanceAlltoall");
-    sendTypes.push_back ("MpiAdvanceNbralltoallv");
-#endif
-    return sendTypes;
+    return Details::distributorSendTypes();
   }
+#endif
 
   Distributor::
   Distributor (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,

--- a/packages/tpetra/core/src/Tpetra_Distributor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.hpp
@@ -29,13 +29,15 @@
 
 namespace Tpetra {
 
+#if defined (TPETRA_ENABLE_DEPRECATED_CODE)
   /// \brief Valid values for Distributor's "Send type" parameter.
   ///
   /// This is mainly useful as an implementation detail of
   /// Distributor.  You may use it if you would like a programmatic
   /// way to get all possible values of the "Send type" parameter of
   /// Distributor.
-  Teuchos::Array<std::string> distributorSendTypes ();
+  [[deprecated]] Teuchos::Array<std::string> distributorSendTypes ();
+#endif
 
   /// \class Distributor
   /// \brief Sets up and executes a communication plan for a Tpetra DistObject.


### PR DESCRIPTION
* Makes `TPETRA_DEFAULT_SEND_TYPE` accept a string rather than an int.
* Adds `Tpetra::Details::distributorSendTypes`.
* Deprecates `Tpetra::distributorSendTypes`. I think this should have always been in `Details` anyway, since it interacts with some enums in `Details`.

Also:
* all valid send type enums were generated in two places. Consolidated to a common function.

Fix for https://github.com/trilinos/Trilinos/issues/14115