### PR TITLE
Galeri: Add missing headers for install in CmakeLists.txt

### DIFF
--- a/packages/galeri/src-xpetra/CMakeLists.txt
+++ b/packages/galeri/src-xpetra/CMakeLists.txt
@@ -28,6 +28,10 @@ APPEND_SET(HEADERS
   Galeri_StencilProblems_Helmholtz.hpp
   Galeri_Elasticity2DProblem.hpp
   Galeri_Elasticity3DProblem.hpp
+  Galeri_Problem_Helmholtz.hpp
+  Galeri_HelmholtzFEM2DProblem.hpp
+  Galeri_HelmholtzFEM3DProblem.hpp
+  Galeri_VelocityModel.hpp
 
   Galeri_VectorTraits.hpp
   Galeri_MatrixTraits.hpp


### PR DESCRIPTION
@trilinos/galeri
@jhux2 @cgcgcg 

This PR adds a few apparently missing headers for install in one of the `Galeri` `CMakeLists.txt`.