### PR TITLE
Framework: Upgrade main GCC + OpenMPI config to C++20 standard

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1851,6 +1851,8 @@ opt-set-cmake-var Belos_gcrodr_complex_hb_MPI_4_DISABLE                         
 opt-set-cmake-var Belos_Tpetra_gcrodr_complex_hb_MPI_4_DISABLE                   BOOL : ON
 opt-set-cmake-var Stratimikos_Galeri_xpetra_complex_double_Jacobi_MPI_4_DISABLE  BOOL : ON
 
+opt-set-cmake-var CMAKE_CXX_STANDARD STRING FORCE : 20
+
 [rhel8_gcc-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use COMMON_SPACK_TPLS
 use COMPILER|GNU


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Want to expand C++20 compatibility given that Kokkos 5.0 will require it.

Will tag leadership members once we see what the build/test results are.