### PR TITLE
Various: compatibility updates for Kokkos' deprecation of View member `stride_N()`

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockComputeResidualVector.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockComputeResidualVector.hpp
@@ -724,7 +724,7 @@ struct ComputeResidualVector {
     using subview_1D_stride_t = decltype(Kokkos::subview(y_packed_scalar, 0, block_range, 0, 0));
     subview_1D_right_t bb(nullptr, blocksize);
     subview_1D_right_t xx(nullptr, blocksize);
-    subview_1D_stride_t yy(nullptr, Kokkos::LayoutStride(blocksize, y_packed_scalar.stride_1()));
+    subview_1D_stride_t yy(nullptr, Kokkos::LayoutStride(blocksize, y_packed_scalar.stride(1)));
     auto A_block_cst = ConstUnmanaged<tpetra_block_access_view_type>(NULL, blocksize, blocksize);
 
     // Get shared allocation for a local copy of x, Ax, and A
@@ -821,7 +821,7 @@ struct ComputeResidualVector {
     subview_1D_right_t bb(nullptr, blocksize);
     subview_1D_right_t xx(nullptr, blocksize);
     subview_1D_right_t xx_remote(nullptr, blocksize);
-    subview_1D_stride_t yy(nullptr, Kokkos::LayoutStride(blocksize, y_packed_scalar.stride_1()));
+    subview_1D_stride_t yy(nullptr, Kokkos::LayoutStride(blocksize, y_packed_scalar.stride(1)));
     auto A_block_cst    = ConstUnmanaged<tpetra_block_access_view_type>(NULL, blocksize, blocksize);
     auto colindsub_used = overlap ? colindsub_remote : colindsub;
     auto rowptr_used    = overlap ? rowptr_remote : rowptr;

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -2554,11 +2554,11 @@ solveSingleVectorNew(const typename Kokkos::TeamPolicy<typename impl_type::execu
   // const local_ordinal_type num_vectors = X_scalar_values.extent(2);
 
   // const local_ordinal_type blocksize = D_scalar_values.extent(1);
-  const local_ordinal_type astep = D_internal_vector_values.stride_0();
-  const local_ordinal_type as0   = D_internal_vector_values.stride_1();  // blocksize*vector_length;
-  const local_ordinal_type as1   = D_internal_vector_values.stride_2();  // vector_length;
-  const local_ordinal_type xstep = X_internal_vector_values.stride_0();
-  const local_ordinal_type xs0   = X_internal_vector_values.stride_1();  // vector_length;
+  const local_ordinal_type astep = D_internal_vector_values.stride(0);
+  const local_ordinal_type as0   = D_internal_vector_values.stride(1);  // blocksize*vector_length;
+  const local_ordinal_type as1   = D_internal_vector_values.stride(2);  // vector_length;
+  const local_ordinal_type xstep = X_internal_vector_values.stride(0);
+  const local_ordinal_type xs0   = X_internal_vector_values.stride(1);  // vector_length;
 
   // move to starting point
   A += i0 * astep + v;
@@ -2629,7 +2629,7 @@ solveSingleVectorNew(const typename Kokkos::TeamPolicy<typename impl_type::execu
     // for multiple rhs
     // X += xs1;
   } else {
-    const local_ordinal_type ws0 = WW.stride_0();
+    const local_ordinal_type ws0 = WW.stride(0);
     auto W                       = WW.data() + v;
     KOKKOSBATCHED_COPY_VECTOR_NO_TRANSPOSE_INTERNAL_INVOKE(default_mode_type,
                                                            member, blocksize, X, xs0, W, ws0);
@@ -4282,11 +4282,11 @@ struct SolveTridiags {
     // const local_ordinal_type num_vectors = X_scalar_values.extent(2);
 
     // const local_ordinal_type blocksize = D_scalar_values.extent(1);
-    const local_ordinal_type astep = D_internal_vector_values.stride_0();
-    const local_ordinal_type as0   = D_internal_vector_values.stride_1();  // blocksize*vector_length;
-    const local_ordinal_type as1   = D_internal_vector_values.stride_2();  // vector_length;
-    const local_ordinal_type xstep = X_internal_vector_values.stride_0();
-    const local_ordinal_type xs0   = X_internal_vector_values.stride_1();  // vector_length;
+    const local_ordinal_type astep = D_internal_vector_values.stride(0);
+    const local_ordinal_type as0   = D_internal_vector_values.stride(1);  // blocksize*vector_length;
+    const local_ordinal_type as1   = D_internal_vector_values.stride(2);  // vector_length;
+    const local_ordinal_type xstep = X_internal_vector_values.stride(0);
+    const local_ordinal_type xs0   = X_internal_vector_values.stride(1);  // vector_length;
 
     // move to starting point
     A += i0 * astep + v;
@@ -4357,7 +4357,7 @@ struct SolveTridiags {
       // for multiple rhs
       // X += xs1;
     } else {
-      const local_ordinal_type ws0 = WW.stride_0();
+      const local_ordinal_type ws0 = WW.stride(0);
       auto W                       = WW.data() + v;
       KOKKOSBATCHED_COPY_VECTOR_NO_TRANSPOSE_INTERNAL_INVOKE(default_mode_type,
                                                              member, blocksize, X, xs0, W, ws0);
@@ -4599,10 +4599,10 @@ struct SolveTridiags {
                                                         member,
                                                         blocksize, blocksize,
                                                         -one,
-                                                        C.data(), C.stride_0(), C.stride_1(),
-                                                        v_1.data(), v_1.stride_0(),
+                                                        C.data(), C.stride(0), C.stride(1),
+                                                        v_1.data(), v_1.stride(0),
                                                         one,
-                                                        v_2.data(), v_2.stride_0());
+                                                        v_2.data(), v_2.stride(0));
       });
     } else if (local_subpartidx == (local_ordinal_type)part2packrowidx0_sub.extent(1) - 2) {
       Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, vector_loop_size), [&](const int &v) {
@@ -4614,10 +4614,10 @@ struct SolveTridiags {
                                                         member,
                                                         blocksize, blocksize,
                                                         -one,
-                                                        C.data(), C.stride_0(), C.stride_1(),
-                                                        v_1.data(), v_1.stride_0(),
+                                                        C.data(), C.stride(0), C.stride(1),
+                                                        v_1.data(), v_1.stride(0),
                                                         one,
-                                                        v_2.data(), v_2.stride_0());
+                                                        v_2.data(), v_2.stride(0));
       });
     } else {
       Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, vector_loop_size), [&](const int &v) {
@@ -4630,10 +4630,10 @@ struct SolveTridiags {
                                                           member,
                                                           blocksize, blocksize,
                                                           -one,
-                                                          C.data(), C.stride_0(), C.stride_1(),
-                                                          v_1.data(), v_1.stride_0(),
+                                                          C.data(), C.stride(0), C.stride(1),
+                                                          v_1.data(), v_1.stride(0),
                                                           one,
-                                                          v_2.data(), v_2.stride_0());
+                                                          v_2.data(), v_2.stride(0));
         }
         {
           auto v_1 = Kokkos::subview(X_internal_vector_values, r0, Kokkos::ALL(), 0, v);
@@ -4644,10 +4644,10 @@ struct SolveTridiags {
                                                           member,
                                                           blocksize, blocksize,
                                                           -one,
-                                                          C.data(), C.stride_0(), C.stride_1(),
-                                                          v_1.data(), v_1.stride_0(),
+                                                          C.data(), C.stride(0), C.stride(1),
+                                                          v_1.data(), v_1.stride(0),
                                                           one,
-                                                          v_2.data(), v_2.stride_0());
+                                                          v_2.data(), v_2.stride(0));
         }
       });
     }
