### PR TITLE
Tpetra, Galeri, MueLu, Ifpack2: Small performance improvements

### DIFF
--- a/packages/galeri/src-xpetra/Galeri_XpetraUtils.hpp
+++ b/packages/galeri/src-xpetra/Galeri_XpetraUtils.hpp
@@ -76,8 +76,7 @@ class Utils {
         nz = list.get<GlobalOrdinal>("nz");
     }
 
-    size_t NumMyElements                                     = map->getLocalNumElements();
-    Teuchos::ArrayView<const GlobalOrdinal> MyGlobalElements = map->getLocalElementList();
+    size_t NumMyElements = map->getLocalNumElements();
 
 #if defined(HAVE_GALERI_KOKKOS) && defined(HAVE_GALERI_KOKKOSKERNELS)
     using Node             = typename Map::node_type;
@@ -146,6 +145,8 @@ class Utils {
     } else
 #endif
     {
+      Teuchos::ArrayView<const GlobalOrdinal> MyGlobalElements = map->getLocalElementList();
+
       GlobalOrdinal ix, iy, iz;
 
       if (coordType == "1D") {

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -1977,6 +1977,9 @@ void performSymbolicPhase(const Teuchos::RCP<const typename BlockHelperDetails::
     const auto colmap = g->getColMap();
     const auto dommap = g->getDomainMap();
     TEUCHOS_ASSERT(!(rowmap.is_null() || colmap.is_null() || dommap.is_null()));
+    rowmap->lazyPushToHost();
+    colmap->lazyPushToHost();
+    dommap->lazyPushToHost();
 
 #if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__) && !defined(__SYCL_DEVICE_ONLY__)
     const Kokkos::RangePolicy<host_execution_space> policy(0, nrows);

--- a/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
@@ -737,14 +737,16 @@ UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     GetMatrixOverlappedDiagonal(const Matrix& A) {
   RCP<const Map> rowMap = A.getRowMap(), colMap = A.getColMap();
   RCP<Vector> localDiag      = GetMatrixDiagonal(A);
-  RCP<Vector> diagonal       = VectorFactory::Build(colMap);
   RCP<const Import> importer = A.getCrsGraph()->getImporter();
-  if (importer == Teuchos::null) {
+  if (importer.is_null() && !rowMap->isSameAs(*colMap)) {
     importer = ImportFactory::Build(rowMap, colMap);
   }
-  diagonal->doImport(*localDiag, *(importer), Xpetra::INSERT);
-
-  return diagonal;
+  if (!importer.is_null()) {
+    RCP<Vector> diagonal = VectorFactory::Build(colMap);
+    diagonal->doImport(*localDiag, *(importer), Xpetra::INSERT);
+    return diagonal;
+  } else
+    return localDiag;
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -2055,6 +2057,12 @@ UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 bool UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     MapsAreNested(const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>& rowMap, const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>& colMap) {
+  if ((rowMap.lib() == Xpetra::UseTpetra) && (colMap.lib() == Xpetra::UseTpetra)) {
+    auto tpRowMap = toTpetra(rowMap);
+    auto tpColMap = toTpetra(colMap);
+    return tpColMap.isLocallyFitted(tpRowMap);
+  }
+
   ArrayView<const GlobalOrdinal> rowElements = rowMap.getLocalElementList();
   ArrayView<const GlobalOrdinal> colElements = colMap.getLocalElementList();
 

--- a/packages/tpetra/core/src/Tpetra_Map_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_decl.hpp
@@ -1096,8 +1096,13 @@ namespace Tpetra {
       const global_ordinal_type indexBase,
       const Teuchos::RCP<const Teuchos::Comm<int>>& comm);
 
+  public:
     /// \brief Push the device data to host, if needed
+    ///
+    /// \warning lazyPushToHost is SUBJECT TO CHANGE and is for EXPERT USERS ONLY.
+    /// We STRONGLY advise against its use.
     void lazyPushToHost() const;
+  private:
 
     //! The communicator over which this Map is distributed.
     Teuchos::RCP<const Teuchos::Comm<int> > comm_;


### PR DESCRIPTION
@trilinos/tpetra @trilinos/galeri @trilinos/muelu @trilinos/ifpack2 

## Motivation
- Galeri: Skip unneeded call to `getLocalElementList`.
- Tpetra: Run `locallySameAs` on device.
- MueLu: Use Tpetra method in `MapsAreNested`, don't construct importer in `GetOverlappedDiagonal` on single rank
- Ifpack2: Fix bug in `BlockTriDiContainer::peformSymbolicPhase`