### PR TITLE
zoltan: elimnate format overflow warnings

### DIFF
--- a/packages/zoltan/src/driver/dr_chaco_io.c
+++ b/packages/zoltan/src/driver/dr_chaco_io.c
@@ -48,7 +48,7 @@ int read_chaco_file(int Proc,
 {
   /* Local declarations. */
   const char  *yo = "read_chaco_mesh";
-  char   cmesg[256];
+  char   cmesg[4188];
   char   chaco_fname[FILENAME_MAX + 8];
 
   int    nvtxs,base;
@@ -172,7 +172,7 @@ for (i=0; i<nvtxs; i++) { /* move 2/3 of points much closer to "a" */
     if (pio_info->init_dist_type == INITIAL_FILE) {
       sprintf(chaco_fname, "%s.assign", pio_info->pexo_fname);
       if (pio_info->file_comp == GZIP)
-	sprintf(chaco_fname, "%s.gz", chaco_fname);
+	sprintf(chaco_fname, "%s.gz", pio_info->pexo_fname);
 
       fp = ZOLTAN_FILE_open(chaco_fname, "r", pio_info->file_comp);
       if (fp == NULL) {

--- a/packages/zoltan/src/driver/dr_hg_io.c
+++ b/packages/zoltan/src/driver/dr_hg_io.c
@@ -540,7 +540,7 @@ int read_mtxplus_file(
   preprocessed = 0;
   sprintf(filename, "%s.mtxp", pio_info->pexo_fname);
   if (pio_info->file_comp == GZIP)
-    sprintf(filename, "%s.gz", filename);      /* but we don't uncompress?? TODO */
+    sprintf(filename, "%s.gz", pio_info->pexo_fname);      /* but we don't uncompress?? TODO */
 
   if (pio_info->chunk_reader == 1 &&              /* read large file in chunks */
       pio_info->init_dist_type == INITIAL_OWNER)  /* each process gets its own objects */
@@ -1209,7 +1209,7 @@ int nexte, nextv, nDistProcs=0;
 float pinVal;
 char *line, *token, *pinBuf, *vwgtBuf, *ewgtBuf;
 float *myvwgt, *myewgt;
-char cmesg[256];
+char cmesg[1074];
 char linestr[MATRIX_MARKET_MAX_LINE+1];
 
   *nGlobalEdges = *nGlobalVtxs = 0;

--- a/packages/zoltan/src/driver/dr_input.c
+++ b/packages/zoltan/src/driver/dr_input.c
@@ -566,7 +566,7 @@ int read_cmd_file (
 	  undef->list_size++;
 	}
 	else{
-	  char buffer[200];
+	  char buffer[4143];
 	  sprintf (buffer,
 	    "fatal error, too many unrecognized commands: %s\n", line);
 	  Gen_Error(0, buffer);

--- a/packages/zoltan/src/driver/dr_output.c
+++ b/packages/zoltan/src/driver/dr_output.c
@@ -181,7 +181,7 @@ int output_results(const char *cmd_file,
   /* Local declarations. */
   const char  *yo = "output_results";
   char   par_out_fname[FILENAME_MAX+1], ctemp[FILENAME_MAX+1];
-  char cmsg[256];
+  char cmsg[4153];
 
   ZOLTAN_ID_TYPE   *global_ids = NULL;
   ZOLTAN_ID_TYPE   *parts = NULL;


### PR DESCRIPTION
Increased the size of 4 character arrays and fixed 2 typos where a character array was printing to itself to eliminate warnings

@trilinos/zoltan 

## Motivation
Eliminate warnings

## Related Issues
* Closes 14257