### PR TITLE
Amesos2: mixed-precision gather/scatter vectors

### DIFF
--- a/packages/amesos2/src/Amesos2_KLU2_decl.hpp
+++ b/packages/amesos2/src/Amesos2_KLU2_decl.hpp
@@ -49,6 +49,7 @@ public:
   typedef SolverCore<Amesos2::KLU2,Matrix,Vector>             super_type;
 
   // Since typedef's are not inheritted, go grab them
+  typedef typename VectorTraits<Vector>::scalar_t        vector_scalar_type;
   typedef typename super_type::scalar_type                      scalar_type;
   typedef typename super_type::local_ordinal_type        local_ordinal_type;
   typedef typename super_type::global_ordinal_type      global_ordinal_type;

--- a/packages/amesos2/src/Amesos2_KLU2_def.hpp
+++ b/packages/amesos2/src/Amesos2_KLU2_def.hpp
@@ -207,7 +207,8 @@ KLU2<Matrix,Vector>::solve_impl(
   bool bDidAssignB;
   bool use_gather = use_gather_; // user param
   use_gather = (use_gather && this->matrixA_->getComm()->getSize() > 1); // only with multiple MPIs
-  use_gather = (use_gather && (std::is_same<scalar_type, float>::value || std::is_same<scalar_type, double>::value)); // only for double or float
+  use_gather = (use_gather && (std::is_same<vector_scalar_type, float>::value ||
+                               std::is_same<vector_scalar_type, double>::value)); // only for double or float vectors
   {
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor mvConvTimer(this->timers_.vecConvTime_);

--- a/packages/amesos2/src/Amesos2_ShyLUBasker_decl.hpp
+++ b/packages/amesos2/src/Amesos2_ShyLUBasker_decl.hpp
@@ -55,6 +55,7 @@ public:
   typedef SolverCore<Amesos2::ShyLUBasker,Matrix,Vector>       super_type;
 
   // Since typedef's are not inheritted, go grab them
+  typedef typename VectorTraits<Vector>::scalar_t       vector_scalar_type;
   typedef typename super_type::scalar_type                     scalar_type;
   typedef typename super_type::local_ordinal_type              local_ordinal_type;
   typedef typename super_type::global_ordinal_type             global_ordinal_type;

--- a/packages/amesos2/src/Amesos2_ShyLUBasker_def.hpp
+++ b/packages/amesos2/src/Amesos2_ShyLUBasker_def.hpp
@@ -298,7 +298,8 @@ ShyLUBasker<Matrix,Vector>::solve_impl(
   const bool do_not_initialize_data = false;
   bool use_gather = use_gather_; // user param
   use_gather = (use_gather && this->matrixA_->getComm()->getSize() > 1); // only with multiple MPIs
-  use_gather = (use_gather && (std::is_same<scalar_type, float>::value || std::is_same<scalar_type, double>::value)); // only for double or float
+  use_gather = (use_gather && (std::is_same<vector_scalar_type, float>::value ||
+                               std::is_same<vector_scalar_type, double>::value)); // only for double or float vectors
   {
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor mvConvTimer(this->timers_.vecConvTime_);

--- a/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_def.hpp
@@ -596,37 +596,47 @@ namespace Amesos2 {
                                  host_ordinal_type_array &recvDisplRows,
                                  EDistribution distribution) const
   {
-    auto nCols = this->mv_->getNumVectors();
-    auto nRows = this->mv_->getGlobalLength();
+    using Teuchos::as;
+    using mv_scalar_t = typename KV::non_const_value_type;
+    size_t nCols = this->mv_->getNumVectors();
+    size_t nRows = this->mv_->getGlobalLength();
+    size_t nRows_l = this->mv_->getLocalLength();
     auto comm = this->mv_->getMap()->getComm();
     auto myRank = comm->getRank();
+
+    bool mixed_precision = !(std::is_same<Scalar, mv_scalar_t>::value);
     if (myRank == 0) {
       if (kokkos_new_view.extent(0) != nRows || kokkos_new_view.extent(1) != nCols) {
         Kokkos::resize(kokkos_new_view, nRows, nCols);
       }
-      if (perm_g2l.extent(0) == nRows) {
+      if (perm_g2l.extent(0) == nRows || mixed_precision) {
         if (this->buf_.extent(0) < nRows) Kokkos::resize(this->buf_, nRows, 1);
       } else {
         Kokkos::resize(this->buf_, 0, 1);
       }
     }
     {
-      auto nRows_l = this->mv_->getLocalLength();
       auto lclMV_d = this->mv_->getLocalViewDevice(Tpetra::Access::ReadOnly);
       auto lclMV = Kokkos::create_mirror_view(lclMV_d);
       Kokkos::deep_copy(lclMV, lclMV_d);
       for (size_t j=0; j<nCols; j++) {
         // lclMV with ReadOnly = const sendbuf
         const Scalar * sendbuf = reinterpret_cast<const Scalar*> (nRows_l > 0 ? &lclMV(0,j) : lclMV.data());
-        Scalar * recvbuf = reinterpret_cast<Scalar*> (this->buf_.extent(0) > 0 || myRank != 0 ? this->buf_.data() : &kokkos_new_view(0,j));
+        void * recvbuf = (this->buf_.extent(0) > 0 || myRank != 0 ? (void*)(this->buf_.data()) : (void*)(&kokkos_new_view(0,j)));
         Teuchos::gatherv<int, Scalar> (sendbuf, nRows_l,
-                                       recvbuf, recvCountRows.data(), recvDisplRows.data(),
+                                       (Scalar*)recvbuf, recvCountRows.data(), recvDisplRows.data(),
                                        0, *comm);
         if (myRank == 0 && this->buf_.extent(0) > 0) {
-          //for (global_size_t i=0; i<nRows; i++) kokkos_new_view(perm_g2l(i),j) = this->buf_(i,0);
           typedef Kokkos::DefaultHostExecutionSpace HostExecSpaceType;
-          Kokkos::parallel_for("Amesos2::TpetraMultiVecAdapter::gather", Kokkos::RangePolicy<HostExecSpaceType>(0, nRows),
-            [&](const int i) { kokkos_new_view(perm_g2l(i),j) = this->buf_(i,0); });
+          if (perm_g2l.extent(0) == nRows) {
+            // permute, and type-casting if needed
+            Kokkos::parallel_for("Amesos2::TpetraMultiVecAdapter::gather", Kokkos::RangePolicy<HostExecSpaceType>(0, nRows),
+              [&](const int i) { kokkos_new_view(perm_g2l(i),j) = as<mv_scalar_t>(this->buf_(i,0)); });
+          } else {
+            // type-casting
+            Kokkos::parallel_for("Amesos2::TpetraMultiVecAdapter::gather", Kokkos::RangePolicy<HostExecSpaceType>(0, nRows),
+              [&](const int i) { kokkos_new_view(i,j) = as<mv_scalar_t>(this->buf_(i,0)); });
+          }
         }
       }
     }
@@ -646,25 +656,34 @@ namespace Amesos2 {
                                   host_ordinal_type_array &sendDisplRows,
                                   EDistribution distribution) const
   {
-    auto nCols = this->mv_->getNumVectors();
-    auto nRows = this->mv_->getGlobalLength();
-    auto nRows_l = this->mv_->getLocalLength();
+    using Teuchos::as;
+    using mv_scalar_t = typename KV::non_const_value_type;
+    size_t nCols = this->mv_->getNumVectors();
+    size_t nRows = this->mv_->getGlobalLength();
+    size_t nRows_l = this->mv_->getLocalLength();
     auto comm = this->mv_->getMap()->getComm();
     auto myRank = comm->getRank();
+
     {
       auto lclMV_d = this->mv_->getLocalViewDevice(Tpetra::Access::OverwriteAll);
       auto lclMV = Kokkos::create_mirror_view(lclMV_d);
       for (size_t j=0; j<nCols; j++) {
         if (myRank == 0 && this->buf_.extent(0) > 0) {
-          //for (global_size_t i=0; i<nRows; i++) this->buf_(i, 0) = kokkos_new_view(perm_g2l(i),j);
           typedef Kokkos::DefaultHostExecutionSpace HostExecSpaceType;
-          Kokkos::parallel_for("Amesos2::TpetraMultiVecAdapter::scatter", Kokkos::RangePolicy<HostExecSpaceType>(0, nRows),
-            [&](const int i) { this->buf_(i, 0) = kokkos_new_view(perm_g2l(i),j); });
+          if (perm_g2l.extent(0) == nRows) {
+            // permute, and type-casting if needed
+            Kokkos::parallel_for("Amesos2::TpetraMultiVecAdapter::scatter", Kokkos::RangePolicy<HostExecSpaceType>(0, nRows),
+              [&](const int i) { this->buf_(i, 0) = as<mv_scalar_t>(kokkos_new_view(perm_g2l(i),j)); });
+          } else {
+            // type-casting
+            Kokkos::parallel_for("Amesos2::TpetraMultiVecAdapter::scatter", Kokkos::RangePolicy<HostExecSpaceType>(0, nRows),
+              [&](const int i) { this->buf_(i, 0) = as<mv_scalar_t>(kokkos_new_view(i,j)); });
+          }
         }
         // lclMV with OverwriteAll
-        Scalar * sendbuf = reinterpret_cast<Scalar*> (this->buf_.extent(0) > 0 || myRank != 0 ? this->buf_.data() : &kokkos_new_view(0,j));
+        void * sendbuf = (this->buf_.extent(0) > 0 || myRank != 0 ? (void*)(this->buf_.data()) : (void*)(&kokkos_new_view(0,j)));
         Scalar * recvbuf = reinterpret_cast<Scalar*> (nRows_l > 0 ? &lclMV(0,j) : lclMV.data());
-        Teuchos::scatterv<int, Scalar> (sendbuf, sendCountRows.data(), sendDisplRows.data(),
+        Teuchos::scatterv<int, Scalar> ((Scalar*)sendbuf, sendCountRows.data(), sendDisplRows.data(),
                                         recvbuf, nRows_l,
                                         0, *comm);
       }


### PR DESCRIPTION

@trilinos/amesos2 

## Motivation

To address compile errors with `complex<double>` matrix + `complex<float>` vectors


## Testing

- Enabling both `complex` and `float` lead to compiler errors in the new `gather` and `scatter` routines in vector adapter.

## Additional Information

- KLU2 will take the vectors in the matrix scalar type, not in the vector scalar type, hence needing type-casting.