@@ -4731,10 +4731,10 @@ struct SolveTridiags {
                                                           member,
                                                           blocksize, blocksize,
                                                           -one,
-                                                          E.data(), E.stride_0(), E.stride_1(),
-                                                          v_2.data(), v_2.stride_0(),
+                                                          E.data(), E.stride(0), E.stride(1),
+                                                          v_2.data(), v_2.stride(0),
                                                           one,
-                                                          v_1.data(), v_1.stride_0());
+                                                          v_1.data(), v_1.stride(0));
         }
       });
     } else if (local_subpartidx == (local_ordinal_type)part2packrowidx0_sub.extent(1) - 2) {
@@ -4749,10 +4749,10 @@ struct SolveTridiags {
                                                           member,
                                                           blocksize, blocksize,
                                                           -one,
-                                                          E.data(), E.stride_0(), E.stride_1(),
-                                                          v_2.data(), v_2.stride_0(),
+                                                          E.data(), E.stride(0), E.stride(1),
+                                                          v_2.data(), v_2.stride(0),
                                                           one,
-                                                          v_1.data(), v_1.stride_0());
+                                                          v_1.data(), v_1.stride(0));
         }
       });
     } else {
@@ -4768,10 +4768,10 @@ struct SolveTridiags {
                                                             member,
                                                             blocksize, blocksize,
                                                             -one,
-                                                            E.data(), E.stride_0(), E.stride_1(),
-                                                            v_2.data(), v_2.stride_0(),
+                                                            E.data(), E.stride(0), E.stride(1),
+                                                            v_2.data(), v_2.stride(0),
                                                             one,
-                                                            v_1.data(), v_1.stride_0());
+                                                            v_1.data(), v_1.stride(0));
           }
         }
         {
@@ -4785,10 +4785,10 @@ struct SolveTridiags {
                                                             member,
                                                             blocksize, blocksize,
                                                             -one,
-                                                            E.data(), E.stride_0(), E.stride_1(),
-                                                            v_2.data(), v_2.stride_0(),
+                                                            E.data(), E.stride(0), E.stride(1),
+                                                            v_2.data(), v_2.stride(0),
                                                             one,
-                                                            v_1.data(), v_1.stride_0());
+                                                            v_1.data(), v_1.stride(0));
           }
         }
       });

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEMDef.hpp
@@ -267,12 +267,12 @@ Basis_HCURL_TET_In_FEM( const ordinal_type order,
       V1.extent(0) ,
       V1.extent(1) ,
       V1.data() ,
-      V1.stride_1() ,
+      V1.stride(1) ,
       S.data() ,
       U.data() ,
-      U.stride_1() ,
+      U.stride(1) ,
       Vt.data() ,
-      Vt.stride_1() ,
+      Vt.stride(1) ,
       work.data() ,
       5*cardVecPn ,
       rWork.data() ,
@@ -504,7 +504,7 @@ Basis_HCURL_TET_In_FEM( const ordinal_type order,
   info = 0;
 
   lapack.GETRF(card, card,
-      vmat.data(), vmat.stride_1(),
+      vmat.data(), vmat.stride(1),
       (ordinal_type*)ipiv.data(),
       &info);
 
@@ -513,7 +513,7 @@ Basis_HCURL_TET_In_FEM( const ordinal_type order,
       ">>> ERROR: (Intrepid2::Basis_HCURL_TET_In_FEM) lapack.GETRF returns nonzero info." );
 
   lapack.GETRI(card,
-      vmat.data(), vmat.stride_1(),
+      vmat.data(), vmat.stride(1),
       (ordinal_type*)ipiv.data(),
       work1.data(), lwork,
       &info);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
@@ -394,7 +394,7 @@ namespace Intrepid2 {
     Teuchos::LAPACK<ordinal_type,scalarType> lapack;
 
     lapack.GETRF(card, card,
-                 vmat.data(), vmat.stride_1(),
+                 vmat.data(), vmat.stride(1),
                  (ordinal_type*)ipiv.data(),
                  &info);
 
@@ -403,7 +403,7 @@ namespace Intrepid2 {
                                   ">>> ERROR: (Intrepid2::Basis_HCURL_TRI_In_FEM) lapack.GETRF returns nonzero info." );
 
     lapack.GETRI(card,
-                 vmat.data(), vmat.stride_1(),
+                 vmat.data(), vmat.stride(1),
                  (ordinal_type*)ipiv.data(),
                  work.data(), lwork,
                  &info);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
@@ -393,7 +393,7 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
   Teuchos::LAPACK<ordinal_type,scalarType> lapack;
 
   lapack.GETRF(card, card,
-      vmat.data(), vmat.stride_1(),
+      vmat.data(), vmat.stride(1),
       (ordinal_type*)ipiv.data(),
       &info);
 
@@ -402,7 +402,7 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
       ">>> ERROR: (Intrepid2::Basis_HDIV_TET_In_FEM) lapack.GETRF returns nonzero info." );
 
   lapack.GETRI(card,
-      vmat.data(), vmat.stride_1(),
+      vmat.data(), vmat.stride(1),
       (ordinal_type*)ipiv.data(),
       work.data(), lwork,
       &info);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
@@ -390,7 +390,7 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
   Teuchos::LAPACK<ordinal_type,scalarType> lapack;
 
   lapack.GETRF(card, card,
-      vmat.data(), vmat.stride_1(),
+      vmat.data(), vmat.stride(1),
       (ordinal_type*)ipiv.data(),
       &info);
 
@@ -399,7 +399,7 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
       ">>> ERROR: (Intrepid2::Basis_HDIV_TRI_In_FEM) lapack.GETRF returns nonzero info." );
 
   lapack.GETRI(card,
-      vmat.data(), vmat.stride_1(),
+      vmat.data(), vmat.stride(1),
       (ordinal_type*)ipiv.data(),
       work.data(), lwork,
       &info);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
@@ -223,7 +223,7 @@ namespace Intrepid2 {
     Teuchos::LAPACK<ordinal_type,typename ScalarViewType::value_type> lapack;
 
     lapack.GETRF(card, card, 
-                 vmat.data(), vmat.stride_1(),
+                 vmat.data(), vmat.stride(1),
                  (ordinal_type*)ipiv.data(),
                  &info);
 
@@ -232,7 +232,7 @@ namespace Intrepid2 {
                                   ">>> ERROR: (Intrepid2::Basis_HGRAD_LINE_Cn_FEM) lapack.GETRF returns nonzero info." );
 
     lapack.GETRI(card, 
-                 vmat.data(), vmat.stride_1(),
+                 vmat.data(), vmat.stride(1),
                  (ordinal_type*)ipiv.data(),
                  work.data(), lwork,
                  &info);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEMDef.hpp
@@ -370,7 +370,7 @@ Basis_HGRAD_TET_Cn_FEM( const ordinal_type order,
   Teuchos::LAPACK<ordinal_type,scalarType> lapack;
 
   lapack.GETRF(card, card,
-      vmat.data(), vmat.stride_1(),
+      vmat.data(), vmat.stride(1),
       (ordinal_type*)ipiv.data(),
       &info);
 
@@ -379,7 +379,7 @@ Basis_HGRAD_TET_Cn_FEM( const ordinal_type order,
       ">>> ERROR: (Intrepid2::Basis_HGRAD_TET_Cn_FEM) lapack.GETRF returns nonzero info." );
 
   lapack.GETRI(card,
-      vmat.data(), vmat.stride_1(),
+      vmat.data(), vmat.stride(1),
       (ordinal_type*)ipiv.data(),
       work.data(), lwork,
       &info);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
@@ -251,7 +251,7 @@ Basis_HGRAD_TRI_Cn_FEM( const ordinal_type order,
   Teuchos::LAPACK<ordinal_type,scalarType> lapack;
 
   lapack.GETRF(card, card,
-      vmat.data(), vmat.stride_1(),
+      vmat.data(), vmat.stride(1),
       (ordinal_type*)ipiv.data(),
       &info);
 
@@ -260,7 +260,7 @@ Basis_HGRAD_TRI_Cn_FEM( const ordinal_type order,
       ">>> ERROR: (Intrepid2::Basis_HGRAD_TRI_Cn_FEM) lapack.GETRF returns nonzero info." );
 
   lapack.GETRI(card,
-      vmat.data(), vmat.stride_1(),
+      vmat.data(), vmat.stride(1),
       (ordinal_type*)ipiv.data(),
       work.data(), lwork,
       &info);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEMDef.hpp
@@ -228,7 +228,7 @@ namespace Intrepid2 {
     Teuchos::LAPACK<ordinal_type,typename ScalarViewType::value_type> lapack;
 
     lapack.GETRF(card, card, 
-                 vmat.data(), vmat.stride_1(),
+                 vmat.data(), vmat.stride(1),
                  (ordinal_type*)ipiv.data(),
                  &info);
 
@@ -237,7 +237,7 @@ namespace Intrepid2 {
                                   ">>> ERROR: (Intrepid2::Basis_HVOL_LINE_Cn_FEM) lapack.GETRF returns nonzero info." );
 
     lapack.GETRI(card, 
-                 vmat.data(), vmat.stride_1(),
+                 vmat.data(), vmat.stride(1),
                  (ordinal_type*)ipiv.data(),
                  work.data(), lwork,
                  &info);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEMDef.hpp
@@ -243,7 +243,7 @@ namespace Intrepid2 {
     Teuchos::LAPACK<ordinal_type,scalarType> lapack;
 
     lapack.GETRF(card, card,
-                 vmat.data(), vmat.stride_1(),
+                 vmat.data(), vmat.stride(1),
                  (ordinal_type*)ipiv.data(),
                  &info);
 
@@ -252,7 +252,7 @@ namespace Intrepid2 {
                                   ">>> ERROR: (Intrepid2::Basis_HVOL_TET_Cn_FEM) lapack.GETRF returns nonzero info." );
 
     lapack.GETRI(card,
-                 vmat.data(), vmat.stride_1(),
+                 vmat.data(), vmat.stride(1),
                  (ordinal_type*)ipiv.data(),
                  work.data(), lwork,
                  &info);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEMDef.hpp
@@ -236,7 +236,7 @@ Basis_HVOL_TRI_Cn_FEM( const ordinal_type order,
   Teuchos::LAPACK<ordinal_type,scalarType> lapack;
 
   lapack.GETRF(card, card,
-      vmat.data(), vmat.stride_1(),
+      vmat.data(), vmat.stride(1),
       (ordinal_type*)ipiv.data(),
       &info);
 
@@ -245,7 +245,7 @@ Basis_HVOL_TRI_Cn_FEM( const ordinal_type order,
       ">>> ERROR: (Intrepid2::Basis_HVOL_TRI_Cn_FEM) lapack.GETRF returns nonzero info." );
 
   lapack.GETRI(card,
-      vmat.data(), vmat.stride_1(),
+      vmat.data(), vmat.stride(1),
       (ordinal_type*)ipiv.data(),
       work.data(), lwork,
       &info);

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HCURL.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HCURL.hpp
@@ -295,9 +295,9 @@ getCoeffMatrix_HCURL(OutputViewType &output,
         Kokkos::View<value_type**,Kokkos::LayoutLeft,host_space_type> work("pivVec", 2*ndofSubcell, 1);
         lapack.GELS('N', ndofSubcell*card, ndofSubcell, ndofSubcell,
             RefMat.data(),
-            RefMat.stride_1(),
+            RefMat.stride(1),
             OrtMat.data(),
-            OrtMat.stride_1(),
+            OrtMat.stride(1),
             work.data(), work.extent(0),
             &info);
 
@@ -305,10 +305,10 @@ getCoeffMatrix_HCURL(OutputViewType &output,
     Kokkos::DynRankView<ordinal_type,host_device_type> pivVec("pivVec", ndofSubcell);
     lapack.GESV(ndofSubcell, ndofSubcell,
         RefMat.data(),
-        RefMat.stride_1(),
+        RefMat.stride(1),
         pivVec.data(),
         OrtMat.data(),
-        OrtMat.stride_1(),
+        OrtMat.stride(1),
         &info);
     //*/
     if (info) {

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HDIV.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HDIV.hpp
@@ -245,10 +245,10 @@ getCoeffMatrix_HDIV(OutputViewType &output,
 
     lapack.GESV(ndofSubcell, ndofSubcell,
         RefMat.data(),
-        RefMat.stride_1(),
+        RefMat.stride(1),
         pivVec.data(),
         OrtMat.data(),
-        OrtMat.stride_1(),
+        OrtMat.stride(1),
         &info);
 
     if (info) {

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HGRAD.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HGRAD.hpp
@@ -199,10 +199,10 @@ getCoeffMatrix_HGRAD(OutputViewType &output, /// this is device view
     Kokkos::DynRankView<ordinal_type,Kokkos::LayoutLeft,host_device_type> pivVec("pivVec", ndofSubcell);
     lapack.GESV(ndofSubcell, ndofSubcell,
                 RefMat.data(),
-                RefMat.stride_1(),
+                RefMat.stride(1),
                 pivVec.data(),
                 OrtMat.data(),
-                OrtMat.stride_1(),
+                OrtMat.stride(1),
                 &info);
     
     if (info) {

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HVOL.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HVOL.hpp
@@ -174,10 +174,10 @@ getCoeffMatrix_HVOL(OutputViewType &output, /// this is device view
     Kokkos::DynRankView<ordinal_type,Kokkos::LayoutLeft,host_device_type> pivVec("pivVec", cardinality);
     lapack.GESV(cardinality, cardinality,
                 RefMat.data(),
-                RefMat.stride_1(),
+                RefMat.stride(1),
                 pivVec.data(),
                 OrtMat.data(),
-                OrtMat.stride_1(),
+                OrtMat.stride(1),
                 &info);
     
     if (info) {

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionTools.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionTools.hpp
@@ -530,8 +530,8 @@ public:
         KokkosBatched::SerialQR_Internal::invoke
 #endif
             (A0_host.extent(0), A0_host.extent(1),
-             A0_host.data(), A0_host.stride_0(), A0_host.stride_1(),
-             tau0_host.data(), tau0_host.stride_0(), w0_host.data());
+             A0_host.data(), A0_host.stride(0), A0_host.stride(1),
+             tau0_host.data(), tau0_host.stride(0), w0_host.data());
 
         Kokkos::deep_copy(A0_device, A0_host);
         Kokkos::deep_copy(A0, A0_device);
@@ -548,9 +548,9 @@ public:
           //b'*Q0 -> b
           KokkosBatched::SerialApplyQ_RightForwardInternal::invoke(
               1, A0.extent(0), A0.extent(1),
-              A0.data(),  A0.stride_0(), A0.stride_1(),
-              tau0.data(), tau0.stride_0(),
-              b.data(),  1, b.stride_0(),
+              A0.data(),  A0.stride(0), A0.stride(1),
+              tau0.data(), tau0.stride(0),
+              b.data(),  1, b.stride(0),
               w.data());
 
           // R0^{-1} b -> b
@@ -560,8 +560,8 @@ public:
           KokkosBatched::SerialTrsvInternalUpper<KokkosBatched::Algo::Trsv::Unblocked>::invoke(false,
               A0.extent(0),
               1.0,
-              A0.data(), A0.stride_0(), A0.stride_1(),
-              b.data(),  b.stride_0());
+              A0.data(), A0.stride(0), A0.stride(1),
+              b.data(),  b.stride(0));
 #endif
 
           //scattering b into the basis coefficients
@@ -591,16 +591,16 @@ public:
           KokkosBatched::SerialQR_Internal::invoke
 #endif
               (A.extent(0), A.extent(1),
-               A.data(), A.stride_0(), A.stride_1(), tau.data(), tau.stride_0(), w.data());
+               A.data(), A.stride(0), A.stride(1), tau.data(), tau.stride(0), w.data());
 
           auto b = Kokkos::subview(elemRhs, ic, Kokkos::ALL());
 
           //b'*Q -> b
           KokkosBatched::SerialApplyQ_RightForwardInternal::invoke(
               1, A.extent(0), A.extent(1),
-              A.data(),  A.stride_0(), A.stride_1(),
-              tau.data(), tau.stride_0(),
-              b.data(),  1, b.stride_0(),
+              A.data(),  A.stride(0), A.stride(1),
+              tau.data(), tau.stride(0),
+              b.data(),  1, b.stride(0),
               w.data());
 
           // R^{-1} b -> b
@@ -610,8 +610,8 @@ public:
           KokkosBatched::SerialTrsvInternalUpper<KokkosBatched::Algo::Trsv::Unblocked>::invoke(false,
               A.extent(0),
               1.0,
-              A.data(), A.stride_0(), A.stride_1(),
-              b.data(),  b.stride_0());
+              A.data(), A.stride(0), A.stride(1),
+              b.data(),  b.stride(0));
 #endif
 
           //scattering b into the basis coefficients

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_HEX_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_HEX_newBasis.hpp
@@ -174,9 +174,9 @@ int OrientationHexNewBasis(const bool verbose) {
 
         lapack.GELS('N', dim*numRefCoords, basisCardinality,1,
             cellMassMat.data(),
-            cellMassMat.stride_1(),
+            cellMassMat.stride(1),
             cellRhsMat.data(),
-            cellRhsMat.stride_1(),
+            cellRhsMat.stride(1),
             work.data(),
             basisCardinality+dim*numRefCoords,
             &info[ic]);

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_QuadFace_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_QuadFace_newBasis.hpp
@@ -203,9 +203,9 @@ int OrientationPyrQuadFaceNewBasis(const bool verbose) {
         }
         lapack.GELS('N', dim*numRefCoords, fullBasisCardinality-dofsToExclude.size(),1,
             cellMassMat.data(),
-            cellMassMat.stride_1(),
+            cellMassMat.stride(1),
             cellRhsMat.data(),
-            cellRhsMat.stride_1(),
+            cellRhsMat.stride(1),
             work.data(),
             fullBasisCardinality-dofsToExclude.size()+dim*numRefCoords,
             &info[ic]);

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_TriFace_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_TriFace_newBasis.hpp
@@ -209,9 +209,9 @@ int OrientationPyrTriFaceNewBasis(const bool verbose) {
         }
         lapack.GELS('N', dim*numRefCoords, fullBasisCardinality-dofsToExclude.size(),1,
             cellMassMat.data(),
-            cellMassMat.stride_1(),
+            cellMassMat.stride(1),
             cellRhsMat.data(),
-            cellRhsMat.stride_1(),
+            cellRhsMat.stride(1),
             work.data(),
             fullBasisCardinality-dofsToExclude.size()+dim*numRefCoords,
             &info[ic]);

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_QUAD_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_QUAD_newBasis.hpp
@@ -172,9 +172,9 @@ int OrientationQuadNewBasis(const bool verbose) {
 
         lapack.GELS('N', dim*numRefCoords, basisCardinality,1,
             cellMassMat.data(),
-            cellMassMat.stride_1(),
+            cellMassMat.stride(1),
             cellRhsMat.data(),
-            cellRhsMat.stride_1(),
+            cellRhsMat.stride(1),
             work.data(),
             basisCardinality+dim*numRefCoords,
             &info[ic]);

--- a/packages/sacado/example/dfad_view_handle_example.cpp
+++ b/packages/sacado/example/dfad_view_handle_example.cpp
@@ -70,8 +70,8 @@ int main(int argc, char **argv)
   typedef Sacado::Fad::ViewFad<double,0,0,FadType> ViewFadType;
 
   // Fad objects
-  ViewFadType afad( &v(0,0), &a, num_deriv, v.stride_1() );
-  ViewFadType bfad( &v(1,0), &b, num_deriv, v.stride_1() );
+  ViewFadType afad( &v(0,0), &a, num_deriv, v.stride(1) );
+  ViewFadType bfad( &v(1,0), &b, num_deriv, v.stride(1) );
   FadType cfad(c);
   FadType rfad;
 

--- a/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
@@ -696,6 +696,12 @@ public:
     { return m_impl_offset.stride_7(); }
 
   template< typename iType >
+  KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>,
+                                                    size_t>
+  stride( iType const s ) const
+    { return m_impl_offset.stride(s) ; }
+
+  template< typename iType >
   KOKKOS_INLINE_FUNCTION void stride( iType * const s ) const
     { m_impl_offset.stride(s); }
 

--- a/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
@@ -1149,6 +1149,16 @@ void deep_copy
          dst.extent(5) == src.extent(5) &&
          dst.extent(6) == src.extent(6) &&
          dst.extent(7) == src.extent(7) &&
+#if KOKKOS_VERSION >= 40799
+         dst.stride(0) == src.stride(0) &&
+         dst.stride(1) == src.stride(1) &&
+         dst.stride(2) == src.stride(2) &&
+         dst.stride(3) == src.stride(3) &&
+         dst.stride(4) == src.stride(4) &&
+         dst.stride(5) == src.stride(5) &&
+         dst.stride(6) == src.stride(6) &&
+         dst.stride(7) == src.stride(7)
+#else
          dst.stride_0() == src.stride_0() &&
          dst.stride_1() == src.stride_1() &&
          dst.stride_2() == src.stride_2() &&
@@ -1157,6 +1167,7 @@ void deep_copy
          dst.stride_5() == src.stride_5() &&
          dst.stride_6() == src.stride_6() &&
          dst.stride_7() == src.stride_7()
+#endif
          ) {
 
       const size_t nbytes = sizeof(typename dst_type::value_type::value_type) * dst.span() ; 

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
@@ -1436,7 +1436,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 
   // Check dimensions are correct
   TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(v2), fad_size+1, out, success);
-  TEUCHOS_TEST_EQUALITY(v2.stride_0(), v1.stride_0(), out, success);
+  TEUCHOS_TEST_EQUALITY(v2.stride(0), v1.stride(0), out, success);
 
   // Check values
   FadType f =
@@ -1473,8 +1473,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   // Check dimensions are correct
   TEUCHOS_TEST_EQUALITY(v2.extent(0), num_rows, out, success);
   TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(v2), fad_size+1, out, success);
-  TEUCHOS_TEST_EQUALITY(v2.stride_0(), v1.stride_0(), out, success);
-  TEUCHOS_TEST_EQUALITY(v2.stride_1(), v1.stride_1(), out, success);
+  TEUCHOS_TEST_EQUALITY(v2.stride(0), v1.stride(0), out, success);
+  TEUCHOS_TEST_EQUALITY(v2.stride(1), v1.stride(1), out, success);
 
   // Check values
   for (size_type i=0; i<num_rows; ++i) {
@@ -1514,9 +1514,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   TEUCHOS_TEST_EQUALITY(v2.extent(0), num_rows, out, success);
   TEUCHOS_TEST_EQUALITY(v2.extent(1), num_cols, out, success);
   TEUCHOS_TEST_EQUALITY(Kokkos::dimension_scalar(v2), fad_size+1, out, success);
-  TEUCHOS_TEST_EQUALITY(v2.stride_0(), v1.stride_0(), out, success);
-  TEUCHOS_TEST_EQUALITY(v2.stride_1(), v1.stride_1(), out, success);
-  TEUCHOS_TEST_EQUALITY(v2.stride_2(), v1.stride_2(), out, success);
+  TEUCHOS_TEST_EQUALITY(v2.stride(0), v1.stride(0), out, success);
+  TEUCHOS_TEST_EQUALITY(v2.stride(1), v1.stride(1), out, success);
+  TEUCHOS_TEST_EQUALITY(v2.stride(2), v1.stride(2), out, success);
 
   // Check values
   for (size_type i=0; i<num_rows; ++i) {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol_External.hpp
@@ -33,7 +33,7 @@ template <typename ArgUplo> struct Chol<ArgUplo, Algo::External> {
       int r_val = 0;
       const ordinal_type m = A.extent(0);
       if (m > 0) {
-        Lapack<value_type>::potrf(ArgUplo::param, m, A.data(), A.stride_1(), &r_val);
+        Lapack<value_type>::potrf(ArgUplo::param, m, A.data(), A.stride(1), &r_val);
         TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LAPACK (potrf) returns non-zero error code.");
       }
       return r_val;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol_Internal.hpp
@@ -31,7 +31,7 @@ template <typename ArgUplo> struct Chol<ArgUplo, Algo::Internal> {
     int r_val = 0;
     const ordinal_type m = A.extent(0);
     if (m > 0)
-      LapackTeam<value_type>::potrf(member, ArgUplo::param, m, A.data(), A.stride_1(), &r_val);
+      LapackTeam<value_type>::potrf(member, ArgUplo::param, m, A.data(), A.stride(1), &r_val);
     return r_val;
   }
 
@@ -44,7 +44,7 @@ template <typename ArgUplo> struct Chol<ArgUplo, Algo::Internal> {
     int r_val = 0;
     const ordinal_type m = A.extent(0);
     if (m > 0)
-      LapackTeam<value_type>::potrf(member, tol, ArgUplo::param, m, A.data(), A.stride_1(), &r_val);
+      LapackTeam<value_type>::potrf(member, tol, ArgUplo::param, m, A.data(), A.stride(1), &r_val);
     return r_val;
   }
 };

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol_OnDevice.hpp
@@ -24,7 +24,7 @@ template <typename ArgUplo> struct Chol<ArgUplo, Algo::OnDevice> {
 
     int r_val(0);
     if (m > 0) {
-      Lapack<value_type>::potrf(ArgUplo::param, m, A.data(), A.stride_1(), &r_val);
+      Lapack<value_type>::potrf(ArgUplo::param, m, A.data(), A.stride(1), &r_val);
     }
     return r_val;
   }
@@ -41,7 +41,7 @@ template <typename ArgUplo> struct Chol<ArgUplo, Algo::OnDevice> {
       int *devInfo = (int *)W.data();
       value_type *workspace = W.data() + 1;
       int lwork = W.span() - 1;
-      r_val = Lapack<value_type>::potrf(handle, ArgUplo::cublas_param, m, A.data(), A.stride_1(), workspace, lwork,
+      r_val = Lapack<value_type>::potrf(handle, ArgUplo::cublas_param, m, A.data(), A.stride(1), workspace, lwork,
                                         devInfo);
     }
     return r_val;
@@ -54,7 +54,7 @@ template <typename ArgUplo> struct Chol<ArgUplo, Algo::OnDevice> {
 
     int r_val(0);
     if (m > 0)
-      r_val = Lapack<value_type>::potrf_buffersize(handle, ArgUplo::cublas_param, m, A.data(), A.stride_1(), lwork);
+      r_val = Lapack<value_type>::potrf_buffersize(handle, ArgUplo::cublas_param, m, A.data(), A.stride(1), lwork);
     return r_val;
   }
 #endif
@@ -68,7 +68,7 @@ template <typename ArgUplo> struct Chol<ArgUplo, Algo::OnDevice> {
     int r_val(0);
     if (m > 0) {
       int *devInfo = (int *)W.data();
-      r_val = Lapack<value_type>::potrf(handle, ArgUplo::rocblas_param, m, A.data(), A.stride_1(), devInfo);
+      r_val = Lapack<value_type>::potrf(handle, ArgUplo::rocblas_param, m, A.data(), A.stride(1), devInfo);
     }
     return r_val;
   }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Chol_Serial.hpp
@@ -33,7 +33,7 @@ template <typename ArgUplo> struct Chol<ArgUplo, Algo::Serial> {
       int r_val = 0;
       const ordinal_type m = A.extent(0);
       if (m > 0) {
-        LapackSerial<value_type>::potrf(ArgUplo::param, m, A.data(), A.stride_1(), &r_val);
+        LapackSerial<value_type>::potrf(ArgUplo::param, m, A.data(), A.stride(1), &r_val);
         TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LAPACK (potrf) returns non-zero error code.");
       }
       return r_val;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_External.hpp
@@ -44,7 +44,7 @@ template <> struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Up
         if (m == n) {
           const ordinal_type b = 32;
           value_type *aptr = A.data(), *bptr = B.data(), *cptr = C.data();
-          const int as1 = A.stride_1(), bs1 = B.stride_1(), cs1 = C.stride_1();
+          const int as1 = A.stride(1), bs1 = B.stride(1), cs1 = C.stride(1);
           for (ordinal_type i = 0; i < m; i += b) {
             const ordinal_type m2 = i + b, mm = (m2 > m ? m : m2), nn = mm - i;
             value_type *aaptr = aptr, *bbptr = bptr + i * bs1, *ccptr = cptr + i * cs1;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_Internal.hpp
@@ -42,8 +42,8 @@ template <> struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Up
     if (m > 0 && n > 0 && k > 0) {
       if (m == n) {
         BlasTeam<value_type>::gemm_upper(member, Trans::Transpose::param, Trans::NoTranspose::param, m, n, k,
-                                         value_type(alpha), A.data(), A.stride_1(), B.data(), B.stride_1(),
-                                         value_type(beta), C.data(), C.stride_1());
+                                         value_type(alpha), A.data(), A.stride(1), B.data(), B.stride(1),
+                                         value_type(beta), C.data(), C.stride(1));
       } else {
         TACHO_TEST_FOR_ABORT(true, "C is not a square matrix");
       }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_OnDevice.hpp
@@ -40,7 +40,7 @@ template <> struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Up
       if (m == n) {
         const ordinal_type b = 32;
         value_type *aptr = A.data(), *bptr = B.data(), *cptr = C.data();
-        const int as1 = A.stride_1(), bs1 = B.stride_1(), cs1 = C.stride_1();
+        const int as1 = A.stride(1), bs1 = B.stride(1), cs1 = C.stride(1);
         for (ordinal_type i = 0; i < m; i += b) {
           const ordinal_type m2 = i + b, mm = (m2 > m ? m : m2), nn = mm - i;
           value_type *aaptr = aptr, *bbptr = bptr + i * bs1, *ccptr = cptr + i * cs1;
@@ -75,7 +75,7 @@ template <> struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Up
       if (m == n) {
         const ordinal_type b = 256;
         value_type *aptr = A.data(), *bptr = B.data(), *cptr = C.data();
-        const int as1 = A.stride_1(), bs1 = B.stride_1(), cs1 = C.stride_1();
+        const int as1 = A.stride(1), bs1 = B.stride(1), cs1 = C.stride(1);
         if (m < 2 * b) {
           Blas<value_type>::gemm(handle, Trans::Transpose::cublas_param, Trans::NoTranspose::cublas_param, m, n, k,
                                  value_type(alpha), aptr, as1, bptr, bs1, value_type(beta), cptr, cs1);
@@ -116,7 +116,7 @@ template <> struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Up
       if (m == n) {
         const ordinal_type b = 256;
         value_type *aptr = A.data(), *bptr = B.data(), *cptr = C.data();
-        const int as1 = A.stride_1(), bs1 = B.stride_1(), cs1 = C.stride_1();
+        const int as1 = A.stride(1), bs1 = B.stride(1), cs1 = C.stride(1);
         if (m < 2 * b) {
           Blas<value_type>::gemm(handle, Trans::Transpose::rocblas_param, Trans::NoTranspose::rocblas_param, m, n, k,
                                  value_type(alpha), aptr, as1, bptr, bs1, value_type(beta), cptr, cs1);

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_Serial.hpp
@@ -44,7 +44,7 @@ template <> struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Up
         if (m == n) {
           const ordinal_type b = 32;
           value_type *aptr = A.data(), *bptr = B.data(), *cptr = C.data();
-          const int as1 = A.stride_1(), bs1 = B.stride_1(), cs1 = C.stride_1();
+          const int as1 = A.stride(1), bs1 = B.stride(1), cs1 = C.stride(1);
           for (ordinal_type i = 0; i < m; i += b) {
             const ordinal_type m2 = i + b, mm = (m2 > m ? m : m2), nn = mm - i;
             value_type *aaptr = aptr, *bbptr = bptr + i * bs1, *ccptr = cptr + i * cs1;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm_External.hpp
@@ -42,8 +42,8 @@ template <typename ArgTransA, typename ArgTransB> struct Gemm<ArgTransA, ArgTran
                          k = (std::is_same<ArgTransB, Trans::NoTranspose>::value ? B.extent(0) : B.extent(1));
 
       if (m > 0 && n > 0 && k > 0) {
-        Blas<value_type>::gemm(ArgTransA::param, ArgTransB::param, m, n, k, value_type(alpha), A.data(), A.stride_1(),
-                               B.data(), B.stride_1(), value_type(beta), C.data(), C.stride_1());
+        Blas<value_type>::gemm(ArgTransA::param, ArgTransB::param, m, n, k, value_type(alpha), A.data(), A.stride(1),
+                               B.data(), B.stride(1), value_type(beta), C.data(), C.stride(1));
       }
     } else {
       TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm_Internal.hpp
@@ -41,7 +41,7 @@ template <typename ArgTransA, typename ArgTransB> struct Gemm<ArgTransA, ArgTran
 
     if (m > 0 && n > 0 && k > 0)
       BlasTeam<value_type>::gemm(member, ArgTransA::param, ArgTransB::param, m, n, k, value_type(alpha), A.data(),
-                                 A.stride_1(), B.data(), B.stride_1(), value_type(beta), C.data(), C.stride_1());
+                                 A.stride(1), B.data(), B.stride(1), value_type(beta), C.data(), C.stride(1));
     return 0;
   }
 };

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm_OnDevice.hpp
@@ -28,8 +28,8 @@ template <typename ArgTransA, typename ArgTransB> struct Gemm<ArgTransA, ArgTran
                        k = (std::is_same<ArgTransB, Trans::NoTranspose>::value ? B.extent(0) : B.extent(1));
 
     if (m > 0 && n > 0 && k > 0) {
-      Blas<value_type>::gemm(ArgTransA::param, ArgTransB::param, m, n, k, value_type(alpha), A.data(), A.stride_1(),
-                             B.data(), B.stride_1(), value_type(beta), C.data(), C.stride_1());
+      Blas<value_type>::gemm(ArgTransA::param, ArgTransB::param, m, n, k, value_type(alpha), A.data(), A.stride(1),
+                             B.data(), B.stride(1), value_type(beta), C.data(), C.stride(1));
     }
     return 0;
   }
@@ -46,7 +46,7 @@ template <typename ArgTransA, typename ArgTransB> struct Gemm<ArgTransA, ArgTran
     int r_val(0);
     if (m > 0 && n > 0 && k > 0) {
       r_val = Blas<value_type>::gemm(handle, ArgTransA::cublas_param, ArgTransB::cublas_param, m, n, k, alpha, A.data(),
-                                     A.stride_1(), B.data(), B.stride_1(), beta, C.data(), C.stride_1());
+                                     A.stride(1), B.data(), B.stride(1), beta, C.data(), C.stride(1));
     }
     return r_val;
   }
@@ -64,7 +64,7 @@ template <typename ArgTransA, typename ArgTransB> struct Gemm<ArgTransA, ArgTran
     int r_val(0);
     if (m > 0 && n > 0 && k > 0) {
       r_val = Blas<value_type>::gemm(handle, ArgTransA::rocblas_param, ArgTransB::rocblas_param, m, n, k, alpha,
-                                     A.data(), A.stride_1(), B.data(), B.stride_1(), beta, C.data(), C.stride_1());
+                                     A.data(), A.stride(1), B.data(), B.stride(1), beta, C.data(), C.stride(1));
     }
     return r_val;
   }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemm_Serial.hpp
@@ -34,9 +34,9 @@ template <typename ArgTransA, typename ArgTransB> struct Gemm<ArgTransA, ArgTran
                          k = (std::is_same<ArgTransB, Trans::NoTranspose>::value ? B.extent(0) : B.extent(1));
 
       BlasSerial<value_type_a>::gemm(ArgTransA::param, ArgTransB::param, m, n, k,
-                                     value_type_a(alpha), A.data(), A.stride_1(),
-                                                          B.data(), B.stride_1(),
-                                     value_type_c(beta),  C.data(), C.stride_1());
+                                     value_type_a(alpha), A.data(), A.stride(1),
+                                                          B.data(), B.stride(1),
+                                     value_type_c(beta),  C.data(), C.stride(1));
     } else {
       TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");
     }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv_External.hpp
@@ -43,12 +43,12 @@ template <typename ArgTrans> struct Gemv<ArgTrans, Algo::External> {
       if (m > 0 && n > 0) {
         if (n == 1) {
           const int mm = A.extent(0), nn = A.extent(1);
-          Blas<value_type>::gemv(ArgTrans::param, mm, nn, value_type(alpha), A.data(), A.stride_1(), B.data(),
-                                 B.stride_0(), value_type(beta), C.data(), C.stride_0());
+          Blas<value_type>::gemv(ArgTrans::param, mm, nn, value_type(alpha), A.data(), A.stride(1), B.data(),
+                                 B.stride(0), value_type(beta), C.data(), C.stride(0));
         } else {
           const int mm = C.extent(0), nn = C.extent(1), kk = B.extent(0);
           Blas<value_type>::gemm(ArgTrans::param, Trans::NoTranspose::param, mm, nn, kk, value_type(alpha), A.data(),
-                                 A.stride_1(), B.data(), B.stride_1(), value_type(beta), C.data(), C.stride_1());
+                                 A.stride(1), B.data(), B.stride(1), value_type(beta), C.data(), C.stride(1));
         }
       }
     } else {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv_Internal.hpp
@@ -40,13 +40,13 @@ template <typename ArgTrans> struct Gemv<ArgTrans, Algo::Internal> {
     if (m > 0 && n > 0) {
       if (n == 1) {
         const int mm = A.extent(0), nn = A.extent(1);
-        BlasTeam<value_type>::gemv(member, ArgTrans::param, mm, nn, value_type(alpha), A.data(), A.stride_1(), B.data(),
-                                   B.stride_0(), value_type(beta), C.data(), C.stride_0());
+        BlasTeam<value_type>::gemv(member, ArgTrans::param, mm, nn, value_type(alpha), A.data(), A.stride(1), B.data(),
+                                   B.stride(0), value_type(beta), C.data(), C.stride(0));
       } else {
         const int mm = C.extent(0), nn = C.extent(1), kk = B.extent(0);
         BlasTeam<value_type>::gemm(member, ArgTrans::param, Trans::NoTranspose::param, mm, nn, kk, value_type(alpha),
-                                   A.data(), A.stride_1(), B.data(), B.stride_1(), value_type(beta), C.data(),
-                                   C.stride_1());
+                                   A.data(), A.stride(1), B.data(), B.stride(1), value_type(beta), C.data(),
+                                   C.stride(1));
       }
     }
     return 0;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv_OnDevice.hpp
@@ -29,12 +29,12 @@ template <typename ArgTrans> struct Gemv<ArgTrans, Algo::OnDevice> {
     if (m > 0 && n > 0) {
       if (n == 1) {
         const int mm = A.extent(0), nn = A.extent(1);
-        Blas<value_type>::gemv(ArgTrans::param, mm, nn, value_type(alpha), A.data(), A.stride_1(), B.data(),
-                               B.stride_0(), value_type(beta), C.data(), C.stride_0());
+        Blas<value_type>::gemv(ArgTrans::param, mm, nn, value_type(alpha), A.data(), A.stride(1), B.data(),
+                               B.stride(0), value_type(beta), C.data(), C.stride(0));
       } else {
         const int mm = C.extent(0), nn = C.extent(1), kk = B.extent(0);
         Blas<value_type>::gemm(ArgTrans::param, Trans::NoTranspose::param, mm, nn, kk, value_type(alpha), A.data(),
-                               A.stride_1(), B.data(), B.stride_1(), value_type(beta), C.data(), C.stride_1());
+                               A.stride(1), B.data(), B.stride(1), value_type(beta), C.data(), C.stride(1));
       }
     }
     return 0;
@@ -51,13 +51,13 @@ template <typename ArgTrans> struct Gemv<ArgTrans, Algo::OnDevice> {
     if (m > 0 && n > 0) {
       if (n == 1) {
         const int mm = A.extent(0), nn = A.extent(1);
-        r_val = Blas<value_type>::gemv(handle, ArgTrans::cublas_param, mm, nn, alpha, A.data(), A.stride_1(), B.data(),
-                                       B.stride_0(), beta, C.data(), C.stride_0());
+        r_val = Blas<value_type>::gemv(handle, ArgTrans::cublas_param, mm, nn, alpha, A.data(), A.stride(1), B.data(),
+                                       B.stride(0), beta, C.data(), C.stride(0));
       } else {
         const int mm = C.extent(0), nn = C.extent(1), kk = B.extent(0);
         r_val =
             Blas<value_type>::gemm(handle, ArgTrans::cublas_param, Trans::NoTranspose::cublas_param, mm, nn, kk, alpha,
-                                   A.data(), A.stride_1(), B.data(), B.stride_1(), beta, C.data(), C.stride_1());
+                                   A.data(), A.stride(1), B.data(), B.stride(1), beta, C.data(), C.stride(1));
       }
     }
     return r_val;
@@ -76,13 +76,13 @@ template <typename ArgTrans> struct Gemv<ArgTrans, Algo::OnDevice> {
     if (m > 0 && n > 0) {
       if (n == 1) {
         const int mm = A.extent(0), nn = A.extent(1);
-        r_val = Blas<value_type>::gemv(handle, ArgTrans::rocblas_param, mm, nn, alpha, A.data(), A.stride_1(), B.data(),
-                                       B.stride_0(), beta, C.data(), C.stride_0());
+        r_val = Blas<value_type>::gemv(handle, ArgTrans::rocblas_param, mm, nn, alpha, A.data(), A.stride(1), B.data(),
+                                       B.stride(0), beta, C.data(), C.stride(0));
       } else {
         const int mm = C.extent(0), nn = C.extent(1), kk = B.extent(0);
         r_val =
             Blas<value_type>::gemm(handle, ArgTrans::rocblas_param, Trans::NoTranspose::rocblas_param, mm, nn, kk,
-                                   alpha, A.data(), A.stride_1(), B.data(), B.stride_1(), beta, C.data(), C.stride_1());
+                                   alpha, A.data(), A.stride(1), B.data(), B.stride(1), beta, C.data(), C.stride(1));
       }
     }
     return r_val;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Gemv_Serial.hpp
@@ -43,12 +43,12 @@ template <typename ArgTrans> struct Gemv<ArgTrans, Algo::Serial> {
       if (m > 0 && n > 0) {
         if (n == 1) {
           const int mm = A.extent(0), nn = A.extent(1);
-          BlasSerial<value_type>::gemv(ArgTrans::param, mm, nn, value_type(alpha), A.data(), A.stride_1(), B.data(),
-                                       B.stride_0(), value_type(beta), C.data(), C.stride_0());
+          BlasSerial<value_type>::gemv(ArgTrans::param, mm, nn, value_type(alpha), A.data(), A.stride(1), B.data(),
+                                       B.stride(0), value_type(beta), C.data(), C.stride(0));
         } else {
           const int mm = C.extent(0), nn = C.extent(1), kk = B.extent(0);
           BlasSerial<value_type>::gemm(ArgTrans::param, Trans::NoTranspose::param, mm, nn, kk, value_type(alpha), A.data(),
-                                       A.stride_1(), B.data(), B.stride_1(), value_type(beta), C.data(), C.stride_1());
+                                       A.stride(1), B.data(), B.stride(1), value_type(beta), C.data(), C.stride(1));
         }
       }
     } else {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk_External.hpp
@@ -37,8 +37,8 @@ template <typename ArgUplo, typename ArgTrans> struct Herk<ArgUplo, ArgTrans, Al
       const ordinal_type n = C.extent(0),
                          k = (std::is_same<ArgTrans, Trans::NoTranspose>::value ? A.extent(1) : A.extent(0));
       if (n > 0 && k > 0) {
-        Blas<value_type>::herk(ArgUplo::param, ArgTrans::param, n, k, value_type(alpha), A.data(), A.stride_1(),
-                               value_type(beta), C.data(), C.stride_1());
+        Blas<value_type>::herk(ArgUplo::param, ArgTrans::param, n, k, value_type(alpha), A.data(), A.stride(1),
+                               value_type(beta), C.data(), C.stride(1));
       }
     } else {
       TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk_Internal.hpp
@@ -37,7 +37,7 @@ template <typename ArgUplo, typename ArgTrans> struct Herk<ArgUplo, ArgTrans, Al
 
     if (n > 0 && k > 0)
       BlasTeam<value_type>::herk(member, ArgUplo::param, ArgTrans::param, n, k, value_type(alpha), A.data(),
-                                 A.stride_1(), value_type(beta), C.data(), C.stride_1());
+                                 A.stride(1), value_type(beta), C.data(), C.stride(1));
     return 0;
   }
 };

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk_OnDevice.hpp
@@ -27,8 +27,8 @@ template <typename ArgUplo, typename ArgTrans> struct Herk<ArgUplo, ArgTrans, Al
                        k = (std::is_same<ArgTrans, Trans::NoTranspose>::value ? A.extent(1) : A.extent(0));
 
     if (n > 0 && k > 0) {
-      Blas<value_type>::herk(ArgUplo::param, ArgTrans::param, n, k, value_type(alpha), A.data(), A.stride_1(),
-                             value_type(beta), C.data(), C.stride_1());
+      Blas<value_type>::herk(ArgUplo::param, ArgTrans::param, n, k, value_type(alpha), A.data(), A.stride(1),
+                             value_type(beta), C.data(), C.stride(1));
     }
     return 0;
   }
@@ -47,11 +47,11 @@ template <typename ArgUplo, typename ArgTrans> struct Herk<ArgUplo, ArgTrans, Al
             Blas<value_type>::herk(handle, ArgUplo::cublas_param,
                                    std::is_same<ArgTrans, Trans::ConjTranspose>::value ? Trans::Transpose::cublas_param
                                                                                        : ArgTrans::cublas_param,
-                                   n, k, alpha, A.data(), A.stride_1(), beta, C.data(), C.stride_1());
+                                   n, k, alpha, A.data(), A.stride(1), beta, C.data(), C.stride(1));
       else if (std::is_same<value_type, Kokkos::complex<float>>::value ||
                std::is_same<value_type, Kokkos::complex<double>>::value)
         r_val = Blas<value_type>::herk(handle, ArgUplo::cublas_param, ArgTrans::cublas_param, n, k, alpha, A.data(),
-                                       A.stride_1(), beta, C.data(), C.stride_1());
+                                       A.stride(1), beta, C.data(), C.stride(1));
     }
     return r_val;
   }
@@ -72,11 +72,11 @@ template <typename ArgUplo, typename ArgTrans> struct Herk<ArgUplo, ArgTrans, Al
             Blas<value_type>::herk(handle, ArgUplo::rocblas_param,
                                    std::is_same<ArgTrans, Trans::ConjTranspose>::value ? Trans::Transpose::rocblas_param
                                                                                        : ArgTrans::rocblas_param,
-                                   n, k, alpha, A.data(), A.stride_1(), beta, C.data(), C.stride_1());
+                                   n, k, alpha, A.data(), A.stride(1), beta, C.data(), C.stride(1));
       else if (std::is_same<value_type, Kokkos::complex<float>>::value ||
                std::is_same<value_type, Kokkos::complex<double>>::value)
         r_val = Blas<value_type>::herk(handle, ArgUplo::rocblas_param, ArgTrans::rocblas_param, n, k, alpha, A.data(),
-                                       A.stride_1(), beta, C.data(), C.stride_1());
+                                       A.stride(1), beta, C.data(), C.stride(1));
     }
     return r_val;
   }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Herk_Serial.hpp
@@ -37,8 +37,8 @@ template <typename ArgUplo, typename ArgTrans> struct Herk<ArgUplo, ArgTrans, Al
       const ordinal_type n = C.extent(0),
                          k = (std::is_same<ArgTrans, Trans::NoTranspose>::value ? A.extent(1) : A.extent(0));
       if (n > 0 && k > 0) {
-        BlasSerial<value_type>::herk(ArgUplo::param, ArgTrans::param, n, k, value_type(alpha), A.data(), A.stride_1(),
-                                     value_type(beta), C.data(), C.stride_1());
+        BlasSerial<value_type>::herk(ArgUplo::param, ArgTrans::param, n, k, value_type(alpha), A.data(), A.stride(1),
+                                     value_type(beta), C.data(), C.stride(1));
       }
     } else {
       TACHO_TEST_FOR_ABORT(true, ">> This function is only allowed in host space.");

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_External.hpp
@@ -40,7 +40,7 @@ template <> struct LDL<Uplo::Lower, Algo::External> {
       const ordinal_type m = A.extent(0);
       if (m > 0) {
         /// factorize LDL
-        Lapack<value_type>::sytrf('L', m, A.data(), A.stride_1(), P.data(), W.data(), W.extent(0), &r_val);
+        Lapack<value_type>::sytrf('L', m, A.data(), A.stride(1), P.data(), W.data(), W.extent(0), &r_val);
         TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LAPACK (sytrf) returns non-zero error code.");
       }
     } else {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_Internal.hpp
@@ -38,7 +38,7 @@ template <> struct LDL<Uplo::Lower, Algo::Internal> {
     const ordinal_type m = A.extent(0);
     if (m > 0) {
       /// factorize LDL
-      LapackTeam<value_type>::sytrf(member, Uplo::Lower::param, m, A.data(), A.stride_1(), P.data(), W.data(), &r_val);
+      LapackTeam<value_type>::sytrf(member, Uplo::Lower::param, m, A.data(), A.stride(1), P.data(), W.data(), &r_val);
     }
     return r_val;
   }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_OnDevice.hpp
@@ -38,7 +38,7 @@ template <> struct LDL<Uplo::Lower, Algo::OnDevice> {
       int *devInfo = (int *)W.data();
       work_value_type *workspace = W.data() + 1;
       int lwork = (W.span() - 1);
-      r_val = Lapack<value_type>::sytrf(handle, CUBLAS_FILL_MODE_LOWER, m, A.data(), A.stride_1(), P.data(), workspace,
+      r_val = Lapack<value_type>::sytrf(handle, CUBLAS_FILL_MODE_LOWER, m, A.data(), A.stride(1), P.data(), workspace,
                                         lwork, devInfo);
     }
     return r_val;
@@ -51,7 +51,7 @@ template <> struct LDL<Uplo::Lower, Algo::OnDevice> {
 
     int r_val(0);
     if (m > 0)
-      r_val = Lapack<value_type>::sytrf_buffersize(handle, m, A.data(), A.stride_1(), lwork);
+      r_val = Lapack<value_type>::sytrf_buffersize(handle, m, A.data(), A.stride(1), lwork);
     return r_val;
   }
 #endif
@@ -66,7 +66,7 @@ template <> struct LDL<Uplo::Lower, Algo::OnDevice> {
     int r_val(0);
     if (m > 0) {
       int *devInfo = (int *)W.data();
-      r_val = Lapack<value_type>::sytrf(handle, rocblas_fill_lower, m, A.data(), A.stride_1(), P.data(), devInfo);
+      r_val = Lapack<value_type>::sytrf(handle, rocblas_fill_lower, m, A.data(), A.stride(1), P.data(), devInfo);
     }
     return r_val;
   }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_Serial.hpp
@@ -40,7 +40,7 @@ template <> struct LDL<Uplo::Lower, Algo::Serial> {
       const ordinal_type m = A.extent(0);
       if (m > 0) {
         /// factorize LDL
-        Lapack<value_type>::sytrf('L', m, A.data(), A.stride_1(), P.data(), W.data(), W.extent(0), &r_val);
+        Lapack<value_type>::sytrf('L', m, A.data(), A.stride(1), P.data(), W.data(), W.extent(0), &r_val);
         TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LAPACK (sytrf) returns non-zero error code.");
       }
     } else {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_External.hpp
@@ -38,7 +38,7 @@ template <> struct LU<Algo::External> {
       const ordinal_type m = A.extent(0), n = A.extent(1);
       if (m > 0 && n > 0) {
         /// factorize LU
-        Lapack<value_type>::getrf(m, n, A.data(), A.stride_1(), P.data(), &r_val);
+        Lapack<value_type>::getrf(m, n, A.data(), A.stride(1), P.data(), &r_val);
         TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LAPACK (getrf) returns non-zero error code.");
       }
     } else {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_Internal.hpp
@@ -35,7 +35,7 @@ template <> struct LU<Algo::Internal> {
     const ordinal_type m = A.extent(0), n = A.extent(1);
     if (m > 0 && n > 0) {
       /// factorize LU
-      LapackTeam<value_type>::getrf(member, m, n, A.data(), A.stride_1(), P.data(), &r_val);
+      LapackTeam<value_type>::getrf(member, m, n, A.data(), A.stride(1), P.data(), &r_val);
     }
     return r_val;
   }
@@ -53,7 +53,7 @@ template <> struct LU<Algo::Internal> {
     const ordinal_type m = A.extent(0), n = A.extent(1);
     if (m > 0 && n > 0) {
       /// factorize LU
-      LapackTeam<value_type>::getrf(member, tol, m, n, A.data(), A.stride_1(), P.data(), &r_val);
+      LapackTeam<value_type>::getrf(member, tol, m, n, A.data(), A.stride(1), P.data(), &r_val);
     }
     return r_val;
   }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_OnDevice.hpp
@@ -37,7 +37,7 @@ template <> struct LU<Algo::OnDevice> {
       int *devInfo = (int *)W.data();
       value_type *workspace = W.data() + 1;
       // int lwork = (W.span()-1);
-      r_val = Lapack<value_type>::getrf(handle, m, n, A.data(), A.stride_1(), workspace, P.data(), devInfo);
+      r_val = Lapack<value_type>::getrf(handle, m, n, A.data(), A.stride(1), workspace, P.data(), devInfo);
     }
     return r_val;
   }
@@ -49,7 +49,7 @@ template <> struct LU<Algo::OnDevice> {
 
     int r_val(0);
     if (m > 0)
-      r_val = Lapack<value_type>::getrf_buffersize(handle, m, n, A.data(), A.stride_1(), lwork);
+      r_val = Lapack<value_type>::getrf_buffersize(handle, m, n, A.data(), A.stride(1), lwork);
     return r_val;
   }
 #endif
@@ -64,7 +64,7 @@ template <> struct LU<Algo::OnDevice> {
     int r_val(0);
     if (m > 0 && n > 0) {
       int *devInfo = (int *)W.data();
-      r_val = Lapack<value_type>::getrf(handle, m, n, A.data(), A.stride_1(), P.data(), devInfo);
+      r_val = Lapack<value_type>::getrf(handle, m, n, A.data(), A.stride(1), P.data(), devInfo);
     }
     return r_val;
   }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LU_Serial.hpp
@@ -38,7 +38,7 @@ template <> struct LU<Algo::Serial> {
       const ordinal_type m = A.extent(0), n = A.extent(1);
       if (m > 0 && n > 0) {
         /// factorize LU
-        LapackSerial<value_type>::getrf(m, n, A.data(), A.stride_1(), P.data(), &r_val);
+        LapackSerial<value_type>::getrf(m, n, A.data(), A.stride(1), P.data(), &r_val);
         TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LAPACK (getrf) returns non-zero error code.");
       }
     } else {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm_External.hpp
@@ -41,7 +41,7 @@ struct Trsm<ArgSide, ArgUplo, ArgTransA, Algo::External> {
 
       if (m > 0 && n > 0)
         Blas<value_type>::trsm(ArgSide::param, ArgUplo::param, ArgTransA::param, diagA.param, m, n, value_type(alpha),
-                               A.data(), A.stride_1(), B.data(), B.stride_1());
+                               A.data(), A.stride(1), B.data(), B.stride(1));
     } else {
       TACHO_TEST_FOR_ABORT(true, "This function is only allowed in host space.");
     }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm_Internal.hpp
@@ -37,7 +37,7 @@ struct Trsm<ArgSide, ArgUplo, ArgTransA, Algo::Internal> {
 
     if (m > 0 && n > 0)
       BlasTeam<value_type>::trsm(member, ArgSide::param, ArgUplo::param, ArgTransA::param, diagA.param, m, n,
-                                 value_type(alpha), A.data(), A.stride_1(), B.data(), B.stride_1());
+                                 value_type(alpha), A.data(), A.stride(1), B.data(), B.stride(1));
     return 0;
   }
 };

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm_OnDevice.hpp
@@ -28,7 +28,7 @@ struct Trsm<ArgSide, ArgUplo, ArgTransA, Algo::OnDevice> {
 
     if (m > 0 && n > 0)
       Blas<value_type>::trsm(ArgSide::param, ArgUplo::param, ArgTransA::param, diagA.param, m, n, value_type(alpha),
-                             A.data(), A.stride_1(), B.data(), B.stride_1());
+                             A.data(), A.stride(1), B.data(), B.stride(1));
     return 0;
   }
 
@@ -43,7 +43,7 @@ struct Trsm<ArgSide, ArgUplo, ArgTransA, Algo::OnDevice> {
     int r_val(0);
     if (m > 0 && n > 0)
       Blas<value_type>::trsm(handle, ArgSide::cublas_param, ArgUplo::cublas_param, ArgTransA::cublas_param,
-                             diagA.cublas_param, m, n, alpha, A.data(), A.stride_1(), B.data(), B.stride_1());
+                             diagA.cublas_param, m, n, alpha, A.data(), A.stride(1), B.data(), B.stride(1));
     return r_val;
   }
 #endif
@@ -59,7 +59,7 @@ struct Trsm<ArgSide, ArgUplo, ArgTransA, Algo::OnDevice> {
     int r_val(0);
     if (m > 0 && n > 0)
       Blas<value_type>::trsm(handle, ArgSide::rocblas_param, ArgUplo::rocblas_param, ArgTransA::rocblas_param,
-                             diagA.rocblas_param, m, n, alpha, A.data(), A.stride_1(), B.data(), B.stride_1());
+                             diagA.rocblas_param, m, n, alpha, A.data(), A.stride(1), B.data(), B.stride(1));
     return r_val;
   }
 #endif

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsm_Serial.hpp
@@ -41,9 +41,9 @@ struct Trsm<ArgSide, ArgUplo, ArgTransA, Algo::Serial> {
 
       if (m > 0 && n > 0)
         //Blas<value_type>::trsm(ArgSide::param, ArgUplo::param, ArgTransA::param, diagA.param, m, n, value_type(alpha),
-        //                       A.data(), A.stride_1(), B.data(), B.stride_1());
+        //                       A.data(), A.stride(1), B.data(), B.stride(1));
         BlasSerial<value_type>::trsm(ArgSide::param, ArgUplo::param, ArgTransA::param, diagA.param, m, n, value_type(alpha),
-                                     A.data(), A.stride_1(), B.data(), B.stride_1());
+                                     A.data(), A.stride(1), B.data(), B.stride(1));
     } else {
       TACHO_TEST_FOR_ABORT(true, "This function is only allowed in host space.");
     }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv_External.hpp
@@ -38,11 +38,11 @@ template <typename ArgUplo, typename ArgTransA> struct Trsv<ArgUplo, ArgTransA, 
 
       if (m > 0 && n > 0) {
         if (n == 1) {
-          Blas<value_type>::trsv(ArgUplo::param, ArgTransA::param, diagA.param, m, A.data(), A.stride_1(), B.data(),
-                                 B.stride_0());
+          Blas<value_type>::trsv(ArgUplo::param, ArgTransA::param, diagA.param, m, A.data(), A.stride(1), B.data(),
+                                 B.stride(0));
         } else {
           Blas<value_type>::trsm(Side::Left::param, ArgUplo::param, ArgTransA::param, diagA.param, m, n, value_type(1),
-                                 A.data(), A.stride_1(), B.data(), B.stride_1());
+                                 A.data(), A.stride(1), B.data(), B.stride(1));
         }
       }
     } else {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv_Internal.hpp
@@ -36,11 +36,11 @@ template <typename ArgUplo, typename ArgTransA> struct Trsv<ArgUplo, ArgTransA, 
 
     if (m > 0 && n > 0) {
       if (n == 1) {
-        BlasTeam<value_type>::trsv(member, ArgUplo::param, ArgTransA::param, diagA.param, m, A.data(), A.stride_1(),
-                                   B.data(), B.stride_0());
+        BlasTeam<value_type>::trsv(member, ArgUplo::param, ArgTransA::param, diagA.param, m, A.data(), A.stride(1),
+                                   B.data(), B.stride(0));
       } else {
         BlasTeam<value_type>::trsm(member, Side::Left::param, ArgUplo::param, ArgTransA::param, diagA.param, m, n,
-                                   value_type(1), A.data(), A.stride_1(), B.data(), B.stride_1());
+                                   value_type(1), A.data(), A.stride(1), B.data(), B.stride(1));
       }
     }
     return 0;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv_OnDevice.hpp
