### PR TITLE
Galeri: Resolve compilation error in Galeri_MatpTraits.hpp

### DIFF
--- a/packages/galeri/src-xpetra/Galeri_MapTraits.hpp
+++ b/packages/galeri/src-xpetra/Galeri_MapTraits.hpp
@@ -96,7 +96,10 @@ class MapTraits<GlobalOrdinal, ::Xpetra::EpetraMapT<GlobalOrdinal, Node>> {
  public:
   static Teuchos::RCP<::Xpetra::EpetraMapT<GlobalOrdinal, Node>> Build(global_size_t numGlobalElements, const Teuchos::ArrayView<const GlobalOrdinal> &elementList, GlobalOrdinal indexBase, const Teuchos::RCP<const Teuchos::Comm<int>> &comm) { return Teuchos::rcp(new ::Xpetra::EpetraMapT<GlobalOrdinal, Node>(numGlobalElements, elementList, indexBase, comm)); }
 
-  static Teuchos::RCP<::Xpetra::EpetraMapT<GlobalOrdinal, Node>> Build(global_size_t numGlobalElements, const typename ::Xpetra::EpetraMapT<GlobalOrdinal, Node>::global_indices_array_device_type &elementList, GlobalOrdinal indexBase, const Teuchos::RCP<const Teuchos::Comm<int>> &comm) { return Teuchos::rcp(new ::Xpetra::EpetraMapT<GlobalOrdinal, Node>(numGlobalElements, elementList, indexBase, comm)); }
+  static Teuchos::RCP<::Xpetra::EpetraMapT<GlobalOrdinal, Node>> Build(global_size_t numGlobalElements, const typename ::Xpetra::EpetraMapT<GlobalOrdinal, Node>::global_indices_array_device_type &elementList, GlobalOrdinal indexBase, const Teuchos::RCP<const Teuchos::Comm<int>> &comm) {
+    Teuchos::ArrayView<const int> elementListArrayView(elementList.data(), elementList.extent(0));
+    return Teuchos::rcp(new ::Xpetra::EpetraMapT<GlobalOrdinal, Node>(numGlobalElements, elementListArrayView, indexBase, comm));
+  }
 
   static Teuchos::RCP<::Xpetra::EpetraMapT<GlobalOrdinal, Node>> Build(global_size_t numGlobalElements, global_size_t numLocalElements, GlobalOrdinal indexBase, const Teuchos::RCP<const Teuchos::Comm<int>> &comm) { return Teuchos::rcp(new ::Xpetra::EpetraMapT<GlobalOrdinal, Node>(numGlobalElements, numLocalElements, indexBase, comm)); }
 };


### PR DESCRIPTION
@trilinos/galeri

I end up hitting compilation errors like:
```
[ 72%] Building CXX object packages/belos/tpetra/example/SolverFactory/CMakeFiles/Belos_SolverFactory_Tpetra_Galeri_Ex.dir/SolverFactoryTpetraGaleriEx.cpp.o
In file included from /tscratch/malphil/muelu-weak-scaling-solid-voltage/Trilinos/packages/galeri/src-xpetra/Galeri_XpetraCartesian.hpp:19,
                 from /tscratch/malphil/muelu-weak-scaling-solid-voltage/Trilinos/packages/galeri/src-xpetra/Galeri_XpetraMaps.hpp:31,
                 from /tscratch/malphil/muelu-weak-scaling-solid-voltage/Trilinos/packages/belos/tpetra/example/SolverFactory/SolverFactoryTpetraGaleriEx.cpp:17:
/tscratch/malphil/muelu-weak-scaling-solid-voltage/Trilinos/packages/galeri/src-xpetra/Galeri_MapTraits.hpp: In instantiation of 'static Teuchos::RCP<Xpetra::EpetraMapT<GlobalOrdinal, Node> > Galeri::Xpetra::MapTraits<GlobalOrdinal, Xpetra::EpetraMapT<GlobalOrdinal, Node> >::Build(Galeri::Xpetra::global_size_t, const typename Xpetra::EpetraMapT<GlobalOrdinal, Node>::global_indices_array_device_type&, GlobalOrdinal, const Teuchos::RCP<const Teuchos::Comm<int> >&) [with GlobalOrdinal = int; Node = Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial>; Galeri::Xpetra::global_size_t = long unsigned int; typename Xpetra::EpetraMapT<GlobalOrdinal, Node>::global_indices_array_device_type = Kokkos::View<const int*, Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace> >]':
/tscratch/malphil/muelu-weak-scaling-solid-voltage/Trilinos/packages/galeri/src-xpetra/Galeri_XpetraCartesian.hpp:90:35:   required from 'Teuchos::RCP<T> Galeri::Xpetra::Maps::Cartesian1D(const Teuchos::RCP<const Teuchos::Comm<int> >&, GlobalOrdinal, GlobalOrdinal, Teuchos::ParameterList&) [with LocalOrdinal = int; GlobalOrdinal = int; Map = Xpetra::EpetraMapT<int, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial> >]'
/tscratch/malphil/muelu-weak-scaling-solid-voltage/Trilinos/packages/galeri/src-xpetra/Galeri_XpetraMaps.hpp:223:63:   required from 'Teuchos::RCP<T> Galeri::Xpetra::CreateMap(const string&, const Teuchos::RCP<const Teuchos::Comm<int> >&, Teuchos::ParameterList&) [with LocalOrdinal = int; GlobalOrdinal = int; Map = Xpetra::EpetraMapT<int, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial> >; std::string = std::__cxx11::basic_string<char>]'
/tscratch/malphil/muelu-weak-scaling-solid-voltage/Trilinos/packages/galeri/src-xpetra/Galeri_XpetraMaps.hpp:89:148:   required from here
/tscratch/malphil/muelu-weak-scaling-solid-voltage/Trilinos/packages/galeri/src-xpetra/Galeri_MapTraits.hpp:99:309: error: no matching function for call to 'Xpetra::EpetraMapT<int, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial> >::EpetraMapT(Galeri::Xpetra::global_size_t&, const global_indices_array_device_type&, int&, const Teuchos::RCP<const Teuchos::Comm<int> >&)'
   99 |   static Teuchos::RCP<::Xpetra::EpetraMapT<GlobalOrdinal, Node>> Build(global_size_t numGlobalElements, const typename ::Xpetra::EpetraMapT<GlobalOrdinal, Node>::global_indices_array_device_type &elementList, GlobalOrdinal indexBase, const Teuchos::RCP<const Teuchos::Comm<int>> &comm) { return Teuchos::rcp(new ::Xpetra::EpetraMapT<GlobalOrdinal, Node>(numGlobalElements, elementList, indexBase, comm)); }
```

See attached files for more details on configuration.


[loadEnvEclipse.sh.txt](https://github.com/user-attachments/files/21692317/loadEnvEclipse.sh.txt)
[configBuildTestEclipse.sh.txt](https://github.com/user-attachments/files/21692318/configBuildTestEclipse.sh.txt)
[slurm-21848534.out.txt](https://github.com/user-attachments/files/21692319/slurm-21848534.out.txt)

