### PR TITLE
MueLu: Fix definition of test MueLu_SetupSolve_Performance_MPI_4

### DIFF
--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -71,10 +71,10 @@ IF (${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK OR ${PACKAGE_NAME}_HAVE_EPETRA_SOLV
   # This an artifact to reproduce the old 4-rank test that is weak scaled by only adding guys in (x,y)
   TRIBITS_ADD_TEST(
       Driver
-      NAME SetupSolve_Performance_4
+      NAME SetupSolve_Performance
       COMM mpi
       ARGS "--stacked-timer --nx=240 --ny=240 --nz=120 --matrixType=Laplace3D"
-      NUM_MPI_PROCS ${NP}
+      NUM_MPI_PROCS 4
       PASS_REGULAR_EXPRESSION "Belos converged"
       RUN_SERIAL
       CATEGORIES PERFORMANCE


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
The definition of the performance test `MueLu_SetupSolve_Performance_MPI_4`.
- The generated name was `MueLu_SetupSolve_Performance_4_MPI_4`.
- The test was set up for 8^3 MPI ranks.