### PR TITLE
Panzer: load exodus cell data for auxiliary fields

### DIFF
--- a/packages/panzer/adapters-stk/example/main_driver/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/main_driver/CMakeLists.txt
@@ -20,6 +20,11 @@ TRIBITS_ADD_EXECUTABLE(
   SOURCES Panzer_xml_to_yaml.cpp
   )
 
+TRIBITS_ADD_EXECUTABLE(
+  write_exodus_initial_condition
+  SOURCES write_exodus_initial_condition.cpp ${PANZER_UNIT_TEST_MAIN}
+  )
+
 TRIBITS_COPY_FILES_TO_BINARY_DIR(main_driver_files
   SOURCE_FILES
     energy-ss.xml
@@ -42,7 +47,14 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(main_driver_files
     make-mesh.sh
     do-runs-multiblock.sh
     set_seacas_decomp.sh
-  EXEDEPS main_driver
+    energy-load-cell-data.xml
+  EXEDEPS main_driver xml_to_yaml
+  )
+
+TRIBITS_COPY_FILES_TO_BINARY_DIR(genesis_initial_condition_files
+  SOURCE_DIR ${PACKAGE_SOURCE_DIR}/test/stk_interface_test/meshes
+  SOURCE_FILES quad8.gen
+  EXEDEPS write_exodus_initial_condition main_driver
   )
 
 IF(PANZER_HAVE_EPETRA_STACK)

--- a/packages/panzer/adapters-stk/example/main_driver/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/main_driver/CMakeLists.txt
@@ -51,12 +51,6 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(main_driver_files
   EXEDEPS main_driver xml_to_yaml
   )
 
-TRIBITS_COPY_FILES_TO_BINARY_DIR(genesis_initial_condition_files
-  SOURCE_DIR ${PACKAGE_SOURCE_DIR}/test/stk_interface_test/meshes
-  SOURCE_FILES quad8.gen
-  EXEDEPS write_exodus_initial_condition main_driver
-  )
-
 IF(PANZER_HAVE_EPETRA_STACK)
   TRIBITS_ADD_ADVANCED_TEST(
     main_driver_energy-ss
@@ -130,6 +124,18 @@ TRIBITS_ADD_ADVANCED_TEST(
   TEST_0 EXEC main_driver
     ARGS  --i=energy-ss-tp-multiblock-ic-bc-issue.xml --time
     PASS_REGULAR_EXPRESSION "panzer::MainDriver run completed."
+    NUM_MPI_PROCS 2
+    ENVIRONMENT IOSS_PROPERTIES=DECOMPOSITION_METHOD=rib
+  )
+
+TRIBITS_ADD_ADVANCED_TEST(
+  main_driver_energy_load_cell_data
+  TEST_0 EXEC write_exodus_initial_condition
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+  TEST_1 EXEC main_driver
+    ARGS  --i=energy-load-cell-data.xml --time
+    PASS_REGULAR_EXPRESSION ": 0.970"
     NUM_MPI_PROCS 2
     ENVIRONMENT IOSS_PROPERTIES=DECOMPOSITION_METHOD=rib
   )

--- a/packages/panzer/adapters-stk/example/main_driver/energy-load-cell-data.xml
+++ b/packages/panzer/adapters-stk/example/main_driver/energy-load-cell-data.xml
@@ -63,8 +63,6 @@
               <Parameter name="Type" type="string" value="Exodus Cell Data"/>
               <Parameter name="Field Names" type="string" value="SOURCE_TEMPERATURE"/>
               <Parameter name="Exodus Names" type="string" value="TEST_FIELD"/>
-              <Parameter name="Index Choice" type="string" value="Fixed"/>
-              <Parameter name="Index Value" type="int" value="6"/>
             </ParameterList>
             <ParameterList name="Heat Capacity">
                 <Parameter name="Value" type="double" value="1.0"/>

--- a/packages/panzer/adapters-stk/example/main_driver/energy-load-cell-data.xml
+++ b/packages/panzer/adapters-stk/example/main_driver/energy-load-cell-data.xml
@@ -4,7 +4,7 @@
         <Parameter name="Source" type="string" value="Exodus File" />
         <ParameterList name="Exodus File">
             <Parameter name="File Name" type="string" value="energy-load-cell-data-SOURCE.exo" />
-            <Parameter name="Restart Index" type="int" value="1" />
+            <Parameter name="Restart Index" type="int" value="10" />
         </ParameterList>
     </ParameterList>
 

--- a/packages/panzer/adapters-stk/example/main_driver/energy-load-cell-data.xml
+++ b/packages/panzer/adapters-stk/example/main_driver/energy-load-cell-data.xml
@@ -1,0 +1,274 @@
+<ParameterList name="Drekar">
+
+    <ParameterList name="Mesh">
+        <Parameter name="Source" type="string" value="Exodus File" />
+        <ParameterList name="Exodus File">
+            <Parameter name="File Name" type="string" value="energy-load-cell-data-SOURCE.exo" />
+            <Parameter name="Restart Index" type="int" value="1" />
+        </ParameterList>
+    </ParameterList>
+
+    <ParameterList name="Initial Conditions">
+        <ParameterList name="eblock-0_0">
+            <ParameterList name="TEMPERATURE">
+                <Parameter name="Value" type="double" value="-1.0"/>
+            </ParameterList>
+        </ParameterList>
+    </ParameterList>
+
+    
+    <ParameterList name="Responses">
+      <ParameterList name="TEMPERATURE Integral">
+         <Parameter name="Type" type="string" value="Functional"/>
+         <Parameter name="Field Name" type="string" value="TEMPERATURE"/>
+         <Parameter name="Element Blocks" type="string" value="eblock-0_0"/>
+         <Parameter name="Evaluation Types" type="string" value="Residual"/>
+         <Parameter name="Requires Cell Integral" type="bool" value="true"/>
+      </ParameterList>
+    </ParameterList>
+    
+    <ParameterList name="Block ID to Physics ID Mapping">
+        <Parameter name="eblock-0_0" type="string" value="solid"/>
+    </ParameterList>
+
+    <ParameterList name="Assembly">
+        <Parameter name="Workset Size" type="int" value="25"/>
+        <Parameter name="Use Tpetra" type="bool" value="true"/>
+    </ParameterList>
+
+    <ParameterList name="Physics Blocks">
+
+        <ParameterList name="solid">
+
+            <ParameterList name="EQ 0">
+                <Parameter name="Type" type="string" value="Energy"/>
+                <Parameter name="Basis Type" type="string" value="HGrad"/>
+                <Parameter name="Basis Order" type="int" value="1"/>
+                <Parameter name="Integration Order" type="int" value="2"/>
+                <Parameter name="Model ID" type="string" value="fluid model"/>
+                <Parameter name="Prefix" type="string" value=""/>
+            </ParameterList>
+
+        </ParameterList>
+
+    </ParameterList>
+
+    <ParameterList name="Closure Models">
+
+        <ParameterList name="fluid model">
+
+            <ParameterList name="Volume Integral">
+            </ParameterList>
+            <ParameterList name="SOURCE_TEMPERATURE">
+              <Parameter name="Type" type="string" value="Exodus Cell Data"/>
+              <Parameter name="Field Names" type="string" value="SOURCE_TEMPERATURE"/>
+              <Parameter name="Exodus Names" type="string" value="TEST_FIELD"/>
+              <Parameter name="Index Choice" type="string" value="Fixed"/>
+              <Parameter name="Index Value" type="int" value="6"/>
+            </ParameterList>
+            <ParameterList name="Heat Capacity">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+            <ParameterList name="Thermal Conductivity">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+            <ParameterList name="DENSITY">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+            <ParameterList name="HEAT_CAPACITY">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+
+        </ParameterList>
+
+    </ParameterList>
+
+    <ParameterList name="User Data">
+        <ParameterList name="function data one">
+        </ParameterList>
+        <ParameterList name="IP Coordinates">
+            <Parameter name="Integration Order" type="int" value="2"/>
+        </ParameterList>
+    </ParameterList>
+
+    <ParameterList name="Boundary Conditions">
+        <ParameterList>
+            <Parameter name="Type" type="string" value="Dirichlet"/>
+            <Parameter name="Sideset ID" type="string" value="top"/>
+            <Parameter name="Element Block ID" type="string" value="eblock-0_0"/>
+            <Parameter name="Equation Set Name" type="string" value="TEMPERATURE"/>
+            <Parameter name="Strategy" type="string" value="Constant"/>
+            <ParameterList name="Data">
+                <Parameter name="Value" type="double" value="0.0"/>
+            </ParameterList>
+        </ParameterList>
+                <ParameterList>
+            <Parameter name="Type" type="string" value="Dirichlet"/>
+            <Parameter name="Sideset ID" type="string" value="bottom"/>
+            <Parameter name="Element Block ID" type="string" value="eblock-0_0"/>
+            <Parameter name="Equation Set Name" type="string" value="TEMPERATURE"/>
+            <Parameter name="Strategy" type="string" value="Constant"/>
+            <ParameterList name="Data">
+                <Parameter name="Value" type="double" value="0.0"/>
+            </ParameterList>
+        </ParameterList>
+                <ParameterList>
+            <Parameter name="Type" type="string" value="Dirichlet"/>
+            <Parameter name="Sideset ID" type="string" value="left"/>
+            <Parameter name="Element Block ID" type="string" value="eblock-0_0"/>
+            <Parameter name="Equation Set Name" type="string" value="TEMPERATURE"/>
+            <Parameter name="Strategy" type="string" value="Constant"/>
+            <ParameterList name="Data">
+                <Parameter name="Value" type="double" value="0.0"/>
+            </ParameterList>
+        </ParameterList>
+                <ParameterList>
+            <Parameter name="Type" type="string" value="Dirichlet"/>
+            <Parameter name="Sideset ID" type="string" value="right"/>
+            <Parameter name="Element Block ID" type="string" value="eblock-0_0"/>
+            <Parameter name="Equation Set Name" type="string" value="TEMPERATURE"/>
+            <Parameter name="Strategy" type="string" value="Constant"/>
+            <ParameterList name="Data">
+                <Parameter name="Value" type="double" value="0.0"/>
+            </ParameterList>
+        </ParameterList>
+    </ParameterList>
+
+    <ParameterList name="Output">
+        <Parameter name="File Name" type="string" value="energy-load-cell-data.exo"/>
+    </ParameterList>
+
+    <ParameterList name="Options">
+        <Parameter name="Write Volume Assembly Graphs" type="bool" value="true"/>
+        <Parameter name="Volume Assembly Graph Prefix" type="string" value="energy-load-cell-data"/>
+    </ParameterList>
+
+<ParameterList name="Solution Control">
+  <Parameter name="Piro Solver" type="string" value="NOX"/>
+  <Parameter name="Compute Sensitivities" type="bool" value="0"/>
+  <Parameter name="Jacobian Operator" type="string" value="Have Jacobian"/>
+  <ParameterList name="LOCA">
+    <ParameterList name="Bifurcation"/>
+    <ParameterList name="Constraints"/>
+    <ParameterList name="Predictor">
+      <Parameter  name="Method" type="string" value="Constant"/>
+    </ParameterList>
+    <ParameterList name="Stepper">
+      <Parameter  name="Continuation Method" type="string" value="Natural"/>
+      <Parameter  name="Initial Value" type="double" value="1.0"/>
+      <Parameter  name="Continuation Parameter" type="string" value="Parameter 0"/>
+      <Parameter  name="Max Steps" type="int" value="6"/>
+      <Parameter  name="Max Value" type="double" value="12.25"/>
+      <Parameter  name="Min Value" type="double" value="0.5"/>
+      <Parameter  name="Compute Eigenvalues" type="bool" value="1"/>
+      <ParameterList name="Eigensolver">
+        <Parameter name="Method" type="string" value="Anasazi"/>
+        <Parameter name="Operator" type="string" value="Shift-Invert"/>
+        <Parameter name="Num Blocks" type="int" value="3"/>
+        <Parameter name="Num Eigenvalues" type="int" value="1"/>
+        <Parameter name="Block Size" type="int" value="1"/>
+        <Parameter name="Maximum Restarts" type="int" value="0"/>
+        <Parameter name="Shift" type="double" value="1.0"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Step Size">
+      <Parameter  name="Initial Step Size" type="double" value="0.5"/>
+      <Parameter  name="Aggressiveness" type="double" value="2.0"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="NOX">
+    <ParameterList name="Direction">
+      <Parameter name="Method" type="string" value="Newton"/>
+      <ParameterList name="Newton">
+        <Parameter name="Forcing Term Method" type="string" value="Constant"/>
+        <Parameter name="Rescue Bad Newton Solve" type="bool" value="1"/>
+        <ParameterList name="Stratimikos Linear Solver">
+          <ParameterList name="NOX Stratimikos Options">
+          </ParameterList>
+          <ParameterList name="Stratimikos">
+            <Parameter name="Linear Solver Type" type="string" value="Belos"/>
+            <Parameter name="Preconditioner Type" type="string" value="Ifpack2"/>
+            <ParameterList name="Linear Solver Types">
+              <ParameterList name="Belos">
+                <Parameter name="Solver Type" type="string" value="Pseudo Block GMRES"/>
+                <ParameterList name="Solver Types">
+                  <ParameterList name="Pseudo Block GMRES">
+                    <Parameter name="Convergence Tolerance" type="double" value="1e-5"/>
+                    <Parameter name="Output Frequency" type="int" value="10"/>
+                    <Parameter name="Output Style" type="int" value="1"/>
+                    <Parameter name="Verbosity" type="int" value="33"/>
+                    <Parameter name="Maximum Iterations" type="int" value="100"/>
+                    <Parameter name="Block Size" type="int" value="1"/>
+                    <Parameter name="Num Blocks" type="int" value="20"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+            <ParameterList name="Preconditioner Types">
+              <ParameterList name="Ifpack2">
+                <Parameter name="Overlap" type="int" value="1"/>
+                <Parameter name="Prec Type" type="string" value="ILUT"/>
+                <ParameterList name="Ifpack2 Settings">
+                  <Parameter name="fact: drop tolerance" type="double" value="0"/>
+                  <Parameter name="fact: ilut level-of-fill" type="double" value="1"/>
+                  <Parameter name="fact: level-of-fill" type="int" value="1"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Line Search">
+      <ParameterList name="Full Step">
+        <Parameter name="Full Step" type="double" value="1"/>
+      </ParameterList>
+      <Parameter name="Method" type="string" value="Full Step"/>
+    </ParameterList>
+    <Parameter name="Nonlinear Solver" type="string" value="Line Search Based"/>
+    <ParameterList name="Printing">
+      <Parameter name="Output Precision" type="int" value="3"/>
+      <Parameter name="Output Processor" type="int" value="0"/>
+      <ParameterList name="Output Information">
+        <Parameter name="Error" type="bool" value="1"/>
+        <Parameter name="Warning" type="bool" value="1"/>
+        <Parameter name="Outer Iteration" type="bool" value="1"/>
+        <Parameter name="Outer Iteration Status Test" type="bool" value="1"/>
+        <Parameter name="Parameters" type="bool" value="1"/>
+        <Parameter name="Details" type="bool" value="1"/>
+        <Parameter name="Linear Solver Details" type="bool" value="1"/>
+        <Parameter name="Stepper Iteration" type="bool" value="1"/>
+        <Parameter name="Stepper Details" type="bool" value="1"/>
+        <Parameter name="Stepper Parameters" type="bool" value="1"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Solver Options">
+      <Parameter name="Status Test Check Type" type="string" value="Minimal"/>
+    </ParameterList>
+    <ParameterList name="Status Tests">
+      <Parameter name="Test Type" type="string" value="Combo"/>
+      <Parameter name="Combo Type" type="string" value="OR"/>
+      <Parameter name="Number of Tests" type="int" value="2"/>
+      <ParameterList name="Test 0">
+        <Parameter name="Test Type" type="string" value="Combo"/>
+        <Parameter name="Combo Type" type="string" value="AND"/>
+        <Parameter name="Number of Tests" type="int" value="2"/>
+        <ParameterList name="Test 0">
+          <Parameter name="Test Type" type="string" value="NormF"/>
+          <Parameter name="Tolerance" type="double" value="1.0e-8"/>
+        </ParameterList>
+        <ParameterList name="Test 1">
+          <Parameter name="Test Type" type="string" value="RelativeNormF"/>
+          <Parameter name="Tolerance" type="double" value="1.0e-4"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Test 1">
+        <Parameter name="Test Type" type="string" value="MaxIters"/>
+        <Parameter name="Maximum Iterations" type="int" value="10"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>
+
+
+</ParameterList>

--- a/packages/panzer/adapters-stk/example/main_driver/user_app_ClosureModel_Factory_STK.hpp
+++ b/packages/panzer/adapters-stk/example/main_driver/user_app_ClosureModel_Factory_STK.hpp
@@ -8,20 +8,30 @@
 // *****************************************************************************
 // @HEADER
 
-#ifndef PANZER_CLOSURE_MODEL_FACTORY_COMPOSITE_DECL_HPP
-#define PANZER_CLOSURE_MODEL_FACTORY_COMPOSITE_DECL_HPP
+#ifndef USER_APP_CLOSURE_MODEL_FACTORY_STK_HPP
+#define USER_APP_CLOSURE_MODEL_FACTORY_STK_HPP
 
 #include "Panzer_ClosureModel_Factory.hpp"
-#include "Panzer_ClosureModel_Factory_TemplateManager.hpp"
+#include "Panzer_STK_MeshAccessor.hpp"
 
 namespace panzer {
+  class InputEquationSet;
+
+  template <typename> class LinearObjFactory;
+}
+
+namespace user_app {
 
   template<typename EvalT>
-  class ClosureModelFactoryComposite : public panzer::ClosureModelFactory<EvalT> {
+  class MyModelFactorySTK : public panzer::ClosureModelFactory<EvalT>,
+                            public panzer_stk::STKMeshAccessor
+  {
+    Teuchos::RCP<const panzer::LinearObjFactory<panzer::Traits> > distr_param_lof;
 
   public:
 
-    ClosureModelFactoryComposite(const std::vector<Teuchos::RCP<panzer::ClosureModelFactory_TemplateManager<panzer::Traits> > >& factories);
+    void setDistributedParameterLOF(const Teuchos::RCP<const panzer::LinearObjFactory<panzer::Traits> > & dpl)
+    { distr_param_lof = dpl; }
 
     Teuchos::RCP< std::vector< Teuchos::RCP<PHX::Evaluator<panzer::Traits> > > >
     buildClosureModels(const std::string& model_id,
@@ -33,15 +43,10 @@ namespace panzer {
 		       const Teuchos::RCP<panzer::GlobalData>& global_data,
 		       PHX::FieldManager<panzer::Traits>& fm) const;
 
-    std::vector<Teuchos::RCP<panzer::ClosureModelFactory_TemplateManager<panzer::Traits>>>&
-    getFactories(){return m_factories;}
-
-  private:
-
-    std::vector<Teuchos::RCP<panzer::ClosureModelFactory_TemplateManager<panzer::Traits>>> m_factories;
-
   };
 
 }
+
+#include "user_app_ClosureModel_Factory_STK_impl.hpp"
 
 #endif

--- a/packages/panzer/adapters-stk/example/main_driver/user_app_ClosureModel_Factory_STK_TemplateBuilder.hpp
+++ b/packages/panzer/adapters-stk/example/main_driver/user_app_ClosureModel_Factory_STK_TemplateBuilder.hpp
@@ -1,0 +1,43 @@
+// @HEADER
+// *****************************************************************************
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//
+// Copyright 2011 NTESS and the Panzer contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef USER_APP_CLOSURE_MODEL_FACTORY_STK_TEMPLATE_BUILDER_HPP
+#define USER_APP_CLOSURE_MODEL_FACTORY_STK_TEMPLATE_BUILDER_HPP
+
+#include <string>
+#include "Sacado_mpl_apply.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Panzer_Base.hpp"
+#include "user_app_ClosureModel_Factory_STK.hpp"
+
+namespace user_app {
+
+  class MyModelFactorySTK_TemplateBuilder {
+    Teuchos::RCP<const panzer::LinearObjFactory<panzer::Traits> > distr_param_lof;
+
+  public:
+
+    void setDistributedParameterLOF(const Teuchos::RCP<const panzer::LinearObjFactory<panzer::Traits> > & dpl)
+    { distr_param_lof = dpl; }
+    
+    template <typename EvalT>
+    Teuchos::RCP<panzer::ClosureModelFactoryBase> build() const {
+      Teuchos::RCP<user_app::MyModelFactorySTK<EvalT> > closure_factory =
+          Teuchos::rcp(new user_app::MyModelFactorySTK<EvalT>) ;
+      closure_factory->setDistributedParameterLOF(distr_param_lof);
+
+      return Teuchos::rcp_static_cast<panzer::ClosureModelFactoryBase>(closure_factory);
+    }
+    
+  };
+  
+}
+
+#endif 

--- a/packages/panzer/adapters-stk/example/main_driver/user_app_ClosureModel_Factory_STK_impl.hpp
+++ b/packages/panzer/adapters-stk/example/main_driver/user_app_ClosureModel_Factory_STK_impl.hpp
@@ -83,10 +83,6 @@ buildClosureModels(const std::string& model_id,
         auto plist_copy = plist;
         {
           validParams.set("Type","Exodus Cell Data");
-          validParams.set("Index Choice","Fixed",
-                          "What index to use",
-                          rcp(new Teuchos::StringValidator(Teuchos::tuple<std::string>("Fixed", "Interpolate","Closest"))));
-          validParams.set("Index Value",0);
           validParams.set("Field Names","");
           validParams.set("Exodus Names","");
           plist_copy.validateParametersAndSetDefaults(validParams);
@@ -100,18 +96,11 @@ buildClosureModels(const std::string& model_id,
         panzer::StringTokenizer(*exodusNames,plist_copy.get<std::string>("Exodus Names"));
         TEUCHOS_ASSERT(exodusNames->size() > 0);
 
-        std::string indexChoice = plist_copy.get<std::string>("Index Choice");
-        TEUCHOS_ASSERT(indexChoice == "Fixed"); // Only suppor tone option for now
-
-        int indexValue = plist_copy.get<int>("Index Value");
-
         auto e = Teuchos::make_rcp<panzer_stk::GatherExodusCellDataToIP<EvalT,panzer::Traits>>
                    (this->getMesh(),
                     *fieldNames,
                     *exodusNames,
-                    ir,
-                    panzer_stk::GatherExodusCellDataToIP<EvalT,panzer::Traits>::IndexChoice::Fixed,
-                    indexValue);
+                    ir);
 
           evaluators->push_back(e);
         found = true;

--- a/packages/panzer/adapters-stk/example/main_driver/user_app_ClosureModel_Factory_STK_impl.hpp
+++ b/packages/panzer/adapters-stk/example/main_driver/user_app_ClosureModel_Factory_STK_impl.hpp
@@ -1,0 +1,133 @@
+// @HEADER
+// *****************************************************************************
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//
+// Copyright 2011 NTESS and the Panzer contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef USER_APP_CLOSURE_MODEL_FACTORY_STK_T_HPP
+#define USER_APP_CLOSURE_MODEL_FACTORY_STK_T_HPP
+
+#include <iostream>
+#include <sstream>
+#include <typeinfo>
+#include "Panzer_IntegrationRule.hpp"
+#include "Panzer_BasisIRLayout.hpp"
+#include "Panzer_Integrator_Scalar.hpp"
+#include "Panzer_String_Utilities.hpp"
+
+#include "Phalanx_FieldTag_Tag.hpp"
+
+#include "Teuchos_ParameterEntry.hpp"
+#include "Teuchos_TypeNameTraits.hpp"
+#include "Teuchos_StandardParameterEntryValidators.hpp"
+
+// Evaluators for this factory
+#include "Panzer_STK_GatherExodusCellDataToIP.hpp"
+
+// ********************************************************************
+// ********************************************************************
+template<typename EvalT>
+Teuchos::RCP< std::vector< Teuchos::RCP<PHX::Evaluator<panzer::Traits> > > >
+user_app::MyModelFactorySTK<EvalT>::
+buildClosureModels(const std::string& model_id,
+                   const Teuchos::ParameterList& models,
+                   const panzer::FieldLayoutLibrary& fl,
+                   const Teuchos::RCP<panzer::IntegrationRule>& ir,
+                   const Teuchos::ParameterList& /* default_params */,
+                   const Teuchos::ParameterList& user_data,
+                   const Teuchos::RCP<panzer::GlobalData>& global_data,
+                   PHX::FieldManager<panzer::Traits>& fm) const
+{
+
+  using std::string;
+  using std::vector;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::ParameterList;
+  using PHX::Evaluator;
+
+  RCP< vector< RCP<Evaluator<panzer::Traits> > > > evaluators =
+      rcp(new vector< RCP<Evaluator<panzer::Traits> > > );
+
+  if (!models.isSublist(model_id)) {
+    models.print(std::cout);
+    std::stringstream msg;
+    msg << "Falied to find requested model, \"" << model_id
+        << "\", for equation set:\n" << std::endl;
+    TEUCHOS_TEST_FOR_EXCEPTION(!models.isSublist(model_id), std::logic_error, msg.str());
+  }
+
+  std::vector<Teuchos::RCP<const panzer::PureBasis> > bases;
+  fl.uniqueBases(bases);
+
+  const ParameterList& my_models = models.sublist(model_id);
+
+  for (ParameterList::ConstIterator model_it = my_models.begin();
+       model_it != my_models.end(); ++model_it) {
+
+    bool found = false;
+
+    const std::string key = model_it->first;
+    const Teuchos::ParameterEntry& entry = model_it->second;
+    const ParameterList& plist = Teuchos::getValue<Teuchos::ParameterList>(entry);
+
+    if (plist.isType<std::string>("Type")) {
+
+      if (plist.get<std::string>("Type") == "Exodus Cell Data") {
+
+        Teuchos::ParameterList validParams("Valid Params");
+        auto plist_copy = plist;
+        {
+          validParams.set("Type","Exodus Cell Data");
+          validParams.set("Index Choice","Fixed",
+                          "What index to use",
+                          rcp(new Teuchos::StringValidator(Teuchos::tuple<std::string>("Fixed", "Interpolate","Closest"))));
+          validParams.set("Index Value",0);
+          validParams.set("Field Names","");
+          validParams.set("Exodus Names","");
+          plist_copy.validateParametersAndSetDefaults(validParams);
+        }
+
+        RCP<std::vector<std::string> > fieldNames = Teuchos::make_rcp<std::vector<std::string>>();
+        panzer::StringTokenizer(*fieldNames,plist_copy.get<std::string>("Field Names"));
+        TEUCHOS_ASSERT(fieldNames->size() > 0);
+
+        RCP<std::vector<std::string> > exodusNames = Teuchos::make_rcp<std::vector<std::string>>();
+        panzer::StringTokenizer(*exodusNames,plist_copy.get<std::string>("Exodus Names"));
+        TEUCHOS_ASSERT(exodusNames->size() > 0);
+
+        std::string indexChoice = plist_copy.get<std::string>("Index Choice");
+        TEUCHOS_ASSERT(indexChoice == "Fixed"); // Only suppor tone option for now
+
+        int indexValue = plist_copy.get<int>("Index Value");
+
+        auto e = Teuchos::make_rcp<panzer_stk::GatherExodusCellDataToIP<EvalT,panzer::Traits>>
+                   (this->getMesh(),
+                    *fieldNames,
+                    *exodusNames,
+                    ir,
+                    panzer_stk::GatherExodusCellDataToIP<EvalT,panzer::Traits>::IndexChoice::Fixed,
+                    indexValue);
+
+          evaluators->push_back(e);
+        found = true;
+      }
+    }
+
+    if (!found && this->m_throw_if_model_not_found) {
+      std::stringstream msg;
+      msg << "ClosureModelFactory failed to build evaluator for key \"" << key
+          << "\"\nin model \"" << model_id
+          << "\".  Please correct the type or add support to the \nfactory." <<std::endl;
+      TEUCHOS_TEST_FOR_EXCEPTION(!found, std::logic_error, msg.str());
+    }
+  }
+
+  return evaluators;
+}
+
+#endif

--- a/packages/panzer/adapters-stk/example/main_driver/write_exodus_initial_condition.cpp
+++ b/packages/panzer/adapters-stk/example/main_driver/write_exodus_initial_condition.cpp
@@ -1,0 +1,109 @@
+// @HEADER
+// *****************************************************************************
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//
+// Copyright 2011 NTESS and the Panzer contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#include <Teuchos_ConfigDefs.hpp>
+#include <Teuchos_UnitTestHarness.hpp>
+#include "Teuchos_DefaultComm.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_ParameterList.hpp"
+
+#include "stk_mesh/base/GetEntities.hpp"
+#include "stk_mesh/base/Selector.hpp"
+#include "Panzer_STK_SquareQuadMeshFactory.hpp"
+
+TEUCHOS_UNIT_TEST(GenerateInitialExodusMesh, WriteFunction)
+{
+  using Teuchos::RCP;
+
+  // To run in parallel we need to set an ioss property to split
+  // genesis file across mpi ranks.
+  // setenv("IOSS_PROPERTIES", "DECOMPOSITION_METHOD=rib", 1);
+
+  // ********************************
+  // Put analytic field on exodus file and write exodus file
+  // ********************************
+  {
+    std::string file_name = "quad8.gen";
+    panzer_stk::SquareQuadMeshFactory factory;
+    auto params = Teuchos::parameterList("Mesh Parameters");
+    params->set("X0",-1.0);
+    params->set("Y0",-1.0);
+    params->set("Xf",1.0);
+    params->set("Yf",1.0);
+    params->set("X Blocks",1);
+    params->set("Y Blocks",1);
+    params->set("X Elements",10);
+    params->set("Y Elements",10);
+    factory.setParameterList(params);
+    RCP<panzer_stk::STK_Interface> mesh = factory.buildUncommitedMesh(MPI_COMM_WORLD);
+    
+    std::vector<std::string> block_names;
+    mesh->getElementBlockNames(block_names);
+    for (const auto& block : block_names)
+      mesh->addCellField("TEST_FIELD",block);
+
+    const bool setupIO = true;
+    const bool doPerceptRefinement = false;
+    mesh->initialize(MPI_COMM_WORLD,setupIO,doPerceptRefinement);
+    factory.completeMeshConstruction(*mesh,MPI_COMM_WORLD);
+
+    const int num_time_steps = 10;
+    const double dt = 0.1;
+    double time = 0.0;
+    const double source_multiplier = 5.0;
+    bool first = true;
+    
+    for (int time_index = 0; time_index < num_time_steps+1; ++time_index) {
+      for (const auto& block : block_names) {
+        std::vector<stk::mesh::Entity> elements;
+        mesh->getMyElements(block,elements);
+        auto field = mesh->getCellField("TEST_FIELD",block);
+        for (size_t elem_idx=0; elem_idx < elements.size(); ++elem_idx) {
+
+          // Compute element centroid
+          double x = 0.0;
+          double y = 0.0;
+          for (int node_idx=0; node_idx < 4; ++node_idx) {
+            auto node = mesh->findConnectivityById(elements[elem_idx],mesh->getNodeRank(),node_idx);
+            const double * const coords = mesh->getNodeCoordinates(node);
+            x += coords[0];
+            y += coords[1];
+          }
+          x /= 4.0;
+          y /= 4.0;
+          double tmp = x*x + y*y;
+          double r = (tmp > 0) ? std::sqrt(tmp) : 0.0;
+
+          double* value = static_cast<double*>(stk::mesh::field_data(*field,elements[elem_idx]));
+          if ( (time > 0.3) && (r < 0.5) ) {
+            *value = time * source_multiplier + 4.0 * r;
+          }
+          else {
+            *value = 0.0;
+          }
+
+          // std::cout  << "block=" << block
+          //            << ", element=" << mesh->getBulkData()->identifier(elements[elem_idx])
+          //            << ", x=" << x
+          //            << ", y=" << y
+          //            << ", val=" << *value << std::endl;
+        }
+      }
+      if (first) {
+        mesh->setInitialStateTime(0.0);
+        mesh->setupExodusFile("energy-load-cell-data-SOURCE.exo");
+        first = false;
+      }
+      mesh->writeToExodus(time);
+      time += dt;
+    }
+
+  }
+}

--- a/packages/panzer/adapters-stk/src/Panzer_STK_MeshAccessor.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_MeshAccessor.hpp
@@ -1,0 +1,30 @@
+#ifndef PANZER_STK_MESH_ACCESSOR_HPP
+#define PANZER_STK_MESH_ACCESSOR_HPP
+
+#include "Teuchos_Assert.hpp"
+#include "Panzer_STK_Interface.hpp"
+
+namespace panzer_stk {
+
+  /** Base class for closure model factories to provide access to the STK_Interface. 
+
+      Applications can derive their closure model factories from this
+      class. The model evalautor factory will create and set the mesh
+      on any factories that derive from this object before calling the
+      buildObjects().
+   */
+  class STKMeshAccessor {
+    Teuchos::RCP<panzer_stk::STK_Interface> mesh_;
+  public:
+    Teuchos::RCP<panzer_stk::STK_Interface> getMesh() const
+    {
+      TEUCHOS_ASSERT(Teuchos::nonnull(mesh_));
+      return mesh_;
+    }
+
+    void setMesh(const Teuchos::RCP<STK_Interface>& mesh){mesh_ = mesh;}
+  };
+
+}
+
+#endif

--- a/packages/panzer/adapters-stk/src/Panzer_STK_ModelEvaluatorFactory.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_ModelEvaluatorFactory.hpp
@@ -295,7 +295,8 @@ namespace panzer_stk {
                                            const Teuchos::ParameterList & closure_models,
                                            int workset_size, Teuchos::ParameterList & user_data) const;
 
-
+    void registerMeshWithClosureModelFactories(const Teuchos::RCP<panzer_stk::STK_Interface>& mesh,
+                                               panzer::ClosureModelFactory_TemplateManager<panzer::Traits> & user_cm_factory);
   private:
 
     Teuchos::RCP<Thyra::ModelEvaluator<ScalarT> > m_physics_me;

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherExodusCellDataToIP.cpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherExodusCellDataToIP.cpp
@@ -1,0 +1,16 @@
+// @HEADER
+// *****************************************************************************
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//
+// Copyright 2011 NTESS and the Panzer contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#include "PanzerAdaptersSTK_config.hpp"
+#include "Panzer_ExplicitTemplateInstantiation.hpp"
+#include "Panzer_STK_GatherExodusCellDataToIP.hpp"
+#include "Panzer_STK_GatherExodusCellDataToIP_impl.hpp"
+
+PANZER_INSTANTIATE_TEMPLATE_CLASS_TWO_T(panzer_stk::GatherExodusCellDataToIP)

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherExodusCellDataToIP.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherExodusCellDataToIP.hpp
@@ -1,0 +1,84 @@
+// @HEADER
+// *****************************************************************************
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//
+// Copyright 2011 NTESS and the Panzer contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef __PANZER_STK_GatherExodusCellDataToIP_decl_HPP__
+#define __PANZER_STK_GatherExodusCellDataToIP_decl_HPP__
+
+#include "Phalanx_config.hpp"
+#include "Phalanx_Evaluator_Macros.hpp"
+#include "Phalanx_MDField.hpp"
+
+#include "Teuchos_ParameterList.hpp"
+
+#include "Panzer_Dimension.hpp"
+#include "Panzer_Traits.hpp"
+#include "Panzer_STK_Interface.hpp"
+
+#include "Panzer_Evaluator_WithBaseImpl.hpp"
+
+namespace panzer_stk {
+
+/** This class is a gathers a cell-based field from a STK Mesh 
+  */
+template<typename EvalT, typename Traits> 
+class GatherExodusCellDataToIP
+  : public panzer::EvaluatorWithBaseImpl<Traits>,
+    public PHX::EvaluatorDerived<EvalT, Traits> {
+  
+public:
+
+  // Strategy to pick the time index for the solution from the input file
+  enum class IndexChoice {
+    /// Specify an index and use it for the whole run
+    Fixed,
+    /// Interpolate using time values
+    Interpolate,
+    /// Pick the closest time value
+    Closest
+  };
+  
+  /**
+     Loads a set of fields from an exodus file into the field
+     manager. The list of exodus names are mapped to the field names.
+
+     @param mesh STK mesh to read value from
+     @param fieldNames Names of all fields in the field manager
+     @param exodusNames Names of the fields in the exodus file 
+     @param indexChoice determines how to pick the index in the exodus file.
+     @param indexValue if indexChoice is set to "Fixed", this is the value to use.
+   */
+  GatherExodusCellDataToIP(const Teuchos::RCP<const panzer_stk::STK_Interface> & mesh,
+                           const std::vector<std::string>& fieldNames,
+                           const std::vector<std::string>& exodusNames,
+                           const Teuchos::RCP<panzer::IntegrationRule>& integrationRule,
+                           const GatherExodusCellDataToIP::IndexChoice& indexChoice,
+                           const int indexValue = 0);
+  
+  void postRegistrationSetup(typename Traits::SetupData d,
+			     PHX::FieldManager<Traits>& vm);
+  
+  void evaluateFields(typename Traits::EvalData d);
+
+private:
+  typedef typename EvalT::ScalarT ScalarT;
+  typedef panzer_stk::STK_Interface::SolutionFieldType VariableField;
+  
+  const Teuchos::RCP<const STK_Interface> mesh_;
+  const std::vector<std::string> exodusNames_;
+  std::vector<PHX::MDField<ScalarT,panzer::Cell,panzer::IP>> gatherFields_;
+  std::vector<VariableField*> stkFields_;
+  const GatherExodusCellDataToIP::IndexChoice indexChoice_;
+  const int indexValue_;
+};
+
+}
+
+// **************************************************************
+#endif

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherExodusCellDataToIP.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherExodusCellDataToIP.hpp
@@ -34,32 +34,20 @@ class GatherExodusCellDataToIP
   
 public:
 
-  // Strategy to pick the time index for the solution from the input file
-  enum class IndexChoice {
-    /// Specify an index and use it for the whole run
-    Fixed,
-    /// Interpolate using time values
-    Interpolate,
-    /// Pick the closest time value
-    Closest
-  };
-  
   /**
      Loads a set of fields from an exodus file into the field
      manager. The list of exodus names are mapped to the field names.
+     The time index from the exodus file for these fields corresponds
+     to the restart value in the exodus mesh reader.
 
      @param mesh STK mesh to read value from
      @param fieldNames Names of all fields in the field manager
      @param exodusNames Names of the fields in the exodus file 
-     @param indexChoice determines how to pick the index in the exodus file.
-     @param indexValue if indexChoice is set to "Fixed", this is the value to use.
    */
   GatherExodusCellDataToIP(const Teuchos::RCP<const panzer_stk::STK_Interface> & mesh,
                            const std::vector<std::string>& fieldNames,
                            const std::vector<std::string>& exodusNames,
-                           const Teuchos::RCP<panzer::IntegrationRule>& integrationRule,
-                           const GatherExodusCellDataToIP::IndexChoice& indexChoice,
-                           const int indexValue = 0);
+                           const Teuchos::RCP<panzer::IntegrationRule>& integrationRule);
   
   void postRegistrationSetup(typename Traits::SetupData d,
 			     PHX::FieldManager<Traits>& vm);
@@ -74,8 +62,6 @@ private:
   const std::vector<std::string> exodusNames_;
   std::vector<PHX::MDField<ScalarT,panzer::Cell,panzer::IP>> gatherFields_;
   std::vector<VariableField*> stkFields_;
-  const GatherExodusCellDataToIP::IndexChoice indexChoice_;
-  const int indexValue_;
 };
 
 }

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherExodusCellDataToIP_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherExodusCellDataToIP_impl.hpp
@@ -1,0 +1,107 @@
+// @HEADER
+// *****************************************************************************
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//
+// Copyright 2011 NTESS and the Panzer contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef PANZER_STK_GATHER_EXODUS_CELL_DATA_TO_IP_IMPL_HPP
+#define PANZER_STK_GATHER_EXODUS_CELL_DATA_TO_IP_IMPL_HPP
+
+#include "Teuchos_Assert.hpp"
+#include "Phalanx_DataLayout.hpp"
+#include "Panzer_BasisIRLayout.hpp"
+#include "Teuchos_FancyOStream.hpp"
+#include <sstream>
+
+// **********************************************************************
+// Specialization: Residual
+// **********************************************************************
+
+template<typename EvalT, typename Traits>
+panzer_stk::GatherExodusCellDataToIP<EvalT, Traits>::
+GatherExodusCellDataToIP(const Teuchos::RCP<const STK_Interface> & mesh,
+                         const std::vector<std::string>& fieldNames,
+                         const std::vector<std::string>& exodusNames,
+                         const Teuchos::RCP<panzer::IntegrationRule>& integrationRule,
+                         const GatherExodusCellDataToIP::IndexChoice& indexChoice,
+                         const int indexValue)
+  : mesh_(mesh),
+    exodusNames_(exodusNames),
+    indexChoice_(indexChoice),
+    indexValue_(indexValue)
+{
+  using panzer::Cell;
+  using panzer::IP;
+
+  TEUCHOS_ASSERT(fieldNames.size() == exodusNames.size());
+  TEUCHOS_ASSERT(nonnull(mesh));
+  TEUCHOS_ASSERT(nonnull(integrationRule));
+  
+  gatherFields_.resize(fieldNames.size());
+  stkFields_.resize(fieldNames.size());
+  for (std::size_t fd = 0; fd < fieldNames.size(); ++fd) {
+    gatherFields_[fd] = PHX::MDField<ScalarT,Cell,IP>(fieldNames[fd],integrationRule->dl_scalar);
+    this->addEvaluatedField(gatherFields_[fd]);
+  }
+
+  std::ostringstream os;
+  for (size_t i=0; i < fieldNames.size(); ++i) {
+    os << fieldNames[i];
+    if (i < fieldNames.size()-1)
+      os << ",";
+  }
+
+  this->setName("GatherExodusCellDataToIP: "+os.str());
+}
+
+// **********************************************************************
+template<typename EvalT, typename Traits>
+void panzer_stk::GatherExodusCellDataToIP<EvalT, Traits>::
+postRegistrationSetup(typename Traits::SetupData /* d */,
+		      PHX::FieldManager<Traits>& /* fm */)
+{
+  for (std::size_t fd = 0; fd < gatherFields_.size(); ++fd) {
+    std::string fieldName = gatherFields_[fd].fieldTag().name();
+
+    stkFields_[fd] = mesh_->getMetaData()->get_field<double>(stk::topology::ELEMENT_RANK, exodusNames_[fd]);
+
+    if(stkFields_[fd]==0) {
+      std::stringstream ss;
+      mesh_->printMetaData(ss);
+      TEUCHOS_TEST_FOR_EXCEPTION(true,std::invalid_argument,
+                                 "panzer_stk::GatherExodusCellDataToIP: STK field " << "\"" << fieldName << "\" "
+                                 "not found.\n STK meta data follows: \n\n" << ss.str());
+    }
+  }
+}
+
+// **********************************************************************
+template<typename EvalT, typename Traits>
+void panzer_stk::GatherExodusCellDataToIP<EvalT, Traits>::
+evaluateFields(typename Traits::EvalData workset)
+{
+  const std::vector<stk::mesh::Entity>& localElementEntities = *mesh_->getElementsOrderedByLID();
+  const std::vector<std::size_t>& localWorksetCellIds = this->wda(workset).cell_local_ids;
+
+  auto host_mirror = Kokkos::create_mirror_view(Kokkos::WithoutInitializing,gatherFields_[0].get_static_view());
+
+  for (std::size_t fieldIndex=0; fieldIndex < gatherFields_.size(); ++fieldIndex) {
+    VariableField* field = stkFields_[fieldIndex];
+    const std::size_t numQuadPoints = gatherFields_[fieldIndex].extent(1);
+
+    for(std::size_t worksetCellIndex=0;worksetCellIndex<localWorksetCellIds.size();++worksetCellIndex) {
+      std::size_t cellLocalId = localWorksetCellIds[worksetCellIndex];
+      for(std::size_t qp=0; qp < numQuadPoints; ++qp) {
+        double value = *stk::mesh::field_data(*field, localElementEntities[cellLocalId]);
+        host_mirror(worksetCellIndex,qp) = value;
+      }
+    }
+
+    Kokkos::deep_copy(gatherFields_[fieldIndex].get_static_view(),host_mirror);
+  }
+}
+#endif

--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherExodusCellDataToIP_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherExodusCellDataToIP_impl.hpp
@@ -26,13 +26,9 @@ panzer_stk::GatherExodusCellDataToIP<EvalT, Traits>::
 GatherExodusCellDataToIP(const Teuchos::RCP<const STK_Interface> & mesh,
                          const std::vector<std::string>& fieldNames,
                          const std::vector<std::string>& exodusNames,
-                         const Teuchos::RCP<panzer::IntegrationRule>& integrationRule,
-                         const GatherExodusCellDataToIP::IndexChoice& indexChoice,
-                         const int indexValue)
+                         const Teuchos::RCP<panzer::IntegrationRule>& integrationRule)
   : mesh_(mesh),
-    exodusNames_(exodusNames),
-    indexChoice_(indexChoice),
-    indexValue_(indexValue)
+    exodusNames_(exodusNames)
 {
   using panzer::Cell;
   using panzer::IP;

--- a/packages/panzer/disc-fe/src/Panzer_ClosureModel_Factory_TemplateManager.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ClosureModel_Factory_TemplateManager.hpp
@@ -25,7 +25,7 @@ namespace panzer {
   template<typename Traits>
   class ClosureModelFactory_TemplateManager : 
     public PHX::TemplateManager<typename Traits::EvalTypes,
-				panzer::ClosureModelFactoryBase,
+				                        panzer::ClosureModelFactoryBase,
                                 panzer::ClosureModelFactory<_> > {
 
   public:

--- a/packages/panzer/disc-fe/test/closure_model/user_app_ClosureModel_Factory_impl.hpp
+++ b/packages/panzer/disc-fe/test/closure_model/user_app_ClosureModel_Factory_impl.hpp
@@ -320,7 +320,7 @@ buildClosureModels(const std::string& model_id,
     }
 
 
-    if (!found) {
+    if (!found && this->m_throw_if_model_not_found) {
       std::stringstream msg;
       msg << "ClosureModelFactory failed to build evaluator for key \"" << key 
           << "\"\nin model \"" << model_id

--- a/packages/panzer/disc-fe/test/closure_model/user_app_InitialConditionEvaluator.hpp
+++ b/packages/panzer/disc-fe/test/closure_model/user_app_InitialConditionEvaluator.hpp
@@ -1,3 +1,6 @@
+#ifndef USER_APP_INITIAL_CONDITION_EVALUATOR_HPP
+#define USER_APP_INITIAL_CONDITION_EVALUATOR_HPP
+
 #include "Phalanx_Evaluator_WithBaseImpl.hpp"
 
 namespace user_app {
@@ -42,3 +45,5 @@ namespace user_app {
     PHX::MDField<ScalarT,panzer::Cell,panzer::Point> temperature_;
   };
 }
+
+#endif


### PR DESCRIPTION
@trilinos/panzer 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Application requires that extra fields stored in the exodus restart file be available in assembly DAG. Added evaluator and factory to support this use case for scalars that are constant in each cell.
 
## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Addresses the issue

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
New test added to adapters-stk/example/main_driver/energy-load-cell-data.xml

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
