### PR TITLE
Framework: Fixes -fp-model=precise flag for Windows Intel compiler

### DIFF
--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -34,7 +34,7 @@ endmacro()
 
 
 IF (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
-  IF(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+  IF(WIN32)
     MESSAGE("-- " "Adding '/fp:precise' to C++ compiler flags because Trilinos needs it when using the Intel OneAPI C++ compiler.")
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:precise")
   ELSE()


### PR DESCRIPTION

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tribits 

## Motivation
To get the precise floating point option for the Intel compiler on Windows the compiler option needs to be different than the current setting.  The Windows OS is a release platform for Xyce, so this needs to be fixed.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes #14345 

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
This was tested on the Xyce Windows development/testing platform

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
