### PR TITLE
Tpetra: Fixes compile time error on Windows VS2022

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
@@ -700,7 +700,7 @@ sortAndMergeCrsEntries (const Teuchos::ArrayView<size_t> &CRS_rowptr,
                         const Teuchos::ArrayView<Ordinal> & CRS_colind)
 {
   Teuchos::ArrayView<Tpetra::Details::DefaultTypes::scalar_type> CRS_vals;
-  return sortAndMergeCrsEntries(CRS_rowptr, CRS_colind, CRS_vals);
+  return sortAndMergeCrsEntries<Tpetra::Details::DefaultTypes::scalar_type, Ordinal>(CRS_rowptr, CRS_colind, CRS_vals);
 }
 
 template<class rowptr_view_type, class colind_view_type, class vals_view_type>


### PR DESCRIPTION



<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
The Xyce team trying to build Trilinos with Tpetra on Windows with VS2022 build tools and Intel OneAPI encountered a compile time error when Tpetra_Import_Utils2.hpp is included (it’s first included through Tpetra_CrsGraph_INT_LONG_LONG_SERIAL.cpp via #include "Tpetra_CrsGraph_def.hpp").

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes #14334

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
This has been tested on VS2022 on the Xyce developer/test machine

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
