### PR TITLE
Intrepid2: Fix build issue

### DIFF
--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationTools.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationTools.hpp
@@ -385,7 +385,8 @@ namespace Intrepid2 {
     // 
     /** \brief  key :: basis name, order, value :: matrix data view type 
      */
-    using OrtCoeffDataType = std::map<std::pair<std::string,ordinal_type>,Kokkos::View<double****,DeviceType> >;
+    using KeyType = std::pair<const std::string,ordinal_type>;
+    using OrtCoeffDataType = std::map<KeyType,Kokkos::View<double****,DeviceType> >;
 
     static OrtCoeffDataType ortCoeffData;
     static OrtCoeffDataType ortInvCoeffData;

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefMatrixData.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefMatrixData.hpp
@@ -269,10 +269,10 @@ namespace Intrepid2 {
   typename OrientationTools<DT>::CoeffMatrixDataViewType
   OrientationTools<DT>::createCoeffMatrix(const BasisType* basis) {
     Kokkos::push_finalize_hook( [=] {
-      ortCoeffData=std::map<std::pair<std::string,ordinal_type>, typename OrientationTools<DT>::CoeffMatrixDataViewType>();
+      ortCoeffData=OrientationTools<DT>::OrtCoeffDataType();
     });
 
-    const std::pair<std::string,ordinal_type> key(basis->getName(), basis->getDegree());
+    const KeyType key(basis->getName(), basis->getDegree());
     const auto found = ortCoeffData.find(key);
     
     CoeffMatrixDataViewType matData;
@@ -294,10 +294,10 @@ namespace Intrepid2 {
   typename OrientationTools<DT>::CoeffMatrixDataViewType
   OrientationTools<DT>::createInvCoeffMatrix(const BasisType* basis) {
     Kokkos::push_finalize_hook( [=] {
-      ortInvCoeffData=std::map<std::pair<std::string,ordinal_type>, typename OrientationTools<DT>::CoeffMatrixDataViewType>();
+      ortInvCoeffData=OrientationTools<DT>::OrtCoeffDataType();
     });
 
-    const std::pair<std::string,ordinal_type> key(basis->getName(), basis->getDegree());
+    const KeyType key(basis->getName(), basis->getDegree());
     const auto found = ortInvCoeffData.find(key);
     
     CoeffMatrixDataViewType matData;


### PR DESCRIPTION
@trilinos/intrepid2

## Motivation
I observed this build error in Intrepid2_OrientationTools.hpp. It doesn't make much sense to me, but the proposed change fixes it..

```
/home/caglusa/Trilinos/packages/intrepid2/src/Orientation/Intrepid2_OrientationTools.hpp:388:289: error: type/value mismatch at argument 1 in template parameter list for 'template<class _Tp> class std::decay'
  388 |     using OrtCoeffDataType = std::map<std::pair<std::string,ordinal_type>,Kokkos::View<double****,DeviceType> >;
      |                                                                                                                                                                                                                                                                                                 ^
/home/caglusa/Trilinos/packages/intrepid2/src/Orientation/Intrepid2_OrientationTools.hpp:388:289: note:   expected a type, got 'std::enable_if<((! is_reference_v<int>) && (! is_const_v<int>)), int>::type'
/home/caglusa/Trilinos/packages/intrepid2/src/Orientation/Intrepid2_OrientationTools.hpp:388:297: error: template argument 1 is invalid
  388 |     using OrtCoeffDataType = std::map<std::pair<std::string,ordinal_type>,Kokkos::View<double****,DeviceType> >;
      |                                                                                                                                                                                                                                                                                                         ^
/home/caglusa/Trilinos/packages/intrepid2/src/Orientation/Intrepid2_OrientationTools.hpp:388:307: error: template argument 2 is invalid
  388 |     using OrtCoeffDataType = std::map<std::pair<std::string,ordinal_type>,Kokkos::View<double****,DeviceType> >;
      |                                                                                                                                                                                                                                                                                                                   ^
/home/caglusa/Trilinos/packages/intrepid2/src/Orientation/Intrepid2_OrientationTools.hpp:388:350: error: template argument 1 is invalid
  388 |     using OrtCoeffDataType = std::map<std::pair<std::string,ordinal_type>,Kokkos::View<double****,DeviceType> >;
      |                                                                                                                                                                                                                                                                                                                                                              ^
/home/caglusa/Trilinos/packages/intrepid2/src/Orientation/Intrepid2_OrientationTools.hpp:388:350: error: template argument 3 is invalid
/home/caglusa/Trilinos/packages/intrepid2/src/Orientation/Intrepid2_OrientationTools.hpp:388:350: error: template argument 4 is invalid
```