### PR TITLE
Amesos2:  Removed repeated typedef to remove shadow warning.

### DIFF
--- a/packages/amesos2/src/Amesos2_TpetraCrsMatrix_MatrixAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_TpetraCrsMatrix_MatrixAdapter_def.hpp
@@ -457,7 +457,6 @@ namespace Amesos2 {
               //    nzvals(transpose_map(k)) = nzvals_t(k);
               //  }
               //}
-              typedef Kokkos::DefaultHostExecutionSpace HostExecSpaceType;
               Kokkos::parallel_for("Amesos2::TpetraCrsMatrixAdapter::gather", Kokkos::RangePolicy<HostExecSpaceType>(0, ret),
                 KOKKOS_LAMBDA(const int k) { if (transpose_map(k) >= 0) nzvals(transpose_map(k)) = nzvals_t(k); });
             }


### PR DESCRIPTION
@trilinos/amesos2 

## Motivation
Remove shadow warnings before turning shadow warnings on in framework.

## Related Issues
* Closes 14233