### PR TITLE
ifpack2:  renamed two variables err to err1 and err2 based on how they are comp…

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockComputeResidualAndSolve.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockComputeResidualAndSolve.hpp
@@ -20,10 +20,10 @@ template <typename ExecSpace, typename DiagOffsets, typename Rowptrs,
 DiagOffsets findDiagOffsets(const Rowptrs& rowptrs, const Entries& entries,
                             size_t nrows, int blocksize) {
   DiagOffsets diag_offsets(do_not_initialize_tag("btdm.diag_offsets"), nrows);
-  int err = 0;
+  int err1 = 0;
   Kokkos::parallel_reduce(
       Kokkos::RangePolicy<ExecSpace>(0, nrows),
-      KOKKOS_LAMBDA(size_t row, int& err) {
+      KOKKOS_LAMBDA(size_t row, int& err2) {
         auto rowBegin = rowptrs(row);
         auto rowEnd   = rowptrs(row + 1);
         for (size_t j = rowBegin; j < rowEnd; j++) {
@@ -32,11 +32,11 @@ DiagOffsets findDiagOffsets(const Rowptrs& rowptrs, const Entries& entries,
             return;
           }
         }
-        err++;
+        err2++;
       },
-      err);
+      err1);
   TEUCHOS_TEST_FOR_EXCEPT_MSG(
-      err, "Ifpack2 BTD: at least one row has no diagonal entry");
+      err1, "Ifpack2 BTD: at least one row has no diagonal entry");
   return diag_offsets;
 }
 


### PR DESCRIPTION
…iled to eliminate shadow warnings.

@trilinos/ifpack2 

## Motivation
Eliminate shadow warnings so shadow warnings can be turned on in framework.

## Related Issues
* Closes 14235