### PR TITLE
Fixes Zoltan utility code compile issue on Windows with MSVC

### DIFF
--- a/packages/zoltan/src/Utilities/Communication/comm_default.c
+++ b/packages/zoltan/src/Utilities/Communication/comm_default.c
@@ -8,12 +8,33 @@
 // @HEADER
 
 #include "comm.h"
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <pthread.h>
+#endif
 
 #ifdef __cplusplus
 /* if C++, define the rest of this header file as extern C */
 extern "C" {
 #endif
+#ifdef _WIN32
+
+//static HANDLE zoltan_global_mpi_lock = CreateMutex(NULL, FALSE, NULL);
+static MPI_Comm Zoltan_Global_MPI_Comm = MPI_COMM_WORLD; // CHECK: ALLOW MPI_COMM_WORLD
+
+/* Function to set the default communicator */
+void zoltan_initialize_global_comm(MPI_Comm comm) {
+  Zoltan_Global_MPI_Comm = comm;
+}
+
+/* Function to get the default communicator */
+MPI_Comm zoltan_get_global_comm() {
+  MPI_Comm comm = Zoltan_Global_MPI_Comm;
+  return comm;
+}
+
+#else
 static pthread_mutex_t zoltan_global_mpi_lock;
 static MPI_Comm Zoltan_Global_MPI_Comm = MPI_COMM_WORLD; // CHECK: ALLOW MPI_COMM_WORLD
 
@@ -31,6 +52,7 @@ MPI_Comm zoltan_get_global_comm() {
   pthread_mutex_unlock(&zoltan_global_mpi_lock);
   return comm;
 }
+#endif
 
 #ifdef __cplusplus
 } /* closing bracket for extern "C" */

--- a/packages/zoltan/src/Utilities/Memory/mem.c
+++ b/packages/zoltan/src/Utilities/Memory/mem.c
@@ -7,9 +7,11 @@
 // *****************************************************************************
 // @HEADER
 
-#ifdef __cplusplus
+#if defined(__cplusplus)
 /* if C++, define the rest of this header file as extern C */
 extern "C" {
+#elif defined(_WIN32)
+#define __STDC__ 1
 #endif
 
 


### PR DESCRIPTION

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan 

## Motivation
One issue is in the Zoltan communications utilities; there is code that unconditionally includes references to functions/types defined in pthreads. These definitions are not available in the standard C++ libraries for Windows.
Trilinos_Root\packages\zoltan\src\Utilities\Communication\comm_default.c

The second issue centers around checks for the preprocessor values __cplusplus and STDC. Trilinos_Root\packages\zoltan\src\Utilities\Memory\mem.c.


## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes #14347 

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
This has been tested on Xyce's Windows development/testing machine with VS2022.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
