### PR TITLE
Tpetra: `default` the DistributorActor copy-ctor

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
@@ -14,11 +14,6 @@ namespace Tpetra::Details {
   DistributorActor::DistributorActor()
     : mpiTag_(DEFAULT_MPI_TAG) {}
 
-  DistributorActor::DistributorActor(const DistributorActor& otherActor)
-    : mpiTag_(otherActor.mpiTag_),
-    requestsRecv_(otherActor.requestsRecv_),
-    requestsSend_(otherActor.requestsSend_) {}
-
   void DistributorActor::doWaits(const DistributorPlan& plan) {
     doWaitsRecv(plan);
     doWaitsSend(plan);

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -42,7 +42,7 @@ class DistributorActor {
 
 public:
   DistributorActor();
-  DistributorActor(const DistributorActor& otherActor);
+  DistributorActor(const DistributorActor& otherActor) = default;
 
   template <class ExpView, class ImpView>
   void doPostsAndWaits(const DistributorPlan& plan,


### PR DESCRIPTION
Removes an opportunity to make a mistake

@trilinos/tpetra 