### PR TITLE
Sacado: Revert "Sacado:  Reorder SFad<> val and dx fields for stria"

### DIFF
--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_StaticFixedStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_StaticFixedStorage.hpp
@@ -219,11 +219,11 @@ namespace Sacado {
 
     protected:
 
-      //! Value
-      T val_;
-
       //! Derivative array
       T dx_[Num];
+
+      //! Value
+      T val_;
 
     }; // class StaticFixedStorage
 


### PR DESCRIPTION
This reverts commit 5fdfeb46f0bb9507d95fc5100cefc56c87928b77.

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/sacado 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

The original commit broke the ability to wrap SFad<> with a Kokkos view. View storage begins with dx_ so it makes sense for SFad<> to follow the same ordering:
https://github.com/trilinos/Trilinos/blob/develop/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp#L82
This change was made to work around a compiler bug for a machine we no longer support so it should be okay to revert.