### PR TITLE
PackagesList.cmake: Add KokkosComm (optional external)

### DIFF
--- a/PackagesList.cmake
+++ b/PackagesList.cmake
@@ -26,6 +26,7 @@ TRIBITS_REPOSITORY_DEFINE_PACKAGES(
   Shards                packages/shards                   PT
   Triutils              packages/triutils                 ST
   EpetraExt             packages/epetraext                ST
+  KokkosComm            packages/kokkos-comm              EX
   Tpetra                packages/tpetra                   PT
   TrilinosSS            packages/common/auxiliarySoftware/SuiteSparse PT # Auxiliary software.
   Domi                  packages/domi                     PT
@@ -121,6 +122,7 @@ TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(xSDKTrilinos)
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(SGM)
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(UMR)
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(TrilinosLinearSolvers)
+TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(KokkosComm)
 
 # TRILFRAME-500
 TRIBITS_ALLOW_MISSING_EXTERNAL_PACKAGES(Rythmos)    # 27115 targets

--- a/packages/tpetra/CMakeLists.txt
+++ b/packages/tpetra/CMakeLists.txt
@@ -817,6 +817,21 @@ ENDIF ()
 ASSERT_DEFINED (${PACKAGE_NAME}_ENABLE_mpi_advance)
 
 # ============================================================
+# Kokkos Comm
+# ============================================================
+
+IF (NOT DEFINED ${PACKAGE_NAME}_ENABLE_KokkosComm)
+  IF (DEFINED TpetraCore_ENABLE_KokkosComm)
+    SET (${PACKAGE_NAME}_ENABLE_KokkosComm "${TpetraCore_ENABLE_KokkosComm}")
+  ELSEIF (DEFINED TPL_ENABLE_KokkosComm)
+    SET (${PACKAGE_NAME}_ENABLE_KokkosComm "${TPL_ENABLE_KokkosComm}")
+  ELSE ()
+    SET (${PACKAGE_NAME}_ENABLE_KokkosComm OFF)
+  ENDIF ()
+ENDIF ()
+ASSERT_DEFINED (${PACKAGE_NAME}_ENABLE_KokkosComm)
+
+# ============================================================
 # Scalar types
 # ============================================================
 

--- a/packages/tpetra/core/cmake/Dependencies.cmake
+++ b/packages/tpetra/core/cmake/Dependencies.cmake
@@ -1,5 +1,5 @@
 TRIBITS_PACKAGE_DEFINE_DEPENDENCIES(
   LIB_REQUIRED_PACKAGES Teuchos Kokkos TeuchosKokkosCompat TeuchosKokkosComm KokkosKernels
-  LIB_OPTIONAL_PACKAGES Epetra TpetraTSQR TeuchosNumerics
+  LIB_OPTIONAL_PACKAGES Epetra TpetraTSQR TeuchosNumerics KokkosComm
   LIB_OPTIONAL_TPLS MPI CUDA QD quadmath mpi_advance
 )

--- a/packages/tpetra/core/cmake/TpetraCore_config.h.in
+++ b/packages/tpetra/core/cmake/TpetraCore_config.h.in
@@ -34,6 +34,9 @@
 /* Determine if we have the mpi_advance TPL */
 #cmakedefine HAVE_TPETRACORE_MPI_ADVANCE
 
+/* Determine if we have the KokkosComm TPL */
+#cmakedefine HAVE_TPETRACORE_KOKKOSCOMM
+
 /* Determine if we have QD */
 #cmakedefine HAVE_TPETRACORE_QD
 #ifdef HAVE_TPETRACORE_QD

--- a/packages/tpetra/core/test/CMakeLists.txt
+++ b/packages/tpetra/core/test/CMakeLists.txt
@@ -22,6 +22,7 @@ ADD_SUBDIRECTORIES(
   ImportExport
   ImportExport2
   inout
+  KokkosComm
   LinearProblem
   Map
   MatrixMatrix

--- a/packages/tpetra/core/test/KokkosComm/CMakeLists.txt
+++ b/packages/tpetra/core/test/KokkosComm/CMakeLists.txt
@@ -1,0 +1,12 @@
+TRIBITS_SET_AND_INC_DIRS(DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+IF (${PACKAGE_NAME}_ENABLE_KokkosComm)
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    KokkosComm_include
+    SOURCES
+      KokkosComm_include.cpp
+    STANDARD_PASS_OUTPUT
+    )
+
+ENDIF()

--- a/packages/tpetra/core/test/KokkosComm/KokkosComm_include.cpp
+++ b/packages/tpetra/core/test/KokkosComm/KokkosComm_include.cpp
@@ -1,0 +1,15 @@
+// @HEADER
+// *****************************************************************************
+//          Tpetra: Templated Linear Algebra Services Package
+//
+// Copyright 2008 NTESS and the Tpetra contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#include <KokkosComm/KokkosComm.hpp>
+
+int main(int argc, char* argv[])
+{
+  return 0;
+}


### PR DESCRIPTION
Add Kokkos Comm as an optional external package `KokkosComm`.

Kokkos Comm is maintained at https://github.com/kokkos/kokkos-comm

Corresponding PR to add TriBITS support to Kokkos Comm: https://github.com/kokkos/kokkos-comm/pull/165

@trilinos/tpetra 

## Motivation
* Facilitate research at transport layer
* Improve Kokkos + MPI ergonomics

## Testing

Currently, a single Tpetra unit test that checks that the KokkosComm headers can be included.
