### PR TITLE
Framework: Skip ccache configuration when performing coverage build

### DIFF
--- a/packages/framework/pr_tools/PullRequestLinuxDriver.sh
+++ b/packages/framework/pr_tools/PullRequestLinuxDriver.sh
@@ -8,14 +8,19 @@ source ${SCRIPTPATH:?}/common.bash
 function configure_ccache() {
     print_banner "Configuring ccache"
 
-    envvar_set_or_create CCACHE_NODISABLE true
-    envvar_set_or_create CCACHE_DIR '/fgs/trilinos/ccache/cache'
-    envvar_set_or_create CCACHE_BASEDIR "${WORKSPACE:?}"
-    envvar_set_or_create CCACHE_NOHARDLINK true
-    envvar_set_or_create CCACHE_UMASK 077
-    envvar_set_or_create CCACHE_MAXSIZE 100G
+    if [[ ${GENCONFIG_BUILD_NAME} == *"coverage"* ]]
+    then
+        message_std "PRDriver> " "Skipping ccache configuration due to being coverage build"
+    else
+        envvar_set_or_create CCACHE_NODISABLE true
+        envvar_set_or_create CCACHE_DIR '/fgs/trilinos/ccache/cache'
+        envvar_set_or_create CCACHE_BASEDIR "${WORKSPACE:?}"
+        envvar_set_or_create CCACHE_NOHARDLINK true
+        envvar_set_or_create CCACHE_UMASK 077
+        envvar_set_or_create CCACHE_MAXSIZE 100G
 
-    message_std "PRDriver> " "$(ccache --show-stats --verbose)"
+        message_std "PRDriver> " "$(ccache --show-stats --verbose)"
+    fi
 }
 
 


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
#14210 updated our `ctest-driver` to use a different `CTest` function for coverage collection and processing with `gcov`. Manual reproduction of those changes resulted in coverage result posting properly to CDash. However, any automated job that configured ccache, failed to replicate the manual result.

The issue is with the ccache variable `CCACHE_BASEDIR` and `gcov`:
- https://gitlab.kitware.com/cmake/cmake/-/issues/21138

This PR attempts to resolve this issue by just not using ccache for the coverage build perform with our Nightly process. Since these jobs run at a time with less congestion, the wall time increase from not using ccache should be fine.


## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

- [TRILFRAME-23](https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-23)

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
These changes were tested and uploaded at the below CDash, showing available coverage results
- https://trilinos-cdash-qual.sandia.gov/builds/1826497

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
