### PR TITLE
Framework: Use shorten build name if given for any Pull Request CDash track

### DIFF
--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -521,14 +521,13 @@ class TrilinosPRConfigurationBase(object):
 
         PR-<PR Number>-test-<Jenkins Job Name>-<Job Number>
         """
+        output = self.arg_pr_genconfig_job_name
         if self.arg_dashboard_build_name:
             output = self.arg_dashboard_build_name
-        elif "Pull Request" in self.arg_pullrequest_cdash_track:
-            output = f"PR-{self.arg_pullrequest_number}-test-{self.arg_pr_genconfig_job_name}"
+        if "Pull Request" in self.arg_pullrequest_cdash_track:
+            output = f"PR-{self.arg_pullrequest_number}-test-{output}"
             if self.arg_jenkins_job_number:
                 output = f"{output}-{self.arg_jenkins_job_number}"
-        else:
-            output = self.arg_pr_genconfig_job_name
         return output
 
 

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -517,18 +517,19 @@ class TrilinosPRConfigurationBase(object):
     @property
     def pullrequest_build_name(self):
         """
-        Generate the build name string to report back to CDash.
+        Generate the build name string to report back to CDash depending on
+        the given CDash track.
 
-        PR-<PR Number>-test-<Jenkins Job Name>-<Job Number>
+        PR-<PR Number>-test-<Build Name>-<Job Number>
         """
-        output = self.arg_pr_genconfig_job_name
+        build_name = self.arg_pr_genconfig_job_name
         if self.arg_dashboard_build_name:
-            output = self.arg_dashboard_build_name
+            build_name = self.arg_dashboard_build_name
         if "Pull Request" in self.arg_pullrequest_cdash_track:
-            output = f"PR-{self.arg_pullrequest_number}-test-{output}"
+            build_name = f"PR-{self.arg_pullrequest_number}-test-{build_name}"
             if self.arg_jenkins_job_number:
-                output = f"{output}-{self.arg_jenkins_job_number}"
-        return output
+                build_name = f"{build_name}-{self.arg_jenkins_job_number}"
+        return build_name
 
 
     @property

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -338,13 +338,24 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         self.assertEqual(build_name, expected_build_name)
 
 
-    def test_TrilinosPRConfigurationBaseBuildGroupContainsPullRequest(self):
+    def test_TrilinosPRConfigurationBase_build_group_contains_PullRequest(self):
         """Test that a group containing 'Pull Request' causes the build name to reflect a PR build."""
         args = self.dummy_args_gcc_720()
         args.pullrequest_cdash_track = "Pull Request (Non-blocking)"
         pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
         build_name = pr_config.pullrequest_build_name
         expected_build_name = f"PR-{args.pullrequest_number}-test-{args.genconfig_build_name}-{args.jenkins_job_number}"
+        self.assertEqual(build_name, expected_build_name)
+
+
+    def test_TrilinosPRConfigurationBase_build_group_contains_PullRequest_dashboard_name(self):
+        """Test that a group containing 'Pull Request,' but with a given shorten dashboard build name."""
+        args = self.dummy_args_gcc_720()
+        args.pullrequest_cdash_track = "Pull Request (Non-blocking)"
+        args.dashboard_build_name = "gcc-7.3.0-short-string"
+        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
+        build_name = pr_config.pullrequest_build_name
+        expected_build_name = f"PR-{args.pullrequest_number}-test-{args.dashboard_build_name}-{args.jenkins_job_number}"
         self.assertEqual(build_name, expected_build_name)
 
 
@@ -357,9 +368,10 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         self.assertEqual(build_name, expected_build_name)
 
 
-    def test_TrilinosPRConfigurationBaseBuildNamePassed(self):
-        """Test that a passed build name is used."""
+    def test_TrilinosPRConfigurationBase_dashboard_name(self):
+        """Test that a given dashboard build name is used."""
         args = self.dummy_args()
+        args.pullrequest_cdash_track = "Nightly"
         args.dashboard_build_name = "some-dashboard-build-name"
         pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
         build_name = pr_config.pullrequest_build_name


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Want to use a shortened build name for certain builds posted to one of the following CDash tracks if a shortened build name is provided:
- Pull Request
- Pull Request (Non-blocking)


## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

- [TRILFRAME-695](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-695)

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
- Included and updated related tests
  - Updated the test names of the tests involved because these CamelCase names are becoming unreadable. We should rename every test to use the snakecase, but that may be out of scope for now :(. 
