### PR TITLE
MueLu: Add option to use max levels for 'multigrid algorithm: combine'

### DIFF
--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -1443,6 +1443,15 @@ Only used when tentative: calculate qr is set to false.</description>
     </parameter>
 
     <parameter>
+      <name>combine: useMaxLevels</name>
+      <type>bool</type>
+      <default>false</default>
+      <description> Used with multigrid algorithm 'combine'. When 'true', use the maximum number of levels across all sub-block hierarchies. </description>
+      <visible>false</visible>
+      <name-ML>not supported by ML</name-ML>
+    </parameter>
+
+    <parameter>
       <name>interp: build coarse coordinates</name>
       <type>bool</type>
       <default>true</default>

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -321,6 +321,8 @@ Only used when tentative: calculate qr is set to false.}
         
 \cbb{combine: numBlks}{int}{1}{ Used with multigrid algorithm 'combine' to combine multiple sub-block prolongators into one  for PDE systems (numBlks x numBlks). }
         
+\cbb{combine: useMaxLevels}{bool}{false}{ Used with multigrid algorithm 'combine'. When 'true', use the maximum number of levels across all sub-block hierarchies. }
+        
 \cbb{interp: build coarse coordinates}{bool}{true}{If false, skip the calculation of coarse coordinates.}
         
 \cba{transfer: params}{\parameterlist}{Sublist of options for use by transfer.}

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -2213,6 +2213,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
   ParameterList Pparams;
   MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "combine: numBlks", int, Pparams);
+  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "combine: useMaxLevels", bool, Pparams);
 
   P->SetParameterList(Pparams);
   manager.SetFactory("P", P);

