### PR TITLE
Ifpack2: use empirical heuristic for Schur sublines

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -1023,14 +1023,33 @@ local_ordinal_type getAutomaticNSubparts(const local_ordinal_type num_parts,
                                          const local_ordinal_type num_teams,
                                          const local_ordinal_type line_length,
                                          const local_ordinal_type block_size) {
-  local_ordinal_type n_subparts_per_part_0 = 1;
-  local_ordinal_type flop_0                = costSolveSchur(num_parts, num_teams, line_length, block_size, n_subparts_per_part_0);
-  local_ordinal_type flop_1                = costSolveSchur(num_parts, num_teams, line_length, block_size, n_subparts_per_part_0 + 1);
-  while (flop_0 > flop_1) {
-    flop_0 = flop_1;
-    flop_1 = costSolveSchur(num_parts, num_teams, line_length, block_size, (++n_subparts_per_part_0) + 1);
-  }
-  return n_subparts_per_part_0;
+  // BMK: replaced theoretical model with empirical model
+  // This is a linear regression based on:
+  // - required vs. available parallelism (num_parts vs num_teams)
+  // - log2 of the line length
+  // - block size
+  double parallelismSurplus = Kokkos::sqrt((double) num_teams / num_parts);
+  double logLineLength = Kokkos::log2((double) line_length);
+  // Directly predict with linear model
+  double modeled = -9.2312 + 4.6946 * parallelismSurplus + 0.4095 * block_size + 0.966 * logLineLength;
+  // Round to nearest integer
+  local_ordinal_type n_subparts_per_part = 0.5 + modeled;
+  // Then clamp the result to valid range
+  // Criteria for valid n_subparts_per_part (where connection_length is 2 for wide separators)
+  //   line_length >= n_subparts_per_part + (n_subparts_per_part - 1) * connection_length
+  // Equivalently,
+  //   line_length >= n_subparts_per_part + n_subparts_per_part * 2 - 2
+  //   line_length >= 3 * n_subparts_per_part - 2
+  local_ordinal_type min_subparts_per_part = 1;
+  local_ordinal_type max_subparts_per_part = (line_length + 2) / 3;
+  // Limit memory usage
+  if(max_subparts_per_part > 16)
+    max_subparts_per_part = 16;
+  if(n_subparts_per_part < min_subparts_per_part)
+    n_subparts_per_part = min_subparts_per_part;
+  if(n_subparts_per_part > max_subparts_per_part)
+    n_subparts_per_part = max_subparts_per_part;
+  return n_subparts_per_part;
 }
 
 template <typename ArgActiveExecutionMemorySpace>


### PR DESCRIPTION
Use linear regression based on experiments done on MI300A. This did a grid search over possible numbers of sublines. Tried to minimize total time of 2000 solve iterations plus 100 numeric setup (100 repetitions of setup + 20 iterations).

Compared to develop:
- geomean speedup: 1.19x
- min speedup: 0.8x
- max speedup: 2.4x

The linear regression estimated the best number of sublines based on these variables:
- block size
- log_2(line length)
- sqrt(teams/lines)

If needed, I can test this on other GPU architectures, but the above quantities should mostly portable (teams is a portable measure of the concurrent work needed to saturate the GPU).

| BlockSize | GridDim | LineLength | After (This PR) | Before (Develop) | Best from grid search  |
|-----------|---------|------------|----------|----------|----------|
| 7         | 32      | 32         | 1.278592 | 1.134088 | 1.092907 |
| 7         | 32      | 64         | 1.705485 | 1.859289 | 1.669912 |
| 7         | 32      | 96         | 2.39444  | 2.906565 | 2.33527  |
| 7         | 32      | 128        | 2.666132 | 3.826124 | 2.785841 |
| 7         | 64      | 32         | 1.667163 | 1.917965 | 1.615576 |
| 7         | 64      | 64         | 2.61813  | 3.581604 | 2.625462 |
| 7         | 64      | 96         | 3.546815 | 5.312238 | 3.71246  |
| 7         | 64      | 128        | 4.281957 | 7.057717 | 4.550959 |
| 7         | 96      | 32         | 2.308805 | 2.369979 | 2.317396 |
| 7         | 96      | 64         | 4.103531 | 4.454457 | 3.987015 |
| 7         | 96      | 96         | 5.873135 | 6.572521 | 5.941552 |
| 7         | 96      | 128        | 7.72292  | 8.874915 | 7.67701  |
| 7         | 128     | 32         | 3.007692 | 2.987741 | 2.985851 |
| 7         | 128     | 64         | 5.898755 | 5.833433 | 5.811923 |
| 7         | 128     | 96         | 8.4781   | 8.67164  | 8.46419  |
| 7         | 128     | 128        | 11.72771 | 11.75581 | 11.47538 |
| 11        | 32      | 32         | 1.767787 | 2.199207 | 1.767787 |
| 11        | 32      | 64         | 2.525387 | 4.811379 | 2.567169 |
| 11        | 32      | 96         | 3.163039 | 7.209693 | 3.249871 |
| 11        | 32      | 128        | 3.994237 | 9.60605  | 3.971134 |
| 11        | 64      | 32         | 2.546133 | 3.014861 | 2.673116 |
| 11        | 64      | 64         | 4.528962 | 5.763379 | 4.349562 |
| 11        | 64      | 96         | 6.22832  | 8.564037 | 6.23687  |
| 11        | 64      | 128        | 7.81321  | 11.4982  | 7.96473  |
| 11        | 96      | 32         | 4.023215 | 3.816842 | 3.809961 |
| 11        | 96      | 64         | 7.42755  | 7.522071 | 7.42755  |
| 11        | 96      | 96         | 10.66388 | 11.13426 | 10.57938 |
| 11        | 96      | 128        | 13.99556 | 15.06879 | 14.03909 |
| 11        | 128     | 32         | 5.44588  | 5.47243  | 5.472205 |
| 11        | 128     | 64         | 11.89053 | 10.78155 | 10.74899 |
| 11        | 128     | 96         | 19.7596  | 15.875   | 15.89231 |
| 11        | 128     | 128        | 26.27283 | 21.39831 | 21.40065 |

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Improves performance of BlockTriDi solver with Schur complement line splitting, where sublines per line is chosen automatically. This can still be set manually.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
