### PR TITLE
Framework: Fix CDash filter in URL of cdash_url GitHub Actions job

### DIFF
--- a/.github/workflows/cdash_urls.yml
+++ b/.github/workflows/cdash_urls.yml
@@ -19,4 +19,4 @@ jobs:
             message-id: cdash
             message: |
               [CDash for AT1 results](https://trilinos-cdash.sandia.gov/index.php?project=Trilinos&filtercombine=and&filtercombine=and&filtercombine=and&filtercombine=and&filtercombine=and&filtercombine=and&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=PR-${{ github.event.number }}-test&field2=buildstarttime&compare2=84&value2=NOW) [Only accessible from Sandia networks]
-              [CDash for AT2 results](https://sems-cdash-son.sandia.gov/cdash/index.php?project=Trilinos&display=project&begin=2024-01-01&end=now&filtercount=1&showfilters=1&field1=buildname&compare1=65&value1=PR-${{ github.event.number }}) [Currently only accessible from Sandia networks]
+              [CDash for AT2 results](https://sems-cdash-son.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=1&showfilters=1&field1=buildname&compare1=65&value1=PR-${{ github.event.number }}) [Currently only accessible from Sandia networks]


### PR DESCRIPTION
@trilinos/framework @cgcgcg 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Want to fix the AT2 CDash link posted in the GitHub comments from `cdash_url` job.


## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
I tried the filter myself. The comment posted here shouldn't work.
- https://sems-cdash-son.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=1&showfilters=1&field1=buildname&compare1=65&value1=PR-14309

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
