### PR TITLE
Vjleung/14237trilinoscouplings shadow warnings

### DIFF
--- a/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidHybridPoisson2DExample.cpp
+++ b/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidHybridPoisson2DExample.cpp
@@ -276,8 +276,8 @@ makeMatrixAndRightHandSide (Teuchos::RCP<sparse_matrix_type>& A,
 
   long long local_num_ijk[3];
   im_ne_get_local_num_ijk_l (id, local_num_ijk);
-  for(int dim = 0; dim < 3; ++dim) {
-    lNodesPerDim[dim] = local_num_ijk[dim];
+  for(int ldim = 0; ldim < 3; ++ldim) {
+    lNodesPerDim[ldim] = local_num_ijk[ldim];
   }
   // Ensure we have the correct nodes per dim for a 2D problem
   lNodesPerDim[2] = 1;
@@ -285,8 +285,8 @@ makeMatrixAndRightHandSide (Teuchos::RCP<sparse_matrix_type>& A,
   Teuchos::Array<LO> nodesPerDim(3);
   long long num_ijk[3];
   im_ne_get_num_ijk_l (id, num_ijk);
-  for(int dim = 0; dim < 3; ++dim) {
-    nodesPerDim[dim] = num_ijk[dim];
+  for(int ldim = 0; ldim < 3; ++ldim) {
+    nodesPerDim[ldim] = num_ijk[ldim];
   }
 
   // Print mesh information

--- a/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidHybridPoisson3DExample.cpp
+++ b/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidHybridPoisson3DExample.cpp
@@ -276,15 +276,15 @@ makeMatrixAndRightHandSide (Teuchos::RCP<sparse_matrix_type>& A,
 
   long long local_num_ijk[3];
   im_ne_get_local_num_ijk_l (id, local_num_ijk);
-  for(int dim = 0; dim < 3; ++dim) {
-    lNodesPerDim[dim] = local_num_ijk[dim];
+  for(int ldim = 0; ldim < 3; ++ldim) {
+    lNodesPerDim[ldim] = local_num_ijk[ldim];
   }
 
   Teuchos::Array<LO> nodesPerDim(3);
   long long num_ijk[3];
   im_ne_get_num_ijk_l (id, num_ijk);
-  for(int dim = 0; dim < 3; ++dim) {
-    nodesPerDim[dim] = num_ijk[dim];
+  for(int ldim = 0; ldim < 3; ++ldim) {
+    nodesPerDim[ldim] = num_ijk[ldim];
   }
 
   // Print mesh information

--- a/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidStructuredPoissonExample.cpp
+++ b/packages/trilinoscouplings/examples/scaling/TrilinosCouplings_TpetraIntrepidStructuredPoissonExample.cpp
@@ -184,7 +184,6 @@ makeMatrixAndRightHandSide (Teuchos::RCP<sparse_matrix_type>& A,
   using Teuchos::TimeMonitor;
   using std::endl;
   //typedef Teuchos::ArrayView<LO>::size_type size_type; // unused
-  typedef Teuchos::ScalarTraits<ST> STS;
 
   (void) verbose;
   (void) debug;
@@ -276,15 +275,15 @@ makeMatrixAndRightHandSide (Teuchos::RCP<sparse_matrix_type>& A,
 
   long long local_num_ijk[3];
   im_ne_get_local_num_ijk_l (id, local_num_ijk);
-  for(int dim = 0; dim < 3; ++dim) {
-    lNodesPerDim[dim] = local_num_ijk[dim];
+  for(int ldim = 0; ldim < 3; ++ldim) {
+    lNodesPerDim[ldim] = local_num_ijk[ldim];
   }
 
   Teuchos::Array<LO> nodesPerDim(3);
   long long num_ijk[3];
   im_ne_get_num_ijk_l (id, num_ijk);
-  for(int dim = 0; dim < 3; ++dim) {
-    nodesPerDim[dim] = num_ijk[dim];
+  for(int ldim = 0; ldim < 3; ++ldim) {
+    nodesPerDim[ldim] = num_ijk[ldim];
   }
 
   // Print mesh information
@@ -1161,8 +1160,6 @@ exactResidualNorm (const Teuchos::RCP<const sparse_matrix_type>& A,
 {
   using Teuchos::RCP;
   using Teuchos::rcp;
-  typedef Teuchos::ScalarTraits<ST> STS;
-  typedef STS::magnitudeType MT;
 
   RCP<vector_type> R = rcp (new vector_type (*B)); // R := B
   // R := 1.0*R - 1.0*A*X_exact.
@@ -1220,13 +1217,13 @@ public:
                const Scalar& y,
                const Scalar& z) const
   {
-    typedef Teuchos::ScalarTraits<Scalar> STS;
+    typedef Teuchos::ScalarTraits<Scalar> STSc;
 
     // We go through this trouble to make numbers, because Scalar
     // isn't necessarily double.  It could be some automatic
     // differentiation type.
-    const Scalar zero = STS::zero ();
-    const Scalar one = STS::one ();
+    const Scalar zero = STSc::zero ();
+    const Scalar one = STSc::one ();
 
     // You can use the value of offDiagVal_ to control the iteration
     // count.  The iteration counts below are for Belos' GMRES with no


### PR DESCRIPTION
Renamed local shadow variables per how they are compiled.

Removed redundant typedefs.

Renamed local typedef variant per how it is used.

@trilinos/trilinoscouplings 

## Motivation
Removing shadow warnings before they are turned on in the framework.

## Related Issues
Most but not all of 14237.