### PR TITLE
Thyra: fix string constructor from null pointer deleted in C++23

### DIFF
--- a/packages/thyra/core/src/interfaces/operator_solve/fundamental/Thyra_SolveSupportTypes.hpp
+++ b/packages/thyra/core/src/interfaces/operator_solve/fundamental/Thyra_SolveSupportTypes.hpp
@@ -60,7 +60,7 @@ const std::string toString(const ESolveMeasureNormType solveMeasureNormType)
     default:
       TEUCHOS_TEST_FOR_EXCEPT(true);
   }
-  TEUCHOS_UNREACHABLE_RETURN(NULL);
+  TEUCHOS_UNREACHABLE_RETURN("");
 }
 
 


### PR DESCRIPTION
@trilinos/thyra
@bartlettroscoe 

The string constructor from null pointer is deleted in C++23, hence this pr to fix a usage in Thyra.
