### PR TITLE
Fix multiple reruns in the MueLu Driver

### DIFF
--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -390,6 +390,15 @@ IF (${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK)
     PASS_REGULAR_EXPRESSION "Belos converged"
   )
 
+  TRIBITS_ADD_TEST(
+    Driver
+    NAME "DriverTpetra_Rerun"
+    POSTFIX_AND_ARGS_0 "InputDeck" --linAlgebra=Tpetra --xml=scaling-with-rerun.xml
+    POSTFIX_AND_ARGS_1 "Repeat"    --linAlgebra=Tpetra --reruns=3 --stacked-timer
+    NUM_MPI_PROCS 4
+    COMM mpi # HAVE_MPI required
+  )
+
 ENDIF()
 
 IF (${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK)
@@ -400,14 +409,6 @@ IF (${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK)
         Driver
         NAME "DriverTpetra"
         ARGS "--linAlgebra=Tpetra --xml=scaling-complex.xml"
-        NUM_MPI_PROCS 4
-        COMM mpi # HAVE_MPI required
-        )
-
-      TRIBITS_ADD_TEST(
-        Driver
-        NAME "DriverTpetra_Rerun"
-        ARGS "--linAlgebra=Tpetra --xml=scaling-with-rerun.xml"
         NUM_MPI_PROCS 4
         COMM mpi # HAVE_MPI required
         )

--- a/packages/muelu/test/scaling/Driver.cpp
+++ b/packages/muelu/test/scaling/Driver.cpp
@@ -649,6 +649,10 @@ int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib& lib, int ar
           auto xmlOut = stacked_timer->reportWatchrXML(watchrProblemName, comm);
           if (xmlOut.length())
             std::cout << "\nAlso created Watchr performance report " << xmlOut << '\n';
+          if (rerunCount < numReruns) {
+            stacked_timer = rcp(new Teuchos::StackedTimer("MueLu_Driver"));
+            Teuchos::TimeMonitor::setStackedTimer(stacked_timer);
+          }
         } else {
           std::ios_base::fmtflags ff(out2.flags());
           if (timingsFormat == "table-fixed")


### PR DESCRIPTION
When running the MueLu driver with reruns > 1, one encounters:

```
Number of iterations performed for this solve: 231

SUCCESS:  Belos converged!

p=0: *** Caught standard std::exception of type 'std::runtime_error' :

 /scratch/malphil/trilinos-devel/Trilinos/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp:28:

 Throw number = 1

 Throw test that evaluated to true: true

 Base_Timer:stop Failed timer not running
```

This PR fixes that issue. Thanks, @cgcgcg!