### PR TITLE
Tpetra: Remove initialization from transpose apply

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -4870,14 +4870,6 @@ CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       }
       return;
     }
-    else if (beta == ZERO) {
-      //Thyra was implicitly assuming that Y gets set to zero / or is overwritten
-      //when bets==0. This was not the case with transpose in a multithreaded
-      //environment where a multiplication with subsequent atomic_adds is used
-      //since 0 is effectively not special cased. Doing the explicit set to zero here
-      //This catches cases where Y is nan or inf.
-      Y_in.putScalar (ZERO);
-    }
 
     const size_t numVectors = X_in.getNumVectors ();
 


### PR DESCRIPTION
@trilinos/tpetra @trilinos/thyra 

## Motivation
This PR removes the initialization of $y$ from $y:=\beta y + \alpha A^T x$ with $\beta=0$.
The comment suggests that this was added for Thyra with vectors $y$ containing infs or NaNs. But if that's the case, this should be done in Thyra, not in Tpetra. Let's see if the AT can identify situations were removing this step breaks things.