### PR TITLE
belos: fixes for gcc/12.2.0 and c++20

### DIFF
--- a/packages/belos/kokkos/src/BelosKokkosAdapter.hpp
+++ b/packages/belos/kokkos/src/BelosKokkosAdapter.hpp
@@ -76,21 +76,21 @@ public:
   ///
   /// The `label` string indicates the label for the internal `Kokkos::view`.
   /// If `zeroOut` is set to `true`, the multivector will be initialized to zeros.
-  KokkosMultiVec<ScalarType, Device> (const std::string label, const int numrows, const int numvecs, const bool zeroOut = true) :
+  KokkosMultiVec (const std::string label, const int numrows, const int numvecs, const bool zeroOut = true) :
     myView (Kokkos::view_alloc(Kokkos::WithoutInitializing,label),numrows,numvecs)
     { if (zeroOut) { Kokkos::deep_copy(myView,0); } }
 
   /// \brief Returns a multivector with `numrows` rows and `numvecs` columns.
   ///
   /// If `zeroOut` is set to `true`, the multivector will be initialized to zeros.
-  KokkosMultiVec<ScalarType, Device> (const int numrows, const int numvecs, const bool zeroOut = true) :
+  KokkosMultiVec (const int numrows, const int numvecs, const bool zeroOut = true) :
     myView (Kokkos::view_alloc(Kokkos::WithoutInitializing,"MV"),numrows,numvecs)
     { if (zeroOut) { Kokkos::deep_copy(myView,0); } }
 
   /// \brief Returns a single column multivector with `numrows` rows.
   ///
   /// If `zeroOut` is set to `true`, the multivector will be initialized to zeros.
-  KokkosMultiVec<ScalarType, Device> (const int numrows, const bool zeroOut = true) :
+  KokkosMultiVec (const int numrows, const bool zeroOut = true) :
     myView(Kokkos::view_alloc(Kokkos::WithoutInitializing,"MV"),numrows,1)
     { if (zeroOut) { Kokkos::deep_copy(myView,0); } }
 
@@ -98,7 +98,7 @@ public:
 
   /// This copy constructor returns a new KokksMultiVec containing a
   /// deep copy of the multivector given by the user.
-  KokkosMultiVec<ScalarType, Device> (const KokkosMultiVec<ScalarType, Device> &sourceVec) :
+  KokkosMultiVec (const KokkosMultiVec<ScalarType, Device> &sourceVec) :
     myView(Kokkos::view_alloc(Kokkos::WithoutInitializing,"MV"),(int)sourceVec.GetGlobalLength(),sourceVec.GetNumberVecs())
   { Kokkos::deep_copy(myView,sourceVec.GetInternalViewConst()); }
 
@@ -109,7 +109,7 @@ public:
   /// The internal data of the multivector is converted from
   /// `ScalarType` to `ScalarType2`.
   template < class ScalarType2 >
-    KokkosMultiVec<ScalarType, Device> (const KokkosMultiVec<ScalarType2, Device> &sourceVec) :
+    KokkosMultiVec (const KokkosMultiVec<ScalarType2, Device> &sourceVec) :
     myView(Kokkos::view_alloc(Kokkos::WithoutInitializing, "MV"),(int)sourceVec.GetGlobalLength(),sourceVec.GetNumberVecs())
   { Kokkos::deep_copy(myView,sourceVec.GetInternalViewConst()); }
 
@@ -119,7 +119,7 @@ public:
   /// the right-hand side KokkosMultiVec to the
   /// left-hand side KokkosMultiVec. The left-hand
   /// side MultiVec will be resized if necessary.
