### PR TITLE
Tpetra: Add getNormInf and getNorm1 to CrsMatrix

### DIFF
--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -700,7 +700,7 @@ IF (${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
     MESSAGE(STATUS "Tpetra: Using Full ETI")
     SET (CrsMatrix_ETI_SCALARS ${MultiVector_ETI_SCALARS})
   ENDIF()
-    
+
   # Generate ETI .cpp files for Tpetra::CrsMatrix.
   TPETRA_PROCESS_ALL_SLGN_TEMPLATES(CRSMATRIX_OUTPUT_FILES "Tpetra_ETI_SC_LO_GO_NT.tmpl" "CrsMatrix" "CRSMATRIX" "${CrsMatrix_ETI_SCALARS}" "${TpetraCore_ETI_LORDS}" "${TpetraCore_ETI_GORDS}" "${TpetraCore_ETI_NODES}" TRUE)
   LIST(APPEND SOURCES ${CRSMATRIX_OUTPUT_FILES})
@@ -785,7 +785,7 @@ IF (${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
   # Generate ETI .cpp files for Tpetra::computeRowAndColumnOneNorms.
   # Do this only for non-integer Scalar types, since we really only
   # need this function for linear solvers.
-  TPETRA_PROCESS_ALL_SLGN_TEMPLATES(COMPUTEROWANDCOLUMNONENORMS_OUTPUT_FILES "Tpetra_ETI_SC_LO_GO_NT.tmpl" "computeRowAndColumnOneNorms" "COMPUTEROWANDCOLUMNONENORMS" "${TpetraCore_ETI_SCALARS_NO_ORDS}" "${TpetraCore_ETI_LORDS}" "${TpetraCore_ETI_GORDS}" "${TpetraCore_ETI_NODES}" FALSE)
+  TPETRA_PROCESS_ALL_SLGN_TEMPLATES(COMPUTEROWANDCOLUMNONENORMS_OUTPUT_FILES "Tpetra_ETI_SC_LO_GO_NT.tmpl" "computeRowAndColumnOneNorms" "COMPUTEROWANDCOLUMNONENORMS" "${CrsMatrix_ETI_SCALARS}" "${TpetraCore_ETI_LORDS}" "${TpetraCore_ETI_GORDS}" "${TpetraCore_ETI_NODES}" TRUE)
   LIST(APPEND SOURCES ${COMPUTEROWANDCOLUMNONENORMS_OUTPUT_FILES})
 
   # Generate ETI .cpp files for Tpetra::replaceDiagonalCrsMatrix.
@@ -955,4 +955,3 @@ SET_PROPERTY(
 # that running "make" will also rerun CMake in order to regenerate Makefiles.
 #
 # Here's another change.  Again.
-

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -479,7 +479,7 @@ private:
                               device_type,
                               void,
                               typename local_graph_device_type::size_type>;
-    using local_matrix_host_type = 
+    using local_matrix_host_type =
           typename local_matrix_device_type::HostMirror;
 
 #if KOKKOSKERNELS_VERSION < 40299
@@ -490,31 +490,31 @@ private:
                              device_type>;
 #endif
 
-    using row_ptrs_device_view_type = 
+    using row_ptrs_device_view_type =
           typename row_matrix_type::row_ptrs_device_view_type;
-    using row_ptrs_host_view_type = 
+    using row_ptrs_host_view_type =
           typename row_matrix_type::row_ptrs_host_view_type;
 
 
-    using local_inds_device_view_type = 
+    using local_inds_device_view_type =
           typename row_matrix_type::local_inds_device_view_type;
-    using local_inds_host_view_type = 
+    using local_inds_host_view_type =
           typename row_matrix_type::local_inds_host_view_type;
-    using nonconst_local_inds_host_view_type = 
+    using nonconst_local_inds_host_view_type =
           typename row_matrix_type::nonconst_local_inds_host_view_type;
 
-    using global_inds_device_view_type = 
+    using global_inds_device_view_type =
           typename row_matrix_type::global_inds_device_view_type;
-    using global_inds_host_view_type = 
+    using global_inds_host_view_type =
           typename row_matrix_type::global_inds_host_view_type;
-    using nonconst_global_inds_host_view_type = 
+    using nonconst_global_inds_host_view_type =
           typename row_matrix_type::nonconst_global_inds_host_view_type;
 
-    using values_device_view_type = 
+    using values_device_view_type =
           typename row_matrix_type::values_device_view_type;
-    using values_host_view_type = 
+    using values_host_view_type =
           typename row_matrix_type::values_host_view_type;
-    using nonconst_values_host_view_type = 
+    using nonconst_values_host_view_type =
           typename row_matrix_type::nonconst_values_host_view_type;
 
     //@}
@@ -2187,7 +2187,7 @@ private:
     ///
     /// \pre The matrix must be fill complete:
     ///   <tt>isFillComplete() == true</tt>.
-    /// 
+    ///
     void
     replaceDomainMap (const Teuchos::RCP<const map_type>& newDomainMap);
 
@@ -2216,7 +2216,7 @@ private:
     ///
     /// \pre The matrix must be fill complete:
     ///   <tt>isFillComplete() == true</tt>.
-    /// 
+    ///
     void
     replaceRangeMap (const Teuchos::RCP<const map_type>& newRangeMap);
 
@@ -2315,7 +2315,7 @@ private:
 #undef TPETRA_DETAILS_ALWAYS_INLINE
 
 #if KOKKOSKERNELS_VERSION < 40299
-    /// \brief The local sparse matrix operator 
+    /// \brief The local sparse matrix operator
     ///   (a wrapper of \c getLocalMatrixDevice()
     ///   that supports local matrix-vector multiply)
     ///
@@ -2518,6 +2518,26 @@ private:
     //! Indicates that the graph is static, so that new entries cannot be added to this matrix.
     bool isStaticGraph () const;
 
+    /// \brief Compute and return the infinity norm of the matrix.
+    ///
+    /// The Frobenius norm of the matrix is defined as
+    /// \f\[
+    ///   \|A\|_\infty = \max_{i}{\sum_{j} \|A(i,j)\|}.
+    /// \f\].
+    ///
+    mag_type getNormInf () const;
+
+    /// \brief Compute and return the 1-norm of the matrix.
+    ///
+    /// \param assumeSymmetric [in] Whether the matrix is symmetric. If so, computes infinity norm instead.
+    //
+    /// The Frobenius norm of the matrix is defined as
+    /// \f\[
+    ///   \|A\|_1 = \max_{j}{\sum_{i} \|A(i,j)\|}.
+    /// \f\].
+    ///
+    mag_type getNorm1 (bool assumeSymmetric = false) const;
+
     /// \brief Compute and return the Frobenius norm of the matrix.
     ///
     /// The Frobenius norm of the matrix is defined as
@@ -2534,7 +2554,7 @@ private:
 protected:
     using values_dualv_type =
           Kokkos::DualView<impl_scalar_type*, device_type>;
-    using values_wdv_type = 
+    using values_wdv_type =
           Details::WrappedDualView<values_dualv_type>;
     values_wdv_type valuesUnpacked_wdv;
     mutable values_wdv_type valuesPacked_wdv;
@@ -3939,7 +3959,7 @@ private:
     /// The specialization of Details::MatrixApplyHelper used by this class in apply().
     using ApplyHelper = Details::MatrixApplyHelper<
       local_matrix_device_type,
-      local_matrix_int_rowptrs_device_type, 
+      local_matrix_int_rowptrs_device_type,
       typename MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::device_view_type>;
 
 
@@ -3964,7 +3984,7 @@ private:
 
 
     // friend Matrix Matrix utility function that needs to access integer-typed rowptrs
-    friend 
+    friend
     void Tpetra::MMdetails::import_and_extract_views<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
     const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>&   A,
     Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >   targetMap,
@@ -4086,7 +4106,7 @@ protected:
       DestOffsetViewType dst_offset_;
       typedef typename DestOffsetViewType::non_const_value_type scalar_index_type;
 
-      pack_functor (DestViewType dst, 
+      pack_functor (DestViewType dst,
                     const SrcViewType src,
                     DestOffsetViewType dst_offset,
                     const SrcOffsetViewType src_offset) :

--- a/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
@@ -148,13 +148,16 @@ computeLocalRowOneNorms_RowMatrix (const Tpetra::RowMatrix<SC, LO, GO, NT>& A)
   equib_info_type result (lclNumRows, lclNumCols, assumeSymmetric);
   auto result_h = result.createMirrorView ();
 
+  const auto val_zero = KAV::zero();
+  const auto mag_zero = KAM::zero();
+
   forEachLocalRowMatrixRow<SC, LO, GO, NT> (A,
     [&] (const LO lclRow,
          const typename Tpetra::RowMatrix<SC, LO, GO, NT>::nonconst_local_inds_host_view_type& ind,
          const typename Tpetra::RowMatrix<SC, LO, GO, NT>::nonconst_values_host_view_type& val,
          std::size_t numEnt) {
-      mag_type rowNorm {0.0};
-      val_type diagVal {0.0};
+      mag_type rowNorm = mag_zero;
+      val_type diagVal = val_zero;
       const GO gblRow = rowMap.getGlobalElement (lclRow);
       // OK if invalid(); then we simply won't find the diagonal entry.
       const GO lclDiagColInd = colMap.getLocalElement (gblRow);
@@ -218,13 +221,16 @@ computeLocalRowAndColumnOneNorms_RowMatrix (const Tpetra::RowMatrix<SC, LO, GO, 
     (lclNumRows, lclNumCols, assumeSymmetric);
   auto result_h = result.createMirrorView ();
 
+  const auto val_zero = KAV::zero();
+  const auto mag_zero = KAM::zero();
+
   forEachLocalRowMatrixRow<SC, LO, GO, NT> (A,
     [&] (const LO lclRow,
          const typename Tpetra::RowMatrix<SC, LO, GO, NT>::nonconst_local_inds_host_view_type& ind,
          const typename Tpetra::RowMatrix<SC, LO, GO, NT>::nonconst_values_host_view_type& val,
          std::size_t numEnt) {
-      mag_type rowNorm {0.0};
-      val_type diagVal {0.0};
+      mag_type rowNorm = mag_zero;
+      val_type diagVal = val_zero;
       const GO gblRow = rowMap.getGlobalElement (lclRow);
       // OK if invalid(); then we simply won't find the diagonal entry.
       const GO lclDiagColInd = colMap.getLocalElement (gblRow);
@@ -425,8 +431,11 @@ public:
     const auto curRow = A_lcl_.rowConst (lclRow);
     const LO numEnt = curRow.length;
 
-    mag_type rowNorm {0.0};
-    val_type diagVal {0.0};
+    const auto val_zero = KAT::zero();
+    const auto mag_zero = KAM::zero();
+
+    mag_type rowNorm = mag_zero;
+    val_type diagVal = val_zero;
     value_type dstThread {0};
 
     Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, numEnt), [&](const LO k, mag_type &normContrib, val_type& diagContrib, value_type& dstContrib) {
@@ -524,8 +533,11 @@ public:
     const auto curRow = A_lcl_.rowConst (lclRow);
     const LO numEnt = curRow.length;
 
-    mag_type rowNorm {0.0};
-    val_type diagVal {0.0};
+    const auto val_zero = KAT::zero();
+    const auto mag_zero = KAM::zero();
+
+    mag_type rowNorm = mag_zero;
+    val_type diagVal = val_zero;
     value_type dstThread {0};
 
     Kokkos::parallel_reduce(Kokkos::TeamThreadRange(team, numEnt), [&](const LO k, mag_type &normContrib, val_type& diagContrib, value_type& dstContrib) {
@@ -717,7 +729,7 @@ auto getLocalView_1d_readOnly (
                             Kokkos::ALL (), 0);
   }
 }
- 
+
 template<class SC, class LO, class GO, class NT>
 auto getLocalView_1d_writeOnly (
   Tpetra::MultiVector<SC, LO, GO, NT>& X,
@@ -735,7 +747,7 @@ auto getLocalView_1d_writeOnly (
                            Kokkos::ALL (), 0);
   }
 }
- 
+
 template<class SC, class LO, class GO, class NT, class ViewValueType>
 void
 copy1DViewIntoMultiVectorColumn (


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Add `getNormInf` and `getNorm1` to `CrsMatrix`.
This is for backward compatibility with Epetra's methods `NormInf` and `NormOne`.