### PR TITLE
Teko: Fix import/export bug related to single block Teko assembly

### DIFF
--- a/packages/teko/src/Tpetra/Teko_TpetraBlockedMappingStrategy.cpp
+++ b/packages/teko/src/Tpetra/Teko_TpetraBlockedMappingStrategy.cpp
@@ -236,8 +236,8 @@ void TpetraBlockedMappingStrategy::rebuildBlockedThyraOp(
         rcp_dynamic_cast<Tpetra::CrsMatrix<ST, LO, GO, NT>>(tAij->getTpetraOperator(), true);
     auto values_dest      = eAij->getLocalMatrixDevice().values;
     const auto values_src = crsContent->getLocalMatrixDevice().values;
-    TEUCHOS_DEBUG(eAij->getCrsGraph()->isIdenticalTo(*crsContent->getCrsGraph()));
-    TEUCHOS_DEBUG(values_dest.extent(0) == values_src.extent(0));
+    TEUCHOS_DEBUG_ASSERT(eAij->getCrsGraph()->isIdenticalTo(*crsContent->getCrsGraph()));
+    TEUCHOS_DEBUG_ASSERT(values_dest.extent(0) == values_src.extent(0));
     Kokkos::deep_copy(values_dest, values_src);
     return;
   }


### PR DESCRIPTION
Essentially forgot to avoid the import/export since we no longer need to map noncontig vectors to contig vectors.