### PR TITLE
Ifpack2 Chebyshev: Use native spmv by default

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -303,7 +303,7 @@ Chebyshev (Teuchos::RCP<const row_matrix_type> A) :
   chebyshevAlgorithm_("first"),
   computeMaxResNorm_ (false),
   computeSpectralRadius_(true),
-  ckUseNativeSpMV_(false),
+  ckUseNativeSpMV_(true),
   debug_ (false)
 {
   checkConstructorInput ();
@@ -336,7 +336,7 @@ Chebyshev (Teuchos::RCP<const row_matrix_type> A,
   chebyshevAlgorithm_("first"),
   computeMaxResNorm_ (false),
   computeSpectralRadius_(true),
-  ckUseNativeSpMV_(false),
+  ckUseNativeSpMV_(true),
   debug_ (false)
 {
   checkConstructorInput ();
@@ -383,7 +383,7 @@ setParameters (Teuchos::ParameterList& plist)
   const std::string defaultChebyshevAlgorithm = "first";
   const bool defaultComputeMaxResNorm = false;
   const bool defaultComputeSpectralRadius = true;
-  const bool defaultCkUseNativeSpMV = false;
+  const bool defaultCkUseNativeSpMV = true;
   const bool defaultDebug = false;
 
   // We'll set the instance data transactionally, after all reads

--- a/packages/ifpack2/src/Ifpack2_Parameters.cpp
+++ b/packages/ifpack2/src/Ifpack2_Parameters.cpp
@@ -45,7 +45,7 @@ void getValidParameters(Teuchos::ParameterList &params) {
   // params.set("chebyshev: operator inv diagonal",Teuchos::null);
   params.set("chebyshev: min diagonal value", STS::eps());
   params.set("chebyshev: zero starting solution", true);
-  params.set("chebyshev: use native spmv", false);
+  params.set("chebyshev: use native spmv", true);
   params.set("chebyshev: algorithm", "first");
 
   // Ifpack2_Amesos.cpp


### PR DESCRIPTION
@trilinos/ifpack2 

## Motivation
Chebyshev has the option to either use the SpMV kernel (and hence benefit from TPLs) or to use a special fused implementation. This PR changes the default to TPL usage as it appears to be faster on several GPU systems.