### PR TITLE
Fix AT2 CDash URL

### DIFF
--- a/.github/workflows/cdash_urls.yml
+++ b/.github/workflows/cdash_urls.yml
@@ -19,4 +19,4 @@ jobs:
             message-id: cdash
             message: |
               [CDash for AT1 results](https://trilinos-cdash.sandia.gov/index.php?project=Trilinos&filtercombine=and&filtercombine=and&filtercombine=and&filtercombine=and&filtercombine=and&filtercombine=and&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=PR-${{ github.event.number }}-test&field2=buildstarttime&compare2=84&value2=NOW) [Only accessible from Sandia networks]
-              [CDash for AT2 results](https://sems-cdash-son.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=1&showfilters=1&field1=buildname&compare1=65&value1=PR-${{ github.event.number }}) [Currently only accessible from Sandia networks]
+              [CDash for AT2 results](https://sems-cdash-son.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=65&value1=PR-${{ github.event.number }}&field2=buildstarttime&compare2=84&value2=now) [Currently only accessible from Sandia networks]


### PR DESCRIPTION
@trilinos/framework 

## Motivation
The AT2 CDash filter did not display all builds.