### PR TITLE
Zoltan:  Shadow warnings

### DIFF
--- a/packages/zoltan/src/lb/lb_init.c
+++ b/packages/zoltan/src/lb/lb_init.c
@@ -163,7 +163,7 @@ void Zoltan_LB_Serialize(struct Zoltan_Struct const *zz, char **buf)
  
   /* Copy Remap array; needed by Point_Assign  */
   if (lb->Remap != NULL) {
-    int *intptr = (int *)bufptr;
+    intptr = (int *)bufptr;
     *intptr = 1;  // Sending Remap data
     bufptr += sizeof(int);
     int nbytes = lb->Num_Global_Parts * sizeof(int);
@@ -171,7 +171,7 @@ void Zoltan_LB_Serialize(struct Zoltan_Struct const *zz, char **buf)
     bufptr += nbytes;
   }
   else {
-    int *intptr = (int *)bufptr;
+    intptr = (int *)bufptr;
     *intptr = 0;  // Not sending Remap data
     bufptr += sizeof(int);
   }

--- a/packages/zoltan/src/zz/zz_gen_files.c
+++ b/packages/zoltan/src/zz/zz_gen_files.c
@@ -300,7 +300,6 @@ int gen_geom, int gen_graph, int gen_hg)
     goto End;
   }
   for (i=0; i<num_obj; i++) {
-    int j;
     for (j = 0; j < lenGID; j++)
       fprintf(fp, ZOLTAN_ID_SPEC" ", global_ids[i*lenGID+j]);
     fprintf(fp, "\n");


### PR DESCRIPTION
Removed 3 declarations to remove 3 shadow warnings.

@trilinos/zoltan 

## Motivation
Cleaning up shadow warnings before turning shadow warnings on in framework.

## Related Issues
* Closes 14228