@@ -26,11 +26,11 @@ template <typename ArgUplo, typename ArgTransA> struct Trsv<ArgUplo, ArgTransA, 
     const ordinal_type m = B.extent(0), n = B.extent(1);
     if (m > 0 && n > 0) {
       if (n == 1) {
-        Blas<value_type>::trsv(ArgUplo::param, ArgTransA::param, diagA.param, m, A.data(), A.stride_1(), B.data(),
-                               B.stride_0());
+        Blas<value_type>::trsv(ArgUplo::param, ArgTransA::param, diagA.param, m, A.data(), A.stride(1), B.data(),
+                               B.stride(0));
       } else {
         Blas<value_type>::trsm(Side::Left::param, ArgUplo::param, ArgTransA::param, diagA.param, m, n, value_type(1),
-                               A.data(), A.stride_1(), B.data(), B.stride_1());
+                               A.data(), A.stride(1), B.data(), B.stride(1));
       }
     }
     return 0;
@@ -46,11 +46,11 @@ template <typename ArgUplo, typename ArgTransA> struct Trsv<ArgUplo, ArgTransA, 
     if (m > 0 && n > 0) {
       if (n == 1) {
         r_val = Blas<value_type>::trsv(handle, ArgUplo::cublas_param, ArgTransA::cublas_param, diagA.cublas_param, m,
-                                       A.data(), A.stride_1(), B.data(), B.stride_0());
+                                       A.data(), A.stride(1), B.data(), B.stride(0));
       } else {
         r_val = Blas<value_type>::trsm(handle, Side::Left::cublas_param, ArgUplo::cublas_param, ArgTransA::cublas_param,
-                                       diagA.cublas_param, m, n, value_type(1), A.data(), A.stride_1(), B.data(),
-                                       B.stride_1());
+                                       diagA.cublas_param, m, n, value_type(1), A.data(), A.stride(1), B.data(),
+                                       B.stride(1));
       }
     }
     return r_val;
