### PR TITLE
Tpetra: Add missing namespace

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -159,7 +159,7 @@ namespace Tpetra {
 
     const bool debug = tpetraDistributorDebugDefault;
 
-    Array<std::string> sendTypes = distributorSendTypes ();
+    Array<std::string> sendTypes = Details::distributorSendTypes ();
     const Array<Details::EDistributorSendType> sendTypeEnums = Details::distributorSendTypeEnums ();
 
     RCP<ParameterList> plist = parameterList ("Tpetra::Distributor");


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Not sure why my compiler complained about it, but not the autotester.

```
/workspace/trilinos/source/packages/tpetra/core/src/Tpetra_Distributor.cpp: In member function 'virtual Teuchos::RCP<const Teuchos::ParameterList> Tpetra::Distributor::getValidParameters() const':
/workspace/trilinos/source/packages/tpetra/core/src/Tpetra_Distributor.cpp:162:36: error: 'distributorSendTypes' was not declared in this scope; did you mean 'Tpetra::Details::distributorSendTypes'?
  162 |     Array<std::string> sendTypes = distributorSendTypes ();
      |                                    ^~~~~~~~~~~~~~~~~~~~
      |                                    Tpetra::Details::distributorSendTypes
In file included from /workspace/trilinos/source/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp:14,
                 from /workspace/trilinos/source/packages/tpetra/core/src/Tpetra_Distributor.hpp:13,
                 from /workspace/trilinos/source/packages/tpetra/core/src/Tpetra_Distributor.cpp:10:
/workspace/trilinos/source/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp:71:29: note: 'Tpetra::Details::distributorSendTypes' declared here
   71 | Teuchos::Array<std::string> distributorSendTypes ();
      |                             ^~~~~~~~~~~~~~~~~~~~
```