### PR TITLE
Zoltan2: Use identity permutation if there's an invalid entry in RCM reordering

### DIFF
--- a/packages/zoltan2/core/src/algorithms/order/Zoltan2_AlgRCM.hpp
+++ b/packages/zoltan2/core/src/algorithms/order/Zoltan2_AlgRCM.hpp
@@ -192,6 +192,18 @@ class AlgRCM : public Algorithm<Adapter>
 
     }
 
+    bool validPermutation = true;
+    for (size_t i = 0; i < nVtx; ++i) {
+      validPermutation &= (invPerm[i] != INVALID);
+    }
+
+    // Invalid permutation -- let's use the identity permutation.
+    if(!validPermutation){
+      for (size_t i = 0; i < nVtx; ++i) {
+        invPerm[i] = i;
+      }
+    }
+
     solution->setHaveInverse(true);
     return ierr;
   }


### PR DESCRIPTION
Fixes #14289

I would have added a unit test, but the matrix file required to reproduce the issue is 5 Mb in size. I don't have an easy means of generating the matrix 'on-the-fly'.