### PR TITLE
Tpetra: standardize ialltofewv profiling labels

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
@@ -49,7 +49,7 @@ namespace Tpetra::Details {
 #ifdef HAVE_TPETRA_MPI
     if (ialltofewv_.req) {
 
-      ProfilingRegion ws("Tpetra::Distributor: doWaitsIalltofewv");
+      ProfilingRegion ws("Tpetra::Distributor::doWaitsIalltofewv");
       ialltofewv_.impl.wait(*ialltofewv_.req);
 
       ialltofewv_.sendcounts.reset();

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -254,7 +254,7 @@ void DistributorActor::doPostsIalltofewvImpl(const DistributorPlan &plan,
   using size_type = Teuchos::Array<size_t>::size_type;
   using ExportValue = typename ExpView::non_const_value_type;
 
-  ProfilingRegion pr("Tpetra::Distributor: doPostsIalltofewvImpl");
+  ProfilingRegion pr("Tpetra::Distributor::doPostsIalltofewvImpl");
 
   TEUCHOS_TEST_FOR_EXCEPTION(
       !plan.getIndicesTo().is_null(), std::runtime_error,


### PR DESCRIPTION
From this:
```
Tpetra::Distributor: doPostsIalltofewvImpl
Tpetra::Distributor: doWaitsIalltofewv
```

To this (the way other labels are)
```
Tpetra::Distributor::doPostsIalltofewvImpl
Tpetra::Distributor::doWaitsIalltofewv
```

@trilinos/tpetra 
