### PR TITLE
Framework: Add CUDA 12 PR build

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -378,6 +378,121 @@ jobs:
           echo "https://github.com/trilinos/Trilinos/wiki/Containers" >> $GITHUB_STEP_SUMMARY
           echo "https://gitlab-ex.sandia.gov/trilinos-project/trilinos-containers/-/wikis/Containers-at-Sandia" >> $GITHUB_STEP_SUMMARY
 
+  cuda12:
+    needs: pre-checks
+    runs-on: [self-hosted, cuda-12.4.1-gcc-10.4.0-openmpi-4.1.6]
+    if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}
+    steps:
+      - name: env
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          env
+      - name: module list
+        shell: bash
+        run: |
+          bash -l -c "module list"
+          printenv PATH
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
+        with:
+          access_token: ${{ github.token }}
+      - name: make dirs
+        working-directory: /
+        run: |
+          mkdir -p /home/Trilinos/src/Trilinos
+          mkdir -p /home/Trilinos/build
+      - name: Clone trilinos
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Repo status
+        run: |
+          git fetch --all
+          pwd
+          ls -lhat
+          git status
+          git branch -vv
+          git branch -a
+      - name: Output ccache stats
+        run: |
+          bash -l -c "ccache --show-stats --verbose"
+      - name: get dependencies
+        working-directory: ./packages/framework
+        run: |
+          bash -l -c "./get_dependencies.sh"
+      - name: PullRequestLinuxDriverTest.py
+        shell: bash -l {0}
+        working-directory: /home/Trilinos/build
+        run: |
+          mkdir bin
+          pushd bin
+          ln -s $(type -p python3) python
+          export PATH=$(pwd):${PATH}
+          popd
+
+          export TRILINOS_DIR=${GITHUB_WORKSPACE:?}
+          export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/GenConfig
+          export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/pr_tools
+          export GENCONFIG_BUILD_NAME=rhel_cuda-12-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+          printf "\n\n\n"
+
+          echo "image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}"
+          type python
+          python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
+            --target-branch-name ${{ github.event.pull_request.base.ref }} \
+            --genconfig-build-name ${GENCONFIG_BUILD_NAME} \
+            --pullrequest-number ${{ github.event.pull_request.number }} \
+            --pullrequest-env-config-file ${GITHUB_WORKSPACE}/packages/framework/pr_tools/trilinos_pr.ini \
+            --pullrequest-gen-config-file ${GITHUB_WORKSPACE}/packages/framework/GenConfig/src/gen-config.ini \
+            --workspace-dir /home/runner/_work/Trilinos \
+            --source-dir ${GITHUB_WORKSPACE} \
+            --build-dir /home/Trilinos/build \
+            --dashboard-build-name=PR-${{ github.event.pull_request.number }}_${AT2_IMAGE}_release_static \
+            --ctest-driver /home/runner/_work/Trilinos/Trilinos/cmake/SimpleTesting/cmake/ctest-driver.cmake \
+            --ctest-drop-site sems-cdash-son.sandia.gov/cdash \
+            --filename-subprojects ./package_subproject_list.cmake \
+            --filename-packageenables ./packageEnables.cmake \
+            --max-cores-allowed=56 \
+            --num-concurrent-tests=112 \
+            --slots-per-gpu=8
+      - name: Copy artifacts
+        if: success() || failure()
+        shell: bash -l {0}
+        working-directory: /home/Trilinos/build
+        run: |
+          cp ./packageEnables.cmake /home/runner/artifacts/
+          cp ./configure_command.txt /home/runner/artifacts/
+          cp ./genconfig_build_name.txt /home/runner/artifacts/
+      - name: Upload artifacts
+        if: success() || failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        env:
+          NODE_TLS_REJECT_UNAUTHORIZED: 0
+        with:
+          name: ${{ github.job }}-artifacts
+          path: /home/runner/artifacts/*
+          retention-days: 90
+      - name: Summary
+        if: ${{ !cancelled() }}
+        shell: bash -l {0}
+        working-directory: /home/Trilinos/build
+        run: |
+          echo "## Run Info" >> $GITHUB_STEP_SUMMARY
+          echo "Image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}" >> $GITHUB_STEP_SUMMARY
+          echo "GenConfig Build ID: $(cat ./genconfig_build_name.txt)" >> $GITHUB_STEP_SUMMARY
+          echo "## CDash Links" >> $GITHUB_STEP_SUMMARY
+          echo "### Current Build" >> $GITHUB_STEP_SUMMARY
+          AT2_URL=$(</home/runner/AT2_URL.txt)
+          echo $AT2_URL >> $GITHUB_STEP_SUMMARY
+          echo "### All Builds" >> $GITHUB_STEP_SUMMARY
+          AT2_ALL_BUILDS=$(</home/runner/AT2_ALL_BUILDS.txt)
+          echo $AT2_ALL_BUILDS >> $GITHUB_STEP_SUMMARY
+          echo "## Helpful Links" >> $GITHUB_STEP_SUMMARY
+          echo "https://github.com/trilinos/Trilinos/wiki/Reproducing-Pull-Request-Testing-Errors" >> $GITHUB_STEP_SUMMARY
+          echo "https://github.com/trilinos/Trilinos/wiki/Containers" >> $GITHUB_STEP_SUMMARY
+          echo "https://gitlab-ex.sandia.gov/trilinos-project/trilinos-containers/-/wikis/Containers-at-Sandia" >> $GITHUB_STEP_SUMMARY
+
   gcc14:
     needs: pre-checks
     runs-on: [self-hosted, gcc-14]
@@ -550,7 +665,7 @@ jobs:
           export TRILINOS_DIR=${GITHUB_WORKSPACE:?}
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/GenConfig
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/pr_tools
-          export GENCONFIG_BUILD_NAME=rhel8_cuda-11-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+          export GENCONFIG_BUILD_NAME=rhel_cuda-11-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables
           printf "\n\n\n"
 
           echo "image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}"

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2059,7 +2059,7 @@ opt-set-cmake-var MueLu_Structured_Interp_SA_Laplace2D_kokkos_MPI_4_DISABLE BOOL
 use rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
-[rhel8_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+[rhel_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use COMMON_SPACK_TPLS
 # Not using currently to prevent warning overload
 #use COMPILER|GNU
@@ -2083,10 +2083,15 @@ use SPACK_NETLIB_BLAS_LAPACK
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS STRING FORCE : --bind-to;none --mca btl ^smcuda
 opt-set-cmake-var Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC BOOL : OFF
 
-[rhel8_cuda-11-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
-use rhel8_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+[rhel_cuda-11-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+use rhel_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 opt-set-cmake-var ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE BOOL : ON
 opt-set-cmake-var PanzerMiniEM_Maxwell_MueLu_order1_tpl_MPI_4_DISABLE BOOL : ON
+
+[rhel_cuda-12-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+use rhel_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_02_CUDA_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL : ON
+opt-set-cmake-var ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE BOOL : ON
 
 [rhel_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables]
 use COMMON_SPACK_TPLS

--- a/packages/framework/ini-files/environment-specs.ini
+++ b/packages/framework/ini-files/environment-specs.ini
@@ -163,12 +163,11 @@ envvar-find-in-path MPIF90 : mpif90
 envvar-set-if-empty TRILINOS_DIR : ${path_to_src}
 envvar-set OMPI_CXX: ${TRILINOS_DIR}/packages/kokkos/bin/nvcc_wrapper
 
-[rhel8_cuda-gcc-openmpi]
-envvar-set-if-empty TRILINOS_DIR : ${path_to_src}
-envvar-set OMPI_CXX: ${TRILINOS_DIR}/packages/kokkos/bin/nvcc_wrapper
+[rhel_cuda-11-gcc-openmpi]
+use rhel_cuda-gcc-openmpi
 
-[rhel8_cuda-11-gcc-openmpi]
-use rhel8_cuda-gcc-openmpi
+[rhel_cuda-12-gcc-openmpi]
+use rhel_cuda-gcc-openmpi
 
 [rhel8_gcc-openmpi]
 

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -141,6 +141,8 @@
 [rhel]
 gcc
 cuda-gcc-openmpi
+cuda-11-gcc-openmpi
+cuda-12-gcc-openmpi
 clang-openmpi
 
 [rhel7]

--- a/packages/kokkos-kernels/sparse/src/KokkosSparse_spmv.hpp
+++ b/packages/kokkos-kernels/sparse/src/KokkosSparse_spmv.hpp
@@ -278,6 +278,12 @@ void spmv(const ExecutionSpace& space, Handle* handle, const char mode[], const 
       if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Cuda>) {
         useNative = useNative || (Conjugate[0] == mode[0]);
       }
+      // cuSPARSE 12 requires that the output (y) vector is 16-byte aligned for
+      // all scalar types
+#if defined(CUSPARSE_VER_MAJOR) && (CUSPARSE_VER_MAJOR == 12)
+      uintptr_t yptr = uintptr_t((void*)y.data());
+      if (yptr % 16 != 0) useNative = true;
+#endif
 #endif
 #ifdef KOKKOSKERNELS_ENABLE_TPL_ROCSPARSE
       if constexpr (std::is_same_v<ExecutionSpace, Kokkos::HIP>) {


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Kokkos 5.0 will require C++20, which necessitates upgrading from CUDA 11 to CUDA 12.

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-720

## Testing
I ran a build and all tests on trilogpu01 (2xA100).  I had to fix one build error (included in this PR) in Krino.  The test failures are as follows:

- @trilinos/ifpack2  `Ifpack2_unit_tests_MPI_4`
cudaMisalignedAddress error.
- @trilinos/intrepid2 `Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_02_CUDA_DOUBLE_DOUBLE_MPI_1`
Not really sure based on the output I see, but we did disable this test (we deliberately did not add it in the CMakeLists.txt) for CUDA11.  It fails reliably.
- @trilinos/rol `ROL_test_elementwise_TpetraMultiVector_MPI_4`
This was disabled for CUDA11, runtime error

