### PR TITLE
IOSS: Fix map error reporting refactor; update version

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_Map.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Map.C
@@ -1,4 +1,4 @@
-// Copyright(C) 1999-2024 National Technology & Engineering Solutions
+// Copyright(C) 1999-2025 National Technology & Engineering Solutions
 // of Sandia, LLC (NTESS).  Under the terms of Contract DE-NA0003525 with
 // NTESS, the U.S. Government retains certain rights in this software.
 //
@@ -597,6 +597,10 @@ int64_t Ioss::Map::global_to_local(int64_t global, bool must_exist, bool output_
 int64_t Ioss::Map::global_to_local_nl(int64_t global, bool must_exist, bool output_error) const
 {
   int64_t local = global;
+
+  // The case where `must_exist==false && output_error == true` is for improving parallel error
+  // reporting, so for all intents, it is `must_exist == true` in the logic below...
+  bool should_exist = must_exist || output_error;
 #if defined USE_LAZY_REVERSE
   if (!is_sequential() && m_reverse.empty() && m_reorder.empty()) {
     auto *new_this = const_cast<Ioss::Map *>(this);
@@ -629,7 +633,7 @@ int64_t Ioss::Map::global_to_local_nl(int64_t global, bool must_exist, bool outp
     }
 #endif
   }
-  else if (!must_exist && global > static_cast<int64_t>(m_map.size()) - 1) {
+  else if (!should_exist && global > static_cast<int64_t>(m_map.size()) - 1) {
     local = 0;
   }
   else {
@@ -655,7 +659,7 @@ int64_t Ioss::Map::global_to_local_nl(int64_t global, bool must_exist, bool outp
                m_entityType, global, m_myProcessor, m_filename);
     IOSS_ERROR(errmsg);
   }
-  else if (local <= 0 && !must_exist && output_error) {
+  else if (local <= 0 && should_exist) {
     fmt::print(stderr,
                "ERROR: Ioss Mapping routines could not find a {0} with global id equal to {1} in "
                "the {0} map\n"

--- a/packages/seacas/libraries/ioss/src/Ioss_Version.h
+++ b/packages/seacas/libraries/ioss/src/Ioss_Version.h
@@ -6,5 +6,5 @@
 
 #pragma once
 namespace Ioss {
-  inline const char *Version() { return "2025-06-07"; }
+  inline const char *Version() { return "2025-06-27"; }
 } // namespace Ioss


### PR DESCRIPTION


@trilinos/seacas 

## Motivation
Minor fix to previous refactor of global_to_local parallel error reporting.  There was an unintended change in behavior in the previous changes.  This has been remedied.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->



<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
All sierra tests now pass.  One test showed the incorrect behavior and it now passes.
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