@@ -67,11 +67,11 @@ template <typename ArgUplo, typename ArgTransA> struct Trsv<ArgUplo, ArgTransA, 
     if (m > 0 && n > 0) {
       if (n == 1) {
         r_val = Blas<value_type>::trsv(handle, ArgUplo::rocblas_param, ArgTransA::rocblas_param, diagA.rocblas_param, m,
-                                       A.data(), A.stride_1(), B.data(), B.stride_0());
+                                       A.data(), A.stride(1), B.data(), B.stride(0));
       } else {
         r_val = Blas<value_type>::trsm(handle, Side::Left::rocblas_param, ArgUplo::rocblas_param,
                                        ArgTransA::rocblas_param, diagA.rocblas_param, m, n, value_type(1), A.data(),
-                                       A.stride_1(), B.data(), B.stride_1());
+                                       A.stride(1), B.data(), B.stride(1));
       }
     }
     return r_val;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Trsv_Serial.hpp
@@ -38,11 +38,11 @@ template <typename ArgUplo, typename ArgTransA> struct Trsv<ArgUplo, ArgTransA, 
 
       if (m > 0 && n > 0) {
         //if (n == 1) {
-        //  Blas<value_type>::trsv(ArgUplo::param, ArgTransA::param, diagA.param, m, A.data(), A.stride_1(), B.data(),
-        //                         B.stride_0());
+        //  Blas<value_type>::trsv(ArgUplo::param, ArgTransA::param, diagA.param, m, A.data(), A.stride(1), B.data(),
+        //                         B.stride(0));
         //} else {
           BlasSerial<value_type>::trsm(Side::Left::param, ArgUplo::param, ArgTransA::param, diagA.param, m, n, value_type(1),
-                                       A.data(), A.stride_1(), B.data(), B.stride_1());
+                                       A.data(), A.stride(1), B.data(), B.stride(1));
         //}
       }
     } else {

--- a/packages/shylu/shylu_node/tacho/unit-test/Tacho_TestDenseLinearAlgebra.hpp
+++ b/packages/shylu/shylu_node/tacho/unit-test/Tacho_TestDenseLinearAlgebra.hpp
@@ -43,9 +43,9 @@ struct Functor_TeamGemm {
 
   template <typename MemberType> KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
     ::BlasTeam<value_type>::gemm(member, _transa, _transb, _m, _n, _k, _alpha, (const value_type *)_A.view_device().data(),
-                                 (int)_A.view_device().stride_1(), (const value_type *)_B.view_device().data(),
-                                 (int)_B.view_device().stride_1(), _beta, (value_type *)_C.view_device().data(),
-                                 (int)_C.view_device().stride_1());
+                                 (int)_A.view_device().stride(1), (const value_type *)_B.view_device().data(),
+                                 (int)_B.view_device().stride(1), _beta, (value_type *)_C.view_device().data(),
+                                 (int)_C.view_device().stride(1));
   }
 
   inline void run() {
@@ -91,8 +91,8 @@ TEST(DenseLinearAlgebra, team_gemm_nn) {
   test.run();
 
   // reference test
-  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride_1(), B2.view_host().data(),
-                         B2.view_host().stride_1(), beta, C2.view_host().data(), C2.view_host().stride_1());
+  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride(1), B2.view_host().data(),
+                         B2.view_host().stride(1), beta, C2.view_host().data(), C2.view_host().stride(1));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < m; ++i)
@@ -129,8 +129,8 @@ TEST(DenseLinearAlgebra, team_gemm_nt) {
   test.run();
 
   // reference test
-  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride_1(), B2.view_host().data(),
-                         B2.view_host().stride_1(), beta, C2.view_host().data(), C2.view_host().stride_1());
+  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride(1), B2.view_host().data(),
+                         B2.view_host().stride(1), beta, C2.view_host().data(), C2.view_host().stride(1));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < m; ++i)
@@ -160,8 +160,8 @@ TEST(DenseLinearAlgebra, team_gemm_nc) {
   ::Test::Functor_TeamGemm test(transa, transb, m, n, k, alpha, A1, B1, beta, C1);
   test.run();
 
-  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride_1(), B2.view_host().data(),
-                         B2.view_host().stride_1(), beta, C2.view_host().data(), C2.view_host().stride_1());
+  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride(1), B2.view_host().data(),
+                         B2.view_host().stride(1), beta, C2.view_host().data(), C2.view_host().stride(1));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < m; ++i)
@@ -191,8 +191,8 @@ TEST(DenseLinearAlgebra, team_gemm_tn) {
   ::Test::Functor_TeamGemm test(transa, transb, m, n, k, alpha, A1, B1, beta, C1);
   test.run();
 
-  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride_1(), B2.view_host().data(),
-                         B2.view_host().stride_1(), beta, C2.view_host().data(), C2.view_host().stride_1());
+  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride(1), B2.view_host().data(),
+                         B2.view_host().stride(1), beta, C2.view_host().data(), C2.view_host().stride(1));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < m; ++i)
@@ -226,8 +226,8 @@ TEST(DenseLinearAlgebra, team_gemm_tt) {
   ::Test::Functor_TeamGemm test(transa, transb, m, n, k, alpha, A1, B1, beta, C1);
   test.run();
 
-  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride_1(), B2.view_host().data(),
-                         B2.view_host().stride_1(), beta, C2.view_host().data(), C2.view_host().stride_1());
+  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride(1), B2.view_host().data(),
+                         B2.view_host().stride(1), beta, C2.view_host().data(), C2.view_host().stride(1));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < m; ++i)
@@ -261,8 +261,8 @@ TEST(DenseLinearAlgebra, team_gemm_tc) {
   ::Test::Functor_TeamGemm test(transa, transb, m, n, k, alpha, A1, B1, beta, C1);
   test.run();
 
-  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride_1(), B2.view_host().data(),
-                         B2.view_host().stride_1(), beta, C2.view_host().data(), C2.view_host().stride_1());
+  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride(1), B2.view_host().data(),
+                         B2.view_host().stride(1), beta, C2.view_host().data(), C2.view_host().stride(1));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < m; ++i)
@@ -296,8 +296,8 @@ TEST(DenseLinearAlgebra, team_gemm_cn) {
   ::Test::Functor_TeamGemm test(transa, transb, m, n, k, alpha, A1, B1, beta, C1);
   test.run();
 
-  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride_1(), B2.view_host().data(),
-                         B2.view_host().stride_1(), beta, C2.view_host().data(), C2.view_host().stride_1());
+  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride(1), B2.view_host().data(),
+                         B2.view_host().stride(1), beta, C2.view_host().data(), C2.view_host().stride(1));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < m; ++i)
@@ -331,8 +331,8 @@ TEST(DenseLinearAlgebra, team_gemm_ct) {
   ::Test::Functor_TeamGemm test(transa, transb, m, n, k, alpha, A1, B1, beta, C1);
   test.run();
 
-  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride_1(), B2.view_host().data(),
-                         B2.view_host().stride_1(), beta, C2.view_host().data(), C2.view_host().stride_1());
+  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride(1), B2.view_host().data(),
+                         B2.view_host().stride(1), beta, C2.view_host().data(), C2.view_host().stride(1));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < m; ++i)
@@ -366,8 +366,8 @@ TEST(DenseLinearAlgebra, team_gemm_cc) {
   ::Test::Functor_TeamGemm test(transa, transb, m, n, k, alpha, A1, B1, beta, C1);
   test.run();
 
-  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride_1(), B2.view_host().data(),
-                         B2.view_host().stride_1(), beta, C2.view_host().data(), C2.view_host().stride_1());
+  Blas<value_type>::gemm(transa, transb, m, n, k, alpha, A2.view_host().data(), A2.view_host().stride(1), B2.view_host().data(),
+                         B2.view_host().stride(1), beta, C2.view_host().data(), C2.view_host().stride(1));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < m; ++i)
@@ -388,9 +388,9 @@ struct Functor_TeamGemv {
 
   template <typename MemberType> KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
     ::BlasTeam<value_type>::gemv(member, _trans, _m, _n, _alpha, (const value_type *)_A.view_device().data(),
-                                 (int)_A.view_device().stride_1(), (const value_type *)_x.view_device().data(),
-                                 (int)_x.view_device().stride_0(), _beta, (value_type *)_y.view_device().data(),
-                                 (int)_y.view_device().stride_0());
+                                 (int)_A.view_device().stride(1), (const value_type *)_x.view_device().data(),
+                                 (int)_x.view_device().stride(0), _beta, (value_type *)_y.view_device().data(),
+                                 (int)_y.view_device().stride(0));
   }
 
   inline void run() {
@@ -433,8 +433,8 @@ TEST(DenseLinearAlgebra, team_gemv_n) {
   ::Test::Functor_TeamGemv test(trans, m, n, alpha, A1, x1, beta, y1);
   test.run();
 
-  Blas<value_type>::gemv(trans, m, n, alpha, A2.view_host().data(), A2.view_host().stride_1(), x2.view_host().data(),
-                         x2.view_host().stride_0(), beta, y2.view_host().data(), y2.view_host().stride_0());
+  Blas<value_type>::gemv(trans, m, n, alpha, A2.view_host().data(), A2.view_host().stride(1), x2.view_host().data(),
+                         x2.view_host().stride(0), beta, y2.view_host().data(), y2.view_host().stride(0));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < m; ++i)
@@ -467,8 +467,8 @@ TEST(DenseLinearAlgebra, team_gemv_t) {
   ::Test::Functor_TeamGemv test(trans, m, n, alpha, A1, x1, beta, y1);
   test.run();
 
-  Blas<value_type>::gemv(trans, m, n, alpha, A2.view_host().data(), A2.view_host().stride_1(), x2.view_host().data(),
-                         x2.view_host().stride_0(), beta, y2.view_host().data(), y2.view_host().stride_0());
+  Blas<value_type>::gemv(trans, m, n, alpha, A2.view_host().data(), A2.view_host().stride(1), x2.view_host().data(),
+                         x2.view_host().stride(0), beta, y2.view_host().data(), y2.view_host().stride(0));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < n; ++i)
@@ -501,8 +501,8 @@ TEST(DenseLinearAlgebra, team_gemv_c) {
   ::Test::Functor_TeamGemv test(trans, m, n, alpha, A1, x1, beta, y1);
   test.run();
 
-  Blas<value_type>::gemv(trans, m, n, alpha, A2.view_host().data(), A2.view_host().stride_1(), x2.view_host().data(),
-                         x2.view_host().stride_0(), beta, y2.view_host().data(), y2.view_host().stride_0());
+  Blas<value_type>::gemv(trans, m, n, alpha, A2.view_host().data(), A2.view_host().stride(1), x2.view_host().data(),
+                         x2.view_host().stride(0), beta, y2.view_host().data(), y2.view_host().stride(0));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < n; ++i)
@@ -522,8 +522,8 @@ struct Functor_TeamHerk {
 
   template <typename MemberType> KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
     ::BlasTeam<value_type>::herk(member, _uplo, _trans, _n, _k, _alpha, (const value_type *)_A.view_device().data(),
-                                 (int)_A.view_device().stride_1(), _beta, (value_type *)_C.view_device().data(),
-                                 (int)_C.view_device().stride_1());
+                                 (int)_A.view_device().stride(1), _beta, (value_type *)_C.view_device().data(),
+                                 (int)_C.view_device().stride(1));
   }
 
   inline void run() {
@@ -563,8 +563,8 @@ TEST(DenseLinearAlgebra, team_herk_un) {
   ::Test::Functor_TeamHerk test(uplo, trans, n, k, alpha, A1, beta, C1);
   test.run();
 
-  Blas<value_type>::herk(uplo, trans, n, k, alpha, A2.view_host().data(), A2.view_host().stride_1(), beta, C2.view_host().data(),
-                         C2.view_host().stride_1());
+  Blas<value_type>::herk(uplo, trans, n, k, alpha, A2.view_host().data(), A2.view_host().stride(1), beta, C2.view_host().data(),
+                         C2.view_host().stride(1));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < n; ++i)
@@ -596,8 +596,8 @@ TEST(DenseLinearAlgebra, team_herk_uc) {
   ::Test::Functor_TeamHerk test(uplo, trans, n, k, alpha, A1, beta, C1);
   test.run();
 
-  Blas<value_type>::herk(uplo, trans, n, k, alpha, A2.view_host().data(), A2.view_host().stride_1(), beta, C2.view_host().data(),
-                         C2.view_host().stride_1());
+  Blas<value_type>::herk(uplo, trans, n, k, alpha, A2.view_host().data(), A2.view_host().stride(1), beta, C2.view_host().data(),
+                         C2.view_host().stride(1));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < n; ++i)
@@ -629,8 +629,8 @@ TEST(DenseLinearAlgebra, team_herk_ln) {
   ::Test::Functor_TeamHerk test(uplo, trans, n, k, alpha, A1, beta, C1);
   test.run();
 
-  Blas<value_type>::herk(uplo, trans, n, k, alpha, A2.view_host().data(), A2.view_host().stride_1(), beta, C2.view_host().data(),
-                         C2.view_host().stride_1());
+  Blas<value_type>::herk(uplo, trans, n, k, alpha, A2.view_host().data(), A2.view_host().stride(1), beta, C2.view_host().data(),
+                         C2.view_host().stride(1));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < n; ++i)
@@ -662,8 +662,8 @@ TEST(DenseLinearAlgebra, team_herk_lc) {
   ::Test::Functor_TeamHerk test(uplo, trans, n, k, alpha, A1, beta, C1);
   test.run();
 
-  Blas<value_type>::herk(uplo, trans, n, k, alpha, A2.view_host().data(), A2.view_host().stride_1(), beta, C2.view_host().data(),
-                         C2.view_host().stride_1());
+  Blas<value_type>::herk(uplo, trans, n, k, alpha, A2.view_host().data(), A2.view_host().stride(1), beta, C2.view_host().data(),
+                         C2.view_host().stride(1));
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < n; ++i)
@@ -683,7 +683,7 @@ struct Functor_TeamTrsv {
 
   template <typename MemberType> KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
     ::BlasTeam<value_type>::trsv(member, _uplo, _trans, _diag, _m, (const value_type *)_A.view_device().data(),
-                                 (int)_A.view_device().stride_1(), (value_type *)_b.view_device().data(), (int)_b.view_device().stride_0());
+                                 (int)_A.view_device().stride(1), (value_type *)_b.view_device().data(), (int)_b.view_device().stride(0));
   }
 
   inline void run() {
@@ -718,8 +718,8 @@ struct Functor_TeamTrsv {
     ::Test::Functor_TeamTrsv test(uplo, trans, diag, m, A1, b1);                                                       \
     test.run();                                                                                                        \
                                                                                                                        \
-    Blas<value_type>::trsv(uplo, trans, diag, m, A2.view_host().data(), A2.view_host().stride_1(), b2.view_host().data(),             \
-                           b2.view_host().stride_0());                                                                      \
+    Blas<value_type>::trsv(uplo, trans, diag, m, A2.view_host().data(), A2.view_host().stride(1), b2.view_host().data(),             \
+                           b2.view_host().stride(0));                                                                      \
                                                                                                                        \
     const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 10000;                                 \
     for (int i = 0; i < m; ++i)                                                                                        \
@@ -860,8 +860,8 @@ struct Functor_TeamTrsm {
 
   template <typename MemberType> KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
     ::BlasTeam<value_type>::trsm(member, _side, _uplo, _trans, _diag, _m, _n, _alpha,
-                                 (const value_type *)_A.view_device().data(), (int)_A.view_device().stride_1(),
-                                 (value_type *)_B.view_device().data(), (int)_B.view_device().stride_1());
+                                 (const value_type *)_A.view_device().data(), (int)_A.view_device().stride(1),
+                                 (value_type *)_B.view_device().data(), (int)_B.view_device().stride(1));
   }
 
   inline void run() {
@@ -896,8 +896,8 @@ struct Functor_TeamTrsm {
     ::Test::Functor_TeamTrsm test(side, uplo, trans, diag, m, n, alpha, A1, B1);                                       \
     test.run();                                                                                                        \
                                                                                                                        \
-    Blas<value_type>::trsm(side, uplo, trans, diag, m, n, alpha, A2.view_host().data(), A2.view_host().stride_1(),               \
-                           B2.view_host().data(), B2.view_host().stride_1());                                                    \
+    Blas<value_type>::trsm(side, uplo, trans, diag, m, n, alpha, A2.view_host().data(), A2.view_host().stride(1),               \
+                           B2.view_host().data(), B2.view_host().stride(1));                                                    \
                                                                                                                        \
     const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 100000;                                \
     for (int i = 0; i < m; ++i)                                                                                        \
@@ -1060,7 +1060,7 @@ struct Functor_TeamChol {
 
   template <typename MemberType> KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
     int r_val = 0;
-    ::LapackTeam<value_type>::potrf(member, _uplo, _m, (value_type *)_A.view_device().data(), (int)_A.view_device().stride_1(),
+    ::LapackTeam<value_type>::potrf(member, _uplo, _m, (value_type *)_A.view_device().data(), (int)_A.view_device().stride(1),
                                     &r_val);
   }
 
@@ -1099,7 +1099,7 @@ TEST(DenseLinearAlgebra, team_chol_u) {
   test.run();
 
   int r_val = 0;
-  Lapack<value_type>::potrf(uplo, m, (value_type *)A2.view_host().data(), (int)A2.view_host().stride_1(), &r_val);
+  Lapack<value_type>::potrf(uplo, m, (value_type *)A2.view_host().data(), (int)A2.view_host().stride(1), &r_val);
 
   const magnitude_type eps = std::numeric_limits<magnitude_type>::epsilon() * 1000;
   for (int i = 0; i < m; ++i)


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 
@trilinos/shylu 
@trilinos/sacado 
@trilinos/intrepid2 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Compatibility updated needed with kokkos@develop (version >= 4.7.99) in order to compile with disable of KOKKOS_ENABLE_DEPRECATED_CODE_4

These changes replace`v.stride_N()` -> `v.stride(N)`
    
See https://github.com/kokkos/kokkos/pull/8109

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Testing these changes with `KOKKOS_ENABLE_DEPRECATED_CODE_4=OFF` also requires updates to deprecated `HostMirror` , handled in a separate PR
* I confirmed these changes do not cause conflict with the WIP PR https://github.com/trilinos/Trilinos/pull/14306

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing

AT will test `KOKKOS_ENABLE_DEPRECATED_CODE_4=ON` case

I manually tested this PR, along with HostMirror updates (separate PR) with kokkos@develop (version 4.7.99) and `KOKKOS_ENABLE_DEPRECATED_CODE_4=OFF` on the Weaver testbed with gcc/11.3.0 and the OpenMP and Serial backends enabled:

```bash
source /etc/profile.d/modules.sh

export TRILINOS_DIR=<path-to...>

module purge
module load git cmake/3.25.1 gcc/11.3.0 openblas/0.3.23
module load boost/1.80.0 zlib/1.3.1 metis/5.1.0
module load openmpi/4.1.6 hdf5/1.14.3 netcdf-c/4.9.2 parallel-netcdf/1.12.3

export CONFIG_HDF5_LIBS="-L${HDF5_ROOT}/lib;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
export CONFIG_NETCDF_ONLY_LIBS="-L${NETCDF_C_ROOT}/lib;${NETCDF_C_ROOT}/lib/libnetcdf.a;${CONFIG_HDF5_LIBS}" \
export NETCDF_ROOT=${NETCDF_C_ROOT}
export PNETCDF_ROOT=${PARALLEL_NETCDF_ROOT}
export CONFIG_NETCDF_ALL_LIBS="-L${NETCDF_C_ROOT}/lib;${NETCDF_C_ROOT}/lib/libnetcdf.a;${PNETCDF_ROOT}/lib/libpnetcdf.a;${CONFIG_HDF5_LIBS}"

cmake \
\
-B build-dep-off \
-D CMAKE_INSTALL_PREFIX:PATH="$PWD/install" \
-D CMAKE_CXX_FLAGS:STRING="-g" \
-D CMAKE_BUILD_TYPE:STRING=RELEASE \
-D BUILD_SHARED_LIBS:BOOL=OFF \
-D Trilinos_VERBOSE_CONFIGURE:BOOL=OFF \
\
-D TPL_ENABLE_MPI:BOOL=ON \
  -D CMAKE_CXX_COMPILER:FILEPATH="`which mpicxx`" \
  -D CMAKE_C_COMPILER:FILEPATH="`which mpicc`" \
  -D CMAKE_Fortran_COMPILER:FILEPATH="`which mpifort`" \
  -D CMAKE_CXX_FLAGS="-Wno-cpp" \
\
-D TPL_ENABLE_METIS:BOOL=ON \
  -D METIS_INCLUDE_DIRS:PATH="${METIS_ROOT}/include" \
  -D METIS_LIBRARY_DIRS:PATH="${METIS_ROOT}/lib" \
  -D METIS_LIBRARY_NAMES:STRING="metis" \
\
-D TPL_ENABLE_BLAS=ON \
 -D TPL_BLAS_LIBRARIES="-L${OPENBLAS_ROOT}/lib;-lopenblas" \
-D TPL_ENABLE_LAPACK=ON \
 -D TPL_LAPACK_LIBRARIES="-L${OPENBLAS_ROOT}/lib;-lopenblas" \
-D TPL_ENABLE_Boost=ON \
 -D TPL_Boost_INCLUDE_DIRS="${BOOST_ROOT}/include" \
 -D TPL_Boost_LIBRARIES="${BOOST_ROOT}/lib/libboost_program_options.a;${BOOST_ROOT}/lib/libboost_system.a" \
-D TPL_ENABLE_BoostLib=ON \
 -D TPL_BoostLib_INCLUDE_DIRS="${BOOST_ROOT}/include" \
 -D TPL_BoostLib_LIBRARIES="${BOOST_ROOT}/lib/libboost_program_options.a;${BOOST_ROOT}/lib/libboost_system.a" \
-D TPL_ENABLE_HDF5=ON \
 -D TPL_HDF5_LIBRARIES="${CONFIG_HDF5_LIBS}" \
-D TPL_ENABLE_Netcdf=ON \
-D TPL_Netcdf_PARALLEL=ON \
 -D TPL_Netcdf_INCLUDE_DIRS="${NETCDF_C_ROOT}/include" \
 -D TPL_Netcdf_LIBRARIES="${CONFIG_NETCDF_ALL_LIBS}" \
\
-D TPL_ENABLE_ParMETIS:BOOL=OFF \
-D TPL_ENABLE_Scotch:BOOL=OFF \
-D TPL_ENABLE_SuperLU:BOOL=OFF \
-D TPL_ENABLE_gtest:BOOL=OFF \
\
-D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
-D Trilinos_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_COMPLEX_DOUBLE:BOOL=ON \
-D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
-D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
-D Trilinos_ENABLE_Gtest:BOOL=ON \
\
-D Trilinos_ENABLE_OpenMP:BOOL=ON \
-D Trilinos_ENABLE_Kokkos:BOOL=ON \
  -D Kokkos_ENABLE_OPENMP:BOOL=ON \
  -D Kokkos_ENABLE_SERIAL:BOOL=ON \
  -D Kokkos_ENABLE_EXAMPLES:BOOL=OFF \
  -D Kokkos_ENABLE_TESTS:BOOL=OFF \
  -D Kokkos_ARCH_POWER9=ON \
  -D Kokkos_ENABLE_DEPRECATED_CODE_4:BOOL=OFF \
  -D KokkosKernels_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_Epetra:BOOL=OFF \
-D Trilinos_ENABLE_Xpetra:BOOL=ON \
-D Trilinos_ENABLE_Tpetra:BOOL=ON \
  -D Tpetra_INST_INT_INT:BOOL=ON \
  -D Tpetra_INST_SERIAL:BOOL=ON \
  -D Tpetra_INST_OPENMP:BOOL=ON \
  -D Tpetra_ENABLE_EXAMPLES:BOOL=ON \
  -D Tpetra_ENABLE_TESTS:BOOL=ON \
-D Trilinos_ENABLE_Teuchos:BOOL=ON \
-D Trilinos_ENABLE_Amesos2:BOOL=ON \
  -D Amesos2_ENABLE_EXAMPLES:BOOL=OFF \
  -D Amesos2_ENABLE_TESTS:BOOL=ON \
  -D Amesos2_ENABLE_KLU2:BOOL=ON \
  -D Amesos2_ENABLE_Basker:BOOL=OFF \
  -D Amesos2_ENABLE_ShyLU_NodeBasker:BOOL=ON \
  -D Amesos2_ENABLE_ShyLU_NodeTacho:BOOL=ON \
-D Trilinos_ENABLE_Ifpack2:BOOL=ON \
-D Trilinos_ENABLE_Ifpack2:BOOL=ON \
  -D Ifpack2_ENABLE_TESTS:BOOL=ON \
-D Trilinos_ENABLE_MueLu:BOOL=ON \
  -D MueLu_ENABLE_TESTS:BOOL=ON \
  -D MueLu_ENABLE_EXAMPLES:BOOL=OFF \
-D Trilinos_ENABLE_Sacado:BOOL=ON \
  -D Sacado_ENABLE_TESTS:BOOL=ON \
-D Trilinos_ENABLE_Belos:BOOL=ON \
  -D Belos_ENABLE_TESTS:BOOL=ON \
-D Trilinos_ENABLE_Intrepid2:BOOL=ON \
  -D Intrepid2_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_Panzer:BOOL=ON \
  -D Panzer_ENABLE_TESTS:BOOL=ON \
-D Trilinos_ENABLE_Stokhos:BOOL=ON \
  -D Stokhos_ENABLE_TESTS:BOOL=ON \
-D Trilinos_ENABLE_Phalanx:BOOL=ON \
  -D Phalanx_ENABLE_TESTS:BOOL=ON \
-D Trilinos_ENABLE_Zoltan2:BOOL=ON \
  -D Zoltan2_ENABLE_TESTS:BOOL=ON \
-D Trilinos_ENABLE_TrilinosCouplings:BOOL=ON \
  -D TrilinosCouplings_ENABLE_TESTS:BOOL=ON \
-D Trilinos_ENABLE_Compadre:BOOL=ON \
  -D Compadre_ENABLE_TESTS:BOOL=ON \
-D Trilinos_ENABLE_Adelus:BOOL=ON \
  -D Adelus_ENABLE_TESTS:BOOL=ON \
\
 -D Kokkos_ENABLE_IMPL_VIEW_LEGACY=ON \
 -D Kokkos_SOURCE_DIR_OVERRIDE:STRING=kokkos \
 -D KokkosKernels_SOURCE_DIR_OVERRIDE:STRING=kokkos-kernels \
\
${TRILINOS_DIR}

```

<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
