### PR TITLE
Ifpack2: Chebyshev Kernel spmv heuristic

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_ChebyshevKernel_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_ChebyshevKernel_def.hpp
@@ -270,7 +270,7 @@ template<class TpetraOperatorType>
 ChebyshevKernel<TpetraOperatorType>::
 ChebyshevKernel (const Teuchos::RCP<const operator_type>& A,
 		 const bool useNativeSpMV):
-  useNativeSpMV_(useNativeSpMV && KokkosKernels::Impl::is_gpu_exec_space_v<typename TpetraOperatorType::node_type::device_type::execution_space>)
+  useNativeSpMV_(useNativeSpMV)
 {
   setMatrix (A);
 }

--- a/packages/ifpack2/src/Ifpack2_Details_ChebyshevKernel_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_ChebyshevKernel_def.hpp
@@ -269,8 +269,8 @@ chebyshev_kernel_vector
 template<class TpetraOperatorType>
 ChebyshevKernel<TpetraOperatorType>::
 ChebyshevKernel (const Teuchos::RCP<const operator_type>& A,
-                   const bool useNativeSpMV):
-  useNativeSpMV_(useNativeSpMV)
+		 const bool useNativeSpMV):
+  useNativeSpMV_(useNativeSpMV && KokkosKernels::Impl::is_gpu_exec_space_v<typename TpetraOperatorType::node_type::device_type::execution_space>)
 {
   setMatrix (A);
 }

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -303,7 +303,7 @@ Chebyshev (Teuchos::RCP<const row_matrix_type> A) :
   chebyshevAlgorithm_("first"),
   computeMaxResNorm_ (false),
   computeSpectralRadius_(true),
-  ckUseNativeSpMV_(true),
+  ckUseNativeSpMV_(MV::node_type::is_gpu),
   debug_ (false)
 {
   checkConstructorInput ();
@@ -336,7 +336,7 @@ Chebyshev (Teuchos::RCP<const row_matrix_type> A,
   chebyshevAlgorithm_("first"),
   computeMaxResNorm_ (false),
   computeSpectralRadius_(true),
-  ckUseNativeSpMV_(true),
+  ckUseNativeSpMV_(MV::node_type::is_gpu),
   debug_ (false)
 {
   checkConstructorInput ();
@@ -383,7 +383,7 @@ setParameters (Teuchos::ParameterList& plist)
   const std::string defaultChebyshevAlgorithm = "first";
   const bool defaultComputeMaxResNorm = false;
   const bool defaultComputeSpectralRadius = true;
-  const bool defaultCkUseNativeSpMV = true;
+  const bool defaultCkUseNativeSpMV = MV::node_type::is_gpu;
   const bool defaultDebug = false;
 
   // We'll set the instance data transactionally, after all reads


### PR DESCRIPTION
On host the fused kernel is clearly beneficial so we pick that implementation by default, while on GPU the TPLs are faster so we go with Kokkos Kernels implementation.


@trilinos/ifpack2 

## Motivation
A performance regression has been observed on CTS-2 machines after the merge of PR #14124 this change should bring back performance on CPU while keeping the improvements on GPU.

## Related Issues
No related issue

## Stakeholder Feedback
@trilinos/tpetra 

## Testing
Tested on Blake