--- a/packages/muelu/src/MueCentral/MueLu_HierarchyUtils_decl.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_HierarchyUtils_decl.hpp
@@ -91,6 +91,7 @@ class HierarchyUtils {
   @param nonSerialList Parameter list containing non-serializable data
   */
   static void AddNonSerializableDataToHierarchy(HierarchyManager& HM, Hierarchy& H, const ParameterList& nonSerialList);
+  static void CopyBetweenLevels(Level& fromLevel, Level& toLevel, const std::string fromLabel, const std::string toLabel, const std::string dataType);
   static void CopyBetweenHierarchies(Hierarchy& fromHierarchy, Hierarchy& toHierarchy, const std::string fromLabel, const std::string toLabel, const std::string dataType);
 };
 

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -101,6 +101,7 @@ namespace MueLu {
     if (name == "sa: rowsumabs replace single entry row with zero") { ss << "<Parameter name=\"sa: rowsumabs replace single entry row with zero\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
     if (name == "replicate: npdes") { ss << "<Parameter name=\"replicate: npdes\" type=\"int\" value=" << value << "/>"; return ss.str(); }      
     if (name == "combine: numBlks") { ss << "<Parameter name=\"combine: numBlks\" type=\"int\" value=" << value << "/>"; return ss.str(); }      
+    if (name == "combine: useMaxLevels") { ss << "<Parameter name=\"combine: useMaxLevels\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
     if (name == "pcoarsen: element") { ss << "<Parameter name=\"pcoarsen: element\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
     if (name == "pcoarsen: schedule") { ss << "<Parameter name=\"pcoarsen: schedule\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
     if (name == "pcoarsen: hi basis") { ss << "<Parameter name=\"pcoarsen: hi basis\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
@@ -280,6 +281,7 @@ namespace MueLu {
   "<Parameter name=\"sa: rowsumabs replace single entry row with zero\" type=\"bool\" value=\"true\"/>"
   "<Parameter name=\"replicate: npdes\" type=\"int\" value=\"1\"/>"
   "<Parameter name=\"combine: numBlks\" type=\"int\" value=\"1\"/>"
+  "<Parameter name=\"combine: useMaxLevels\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"interp: build coarse coordinates\" type=\"bool\" value=\"true\"/>"
   "<ParameterList name=\"transfer: params\"/>"
   "<Parameter name=\"pcoarsen: element\" type=\"string\" value=\"\"/>"
@@ -835,6 +837,8 @@ namespace MueLu {
          ("not supported by ML","replicate: npdes")
       
          ("not supported by ML","combine: numBlks")
+      
+         ("not supported by ML","combine: useMaxLevels")
       
          ("interp: build coarse coordinates","interp: build coarse coordinates")
       

--- a/packages/muelu/src/Transfers/Generic/MueLu_CombinePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_CombinePFactory_def.hpp
@@ -39,6 +39,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RCP<const ParameterList> CombinePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
   validParamList->setEntry("combine: numBlks", ParameterEntry(1));
+  validParamList->setEntry("combine: useMaxLevels", ParameterEntry(false));
   validParamList->set<RCP<const FactoryBase>>("A", Teuchos::null, "Generating factory of the matrix A");
 
   return validParamList;
@@ -56,6 +57,40 @@ void CombinePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level& fi
   return BuildP(fineLevel, coarseLevel);
 }
 
+namespace {
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+Teuchos::RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
+constructIdentityProlongator(const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& map) {
+  using local_matrix_type = typename Xpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::local_matrix_type;
+  using local_graph_type  = typename Xpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::local_graph_type;
+  using row_map_type      = typename local_matrix_type::row_map_type::non_const_type;
+  using entries_type      = typename local_graph_type::entries_type::non_const_type;
+  using values_type       = typename local_matrix_type::values_type;
+
+  auto numLocal = map->getLocalNumElements();
+  row_map_type rowptr("rowptr", numLocal + 1);
+  entries_type colind("colind", numLocal);
+  values_type values("values", numLocal);
+
+  Kokkos::parallel_for(
+      "Setup CRS values for identity prolongator",
+      Kokkos::RangePolicy<LocalOrdinal, typename Node::execution_space>(0, numLocal),
+      KOKKOS_LAMBDA(const LocalOrdinal index) {
+        rowptr(index) = index;
+        colind(index) = index;
+        values(index) = Scalar(1.0);
+        if (index == (numLocal - 1)) {
+          rowptr(numLocal) = numLocal;
+        }
+      });
+
+  auto eye = Xpetra::CrsMatrixFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(map, map, 0);
+  eye->setAllValues(rowptr, colind, values);
+  eye->expertStaticFillComplete(map, map);
+  return Teuchos::make_rcp<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(eye);
+}
+}  // namespace
+
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void CombinePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& fineLevel,
                                                                         Level& coarseLevel) const {
@@ -63,6 +98,7 @@ void CombinePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& f
 
   const ParameterList& pL = GetParameterList();
   const LO nBlks          = as<LO>(pL.get<int>("combine: numBlks"));
+  const bool useMaxLevels = pL.get<bool>("combine: useMaxLevels");
 
   RCP<Matrix> A = Get<RCP<Matrix>>(fineLevel, "A");
 
@@ -80,35 +116,68 @@ void CombinePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& f
   Teuchos::ArrayRCP<size_t> ColMapRemoteSizePerBlk(nBlks);
   Teuchos::ArrayRCP<size_t> ColMapLocalCumulativePerBlk(nBlks + 1);   // hardwire 0th entry so that it has the value of 0
   Teuchos::ArrayRCP<size_t> ColMapRemoteCumulativePerBlk(nBlks + 1);  // hardwire 0th entry so that it has the value of 0
+
+  bool anyCoarseGridsRemaining = false;
+
+  if (useMaxLevels) {
+    for (int j = 0; j < nBlks; j++) {
+      std::string blockName = "Psubblock" + Teuchos::toString(j);
+      anyCoarseGridsRemaining |= coarseLevel.IsAvailable(blockName, NoFactory::get());
+    };
+
+    int localAnyCoarseGridsRemaining  = anyCoarseGridsRemaining;
+    int globalAnyCoarseGridsRemaining = localAnyCoarseGridsRemaining;
+    Teuchos::reduceAll(*A->getDomainMap()->getComm(), Teuchos::REDUCE_MAX, localAnyCoarseGridsRemaining, Teuchos::ptr(&globalAnyCoarseGridsRemaining));
+
+    anyCoarseGridsRemaining |= globalAnyCoarseGridsRemaining > 0;
+  }
+
+  auto setSubblockProlongator = [&](RCP<Matrix> Psubblock, int j) {
+    arrayOfMatrices[j] = Psubblock;
+    nComboRowMap += Teuchos::as<size_t>((arrayOfMatrices[j])->getRowMap()->getLocalNumElements());
+    DomMapSizePerBlk[j] = Teuchos::as<size_t>((arrayOfMatrices[j])->getDomainMap()->getLocalNumElements());
+    ColMapSizePerBlk[j] = Teuchos::as<size_t>((arrayOfMatrices[j])->getColMap()->getLocalNumElements());
+    nComboDomMap += DomMapSizePerBlk[j];
+    nComboColMap += ColMapSizePerBlk[j];
+    nnzCombo += Teuchos::as<size_t>((arrayOfMatrices[j])->getLocalNumEntries());
+    TEUCHOS_TEST_FOR_EXCEPTION((arrayOfMatrices[j])->getDomainMap()->getIndexBase() != 0, Exceptions::RuntimeError, "interpolation subblocks must use 0 indexbase");
+
+    // figure out how many empty entries in each column map
+    int tempii = 0;
+    for (int i = 0; i < (int)DomMapSizePerBlk[j]; i++) {
+      if ((arrayOfMatrices[j])->getDomainMap()->getGlobalElement(i) == (arrayOfMatrices[j])->getColMap()->getGlobalElement(tempii)) tempii++;
+    }
+    nTotalNumberLocalColMapEntries += tempii;
+    ColMapLocalSizePerBlk[j]  = tempii;
+    ColMapRemoteSizePerBlk[j] = ColMapSizePerBlk[j] - ColMapLocalSizePerBlk[j];
+  };
+
   for (int j = 0; j < nBlks; j++) {
     std::string blockName = "Psubblock" + Teuchos::toString(j);
     if (coarseLevel.IsAvailable(blockName, NoFactory::get())) {
-      arrayOfMatrices[j] = coarseLevel.Get<RCP<Matrix>>(blockName, NoFactory::get());
-      nComboRowMap += Teuchos::as<size_t>((arrayOfMatrices[j])->getRowMap()->getLocalNumElements());
-      DomMapSizePerBlk[j] = Teuchos::as<size_t>((arrayOfMatrices[j])->getDomainMap()->getLocalNumElements());
-      ColMapSizePerBlk[j] = Teuchos::as<size_t>((arrayOfMatrices[j])->getColMap()->getLocalNumElements());
-      nComboDomMap += DomMapSizePerBlk[j];
-      nComboColMap += ColMapSizePerBlk[j];
-      nnzCombo += Teuchos::as<size_t>((arrayOfMatrices[j])->getLocalNumEntries());
-      TEUCHOS_TEST_FOR_EXCEPTION((arrayOfMatrices[j])->getDomainMap()->getIndexBase() != 0, Exceptions::RuntimeError, "interpolation subblocks must use 0 indexbase");
-
-      // figure out how many empty entries in each column map
-      int tempii = 0;
-      for (int i = 0; i < (int)DomMapSizePerBlk[j]; i++) {
-        //          if ( (arrayOfMatrices[j])->getDomainMap()->getGlobalElement(i) == (arrayOfMatrices[j])->getColMap()->getGlobalElement(tempii) )  nTotalNumberLocalColMapEntries++;
-        if ((arrayOfMatrices[j])->getDomainMap()->getGlobalElement(i) == (arrayOfMatrices[j])->getColMap()->getGlobalElement(tempii)) tempii++;
-      }
-      nTotalNumberLocalColMapEntries += tempii;
-      ColMapLocalSizePerBlk[j]  = tempii;
-      ColMapRemoteSizePerBlk[j] = ColMapSizePerBlk[j] - ColMapLocalSizePerBlk[j];
+      setSubblockProlongator(coarseLevel.Get<RCP<Matrix>>(blockName, NoFactory::get()), j);
     } else {
-      arrayOfMatrices[j]        = Teuchos::null;
-      ColMapLocalSizePerBlk[j]  = 0;
-      ColMapRemoteSizePerBlk[j] = 0;
+      std::string subblockOpName = "Operatorsubblock" + Teuchos::toString(j);
+      bool hasOperator           = false;
+      if (coarseLevel.IsAvailable(subblockOpName)) {
+        auto A_blk  = coarseLevel.Get<RCP<Operator>>(subblockOpName);
+        hasOperator = A_blk != Teuchos::null;
+      }
+
+      if (useMaxLevels && anyCoarseGridsRemaining && hasOperator) {
+        // Use Psubblock = I
+        auto P_id = constructIdentityProlongator<Scalar, LocalOrdinal, GlobalOrdinal, Node>(coarseLevel.Get<RCP<Operator>>(subblockOpName)->getDomainMap());
+        setSubblockProlongator(P_id, j);
+      } else {
+        arrayOfMatrices[j]        = Teuchos::null;
+        ColMapLocalSizePerBlk[j]  = 0;
+        ColMapRemoteSizePerBlk[j] = 0;
+      }
     }
     ColMapLocalCumulativePerBlk[j + 1]  = ColMapLocalSizePerBlk[j] + ColMapLocalCumulativePerBlk[j];
     ColMapRemoteCumulativePerBlk[j + 1] = ColMapRemoteSizePerBlk[j] + ColMapRemoteCumulativePerBlk[j];
   }
+
   TEUCHOS_TEST_FOR_EXCEPTION(nComboRowMap != A->getRowMap()->getLocalNumElements(), Exceptions::RuntimeError, "sum of subblock rows != #row's Afine");
 
   // build up csr arrays for combo block diagonal P

--- a/packages/muelu/src/Transfers/Generic/MueLu_CombinePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_CombinePFactory_def.hpp
@@ -67,7 +67,7 @@ constructIdentityProlongator(const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, 
   using entries_type      = typename local_graph_type::entries_type::non_const_type;
   using values_type       = typename local_matrix_type::values_type;
 
-  auto numLocal = map->getLocalNumElements();
+  LocalOrdinal numLocal = map->getLocalNumElements();
   row_map_type rowptr("rowptr", numLocal + 1);
   entries_type colind("colind", numLocal);
   values_type values("values", numLocal);

--- a/packages/muelu/test/scaling/comboP.xml
+++ b/packages/muelu/test/scaling/comboP.xml
@@ -34,6 +34,8 @@
   </ParameterList>
   <!--Parameter name="coarse: type" type="string" value="none"/-->
 
+  <Parameter name="combine: useMaxLevels" type="bool" value="true"/>
+
   <ParameterList name="subblockList0">
     <Parameter name="use kokkos refactor" type="bool" value="false"/>
     <Parameter name="multigrid algorithm" type="string" value="sa"/>
@@ -43,9 +45,8 @@
     <Parameter name="transpose: use implicit" type="bool" value="false"/>
     <Parameter name="aggregation: type" type="string" value="uncoupled"/>
     <Parameter name="aggregation: drop tol" type="double" value="0.000000001"/>
-    <!--Parameter name="coarse: max size" type="int" value="56"/-->
-    <Parameter name="coarse: max size" type="int" value="56"/>
-    <Parameter name="max levels" type="int" value="5"/>
+    <Parameter name="coarse: max size" type="int" value="1000"/>
+    <Parameter name="max levels" type="int" value="3"/>
     <Parameter name="coarse: type" type="string" value="none"/>    <!--- change the driver so that this is always forced -->
     <Parameter name="smoother: type" type="string" value="RELAXATION"/>
     <ParameterList name="export data">
@@ -64,7 +65,7 @@
     <Parameter name="repartition: explicit via new copy rebalance P and R" type="bool" value="true"/>
     -->
     <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-    <Parameter name="repartition: start level" type="int" value="1"/>
+    <Parameter name="repartition: start level" type="int" value="2"/>
     <Parameter name="repartition: min rows per proc" type="int" value="65"/>
     <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
     <Parameter name="repartition: remap parts" type="bool" value="true"/>
@@ -101,7 +102,7 @@
     <Parameter name="repartition: explicit via new copy rebalance P and R" type="bool" value="true"/>
     -->
     <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-    <Parameter name="repartition: start level" type="int" value="1"/>
+    <Parameter name="repartition: start level" type="int" value="2"/>
     <Parameter name="repartition: min rows per proc" type="int" value="190"/>
     <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
     <Parameter name="repartition: remap parts" type="bool" value="true"/>
@@ -136,7 +137,7 @@
     <Parameter name="repartition: explicit via new copy rebalance P and R" type="bool" value="true"/>
     -->
     <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-    <Parameter name="repartition: start level" type="int" value="1"/>
+    <Parameter name="repartition: start level" type="int" value="2"/>
     <Parameter name="repartition: min rows per proc" type="int" value="200"/>
     <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
     <Parameter name="repartition: remap parts" type="bool" value="true"/>
@@ -171,7 +172,7 @@
     <Parameter name="repartition: explicit via new copy rebalance P and R" type="bool" value="true"/>
     -->
     <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-    <Parameter name="repartition: start level" type="int" value="1"/>
+    <Parameter name="repartition: start level" type="int" value="2"/>
     <Parameter name="repartition: min rows per proc" type="int" value="60"/>
     <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
     <Parameter name="repartition: remap parts" type="bool" value="true"/>
@@ -208,7 +209,7 @@
     <Parameter name="repartition: explicit via new copy rebalance P and R" type="bool" value="true"/>
     -->
     <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
-    <Parameter name="repartition: start level" type="int" value="10"/>
+    <Parameter name="repartition: start level" type="int" value="2"/>
     <Parameter name="repartition: min rows per proc" type="int" value="200"/>
     <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
     <Parameter name="repartition: remap parts" type="bool" value="true"/>


### PR DESCRIPTION
@trilinos/muelu

Motivation behind this is to enable a sub-block to use an identity prolongator to ensure that each sub-block reaches the intended `coarse: max size`.

For example, a two-block case may generate coarse-grid sizes that are much too large solely because one sub-block reaches the `coarse: max size` much faster:

```
--------------------------------------------------------------------------------
---                            Multigrid Summary MultiPhys (0,0)             ---
--------------------------------------------------------------------------------
Number of levels    = 7
Operator complexity = 1.58
Smoother complexity = 1.74
Cycle type          = V

level  rows     nnz       nnz/row  c ratio  procs
  0  8127945  73105753  8.99                  2048
  1  2477335  28298001  11.42    3.28         2048
  2  764464   10651680  13.93    3.24         30
  3  138528   2708356   19.55    5.52         5
  4  24111    434089    18.00    5.75         1
  5  5138     70494     13.72    4.69         1
  6  1760     21838     12.41    2.92         1

--------------------------------------------------------------------------------
---                            Multigrid Summary MultiPhys (1,1)             ---
--------------------------------------------------------------------------------
Number of levels    = 9
Operator complexity = 1.76
Smoother complexity = 1.93
Cycle type          = V

level  rows     nnz       nnz/row  c ratio  procs
  0  5865699  52617859  8.97                  2048
  1  1800819  20163716  11.20    3.26         2048
  2  837574   13403575  16.00    2.15         33
  3  246485   3881834   15.75    3.40         9
  4  93027    1793112   19.28    2.65         9
  5  33804    460804    13.63    2.75         1
  6  15045    136776    9.09     2.25         1
  7  6213     34354     5.53     2.42         1
  8  2625     10616     4.04     2.37         1

--------------------------------------------------------------------------------
---                            Multigrid Summary Combo                       ---
--------------------------------------------------------------------------------
Number of levels    = 7
Operator complexity = 1.43
Smoother complexity = 1.52
Cycle type          = V

level  rows      nnz        nnz/row  c ratio  procs
  0  13993644  230959330  16.50                 2048
  1  4278154   56931937   13.31    3.27         2048
  2  1602038   29289589   18.28    2.67         2048
  3  385013    9490525    24.65    4.16         2048
  4  117138    3353502    28.63    3.29         2048
  5  38942     833932     21.41    3.01         2048
  6  16805     287508     17.11    2.32         2048
```

When the optional parameter `combine: useMaxLevels = true`, the behavior is changed to use levels 0-8 in the above example for the `Multigrid Summary Combo` block. The prolongators for the (0,0) subblock are identity for level ids > 6. 