### PR TITLE
Tpetra: Add "Ialltofewv" send type

### DIFF
--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -651,6 +651,10 @@ IF (NOT Tpetra_ENABLE_DEPRECATED_CODE OR NOT TpetraCore_ENABLE_Epetra)
   LIST(REMOVE_ITEM SOURCES ${DIR}/Epetra_TsqrMessenger.cpp)
   LIST(REMOVE_ITEM SOURCES ${DIR}/Tpetra_EpetraRowMatrix.cpp)
 ENDIF()
+IF (NOT HAVE_TPETRACORE_MPI)
+  LIST(REMOVE_ITEM HEADERS ${DIR}/Tpetra_Details_Ialltofewv.hpp)
+  LIST(REMOVE_ITEM SOURCES ${DIR}/Tpetra_Details_Ialltofewv.cpp)
+ENDIF()
 TRILINOS_CREATE_CLIENT_TEMPLATE_HEADERS(${DIR})
 
 # Pull in the Kokkos refactor code.

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
@@ -17,31 +17,13 @@ namespace Tpetra::Details {
     : mpiTag_(DEFAULT_MPI_TAG) {}
 
   void DistributorActor::doWaits(const DistributorPlan& plan) {
-    if (requestsRecv_.size() > 0) {
-      ProfilingRegion wr("Tpetra::Distributor: doWaitsRecv[via doWaits]");
-
-      Teuchos::waitAll(*plan.getComm(), requestsRecv_());
-
-      // Restore the invariant that requests_.size() is the number of
-      // outstanding nonblocking communication requests.
-      requestsRecv_.resize(0);
-    }
-
-    if (requestsSend_.size() > 0) {
-      ProfilingRegion ws("Tpetra::Distributor: doWaitsSend[via doWaits]");
-
-      Teuchos::waitAll(*plan.getComm(), requestsSend_());
-
-      // Restore the invariant that requests_.size() is the number of
-      // outstanding nonblocking communication requests.
-      requestsSend_.resize(0);
-    }
+    doWaitsRecv(plan);
+    doWaitsSend(plan);
 
     {
       ProfilingRegion ws("Tpetra::Distributor: doWaitsIalltofewv[via doWaits]");
       doWaitsIalltofewv(plan);
     }
-
   }
 
   void DistributorActor::doWaitsRecv(const DistributorPlan& plan) {

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
@@ -9,8 +9,6 @@
 
 #include "Tpetra_Details_DistributorActor.hpp"
 
-#include <fstream>
-
 namespace Tpetra::Details {
 
   DistributorActor::DistributorActor()

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
@@ -9,14 +9,39 @@
 
 #include "Tpetra_Details_DistributorActor.hpp"
 
+#include <fstream>
+
 namespace Tpetra::Details {
 
   DistributorActor::DistributorActor()
     : mpiTag_(DEFAULT_MPI_TAG) {}
 
   void DistributorActor::doWaits(const DistributorPlan& plan) {
-    doWaitsRecv(plan);
-    doWaitsSend(plan);
+    if (requestsRecv_.size() > 0) {
+      ProfilingRegion wr("Tpetra::Distributor: doWaitsRecv[via doWaits]");
+
+      Teuchos::waitAll(*plan.getComm(), requestsRecv_());
+
+      // Restore the invariant that requests_.size() is the number of
+      // outstanding nonblocking communication requests.
+      requestsRecv_.resize(0);
+    }
+
+    if (requestsSend_.size() > 0) {
+      ProfilingRegion ws("Tpetra::Distributor: doWaitsSend[via doWaits]");
+
+      Teuchos::waitAll(*plan.getComm(), requestsSend_());
+
+      // Restore the invariant that requests_.size() is the number of
+      // outstanding nonblocking communication requests.
+      requestsSend_.resize(0);
+    }
+
+    {
+      ProfilingRegion ws("Tpetra::Distributor: doWaitsIalltofewv[via doWaits]");
+      doWaitsIalltofewv(plan);
+    }
+
   }
 
   void DistributorActor::doWaitsRecv(const DistributorPlan& plan) {
@@ -28,6 +53,11 @@ namespace Tpetra::Details {
       // Restore the invariant that requests_.size() is the number of
       // outstanding nonblocking communication requests.
       requestsRecv_.resize(0);
+    }
+
+    {
+      ProfilingRegion ws("Tpetra::Distributor: doWaitsIalltofewv[via doWaitsRecv]");
+      doWaitsIalltofewv(plan);
     }
   }
 
@@ -43,6 +73,24 @@ namespace Tpetra::Details {
     }
   }
 
+  void DistributorActor::doWaitsIalltofewv(const DistributorPlan& plan) {
+    #ifdef HAVE_TPETRA_MPI
+    if (ialltofewv_.req) {
+
+      ProfilingRegion ws("Tpetra::Distributor: doWaitsIalltofewv");
+      ialltofewv_.impl.wait(*ialltofewv_.req);
+
+      ialltofewv_.sendcounts.reset();
+      ialltofewv_.sdispls.reset();
+      ialltofewv_.recvcounts.reset();
+      ialltofewv_.rdispls.reset();
+      ialltofewv_.req = std::nullopt;
+      ialltofewv_.roots.clear();
+    }
+  #endif
+
+  }
+
   bool DistributorActor::isReady() const {
     bool result = true;
     for (auto& request : requestsRecv_) {
@@ -51,6 +99,18 @@ namespace Tpetra::Details {
     for (auto& request : requestsSend_) {
       result &= request->isReady();
     }
+
+    // isReady just calls MPI_Test and returns flag != 0
+    // don't use test because these are for a collective, and not
+    // all ranks may call test, so progress may not be possible
+#ifdef HAVE_TPETRA_MPI
+    if (ialltofewv_.req) {
+      int flag;
+      ialltofewv_.impl.get_status(*ialltofewv_.req, &flag, MPI_STATUS_IGNORE);
+      result &= flag;
+    }
+#endif
+
     return result;
   }
 }

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
@@ -32,10 +32,7 @@ namespace Tpetra::Details {
       requestsRecv_.resize(0);
     }
 
-    {
-      ProfilingRegion ws("Tpetra::Distributor: doWaitsIalltofewv[via doWaitsRecv]");
-      doWaitsIalltofewv(plan);
-    }
+    doWaitsIalltofewv(plan);
   }
 
   void DistributorActor::doWaitsSend(const DistributorPlan& plan) {

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
@@ -46,7 +46,7 @@ namespace Tpetra::Details {
   }
 
   void DistributorActor::doWaitsIalltofewv(const DistributorPlan& plan) {
-    #ifdef HAVE_TPETRA_MPI
+#ifdef HAVE_TPETRA_MPI
     if (ialltofewv_.req) {
 
       ProfilingRegion ws("Tpetra::Distributor: doWaitsIalltofewv");
@@ -59,8 +59,7 @@ namespace Tpetra::Details {
       ialltofewv_.req = std::nullopt;
       ialltofewv_.roots.clear();
     }
-  #endif
-
+#endif
   }
 
   bool DistributorActor::isReady() const {

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
@@ -19,11 +19,6 @@ namespace Tpetra::Details {
   void DistributorActor::doWaits(const DistributorPlan& plan) {
     doWaitsRecv(plan);
     doWaitsSend(plan);
-
-    {
-      ProfilingRegion ws("Tpetra::Distributor: doWaitsIalltofewv[via doWaits]");
-      doWaitsIalltofewv(plan);
-    }
   }
 
   void DistributorActor::doWaitsRecv(const DistributorPlan& plan) {

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -130,8 +130,11 @@ DistributorPlan::DistributorPlan(const DistributorPlan& otherPlan)
     lengthsFrom_(otherPlan.lengthsFrom_),
     procsFrom_(otherPlan.procsFrom_),
     startsFrom_(otherPlan.startsFrom_),
-    indicesFrom_(otherPlan.indicesFrom_),
+    indicesFrom_(otherPlan.indicesFrom_)
+#if defined(HAVE_TPETRACORE_MPI)
+    ,
     roots_(otherPlan.roots_)
+#endif
 { }
 
 size_t DistributorPlan::createFromSends(const Teuchos::ArrayView<const int>& exportProcIDs) {
@@ -625,6 +628,7 @@ void DistributorPlan::createReversePlan() const
   reversePlan_ = Teuchos::rcp(new DistributorPlan(comm_));
   reversePlan_->howInitialized_ = Details::DISTRIBUTOR_INITIALIZED_BY_REVERSE;
 
+#if defined(HAVE_TPETRACORE_MPI)
   // If the forward plan matches an all-to-few communication pattern,
   // the reverse plan is few-to-all, so don't use a special all-to-few
   // implementation for it
@@ -639,6 +643,7 @@ void DistributorPlan::createReversePlan() const
   } else {
     reversePlan_->sendType_ = sendType_;
   }
+#endif
 
 
   // The total length of all the sends of this DistributorPlan.  We

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -1064,7 +1064,8 @@ void DistributorPlan::initializeMpiAdvance() {
       }
     }
 
-    // If anyone is using slow-path communication, skip collectives
+    // In "slow-path" communication, the data is not blocked according to sending / receiving proc.
+    // The root-detection algorithm expects data to be blocked, so disable.
     int slow = !getIndicesTo().is_null() ? 1 : 0;
     MPI_Allreduce(MPI_IN_PLACE, &slow, 1, MPI_INT, MPI_LOR, comm);
     if (slow) {
@@ -1072,7 +1073,7 @@ void DistributorPlan::initializeMpiAdvance() {
       if (Tpetra::Details::Behavior::verbose()) {
         {
           std::stringstream ss;
-          ss << __FILE__ << ":" << __LINE__ << " " << comm_->getRank() << ": WARNING: you used Ialltoallv send mode, but someone is slow-path. Setting send-type to \"Send\"" << std::endl;
+          ss << __FILE__ << ":" << __LINE__ << " " << comm_->getRank() << ": WARNING: Ialltoallv send mode set, at least one rank's data is not grouped by rank. Setting to \"Send\"" << std::endl;
           std::cerr << ss.str();
         }
       }

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -627,6 +627,7 @@ void DistributorPlan::createReversePlan() const
 {
   reversePlan_ = Teuchos::rcp(new DistributorPlan(comm_));
   reversePlan_->howInitialized_ = Details::DISTRIBUTOR_INITIALIZED_BY_REVERSE;
+  reversePlan_->sendType_ = sendType_;
 
 #if defined(HAVE_TPETRACORE_MPI)
   // If the forward plan matches an all-to-few communication pattern,
@@ -640,8 +641,6 @@ void DistributorPlan::createReversePlan() const
     }
 
     reversePlan_->sendType_ = DistributorSendTypeStringToEnum(Behavior::defaultSendType());
-  } else {
-    reversePlan_->sendType_ = sendType_;
   }
 #endif
 

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -1028,8 +1028,9 @@ void DistributorPlan::initializeMpiAdvance() {
   // FIXME: probably need to rename this function since it might change the sendType
   void DistributorPlan::maybeInitializeRoots() {
 
-    // some collective send types need to know the roots
+    // Only IALLTOFEWV needs to know the roots
     if (DISTRIBUTOR_IALLTOFEWV != sendType_) {
+      roots_.clear();
       return;
     }
 
@@ -1078,11 +1079,11 @@ void DistributorPlan::initializeMpiAdvance() {
     if (roots_.size() * roots_.size() >= size_t(comm_->getSize())) {
       if (Tpetra::Details::Behavior::verbose()) {
         std::stringstream ss;
-        ss << __FILE__ << ":" << __LINE__ << " " << comm_->getRank() << ": WARNING (Ialltoallv send type): too many roots (" << roots_.size() << ") for " << comm_->getSize() << " ranks. Setting send-type to default" << std::endl;
+        ss << __FILE__ << ":" << __LINE__ << " " << comm_->getRank() << ": WARNING (Ialltoallv send type): too many roots (" << roots_.size() << ") for " << comm_->getSize() << " ranks. Setting send-type to \"Send\"" << std::endl;
         std::cerr << ss.str();
       }
       roots_.clear();
-      sendType_ = DistributorSendTypeStringToEnum(Behavior::defaultSendType());
+      sendType_ = DISTRIBUTOR_SEND;
     }
   }
 #endif // HAVE_TPETRA_MPI

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -410,6 +410,10 @@ size_t DistributorPlan::createFromSends(const Teuchos::ArrayView<const int>& exp
   // Invert map to see what msgs are received and what length
   computeReceives();
 
+#if defined(HAVE_TPETRA_MPI)
+  maybeInitializeRoots();
+#endif
+
   // createFromRecvs() calls createFromSends(), but will set
   // howInitialized_ again after calling createFromSends().
   howInitialized_ = Details::DISTRIBUTOR_INITIALIZED_BY_CREATE_FROM_SENDS;
@@ -605,6 +609,10 @@ void DistributorPlan::createFromSendsAndRecvs(const Teuchos::ArrayView<const int
   totalReceiveLength_ = remoteProcIDs.size();
   indicesFrom_.clear ();
   numReceives_-=sendMessageToSelf_;
+
+#if defined(HAVE_TPETRA_MPI)
+  maybeInitializeRoots();
+#endif
 }
 
 Teuchos::RCP<DistributorPlan> DistributorPlan::getReversePlan() const {
@@ -931,9 +939,9 @@ void DistributorPlan::setParameterList(const Teuchos::RCP<Teuchos::ParameterList
     // sublist passed to setParameterList(), so we save the pointer.
     this->setMyParamList (plist);
 
-
+#if defined(HAVE_TPETRA_MPI)
     maybeInitializeRoots();
-    // FIXME: MPI Advance
+#endif
   }
 }
 
@@ -1042,7 +1050,7 @@ void DistributorPlan::initializeMpiAdvance() {
     std::vector<int> recvbuf(comm_->getSize());
 
     // FIXME: is there a more natural way to do this?
-    // Maybe MPI_Allreduce is better, we just care if anyone is sending anything to each proces
+    // Maybe MPI_Allreduce is better, we just care if anyone is sending anything to each process
     // we just need to know all processes that receive anything (including a self message)
     Teuchos::RCP<const Teuchos::MpiComm<int> > mpiComm = Teuchos::rcp_dynamic_cast<const Teuchos::MpiComm<int> >(comm_);
     Teuchos::RCP<const Teuchos::OpaqueWrapper<MPI_Comm> > rawComm = mpiComm->getRawMpiComm();

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.cpp
@@ -55,6 +55,9 @@ DistributorSendTypeStringToEnum (const std::string_view s)
   if (s == "Isend") return DISTRIBUTOR_ISEND;
   if (s == "Send") return DISTRIBUTOR_SEND;
   if (s == "Alltoall") return DISTRIBUTOR_ALLTOALL;
+#if defined(HAVE_TPETRA_MPI)
+  if (s == "Ialltofewv") return DISTRIBUTOR_IALLTOFEWV;
+#endif
 #if defined(HAVE_TPETRACORE_MPI_ADVANCE)
   if (s == "MpiAdvanceAlltoall") return DISTRIBUTOR_MPIADVANCE_ALLTOALL;
   if (s == "MpiAdvanceNbralltoallv") return DISTRIBUTOR_MPIADVANCE_NBRALLTOALLV;

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorPlan.hpp
@@ -43,6 +43,10 @@ enum EDistributorSendType {
   DISTRIBUTOR_ISEND, // Use MPI_Isend (Teuchos::isend)
   DISTRIBUTOR_SEND,  // Use MPI_Send (Teuchos::send)
   DISTRIBUTOR_ALLTOALL // Use MPI_Alltoall
+#if defined(HAVE_TPETRA_MPI)
+  ,
+  DISTRIBUTOR_IALLTOFEWV
+#endif
 #if defined(HAVE_TPETRACORE_MPI_ADVANCE)
   ,
   DISTRIBUTOR_MPIADVANCE_ALLTOALL,
@@ -146,11 +150,20 @@ public:
   SubViewLimits getExportViewLimits(size_t numPackets) const;
   SubViewLimits getExportViewLimits(const Teuchos::ArrayView<const size_t> &numExportPacketsPerLID) const;
 
+#if defined(HAVE_TPETRA_MPI)
+  const std::vector<int> getRoots() const {
+    return roots_;
+  }
+#endif
 private:
 
   // after the plan has been created we have the info we need to initialize the MPI advance communicator
 #if defined(HAVE_TPETRACORE_MPI_ADVANCE)
   void initializeMpiAdvance();
+#endif
+
+#if defined(HAVE_TPETRA_MPI)
+  void maybeInitializeRoots();
 #endif
 
   Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
@@ -271,6 +284,15 @@ private:
   /// reverse Distributor, this is assigned to the reverse
   /// Distributor's indicesTo_.
   Teuchos::Array<size_t> indicesFrom_;
+
+#if defined(HAVE_TPETRA_MPI)
+  /// \brief The roots for the Ialltofewv communication mode.
+  ///
+  /// This is the same on all ranks, and this contains any rank that
+  /// is importing data.
+  std::vector<int> roots_;
+
+#endif
 };
 
 }

--- a/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
@@ -176,7 +176,7 @@ struct Ialltofewv::Cache::impl {
 
 };
 
-Ialltofewv::Cache::Cache() : pimpl(std::make_shared<Cache::impl>()) {}
+Ialltofewv::Cache::Cache() = default;
 Ialltofewv::Cache::~Cache() = default;
 
 namespace {
@@ -192,6 +192,11 @@ int wait_impl(Ialltofewv::Req &req, Ialltofewv::Cache &cache) {
   }
 
   ProfilingRegion pr("alltofewv::wait");
+
+  // lazy-init view cache
+  if (!cache.pimpl) {
+    cache.pimpl = std::make_shared<Ialltofewv::Cache::impl>();
+  }
 
   const int rank = [&]() -> int {
     int _rank;

--- a/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
@@ -337,7 +337,7 @@ int wait_impl(Ialltofewv::Req &req, Ialltofewv::Cache &cache) {
   MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
   reqs.resize(0);
 
-  // if I am a root, recieve data from each aggregator
+  // if I am a root, receive data from each aggregator
   // The aggregator will send contiguous data, which we may need to spread out according to rdispls
   auto rootBuf = cache.pimpl->get_rootBuf<RecvExecSpace>(0);
   if (isRoot) {

--- a/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
@@ -367,7 +367,6 @@ int wait_impl(Ialltofewv::Req &req, Ialltofewv::Cache &cache) {
 
       if (count) {
         MPI_Request rreq;
-        // &rootBuf(displ)
         MPI_Irecv(rootBuf.data() + displ, count, req.recvtype, aggSrc, ROOT_TAG,  req.comm, &rreq);
         reqs.push_back(rreq);
         displ += size_t(count) * recvSize;

--- a/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
@@ -1,0 +1,581 @@
+// @HEADER
+// *****************************************************************************
+//          Tpetra: Templated Linear Algebra Services Package
+//
+// Copyright 2008 NTESS and the Tpetra contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#include "Tpetra_Details_Ialltofewv.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include <mpi.h>
+#include <Kokkos_Core.hpp>
+
+#ifndef NDEBUG
+#include <iostream>
+#include <sstream>
+#endif
+
+namespace {
+
+  struct ProfilingRegion {
+    ProfilingRegion() = delete;
+    ProfilingRegion(const ProfilingRegion &other) = delete;
+    ProfilingRegion(ProfilingRegion &&other) = delete;
+    
+    ProfilingRegion(const std::string &name) {
+        Kokkos::Profiling::pushRegion(name);
+    }
+    ~ProfilingRegion() {
+        Kokkos::Profiling::popRegion();
+    }
+};
+
+  struct MemcpyArg {
+    void *dst;
+    void *src;
+    size_t count;
+};
+
+
+template <typename T>
+KOKKOS_INLINE_FUNCTION bool is_compatible(const MemcpyArg &arg) {
+    return (0 == (uintptr_t(arg.dst) % sizeof(T)))
+        && (0 == (uintptr_t(arg.src) & sizeof(T)))
+        && (0 == (arg.count % sizeof(T)));
+}
+
+template <typename T, typename Member>
+KOKKOS_INLINE_FUNCTION void team_memcpy_as(const Member &member, void *dst, void *const src, size_t count) {
+    Kokkos::parallel_for(
+        Kokkos::TeamThreadRange(member, count),
+        [&] (size_t i) {
+            reinterpret_cast<T *>(dst)[i] = reinterpret_cast<T const *>(src)[i];
+        }
+    );
+}
+
+template <typename Member>
+KOKKOS_INLINE_FUNCTION void team_memcpy(const Member &member, MemcpyArg &arg) {
+    if (is_compatible<uint64_t>(arg)) {
+        team_memcpy_as<uint64_t>(member, arg.dst, arg.src, arg.count / sizeof(uint64_t));
+    } else if (is_compatible<uint32_t>(arg)) {
+        team_memcpy_as<uint32_t>(member, arg.dst, arg.src, arg.count / sizeof(uint32_t));
+    } else {
+        team_memcpy_as<uint8_t>(member, arg.dst, arg.src, arg.count);
+    }
+}
+
+} // namespace
+
+namespace Tpetra::Details {
+  
+struct Ialltofewv::Cache::impl {
+
+  impl() : 
+    rootBufDev("rootBufDev"), rootBufHost("rootBufHost"),
+    aggBufDev("aggBufDev"), aggBufHost("rootBufHost"),
+    argsDev("argsDev"), argsHost("argsHost"),
+    rootBufGets_(0), rootBufHits_(0),
+    aggBufGets_(0), aggBufHits_(0),
+    argsGets_(0), argsHits_(0),
+    rootBufDevSize_(0), aggBufDevSize_(0), 
+    argsDevSize_(0), argsHostSize_(0),
+    rootBufHostSize_(0), aggBufHostSize_(0)
+{}
+
+  // cached views
+  Kokkos::View<uint8_t *, typename Kokkos::DefaultExecutionSpace::memory_space> rootBufDev;
+  Kokkos::View<uint8_t *, typename Kokkos::DefaultHostExecutionSpace::memory_space> rootBufHost;
+  Kokkos::View<char *, typename Kokkos::DefaultExecutionSpace::memory_space> aggBufDev;
+  Kokkos::View<char *, typename Kokkos::DefaultHostExecutionSpace::memory_space> aggBufHost;
+  Kokkos::View<MemcpyArg *, typename Kokkos::DefaultExecutionSpace::memory_space> argsDev;
+  Kokkos::View<MemcpyArg *, typename Kokkos::DefaultHostExecutionSpace::memory_space> argsHost;
+
+  size_t rootBufGets_;
+  size_t rootBufHits_;
+  size_t aggBufGets_;
+  size_t aggBufHits_;
+  size_t argsGets_;
+  size_t argsHits_;
+  
+  size_t rootBufDevSize_, aggBufDevSize_;
+  size_t argsDevSize_, argsHostSize_;
+  size_t rootBufHostSize_, aggBufHostSize_;
+
+  template <typename ExecSpace>
+  auto get_rootBuf(size_t size) {
+    ++rootBufGets_;
+    if constexpr(std::is_same_v<ExecSpace, Kokkos::DefaultExecutionSpace>) {
+      if (rootBufDev.extent(0) < size) {
+        Kokkos::resize(Kokkos::WithoutInitializing, rootBufDev, size);
+        rootBufDevSize_ = size;
+      } else {
+        ++rootBufHits_;
+      }
+      return Kokkos::subview(rootBufDev, Kokkos::pair{size_t(0), size});
+    } else {
+      if (rootBufHost.extent(0) < size) {
+        Kokkos::resize(Kokkos::WithoutInitializing, rootBufHost, size);
+        rootBufHostSize_ = size;
+      } else {
+        ++rootBufHits_;
+      }
+      return Kokkos::subview(rootBufHost, Kokkos::pair{size_t(0), size});
+    }
+  }
+
+  template <typename ExecSpace>
+  auto get_aggBuf(size_t size) {
+    ++aggBufGets_;
+    if constexpr(std::is_same_v<ExecSpace, Kokkos::DefaultExecutionSpace>) {
+      if (aggBufDev.extent(0) < size) {
+        Kokkos::resize(Kokkos::WithoutInitializing, aggBufDev, size);
+        aggBufHostSize_ = size;
+      } else {
+        ++aggBufHits_;
+      }
+      return Kokkos::subview(aggBufDev, Kokkos::pair{size_t(0), size});
+    } else {
+      if (aggBufHost.extent(0) < size) {
+        Kokkos::resize(Kokkos::WithoutInitializing, aggBufHost, size);
+        aggBufHostSize_ = size;
+      } else {
+        ++aggBufHits_;
+      }
+      return Kokkos::subview(aggBufHost, Kokkos::pair{size_t(0), size});
+    }
+  }
+
+  template <typename ExecSpace>
+  auto get_args(size_t size) {
+    ++argsGets_;
+    if constexpr(std::is_same_v<ExecSpace, Kokkos::DefaultExecutionSpace>) {
+      if (argsDev.extent(0) < size) {
+        Kokkos::resize(Kokkos::WithoutInitializing, argsDev, size);
+        argsHostSize_ = size;
+      } else {
+        ++argsHits_;
+      }
+      return Kokkos::subview(argsDev, Kokkos::pair{size_t(0), size});
+    } else {
+      if (argsHost.extent(0) < size) {
+        Kokkos::resize(Kokkos::WithoutInitializing, argsHost, size);
+        argsHostSize_ = size;
+      } else {
+        ++argsHits_;
+      }
+      return Kokkos::subview(argsHost, Kokkos::pair{size_t(0), size});
+    }
+  }
+
+};
+
+Ialltofewv::Cache::Cache() : pimpl(std::make_shared<Cache::impl>()) {}
+#ifdef NDEBUG
+Ialltofewv::Cache::~Cache() = default;
+#else
+Ialltofewv::Cache::~Cache() {
+  if (pimpl->rootBufGets_) {
+    std::cerr << "rootBuf:" 
+    << " " << pimpl->rootBufDevSize_ + pimpl->rootBufHostSize_
+    << " " << pimpl->rootBufHits_ << "/" << pimpl->rootBufGets_ << "\n";
+  }
+  if (pimpl->aggBufGets_) {
+    std::cerr << "aggBuf:" 
+    << " " << pimpl->aggBufDevSize_ + pimpl->aggBufHostSize_
+    << " " << pimpl->aggBufHits_ << "/" << pimpl->aggBufGets_ << "\n";
+  }
+  if (pimpl->argsGets_) {
+    std::cerr << "args:" 
+    << " " << pimpl->argsDevSize_ + pimpl->argsHostSize_
+    << " " << pimpl->argsHits_ << "/" << pimpl->argsGets_ << "\n";
+  }
+}
+#endif
+
+namespace {
+template <typename RecvExecSpace>  
+int wait_impl(Ialltofewv::Req &req, Ialltofewv::Cache &cache) {
+
+  auto finalize = [&]() -> int {
+    req.completed = true;
+    return MPI_SUCCESS;
+  };
+
+  if (0 == req.nroots) {
+    return finalize();
+  }
+
+  ProfilingRegion pr("alltofewv::wait");
+
+  const int AGG_TAG = req.tag + 0;
+  const int ROOT_TAG = req.tag + 1;
+
+  const int rank = [&]() -> int {
+    int _rank;
+    MPI_Comm_rank(req.comm, &_rank);
+    return _rank;
+  }();
+
+  const int size = [&]() -> int {
+    int _size;
+    MPI_Comm_size(req.comm, &_size);
+    return _size;
+  }();
+
+  const size_t sendSize = [&]() -> size_t {
+    int _size;
+    MPI_Type_size(req.sendtype, &_size);
+    return _size;
+  }();
+
+  const size_t recvSize = [&]() -> size_t {
+    int _size;
+    MPI_Type_size(req.recvtype, &_size);
+    return _size;
+  }();
+  
+
+    // Balance the number of incoming messages at each phase:
+    // Aggregation = size / naggs * nroots
+    // Root =        naggs
+    // so
+    // size / naggs * nroots = naggs
+    // size * nroots = naggs^2
+    // naggs = sqrt(size * nroots)
+    const int naggs = std::sqrt(size_t(size) * size_t(req.nroots)) + /*rounding*/ 0.5;
+  
+    // how many srcs go to each aggregator
+    const int srcsPerAgg = (size + naggs - 1) / naggs;
+  
+    // the aggregator I send to
+    const int myAgg = rank / srcsPerAgg * srcsPerAgg;
+  
+    // is this rank a root? linear search - nroots expected to be small
+    const bool isRoot = std::find(req.roots, req.roots + req.nroots, rank) !=  req.roots + req.nroots;
+
+    // ensure aggregators know how much data each rank is sending to the root
+    // [si * nroots + r1] -> how much rank si wants to send to root ri
+    std::vector<int> groupSendCounts(size_t(req.nroots) * size_t(srcsPerAgg));
+    std::vector<MPI_Request> reqs;
+    if (rank == myAgg) {
+      reqs.reserve(srcsPerAgg);
+      // recv counts from each member of my group
+      for (int si = 0; si < srcsPerAgg && si + rank < size; ++si) {
+        MPI_Request rreq;
+
+#ifndef NDEBUG
+        // if (size_t(si) * req.nroots + req.nroots > groupSendCounts.size()) {
+        //   std::stringstream ss;
+        //   ss << __FILE__ << ":" << __LINE__ 
+        //      << " [" << rank << "]"
+        //      << " OOB\n";
+        //   std::cerr << ss.str();
+        // }
+#endif
+#ifndef NDEBUG
+    // {
+    //   std::stringstream ss;
+    //   ss << __FILE__ << ":" << __LINE__ 
+    //   << " [" << rank << "] ph0 Irecv\n";
+    //   std::cerr << ss.str();
+    // }
+#endif
+        MPI_Irecv(&groupSendCounts[size_t(si) * size_t(req.nroots)], req.nroots, MPI_INT, si + rank, 
+                  req.tag, req.comm, &rreq);
+        reqs.push_back(rreq);
+      }
+    }
+    // send sendcounts to aggregator
+#ifndef NDEBUG
+    // {
+    //   std::stringstream ss;
+    //   ss << __FILE__ << ":" << __LINE__ 
+    //   << " [" << rank << "] ph0 Send\n";
+    //   std::cerr << ss.str();
+    // }
+#endif
+    MPI_Send(req.sendcounts, req.nroots, MPI_INT, myAgg, req.tag, req.comm);
+    MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
+    reqs.resize(0);
+
+#ifndef NDEBUG
+    // if (rank == myAgg) {
+    //   std::stringstream ss;
+    //   ss << __FILE__ << ":" << __LINE__ 
+    //      << " [" << rank << "] groupSendCounts=";
+    //   for (auto e : groupSendCounts) {
+    //     ss << e << " ";
+    //   }
+    //   ss << "\n";
+    //   std::cerr << ss.str();
+    // }
+#endif
+
+    // at this point, in each aggregator, groupSendCounts holds the send counts
+    // from each member of the aggregator. The first nroots entries are from the first rank,
+    // the second nroots entries are from the second rank, etc
+
+    // a temporary buffer to aggregate data. Data for a root is contiguous.
+#if 0
+    Kokkos::View<char *, typename RecvExecSpace::memory_space>aggBuf("aggBuf");
+#else
+    auto aggBuf = cache.pimpl->get_aggBuf<RecvExecSpace>(0);
+#endif
+    std::vector<size_t> rootCount(req.nroots, 0); // [ri] the count of data held for root ri
+    if (rank == myAgg) {
+      size_t aggBytes = 0;
+      for (int si = 0; si < srcsPerAgg && si + rank < size; ++si) {
+        for (int ri = 0; ri < req.nroots; ++ri) {
+          int count = groupSendCounts[si * req.nroots + ri];
+          rootCount[ri] += count;
+          aggBytes += count * sendSize;
+        }
+      }
+
+  #ifndef NDEBUG
+      // {
+      //   std::stringstream ss;
+      //   ss << __FILE__ << ":" << __LINE__ 
+      //      << " [" << rank << "] rootCount=";
+      //   for (auto e : rootCount) {
+      //     ss << e << " ";
+      //   }
+      //   ss << "\n";
+      //   std::cerr << ss.str();
+      // }
+  #endif
+
+#ifndef NDEBUG
+      // {
+      //   std::stringstream ss;
+      //   ss << __FILE__ << ":" << __LINE__ 
+      //      << " [" << rank << "] aggBuf.resize(" << aggBytes << ")\n";
+      //   std::cerr << ss.str();
+      // }
+  #endif
+#if 0
+      Kokkos::resize(Kokkos::view_alloc(Kokkos::WithoutInitializing), aggBuf, aggBytes);
+#else
+      aggBuf = cache.pimpl->get_aggBuf<RecvExecSpace>(aggBytes);
+#endif
+    }
+    // now, on the aggregator ranks,
+    // * aggBuf is resized to accomodate all incoming data
+    // * rootCount holds how much data i hold for each root
+    
+
+
+    // Send the actual data to the aggregator
+    reqs.reserve(srcsPerAgg);
+    if (rank == myAgg) {
+      reqs.reserve(srcsPerAgg + req.nroots);
+      // receive from all ranks in my group
+      size_t displ = 0;
+      // senders will send in root order, so we will recv in that order as well
+      // this puts all data for a root contiguous in the aggregation buffer
+      for (int ri = 0; ri < req.nroots; ++ri) {
+        for (int si = 0; si < srcsPerAgg && si + rank < size; ++si) {
+          // receive data for the ri'th root from the si'th sender
+          const int count = groupSendCounts[si * req.nroots + ri];
+          if (count) {
+#ifndef NDEBUG
+            // {
+            //   std::stringstream ss;
+            //   ss << __FILE__ << ":" << __LINE__ 
+            //   << " [" << rank << "] ph1 recv(@" << displ << ", " << count << ", ..., " << si+rank << "\n";
+            //   std::cerr << ss.str();
+            // }
+#endif
+#ifndef NDEBUG
+            if (displ + count * sendSize > aggBuf.size()) {
+              std::stringstream ss;
+              ss << __FILE__ << ":" << __LINE__ 
+              << " [" << rank << "] OOB\n";
+              std::cerr << ss.str();
+            }
+#endif
+            MPI_Request rreq;
+            // &aggBuf(displ)
+            MPI_Irecv(aggBuf.data() + displ, count, req.sendtype, si + rank, req.tag, req.comm, &rreq);
+            reqs.push_back(rreq);
+            displ += size_t(count) * sendSize;
+          }
+        }
+      } 
+    } else {
+      reqs.reserve(req.nroots); // prepare for one send per root
+    }
+    
+    // send data to aggregator
+    for (int ri = 0; ri < req.nroots; ++ri) {
+      const size_t displ = size_t(req.sdispls[ri]) * sendSize;
+      const int count = req.sendcounts[ri];
+      if (count) {
+#ifndef NDEBUG
+        // {
+        //   std::stringstream ss;
+        //   ss << __FILE__ << ":" << __LINE__ 
+        //   << " [" << rank << "] ph1 Isend(@" << displ << ", " << count << ", ..., " << myAgg << "\n";
+        //   std::cerr << ss.str();
+        // }
+#endif
+        MPI_Request sreq;
+        MPI_Isend(&reinterpret_cast<const char *>(req.sendbuf)[displ], req.sendcounts[ri],
+        req.sendtype, myAgg, AGG_TAG, req.comm, &sreq);
+        reqs.push_back(sreq);
+      }
+    }
+  
+    MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
+    reqs.resize(0);
+
+
+    // if I am a root, recieve data from each aggregator
+    // The aggregator will send contiguous data, which we may need to spread out according to rdispls
+#if 0
+    Kokkos::View<uint8_t *, typename RecvExecSpace::memory_space>rootBuf("rootBuf");
+#else
+    auto rootBuf = cache.pimpl->get_rootBuf<RecvExecSpace>(0);
+#endif
+    if (isRoot) {
+      reqs.reserve(naggs); // receive from each aggregator
+
+      const size_t totalRecvd = recvSize * [&]() -> size_t {
+        size_t acc = 0;
+        for (int i = 0; i < size; ++i) {
+          acc += req.recvcounts[i];
+        }
+        return acc;
+      }();
+#if 0
+      Kokkos::resize(Kokkos::view_alloc(Kokkos::WithoutInitializing), rootBuf, totalRecvd);
+#else
+      rootBuf = cache.pimpl->get_rootBuf<RecvExecSpace>(totalRecvd);
+#endif
+
+      // Receive data from each aggregator.
+      // Aggregators send data in order of the ranks they're aggregating,
+      // which is also the order the root needs in its recv buffer.
+      size_t displ = 0;
+      for (int aggSrc = 0; aggSrc < size; aggSrc += srcsPerAgg) {
+  
+        // tally up the total data to recv from the sending aggregator
+        int count = 0;
+        for (int origSrc = aggSrc;
+              origSrc < aggSrc + srcsPerAgg && origSrc < size; ++origSrc) {
+          count += req.recvcounts[origSrc];
+        }
+  
+        if (count) {
+#ifndef NDEBUG
+          // {
+          //   std::stringstream ss;
+          //   ss << __FILE__ << ":" << __LINE__ 
+          //   << " [" << rank << "] ph2 Irecv(@" << displ << ", " << count << ", ..., " << aggSrc << "\n";
+          //   std::cerr << ss.str();
+          // }
+#endif
+          MPI_Request rreq;
+          // &rootBuf(displ)
+          MPI_Irecv(rootBuf.data() + displ, count, req.recvtype, aggSrc, ROOT_TAG,  req.comm, &rreq);
+          reqs.push_back(rreq);
+          displ += size_t(count) * recvSize;
+        }
+      }
+    }
+
+    // if I am an aggregator, forward data to the roots
+    // To each root, send my data in order of the ranks that sent to me
+    // which is the order the recvers expect
+    if (rank == myAgg) {
+      size_t displ = 0;
+      for (int ri = 0; ri < req.nroots; ++ri) {
+        const size_t count = rootCount[ri];
+        if (count) {
+#ifndef NDEBUG
+          // {
+          //   std::stringstream ss;
+          //   ss << __FILE__ << ":" << __LINE__ 
+          //   << " [" << rank << "] ph2 send(@" << displ << ", " << count << ", ..., " << req.roots[ri] << "\n";
+          //   std::cerr << ss.str();
+          // }
+#endif
+          // &aggBuf[displ]
+          MPI_Send(aggBuf.data() + displ, count, req.sendtype, req.roots[ri], ROOT_TAG, req.comm);
+          displ += count * sendSize;
+        }
+      }
+    }
+  
+    MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
+
+    // at root, copy data from contiguous buffer into recv buffer
+    if (isRoot) {
+
+      // set up src and dst for each block
+#if 0
+      Kokkos::View<MemcpyArg*> args(Kokkos::view_alloc("args", Kokkos::WithoutInitializing), size);
+#else
+      auto args = cache.pimpl->get_args<RecvExecSpace>(size);
+#endif
+      auto args_h = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, args);
+
+      size_t srcOff = 0;
+      for (int sRank = 0; sRank < size; ++sRank) {
+        const size_t dstOff = req.rdispls[sRank] * recvSize;
+        
+        void *dst = &reinterpret_cast<char *>(req.recvbuf)[dstOff];
+        void *const src = rootBuf.data() + srcOff; // &rootBuf(srcOff);
+        const size_t count = req.recvcounts[sRank] * recvSize;
+        args_h(sRank) = MemcpyArg{dst, src, count};
+
+#ifndef NDEBUG
+        if (srcOff + count > rootBuf.extent(0)) {
+          std::stringstream ss;
+          ss << __FILE__ << ":" << __LINE__ << " OOB!\n";
+          std::cerr << ss.str();
+        }
+#endif
+        srcOff += count;
+      }
+
+      // Actually copy the data
+      Kokkos::deep_copy(args, args_h);
+      using Policy = Kokkos::TeamPolicy<RecvExecSpace>;
+      Policy policy(size, Kokkos::AUTO);
+      Kokkos::parallel_for("fixup rdispl", policy, 
+        KOKKOS_LAMBDA(typename Policy::member_type member){
+          team_memcpy(member, args(member.league_rank()));
+        }
+      );
+      Kokkos::fence("after fixup rdispl");
+
+    }
+
+    return finalize();
+}
+} //  namespace
+
+
+int Ialltofewv::wait(Req &req) {
+  if (req.devAccess) {
+    return wait_impl<Kokkos::DefaultExecutionSpace>(req, cache_);
+  } else {
+    return wait_impl<Kokkos::DefaultHostExecutionSpace>(req, cache_);
+  }
+}
+
+int Ialltofewv::get_status(const Req &req, int *flag, MPI_Status */*status*/) const {
+  *flag = req.completed;
+  return MPI_SUCCESS;
+}
+
+
+} // namespace Tpetra::Details

--- a/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
@@ -422,12 +422,12 @@ int wait_impl(Ialltofewv::Req &req, Ialltofewv::Cache &cache) {
     Kokkos::deep_copy(args, args_h);
     using Policy = Kokkos::TeamPolicy<RecvExecSpace>;
     Policy policy(size, Kokkos::AUTO);
-    Kokkos::parallel_for("fixup rdispl", policy, 
+    Kokkos::parallel_for("Tpetra::Details::Ialltofewv: apply rdispls to contiguous root buffer", policy,
       KOKKOS_LAMBDA(typename Policy::member_type member){
         team_memcpy(member, args(member.league_rank()));
       }
     );
-    Kokkos::fence("after fixup rdispl");
+    Kokkos::fence("Tpetra::Details::Ialltofewv: after apply rdispls to contiguous root buffer");
 
   }
 

--- a/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.hpp
@@ -93,5 +93,4 @@ private:
     Cache cache_;
 
 }; // struct Ialltofewv
-
 } // namespace Tpetra::Details

--- a/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.hpp
@@ -1,0 +1,97 @@
+// @HEADER
+// *****************************************************************************
+//          Tpetra: Templated Linear Algebra Services Package
+//
+// Copyright 2008 NTESS and the Tpetra contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#pragma once
+
+#include <memory>
+
+#include <mpi.h>
+
+namespace Tpetra::Details {
+
+struct Ialltofewv {
+
+    struct Req {
+        const void *sendbuf;
+        const int *sendcounts; 
+        const int *sdispls;
+        MPI_Datatype sendtype;
+        void *recvbuf;
+        const int *recvcounts;              
+        const int *rdispls;                    
+        const int *roots;
+        int nroots;
+        MPI_Datatype recvtype;
+        int tag;
+        MPI_Comm comm;
+
+        bool devAccess;
+        bool completed;
+    };
+    
+    template <bool DevAccess>
+    int post(const void *sendbuf,
+        const int *sendcounts, // how much to each root (length nroots)
+        const int *sdispls,    // where data for each root starts (length nroots)
+        MPI_Datatype sendtype,
+        void *recvbuf,         // address of recv buffer (significant only at root)
+        const int *recvcounts, // the number of elements recvd from each process
+                                // (signficant only at roots)
+        const int *rdispls,    // where in `recvbuf` to place incoming data from
+                                // process i (signficant only at roots)
+        const int *roots,      // list of root ranks (must be same on all procs)
+        int nroots,            // size of list of root ranks
+        MPI_Datatype recvtype, 
+        int tag,
+        MPI_Comm comm,
+        Req *req) {
+        req->sendbuf = sendbuf;
+        req->sendcounts = sendcounts;
+        req->sdispls = sdispls;
+        req->sendtype = sendtype;
+        req->recvbuf = recvbuf;
+        req->recvcounts = recvcounts;
+        req->rdispls = rdispls;
+        req->roots = roots;
+        req->nroots = nroots;
+        req->recvtype = recvtype;
+        req->tag = tag;
+        req->comm = comm;
+
+        req->devAccess = DevAccess;
+        req->completed = false;
+    #ifndef NDEBUG
+        // {
+        //   std::stringstream ss;
+        //   ss << __FILE__ << ":" << __LINE__ << "\n";
+        //   std::cerr << ss.str();
+        // }
+    #endif
+        return MPI_SUCCESS;
+    }
+
+    int wait(Req &req);
+
+    int get_status(const Req &req, int *flag, MPI_Status *status) const;
+
+    struct Cache {
+        struct impl;
+        std::shared_ptr<impl> pimpl;
+
+        Cache();
+        ~Cache();
+    };
+
+private:
+
+    Cache cache_;
+
+}; // struct Ialltofewv
+
+} // namespace Tpetra::Details

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -1048,13 +1048,8 @@ namespace Tpetra {
         }
       }
       else {
-        ProfilingRegion region_dpw
-          ("Tpetra::DistObject::doTransferNew::doPosts");
-#ifdef HAVE_TPETRA_TRANSFER_TIMERS
-        // FIXME (mfh 04 Feb 2019) Deprecate Teuchos::TimeMonitor in
-        // favor of Kokkos profiling.
-        Teuchos::TimeMonitor doPostsAndWaitsMon (*doPostsAndWaitsTimer_);
-#endif // HAVE_TPETRA_TRANSFER_TIMERS
+        ////////////////////////////////////////////////////////////////////
+        // packAndPrepare
 
         if (constantNumPackets == 0) {
           if (verbose) {

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -1048,8 +1048,13 @@ namespace Tpetra {
         }
       }
       else {
-        ////////////////////////////////////////////////////////////////////
-        // packAndPrepare
+        ProfilingRegion region_dpw
+          ("Tpetra::DistObject::doTransferNew::doPosts");
+#ifdef HAVE_TPETRA_TRANSFER_TIMERS
+        // FIXME (mfh 04 Feb 2019) Deprecate Teuchos::TimeMonitor in
+        // favor of Kokkos profiling.
+        Teuchos::TimeMonitor doPostsAndWaitsMon (*doPostsAndWaitsTimer_);
+#endif // HAVE_TPETRA_TRANSFER_TIMERS
 
         if (constantNumPackets == 0) {
           if (verbose) {

--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -161,10 +161,11 @@ namespace Tpetra {
 
     Array<std::string> sendTypes = Details::distributorSendTypes ();
     const Array<Details::EDistributorSendType> sendTypeEnums = Details::distributorSendTypeEnums ();
+    const std::string validatedSendType = Details::validSendTypeOrThrow(Details::Behavior::defaultSendType());
 
     RCP<ParameterList> plist = parameterList ("Tpetra::Distributor");
     setStringToIntegralParameter<Details::EDistributorSendType> ("Send type",
-      Details::Behavior::defaultSendType(), "When using MPI, the variant of send to use in "
+      validatedSendType, "When using MPI, the variant of send to use in "
       "do[Reverse]Posts()", sendTypes(), sendTypeEnums(), plist.getRawPtr());
     plist->set ("Debug", debug, "Whether to print copious debugging output on "
                 "all processes.");

--- a/packages/tpetra/core/test/ImportExport2/CMakeLists.txt
+++ b/packages/tpetra/core/test/ImportExport2/CMakeLists.txt
@@ -30,6 +30,16 @@ TRIBITS_ADD_TEST(
   STANDARD_PASS_OUTPUT
   )
 
+if (TPL_ENABLE_MPI)
+TRIBITS_ADD_TEST(
+  ImportExport2_UnitTests
+  NAME ImportExport2_UnitTests_Ialltofewv
+  COMM serial mpi
+  ARGS "--distributor-send-type=Ialltofewv --globally-reduce-test-result --output-show-proc-rank --output-to-root-rank-only=-1"
+  STANDARD_PASS_OUTPUT
+)
+endif()
+
 IF (${PACKAGE_NAME}_ENABLE_mpi_advance)
   message(STATUS "Tpetra: adding MPI Advance ImportExport2 unit tests because ${PACKAGE_NAME}_ENABLE_mpi_advance is truthy")
 

--- a/packages/tpetra/core/test/ImportExport2/CMakeLists.txt
+++ b/packages/tpetra/core/test/ImportExport2/CMakeLists.txt
@@ -34,7 +34,7 @@ if (TPL_ENABLE_MPI)
 TRIBITS_ADD_TEST(
   ImportExport2_UnitTests
   NAME ImportExport2_UnitTests_Ialltofewv
-  COMM serial mpi
+  COMM mpi
   ARGS "--distributor-send-type=Ialltofewv --globally-reduce-test-result --output-show-proc-rank --output-to-root-rank-only=-1"
   STANDARD_PASS_OUTPUT
 )


### PR DESCRIPTION
@trilinos/tpetra 

This introduces an opt-in MPI-based implementation for all-to-few communication patterns, enabled via the `"Ialltofewv"` send type. The implementation uses Kokkos to support GPU-aware MPI.

FYI @searhein

This implementation has been demonstrated to speed up all-to-one and all-to-few communication patterns by several orders of magnitude under certain configurations:

## ShyLU_DDFROSch_thyra_xpetra_elasticity

This is a CPU run on Broadwell using MPICH. Groups of bar graphs are 144, 256, 512, and 1024 ranks.

<img width="518" alt="image" src="https://github.com/user-attachments/assets/c8a38705-138a-4748-80be-686472d28530" />

The left-most bar of each group is upstream Trilinos. The right-most bar uses this new implementation (the middle bar can be ignored).

Another CPU run on Sapphire Rapids using MPICH. Groups of bar graphs are 128, 256, 512, and 1025 nodes.

<img width="528" alt="image" src="https://github.com/user-attachments/assets/8d6b4c9b-08fc-4262-8f7e-551147e1a25b" />

## Microbenchmarks of gather-like operations under MPICH and OpenMPI on Sapphire Rapids:

"Ialltofewv" is this implementation. "naive" is a combination of MPI_Isend / MPI_Irecv. There is also a line for MPI_Igatherv.

<img width="358" alt="image" src="https://github.com/user-attachments/assets/b99950cf-fe12-4b1c-9286-014f3d20e371" />

<img width="356" alt="image" src="https://github.com/user-attachments/assets/2080c095-7b18-4b09-b40b-5633a58740a8" />

## Outline

The algorithm presumes all (or nearly all) ranks are attempting a gather-like collective operation to few (or a single) root rank.
Conceptually, each rank wishes to send some variable amount of data to one or more roots.

The interface is modeled after MPI collectives, and looks like this:

```c++
Tpetra::Details::Ialltofewv::post(
       const void *sendbuf,
        const int *sendcounts, // how much to each root (length nroots)
        const int *sdispls,    // where data for each root starts (length nroots)
        MPI_Datatype sendtype,
        void *recvbuf,         // address of recv buffer (significant only at root)
        const int *recvcounts, // the number of elements recvd from each process
                                // (signficant only at roots)
        const int *rdispls,    // where in `recvbuf` to place incoming data from
                                // process i (signficant only at roots)
        const int *roots,      // list of root ranks (must be same on all procs)
        int nroots,            // size of list of root ranks
        MPI_Datatype recvtype, 
        int tag,
        MPI_Comm comm,
        Req *req
)
```


This is a two-phase operation. In the first phase, the participating ranks are divided into evenly-sized groups, and the first rank in each group is selected as a leader. All ranks in each group send their data to the group leader. In the second phase, an all-to-all-style operation is performed among group leaders and roots to distribute data from group leaders to roots.

This implementation is faster than a naive pairwise point-to-point operation due to reduce number of in-flight messages at any given time.
