### PR TITLE
Teuchos Stacked Timer: Add per proc std dev of call times

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -72,7 +72,9 @@ public:
   void stop(){
     if (!running_)
       error_out("Base_Timer:stop Failed timer not running");
-    accumulation_ += std::chrono::duration_cast<std::chrono::duration<double>>(Clock::now() - start_time_).count();
+    auto elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(Clock::now() - start_time_).count();
+    accumulation_ += elapsed;
+    accumulationSquared_ += elapsed*elapsed;
     running_ = false;
   }
 
@@ -83,7 +85,10 @@ public:
   double accumulatedTime() const {return accumulation_;}
 
   /// Setter for accumulated time
-  void setAccumulatedTime(double accum=0)  {accumulation_=accum;}
+  void setAccumulatedTime(double accum = 0) { accumulation_ = accum; }
+
+  /// Setter for squared accumulated time
+  void setAccumulatedTimeSquared(double accumSq=0)  {accumulationSquared_=accumSq;}
 
   /**
    * \brief return the average time per item updated
@@ -112,6 +117,22 @@ public:
   double accumulatedTimePerTimerCall() const {
     if (count_started_> 0) {
       return accumulation_/count_started_;
+    } else {
+      return 0;
+    }
+  }
+
+  /**
+   * \brief return the std dev in time per timer start/stop
+   *
+   * This returns the standard deviation in time that the code spends between
+   * a call to start and stop.  If it is running than it will not include the current time
+   * @return std dev in time per start/stop pair
+   */
+  double timePerCallStdDev() const {
+    if (count_started_ > 0) {
+      double mean = accumulatedTimePerTimerCall();
+      return sqrt(std::max<double>(accumulationSquared_ / count_started_ - mean*mean, 0.0));
     } else {
       return 0;
     }
@@ -153,9 +174,10 @@ public:
   { count_updates_ = num_updates; }
 
   struct TimeInfo {
-    TimeInfo():time(0.0), count(0), updates(0), running(false){}
-    TimeInfo(BaseTimer* t): time(t->accumulation_), count(t->count_started_), updates(t->count_updates_), running(t->running()) {}
+    TimeInfo():time(0.0), stdDev(0.0), count(0), updates(0), running(false){}
+    TimeInfo(BaseTimer* t): time(t->accumulation_), stdDev(t->timePerCallStdDev()), count(t->count_started_), updates(t->count_updates_), running(t->running()) {}
     double time;
+    double stdDev;
     unsigned long count;
     unsigned long long updates;
     bool running;
@@ -163,6 +185,7 @@ public:
 
 protected:
   double accumulation_;       // total time
+  double accumulationSquared_;  // Sum of squares of elapsed times
   unsigned long count_started_; // Number of times this timer has been started
   unsigned long long count_updates_; // Total count of items updated during this timer
   Clock::time_point start_time_;
@@ -416,7 +439,7 @@ protected:
      * @return pointer to BaseTimer (nullptr if none found)
      */
     const BaseTimer* findBaseTimer(const std::string &name) const;
-    
+
      /**
       * Return the time info for a given string
       * @param name input string to search for
@@ -597,7 +620,7 @@ public:
      else
        return timer_.accumulatedTimePerTimerCall(name);
    }
-  
+
   /**
    * Return pointer to the BaseTimer corresponding to a given string (full string name)
    * @param name input string to search for
@@ -631,20 +654,21 @@ public:
 
       @param output_fraction Print the timer fractions within a level.
       @param output_total_updates Print the updates counter.
-      @param output_historgram Print the histogram.
+      @param output_histogram Print the histogram.
       @param output_minmax Print the min max and standard deviation across MPI processes.
-      @param num_histogram The number of equally size bickets to use in the histogram.
+      @param num_histogram The number of equally size buckets to use in the histogram.
       @param max_level The number of levels in the stacked timer to print (default prints all levels).
       @param print_warnings Print any relevant warnings on stacked timer use.
-      @param align_columns Output will align the columsn of stacked timer data.
+      @param align_columns Output will align the columns of stacked timer data.
       @param print_names_before_values If set to true, writes the timer names before values.
       @param drop_time If a timer has a total time less that this value, the timer will not be printed and the total time of that timer will be added to the Remainder. Useful for ignoring negligible timers. Default is -1.0 to force printing of all timers even if they have zero accumulated time.
+      @param output_per_proc_stddev Output the minimum and maximum across MPI processes of the per call standard deviation.
    */
   struct OutputOptions {
     OutputOptions() : output_fraction(false), output_total_updates(false), output_histogram(false),
                       output_minmax(false), output_proc_minmax(false), num_histogram(10), max_levels(INT_MAX),
                       print_warnings(true), align_columns(false), print_names_before_values(true),
-                      drop_time(-1.0) {}
+                      drop_time(-1.0), output_per_proc_stddev(false) {}
     bool output_fraction;
     bool output_total_updates;
     bool output_histogram;
@@ -656,6 +680,7 @@ public:
     bool align_columns;
     bool print_names_before_values;
     double drop_time;
+    bool output_per_proc_stddev;
   };
 
   /**
@@ -779,6 +804,8 @@ protected:
   Array<double> sum_;
   Array<double> sum_sq_;
   Array<Array<int>> hist_;
+  Array<double> per_proc_stddev_min_;
+  Array<double> per_proc_stddev_max_;
   Array<unsigned long> count_;
   Array<unsigned long long> updates_;
   Array<int> active_;


### PR DESCRIPTION
@trilinos/teuchos 

## Motivation
This PR adds an option to the stacked timer to output the minimum and maximum across MPI ranks of the standard deviation of call times. The intended use is to simplify detection of slowdowns in a given timer region over the coarse of a simulation.

Sample output from the unit test:
```
 L0: 2.5 [1] {min=2, max=3, proc min=1, proc max=0, std dev=0.707107}, std dev per proc min/max=0/0.5
```