-  KokkosMultiVec<ScalarType, Device> & operator=(const KokkosMultiVec<ScalarType, Device> & sourceVec) {
+  KokkosMultiVec & operator=(const KokkosMultiVec<ScalarType, Device> & sourceVec) {
     int len = sourceVec.GetGlobalLength();
     int cols = sourceVec.GetNumberVecs();
     if( len != (int)myView.extent(0) || cols != (int)myView.extent(1) ){
@@ -138,7 +138,7 @@ public:
   /// The internal data of the right-hand side multivec
   /// is converted from `ScalarType` to `ScalarType2`.
   template < class ScalarType2 >
-  KokkosMultiVec<ScalarType, Device> & operator=(const KokkosMultiVec<ScalarType2, Device> & sourceVec) {
+  KokkosMultiVec & operator=(const KokkosMultiVec<ScalarType2, Device> & sourceVec) {
     int len = sourceVec.GetGlobalLength();
     int cols = sourceVec.GetNumberVecs();
     if( len != (int)myView.extent(0) || cols != (int)myView.extent(1) ){
@@ -157,7 +157,7 @@ public:
   /// shallow copy of the given `Kokkos::view`.  (This option assumes that
   /// the user will make no changes to that view outside of
   /// the KokkosMultiVec interface.)
-  KokkosMultiVec<ScalarType, Device> (const ViewMatrixType & sourceView, bool makeCopy = true) {
+  KokkosMultiVec (const ViewMatrixType & sourceView, bool makeCopy = true) {
     if( makeCopy ){
       if( sourceView.extent(0) != myView.extent(0) || sourceView.extent(1) != myView.extent(1) ){
         Kokkos::resize(myView, sourceView.extent(0), sourceView.extent(1));
@@ -176,12 +176,12 @@ public:
   /// a deep copy of the sourceView in order to change scalar
   /// types.
   template < class ScalarType2 > //TODO: Fix this so that passing in a view without device specified actually compiles...
-  KokkosMultiVec<ScalarType, Device> (const Kokkos::View<ScalarType2**,Kokkos::LayoutLeft, Device> & sourceView) :
+  KokkosMultiVec (const Kokkos::View<ScalarType2**,Kokkos::LayoutLeft, Device> & sourceView) :
     myView(Kokkos::view_alloc(Kokkos::WithoutInitializing, "MV"),sourceView.extent(0),sourceView.extent(1))
   { Kokkos::deep_copy(myView,sourceView); }
 
   //! Destructor (default)
-  ~KokkosMultiVec<ScalarType, Device>(){}
+  ~KokkosMultiVec(){}
 
   //@}
 
@@ -585,11 +585,11 @@ public:
   //! @name Constructor/Destructor
   //@{
   //! Constructor obtains a shallow copy of the given CrsMatrix.
-  KokkosCrsOperator<ScalarType, OrdinalType, Device> (const KokkosSparse::CrsMatrix<ScalarType, OrdinalType, Device> mat)
+  KokkosCrsOperator (const KokkosSparse::CrsMatrix<ScalarType, OrdinalType, Device> mat)
    : myMatrix(mat) {}
 
   //! Destructor.
-  ~KokkosCrsOperator<ScalarType, OrdinalType, Device>(){}
+  ~KokkosCrsOperator(){}
   //@}
 
   //! @name Methods relating to applying the operator

--- a/packages/belos/tpetra/test/BiCGStab/test_bicgstab_diag.cpp
+++ b/packages/belos/tpetra/test/BiCGStab/test_bicgstab_diag.cpp
@@ -93,7 +93,7 @@ class Diagonal_Operator_2 : public Vector_Operator<MV>
 {
   public:
 
-    Diagonal_Operator_2<ST,MV>(int n_in, int min_gid_in, ST v_in)
+    Diagonal_Operator_2(int n_in, int min_gid_in, ST v_in)
     : Vector_Operator<MV>(n_in, n_in), min_gid(min_gid_in), v(v_in) {}
 
     ~Diagonal_Operator_2() { };

--- a/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_diag.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_diag.cpp
@@ -92,7 +92,7 @@ class Diagonal_Operator_2 : public Vector_Operator<MV>
 {
   public:
 
-    Diagonal_Operator_2<ST,MV>(int n_in, ST v_in)
+    Diagonal_Operator_2(int n_in, ST v_in)
     : Vector_Operator<MV>(n_in, n_in), v(v_in) {}
 
     ~Diagonal_Operator_2() { };

--- a/packages/belos/tpetra/test/MINRES/test_minres_diag.cpp
+++ b/packages/belos/tpetra/test/MINRES/test_minres_diag.cpp
@@ -74,7 +74,7 @@ class DiagonalOperator : public VectorOperator<MV> {
 template <class ST, class MV>
 class DiagonalOperator2 : public VectorOperator<MV> {
  public:
-  DiagonalOperator2<ST, MV>(int n_in, int min_gid_in, ST v_in)
+  DiagonalOperator2(int n_in, int min_gid_in, ST v_in)
       : VectorOperator<MV>(n_in, n_in), min_gid(min_gid_in), v(v_in) {}
 
   ~DiagonalOperator2(){};

--- a/packages/belos/tpetra/test/MultiMatrixSolve/test_pseudo_gmres_multidiag.cpp
+++ b/packages/belos/tpetra/test/MultiMatrixSolve/test_pseudo_gmres_multidiag.cpp
@@ -92,7 +92,7 @@ class Diagonal_Operator_2 : public Vector_Operator<MV>
 {
   public:
 
-    Diagonal_Operator_2<ST,MV>(int n_in, ST v_in)
+    Diagonal_Operator_2(int n_in, ST v_in)
     : Vector_Operator<MV>(n_in, n_in), v(v_in) {}
 
     ~Diagonal_Operator_2() { };

--- a/packages/belos/tpetra/test/TFQMR/test_tfqmr_diag.cpp
+++ b/packages/belos/tpetra/test/TFQMR/test_tfqmr_diag.cpp
@@ -87,7 +87,7 @@ class DiagonalOperator2 : public VectorOperator<MV>
 {
   public:
 
-    DiagonalOperator2<ST,MV>(int n_in, int min_gid_in, ST v_in)
+    DiagonalOperator2(int n_in, int min_gid_in, ST v_in)
     : VectorOperator<MV>(n_in, n_in), min_gid(min_gid_in), v(v_in) {}
 
     ~DiagonalOperator2() { };


### PR DESCRIPTION
These changes resolved compilation errors in OpenMP+Serial build using gcc/12.2.0 with c++20, errors had messages like below:
```
Trilinos/packages/belos/tpetra/test/TFQMR/test_tfqmr_diag.cpp:90:30: error: expected unqualified-id before 'int'
   90 |     DiagonalOperator2<ST,MV>(int n_in, int min_gid_in, ST v_in)
```

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos @hkthorn 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Resolve some compilation issues I ran into testing with c++20


<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->



<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing

Manual testing on weaver testbed with gcc/12.2.0 and c++20 enabled (OpenMP+Serial backends)

<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
