### PR TITLE
teuchos maybe uninitialized warnings 14259

### DIFF
--- a/packages/teuchos/core/test/ScalarTraits/ScalarTraits_test.cpp
+++ b/packages/teuchos/core/test/ScalarTraits/ScalarTraits_test.cpp
@@ -51,7 +51,7 @@ void TYPE_CHAIN_A(Teuchos::FancyOStream &out) {
 
   T b;
   // double_type d; // unused
-  out << Teuchos::typeName (b);
+  out << Teuchos::typeName (&b);
   if (! std::is_same_v<T, double_type>) {
     out << " -> ";
     TYPE_CHAIN_A<double_type>(out);
@@ -64,7 +64,7 @@ void TYPE_CHAIN_D(Teuchos::FancyOStream &out) {
 
   T b;
   // half_type d; // unused
-  out << Teuchos::typeName (b);
+  out << Teuchos::typeName (&b);
 
   if (! std::is_same_v<T, half_type>) {
     out << " -> ";


### PR DESCRIPTION
changed a couple of uninitialized arguments to the address of those arguments which is used elsewhere and compiles without warnings.

@trilinos/teuchos 

## Motivation
removing warnings

## Related Issues
* Closes 14259
