### PR TITLE
ROL: Begin migration of PDE-OPT examples to Intrepid2

### DIFF
--- a/packages/rol/example/PDE-OPT/CMakeLists.txt
+++ b/packages/rol/example/PDE-OPT/CMakeLists.txt
@@ -5,12 +5,14 @@ SET(NOINSTALLHEADERS "")
 APPEND_SET(SOURCES
   TOOLS/solver.cpp
   TOOLS/assembler.cpp
+  TOOLS/assemblerK.cpp
 )
 
 APPEND_SET(NOINSTALLHEADERS
   TOOLS/solver.hpp
   TOOLS/solver_def.hpp
   TOOLS/assembler.hpp
+  TOOLS/assemblerK.hpp
 )
 
 IF(${PROJECT_NAME}_ENABLE_Intrepid AND

--- a/packages/rol/example/PDE-OPT/TOOLS/assemblerK.cpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/assemblerK.cpp
@@ -1,0 +1,16 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  assembler.cpp
+    \brief Template specialization for the Assembler class for PDE-OPT.
+*/
+
+#include "assemblerK.hpp"
+
+template class Assembler<double,Kokkos::HostSpace>;

--- a/packages/rol/example/PDE-OPT/TOOLS/assemblerK.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/assemblerK.hpp
@@ -1,0 +1,768 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  assembler.hpp
+    \brief Finite element assembly class.
+*/
+
+#ifndef ROL_PDEOPT_ASSEMBLERK_H
+#define ROL_PDEOPT_ASSEMBLERK_H
+
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+
+#include "Tpetra_MultiVector.hpp"
+#include "Tpetra_Vector.hpp"
+#include "Tpetra_CrsGraph.hpp"
+#include "Tpetra_CrsMatrix.hpp"
+#include "Tpetra_Version.hpp"
+#include "Tpetra_RowMatrixTransposer.hpp"
+#include "MatrixMarket_Tpetra.hpp"
+
+#include "Intrepid2_DefaultCubatureFactory.hpp"
+
+#include "feK.hpp"
+#include "feK_curl.hpp"
+#include "pdeK.hpp"
+#include "dynpdeK.hpp"
+#include "qoiK.hpp"
+#include "dofmanagerK.hpp"
+#include "meshmanagerK.hpp"
+#include "fieldhelperK.hpp"
+
+//// Global Timers.
+#ifdef ROL_TIMERS
+namespace ROL {
+  namespace PDEOPT {
+    ROL::Ptr<Teuchos::Time> AssemblePDEResidual         = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble PDE Residual");
+    ROL::Ptr<Teuchos::Time> AssemblePDEJacobian1        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble PDE Jacobian1");
+    ROL::Ptr<Teuchos::Time> AssemblePDEJacobian2        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble PDE Jacobian2");
+    ROL::Ptr<Teuchos::Time> AssemblePDEJacobian3        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble PDE Jacobian3");
+    ROL::Ptr<Teuchos::Time> AssemblePDEHessian11        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble PDE Hessian11");
+    ROL::Ptr<Teuchos::Time> AssemblePDEHessian12        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble PDE Hessian12");
+    ROL::Ptr<Teuchos::Time> AssemblePDEHessian13        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble PDE Hessian13");
+    ROL::Ptr<Teuchos::Time> AssemblePDEHessian21        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble PDE Hessian21");
+    ROL::Ptr<Teuchos::Time> AssemblePDEHessian22        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble PDE Hessian22");
+    ROL::Ptr<Teuchos::Time> AssemblePDEHessian23        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble PDE Hessian23");
+    ROL::Ptr<Teuchos::Time> AssemblePDEHessian31        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble PDE Hessian31");
+    ROL::Ptr<Teuchos::Time> AssemblePDEHessian32        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble PDE Hessian32");
+    ROL::Ptr<Teuchos::Time> AssemblePDEHessian33        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble PDE Hessian33");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEResidual      = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Residual");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEJacobian_uo   = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Jacobian_uo");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEJacobian_un   = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Jacobian_un");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEJacobian_zf   = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Jacobian_zf");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEJacobian_zp   = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Jacobian_zp");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_uo_uo = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_uo_uo");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_uo_un = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_uo_un");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_uo_zf = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_uo_zf");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_uo_zp = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_uo_zp");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_un_uo = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_un_uo");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_un_un = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_un_un");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_un_zf = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_un_zf");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_un_zp = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_un_zp");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_zf_uo = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_zf_uo");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_zf_un = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_zf_un");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_zf_zf = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_zf_zf");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_zf_zp = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_zf_zp");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_zp_uo = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_zp_uo");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_zp_un = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_zp_un");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_zp_zf = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_zp_zf");
+    ROL::Ptr<Teuchos::Time> AssembleDynPDEHessian_zp_zp = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble DynamicPDE Hessian_zp_zp");
+    ROL::Ptr<Teuchos::Time> AssembleQOIValue            = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI Value");
+    ROL::Ptr<Teuchos::Time> AssembleQOIGradient1        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI Gradient1");
+    ROL::Ptr<Teuchos::Time> AssembleQOIGradient2        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI Gradient2");
+    ROL::Ptr<Teuchos::Time> AssembleQOIGradient3        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI Gradient3");
+    ROL::Ptr<Teuchos::Time> AssembleQOIHessVec11        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI HessVec11");
+    ROL::Ptr<Teuchos::Time> AssembleQOIHessVec12        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI HessVec12");
+    ROL::Ptr<Teuchos::Time> AssembleQOIHessVec13        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI HessVec13");
+    ROL::Ptr<Teuchos::Time> AssembleQOIHessVec21        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI HessVec21");
+    ROL::Ptr<Teuchos::Time> AssembleQOIHessVec22        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI HessVec22");
+    ROL::Ptr<Teuchos::Time> AssembleQOIHessVec23        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI HessVec23");
+    ROL::Ptr<Teuchos::Time> AssembleQOIHessVec31        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI HessVec31");
+    ROL::Ptr<Teuchos::Time> AssembleQOIHessVec32        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI HessVec32");
+    ROL::Ptr<Teuchos::Time> AssembleQOIHessVec33        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI HessVec33");
+    ROL::Ptr<Teuchos::Time> AssembleQOIHessian11        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI Hessian11");
+    ROL::Ptr<Teuchos::Time> AssembleQOIHessian12        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI Hessian12");
+    ROL::Ptr<Teuchos::Time> AssembleQOIHessian21        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI Hessian21");
+    ROL::Ptr<Teuchos::Time> AssembleQOIHessian22        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Assemble QOI Hessian22");
+  }
+}
+#endif
+
+template<class Real>
+class Solution {
+public:
+
+  virtual ~Solution() {}
+  Solution(void) {}
+  virtual Real evaluate(const std::vector<Real> &x, const int fieldNumber) const = 0;
+};
+
+template<class Real, class DeviceType>
+class Assembler {
+
+public:
+
+  using scalar_view = Kokkos::DynRankView<Real, DeviceType>;
+  using int_view = Kokkos::DynRankView<int, DeviceType>;
+  using basis_ptr = Intrepid2::BasisPtr<DeviceType, Real, Real>;
+  using MeshManager_type = MeshManager<Real, DeviceType>;
+  using DofManager_type = DofManager<Real, DeviceType>;
+  using QoI_type = QoI<Real, DeviceType>;
+  using PDE_type = PDE<Real, DeviceType>;
+  using DynPDE_type = DynamicPDE<Real, DeviceType>;
+  using FE_type = FE<Real, DeviceType>;
+  using FE_CURL_type = FE_CURL<Real, DeviceType>;
+  using FieldHelper_type = FieldHelper<Real, DeviceType>;
+
+  using fst = Intrepid2::FunctionSpaceTools<DeviceType>;
+  using ct = Intrepid2::CellTools<DeviceType>;
+
+
+  typedef Tpetra::Map<>::local_ordinal_type LO;
+  typedef Tpetra::Map<>::global_ordinal_type GO;
+  typedef Tpetra::Map<>::node_type NO;
+  typedef Tpetra::MultiVector<Real,LO,GO,NO> MV;
+  typedef Tpetra::Operator<Real,LO,GO,NO> OP;
+
+private:
+  // Timers
+//  ROL::Ptr<Teuchos::Time::Time> timerSolverFactorization_;
+//  ROL::Ptr<Teuchos::Time::Time> timerSolverSubstitution_;
+//  ROL::Ptr<Teuchos::Time::Time> timerAssemblyNonlinear_;
+//  ROL::Ptr<Teuchos::Time::Time> timerSolverUpdate_;
+
+  // Set in Constructor.
+  bool verbose_;
+  bool isJ1Transposed_, isJ2Transposed_, isJuoTransposed_, isJunTransposed_, isJzfTransposed_;
+
+  // Set in SetCommunicator.
+  ROL::Ptr<const Teuchos::Comm<int>> comm_;
+  int myRank_, numProcs_;
+
+  // Set in SetBasis.
+  std::vector<basis_ptr> basisPtrs1_, basisPtrs2_;
+
+  // Set in SetDiscretization.
+  ROL::Ptr<MeshManager_type> meshMgr_;
+  ROL::Ptr<DofManager_type>  dofMgr1_, dofMgr2_;
+
+  // Set in SetParallelStructure.
+  int numCells_;
+  Teuchos::Array<GO> myCellIds_;
+  Teuchos::Array<GO> cellOffsets_;
+  ROL::Ptr<const Tpetra::Map<>> myOverlapStateMap_;
+  ROL::Ptr<const Tpetra::Map<>> myUniqueStateMap_;
+  ROL::Ptr<const Tpetra::Map<>> myOverlapControlMap_;
+  ROL::Ptr<const Tpetra::Map<>> myUniqueControlMap_;
+  ROL::Ptr<const Tpetra::Map<>> myOverlapResidualMap_;
+  ROL::Ptr<const Tpetra::Map<>> myUniqueResidualMap_;
+  ROL::Ptr<Tpetra::CrsGraph<>>  matJ1Graph_;
+  ROL::Ptr<Tpetra::CrsGraph<>>  matJ2Graph_;
+  ROL::Ptr<Tpetra::CrsGraph<>>  matR1Graph_;
+  ROL::Ptr<Tpetra::CrsGraph<>>  matR2Graph_;
+  ROL::Ptr<Tpetra::CrsGraph<>>  matH11Graph_;
+  ROL::Ptr<Tpetra::CrsGraph<>>  matH12Graph_;
+  ROL::Ptr<Tpetra::CrsGraph<>>  matH21Graph_;
+  ROL::Ptr<Tpetra::CrsGraph<>>  matH22Graph_;
+
+  // Set in SetCellNodes.
+  scalar_view volCellNodes_;
+  ROL::Ptr<std::vector<std::vector<std::vector<int>>>>  bdryCellIds_;
+  std::vector<std::vector<std::vector<int>>>  bdryCellLocIds_;
+  std::vector<std::vector<scalar_view>> bdryCellNodes_;
+
+  // Finite element vectors and matrices for PDE.
+  ROL::Ptr<Tpetra::MultiVector<>> pde_vecR_overlap_;
+  ROL::Ptr<Tpetra::MultiVector<>> pde_vecJ2_overlap_;
+  ROL::Ptr<Tpetra::MultiVector<>> pde_vecJ3_overlap_;
+  ROL::Ptr<Tpetra::MultiVector<>> pde_vecH13_overlap_;
+  ROL::Ptr<Tpetra::MultiVector<>> pde_vecH23_overlap_;
+
+  // Finite element vectors and matrices for QoI.
+  ROL::Ptr<Tpetra::MultiVector<>> qoi_vecG1_overlap_;
+  ROL::Ptr<Tpetra::MultiVector<>> qoi_vecG2_overlap_;
+  ROL::Ptr<Tpetra::MultiVector<>> qoi_vecH11_overlap_;
+  ROL::Ptr<Tpetra::MultiVector<>> qoi_vecH12_overlap_;
+  ROL::Ptr<Tpetra::MultiVector<>> qoi_vecH13_overlap_;
+  ROL::Ptr<Tpetra::MultiVector<>> qoi_vecH21_overlap_;
+  ROL::Ptr<Tpetra::MultiVector<>> qoi_vecH22_overlap_;
+  ROL::Ptr<Tpetra::MultiVector<>> qoi_vecH23_overlap_;
+
+  bool store_;
+
+private:
+
+  void setCommunicator(const ROL::Ptr<const Teuchos::Comm<int>> &comm,
+                       Teuchos::ParameterList &parlist,
+                       std::ostream &outStream = std::cout);
+  void setBasis(
+         const std::vector<basis_ptr>& basisPtrs1,
+         const std::vector<basis_ptr>& basisPtrs2,
+         Teuchos::ParameterList &parlist,
+         std::ostream &outStream = std::cout);
+  void setDiscretization(Teuchos::ParameterList &parlist,
+                         const ROL::Ptr<MeshManager_type> &meshMgr = ROL::nullPtr,
+                         std::ostream &outStream = std::cout);
+  void setParallelStructure(Teuchos::ParameterList &parlist,
+                            std::ostream &outStream = std::cout);
+  void setCellNodes(std::ostream &outStream = std::cout);
+  int mapGlobalToLocalCellId(const int & gid);
+  void getCoeffFromStateVector(scalar_view& xcoeff,
+                               const ROL::Ptr<const Tpetra::MultiVector<>> &x) const;
+  void getCoeffFromControlVector(scalar_view& xcoeff,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &x) const;
+
+  /***************************************************************************/
+  /****** GENERIC ASSEMBLY ROUTINES ******************************************/
+  /***************************************************************************/
+  Real assembleScalar(const scalar_view val);
+  void assembleFieldVector(ROL::Ptr<Tpetra::MultiVector<>> &v,
+                           scalar_view val,
+                           ROL::Ptr<Tpetra::MultiVector<>> &vecOverlap,
+                           const ROL::Ptr<DofManager_type> &dofMgr);
+  void assembleParamVector(ROL::Ptr<std::vector<Real>> &v,
+                           std::vector<scalar_view> &val);
+  void assembleFieldMatrix(ROL::Ptr<Tpetra::CrsMatrix<>> &M,
+                           scalar_view val,
+                           const ROL::Ptr<DofManager_type> &dofMgr1,
+                           const ROL::Ptr<DofManager_type> &dofMgr2);
+  void assembleParamFieldMatrix(ROL::Ptr<Tpetra::MultiVector<>> &M,
+                                std::vector<scalar_view> &val,
+                                ROL::Ptr<Tpetra::MultiVector<>> &matOverlap,
+                                const ROL::Ptr<DofManager_type> &dofMgr);
+  void assembleParamMatrix(ROL::Ptr<std::vector<std::vector<Real>>> &M,
+                           std::vector<std::vector<scalar_view>> &val,
+                           const ROL::Ptr<DofManager_type> &dofMgr);
+  void transformToFieldPattern(scalar_view array,
+                               const ROL::Ptr<DofManager_type> &dofMgr1,
+                               const ROL::Ptr<DofManager_type> &dofMgr2 = ROL::nullPtr) const;
+
+public:
+  // destructor
+  virtual ~Assembler() {}
+  // Constuctor: Discretization set from ParameterList
+  Assembler(const std::vector<basis_ptr> &basisPtrs,
+          const ROL::Ptr<const Teuchos::Comm<int>> &comm,
+          Teuchos::ParameterList &parlist,
+          std::ostream &outStream = std::cout);
+  // Constructor: Discretization set from MeshManager input
+  Assembler(const std::vector<basis_ptr> &basisPtrs,
+          const ROL::Ptr<MeshManager_type> &meshMgr,
+          const ROL::Ptr<const Teuchos::Comm<int>> &comm,
+          Teuchos::ParameterList &parlist,
+          std::ostream &outStream = std::cout);
+  // Constuctor: Discretization set from ParameterList
+  Assembler(const std::vector<basis_ptr> &basisPtrs1,
+          const std::vector<basis_ptr> &basisPtrs2,
+          const ROL::Ptr<const Teuchos::Comm<int>> &comm,
+          Teuchos::ParameterList &parlist,
+          std::ostream &outStream = std::cout);
+  // Constructor: Discretization set from MeshManager input
+  Assembler(const std::vector<basis_ptr> &basisPtrs1,
+          const std::vector<basis_ptr> &basisPtrs2,
+          const ROL::Ptr<MeshManager_type> &meshMgr,
+          const ROL::Ptr<const Teuchos::Comm<int>> &comm,
+          Teuchos::ParameterList &parlist,
+          std::ostream &outStream = std::cout);
+  void setCellNodes(PDE_type &pde) const;
+  void setCellNodes(DynPDE_type &pde) const;
+
+  /***************************************************************************/
+  /* PDE assembly routines                                                   */
+  /***************************************************************************/
+  void assemblePDEResidual(ROL::Ptr<Tpetra::MultiVector<>> &r,
+                           const ROL::Ptr<PDE_type> &pde,
+                           const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                           const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                           const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEJacobian1(ROL::Ptr<Tpetra::CrsMatrix<>> &J1,
+                            const ROL::Ptr<PDE_type> &pde,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEJacobian2(ROL::Ptr<Tpetra::CrsMatrix<>> &J2,
+                            const ROL::Ptr<PDE_type> &pde,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEJacobian3(ROL::Ptr<Tpetra::MultiVector<>> &J3,
+                            const ROL::Ptr<PDE_type> &pde,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEapplyJacobian1(ROL::Ptr<Tpetra::MultiVector<>> &Jv1,
+                                 const ROL::Ptr<PDE_type> &pde,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                 const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEapplyAdjointJacobian1(ROL::Ptr<Tpetra::MultiVector<>> &Jv1,
+                                        const ROL::Ptr<PDE_type> &pde,
+                                        const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                        const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                        const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                        const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEapplyJacobian2(ROL::Ptr<Tpetra::MultiVector<>> &Jv2,
+                                 const ROL::Ptr<PDE_type> &pde,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                 const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEapplyAdjointJacobian2(ROL::Ptr<Tpetra::MultiVector<>> &Jv2,
+                                        const ROL::Ptr<PDE_type> &pde,
+                                        const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                        const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                        const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                        const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEHessian11(ROL::Ptr<Tpetra::CrsMatrix<>> &H11,
+                            const ROL::Ptr<PDE_type> &pde,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEHessian12(ROL::Ptr<Tpetra::CrsMatrix<>> &H12,
+                            const ROL::Ptr<PDE_type> &pde,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEHessian13(ROL::Ptr<Tpetra::MultiVector<>> &H13,
+                            const ROL::Ptr<PDE_type> &pde,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEHessian21(ROL::Ptr<Tpetra::CrsMatrix<>> &H21,
+                            const ROL::Ptr<PDE_type> &pde,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEHessian22(ROL::Ptr<Tpetra::CrsMatrix<>> &H22,
+                            const ROL::Ptr<PDE_type> &pde,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEHessian23(ROL::Ptr<Tpetra::MultiVector<>> &H23,
+                            const ROL::Ptr<PDE_type> &pde,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEHessian31(ROL::Ptr<Tpetra::MultiVector<>> &H31,
+                            const ROL::Ptr<PDE_type> &pde,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEHessian32(ROL::Ptr<Tpetra::MultiVector<>> &H32,
+                            const ROL::Ptr<PDE_type> &pde,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEHessian33(ROL::Ptr<std::vector<std::vector<Real>>> &H33,
+                            const ROL::Ptr<PDE_type> &pde,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEapplyHessian11(ROL::Ptr<Tpetra::MultiVector<>> &Hv,
+                                 const ROL::Ptr<PDE_type> &pde,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                 const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEapplyHessian12(ROL::Ptr<Tpetra::MultiVector<>> &Hv,
+                                 const ROL::Ptr<PDE_type> &pde,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                 const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEapplyHessian21(ROL::Ptr<Tpetra::MultiVector<>> &Hv,
+                                 const ROL::Ptr<PDE_type> &pde,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                 const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assemblePDEapplyHessian22(ROL::Ptr<Tpetra::MultiVector<>> &Hv,
+                                 const ROL::Ptr<PDE_type> &pde,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                 const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  /***************************************************************************/
+  /* End of PDE assembly routines.                                           */
+  /***************************************************************************/
+
+  /***************************************************************************/
+  /* Dynamic PDE assembly routines                                           */
+  /***************************************************************************/
+  void assembleDynPDEResidual(ROL::Ptr<Tpetra::MultiVector<>> &r,
+                              const ROL::Ptr<DynPDE_type> &pde,
+                              const ROL::TimeStamp<Real> &ts,
+                              const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                              const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                              const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                              const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEJacobian_uo(ROL::Ptr<Tpetra::CrsMatrix<>> &J,
+                                 const ROL::Ptr<DynPDE_type> &pde,
+                                 const ROL::TimeStamp<Real> &ts,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                 const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEJacobian_un(ROL::Ptr<Tpetra::CrsMatrix<>> &J,
+                                 const ROL::Ptr<DynPDE_type> &pde,
+                                 const ROL::TimeStamp<Real> &ts,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                 const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEJacobian_zf(ROL::Ptr<Tpetra::CrsMatrix<>> &J,
+                                 const ROL::Ptr<DynPDE_type> &pde,
+                                 const ROL::TimeStamp<Real> &ts,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                 const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEJacobian_zp(ROL::Ptr<Tpetra::MultiVector<>> &J,
+                                 const ROL::Ptr<DynPDE_type> &pde,
+                                 const ROL::TimeStamp<Real> &ts,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                 const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                 const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_uo_uo(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_uo_un(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_uo_zf(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_uo_zp(ROL::Ptr<Tpetra::MultiVector<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_un_uo(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_un_un(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_un_zf(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_un_zp(ROL::Ptr<Tpetra::MultiVector<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_zf_uo(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_zf_un(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_zf_zf(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_zf_zp(ROL::Ptr<Tpetra::MultiVector<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_zp_uo(ROL::Ptr<Tpetra::MultiVector<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_zp_un(ROL::Ptr<Tpetra::MultiVector<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_zp_zf(ROL::Ptr<Tpetra::MultiVector<>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleDynPDEHessian_zp_zp(ROL::Ptr<std::vector<std::vector<Real>>> &H,
+                                   const ROL::Ptr<DynPDE_type> &pde,
+                                   const ROL::TimeStamp<Real> &ts,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  /***************************************************************************/
+  /* End of DynamicPDE assembly routines.                                    */
+  /***************************************************************************/
+
+  /***************************************************************************/
+  /* QoI assembly routines                                                   */
+  /***************************************************************************/
+  Real assembleQoIValue(const ROL::Ptr<QoI_type> &qoi,
+                        const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                        const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                        const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assembleQoIGradient1(ROL::Ptr<Tpetra::MultiVector<>> &g1,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assembleQoIGradient2(ROL::Ptr<Tpetra::MultiVector<>> &g2,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assembleQoIGradient3(ROL::Ptr<std::vector<Real>> &g3,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assembleQoIHessVec11(ROL::Ptr<Tpetra::MultiVector<>> &H11,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assembleQoIHessVec12(ROL::Ptr<Tpetra::MultiVector<>> &H12,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assembleQoIHessVec13(ROL::Ptr<Tpetra::MultiVector<>> &H13,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const std::vector<Real>> &v,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleQoIHessVec21(ROL::Ptr<Tpetra::MultiVector<>> &H21,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assembleQoIHessVec22(ROL::Ptr<Tpetra::MultiVector<>> &H22,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assembleQoIHessVec23(ROL::Ptr<Tpetra::MultiVector<>> &H23,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const std::vector<Real>> &v,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assembleQoIHessVec31(ROL::Ptr<std::vector<Real>> &H31,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assembleQoIHessVec32(ROL::Ptr<std::vector<Real>> &H32,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assembleQoIHessVec33(ROL::Ptr<std::vector<Real>> &H33,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const std::vector<Real>> &v,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr);
+  void assembleQoIHessian11(ROL::Ptr<Tpetra::CrsMatrix<>> &H11,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assembleQoIHessian12(ROL::Ptr<Tpetra::CrsMatrix<>> &H12,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assembleQoIHessian21(ROL::Ptr<Tpetra::CrsMatrix<>> &H21,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  void assembleQoIHessian22(ROL::Ptr<Tpetra::CrsMatrix<>> &H22,
+                            const ROL::Ptr<QoI_type> &qoi,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr);
+  /***************************************************************************/
+  /* End QoI assembly routines                                               */
+  /***************************************************************************/
+
+  /***************************************************************************/
+  /* Assemble and apply Riesz operator corresponding to simulation variables */
+  /***************************************************************************/
+  void assemblePDERieszMap1(ROL::Ptr<Tpetra::CrsMatrix<>> &R1,
+                            const ROL::Ptr<PDE_type> &pde);
+  void assembleDynPDERieszMap1(ROL::Ptr<Tpetra::CrsMatrix<>> &R1,
+                               const ROL::Ptr<DynPDE_type> &pde);
+  /***************************************************************************/
+  /* End of functions for Riesz operator of simulation variables.            */
+  /***************************************************************************/
+
+  /***************************************************************************/
+  /* Assemble and apply Riesz operator corresponding to optimization         */
+  /* variables                                                               */
+  /***************************************************************************/
+  void assemblePDERieszMap2(ROL::Ptr<Tpetra::CrsMatrix<>> &R2,
+                            const ROL::Ptr<PDE_type> &pde);
+  void assembleDynPDERieszMap2(ROL::Ptr<Tpetra::CrsMatrix<>> &R2,
+                               const ROL::Ptr<DynPDE_type> &pde);
+  /***************************************************************************/
+  /* End of functions for Riesz operator of optimization variables.          */
+  /***************************************************************************/
+
+  /***************************************************************************/
+  /* Compute error routines.                                                 */
+  /***************************************************************************/
+  Real computeStateError(const ROL::Ptr<const Tpetra::MultiVector<>> &soln,
+                         const ROL::Ptr<Solution<Real>> &trueSoln,
+                         const int cubDeg = 6,
+                         const ROL::Ptr<FieldHelper_type> &fieldHelper = ROL::nullPtr) const;
+  Real computeControlError(const ROL::Ptr<const Tpetra::MultiVector<>> &soln,
+                           const ROL::Ptr<Solution<Real>> &trueSoln,
+                           const int cubDeg = 6,
+                           const ROL::Ptr<FieldHelper_type> &fieldHelper = ROL::nullPtr) const;
+  /***************************************************************************/
+  /* End of compute solution routines.                                       */
+  /***************************************************************************/
+
+  /***************************************************************************/
+  /* Output routines.                                                        */
+  /***************************************************************************/
+  void printMeshData(std::ostream &outStream) const;
+  void outputTpetraVector(const ROL::Ptr<const Tpetra::MultiVector<>> &vec,
+                          const std::string &filename) const;
+  void inputTpetraVector(ROL::Ptr<Tpetra::MultiVector<>> &vec,
+                         const std::string &filename) const;
+  void printDataPDE(const ROL::Ptr<PDE_type> &pde,
+                    const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                    const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                    const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr) const;
+  void printCellAveragesPDE(const ROL::Ptr<PDE_type> &pde,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                            const ROL::Ptr<const Tpetra::MultiVector<>> &z = ROL::nullPtr,
+                            const ROL::Ptr<const std::vector<Real>> &z_param = ROL::nullPtr) const;
+  void serialPrintStateEdgeField(const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                 const ROL::Ptr<FieldHelper_type> &fieldHelper,
+                                 const std::string &filename,
+                                 const ROL::Ptr<FE_CURL_type> &fe) const;
+  /***************************************************************************/
+  /* End of output routines.                                                 */
+  /***************************************************************************/
+
+  /***************************************************************************/
+  /* Vector generation routines.                                             */
+  /***************************************************************************/
+  const ROL::Ptr<const Tpetra::Map<>> getStateMap(void) const;
+  const ROL::Ptr<const Tpetra::Map<>> getControlMap(void) const;
+  const ROL::Ptr<const Tpetra::Map<>> getResidualMap(void) const;
+  ROL::Ptr<Tpetra::MultiVector<>> createStateVector(void) const;
+  ROL::Ptr<Tpetra::MultiVector<>> createControlVector(void) const;
+  ROL::Ptr<Tpetra::MultiVector<>> createResidualVector(void) const;
+  /***************************************************************************/
+  /* End of vector generation routines.                                      */
+  /***************************************************************************/
+
+  /***************************************************************************/
+  /* Accessor routines.                                                      */
+  /***************************************************************************/
+  const ROL::Ptr<DofManager_type> getDofManager(void) const;
+  const ROL::Ptr<DofManager_type> getDofManager2(void) const;
+  Teuchos::Array<GO> getCellIds(void) const;
+  /***************************************************************************/
+  /* End of accessor routines.                                               */
+  /***************************************************************************/
+}; // class Assembler
+
+#include "assemblerK_def.hpp"
+
+#endif

--- a/packages/rol/example/PDE-OPT/TOOLS/assemblerK_def.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/assemblerK_def.hpp
@@ -1,0 +1,3249 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  assemblerK_def.hpp
+    \brief Finite element assembly class.
+*/
+
+#ifndef ROL_PDEOPT_ASSEMBLERK_DEF_H
+#define ROL_PDEOPT_ASSEMBLERK_DEF_H
+
+#include "assemblerK.hpp"
+
+/*****************************************************************************/
+/******************* PUBLIC MEMBER FUNCTIONS *********************************/
+/*****************************************************************************/
+// Constuctor: Discretization set from ParameterList
+template<class Real, class DeviceType>
+Assembler<Real, DeviceType>::Assembler(
+        const std::vector<basis_ptr> &basisPtrs,
+        const ROL::Ptr<const Teuchos::Comm<int>> &comm,
+        Teuchos::ParameterList &parlist,
+        std::ostream &outStream)
+  : isJ1Transposed_(false), isJ2Transposed_(false),
+    isJuoTransposed_(false), isJunTransposed_(false), isJzfTransposed_(false) {
+  setCommunicator(comm,parlist,outStream);
+  setBasis(basisPtrs,basisPtrs,parlist,outStream);
+  setDiscretization(parlist,ROL::nullPtr,outStream);
+  setParallelStructure(parlist,outStream);
+  setCellNodes(outStream);
+  store_ = parlist.sublist("Assembler").get("Store Overlap Vectors",true);
+}
+
+// Constructor: Discretization set from MeshManager input
+template<class Real, class DeviceType>
+Assembler<Real,DeviceType>::Assembler(
+        const std::vector<basis_ptr> &basisPtrs,
+        const ROL::Ptr<MeshManager_type> &meshMgr,
+        const ROL::Ptr<const Teuchos::Comm<int>> &comm,
+        Teuchos::ParameterList &parlist,
+        std::ostream &outStream)
+  : isJ1Transposed_(false), isJ2Transposed_(false),
+    isJuoTransposed_(false), isJunTransposed_(false), isJzfTransposed_(false) {
+  setCommunicator(comm,parlist,outStream);
+  setBasis(basisPtrs,basisPtrs,parlist,outStream);
+  setDiscretization(parlist,meshMgr,outStream);
+  setParallelStructure(parlist,outStream);
+  setCellNodes(outStream);
+  store_ = parlist.sublist("Assembler").get("Store Overlap Vectors",true);
+}
+// Constuctor: Discretization set from ParameterList
+template<class Real, class DeviceType>
+Assembler<Real,DeviceType>::Assembler(
+        const std::vector<basis_ptr> &basisPtrs1,
+        const std::vector<basis_ptr> &basisPtrs2,
+        const ROL::Ptr<const Teuchos::Comm<int>> &comm,
+        Teuchos::ParameterList &parlist,
+        std::ostream &outStream)
+  : isJ1Transposed_(false), isJ2Transposed_(false),
+    isJuoTransposed_(false), isJunTransposed_(false), isJzfTransposed_(false) {
+  setCommunicator(comm,parlist,outStream);
+  setBasis(basisPtrs1,basisPtrs2,parlist,outStream);
+  setDiscretization(parlist,ROL::nullPtr,outStream);
+  setParallelStructure(parlist,outStream);
+  setCellNodes(outStream);
+  store_ = parlist.sublist("Assembler").get("Store Overlap Vectors",true);
+}
+
+// Constructor: Discretization set from MeshManager input
+template<class Real, class DeviceType>
+Assembler<Real,DeviceType>::Assembler(
+        const std::vector<basis_ptr> &basisPtrs1,
+        const std::vector<basis_ptr> &basisPtrs2,
+        const ROL::Ptr<MeshManager_type> &meshMgr,
+        const ROL::Ptr<const Teuchos::Comm<int>> &comm,
+        Teuchos::ParameterList &parlist,
+        std::ostream &outStream)
+  : isJ1Transposed_(false), isJ2Transposed_(false),
+    isJuoTransposed_(false), isJunTransposed_(false), isJzfTransposed_(false) {
+  setCommunicator(comm,parlist,outStream);
+  setBasis(basisPtrs1,basisPtrs2,parlist,outStream);
+  setDiscretization(parlist,meshMgr,outStream);
+  setParallelStructure(parlist,outStream);
+  setCellNodes(outStream);
+  store_ = parlist.sublist("Assembler").get("Store Overlap Vectors",true);
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::setCellNodes(PDE_type &pde) const {
+  // Set PDE cell nodes
+  pde.setFieldPattern(dofMgr1_->getFieldPattern(),dofMgr2_->getFieldPattern());
+  pde.setCellNodes(volCellNodes_, bdryCellNodes_, bdryCellLocIds_);
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::setCellNodes(DynPDE_type &pde) const {
+  // Set PDE cell nodes
+  pde.setFieldPattern(dofMgr1_->getFieldPattern(),dofMgr2_->getFieldPattern());
+  pde.setCellNodes(volCellNodes_, bdryCellNodes_, bdryCellLocIds_);
+}
+
+/***************************************************************************/
+/* PDE assembly routines                                                   */
+/***************************************************************************/
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEResidual(ROL::Ptr<Tpetra::MultiVector<>> &r,
+                                    const ROL::Ptr<PDE_type> &pde,
+                                    const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                    const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                    const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEResidual);
+  #endif
+  // Initialize residual vectors if not done so
+  if ( r == ROL::nullPtr ) // Unique components of residual vector
+    r = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueResidualMap_, 1, true);
+  ROL::Ptr<Tpetra::MultiVector<>> overlapVec;
+  if ( store_ ) {
+    if ( pde_vecR_overlap_ == ROL::nullPtr ) // Overlapping components of residual vector
+      pde_vecR_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, 1, true);
+    overlapVec = pde_vecR_overlap_;
+  }
+  else {
+    overlapVec = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, 1, true);
+  }
+  // Get u_coeff from u and z_coeff from z
+  scalar_view u_coeff, z_coeff;
+  getCoeffFromStateVector(u_coeff,u);
+  getCoeffFromControlVector(z_coeff,z);
+  // Assemble
+  scalar_view localVal;
+  pde->residual(localVal,u_coeff,z_coeff,z_param);
+  assembleFieldVector( r, localVal, overlapVec, dofMgr1_ );
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEJacobian1(ROL::Ptr<Tpetra::CrsMatrix<>> &J1,
+                                     const ROL::Ptr<PDE_type> &pde,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEJacobian1);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view u_coeff, z_coeff;
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Initialize Jacobian matrices
+    if ( J1 == ROL::nullPtr ) {
+      J1 = ROL::makePtr<Tpetra::CrsMatrix<>>(matJ1Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Jacobian_1(localVal,u_coeff,z_coeff,z_param);
+    assembleFieldMatrix( J1, localVal, dofMgr1_, dofMgr1_ );
+    isJ1Transposed_ = false;
+    // Output
+    //Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix<>> matWriter;
+    //matWriter.writeSparseFile("jacobian_1.txt", J1);
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assemblePDEJacobian1): Jacobian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEJacobian1): Jacobian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEJacobian2(ROL::Ptr<Tpetra::CrsMatrix<>> &J2,
+                                     const ROL::Ptr<PDE_type> &pde,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEJacobian2);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view u_coeff, z_coeff;
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Initialize Jacobian matrices
+    if ( J2 == ROL::nullPtr ) {
+      J2 = ROL::makePtr<Tpetra::CrsMatrix<>>(matJ2Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Jacobian_2(localVal,u_coeff,z_coeff,z_param);
+    assembleFieldMatrix( J2, localVal, dofMgr1_, dofMgr2_ );
+    isJ2Transposed_ = false;
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assemblePDEJacobian2): Jacobian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEJacobian2): Jacobian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEJacobian3(ROL::Ptr<Tpetra::MultiVector<>> &J3,
+                                     const ROL::Ptr<PDE_type> &pde,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEJacobian3);
+  #endif
+  if ( z_param != ROL::nullPtr ) {
+    try {
+      const int size = static_cast<int>(z_param->size());
+      // Initialize Jacobian storage if not done so already
+      if (J3 == ROL::nullPtr)
+        J3 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueResidualMap_, size, true);
+      ROL::Ptr<Tpetra::MultiVector<>> overlapVec;
+      if ( store_ ) {
+        if ( pde_vecJ3_overlap_ == ROL::nullPtr)
+          pde_vecJ3_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, size, true);
+        overlapVec = pde_vecJ3_overlap_;
+      }
+      else {
+        overlapVec = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, size, true);
+      }
+      // Get u_coeff from u and z_coeff from z
+      scalar_view u_coeff, z_coeff;
+      getCoeffFromStateVector(u_coeff,u);
+      getCoeffFromControlVector(z_coeff,z);
+      // Assemble
+      std::vector<scalar_view> localVal(size);
+      pde->Jacobian_3(localVal,u_coeff,z_coeff,z_param);
+      assembleParamFieldMatrix( J3, localVal, overlapVec, dofMgr1_ );
+    }
+    catch ( Exception::Zero & ez ) {
+      throw Exception::Zero(">>> (Assembler::assemblePDEJacobian3): Jacobian is zero.");
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      throw Exception::NotImplemented(">>> (Assembler::assemblePDEJacobian3): Jacobian not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEJacobian3): Jacobian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEapplyJacobian1(ROL::Ptr<Tpetra::MultiVector<>> &Jv1,
+                                                const ROL::Ptr<PDE_type> &pde,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                                const ROL::Ptr<const std::vector<Real>> & z_param) {
+//  #ifdef ROL_TIMERS
+//    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEapplyJacobian1);
+//  #endif
+  try {
+    // Initialize residual vectors if not done so
+    if ( Jv1 == ROL::nullPtr ) // Unique components of residual vector
+      Jv1 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueResidualMap_, 1, true);
+    ROL::Ptr<Tpetra::MultiVector<>> overlapVec;
+    if ( store_ ) {
+      if ( pde_vecR_overlap_ == ROL::nullPtr ) // Overlapping components of residual vector
+        pde_vecR_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, 1, true);
+      overlapVec = pde_vecR_overlap_;
+    }
+    else {
+      overlapVec = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, 1, true);
+    }
+    // Get u_coeff from u and z_coeff from z
+    scalar_view v_coeff, u_coeff, z_coeff;
+    getCoeffFromStateVector(v_coeff,v);
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Assemble
+    scalar_view localVal;
+    pde->applyJacobian_1(localVal,v_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldVector( Jv1, localVal, pde_vecR_overlap_, dofMgr1_ );
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assemblePDEapplyJacobian1): Jacobian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEapplyJacobian1): Jacobian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEapplyAdjointJacobian1(ROL::Ptr<Tpetra::MultiVector<>> &Jv1,
+                                                       const ROL::Ptr<PDE_type> &pde,
+                                                       const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                                       const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                                       const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                                       const ROL::Ptr<const std::vector<Real>> & z_param) {
+//  #ifdef ROL_TIMERS
+//    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEapplyAdjointJacobian1);
+//  #endif
+  try {
+    // Initialize residual vectors if not done so
+    if ( Jv1 == ROL::nullPtr ) // Unique components of residual vector
+      Jv1 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueResidualMap_, 1, true);
+    ROL::Ptr<Tpetra::MultiVector<>> overlapVec;
+    if ( store_ ) {
+      if ( pde_vecR_overlap_ == ROL::nullPtr ) // Overlapping components of residual vector
+        pde_vecR_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, 1, true);
+      overlapVec = pde_vecR_overlap_;
+    }
+    else {
+      overlapVec = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, 1, true);
+    }
+    // Get u_coeff from u and z_coeff from z
+    scalar_view v_coeff, u_coeff, z_coeff;
+    getCoeffFromStateVector(v_coeff,v);
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Assemble
+    scalar_view localVal;
+    pde->applyAdjointJacobian_1(localVal,v_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldVector( Jv1, localVal, overlapVec, dofMgr1_ );
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assemblePDEapplyAdjointJacobian1): Jacobian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEapplyAdjointJacobian1): Jacobian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEapplyJacobian2(ROL::Ptr<Tpetra::MultiVector<>> &Jv2,
+                                                const ROL::Ptr<PDE_type> &pde,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                                const ROL::Ptr<const std::vector<Real>> & z_param) {
+//  #ifdef ROL_TIMERS
+//    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEapplyJacobian2);
+//  #endif
+  try {
+    // Initialize residual vectors if not done so
+    if ( Jv2 == ROL::nullPtr ) // Unique components of residual vector
+      Jv2 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueResidualMap_, 1, true);
+    ROL::Ptr<Tpetra::MultiVector<>> overlapVec;
+    if ( store_ ) {
+      if ( pde_vecR_overlap_ == ROL::nullPtr ) // Overlapping components of residual vector
+        pde_vecR_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, 1, true);
+      overlapVec = pde_vecR_overlap_;
+    }
+    else {
+      overlapVec = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, 1, true);
+    }
+    // Get u_coeff from u and z_coeff from z
+    scalar_view v_coeff, u_coeff, z_coeff;
+    getCoeffFromControlVector(v_coeff,v);
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Assemble
+    scalar_view localVal;
+    pde->applyJacobian_2(localVal,v_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldVector( Jv2, localVal, overlapVec, dofMgr1_ );
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assemblePDEapplyJacobian2): Jacobian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEapplyJacobian2): Jacobian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEapplyAdjointJacobian2(ROL::Ptr<Tpetra::MultiVector<>> &Jv2,
+                                                       const ROL::Ptr<PDE_type> &pde,
+                                                       const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                                       const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                                       const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                                       const ROL::Ptr<const std::vector<Real>> & z_param) {
+//  #ifdef ROL_TIMERS
+//    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEapplyAdjointJacobian2);
+//  #endif
+  try {
+    // Initialize residual vectors if not done so
+    if ( Jv2 == ROL::nullPtr ) // Unique components of residual vector
+      Jv2 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueControlMap_, 1, true);
+    ROL::Ptr<Tpetra::MultiVector<>> overlapVec;
+    if ( store_ ) {
+      if ( pde_vecJ2_overlap_ == ROL::nullPtr ) // Overlapping components of residual vector
+        pde_vecJ2_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapControlMap_, 1, true);
+      overlapVec = pde_vecJ2_overlap_;
+    }
+    else {
+      overlapVec = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapControlMap_, 1, true);
+    }
+    // Get u_coeff from u and z_coeff from z
+    scalar_view v_coeff, u_coeff, z_coeff;
+    getCoeffFromStateVector(v_coeff,v);
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Assemble
+    scalar_view localVal;
+    pde->applyAdjointJacobian_2(localVal,v_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldVector( Jv2, localVal, overlapVec, dofMgr2_ );
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assemblePDEapplyAdjointJacobian2): Jacobian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEapplyAdjointJacobian2): Jacobian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEHessian11(ROL::Ptr<Tpetra::CrsMatrix<>> &H11,
+                                     const ROL::Ptr<PDE_type> &pde,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEHessian11);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view u_coeff, z_coeff, l_coeff;
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    getCoeffFromStateVector(l_coeff,l);
+    // Initialize Hessian storage if not done so already
+    if ( H11 == ROL::nullPtr ) {
+      H11 = ROL::makePtr<Tpetra::CrsMatrix<>>(matH11Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Hessian_11(localVal,l_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H11, localVal, dofMgr1_, dofMgr1_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assemblePDEHessian11): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEHessian11): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEHessian12(ROL::Ptr<Tpetra::CrsMatrix<>> &H12,
+                                     const ROL::Ptr<PDE_type> &pde,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEHessian12);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view u_coeff, z_coeff, l_coeff;
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    getCoeffFromStateVector(l_coeff,l);
+    // Initialize Hessian storage if not done so already
+    if ( H12 == ROL::nullPtr ) {
+      H12 = ROL::makePtr<Tpetra::CrsMatrix<>>(matH12Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Hessian_12(localVal,l_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H12, localVal, dofMgr2_, dofMgr1_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assemblePDEHessian12): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEHessian12): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEHessian13(ROL::Ptr<Tpetra::MultiVector<>> &H13,
+                                     const ROL::Ptr<PDE_type> &pde,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEHessian13);
+  #endif
+  if ( z_param != ROL::nullPtr ) {
+    try {
+      int size = static_cast<int>(z_param->size());
+      // Get u_coeff from u, z_coeff from z and l_coeff from l
+      scalar_view u_coeff, z_coeff, l_coeff;
+      getCoeffFromStateVector(u_coeff,u);
+      getCoeffFromControlVector(z_coeff,z);
+      getCoeffFromStateVector(l_coeff,l);
+      // Initialize Jacobian storage if not done so already
+      if (H13 == ROL::nullPtr) {
+        H13 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueStateMap_, size, true);
+      }
+      if ( pde_vecH13_overlap_ == ROL::nullPtr) {
+        pde_vecH13_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapStateMap_, size, true);
+      }
+      // Assemble
+      std::vector<scalar_view> localVal(size);
+      pde->Hessian_13(localVal,l_coeff,u_coeff,z_coeff,z_param);
+      assembleParamFieldMatrix( H13, localVal, pde_vecH13_overlap_, dofMgr1_ );
+    }
+    catch ( Exception::Zero & ez ) {
+      throw Exception::Zero(">>> (Assembler::assemblePDEHessian13): Hessian is zero.");
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      throw Exception::NotImplemented(">>> (Assembler::assemblePDEHessian13): Hessian not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEHessian13): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEHessian21(ROL::Ptr<Tpetra::CrsMatrix<>> &H21,
+                                     const ROL::Ptr<PDE_type> &pde,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEHessian21);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view u_coeff, z_coeff, l_coeff;
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    getCoeffFromStateVector(l_coeff,l);
+    // Initialize Hessian storage if not done so already
+    if ( H21 == ROL::nullPtr ) {
+      H21 = ROL::makePtr<Tpetra::CrsMatrix<>>(matH21Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Hessian_21(localVal,l_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H21, localVal, dofMgr1_, dofMgr2_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assemblePDEHessian21): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEHessian21): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEHessian22(ROL::Ptr<Tpetra::CrsMatrix<>> &H22,
+                                     const ROL::Ptr<PDE_type> &pde,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEHessian22);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view u_coeff, z_coeff, l_coeff;
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    getCoeffFromStateVector(l_coeff,l);
+    // Initialize Hessian storage if not done so already
+    if ( H22 == ROL::nullPtr ) {
+      H22 = ROL::makePtr<Tpetra::CrsMatrix<>>(matH22Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Hessian_22(localVal,l_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H22, localVal, dofMgr2_, dofMgr2_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assemblePDEHessian22): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEHessian22): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEHessian23(ROL::Ptr<Tpetra::MultiVector<>> &H23,
+                                     const ROL::Ptr<PDE_type> &pde,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEHessian23);
+  #endif
+  if ( z_param != ROL::nullPtr ) {
+    try {
+      int size = static_cast<int>(z_param->size());
+      // Get u_coeff from u, z_coeff from z and l_coeff from l
+      scalar_view u_coeff, z_coeff, l_coeff;
+      getCoeffFromStateVector(u_coeff,u);
+      getCoeffFromControlVector(z_coeff,z);
+      getCoeffFromStateVector(l_coeff,l);
+      // Initialize Jacobian storage if not done so already
+      if (H23 == ROL::nullPtr) {
+        H23 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueControlMap_, size, true);
+      }
+      if ( pde_vecH23_overlap_ == ROL::nullPtr) {
+        pde_vecH23_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapControlMap_, size, true);
+      }
+      // Assemble
+      std::vector<scalar_view> localVal(size);
+      pde->Hessian_23(localVal,l_coeff,u_coeff,z_coeff,z_param);
+      assembleParamFieldMatrix( H23, localVal, pde_vecH23_overlap_, dofMgr2_ );
+    }
+    catch ( Exception::Zero & ez ) {
+      throw Exception::Zero(">>> (Assembler::assemblePDEHessian23): Hessian is zero.");
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      throw Exception::NotImplemented(">>> (Assembler::assemblePDEHessian23): Hessian not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEHessian23): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEHessian31(ROL::Ptr<Tpetra::MultiVector<>> &H31,
+                                     const ROL::Ptr<PDE_type> &pde,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEHessian31);
+  #endif
+  assemblePDEHessian13(H31,pde,l,u,z,z_param);
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEHessian32(ROL::Ptr<Tpetra::MultiVector<>> &H32,
+                                     const ROL::Ptr<PDE_type> &pde,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEHessian32);
+  #endif
+  assemblePDEHessian23(H32,pde,l,u,z,z_param);
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEHessian33(ROL::Ptr<std::vector<std::vector<Real>>> &H33,
+                                     const ROL::Ptr<PDE_type> &pde,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEHessian33);
+  #endif
+  if ( z_param != ROL::nullPtr ) {
+    try {
+      int size = static_cast<int>(z_param->size());
+      // Get u_coeff from u, z_coeff from z and l_coeff from l
+      scalar_view u_coeff, z_coeff, l_coeff;
+      getCoeffFromStateVector(u_coeff,u);
+      getCoeffFromControlVector(z_coeff,z);
+      getCoeffFromStateVector(l_coeff,l);
+      // Initialize Jacobian storage if not done so already
+      if (H33 == ROL::nullPtr) {
+        std::vector<Real> col(size,static_cast<Real>(0));
+        H33 = ROL::makePtr<std::vector<std::vector<Real>>>(size,col);
+      }
+      // Assemble
+      std::vector<std::vector<scalar_view>> localVal(size);
+      for (int i=0; i< size; ++i) {
+        localVal[i].resize(size);
+      }
+      pde->Hessian_33(localVal,l_coeff,u_coeff,z_coeff,z_param);
+      assembleParamMatrix( H33, localVal, dofMgr1_ );
+    }
+    catch ( Exception::Zero & ez ) {
+      throw Exception::Zero(">>> (Assembler::assemblePDEHessian33): Hessian is zero.");
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      throw Exception::NotImplemented(">>> (Assembler::assemblePDEHessian33): Hessian not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEHessian33): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEapplyHessian11(ROL::Ptr<Tpetra::MultiVector<>> &Hv,
+                                                const ROL::Ptr<PDE_type> &pde,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                                const ROL::Ptr<const std::vector<Real>> & z_param) {
+//  #ifdef ROL_TIMERS
+//    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEapplyJacobian2);
+//  #endif
+  try {
+    // Initialize residual vectors if not done so
+    if ( Hv == ROL::nullPtr ) // Unique components of residual vector
+      Hv = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueResidualMap_, 1, true);
+    ROL::Ptr<Tpetra::MultiVector<>> overlapVec;
+    if ( store_ ) {
+      if ( pde_vecR_overlap_ == ROL::nullPtr ) // Overlapping components of residual vector
+        pde_vecR_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, 1, true);
+      overlapVec = pde_vecR_overlap_;
+    }
+    else {
+      overlapVec = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, 1, true);
+    }
+    // Get u_coeff from u and z_coeff from z
+    scalar_view v_coeff, l_coeff, u_coeff, z_coeff;
+    getCoeffFromStateVector(v_coeff,v);
+    getCoeffFromStateVector(l_coeff,l);
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Assemble
+    scalar_view localVal;
+    pde->applyHessian_11(localVal,v_coeff,l_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldVector( Hv, localVal, overlapVec, dofMgr1_ );
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assemblePDEapplyHessian11): Hessian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEapplyHessian11): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEapplyHessian12(ROL::Ptr<Tpetra::MultiVector<>> &Hv,
+                                                const ROL::Ptr<PDE_type> &pde,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                                const ROL::Ptr<const std::vector<Real>> & z_param) {
+//  #ifdef ROL_TIMERS
+//    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEapplyJacobian2);
+//  #endif
+  try {
+    // Initialize residual vectors if not done so
+    if ( Hv == ROL::nullPtr ) // Unique components of residual vector
+      Hv = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueControlMap_, 1, true);
+    ROL::Ptr<Tpetra::MultiVector<>> overlapVec;
+    if ( store_ ) {
+      if ( pde_vecJ2_overlap_ == ROL::nullPtr ) // Overlapping components of residual vector
+        pde_vecJ2_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapControlMap_, 1, true);
+      overlapVec = pde_vecJ2_overlap_;
+    }
+    else {
+      overlapVec = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapControlMap_, 1, true);
+    }
+    // Get u_coeff from u and z_coeff from z
+    scalar_view v_coeff, l_coeff, u_coeff, z_coeff;
+    getCoeffFromStateVector(v_coeff,v);
+    getCoeffFromStateVector(l_coeff,l);
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Assemble
+    scalar_view localVal;
+    pde->applyHessian_12(localVal,v_coeff,l_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldVector( Hv, localVal, overlapVec, dofMgr2_ );
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assemblePDEapplyHessian12): Hessian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEapplyHessian12): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEapplyHessian21(ROL::Ptr<Tpetra::MultiVector<>> &Hv,
+                                                const ROL::Ptr<PDE_type> &pde,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                                const ROL::Ptr<const std::vector<Real>> & z_param) {
+//  #ifdef ROL_TIMERS
+//    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEapplyJacobian2);
+//  #endif
+  try {
+    // Initialize residual vectors if not done so
+    if ( Hv == ROL::nullPtr ) // Unique components of residual vector
+      Hv = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueResidualMap_, 1, true);
+    ROL::Ptr<Tpetra::MultiVector<>> overlapVec;
+    if ( store_ ) {
+      if ( pde_vecR_overlap_ == ROL::nullPtr ) // Overlapping components of residual vector
+        pde_vecR_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, 1, true);
+      overlapVec = pde_vecR_overlap_;
+    }
+    else {
+      overlapVec = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, 1, true);
+    }
+    // Get u_coeff from u and z_coeff from z
+    scalar_view v_coeff, l_coeff, u_coeff, z_coeff;
+    getCoeffFromControlVector(v_coeff,v);
+    getCoeffFromStateVector(l_coeff,l);
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Assemble
+    scalar_view localVal;
+    pde->applyHessian_21(localVal,v_coeff,l_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldVector( Hv, localVal, overlapVec, dofMgr2_ );
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assemblePDEapplyHessian21): Hessian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEapplyHessian21): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDEapplyHessian22(ROL::Ptr<Tpetra::MultiVector<>> &Hv,
+                                                const ROL::Ptr<PDE_type> &pde,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                                const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                                const ROL::Ptr<const std::vector<Real>> & z_param) {
+//  #ifdef ROL_TIMERS
+//    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssemblePDEapplyJacobian2);
+//  #endif
+  try {
+    // Initialize residual vectors if not done so
+    if ( Hv == ROL::nullPtr ) // Unique components of residual vector
+      Hv = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueControlMap_, 1, true);
+    ROL::Ptr<Tpetra::MultiVector<>> overlapVec;
+    if ( store_ ) {
+      if ( pde_vecJ2_overlap_ == ROL::nullPtr ) // Overlapping components of residual vector
+        pde_vecJ2_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapControlMap_, 1, true);
+      overlapVec = pde_vecJ2_overlap_;
+    }
+    else {
+      overlapVec = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapControlMap_, 1, true);
+    }
+    // Get u_coeff from u and z_coeff from z
+    scalar_view v_coeff, l_coeff, u_coeff, z_coeff;
+    getCoeffFromControlVector(v_coeff,v);
+    getCoeffFromStateVector(l_coeff,l);
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Assemble
+    scalar_view localVal;
+    pde->applyHessian_22(localVal,v_coeff,l_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldVector( Hv, localVal, overlapVec, dofMgr2_ );
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assemblePDEapplyHessian22): Hessian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assemblePDEapplyHessian22): Hessian not implemented.");
+  }
+}
+/***************************************************************************/
+/* End of PDE assembly routines.                                           */
+/***************************************************************************/
+
+/***************************************************************************/
+/* DynamicPDE assembly routines                                            */
+/***************************************************************************/
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEResidual(ROL::Ptr<Tpetra::MultiVector<>> &r,
+                                       const ROL::Ptr<DynPDE_type> &pde,
+                                       const ROL::TimeStamp<Real> &ts,
+                                       const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                       const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                       const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                       const ROL::Ptr<const std::vector<Real>> &z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEResidual);
+  #endif
+  // Initialize residual vectors if not done so
+  if ( r == ROL::nullPtr ) { // Unique components of residual vector
+    r = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueResidualMap_, 1, true);
+  }
+  if ( pde_vecR_overlap_ == ROL::nullPtr ) { // Overlapping components of residual vector
+    pde_vecR_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, 1, true);
+  }
+  // Get u_coeff from u and z_coeff from z
+  scalar_view uo_coeff, un_coeff, z_coeff;
+  getCoeffFromStateVector(uo_coeff,uo);
+  getCoeffFromStateVector(un_coeff,un);
+  getCoeffFromControlVector(z_coeff,z);
+  // Assemble
+  scalar_view localVal;
+  pde->residual(localVal,ts,uo_coeff,un_coeff,z_coeff,z_param);
+  assembleFieldVector( r, localVal, pde_vecR_overlap_, dofMgr1_ );
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEJacobian_uo(ROL::Ptr<Tpetra::CrsMatrix<>> &J,
+                                          const ROL::Ptr<DynPDE_type> &pde,
+                                          const ROL::TimeStamp<Real> &ts,
+                                          const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                          const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                          const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                          const ROL::Ptr<const std::vector<Real>> &z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEJacobian_uo);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view uo_coeff, un_coeff, z_coeff;
+    getCoeffFromStateVector(uo_coeff,uo);
+    getCoeffFromStateVector(un_coeff,un);
+    getCoeffFromControlVector(z_coeff,z);
+    // Initialize Jacobian matrices
+    if ( J == ROL::nullPtr ) {
+      J = ROL::makePtr<Tpetra::CrsMatrix<>>(matJ1Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Jacobian_uo(localVal,ts,uo_coeff,un_coeff,z_coeff,z_param);
+    assembleFieldMatrix( J, localVal, dofMgr1_, dofMgr1_ );
+    isJuoTransposed_ = false;
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assembleDynPDEJacobian_uo): Jacobian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEJacobian_uo): Jacobian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEJacobian_un(ROL::Ptr<Tpetra::CrsMatrix<>> &J,
+                                          const ROL::Ptr<DynPDE_type> &pde,
+                                          const ROL::TimeStamp<Real> &ts,
+                                          const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                          const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                          const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                          const ROL::Ptr<const std::vector<Real>> &z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEJacobian_un);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view uo_coeff, un_coeff, z_coeff;
+    getCoeffFromStateVector(uo_coeff,uo);
+    getCoeffFromStateVector(un_coeff,un);
+    getCoeffFromControlVector(z_coeff,z);
+    // Initialize Jacobian matrices
+    if ( J == ROL::nullPtr ) {
+      J = ROL::makePtr<Tpetra::CrsMatrix<>>(matJ1Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Jacobian_un(localVal,ts,uo_coeff,un_coeff,z_coeff,z_param);
+    assembleFieldMatrix( J, localVal, dofMgr1_, dofMgr1_ );
+    isJunTransposed_ = false;
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assembleDynPDEJacobian_un): Jacobian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEJacobian_un): Jacobian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEJacobian_zf(ROL::Ptr<Tpetra::CrsMatrix<>> &J,
+                                          const ROL::Ptr<DynPDE_type> &pde,
+                                          const ROL::TimeStamp<Real> &ts,
+                                          const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                          const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                          const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                          const ROL::Ptr<const std::vector<Real>> &z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEJacobian_zf);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view uo_coeff, un_coeff, z_coeff;
+    getCoeffFromStateVector(uo_coeff,uo);
+    getCoeffFromStateVector(un_coeff,un);
+    getCoeffFromControlVector(z_coeff,z);
+    // Initialize Jacobian matrices
+    if ( J == ROL::nullPtr ) {
+      J = ROL::makePtr<Tpetra::CrsMatrix<>>(matJ2Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Jacobian_zf(localVal,ts,uo_coeff,un_coeff,z_coeff,z_param);
+    assembleFieldMatrix( J, localVal, dofMgr1_, dofMgr2_ );
+    isJzfTransposed_ = false;
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assembleDynPDEJacobian_zf): Jacobian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEJacobian_zf): Jacobian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEJacobian_zp(ROL::Ptr<Tpetra::MultiVector<>> &J,
+                                          const ROL::Ptr<DynPDE_type> &pde,
+                                          const ROL::TimeStamp<Real> &ts,
+                                          const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                          const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                          const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                          const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEJacobian_zp);
+  #endif
+  if ( z_param != ROL::nullPtr ) {
+    try {
+      int size = static_cast<int>(z_param->size());
+      // Get u_coeff from u and z_coeff from z
+      scalar_view uo_coeff, un_coeff, z_coeff;
+      getCoeffFromStateVector(uo_coeff,uo);
+      getCoeffFromStateVector(un_coeff,un);
+      getCoeffFromControlVector(z_coeff,z);
+      // Initialize Jacobian storage if not done so already
+      if (J == ROL::nullPtr) {
+        J = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueResidualMap_, size, true);
+      }
+      if ( pde_vecJ3_overlap_ == ROL::nullPtr) {
+        pde_vecJ3_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapResidualMap_, size, true);
+      }
+      // Assemble
+      std::vector<scalar_view> localVal(size);
+      pde->Jacobian_zp(localVal,ts,uo_coeff,un_coeff,z_coeff,z_param);
+      assembleParamFieldMatrix( J, localVal, pde_vecJ3_overlap_, dofMgr1_ );
+    }
+    catch ( Exception::Zero & ez ) {
+      throw Exception::Zero(">>> (Assembler::assembleDynPDEJacobian_zp): Jacobian is zero.");
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEJacobian_zp): Jacobian not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEJacobian_zp): Jacobian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_uo_uo(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_uo_uo);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view uo_coeff, un_coeff, z_coeff, l_coeff;
+    getCoeffFromStateVector(uo_coeff,uo);
+    getCoeffFromStateVector(un_coeff,un);
+    getCoeffFromControlVector(z_coeff,z);
+    getCoeffFromStateVector(l_coeff,l);
+    // Initialize Hessian storage if not done so already
+    if ( H == ROL::nullPtr ) {
+      H = ROL::makePtr<Tpetra::CrsMatrix<>>(matH11Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Hessian_uo_uo(localVal,ts,l_coeff,uo_coeff,un_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H, localVal, dofMgr1_, dofMgr1_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assembleDynPDEHessian_uo_uo): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_uo_uo): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_uo_un(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_uo_un);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view uo_coeff, un_coeff, z_coeff, l_coeff;
+    getCoeffFromStateVector(uo_coeff,uo);
+    getCoeffFromStateVector(un_coeff,un);
+    getCoeffFromControlVector(z_coeff,z);
+    getCoeffFromStateVector(l_coeff,l);
+    // Initialize Hessian storage if not done so already
+    if ( H == ROL::nullPtr ) {
+      H = ROL::makePtr<Tpetra::CrsMatrix<>>(matH11Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Hessian_uo_un(localVal,ts,l_coeff,uo_coeff,un_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H, localVal, dofMgr1_, dofMgr1_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assembleDynPDEHessian_uo_un): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_uo_un): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_uo_zf(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_uo_zf);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view uo_coeff, un_coeff, z_coeff, l_coeff;
+    getCoeffFromStateVector(uo_coeff,uo);
+    getCoeffFromStateVector(un_coeff,un);
+    getCoeffFromControlVector(z_coeff,z);
+    getCoeffFromStateVector(l_coeff,l);
+    // Initialize Hessian storage if not done so already
+    if ( H == ROL::nullPtr ) {
+      H = ROL::makePtr<Tpetra::CrsMatrix<>>(matH12Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Hessian_uo_zf(localVal,ts,l_coeff,uo_coeff,un_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H, localVal, dofMgr1_, dofMgr2_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assembleDynPDEHessian_uo_zf): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_uo_zf): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_uo_zp(ROL::Ptr<Tpetra::MultiVector<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_uo_zp);
+  #endif
+  if ( z_param != ROL::nullPtr ) {
+    try {
+      int size = static_cast<int>(z_param->size());
+      // Get u_coeff from u, z_coeff from z and l_coeff from l
+      scalar_view uo_coeff, un_coeff, z_coeff, l_coeff;
+      getCoeffFromStateVector(uo_coeff,uo);
+      getCoeffFromStateVector(un_coeff,un);
+      getCoeffFromControlVector(z_coeff,z);
+      getCoeffFromStateVector(l_coeff,l);
+      // Initialize Jacobian storage if not done so already
+      if (H == ROL::nullPtr) {
+        H = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueStateMap_, size, true);
+      }
+      if ( pde_vecH13_overlap_ == ROL::nullPtr) {
+        pde_vecH13_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapStateMap_, size, true);
+      }
+      // Assemble
+      std::vector<scalar_view> localVal(size);
+      pde->Hessian_uo_zp(localVal,ts,l_coeff,uo_coeff,un_coeff,z_coeff,z_param);
+      assembleParamFieldMatrix( H, localVal, pde_vecH13_overlap_, dofMgr1_ );
+    }
+    catch ( Exception::Zero & ez ) {
+      throw Exception::Zero(">>> (Assembler::assembleDynPDEHessian_uo_zp): Hessian is zero.");
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_uo_zp): Hessian not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_uo_zp): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_un_uo(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_un_uo);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view uo_coeff, un_coeff, z_coeff, l_coeff;
+    getCoeffFromStateVector(uo_coeff,uo);
+    getCoeffFromStateVector(un_coeff,un);
+    getCoeffFromControlVector(z_coeff,z);
+    getCoeffFromStateVector(l_coeff,l);
+    // Initialize Hessian storage if not done so already
+    if ( H == ROL::nullPtr ) {
+      H = ROL::makePtr<Tpetra::CrsMatrix<>>(matH11Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Hessian_un_uo(localVal,ts,l_coeff,uo_coeff,un_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H, localVal, dofMgr1_, dofMgr1_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assembleDynPDEHessian_un_uo): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_un_uo): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_un_un(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_un_un);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view uo_coeff, un_coeff, z_coeff, l_coeff;
+    getCoeffFromStateVector(uo_coeff,uo);
+    getCoeffFromStateVector(un_coeff,un);
+    getCoeffFromControlVector(z_coeff,z);
+    getCoeffFromStateVector(l_coeff,l);
+    // Initialize Hessian storage if not done so already
+    if ( H == ROL::nullPtr ) {
+      H = ROL::makePtr<Tpetra::CrsMatrix<>>(matH11Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Hessian_un_un(localVal,ts,l_coeff,uo_coeff,un_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H, localVal, dofMgr1_, dofMgr1_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assembleDynPDEHessian_un_un): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_un_un): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_un_zf(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_un_zf);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view uo_coeff, un_coeff, z_coeff, l_coeff;
+    getCoeffFromStateVector(uo_coeff,uo);
+    getCoeffFromStateVector(un_coeff,un);
+    getCoeffFromControlVector(z_coeff,z);
+    getCoeffFromStateVector(l_coeff,l);
+    // Initialize Hessian storage if not done so already
+    if ( H == ROL::nullPtr ) {
+      H = ROL::makePtr<Tpetra::CrsMatrix<>>(matH12Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Hessian_un_zf(localVal,ts,l_coeff,uo_coeff,un_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H, localVal, dofMgr1_, dofMgr2_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assembleDynPDEHessian_un_zf): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_un_zf): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_un_zp(ROL::Ptr<Tpetra::MultiVector<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_un_zp);
+  #endif
+  if ( z_param != ROL::nullPtr ) {
+    try {
+      int size = static_cast<int>(z_param->size());
+      // Get u_coeff from u, z_coeff from z and l_coeff from l
+      scalar_view uo_coeff, un_coeff, z_coeff, l_coeff;
+      getCoeffFromStateVector(uo_coeff,uo);
+      getCoeffFromStateVector(un_coeff,un);
+      getCoeffFromControlVector(z_coeff,z);
+      getCoeffFromStateVector(l_coeff,l);
+      // Initialize Jacobian storage if not done so already
+      if (H == ROL::nullPtr) {
+        H = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueStateMap_, size, true);
+      }
+      if ( pde_vecH13_overlap_ == ROL::nullPtr) {
+        pde_vecH13_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapStateMap_, size, true);
+      }
+      // Assemble
+      std::vector<scalar_view> localVal(size);
+      pde->Hessian_un_zp(localVal,ts,l_coeff,uo_coeff,un_coeff,z_coeff,z_param);
+      assembleParamFieldMatrix( H, localVal, pde_vecH13_overlap_, dofMgr1_ );
+    }
+    catch ( Exception::Zero & ez ) {
+      throw Exception::Zero(">>> (Assembler::assembleDynPDEHessian_un_zp): Hessian is zero.");
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_un_zp): Hessian not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_un_zp): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_zf_uo(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_zf_uo);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view uo_coeff, un_coeff, z_coeff, l_coeff;
+    getCoeffFromStateVector(uo_coeff,uo);
+    getCoeffFromStateVector(un_coeff,un);
+    getCoeffFromControlVector(z_coeff,z);
+    getCoeffFromStateVector(l_coeff,l);
+    // Initialize Hessian storage if not done so already
+    if ( H == ROL::nullPtr ) {
+      H = ROL::makePtr<Tpetra::CrsMatrix<>>(matH21Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Hessian_zf_uo(localVal,ts,l_coeff,uo_coeff,un_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H, localVal, dofMgr2_, dofMgr1_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assembleDynPDEHessian_zf_uo): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_zf_uo): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_zf_un(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_zf_un);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view uo_coeff, un_coeff, z_coeff, l_coeff;
+    getCoeffFromStateVector(uo_coeff,uo);
+    getCoeffFromStateVector(un_coeff,un);
+    getCoeffFromControlVector(z_coeff,z);
+    getCoeffFromStateVector(l_coeff,l);
+    // Initialize Hessian storage if not done so already
+    if ( H == ROL::nullPtr ) {
+      H = ROL::makePtr<Tpetra::CrsMatrix<>>(matH21Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Hessian_zf_un(localVal,ts,l_coeff,uo_coeff,un_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H, localVal, dofMgr2_, dofMgr1_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assembleDynPDEHessian_zf_un): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_zf_un): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_zf_zf(ROL::Ptr<Tpetra::CrsMatrix<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_zf_zf);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view uo_coeff, un_coeff, z_coeff, l_coeff;
+    getCoeffFromStateVector(uo_coeff,uo);
+    getCoeffFromStateVector(un_coeff,un);
+    getCoeffFromControlVector(z_coeff,z);
+    getCoeffFromStateVector(l_coeff,l);
+    // Initialize Hessian storage if not done so already
+    if ( H == ROL::nullPtr ) {
+      H = ROL::makePtr<Tpetra::CrsMatrix<>>(matH22Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->Hessian_zf_zf(localVal,ts,l_coeff,uo_coeff,un_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H, localVal, dofMgr2_, dofMgr2_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assembleDynPDEHessian_zf_zf): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_zf_zf): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_zf_zp(ROL::Ptr<Tpetra::MultiVector<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_zf_zp);
+  #endif
+  if ( z_param != ROL::nullPtr ) {
+    try {
+      int size = static_cast<int>(z_param->size());
+      // Get u_coeff from u, z_coeff from z and l_coeff from l
+      scalar_view uo_coeff, un_coeff, z_coeff, l_coeff;
+      getCoeffFromStateVector(uo_coeff,uo);
+      getCoeffFromStateVector(un_coeff,un);
+      getCoeffFromControlVector(z_coeff,z);
+      getCoeffFromStateVector(l_coeff,l);
+      // Initialize Jacobian storage if not done so already
+      if (H == ROL::nullPtr) {
+        H = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueControlMap_, size, true);
+      }
+      if ( pde_vecH23_overlap_ == ROL::nullPtr) {
+        pde_vecH23_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapControlMap_, size, true);
+      }
+      // Assemble
+      std::vector<scalar_view> localVal(size);
+      pde->Hessian_zf_zp(localVal,ts,l_coeff,uo_coeff,un_coeff,z_coeff,z_param);
+      assembleParamFieldMatrix( H, localVal, pde_vecH23_overlap_, dofMgr2_ );
+    }
+    catch ( Exception::Zero & ez ) {
+      throw Exception::Zero(">>> (Assembler::assembleDynPDEHessian_zf_zp): Hessian is zero.");
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_zf_zp): Hessian not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_zf_zp): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_zp_uo(ROL::Ptr<Tpetra::MultiVector<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_zp_uo);
+  #endif
+  assembleDynPDEHessian_uo_zp(H,pde,ts,l,uo,un,z,z_param);
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_zp_un(ROL::Ptr<Tpetra::MultiVector<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_zp_un);
+  #endif
+  assembleDynPDEHessian_un_zp(H,pde,ts,l,uo,un,z,z_param);
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_zp_zf(ROL::Ptr<Tpetra::MultiVector<>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_zp_zf);
+  #endif
+  assembleDynPDEHessian_zf_zp(H,pde,ts,l,uo,un,z,z_param);
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDEHessian_zp_zp(ROL::Ptr<std::vector<std::vector<Real>>> &H,
+                                            const ROL::Ptr<DynPDE_type> &pde,
+                                            const ROL::TimeStamp<Real> &ts,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &l,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &uo,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &un,
+                                            const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                            const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleDynPDEHessian_zp_zp);
+  #endif
+  if ( z_param != ROL::nullPtr ) {
+    try {
+      int size = static_cast<int>(z_param->size());
+      // Get u_coeff from u, z_coeff from z and l_coeff from l
+      scalar_view uo_coeff, un_coeff, z_coeff, l_coeff;
+      getCoeffFromStateVector(uo_coeff,uo);
+      getCoeffFromStateVector(un_coeff,un);
+      getCoeffFromControlVector(z_coeff,z);
+      getCoeffFromStateVector(l_coeff,l);
+      // Initialize Jacobian storage if not done so already
+      if (H == ROL::nullPtr) {
+        std::vector<Real> col(size,static_cast<Real>(0));
+        H = ROL::makePtr<std::vector<std::vector<Real>>>(size,col);
+      }
+      // Assemble
+      std::vector<std::vector<scalar_view>> localVal(size);
+      for (int i=0; i<size; ++i)
+        localVal[i].resize(size);
+      pde->Hessian_zp_zp(localVal,ts,l_coeff,uo_coeff,un_coeff,z_coeff,z_param);
+      assembleParamMatrix( H, localVal, dofMgr1_ );
+    }
+    catch ( Exception::Zero & ez ) {
+      throw Exception::Zero(">>> (Assembler::assembleDynPDEHessian_zp_zp): Hessian is zero.");
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_zp_zp): Hessian not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assembleDynPDEHessian_zp_zp): Hessian not implemented.");
+  }
+}
+/***************************************************************************/
+/* End of PDE assembly routines.                                           */
+/***************************************************************************/
+
+/***************************************************************************/
+/* QoI assembly routines                                                   */
+/***************************************************************************/
+template<class Real, class DeviceType>
+Real Assembler<Real,DeviceType>::assembleQoIValue(const ROL::Ptr<QoI_type> &qoi,
+                                       const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                       const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                       const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIValue);
+  #endif
+  Real val(0);
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view u_coeff, z_coeff;
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Assemble
+    scalar_view localVal;
+    val  = qoi->value(localVal,u_coeff,z_coeff,z_param);
+    val += assembleScalar( localVal );
+  }
+  catch ( Exception::Zero & ez ) {
+    val = static_cast<Real>(0);
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIValue): Value not implemented.");
+  }
+  return val;
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIGradient1(ROL::Ptr<Tpetra::MultiVector<>> &g1,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIGradient1);
+  #endif
+  try {
+    // Initialize state QoI gradient vectors
+    if ( g1 == ROL::nullPtr ) {
+      g1 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueStateMap_, 1, true);
+    }
+    if ( qoi_vecG1_overlap_ == ROL::nullPtr ) {
+      qoi_vecG1_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapStateMap_, 1, true);
+    }
+    // Get u_coeff from u and z_coeff from z
+    scalar_view u_coeff, z_coeff;
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Assemble
+    scalar_view localVal;
+    qoi->gradient_1(localVal,u_coeff,z_coeff,z_param);
+    assembleFieldVector( g1, localVal, qoi_vecG1_overlap_, dofMgr1_ );
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assembleQoIGradient1): Gradient is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIGradient1): Gradient not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIGradient2(ROL::Ptr<Tpetra::MultiVector<>> &g2,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIGradient2);
+  #endif
+  try {
+    // Initialize control gradient vectors
+    if ( g2 == ROL::nullPtr ) {
+      g2 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueControlMap_, 1, true);
+    }
+    if ( qoi_vecG2_overlap_ == ROL::nullPtr ) {
+      qoi_vecG2_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapControlMap_, 1, true);
+    }
+    // Get u_coeff from u and z_coeff from z
+    scalar_view u_coeff, z_coeff;
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Assemble
+    scalar_view localVal;
+    qoi->gradient_2(localVal,u_coeff,z_coeff,z_param);
+    assembleFieldVector( g2, localVal, qoi_vecG2_overlap_, dofMgr2_ );
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assembleQoIGradient2): Gradient is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIGradient2): Gradient not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIGradient3(ROL::Ptr<std::vector<Real>> &g3,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIGradient3);
+  #endif
+  if ( z_param != ROL::nullPtr ) {
+    const int size = z_param->size();
+    if ( g3 == ROL::nullPtr ) {
+      g3 = ROL::makePtr<std::vector<Real>>(size,0);
+    }
+    try {
+      // Get u_coeff from u and z_coeff from z
+      scalar_view u_coeff, z_coeff;
+      getCoeffFromStateVector(u_coeff,u);
+      getCoeffFromControlVector(z_coeff,z);
+      // Assemble
+      std::vector<scalar_view> localVal(size);
+      std::vector<Real> g = qoi->gradient_3(localVal,u_coeff,z_coeff,z_param);
+      assembleParamVector( g3, localVal );
+      for (int i = 0; i < size; ++i) {
+        (*g3)[i] += g[i];
+      }
+    }
+    catch ( Exception::Zero & ez ) {
+      g3->assign(size,0);
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      throw Exception::NotImplemented(">>> (Assembler::assembleQoIGradient3): Gradient not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIGradient3): Gradient not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIHessVec11(ROL::Ptr<Tpetra::MultiVector<>> &H11,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIHessVec11);
+  #endif
+	  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view v_coeff, u_coeff, z_coeff;
+    getCoeffFromStateVector(v_coeff,v);
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Initialize state-state HessVec vectors
+    if ( H11 == ROL::nullPtr ) {
+      H11 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueStateMap_, 1, true);
+    }
+    if ( qoi_vecH11_overlap_ == ROL::nullPtr ) {
+      qoi_vecH11_overlap_  = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapStateMap_, 1, true);
+    }
+    // Assemble
+    scalar_view localVal;
+    qoi->HessVec_11(localVal,v_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldVector( H11, localVal, qoi_vecH11_overlap_, dofMgr1_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assembleQoIHessVec11): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessVec11): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIHessVec12(ROL::Ptr<Tpetra::MultiVector<>> &H12,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIHessVec12);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view v_coeff, u_coeff, z_coeff;
+    getCoeffFromControlVector(v_coeff,v);
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Initialize state-control HessVec vectors
+    if ( H12 == ROL::nullPtr ) {
+      H12 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueStateMap_, 1, true);
+    }
+    if ( qoi_vecH12_overlap_ == ROL::nullPtr ) {
+      qoi_vecH12_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapStateMap_, 1, true);
+    }
+    // Assemble
+    scalar_view localVal;
+    qoi->HessVec_12(localVal,v_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldVector( H12, localVal, qoi_vecH12_overlap_, dofMgr1_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assembleQoIHessVec12): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessVec12): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIHessVec13(ROL::Ptr<Tpetra::MultiVector<>> &H13,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const std::vector<Real>> &v,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> &z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIHessVec13);
+  #endif
+  if (z_param != ROL::nullPtr) {
+    try {
+      // Get u_coeff from u and z_coeff from z
+      scalar_view u_coeff, z_coeff;
+      getCoeffFromStateVector(u_coeff,u);
+      getCoeffFromControlVector(z_coeff,z);
+      // Initialize state-control HessVec vectors
+      if ( H13 == ROL::nullPtr ) {
+        H13 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueStateMap_, 1, true);
+      }
+      if ( qoi_vecH13_overlap_ == ROL::nullPtr ) {
+        qoi_vecH13_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapStateMap_, 1, true);
+      }
+      // Assemble
+      scalar_view localVal;
+      qoi->HessVec_13(localVal,v,u_coeff,z_coeff,z_param);
+      assembleFieldVector( H13, localVal, qoi_vecH13_overlap_, dofMgr1_ );
+    }
+    catch (Exception::Zero &ez) {
+      throw Exception::Zero(">>> (Assembler::assembleQoIHessVec13): Hessian is zero.");
+    }
+    catch (Exception::NotImplemented &eni) {
+      throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessVec13): Hessian not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessVec13): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIHessVec21(ROL::Ptr<Tpetra::MultiVector<>> &H21,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIHessVec21);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view v_coeff, u_coeff, z_coeff;
+    getCoeffFromStateVector(v_coeff,v);
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Initialize control-state HessVec vectors
+    if ( H21 == ROL::nullPtr ) {
+      H21 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueControlMap_, 1, true);
+    }
+    if ( qoi_vecH21_overlap_ == ROL::nullPtr ) {
+      qoi_vecH21_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapControlMap_, 1, true);
+    }
+    // Assemble
+    scalar_view localVal;
+    qoi->HessVec_21(localVal,v_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldVector( H21, localVal, qoi_vecH21_overlap_, dofMgr2_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assembleQoIHessVec21): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessVec21): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIHessVec22(ROL::Ptr<Tpetra::MultiVector<>> &H22,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIHessVec22);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view v_coeff, u_coeff, z_coeff;
+    getCoeffFromControlVector(v_coeff,v);
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Initialize control-control HessVec vectors
+    if ( H22 == ROL::nullPtr ) {
+      H22 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueControlMap_, 1, true);
+    }
+    if ( qoi_vecH22_overlap_ == ROL::nullPtr ) {
+      qoi_vecH22_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapControlMap_, 1, true);
+    }
+    // Assemble
+    scalar_view localVal;
+    qoi->HessVec_22(localVal,v_coeff,u_coeff,z_coeff,z_param);
+    assembleFieldVector( H22, localVal, qoi_vecH22_overlap_, dofMgr2_ );
+  }
+  catch (Exception::Zero &ez) {
+    throw Exception::Zero(">>> (Assembler::assembleQoIHessVec22): Hessian is zero.");
+  }
+  catch (Exception::NotImplemented &eni) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessVec22): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIHessVec23(ROL::Ptr<Tpetra::MultiVector<>> &H23,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const std::vector<Real>> &v,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIHessVec23);
+  #endif
+  if (z_param != ROL::nullPtr) {
+    try {
+      // Get u_coeff from u and z_coeff from z
+      scalar_view u_coeff, z_coeff;
+      getCoeffFromStateVector(u_coeff,u);
+      getCoeffFromControlVector(z_coeff,z);
+      // Initialize control-control HessVec vectors
+      if ( H23 == ROL::nullPtr ) {
+        H23 = ROL::makePtr<Tpetra::MultiVector<>>(myUniqueControlMap_, 1, true);
+      }
+      if ( qoi_vecH23_overlap_ == ROL::nullPtr ) {
+        qoi_vecH23_overlap_ = ROL::makePtr<Tpetra::MultiVector<>>(myOverlapControlMap_, 1, true);
+      }
+      // Assemble
+      scalar_view localVal;
+      qoi->HessVec_23(localVal,v,u_coeff,z_coeff,z_param);
+      assembleFieldVector( H23, localVal, qoi_vecH23_overlap_, dofMgr2_ );
+    }
+    catch (Exception::Zero &ez) {
+      throw Exception::Zero(">>> (Assembler::assembleQoIHessVec23): Hessian is zero.");
+    }
+    catch (Exception::NotImplemented &eni) {
+      throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessVec23): Hessian not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessVec23): Hessian not implemented.");
+  }
+
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIHessVec31(ROL::Ptr<std::vector<Real>> &H31,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIHessVec31);
+  #endif
+  if ( z_param != ROL::nullPtr ) {
+    const int size = z_param->size();
+    if ( H31 == ROL::nullPtr ) {
+      H31 = ROL::makePtr<std::vector<Real>>(size,0);
+    }
+    try {
+      H31->assign(size,0);
+      // Get u_coeff from u and z_coeff from z
+      scalar_view v_coeff, u_coeff, z_coeff;
+      getCoeffFromStateVector(v_coeff,v);
+      getCoeffFromStateVector(u_coeff,u);
+      getCoeffFromControlVector(z_coeff,z);
+      // Assemble
+      std::vector<scalar_view> localVal(size);
+      std::vector<Real> H = qoi->HessVec_31(localVal,v_coeff,u_coeff,z_coeff,z_param);
+      assembleParamVector( H31, localVal );
+      for (int i = 0; i < size; ++i) {
+        (*H31)[i] += H[i];
+      }
+    }
+    catch ( Exception::Zero & ez ) {
+      H31->assign(size,0);
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessVec31): HessVec not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessVec31): HessVec not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIHessVec32(ROL::Ptr<std::vector<Real>> &H32,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &v,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIHessVec32);
+  #endif
+  if ( z_param != ROL::nullPtr ) {
+    const int size = z_param->size();
+    if ( H32 == ROL::nullPtr ) {
+      H32 = ROL::makePtr<std::vector<Real>>(size,0);
+    }
+    try {
+      H32->assign(size,0);
+      // Get u_coeff from u and z_coeff from z
+      scalar_view v_coeff, u_coeff, z_coeff;
+      getCoeffFromControlVector(v_coeff,v);
+      getCoeffFromStateVector(u_coeff,u);
+      getCoeffFromControlVector(z_coeff,z);
+      // Assemble
+      std::vector<scalar_view> localVal(size);
+      std::vector<Real> H = qoi->HessVec_32(localVal,v_coeff,u_coeff,z_coeff,z_param);
+      assembleParamVector( H32, localVal );
+      for (int i = 0; i < size; ++i) {
+        (*H32)[i] += H[i];
+      }
+    }
+    catch ( Exception::Zero & ez ) {
+      H32->assign(size,0);
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessVec32): HessVec not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessVec32): HessVec not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIHessVec33(ROL::Ptr<std::vector<Real>> &H33,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const std::vector<Real>> &v,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> &z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIHessVec33);
+  #endif
+  if ( z_param != ROL::nullPtr ) {
+    const int size = z_param->size();
+    if ( H33 == ROL::nullPtr ) {
+      H33 = ROL::makePtr<std::vector<Real>>(size,0);
+    }
+    try {
+      H33->assign(size,0);
+      // Get u_coeff from u and z_coeff from z
+      scalar_view u_coeff, z_coeff;
+      getCoeffFromStateVector(u_coeff,u);
+      getCoeffFromControlVector(z_coeff,z);
+      // Assemble
+      std::vector<scalar_view> localVal(size);
+      std::vector<Real> H = qoi->HessVec_33(localVal,v,u_coeff,z_coeff,z_param);
+      assembleParamVector( H33, localVal );
+      for (int i = 0; i < size; ++i) {
+        (*H33)[i] += H[i];
+      }
+    }
+    catch ( Exception::Zero & ez ) {
+      H33->assign(size,0);
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessVec33): HessVec not implemented.");
+    }
+  }
+  else {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessVec33): HessVec not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIHessian11(ROL::Ptr<Tpetra::CrsMatrix<>> &H11,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIHessian11);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view u_coeff, z_coeff;
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Initialize Jacobian matrices
+    if ( H11 == ROL::nullPtr ) {
+      H11 = ROL::makePtr<Tpetra::CrsMatrix<>>(matH11Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    qoi->Hessian_11(localVal,u_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H11, localVal, dofMgr1_, dofMgr1_ );
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assembleQoIHessian11): Hessian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessian11): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIHessian12(ROL::Ptr<Tpetra::CrsMatrix<>> &H12,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIHessian12);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view u_coeff, z_coeff;
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Initialize Jacobian matrices
+    if ( H12 == ROL::nullPtr ) {
+      H12 = ROL::makePtr<Tpetra::CrsMatrix<>>(matH12Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    qoi->Hessian_12(localVal,u_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H12, localVal, dofMgr1_, dofMgr2_ );
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assembleQoIHessian12): Hessian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessian12): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIHessian21(ROL::Ptr<Tpetra::CrsMatrix<>> &H21,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIHessian21);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view u_coeff, z_coeff;
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Initialize Jacobian matrices
+    if ( H21 == ROL::nullPtr ) {
+      H21 = ROL::makePtr<Tpetra::CrsMatrix<>>(matH21Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    qoi->Hessian_21(localVal,u_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H21, localVal, dofMgr2_, dofMgr1_ );
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assembleQoIHessian21): Hessian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessian21): Hessian not implemented.");
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleQoIHessian22(ROL::Ptr<Tpetra::CrsMatrix<>> &H22,
+                                     const ROL::Ptr<QoI_type> &qoi,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                     const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                     const ROL::Ptr<const std::vector<Real>> & z_param) {
+  #ifdef ROL_TIMERS
+    Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::AssembleQOIHessian22);
+  #endif
+  try {
+    // Get u_coeff from u and z_coeff from z
+    scalar_view u_coeff, z_coeff;
+    getCoeffFromStateVector(u_coeff,u);
+    getCoeffFromControlVector(z_coeff,z);
+    // Initialize Jacobian matrices
+    if ( H22 == ROL::nullPtr ) {
+      H22 = ROL::makePtr<Tpetra::CrsMatrix<>>(matH11Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    qoi->Hessian_22(localVal,u_coeff,z_coeff,z_param);
+    assembleFieldMatrix( H22, localVal, dofMgr2_, dofMgr2_ );
+  }
+  catch ( Exception::Zero & ez ) {
+    throw Exception::Zero(">>> (Assembler::assembleQoIHessian22): Hessian is zero.");
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    throw Exception::NotImplemented(">>> (Assembler::assembleQoIHessian22): Hessian not implemented.");
+  }
+}
+/***************************************************************************/
+/* End QoI assembly routines                                               */
+/***************************************************************************/
+
+/***************************************************************************/
+/* Assemble and apply Riesz operator corresponding to simulation variables */
+/***************************************************************************/
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDERieszMap1(ROL::Ptr<Tpetra::CrsMatrix<>> &R1,
+                                     const ROL::Ptr<PDE_type> &pde) {
+  try {
+    // Initialize Riesz matrix if not done so already
+    if ( R1 == ROL::nullPtr ) {
+    R1 = ROL::makePtr<Tpetra::CrsMatrix<>>(matR1Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->RieszMap_1(localVal);
+    assembleFieldMatrix( R1, localVal, dofMgr1_, dofMgr1_ );
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    //throw Exception::NotImplemented(">>> (Assembler::assemblePDERieszMap1): Riesz map not implemented!");
+  }
+  catch ( Exception::Zero & ez ) {
+    //throw Exception::Zero(">>> (Assembler::assemblePDERieszMap1): Riesz map is zero!");
+  }
+}
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDERieszMap1(ROL::Ptr<Tpetra::CrsMatrix<>> &R1,
+                                        const ROL::Ptr<DynPDE_type> &pde) {
+  try {
+    // Initialize Riesz matrix if not done so already
+    if ( R1 == ROL::nullPtr ) {
+    R1 = ROL::makePtr<Tpetra::CrsMatrix<>>(matR1Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->RieszMap_1(localVal);
+    assembleFieldMatrix( R1, localVal, dofMgr1_, dofMgr1_ );
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    //throw Exception::NotImplemented(">>> (Assembler::assemblePDERieszMap1): Riesz map not implemented!");
+  }
+  catch ( Exception::Zero & ez ) {
+    //throw Exception::Zero(">>> (Assembler::assemblePDERieszMap1): Riesz map is zero!");
+  }
+}
+/***************************************************************************/
+/* End of functions for Riesz operator of simulation variables.            */
+/***************************************************************************/
+
+/***************************************************************************/
+/* Assemble and apply Riesz operator corresponding to optimization         */
+/* variables                                                               */
+/***************************************************************************/
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assemblePDERieszMap2(ROL::Ptr<Tpetra::CrsMatrix<>> &R2,
+                                     const ROL::Ptr<PDE_type> &pde) {
+  try {
+    // Initialize Riesz matrix if not done so already
+    if ( R2 == ROL::nullPtr ) {
+      R2 = ROL::makePtr<Tpetra::CrsMatrix<>>(matR2Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->RieszMap_2(localVal);
+    assembleFieldMatrix( R2, localVal, dofMgr2_, dofMgr2_ );
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    //throw Exception::NotImplemented(">>> (Assembler::assemblePDERieszMap2): Riesz map not implemented!");
+  }
+  catch ( Exception::Zero & ez ) {
+    //throw Exception::Zero(">>> (Assembler::assemblePDERieszMap2): Riesz map is zero!");
+  }
+}
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleDynPDERieszMap2(ROL::Ptr<Tpetra::CrsMatrix<>> &R2,
+                                        const ROL::Ptr<DynPDE_type> &pde) {
+  try {
+    // Initialize Riesz matrix if not done so already
+    if ( R2 == ROL::nullPtr ) {
+      R2 = ROL::makePtr<Tpetra::CrsMatrix<>>(matR2Graph_);
+    }
+    // Assemble
+    scalar_view localVal;
+    pde->RieszMap_2(localVal);
+    assembleFieldMatrix( R2, localVal, dofMgr2_, dofMgr2_ );
+  }
+  catch ( Exception::NotImplemented & eni ) {
+    //throw Exception::NotImplemented(">>> (Assembler::assemblePDERieszMap2): Riesz map not implemented!");
+  }
+  catch ( Exception::Zero & ez ) {
+    //throw Exception::Zero(">>> (Assembler::assemblePDERieszMap2): Riesz map is zero!");
+  }
+}
+/***************************************************************************/
+/* End of functions for Riesz operator of optimization variables.          */
+/***************************************************************************/
+
+/***************************************************************************/
+/* Compute error routines.                                                 */
+/***************************************************************************/
+template<class Real, class DeviceType>
+Real Assembler<Real,DeviceType>::computeStateError(const ROL::Ptr<const Tpetra::MultiVector<>> &soln,
+                                       const ROL::Ptr<Solution<Real>> &trueSoln,
+                                       const int cubDeg,
+                                       const ROL::Ptr<FieldHelper_type> &fieldHelper) const {
+  Real totalError(0);
+  // populate inCoeffs
+  scalar_view inCoeffs0;
+  getCoeffFromStateVector(inCoeffs0, soln);
+  // split fields
+  int numFields = 1;
+  std::vector<scalar_view> inCoeffs;
+  if (fieldHelper != ROL::nullPtr) {
+    numFields = fieldHelper->numFields();
+    fieldHelper->splitFieldCoeff(inCoeffs,inCoeffs0);
+  }
+  else {
+    inCoeffs.push_back(inCoeffs0);
+  }
+  // compute error
+  for (int fn = 0; fn < numFields; ++fn) {
+    // create fe object for error computation
+    Intrepid2::DefaultCubatureFactory cubFactory;
+    shards::CellTopology cellType = basisPtrs1_[fn]->getBaseCellTopology();
+    auto cellCub = cubFactory.create<DeviceType,Real,Real>(cellType, cubDeg);
+    ROL::Ptr<FE_type> fe
+      = ROL::makePtr<FE_type>(volCellNodes_,basisPtrs1_[fn],cellCub);
+
+    // get dimensions
+    int c = fe->gradN().extent_int(0);
+    int p = fe->gradN().extent_int(2);
+    int d = fe->gradN().extent_int(3);
+
+    // evaluate input coefficients on fe basis
+    scalar_view funcVals = scalar_view("funcVals", c, p);
+    fe->evaluateValue(funcVals, inCoeffs[fn]);
+
+    // subtract off true solution
+    std::vector<Real> x(d);
+    for (int i=0; i<c; ++i) {
+      for (int j=0; j<p; ++j) {
+        for (int k=0; k<d; ++k) {
+          x[k] = fe->cubPts()(i, j, k);
+        }
+        funcVals(i, j) -= trueSoln->evaluate(x,fn);
+      }
+    }
+
+    // compute norm squared of local error
+    scalar_view normSquaredError = scalar_view("normSquaredError", c);
+    fe->computeIntegral(normSquaredError, funcVals, funcVals, false);
+
+    Real localErrorSum(0);
+    Real globalErrorSum(0);
+    for (int i=0; i<numCells_; ++i) {
+      localErrorSum += normSquaredError(i);
+    }
+    Teuchos::reduceAll<int, Real>(*comm_, Teuchos::REDUCE_SUM, 1, &localErrorSum, &globalErrorSum);
+    totalError += globalErrorSum;
+  }
+
+  return std::sqrt(totalError);
+}
+
+template<class Real, class DeviceType>
+Real Assembler<Real,DeviceType>::computeControlError(const ROL::Ptr<const Tpetra::MultiVector<>> &soln,
+                                          const ROL::Ptr<Solution<Real>> &trueSoln,
+                                          const int cubDeg,
+                                          const ROL::Ptr<FieldHelper_type> &fieldHelper) const {
+  Real totalError(0);
+  // populate inCoeffs
+  scalar_view inCoeffs0;
+  getCoeffFromControlVector(inCoeffs0, soln);
+  // split fields
+  int numFields = 1;
+  std::vector<scalar_view> inCoeffs;
+  if (fieldHelper != ROL::nullPtr) {
+    numFields = fieldHelper->numFields();
+    fieldHelper->splitFieldCoeff(inCoeffs,inCoeffs0);
+  }
+  else {
+    inCoeffs.push_back(inCoeffs0);
+  }
+  // compute error
+  for (int fn = 0; fn < numFields; ++fn) {
+    // create fe object for error computation
+    Intrepid2::DefaultCubatureFactory cubFactory;
+    shards::CellTopology cellType = basisPtrs2_[fn]->getBaseCellTopology();
+    auto cellCub = cubFactory.create<DeviceType,Real,Real>(cellType, cubDeg);
+    ROL::Ptr<FE_type> fe = ROL::makePtr<FE_type>(volCellNodes_,basisPtrs2_[fn],cellCub);
+
+    // get dimensions
+    int c = fe->gradN().extent_int(0);
+    int p = fe->gradN().extent_int(2);
+    int d = fe->gradN().extent_int(3);
+
+    // evaluate input coefficients on fe basis
+    scalar_view funcVals = scalar_view ("funcVals", c, p);
+    fe->evaluateValue(funcVals, inCoeffs[fn]);
+
+    // subtract off true solution
+    std::vector<Real> x(d);
+    for (int i=0; i<c; ++i) {
+      for (int j=0; j<p; ++j) {
+        for (int k=0; k<d; ++k) {
+          x[k] = fe->cubPts()(i, j, k);
+        }
+        funcVals(i, j) -= trueSoln->evaluate(x,fn);
+      }
+    }
+
+    // compute norm squared of local error
+    scalar_view normSquaredError = scalar_view("normSquaredError", c);
+    fe->computeIntegral(normSquaredError, funcVals, funcVals, false);
+
+    Real localErrorSum(0);
+    Real globalErrorSum(0);
+    for (int i=0; i<numCells_; ++i) {
+      localErrorSum += normSquaredError(i);
+    }
+    Teuchos::reduceAll<int, Real>(*comm_, Teuchos::REDUCE_SUM, 1, &localErrorSum, &globalErrorSum);
+    totalError += globalErrorSum;
+  }
+
+  return std::sqrt(totalError);
+}
+/***************************************************************************/
+/* End of compute solution routines.                                       */
+/***************************************************************************/
+
+/***************************************************************************/
+/* Output routines.                                                        */
+/***************************************************************************/
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::printMeshData(std::ostream &outStream) const {
+  scalar_view nodes = meshMgr_->getNodes();
+  int_view  cellToNodeMap = meshMgr_->getCellToNodeMap();
+  if ( verbose_ && myRank_ == 0) {
+    outStream << std::endl;
+    outStream << "Number of nodes = " << meshMgr_->getNumNodes() << std::endl;
+    outStream << "Number of cells = " << meshMgr_->getNumCells() << std::endl;
+    outStream << "Number of edges = " << meshMgr_->getNumEdges() << std::endl;
+  }
+  // Print mesh to file.
+  if ((myRank_ == 0)) {
+    std::ofstream meshfile;
+    meshfile.open("cell_to_node_quad.txt");
+    for (int i=0; i<cellToNodeMap.extent_int(0); ++i) {
+      for (int j=0; j<cellToNodeMap.extent_int(1); ++j) {
+        meshfile << cellToNodeMap(i,j) << "  ";
+      }
+      meshfile << std::endl;
+    }
+    meshfile.close();
+    
+//    meshfile.open("cell_to_node_tri.txt");
+//    for (int i=0; i<cellToNodeMap.extent_int(0); ++i) {
+//      for (int j=0; j<3; ++j) {
+//        meshfile << cellToNodeMap(i,j) << "  ";
+//      }
+//      meshfile << std::endl;
+//      for (int j=2; j<5; ++j) {
+//        meshfile << cellToNodeMap(i,j%4) << "  ";
+//      }
+//      meshfile << std::endl;
+//    }
+//    meshfile.close();
+   
+    meshfile.open("nodes.txt");
+    meshfile.precision(16);
+    for (int i=0; i<nodes.extent_int(0); ++i) {
+      for (int j=0; j<nodes.extent_int(1); ++j) {
+        meshfile << std::scientific << nodes(i,j) << "  ";
+      }
+      meshfile << std::endl;
+    }
+    meshfile.close();
+  }
+} // prinf function end
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::outputTpetraVector(const ROL::Ptr<const Tpetra::MultiVector<>> &vec,
+                                         const std::string &filename) const {
+  Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix<>> vecWriter;
+  vecWriter.writeDenseFile(filename, vec);
+  std::string mapfile = "map_" + filename;
+  vecWriter.writeMapFile(mapfile, *(vec->getMap()));
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::inputTpetraVector(ROL::Ptr<Tpetra::MultiVector<>> &vec,
+                                        const std::string &filename) const {
+  Tpetra::MatrixMarket::Reader< Tpetra::CrsMatrix<>> vecReader;
+  auto map = vec->getMap();
+  auto comm = map->getComm();
+  auto vec_rcp = vecReader.readDenseFile(filename, comm, map);
+  vec->scale(1.0, *vec_rcp);
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::printDataPDE(const ROL::Ptr<PDE_type> &pde,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                   const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                   const ROL::Ptr<const std::vector<Real>> &z_param) const {
+  std::stringstream tag;
+  if (numProcs_==1) tag << "";
+  else              tag << "_" << myRank_ << "_" << numProcs_;
+
+  scalar_view u_coeff;
+  getCoeffFromStateVector(u_coeff,u);
+
+  scalar_view z_coeff;
+  getCoeffFromControlVector(z_coeff,z);
+
+  pde->printData(tag.str(),u_coeff,z_coeff,z_param);
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::printCellAveragesPDE(const ROL::Ptr<PDE_type> &pde,
+                                           const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                           const ROL::Ptr<const Tpetra::MultiVector<>> &z,
+                                           const ROL::Ptr<const std::vector<Real>> &z_param) const {
+  std::stringstream tag;
+  if (numProcs_==1) tag << "";
+  else              tag << "_" << myRank_ << "_" << numProcs_;
+
+  scalar_view u_coeff;
+  getCoeffFromStateVector(u_coeff,u);
+
+  scalar_view z_coeff;
+  getCoeffFromControlVector(z_coeff,z);
+
+  // Print to cell id file.
+  std::stringstream nameCellid;
+  nameCellid << "cellid" << tag.str() << ".txt";
+  std::ofstream fileCellid;
+  fileCellid.open(nameCellid.str());
+  for (int i = 0; i < numCells_; ++i) {
+      fileCellid << myCellIds_[i] << std::endl;
+  }
+  fileCellid.close();
+
+  // Print cell average data.
+  pde->printCellAverages(tag.str(),u_coeff,z_coeff,z_param);
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::serialPrintStateEdgeField(const ROL::Ptr<const Tpetra::MultiVector<>> &u,
+                                                const ROL::Ptr<FieldHelper_type> &fieldHelper,
+                                                const std::string &filename,
+                                                const ROL::Ptr<FE_CURL_type> &fe) const {
+  const int c = fe->curlN().extent_int(0);
+  const int f = fe->curlN().extent_int(1);
+  const int p = 1, d = 3;
+
+  scalar_view u_coeff;
+  getCoeffFromStateVector(u_coeff,u);
+
+  std::vector<scalar_view> U;
+  fieldHelper->splitFieldCoeff(U, u_coeff);
+  int numFields = U.size();
+
+  // Transform cell center to physical
+  scalar_view rx("rx", p,d);
+  scalar_view px("px", c,p,d);
+  fe->mapRefPointsToPhysical(px,rx);
+  // Transform reference values into physical space.
+  scalar_view cellJac("cellJac", c,p,d,d);
+  scalar_view cellJacInv("cellJacInv", c,p,d,d);
+  ROL::Ptr<shards::CellTopology> cellTopo
+    = ROL::makePtr<shards::CellTopology>(basisPtrs1_[0]->getBaseCellTopology());
+  scalar_view valReference("valReference", f,p,d);
+  basisPtrs1_[0]->getValues(valReference,rx,Intrepid2::OPERATOR_VALUE);
+  scalar_view valPhysical("valPhysical",c,f,p,d);
+  ct::setJacobian(cellJac,rx,volCellNodes_,*cellTopo);
+  ct::setJacobianInv(cellJacInv, cellJac);
+  fst::HCURLtransformVALUE(valPhysical, cellJacInv, valReference);
+
+  std::vector<scalar_view> uval(numFields);
+  for (int k = 0; k < numFields; ++k) {
+    uval[k] = scalar_view("uvalk", c,p,d);
+    fst::evaluate(uval[k], U[k], valPhysical);
+  }
+  // Print
+  std::ofstream file;
+  file.open(filename);
+  for (int i = 0; i < c; ++i) {
+    file << std::scientific << std::setprecision(15);
+    for (int j = 0; j < d; ++j) {
+      file << std::setw(25) << px(i,0,j);
+    }
+    for (int k = 0; k < numFields; ++k) {
+      for (int j = 0; j < d; ++j) {
+        file << std::setw(25) << uval[k](i,0,j);
+      }
+    }
+    file << std::endl;
+  }
+  file.close();
+}
+/***************************************************************************/
+/* End of output routines.                                                 */
+/***************************************************************************/
+
+/***************************************************************************/
+/* Vector generation routines.                                             */
+/***************************************************************************/
+template<class Real, class DeviceType>
+const ROL::Ptr<const Tpetra::Map<>> Assembler<Real,DeviceType>::getStateMap(void) const {
+  return myUniqueStateMap_;
+}
+
+template<class Real, class DeviceType>
+const ROL::Ptr<const Tpetra::Map<>> Assembler<Real,DeviceType>::getControlMap(void) const {
+  return myUniqueControlMap_;
+}
+
+template<class Real, class DeviceType>
+const ROL::Ptr<const Tpetra::Map<>> Assembler<Real,DeviceType>::getResidualMap(void) const {
+  return myUniqueResidualMap_;
+}
+
+template<class Real, class DeviceType>
+ROL::Ptr<Tpetra::MultiVector<>> Assembler<Real,DeviceType>::createStateVector(void) const {
+  return ROL::makePtr<Tpetra::MultiVector<>>(myUniqueStateMap_, 1, true);
+}
+
+template<class Real, class DeviceType>
+ROL::Ptr<Tpetra::MultiVector<>> Assembler<Real,DeviceType>::createControlVector(void) const {
+  return ROL::makePtr<Tpetra::MultiVector<>>(myUniqueControlMap_, 1, true);
+}
+
+template<class Real, class DeviceType>
+ROL::Ptr<Tpetra::MultiVector<>> Assembler<Real,DeviceType>::createResidualVector(void) const {
+  return ROL::makePtr<Tpetra::MultiVector<>>(myUniqueResidualMap_, 1, true);
+}
+/***************************************************************************/
+/* End of vector generation routines.                                      */
+/***************************************************************************/
+
+/***************************************************************************/
+/* Accessor routines.                                                      */
+/***************************************************************************/
+template<class Real, class DeviceType>
+const ROL::Ptr<DofManager<Real,DeviceType>> Assembler<Real,DeviceType>::getDofManager(void) const {
+  return dofMgr1_;
+}
+template<class Real, class DeviceType>
+const ROL::Ptr<DofManager<Real,DeviceType>> Assembler<Real,DeviceType>::getDofManager2(void) const {
+  return dofMgr2_;
+}
+
+template<class Real, class DeviceType>
+Teuchos::Array<typename Tpetra::Map<>::global_ordinal_type> Assembler<Real,DeviceType>::getCellIds(void) const {
+  return myCellIds_;
+}
+/***************************************************************************/
+/* End of accessor routines.                                               */
+/***************************************************************************/
+
+/*****************************************************************************/
+/******************* PRIVATE MEMBER FUNCTIONS ********************************/
+/*****************************************************************************/
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::setCommunicator(const ROL::Ptr<const Teuchos::Comm<int>> &comm,
+                                      Teuchos::ParameterList &parlist,
+                                      std::ostream &outStream) {
+  comm_ = comm;
+  // Get number of processors and my rank
+  myRank_    = comm->getRank();
+  numProcs_  = comm->getSize();
+  // Parse parameter list
+  verbose_ = parlist.sublist("PDE FEM").get("Verbose Output",false);
+  if (verbose_ && myRank_==0 ) {
+    outStream << "Initialized communicator. " << std::endl;
+  }
+  if (verbose_ && myRank_==0 ) {
+    outStream << "Total number of processors: " << numProcs_ << std::endl;
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::setBasis(
+       const std::vector<basis_ptr> &basisPtrs1,
+       const std::vector<basis_ptr> &basisPtrs2,
+       Teuchos::ParameterList &parlist,
+       std::ostream &outStream) {
+  basisPtrs1_ = basisPtrs1;
+  basisPtrs2_ = basisPtrs2;
+  if (verbose_ && myRank_==0) {
+    outStream << "Initialized PDE." << std::endl;
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::setDiscretization(Teuchos::ParameterList &parlist,
+                                  const ROL::Ptr<MeshManager_type> &meshMgr,
+                                        std::ostream &outStream) {
+  if ( meshMgr != ROL::nullPtr ) {
+    // Use MeshManager object if supplied
+    meshMgr_ = meshMgr;
+  }
+  else {
+    // Otherwise construct MeshManager objective from parameter list
+  }
+  dofMgr1_ = ROL::makePtr<DofManager_type>(meshMgr_,basisPtrs1_);
+  dofMgr2_ = ROL::makePtr<DofManager_type>(meshMgr_,basisPtrs2_);
+  if (verbose_ && myRank_==0) {
+    outStream << "Initialized discretization (MeshManager and DofManager)." << std::endl;
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::setParallelStructure(Teuchos::ParameterList &parlist,
+                                           std::ostream &outStream) {
+  int cellSplit = parlist.sublist("Geometry").get<int>("Partition type");
+  /****************************************************/
+  /*** Build parallel communication infrastructure. ***/
+  /****************************************************/
+  // Partition the cells in the mesh.  We use a basic quasi-equinumerous partitioning,
+  // where the remainder, if any, is assigned to the last processor.
+  Teuchos::Array<GO> myGlobalIds1, myGlobalIds2;
+  cellOffsets_.assign(numProcs_, 0);
+  int totalNumCells = meshMgr_->getNumCells();
+  int cellsPerProc  = totalNumCells / numProcs_;
+  numCells_         = cellsPerProc;
+  ROL::Ptr<std::vector<std::vector<int>>> procCellIds = meshMgr_->getProcCellIds();
+  switch(cellSplit) {
+    case 0:
+      if (myRank_ == 0) {
+        // remainder in the first
+        numCells_ += totalNumCells % numProcs_;
+      }
+      for (int i=1; i<numProcs_; ++i) {
+        cellOffsets_[i] = cellOffsets_[i-1] + cellsPerProc
+                          + (static_cast<int>(i==1))*(totalNumCells % numProcs_);
+      }
+      break;
+    case 1:
+      if (myRank_ == numProcs_-1) {
+        // remainder in the last
+        numCells_ += totalNumCells % numProcs_;
+      }
+      for (int i=1; i<numProcs_; ++i) {
+        cellOffsets_[i] = cellOffsets_[i-1] + cellsPerProc;
+      }
+      break;
+    case 2:
+      if (myRank_ < (totalNumCells%numProcs_)) {
+        // spread remainder, starting from the first
+        numCells_++;
+      }
+      for (int i=1; i<numProcs_; ++i) {
+        cellOffsets_[i] = cellOffsets_[i-1] + cellsPerProc
+                          + (static_cast<int>(i-1<(totalNumCells%numProcs_)));
+      }
+      break;
+    case 3:
+      // Define using MeshManager.
+      numCells_ = (*procCellIds)[myRank_].size();
+      break;
+  }
+
+  int_view cellDofs1 = dofMgr1_->getCellDofs();
+  int_view cellDofs2 = dofMgr2_->getCellDofs();
+  int numLocalDofs1 = cellDofs1.extent_int(1);
+  int numLocalDofs2 = cellDofs2.extent_int(1);
+  if (verbose_) {
+    outStream << "Cell offsets across processors: " << cellOffsets_
+              << std::endl;
+  }
+  switch(cellSplit) {
+    case 0:
+    case 1:
+    case 2:
+    for (int i=0; i<numCells_; ++i) {
+      myCellIds_.push_back(cellOffsets_[myRank_]+i);
+      for (int j=0; j<numLocalDofs1; ++j) {
+        myGlobalIds1.push_back( cellDofs1(cellOffsets_[myRank_]+i,j) );
+      }
+      for (int j=0; j<numLocalDofs2; ++j) {
+        myGlobalIds2.push_back( cellDofs2(cellOffsets_[myRank_]+i,j) );
+      }
+    }
+      break;
+    case 3:
+    for (int i=0; i<numCells_; ++i) {
+      myCellIds_.push_back((*procCellIds)[myRank_][i]);
+      for (int j=0; j<numLocalDofs1; ++j) {
+        myGlobalIds1.push_back( cellDofs1((*procCellIds)[myRank_][i],j) );
+      }
+      for (int j=0; j<numLocalDofs2; ++j) {
+        myGlobalIds2.push_back( cellDofs2((*procCellIds)[myRank_][i],j) );
+      }
+    }
+      break;
+  }
+  std::sort(myGlobalIds1.begin(), myGlobalIds1.end());
+  myGlobalIds1.erase( std::unique(myGlobalIds1.begin(),myGlobalIds1.end()),myGlobalIds1.end() );
+  std::sort(myGlobalIds2.begin(), myGlobalIds2.end());
+  myGlobalIds2.erase( std::unique(myGlobalIds2.begin(),myGlobalIds2.end()),myGlobalIds2.end() );
+
+  // Build maps.
+  myOverlapStateMap_    = ROL::makePtr<Tpetra::Map<>>
+    (Teuchos::OrdinalTraits<GO>::invalid(), myGlobalIds1, GO(0), comm_);
+  //std::cout << std::endl << myOverlapMap_->getLocalElementList()<<std::endl;
+  /** One can also use the non-member function:
+      myOverlapMap_ = Tpetra::createNonContigMap<int,int>(myGlobalIds_, comm_);
+      to build the overlap map.
+  **/
+  myUniqueStateMap_     = Tpetra::createOneToOne(myOverlapStateMap_);
+  myOverlapResidualMap_ = myOverlapStateMap_;
+  myUniqueResidualMap_  = myUniqueStateMap_;
+  myOverlapControlMap_  = ROL::makePtr<Tpetra::Map<>>
+     (Teuchos::OrdinalTraits<GO>::invalid(), myGlobalIds2, GO(0), comm_);
+  myUniqueControlMap_   = Tpetra::createOneToOne(myOverlapControlMap_);;
+  //std::cout << std::endl << myUniqueMap_->getLocalElementList() << std::endl;
+  //  myCellMap_ = ROL::makePtr<Tpetra::Map<>>(
+  //               Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(),
+  //               myCellIds_, 0, comm_);
+
+  /****************************************/
+  /*** Assemble global graph structure. ***/
+  /****************************************/
+
+  // Estimate the max number of entries per row 
+  // using a map (row indicies can be non-contiguous)
+  GO maxEntriesPerRow1(0), maxEntriesPerRow2(0);
+  {
+    std::map<GO,GO> numEntriesCount1, numEntriesCount2;
+    for (int i=0; i<numCells_; ++i) { 
+      for (int j=0; j<numLocalDofs1; ++j) {
+        numEntriesCount1[GO(cellDofs1(myCellIds_[i],j))] += numLocalDofs1;
+      }
+      for (int j=0; j<numLocalDofs2; ++j) {
+        numEntriesCount2[GO(cellDofs2(myCellIds_[i],j))] += numLocalDofs2;
+      }
+    }
+    const auto rowIndexWithMaxEntries1 
+      = std::max_element(std::begin(numEntriesCount1), std::end(numEntriesCount1), 
+                         [](const std::pair<GO,GO> &pa, const std::pair<GO,GO> &pb) {
+                           return pa.second < pb.second;
+                         });
+    const auto rowIndexWithMaxEntries2
+      = std::max_element(std::begin(numEntriesCount2), std::end(numEntriesCount2), 
+                         [](const std::pair<GO,GO> &pa, const std::pair<GO,GO> &pb) {
+                           return pa.second < pb.second;
+                         });
+    if (!numEntriesCount1.empty())
+      maxEntriesPerRow1 = rowIndexWithMaxEntries1->second;
+    if (!numEntriesCount2.empty())
+      maxEntriesPerRow2 = rowIndexWithMaxEntries2->second;
+  }
+  
+  Teuchos::ArrayRCP<GO> cellDofs1GO(numLocalDofs1, GO());
+  matJ1Graph_ = ROL::makePtr<Tpetra::CrsGraph<>>(myUniqueStateMap_, maxEntriesPerRow1);
+  for (int i=0; i<numCells_; ++i) {
+    for (int j=0; j<numLocalDofs1; ++j)
+      cellDofs1GO[j] = cellDofs1(myCellIds_[i],j);
+    for (int j=0; j<numLocalDofs1; ++j) {
+      matJ1Graph_->insertGlobalIndices(cellDofs1GO[j],cellDofs1GO());
+    }
+  }
+  matJ1Graph_->fillComplete(myUniqueStateMap_,myUniqueStateMap_);
+  matR1Graph_  = matJ1Graph_;
+  matH11Graph_ = matJ1Graph_;
+
+  Teuchos::ArrayRCP<GO> cellDofs2GO(numLocalDofs2, GO());
+  matJ2Graph_ = ROL::makePtr<Tpetra::CrsGraph<>>(myUniqueStateMap_, std::max(maxEntriesPerRow1,maxEntriesPerRow2));
+  for (int i=0; i<numCells_; ++i) {
+    for (int j=0; j<numLocalDofs2; ++j)
+      cellDofs2GO[j] = cellDofs2(myCellIds_[i],j);
+    for (int j=0; j<numLocalDofs1; ++j) {
+      matJ2Graph_->insertGlobalIndices(GO(cellDofs1(myCellIds_[i],j)),cellDofs2GO());
+    }
+  }
+  matJ2Graph_->fillComplete(myUniqueControlMap_,myUniqueStateMap_);
+  matH21Graph_ = matJ2Graph_;
+
+  matH12Graph_ = ROL::makePtr<Tpetra::CrsGraph<>>(myUniqueControlMap_, maxEntriesPerRow1);
+  for (int i=0; i<numCells_; ++i) {
+    for (int j=0; j<numLocalDofs1; ++j)
+      cellDofs1GO[j] = cellDofs1(myCellIds_[i],j);
+    for (int j=0; j<numLocalDofs2; ++j) {
+      matH12Graph_->insertGlobalIndices(GO(cellDofs2(myCellIds_[i],j)), cellDofs1GO());
+    }
+  }
+  matH12Graph_->fillComplete(myUniqueStateMap_,myUniqueControlMap_);
+
+  matR2Graph_ = ROL::makePtr<Tpetra::CrsGraph<>>(myUniqueControlMap_, maxEntriesPerRow2);
+  for (int i=0; i<numCells_; ++i) {
+    for (int j=0; j<numLocalDofs2; ++j)
+      cellDofs2GO[j] = cellDofs2(myCellIds_[i],j);
+    for (int j=0; j<numLocalDofs2; ++j) {
+      matR2Graph_->insertGlobalIndices(cellDofs2GO[j], cellDofs2GO());
+    }
+  }
+  matR2Graph_->fillComplete(myUniqueControlMap_,myUniqueControlMap_);
+  matH22Graph_ = matR2Graph_;
+
+  if (verbose_ && myRank_==0) {
+    outStream << "Initialized parallel structures." << std::endl;
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::setCellNodes(std::ostream &outStream) {
+  // Build volume cell nodes
+  shards::CellTopology cellType = basisPtrs1_[0]->getBaseCellTopology();
+  int spaceDim = cellType.getDimension();
+  int numNodesPerCell = cellType.getNodeCount();
+  volCellNodes_ = scalar_view("volCellNodes_", numCells_, numNodesPerCell, spaceDim);
+  scalar_view nodes = meshMgr_->getNodes();
+  int_view ctn   = meshMgr_->getCellToNodeMap();
+  for (int i=0; i<numCells_; ++i) {
+    for (int j=0; j<numNodesPerCell; ++j) {
+      for (int k=0; k<spaceDim; ++k) {
+        volCellNodes_(i, j, k) = nodes(ctn(myCellIds_[i],j), k);
+      }
+    }
+  }
+  // Build boundary cell nodes
+  bdryCellIds_    = meshMgr_->getSideSets((verbose_ && myRank_==0), outStream);
+  int numSideSets = bdryCellIds_->size();
+  if (numSideSets > 0) {
+    bdryCellNodes_.resize(numSideSets);
+    bdryCellLocIds_.resize(numSideSets);
+    for (int i=0; i<numSideSets; ++i) {
+      int numLocSides = (*bdryCellIds_)[i].size();
+      bdryCellNodes_[i].resize(numLocSides);
+      bdryCellLocIds_[i].resize(numLocSides);
+      for (int j=0; j<numLocSides; ++j) {
+        if ((*bdryCellIds_)[i][j].size() > 0) {
+          int numCellsSide = (*bdryCellIds_)[i][j].size();
+          for (int k=0; k<numCellsSide; ++k) {
+            int idx = mapGlobalToLocalCellId((*bdryCellIds_)[i][j][k]);
+            if (idx > -1) {
+              bdryCellLocIds_[i][j].push_back(idx);
+              //if (myRank_==1) {std::cout << "\nrank " << myRank_ << "   bcid " << i << "  " << j << "  " << k << "  " << myCellIds_[idx] << "  " << idx;}
+            }
+          }
+          int myNumCellsSide = bdryCellLocIds_[i][j].size();
+          if (myNumCellsSide > 0) {
+            bdryCellNodes_[i][j] = scalar_view("bdryCellNodes_", myNumCellsSide, numNodesPerCell, spaceDim);
+          }
+          for (int k=0; k<myNumCellsSide; ++k) {
+            for (int l=0; l<numNodesPerCell; ++l) {
+              for (int m=0; m<spaceDim; ++m) {
+                bdryCellNodes_[i][j](k, l, m) = nodes(ctn(myCellIds_[bdryCellLocIds_[i][j][k]],l), m);
+              }
+            }
+          }
+        }
+        //if ((myRank_==1) && (myNumCellsSide > 0)) {std::cout << (*bdryCellNodes_[i][j]);}
+      }
+    }
+  }
+  bdryCellNodes_.resize(numSideSets);
+}
+
+template<class Real, class DeviceType>
+int Assembler<Real,DeviceType>::mapGlobalToLocalCellId(const int & gid) {
+  auto it = std::find(myCellIds_.begin(),myCellIds_.end(),gid);
+  if (it != myCellIds_.end()) {
+    return it-myCellIds_.begin();
+  }
+  else {
+    return -1;
+  }
+/*
+  int minId = cellOffsets_[myRank_];
+  int maxId = cellOffsets_[myRank_]+numCells_-1;
+  if ((gid >= minId) && (gid <= maxId)) {
+    return (gid - cellOffsets_[myRank_]);
+  }
+  else {
+    return -1;
+  }
+*/
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::getCoeffFromStateVector(scalar_view &xcoeff,
+                                        const ROL::Ptr<const Tpetra::MultiVector<>> &x) const {
+  if ( x != ROL::nullPtr ) {
+    // Perform import onto myOverlapMap
+    ROL::Ptr<Tpetra::MultiVector<>> xshared =
+      ROL::makePtr<Tpetra::MultiVector<>>(myOverlapStateMap_, 1, true);
+    Tpetra::Import<> importer(myUniqueStateMap_, myOverlapStateMap_);
+    xshared->doImport(*x,importer,Tpetra::REPLACE);
+    // Populate xcoeff
+    int_view cellDofs = dofMgr1_->getCellDofs();
+    int lfs = dofMgr1_->getLocalFieldSize();
+    xcoeff = scalar_view("xcoeff", numCells_, lfs);
+    Teuchos::ArrayRCP<const Real> xdata = xshared->get1dView();
+    for (int i=0; i<numCells_; ++i) {
+      for (int j=0; j<lfs; ++j) {
+        xcoeff(i,j) = xdata[xshared->getMap()->getLocalElement(cellDofs(myCellIds_[i],j))];
+      }
+    }
+    dofMgr1_->transformToIntrepidPattern(xcoeff);
+  }
+  else {
+    xcoeff = scalar_view();
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::getCoeffFromControlVector(scalar_view &xcoeff,
+                                          const ROL::Ptr<const Tpetra::MultiVector<>> &x) const {
+  if ( x != ROL::nullPtr ) {
+    // Perform import onto myOverlapMap
+    ROL::Ptr<Tpetra::MultiVector<>> xshared =
+      ROL::makePtr<Tpetra::MultiVector<>>(myOverlapControlMap_, 1, true);
+    Tpetra::Import<> importer(myUniqueControlMap_, myOverlapControlMap_);
+    xshared->doImport(*x,importer,Tpetra::REPLACE);
+    // Populate xcoeff
+    int_view cellDofs = dofMgr2_->getCellDofs();
+    int lfs = dofMgr2_->getLocalFieldSize();
+    xcoeff = scalar_view("xcoeff", numCells_, lfs);
+    Teuchos::ArrayRCP<const Real> xdata = xshared->get1dView();
+    for (int i=0; i<numCells_; ++i) {
+      for (int j=0; j<lfs; ++j) {
+        xcoeff(i,j) = xdata[xshared->getMap()->getLocalElement(cellDofs(myCellIds_[i],j))];
+      }
+    }
+    dofMgr2_->transformToIntrepidPattern(xcoeff);
+  }
+  else {
+    xcoeff = scalar_view();
+  }
+}
+
+/***************************************************************************/
+/****** GENERIC ASSEMBLY ROUTINES ******************************************/
+/***************************************************************************/
+template<class Real, class DeviceType>
+Real Assembler<Real,DeviceType>::assembleScalar(const scalar_view val) {
+  // Assembly
+  if ( val.is_allocated() ) {
+    Real myval(0), gval(0);
+    for (int i=0; i<numCells_; ++i) {
+      myval += val(i);
+    }
+    Teuchos::reduceAll<int,Real>(*comm_,Teuchos::REDUCE_SUM,1,&myval,&gval);
+    return gval;
+  }
+  return static_cast<Real>(0);
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleFieldVector(ROL::Ptr<Tpetra::MultiVector<>> &v,
+                                          scalar_view val,
+                                          ROL::Ptr<Tpetra::MultiVector<>> &vecOverlap,
+                                          const ROL::Ptr<DofManager_type> &dofMgr) {
+  // Set residual vectors to zero
+  v->putScalar(static_cast<Real>(0));
+  vecOverlap->putScalar(static_cast<Real>(0));
+  // Get degrees of freedom
+  int_view cellDofs = dofMgr->getCellDofs();
+  int numLocalDofs = cellDofs.extent_int(1);
+  // Transform values
+  transformToFieldPattern(val,dofMgr);
+  // assembly on the overlap map
+  for (int i=0; i<numCells_; ++i) {
+    for (int j=0; j<numLocalDofs; ++j) {
+      vecOverlap->sumIntoGlobalValue(cellDofs(myCellIds_[i],j),0,val(i,j));
+    }
+  }
+  // change map
+  Tpetra::Export<> exporter(vecOverlap->getMap(), v->getMap()); // redistribution
+  v->doExport(*vecOverlap, exporter, Tpetra::ADD);              // from the overlap map to the unique map
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleParamVector(ROL::Ptr<std::vector<Real>> &v,
+                                          std::vector<scalar_view> &val) {
+  int size = v->size();
+  v->assign(size,0);
+//  for (int i = 0; i < size; ++i) {
+//    dofMgr_->transformToFieldPattern(val[i]);
+//  }
+  // Assembly
+  std::vector<Real> myVal(size,0);
+  for (int j = 0; j < size; ++j) {
+    if ( val[j].is_allocated() ) {
+      for (int i=0; i<numCells_; ++i) {
+        myVal[j] += (val[j])(i);
+      }
+    }
+  }
+  Teuchos::reduceAll<int,Real>(*comm_,Teuchos::REDUCE_SUM,size,&myVal[0],&(*v)[0]);
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleFieldMatrix(ROL::Ptr<Tpetra::CrsMatrix<>> &M,
+                                          scalar_view val,
+                                          const ROL::Ptr<DofManager_type> &dofMgr1,
+                                          const ROL::Ptr<DofManager_type> &dofMgr2) {
+  // Transform data
+  transformToFieldPattern(val,dofMgr1,dofMgr2);
+  // Zero PDE Jacobian
+  M->resumeFill(); M->setAllToScalar(static_cast<Real>(0));
+  // Assemble PDE Jacobian
+  int_view cellDofs1 = dofMgr1->getCellDofs();
+  int_view cellDofs2 = dofMgr2->getCellDofs();
+  int numLocalDofs1 = cellDofs1.extent_int(1);
+  int numLocalDofs2 = cellDofs2.extent_int(1);
+  Teuchos::ArrayRCP<GO> cellDofs2GO(numLocalDofs2);
+  Teuchos::ArrayRCP<Real> values(numLocalDofs2);
+  for (int i=0; i<numCells_; ++i) {
+    for (int j=0; j<numLocalDofs2; ++j)
+      cellDofs2GO[j] = cellDofs2(myCellIds_[i],j);
+    for (int j=0; j<numLocalDofs1; ++j) {
+      for (int k=0; k<numLocalDofs2; ++k)
+        values[k] = val(i,j,k);
+      M->sumIntoGlobalValues(GO(cellDofs1(myCellIds_[i],j)), cellDofs2GO(), values());
+    }
+  }
+  M->fillComplete();
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleParamFieldMatrix(ROL::Ptr<Tpetra::MultiVector<>> &M,
+                                               std::vector<scalar_view> &val,
+                                               ROL::Ptr<Tpetra::MultiVector<>> &matOverlap,
+                                               const ROL::Ptr<DofManager_type> &dofMgr) {
+  // Initialize res
+  int size = M->getNumVectors();
+  // Compute PDE local Jacobian wrt parametric controls
+  for (int i = 0; i < size; ++i) {
+    transformToFieldPattern(val[i],dofMgr);
+  }
+  // Assemble PDE Jacobian wrt parametric controls
+  M->scale(static_cast<Real>(0));
+  matOverlap->scale(static_cast<Real>(0));
+  for (int k = 0; k < size; ++k) {
+    int_view cellDofs = dofMgr->getCellDofs();
+    int numLocalDofs = cellDofs.extent_int(1);
+    // assembly on the overlap map
+    for (int i=0; i<numCells_; ++i) {
+      for (int j=0; j<numLocalDofs; ++j) {
+        matOverlap->sumIntoGlobalValue(cellDofs(myCellIds_[i],j),
+                                        k,(val[k])[i*numLocalDofs+j]);
+      }
+    }
+    // change map
+    Tpetra::Export<> exporter(matOverlap->getMap(), M->getMap()); // redistribution
+    M->doExport(*matOverlap, exporter, Tpetra::ADD);              // from the overlap map to the unique map
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::assembleParamMatrix(ROL::Ptr<std::vector<std::vector<Real>>> &M,
+                                          std::vector<std::vector<scalar_view>> &val,
+                                          const ROL::Ptr<DofManager_type> &dofMgr) {
+  // Initialize local matrix
+  int size = M->size();
+  std::vector<scalar_view> tmp(size);
+  // Compute local matrix
+  //for (int i = 0; i < size; ++i) {
+  //  for (int j = 0; j < size; ++j) {
+  //    transformToFieldPattern(val[i][j],dofMgr);
+  //  }
+  //}
+  // Assemble PDE Jacobian wrt parametric controls
+  int cnt = 0, matSize = static_cast<int>(0.5*static_cast<Real>((size+1)*size));
+  std::vector<Real> myMat(matSize,static_cast<Real>(0));
+  std::vector<Real> globMat(matSize,static_cast<Real>(0));
+  for (int k = 0; k < size; ++k) {
+    for (int j = k; j < size; ++j) {
+      for (int i=0; i<numCells_; ++i) {
+        myMat[cnt] += (val[k][j])(i);
+      }
+      cnt++;
+    }
+  }
+  Teuchos::reduceAll<int,Real>(*comm_,Teuchos::REDUCE_SUM,matSize,&myMat[0],&globMat[0]);
+  cnt = 0;
+  for (int k = 0; k < size; ++k) {
+    for (int j = k; j < size; ++j) {
+      (*M)[k][j] += globMat[cnt];
+      if ( j != k ) { 
+        (*M)[j][k] += globMat[cnt];
+      }
+      cnt++;
+    }
+  }
+}
+
+template<class Real, class DeviceType>
+void Assembler<Real,DeviceType>::transformToFieldPattern(scalar_view array,
+                                              const ROL::Ptr<DofManager_type> &dofMgr1,
+                                              const ROL::Ptr<DofManager_type> &dofMgr2) const {
+  if ( array.is_allocated() ) {
+    int rank = array.rank();
+    int nc   = array.extent_int(0);
+    if ( rank == 2 ) {
+      int nf = array.extent_int(1);
+      scalar_view tmp("tmp", nc, nf);
+      for (int c = 0; c < nc; ++c) {
+        for (int f = 0; f < nf; ++f) {
+          tmp(c, dofMgr1->mapToFieldPattern(f)) = array(c, f);
+        }
+      }
+      Kokkos::deep_copy(array, tmp);
+    }
+    else if (rank == 3 ) {
+      int nf1 = array.extent_int(1);
+      int nf2 = array.extent_int(2);
+      scalar_view tmp("tmp", nc, nf1, nf2);
+      for (int c = 0; c < nc; ++c) {
+        for (int f1 = 0; f1 < nf1; ++f1) {
+          for (int f2 = 0; f2 < nf2; ++f2) {
+            tmp(c, dofMgr1->mapToFieldPattern(f1), dofMgr2->mapToFieldPattern(f2)) = array(c, f1, f2);
+          }
+        }
+      }
+      Kokkos::deep_copy(array, tmp);
+    }
+    else {
+      TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
+        ">>> PDE-OPT/TOOLS/assembler.hpp (transformToFieldPattern): Input array rank not 2 or 3!");
+    }
+  }
+}
+
+#endif

--- a/packages/rol/example/PDE-OPT/TOOLS/dofmanagerK.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/dofmanagerK.hpp
@@ -1,0 +1,596 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  dofmanager.hpp
+    \brief Given a mesh with connectivity information, sets up data
+           structures for the indexing of the global degrees of
+           freedom (Dofs).
+*/
+
+#ifndef DOFMANAGERK_HPP
+#define DOFMANAGERK_HPP
+
+#include "Teuchos_ParameterList.hpp"
+#include "Intrepid2_Basis.hpp"
+#include "meshmanagerK.hpp"
+
+template <class Real, class DeviceType>
+class DofManager {
+
+public:
+  using scalar_view = Kokkos::DynRankView<Real,DeviceType>;
+  using int_view = Kokkos::DynRankView<int,DeviceType>;
+  using basis_ptr = Intrepid2::BasisPtr<DeviceType, Real, Real>;
+
+private:
+  ROL::Ptr<MeshManager<Real,DeviceType> > meshManager_;
+  std::vector<basis_ptr> intrepidBasis_;
+
+  int cellDim_;          // cell dimension
+
+  int numCells_;         // number of mesh cells
+  int numNodes_;         // number of mesh nodes
+  int numEdges_;         // number of mesh edges
+  int numFaces_;         // number of mesh faces
+
+  int_view meshCellToNodeMap_;
+  int_view meshCellToEdgeMap_;
+  int_view meshCellToFaceMap_;
+
+  // Local dof information.
+  int numBases_;                                  // number of bases (fields)
+  int numLocalNodes_;                             // number of nodes in the basic cell topology
+  int numLocalEdges_;                             // number of edges in the basic cell topology
+  int numLocalFaces_;                             // number of faces in the basic cell topology
+  int numLocalVoids_;                             // number of voids in the basic cell topology, =1
+  int numLocalNodeDofs_;                          // number of local (single-cell) node dofs for all bases
+  int numLocalEdgeDofs_;                          // number of local (single-cell) edge dofs for all bases
+  int numLocalFaceDofs_;                          // number of local (single-cell) face dofs for all bases
+  int numLocalVoidDofs_;                          // number of local (single-cell) face dofs for all bases
+  int numLocalDofs_;                              // total number of local (single-cell) face dofs for all bases
+  std::vector<int> numDofsPerNode_;               // number of dofs per node in a cell (assumed constant), per basis
+  std::vector<int> numDofsPerEdge_;               // number of dofs per edge in a cell (assumed constant), per basis
+  std::vector<int> numDofsPerFace_;               // number of dofs per face in a cell (assumed constant), per basis
+  std::vector<int> numDofsPerVoid_;               // number of dofs per void in a cell (assumed constant), per basis
+  std::vector<std::vector<int> > fieldPattern_;   // local indexing of fields into the array [0,1,...,numLocalDofs-1];
+                                                  // contains [number of bases] index vectors, where each index vector
+                                                  // is of size [basis cardinality]
+  // Global dof information.
+  int numNodeDofs_;  // number of global node dofs
+  int numEdgeDofs_;  // number of global edge dofs
+  int numFaceDofs_;  // number of global face dofs
+  int numVoidDofs_;  // number of global void dofs
+  int numDofs_;      // total number of global dofs
+
+  int_view nodeDofs_;  // global node dofs, of size [numNodes_ x numLocalNodeDofs_]
+  int_view edgeDofs_;  // global edge dofs, of size [numEdges_ x numLocalEdgeDofs_]
+  int_view faceDofs_;  // global face dofs, of size [numFaces_ x numLocalFaceDofs_]
+  int_view voidDofs_;  // global face dofs, of size [numFaces_ x numLocalFaceDofs_]
+  int_view cellDofs_;  // global cell dofs, of size [numCells_ x numLocalDofs_];
+                                                           // ordered by subcell (node, then edge, then face) and basis index
+  std::vector<int> mapToIntrepidPattern_;
+  std::vector<int> mapToFieldPattern_;
+  std::vector<int_view> fieldDofs_;  // global cell dofs, indexed by field/basis, of size [numCells_ x basis cardinality];
+                                                                          // ordered by subcell (node, then edge, then face)
+
+public:
+
+  DofManager(ROL::Ptr<MeshManager<Real,DeviceType> > &meshManager,
+             std::vector<basis_ptr> intrepidBasis) {
+
+    meshManager_ = meshManager;
+    intrepidBasis_ = intrepidBasis;
+    cellDim_  = intrepidBasis_[0]->getBaseCellTopology().getDimension();
+    numCells_ = meshManager_->getNumCells();
+    numNodes_ = meshManager_->getNumNodes();
+    numEdges_ = meshManager_->getNumEdges();
+    numFaces_ = meshManager_->getNumFaces();
+
+    // Mesh data structures.
+    meshCellToNodeMap_ = meshManager_->getCellToNodeMap();
+    meshCellToEdgeMap_ = meshManager_->getCellToEdgeMap();
+    meshCellToFaceMap_ = meshManager_->getCellToFaceMap();
+
+    // Local degree-of-freedom footprint.
+    numBases_ = static_cast<int>(intrepidBasis_.size());
+    numDofsPerNode_.resize(numBases_, 0);
+    numDofsPerEdge_.resize(numBases_, 0);
+    numDofsPerFace_.resize(numBases_, 0);
+    numDofsPerVoid_.resize(numBases_, 0);
+    numLocalDofs_ = 0;
+    for (int i=0; i<numBases_; ++i) {
+      auto dofTags = (intrepidBasis_[i])->getAllDofTags();
+      for (int j=0; j<(intrepidBasis_[i])->getCardinality(); ++j) {
+        if (dofTags(j,0) == 0) {
+          numDofsPerNode_[i] = dofTags(j,3);
+        }
+        else if (dofTags(j,0) == 1) {
+          if (cellDim_ == 1) { // 1D
+            numDofsPerVoid_[i] = dofTags(j,3);
+          }
+          else { // 2D, 3D
+            numDofsPerEdge_[i] = dofTags(j,3);
+          }
+        }
+        else if (dofTags(j,0) == 2) {
+          if (cellDim_ == 2) { // 2D
+            numDofsPerVoid_[i] = dofTags(j,3);
+          }
+          else { // 3D
+            numDofsPerFace_[i] = dofTags(j,3);
+          }
+        }
+        else if (dofTags(j,0) == 3) {
+          numDofsPerVoid_[i] = dofTags(j,3);
+        }
+      }
+      numLocalDofs_ += (intrepidBasis_[i])->getCardinality();
+    }
+    numLocalNodeDofs_ = 0;
+    numLocalEdgeDofs_ = 0;
+    numLocalFaceDofs_ = 0;
+    numLocalVoidDofs_ = 0;
+    for (int i=0; i<numBases_; ++i) {
+      numLocalNodeDofs_ += numDofsPerNode_[i];
+      numLocalEdgeDofs_ += numDofsPerEdge_[i];
+      numLocalFaceDofs_ += numDofsPerFace_[i];
+      numLocalVoidDofs_ += numDofsPerVoid_[i];
+    }
+    numLocalNodes_ = static_cast<int>( (intrepidBasis_[0])->getBaseCellTopology().getVertexCount() );
+    numLocalEdges_ = static_cast<int>( (intrepidBasis_[0])->getBaseCellTopology().getEdgeCount() );
+    numLocalFaces_ = static_cast<int>( (intrepidBasis_[0])->getBaseCellTopology().getFaceCount() );
+    numLocalVoids_ = 1;
+    computeFieldPattern();
+
+    // Global data structures.
+    computeDofArrays();
+    computeCellDofs();
+    computeFieldDofs();
+    computeDofTransforms();
+  }
+
+
+  int_view getNodeDofs() const {
+    return nodeDofs_;
+  }
+
+
+  int_view getEdgeDofs() const {
+    return edgeDofs_;
+  }
+
+
+  int_view getFaceDofs() const {
+    return faceDofs_;
+  }
+
+
+  int_view getVoidDofs() const {
+    return voidDofs_;
+  }
+
+
+  int_view getCellDofs() const {
+    return cellDofs_;
+  }
+
+
+  int_view getFieldDofs() const {
+    return fieldDofs_;
+  }
+
+
+  int_view getFieldDofs(const int & fieldNumber) const {
+    return fieldDofs_[fieldNumber];
+  }
+
+
+  int getNumNodeDofs() const {
+    return numNodeDofs_;
+  }
+
+
+  int getNumEdgeDofs() const {
+    return numEdgeDofs_;
+  }
+
+
+  int getNumFaceDofs() const {
+    return numFaceDofs_;
+  }
+
+
+  int getNumVoidDofs() const {
+    return numVoidDofs_;
+  }
+
+
+  int getNumDofs() const {
+    return numDofs_;
+  }
+
+
+  int getNumFields() const {
+    return numBases_;
+  }
+
+
+  int getLocalFieldSize() const {
+    return numLocalDofs_;
+  }
+
+
+  int getLocalFieldSize(const int & fieldNumber) const {
+    return (intrepidBasis_[fieldNumber])->getCardinality();
+  }
+
+
+  std::vector<std::vector<int> > getFieldPattern() const {
+    return fieldPattern_;
+  }
+
+
+  std::vector<int> getFieldPattern(const int & fieldNumber) const {
+    return fieldPattern_[fieldNumber];
+  }
+
+  void transformToIntrepidPattern(const scalar_view array) const {
+    if ( array.is_allocated() ) {
+      int rank = array.rank();
+      int nc   = array.extent(0);
+      if ( rank == 2 ) {
+        int nf = array.extent(1);
+        scalar_view tmp("tmp2d", nc, nf);
+        for (int c = 0; c < nc; ++c) {
+          for (int f = 0; f < nf; ++f) {
+            tmp(c, mapToIntrepidPattern_[f]) = array(c, f);
+          }
+        }
+        Kokkos::deep_copy(array, tmp);
+      }
+      else if (rank == 3 ) {
+        int nf1 = array.extent_int(1);
+        int nf2 = array.extent_int(2);
+        scalar_view tmp("tmp3d", nc, nf1, nf2);
+        for (int c = 0; c < nc; ++c) {
+          for (int f1 = 0; f1 < nf1; ++f1) {
+            for (int f2 = 0; f2 < nf2; ++f2) {
+              tmp(c, mapToIntrepidPattern_[f1], mapToIntrepidPattern_[f2]) = array(c, f1, f2);
+            }
+          }
+        }
+        Kokkos::deep_copy(array, tmp);
+      }
+      else {
+        TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
+          ">>> PDE-OPT/TOOLS/dofmanager.hpp (transformToIntrepidPattern): Input array rank not 2 or 3!");
+      }
+    }
+  }
+
+  int mapToFieldPattern(int f) const {
+    return mapToFieldPattern_[f];
+  }
+
+  void transformToFieldPattern(const scalar_view array) const {
+    if ( array.is_allocated() ) {
+      int rank = array.rank();
+      int nc   = array.extent_int(0);
+      if ( rank == 2 ) {
+        int nf = array.extent_int(1);
+        scalar_view tmp("tmp2d", nc, nf);
+        for (int c = 0; c < nc; ++c) {
+          for (int f = 0; f < nf; ++f) {
+            tmp(c, mapToFieldPattern_[f]) = array(c, f);
+          }
+        }
+        Kokkos::deep_copy(array, tmp);
+      }
+      else if (rank == 3 ) {
+        int nf1 = array->dimension(1);
+        int nf2 = array->dimension(2);
+        scalar_view tmp("tmp3d", nc, nf1, nf2);
+        for (int c = 0; c < nc; ++c) {
+          for (int f1 = 0; f1 < nf1; ++f1) {
+            for (int f2 = 0; f2 < nf2; ++f2) {
+              tmp(c, mapToFieldPattern_[f1], mapToFieldPattern_[f2]) = array(c, f1, f2);
+            }
+          }
+        }
+        Kokkos::deep_copy(array, tmp);
+      }
+      else {
+        TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
+          ">>> PDE-OPT/TOOLS/dofmanager.hpp (transformToFieldPattern): Input array rank not 2 or 3!");
+      }
+    }
+  }
+
+private:
+
+  void computeDofArrays() {
+
+    nodeDofs_ = int_view("nodeDofs_", numNodes_, numLocalNodeDofs_);
+    edgeDofs_ = int_view("edgeDofs_", numEdges_, numLocalEdgeDofs_);
+    faceDofs_ = int_view("faceDofs_", numFaces_, numLocalFaceDofs_);
+    voidDofs_ = int_view("voidDofs_", numCells_, numLocalVoidDofs_);
+
+    int dofCt = -1;
+
+    //
+    // This is the independent node id --> edge id --> cell id ordering.
+    // For example, for a Q2-Q2-Q1 basis (Taylor-Hood), we would have:
+    // 
+    //     Q2   Q2   Q1
+    //     -------------- 
+    // n1  1    1    1
+    // n2  1    1    1
+    // ...
+    // e1  1    1    0
+    // e2  1    1    0
+    // ...
+    // c1  1    1    0
+    // c2  1    1    0
+    // ...
+    //
+
+    // count node dofs
+    for (int i=0; i<numNodes_; ++i) {
+      int locNodeCt = -1;
+      for (int j=0; j<numBases_; ++j) {
+        for (int k=0; k<numDofsPerNode_[j]; ++k) {
+          nodeDofs_(i, ++locNodeCt) = ++dofCt;
+        }
+      }
+    }
+    numNodeDofs_ = dofCt+1;
+
+    // count edge dofs
+    for (int i=0; i<numEdges_; ++i) {
+      int locEdgeCt = -1;
+      for (int j=0; j<numBases_; ++j) {
+        for (int k=0; k<numDofsPerEdge_[j]; ++k) {
+          edgeDofs_(i, ++locEdgeCt) = ++dofCt;
+        }
+      }
+    }
+    numEdgeDofs_ = dofCt+1-numNodeDofs_;
+
+    // count face dofs
+    for (int i=0; i<numFaces_; ++i) {
+      int locFaceCt = -1;
+      for (int j=0; j<numBases_; ++j) {
+        for (int k=0; k<numDofsPerFace_[j]; ++k) {
+          faceDofs_(i, ++locFaceCt) = ++dofCt;
+        }
+      }
+    }
+    numFaceDofs_ = dofCt+1-numNodeDofs_-numEdgeDofs_;
+
+    // count void dofs
+    for (int i=0; i<numCells_; ++i) {
+      int locVoidCt = -1;
+      for (int j=0; j<numBases_; ++j) {
+        for (int k=0; k<numDofsPerVoid_[j]; ++k) {
+          voidDofs_(i, ++locVoidCt) = ++dofCt;
+        }
+      }
+    }
+    numVoidDofs_ = dofCt+1-numNodeDofs_-numEdgeDofs_-numFaceDofs_;
+
+    numDofs_ = numNodeDofs_+numEdgeDofs_+numFaceDofs_+numVoidDofs_;
+
+  } // computeDofArrays
+
+
+  void computeCellDofs() {
+
+    cellDofs_ = int_view("cellDofs_", numCells_, numLocalDofs_);
+
+    for (int i=0; i<numCells_; ++i) {
+      int ct = -1;
+      for (int j=0; j<numLocalNodes_; ++j) {
+        for (int k=0; k<numLocalNodeDofs_; ++k) {
+          cellDofs_(i,++ct) = nodeDofs_(meshCellToNodeMap_(i,j), k);
+        }
+      }
+      for (int j=0; j<numLocalEdges_; ++j) {
+        for (int k=0; k<numLocalEdgeDofs_; ++k) {
+          cellDofs_(i,++ct) = edgeDofs_(meshCellToEdgeMap_(i,j), k);
+        }
+      }
+      for (int j=0; j<numLocalFaces_; ++j) {
+        for (int k=0; k<numLocalFaceDofs_; ++k) {
+          cellDofs_(i,++ct) = faceDofs_(meshCellToFaceMap_(i,j), k);
+        }
+      }
+      for (int j=0; j<numLocalVoids_; ++j) {
+        for (int k=0; k<numLocalVoidDofs_; ++k) {
+          cellDofs_(i,++ct) = voidDofs_(i, k);
+        }
+      }
+    }
+  } // computeCellDofs
+
+
+  void computeFieldPattern() {
+
+    fieldPattern_.resize(numBases_);
+
+    int dofCt = -1;
+
+    // count node dofs
+    for (int i=0; i<numLocalNodes_; ++i) {
+      for (int j=0; j<numBases_; ++j) {
+        for (int k=0; k<numDofsPerNode_[j]; ++k) {
+          fieldPattern_[j].push_back(++dofCt);
+        }
+      }
+    }
+
+    // count edge dofs
+    for (int i=0; i<numLocalEdges_; ++i) {
+      for (int j=0; j<numBases_; ++j) {
+        for (int k=0; k<numDofsPerEdge_[j]; ++k) {
+          fieldPattern_[j].push_back(++dofCt);
+        }
+      }
+    }
+
+    // count face dofs
+    for (int i=0; i<numLocalFaces_; ++i) {
+      for (int j=0; j<numBases_; ++j) {
+        for (int k=0; k<numDofsPerFace_[j]; ++k) {
+          fieldPattern_[j].push_back(++dofCt);
+        }
+      }
+    }
+
+    // count void dofs
+    for (int i=0; i<numLocalVoids_; ++i) {
+      for (int j=0; j<numBases_; ++j) {
+        for (int k=0; k<numDofsPerVoid_[j]; ++k) {
+          fieldPattern_[j].push_back(++dofCt);
+        }
+      }
+    }
+
+  } // computeFieldPattern
+
+
+  void computeFieldDofs() {
+
+    fieldDofs_.resize(numBases_);
+
+    for (int fieldNum=0; fieldNum<numBases_; ++fieldNum) { 
+      int basisCard = intrepidBasis_[fieldNum]->getCardinality();
+      int_view fdofs("fieldDofs_", numCells_, basisCard);
+      for (int i=0; i<numCells_; ++i) {
+        for (int j=0; j<basisCard; ++j) {
+          fdofs(i,j) = cellDofs_(i, fieldPattern_[fieldNum][j]);
+        }
+      }
+      fieldDofs_[fieldNum] = fdofs;
+    }
+  } // computeFieldDofs
+
+  void computeDofTransforms(void) {
+    // Build basis maps
+    std::vector<std::vector<int> > map2IP(numBases_);
+    std::vector<std::vector<int> > map2FP(numBases_);
+    shards::CellTopology cellType = intrepidBasis_[0]->getBaseCellTopology();
+    int nv = cellType.getVertexCount();
+    for (int f=0; f<numBases_; ++f) { 
+      int basisDeg = intrepidBasis_[f]->getDegree();
+      if (cellDim_ == 1) {
+        if (basisDeg == 0) {
+          map2IP[f] = {0};
+          map2FP[f] = {0};
+        }
+        else if (basisDeg == 1) {
+          map2IP[f] = {0, 1};
+          map2FP[f] = {0, 1};
+        }
+        else if (basisDeg == 2) {
+          // C2 LINE basis does *not* follow the LINE<3> topology node order
+          map2IP[f] = {0, 2, 1};
+          map2FP[f] = {0, 2, 1};
+        }
+        else {
+          TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
+            ">>> PDE-OPT/TOOLS/dofmanager.hpp (ComputeDofTransforms): basisDeg > 2");
+        }
+      }
+      else if (cellDim_ == 2) {
+        if (basisDeg == 0) {
+          map2IP[f] = {0};
+          map2FP[f] = {0};
+        }
+        else if (basisDeg == 1) {
+          map2IP[f].resize(nv);
+          map2FP[f].resize(nv);
+          for (int i = 0; i < nv; ++i) {
+            map2IP[f][i] = i;
+            map2FP[f][i] = i;
+          }
+          //map2IP[f] = {0, 1, 2, 3}; // C1 QUAD
+          //map2FP[f] = {0, 1, 2, 3}; // C1 QUAD
+        }
+        else if (basisDeg == 2) {
+          int nbfs = (nv==3 ? 6 : 9);
+          map2IP[f].resize(nbfs);
+          map2FP[f].resize(nbfs);
+          for (int i = 0; i < nbfs; ++i) {
+            map2IP[f][i] = i;
+            map2FP[f][i] = i;
+          }
+          //map2IP[f] = {0, 1, 2, 3, 4, 5, 6, 7, 8}; // C2 QUAD
+          //map2FP[f] = {0, 1, 2, 3, 4, 5, 6, 7, 8}; // C2 QUAD
+        }
+        else {
+          TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
+            ">>> PDE-OPT/TOOLS/dofmanager.hpp (ComputeDofTransforms): basisDeg > 2");
+        }
+      }
+      else if (cellDim_ == 3) {
+        if (basisDeg == 0) {
+          map2IP[f] = {0};
+          map2FP[f] = {0};
+        }
+        else if (basisDeg == 1) {
+          map2IP[f].resize(nv);
+          map2FP[f].resize(nv);
+          for (int i = 0; i < nv; ++i) {
+            map2IP[f][i] = i;
+            map2FP[f][i] = i;
+          }
+          //map2IP[f] = {0, 1, 2, 3, 4, 5, 6, 7}; // C1 HEX
+          //map2FP[f] = {0, 1, 2, 3, 4, 5, 6, 7}; // C1 HEX
+        }
+        else if (basisDeg == 2) {
+          if (nv == 4) { // C2 TET basis follows the TET<10> topology node order
+            int nbfs = 10;
+            map2IP[f].resize(nbfs);
+            map2FP[f].resize(nbfs);
+            for (int i = 0; i < nbfs; ++i) {
+              map2IP[f][i] = i;
+              map2FP[f][i] = i;
+            }
+          }
+          else if (nv == 8) { // C2 HEX basis does *not* follow the HEX<27> topology node order
+            map2IP[f] = {0, 1, 2, 3, 4 ,5, 6, 7,                       // Nodes
+                         8, 9, 10, 11, 16, 17, 18, 19, 12, 13, 14, 15, // Edges
+                         25, 24, 26, 23, 21, 22,                       // Faces
+                         20};                                          // Voids
+            map2FP[f] = {0, 1, 2, 3, 4 ,5, 6, 7,                       // Nodes
+                         8, 9, 10, 11, 16, 17, 18, 19, 12, 13, 14, 15, // Edges
+                         26,                                           // Voids
+                         24, 25, 23, 21, 20, 22};                      // Faces
+          }
+        }
+        else {
+          TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
+            ">>> PDE-OPT/TOOLS/dofmanager.hpp (ComputeDofTransforms): basisDeg > 2");
+        }
+      }
+    }
+    // Apply transformation to ind
+    mapToIntrepidPattern_.clear(); mapToIntrepidPattern_.resize(numDofs_);
+    mapToFieldPattern_.clear();    mapToFieldPattern_.resize(numDofs_);
+    for (int i = 0; i < numBases_; ++i) {
+      for (int j = 0; j < static_cast<int>(map2IP[i].size()); ++j) {
+        mapToIntrepidPattern_[fieldPattern_[i][j]] = fieldPattern_[i][map2IP[i][j]];
+        mapToFieldPattern_[fieldPattern_[i][j]]    = fieldPattern_[i][map2FP[i][j]];
+      }
+    }
+  }
+
+}; // DofManager
+
+#endif

--- a/packages/rol/example/PDE-OPT/TOOLS/dynpdeK.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/dynpdeK.hpp
@@ -1,0 +1,270 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  dynpdeK.hpp
+    \brief Provides the interface for local (cell-based) PDE residual computations.
+*/
+
+#ifndef PDEOPT_DYNPDEK_HPP
+#define PDEOPT_DYNPDEK_HPP
+
+#include "ROL_Ptr.hpp"
+#include "ROL_TimeStamp.hpp"
+#include "Intrepid2_Basis.hpp"
+
+template <class Real, class DeviceType>
+class DynamicPDE {
+public:
+  using scalar_view = Kokkos::DynRankView<Real,DeviceType>;
+  using basis_ptr = Intrepid2::BasisPtr<DeviceType, Real, Real>;
+
+  virtual ~DynamicPDE() {}
+
+  virtual void residual(scalar_view & res,
+                        const ROL::TimeStamp<Real> &ts,
+                        const scalar_view uo_coeff,
+                        const scalar_view un_coeff,
+                        const scalar_view z_coeff = scalar_view(),
+                        const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) = 0;
+
+  virtual void Jacobian_uo(scalar_view & jac,
+                           const ROL::TimeStamp<Real> &ts,
+                           const scalar_view uo_coeff,
+                           const scalar_view un_coeff,
+                           const scalar_view z_coeff = scalar_view(),
+                           const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Jacobian_uo not implemented.");
+  }
+
+  virtual void Jacobian_un(scalar_view & jac,
+                           const ROL::TimeStamp<Real> &ts,
+                           const scalar_view uo_coeff,
+                           const scalar_view un_coeff,
+                           const scalar_view z_coeff = scalar_view(),
+                           const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Jacobian_un not implemented.");
+  }
+
+  virtual void Jacobian_zf(scalar_view & jac,
+                           const ROL::TimeStamp<Real> &ts,
+                           const scalar_view uo_coeff,
+                           const scalar_view un_coeff,
+                           const scalar_view z_coeff = scalar_view(),
+                           const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Jacobian_zf not implemented.");
+  }
+
+  virtual void Jacobian_zp(std::vector<scalar_view> & jac,
+                           const ROL::TimeStamp<Real> &ts,
+                           const scalar_view uo_coeff,
+                           const scalar_view un_coeff,
+                           const scalar_view z_coeff = scalar_view(),
+                           const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Jacobian_3 not implemented.");
+  }
+
+  virtual void Hessian_uo_uo(scalar_view & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_uo_uo not implemented.");
+  }
+
+  virtual void Hessian_uo_un(scalar_view & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_uo_un not implemented.");
+  }
+
+  virtual void Hessian_uo_zf(scalar_view & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_uo_zf not implemented.");
+  }
+
+  virtual void Hessian_uo_zp(std::vector<scalar_view> & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_uo_zp not implemented.");
+  }
+
+  virtual void Hessian_un_uo(scalar_view & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_un_uo not implemented.");
+  }
+
+  virtual void Hessian_un_un(scalar_view & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_un_un not implemented.");
+  }
+
+  virtual void Hessian_un_zf(scalar_view & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_un_zf not implemented.");
+  }
+
+  virtual void Hessian_un_zp(std::vector<scalar_view> & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_un_zp not implemented.");
+  }
+
+  virtual void Hessian_zf_uo(scalar_view & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_zf_uo not implemented.");
+  }
+
+  virtual void Hessian_zf_un(scalar_view & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = ROL::nullPtr,
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_zf_un not implemented.");
+  }
+
+  virtual void Hessian_zf_zf(scalar_view & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_zf_zf not implemented.");
+  }
+
+  virtual void Hessian_zf_zp(std::vector<scalar_view> & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_zf_zp not implemented.");
+  }
+
+  virtual void Hessian_zp_uo(std::vector<scalar_view> & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_zp_uo not implemented.");
+  }
+
+  virtual void Hessian_zp_un(std::vector<scalar_view> & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_zp_un not implemented.");
+  }
+
+  virtual void Hessian_zp_zf(std::vector<scalar_view> & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_zp_zf not implemented.");
+  }
+
+  virtual void Hessian_zp_zp(std::vector<std::vector<scalar_view>> & hess,
+                             const ROL::TimeStamp<Real> &ts,
+                             const scalar_view l_coeff,
+                             const scalar_view uo_coeff,
+                             const scalar_view un_coeff,
+                             const scalar_view z_coeff = scalar_view(),
+                             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_zp_zp not implemented.");
+  }
+
+  virtual void RieszMap_1(scalar_view &riesz) {
+    throw Exception::NotImplemented(">>> RieszMap_1 not implemented.");
+  }
+
+  virtual void RieszMap_2(scalar_view &riesz) {
+    throw Exception::NotImplemented(">>> RieszMap_2 not implemented.");
+  }
+
+  virtual std::vector<basis_ptr> getFields() = 0;
+  //virtual std::vector<basis_ptr> getFields2() {
+  //  return getFields();
+  //}
+
+  virtual void setCellNodes(const scalar_view &cellNodes,
+                            const std::vector<std::vector<scalar_view>> &bdryCellNodes,
+                            const std::vector<std::vector<std::vector<int>>> &bdryCellLocIds) = 0;
+
+  virtual void setFieldPattern(const std::vector<std::vector<int>> &fieldPattern) {}
+  virtual void setFieldPattern(const std::vector<std::vector<int>> &fieldPattern1,
+                               const std::vector<std::vector<int>> &fieldPattern2) {
+    setFieldPattern(fieldPattern1);
+  }
+
+private:
+  std::vector<Real> param_;
+
+protected:
+  std::vector<Real> getParameter(void) const {
+    return param_;
+  }
+
+public:
+  void setParameter(const std::vector<Real> &param) {
+    param_.assign(param.begin(),param.end());
+  }
+
+}; // DynamicPDE
+
+#endif

--- a/packages/rol/example/PDE-OPT/TOOLS/feK.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/feK.hpp
@@ -1,0 +1,659 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  feK.hpp
+    \brief Given a set of cells with geometric node information, sets up
+           data structures used in finite element integration in HGRAD.
+*/
+
+#ifndef PDEOPT_FE_HPP
+#define PDEOPT_FE_HPP
+
+#include "ROL_Ptr.hpp"
+
+#include "Teuchos_ParameterList.hpp"
+#include "Intrepid2_Basis.hpp"
+#include "Intrepid2_Cubature.hpp"
+#include "Intrepid2_CellTools.hpp"
+#include "Intrepid2_FunctionSpaceTools.hpp"
+
+template <class Real, class DeviceType>
+class FE {
+
+public:
+  using scalar_view = Kokkos::DynRankView<Real,DeviceType>;
+  using fst = Intrepid2::FunctionSpaceTools<DeviceType>;
+  using ct = Intrepid2::CellTools<DeviceType>;
+  using rst = Intrepid2::RealSpaceTools<DeviceType>;
+
+private:
+
+  const scalar_view cellNodes_;                                 // coordinates of the cell nodes
+  Intrepid2::BasisPtr<DeviceType, Real, Real> basis_;           // Intrepid basis
+  const ROL::Ptr<Intrepid2::Cubature<DeviceType, Real, Real>> cubature_;  // Intrepid cubature (quadrature, integration) rule
+  const int sideId_;                                                                         // local side id for boundary integration
+
+  int c_;    // number of cells in the FE object
+  int f_;    // number of basis functions per cell
+  int p_;    // number of cubature points per cell
+  int d_;    // space dimension of the (parent) cells
+  int sd_;   // space dimension of the side cells
+
+  ROL::Ptr<shards::CellTopology> cellTopo_;   // base (parent) cell topology
+  ROL::Ptr<shards::CellTopology> sideTopo_;   // side (subcell) topology; assumed uniform
+
+  std::vector<std::vector<int> > sideDofs_;       // local dofs on cell sides; 1st index: side number; 2nd index: dof number
+
+  // Containers for local finite element data.
+  scalar_view cubPoints_;             // points of the cubature rule on the reference cell
+  scalar_view cubWeights_;            // weights of the cubature rule on the reference cell
+  scalar_view cubPointsSubcell_;      // cubature points on the side reference cell
+  scalar_view cubWeightsSubcell_;     // cubature weights on the side reference cell
+  scalar_view cellJac_;               // cell Jacobian matrices
+  scalar_view cellJacInv_;            // inverses of cell Jacobians
+  scalar_view cellJacDet_;            // determinants of cell Jacobians
+  scalar_view cellWeightedMeasure_;   // cell measure (Jacobian determinant) multiplied by the cubature weights
+  scalar_view valReference_;          // value of FE basis in reference space
+  scalar_view gradReference_;         // gradient of FE basis in reference space
+  scalar_view valPhysical_;           // value of FE basis in physical space
+  scalar_view gradPhysical_;          // gradient of FE basis in physical space
+  scalar_view gradPhysicalX_;         // x-component of gradient of FE basis in physical space
+  scalar_view gradPhysicalY_;         // y-component of gradient of FE basis in physical space
+  scalar_view gradPhysicalZ_;         // z-component of gradient of FE basis in physical space
+  scalar_view gradPhysicalXWeighted_; // x-component of gradient of FE basis in physical space weighted
+  scalar_view gradPhysicalYWeighted_; // y-component of gradient of FE basis in physical space weighted
+  scalar_view gradPhysicalZWeighted_; // z-component of gradient of FE basis in physical space weighted
+  scalar_view divPhysical_;           // divergence of FE basis in physical space
+  scalar_view valPhysicalWeighted_;   // value of FE basis in physical space multiplied by weighted cell measure
+  scalar_view gradPhysicalWeighted_;  // gradient of FE basis in physical space multiplied by weighted cell measure
+  scalar_view divPhysicalWeighted_;   // divergence of FE basis in physical space multiplied by weighted cell measure
+  scalar_view gradgradMats_;          // cell stiffness matrices
+  scalar_view valvalMats_;            // cell mass matrices
+  scalar_view cubPointsPhysical_;     // cubature points on the physical cells
+  scalar_view dofPoints_;             // degree of freedom points on the reference cell
+
+public:
+
+  FE(const scalar_view                                           cellNodes,
+     const Intrepid2::BasisPtr<DeviceType, Real, Real>           basis,
+     const ROL::Ptr<Intrepid2::Cubature<DeviceType, Real, Real>> cubature,
+     bool computeBdryDofs = true) :
+       cellNodes_(cellNodes), basis_(basis), cubature_(cubature), sideId_(-1) {
+
+    // Get base cell topology from basis.
+    cellTopo_ = ROL::makePtr<shards::CellTopology>(basis_->getBaseCellTopology());
+
+    // Compute dimensions of multidimensional array members.
+    c_  = cellNodes_.extent_int(0);
+    f_  = basis_->getCardinality();
+    p_  = cubature_->getNumPoints();
+    d_  = cellTopo_->getDimension();
+    sd_ = d_ - 1;
+
+    // Get side subcell topology.
+    sideTopo_ = ROL::nullPtr;
+
+    // Allocate multidimensional arrays.
+    cubPoints_               = scalar_view("cubPoints_", p_, d_);
+    cubWeights_              = scalar_view("cubWeights_", p_);
+    cellJac_                 = scalar_view("cellJac_", c_, p_, d_, d_);
+    cellJacInv_              = scalar_view("cellJacInv_", c_, p_, d_, d_);
+    cellJacDet_              = scalar_view("cellJacDet_", c_, p_);
+    cellWeightedMeasure_     = scalar_view("cellWeightedMeasure_", c_, p_);
+    valReference_            = scalar_view("valReference_", f_, p_);
+    gradReference_           = scalar_view("gradReference_", f_, p_, d_);
+    valPhysical_             = scalar_view("valPhysical_", c_, f_, p_);
+    gradPhysical_            = scalar_view("gradPhysical_", c_, f_, p_, d_);
+    gradPhysicalX_           = scalar_view("gradPhysicalX_", c_, f_, p_);
+    if (d_ > 1) {
+      gradPhysicalY_         = scalar_view("gradPhysicalY_", c_, f_, p_);
+    }
+    if (d_ > 2) {
+      gradPhysicalZ_         = scalar_view("gradPhysicalZ_", c_, f_, p_);
+    }
+    gradPhysicalXWeighted_   = scalar_view("gradPhysicalXWeighted_", c_, f_, p_);
+    if (d_ > 1) {
+      gradPhysicalYWeighted_ = scalar_view("gradPhysicalYWeighted_", c_, f_, p_);
+    }
+    if (d_ > 2) {
+      gradPhysicalZWeighted_ = scalar_view("gradPhysicalZWeighted_", c_, f_, p_);
+    }
+    divPhysical_             = scalar_view("divPhysical_", c_, f_, p_);
+    valPhysicalWeighted_     = scalar_view("valPhysicalWeighted_", c_, f_, p_);
+    gradPhysicalWeighted_    = scalar_view("gradPhysicalWeighted_", c_, f_, p_, d_);
+    divPhysicalWeighted_     = scalar_view("divPhysicalWeighted_", c_, f_, p_);
+    gradgradMats_            = scalar_view("gradgradMats_", c_, f_, f_);
+    valvalMats_              = scalar_view("valvalMats_", c_, f_, f_);
+    cubPointsPhysical_       = scalar_view("cubPointsPhysical_", c_, p_, d_);
+    dofPoints_               = scalar_view("dofPoints_", f_, d_);
+
+    /*** START: Fill multidimensional arrays. ***/
+
+    // Compute cubature points and weights.
+    cubature_->getCubature(cubPoints_, cubWeights_);
+
+    // Compute reference basis value and gradient.
+    basis_->getValues(gradReference_, cubPoints_, Intrepid2::OPERATOR_GRAD);       // evaluate grad operator at cubature points
+    basis_->getValues(valReference_, cubPoints_, Intrepid2::OPERATOR_VALUE);       // evaluate value operator at cubature points
+
+    // Compute cell Jacobian matrices, its inverses and determinants.
+    ct::setJacobian(cellJac_, cubPoints_, cellNodes_, *cellTopo_);  // compute cell Jacobians
+    ct::setJacobianInv(cellJacInv_, cellJac_);                       // compute inverses of cell Jacobians
+    ct::setJacobianDet(cellJacDet_, cellJac_);                       // compute determinants of cell Jacobians
+
+    // Compute weighted cell measure, i.e., det(J)*(cubature weight).
+    fst::computeCellMeasure(cellWeightedMeasure_, cellJacDet_, cubWeights_);
+
+    // Transform reference values into physical space.
+    fst::HGRADtransformVALUE(valPhysical_, valReference_);
+
+    // Multiply with weighted measure to get weighted values in physical space.
+    fst::multiplyMeasure(valPhysicalWeighted_, cellWeightedMeasure_, valPhysical_);
+
+    // Transform reference gradients into physical space.
+    fst::HGRADtransformGRAD(gradPhysical_, cellJacInv_, gradReference_);
+
+    // Multiply with weighted measure to get weighted gradients in physical space.
+    fst::multiplyMeasure(gradPhysicalWeighted_, cellWeightedMeasure_, gradPhysical_);
+
+    // Extract individual (x, y, z) components of the gradients in physical space.
+    for (int c=0; c<c_; ++c) {
+      for (int f=0; f<f_; ++f) {
+        for (int p=0; p<p_; ++p) {
+          gradPhysicalX_(c,f,p) = gradPhysical_(c,f,p,0);
+            gradPhysicalXWeighted_(c,f,p) = gradPhysicalWeighted_(c,f,p,0);
+          if (d_ > 1) {
+            gradPhysicalY_(c,f,p) = gradPhysical_(c,f,p,1);
+            gradPhysicalYWeighted_(c,f,p) = gradPhysicalWeighted_(c,f,p,1);
+          }
+          if (d_ > 2) {
+            gradPhysicalZ_(c,f,p) = gradPhysical_(c,f,p,2);
+            gradPhysicalZWeighted_(c,f,p) = gradPhysicalWeighted_(c,f,p,2);
+          }
+        }
+      }
+    }
+
+    // Build divergence in physical space.
+    rst::add(divPhysical_, gradPhysicalX_);
+    if (d_ > 1) {
+      rst::add(divPhysical_, gradPhysicalY_);
+    }
+    if (d_ > 2) {
+      rst::add(divPhysical_, gradPhysicalZ_);
+    }
+
+    // Multiply with weighted measure to get weighted divegence in physical space.
+    fst::multiplyMeasure(divPhysicalWeighted_, cellWeightedMeasure_, divPhysical_);
+
+    // Compute stiffness matrices.
+    fst::integrate(gradgradMats_, gradPhysical_, gradPhysicalWeighted_);
+
+    // Compute mass matrices.
+    fst::integrate(valvalMats_, valPhysical_, valPhysicalWeighted_);
+
+    // Map reference cubature points to cells in physical space.
+    ct::mapToPhysicalFrame(cubPointsPhysical_, cubPoints_, cellNodes_, *cellTopo_);
+
+    // Compute local degrees of freedom on reference cell sides.
+    if (computeBdryDofs) {
+      int numSides = cellTopo_->getSideCount();
+      if (cellTopo_->getDimension() == 1) {
+        numSides = 2;
+      }
+      if ( numSides ) {
+        for (int i=0; i<numSides; ++i) {
+          sideDofs_.push_back(computeBoundaryDofs(i));
+        }
+      }
+      else {
+        sideDofs_.push_back(computeBoundaryDofs(0));
+      }
+    }
+
+    // Get coordinates of DOFs in reference cell.
+    basis->getDofCoords(dofPoints_);
+
+    /*** END: Fill multidimensional arrays. ***/
+
+  }
+
+  FE(const scalar_view cellNodes,
+     const Intrepid2::BasisPtr<DeviceType, Real, Real>           basis,
+     const ROL::Ptr<Intrepid2::Cubature<DeviceType, Real, Real>> cubature,
+     const int&                                                  sideId) :
+       cellNodes_(cellNodes), basis_(basis), cubature_(cubature), sideId_(sideId) {
+
+    // Get base cell topology from basis.
+    cellTopo_ = ROL::makePtr<shards::CellTopology>(basis_->getBaseCellTopology());
+
+    // Compute dimensions of multidimensional array members.
+    c_  = cellNodes_->dimension(0);
+    f_  = basis_->getCardinality();
+    p_  = cubature_->getNumPoints();
+    d_  = cellTopo_->getDimension();
+    sd_ = d_ - 1;
+    //std::cout << "FE: c = " << c_ << ", f = " << f_ << ", p = " << p_ << ", d = " << d_ << std::endl;
+
+    // Get side subcell topology.
+    sideTopo_ = ROL::makePtr<shards::CellTopology>(cellTopo_->getCellTopologyData(sd_, sideId_));
+
+    // Allocate multidimensional arrays.
+    cubPoints_            = scalar_view("cubPoints_", p_, d_);
+    cubWeights_           = scalar_view("cubWeights_", p_);
+    cubPointsSubcell_     = scalar_view("cubPointsSubcell_", p_, sd_);
+    cubWeightsSubcell_    = scalar_view("cubWeightsSubcell_", p_);
+    cellJac_              = scalar_view("cellJac_", c_, p_, d_, d_);
+    cellJacInv_           = scalar_view("cellJacInv_", c_, p_, d_, d_);
+    cellJacDet_           = scalar_view("cellJacDet_", c_, p_);
+    cellWeightedMeasure_  = scalar_view("cellWeightedMeasure_", c_, p_);
+    valReference_         = scalar_view("valReference_", f_, p_);
+    gradReference_        = scalar_view("gradReference_", f_, p_, d_);
+    valPhysical_          = scalar_view("valPhysical_", c_, f_, p_);
+    gradPhysical_         = scalar_view("gradPhysical_", c_, f_, p_, d_);
+    gradPhysicalX_        = scalar_view("gradPhysicalX_", c_, f_, p_);
+    if (d_ > 1) {
+      gradPhysicalY_      = scalar_view("gradPhysicalY_", c_, f_, p_);
+    }
+    if (d_ > 2) {
+      gradPhysicalZ_      = scalar_view("gradPhysicalZ_", c_, f_, p_);
+    }
+    divPhysical_          = scalar_view("divPhysical_", c_, f_, p_);
+    valPhysicalWeighted_  = scalar_view("valPhysicalWeighted_", c_, f_, p_);
+    gradPhysicalWeighted_ = scalar_view("gradPhysicalWeighted_", c_, f_, p_, d_);
+    gradPhysicalXWeighted_  = scalar_view("gradPhysicalXWeighted_", c_, f_, p_);
+    if (d_ > 1) {
+      gradPhysicalYWeighted_ = scalar_view("gradPhysicalYWeighted_", c_, f_, p_);
+    }
+    if (d_ > 2) {
+      gradPhysicalZWeighted_ = scalar_view("gradPhysicalZWeighted_", c_, f_, p_);
+    }
+    divPhysicalWeighted_  = scalar_view("divPhysicalWeighted_", c_, f_, p_);
+    gradgradMats_         = scalar_view("gradgradMats_", c_, f_, f_);
+    valvalMats_           = scalar_view("valvalMats_", c_, f_, f_);
+    cubPointsPhysical_    = scalar_view("cubPointsPhysical_", c_, p_, d_);
+    dofPoints_            = scalar_view("dofPoints_", f_, d_);
+
+    /*** START: Fill multidimensional arrays. ***/
+
+    // Compute cubature points and weights.
+    cubature_->getCubature(cubPointsSubcell_, cubWeights_);
+
+    // Compute reference basis value and gradient.
+    ct::mapToReferenceSubcell(cubPoints_, cubPointsSubcell_, sd_, sideId_, *cellTopo_);
+    basis_->getValues(gradReference_, cubPoints_, Intrepid2::OPERATOR_GRAD);       // evaluate grad operator at cubature points
+    basis_->getValues(valReference_, cubPoints_, Intrepid2::OPERATOR_VALUE);       // evaluate value operator at cubature points
+
+    // Compute cell Jacobian matrices, its inverses and determinants.
+    ct::setJacobian(cellJac_, cubPoints_, cellNodes_, *cellTopo_);  // compute cell Jacobians
+    ct::setJacobianInv(cellJacInv_, cellJac_);                      // compute inverses of cell Jacobians
+    ct::setJacobianDet(cellJacDet_, cellJac_);                      // compute determinants of cell Jacobians
+
+    // Compute weighted cell measure.
+    if (d_ == 2) {
+      fst::computeEdgeMeasure(cellWeightedMeasure_, cellJac_, cubWeights_, sideId_, *cellTopo_);
+    }
+    else if (d_ == 3) {
+      fst::computeFaceMeasure(cellWeightedMeasure_, cellJac_, cubWeights_, sideId_, *cellTopo_);
+    }
+
+    // Transform reference values into physical space.
+    fst::HGRADtransformVALUE(valPhysical_,valReference_);
+
+    // Multiply with weighted measure to get weighted values in physical space.
+    fst::multiplyMeasure(valPhysicalWeighted_, cellWeightedMeasure_, valPhysical_);
+
+    // Transform reference gradients into physical space.
+    fst::HGRADtransformGRAD(gradPhysical_, cellJacInv_, gradReference_);
+
+    // Multiply with weighted measure to get weighted gradients in physical space.
+    fst::multiplyMeasure(gradPhysicalWeighted_, cellWeightedMeasure_, gradPhysical_);
+
+    // Extract individual (x, y, z) components of the weighted gradients in physical space.
+    for (int c=0; c<c_; ++c) {
+      for (int f=0; f<f_; ++f) {
+        for (int p=0; p<p_; ++p) {
+          (*gradPhysicalX_)(c,f,p) = (*gradPhysical_)(c,f,p,0);
+          (*gradPhysicalXWeighted_)(c,f,p) = (*gradPhysicalWeighted_)(c,f,p,0);
+          if (d_ > 1) {
+          (*gradPhysicalY_)(c,f,p) = (*gradPhysical_)(c,f,p,1);
+          (*gradPhysicalYWeighted_)(c,f,p) = (*gradPhysicalWeighted_)(c,f,p,1);
+          }
+          if (d_ > 2) {
+          (*gradPhysicalZ_)(c,f,p) = (*gradPhysical_)(c,f,p,2);
+          (*gradPhysicalZWeighted_)(c,f,p) = (*gradPhysicalWeighted_)(c,f,p,2);
+          }
+        }
+      }
+    }
+
+    // Build divergence in physical space.
+    rst::add(divPhysical_, gradPhysicalX_);
+    if (d_ > 1) {
+      rst::add(divPhysical_, gradPhysicalY_);
+    }
+    if (d_ > 2) {
+      rst::add(divPhysical_, gradPhysicalZ_);
+    }
+
+    // Multiply with weighted measure to get weighted divegence in physical space.
+    fst::multiplyMeasure(divPhysicalWeighted_, cellWeightedMeasure_, divPhysical_);
+
+    // Compute stiffness matrices.
+    fst::integrate(gradgradMats_, gradPhysical_, gradPhysicalWeighted_);
+
+    // Compute mass matrices.
+    fst::integrate(valvalMats_, valPhysical_, valPhysicalWeighted_);
+
+    // Map reference cubature points to cells in physical space.
+    ct::mapToPhysicalFrame(cubPointsPhysical_,
+                                                  cubPoints_,
+                                                  cellNodes_,
+                                                  *cellTopo_);
+
+    // Compute local degrees of freedom on reference cell sides.
+    int numSides = cellTopo_->getSideCount();
+    for (int i=0; i<numSides; ++i) {
+      sideDofs_.push_back(computeBoundaryDofs(i));
+    }
+
+    // Get coordinates of DOFs in reference cell.
+      basis->getDofCoords(dofPoints_);
+
+    /*** END: Fill multidimensional arrays. ***/
+
+  }
+
+  /** \brief  Returns cell Jacobian matrices at cubature points.
+  */
+  scalar_view J() const {
+    return cellJac_;
+  }
+
+  /** \brief  Returns inverses of cell Jacobians at cubature points.
+  */
+  scalar_view invJ() const {
+    return cellJacInv_;
+  }
+
+  /** \brief  Returns determinants of cell Jacobians at cubature points.
+  */
+  scalar_view detJ() const {
+    return cellJacDet_;
+  }
+
+  /** \brief  Returns values of FE basis at cubature points in reference space.
+  */
+  scalar_view Nref() const {
+    return valReference_;
+  }
+
+  /** \brief  Returns gradients of FE basis at cubature points in reference space.
+  */
+  scalar_view gradNref() const {
+    return gradReference_;
+  }
+
+  /** \brief  Returns value of FE basis at cubature points in physical space.
+  */
+  scalar_view N() const {
+    return valPhysical_;
+  }
+
+  /** \brief  Returns value of FE basis at cubature points in physical space,
+              multiplied by weighted cell measures.
+  */
+  scalar_view NdetJ() const {
+    return valPhysicalWeighted_;
+  }
+
+  /** \brief  Returns gradient of FE basis at cubature points in physical space.
+  */
+  scalar_view gradN() const {
+    return gradPhysical_;
+  }
+
+  /** \brief  Returns gradient of FE basis at cubature points in physical space,
+              multiplied by weighted cell measures.
+  */
+  scalar_view gradNdetJ() const {
+    return gradPhysicalWeighted_;
+  }
+
+  /** \brief  Returns divergence of FE basis at cubature points in physical space.
+  */
+  scalar_view divN() const {
+    return divPhysical_;
+  }
+
+  /** \brief  Returns divergence of FE basis at cubature points in physical space,
+              multiplied by weighted cell measures.
+  */
+  scalar_view divNdetJ() const {
+    return divPhysicalWeighted_;
+  }
+
+  /** \brief  Returns x, y or z component of the gradient of FE basis at
+              cubature points in physical space.
+
+      \param  coord    [in]   - coordinate index (x=0, y=1, z=2)
+  */
+  scalar_view DND(const int & coord) const {
+    if (coord == 0) {
+      return gradPhysicalX_;
+    }
+    else if (coord == 1) {
+      return gradPhysicalY_;
+    }
+    else if (coord == 2) {
+      return gradPhysicalZ_;
+    }
+    else {
+      TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
+        ">>> ERROR (PDEOPT::FE::DND): Invalid coordinate argument!");
+    }
+  }
+
+  /** \brief  Returns x, y or z component of the gradient of FE basis at
+              cubature points in physical space, multiplied by weighted
+              cell measures.
+
+      \param  coord    [in]   - coordinate index (x=0, y=1, z=2)
+  */
+  scalar_view DNDdetJ(const int & coord) const {
+    if (coord == 0) {
+      return gradPhysicalXWeighted_;
+    }
+    else if (coord == 1) {
+      return gradPhysicalYWeighted_;
+    }
+    else if (coord == 2) {
+      return gradPhysicalZWeighted_;
+    }
+    else {
+      TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
+        ">>> ERROR (PDEOPT::FE::DNDdetJ): Invalid coordinate argument!");
+    }
+  }
+
+  /** \brief  Returns stiffness matrices on cells.
+  */
+  scalar_view stiffMat() const {
+    return gradgradMats_;
+  }
+
+  /** \brief  Returns mass matrices on cells.
+  */
+  scalar_view massMat() const {
+    return valvalMats_;
+  }
+
+  /** \brief Returns cubature points on cells in physical space.
+  */
+  scalar_view cubPts() const {
+    return cubPointsPhysical_;
+  }
+
+  /** \brief Builds FE value interpolant and evaluates it at cubature
+             points in physical space.
+  */
+  void evaluateValue(scalar_view fVals,
+                     const scalar_view inCoeffs) const {
+    fst::evaluate(fVals, inCoeffs, valPhysical_);
+  }
+
+  /** \brief Builds FE gradient interpolant and evaluates it at cubature
+             points in physical space.
+  */
+  void evaluateGradient(scalar_view fGrads,
+                        const scalar_view inCoeffs) const {
+    fst::evaluate(fGrads, inCoeffs, gradPhysical_);
+  }
+
+  /** \brief Computes integral of the product or dot-product of interpolated
+             FE fields f1 and f2, indexed by (C,P), for values, or (C,P,D),
+             for gradients.
+  */
+  void computeIntegral(scalar_view integral,
+                       const scalar_view f1,
+                       const scalar_view f2,
+                       const bool sumInto = false) const {
+    scalar_view f2Weighted;
+    if(f2.rank() == 3) {
+      f2Weighted = scalar_view("f2Weighted", f2.extent(0), f2.extent(1), f2.extent(2));
+    } else { //rank = 2
+      f2Weighted = scalar_view("f2Weighted", f2.extent(0), f2.extent(1));
+    }
+    fst::scalarMultiplyDataData(f2Weighted, cellWeightedMeasure_, f2);  // multiply with weighted measure
+                                                              
+    fst::integrate(integral, f1, f2Weighted, sumInto);                  // compute integral of f1*f2
+  }
+
+  /** \brief Computes the degrees of freedom on a side.
+  */
+  std::vector<int> computeBoundaryDofs(const int & locSideId) const {
+
+    std::vector<int> bdrydofs;
+    std::vector<int> nodeids, edgeids, faceids;
+
+    if (cellTopo_->getDimension() == 1) {
+      nodeids.push_back(locSideId);
+    }
+    else if (cellTopo_->getDimension() == 2) {
+      edgeids.push_back(locSideId);
+      int numVertices = 2;
+      for (int i=0; i<numVertices; ++i) {
+        nodeids.push_back(cellTopo_->getNodeMap(1, locSideId, i));
+      }
+      //for (unsigned i=0; i<nodeids.size(); ++i) {
+      //  std::cout << "\nnodeid = " << nodeids[i];
+      //}
+      //for (unsigned i=0; i<edgeids.size(); ++i) {
+      //  std::cout << "\nedgeid = " << edgeids[i];
+      //}
+    }
+    else if (cellTopo_->getDimension() == 3) {
+      faceids.push_back(locSideId);
+      CellTopologyData_Subcell face = cellTopo_->getCellTopologyData()->subcell[2][locSideId];
+      shards::CellTopology face_topo(face.topology);
+      int numVertices = face_topo.getVertexCount();
+      for (int i=0; i<numVertices; ++i) {
+        nodeids.push_back(cellTopo_->getNodeMap(2, locSideId, i));
+      }
+      int numEdges = face_topo.getEdgeCount();
+      for (int i=0; i<numEdges; ++i) {
+        edgeids.push_back(mapCellFaceEdge(cellTopo_->getCellTopologyData(), locSideId, i));
+      }
+      //for (unsigned i=0; i<nodeids.size(); ++i) {
+      //  std::cout << "\nnodeid = " << nodeids[i];
+      //}
+      //for (unsigned i=0; i<edgeids.size(); ++i) {
+      //  std::cout << "\nedgeid = " << edgeids[i];
+      //}
+      //for (unsigned i=0; i<faceids.size(); ++i) {
+      //  std::cout << "\nfaceid = " << faceids[i];
+      //}
+    }
+
+    auto tagToId = basis_->getAllDofOrdinal();
+    std::vector<std::vector<std::vector<int> > > tagToIdCompact;
+    int scdim = tagToId.extent_int(0);
+    tagToIdCompact.resize(scdim);
+    for (int i=0; i<scdim; ++i) {
+      for (int j=0; j<tagToId.extent_int(1); ++j) {
+        std::vector<int> ids;
+        for (int k=0; k<tagToId.extent_int(2); ++k) {
+          //std::cout << "\n  i=" << i << "  j=" << j << "  k=" << k << "  id=" << tagToId[i][j][k];
+          if (tagToId(i,j,k) != -1) {
+            ids.push_back(tagToId(i,j,k));
+          }
+        }
+        tagToIdCompact[i].push_back(ids);
+        //int dofordcompact = tagToIdCompact[i][j].size();
+        //for (int k=0; k<dofordcompact; ++k) {
+        //  std::cout << "\n  i=" << i << "  j=" << j << "  k=" << k << "  id=" << tagToIdCompact[i][j][k];
+        //}
+      }
+    }
+
+    int numNodeIds = nodeids.size();
+    if (tagToIdCompact.size() > 0) {
+      for (int i=0; i<numNodeIds; ++i) {
+        int numdofs = tagToIdCompact[0][nodeids[i]].size();
+        for (int j=0; j<numdofs; ++j) {
+          bdrydofs.push_back(tagToIdCompact[0][nodeids[i]][j]);
+        }
+      }
+    }
+
+    int numEdgeIds = edgeids.size();
+    if (tagToIdCompact.size() > 1) {
+      for (int i=0; i<numEdgeIds; ++i) {
+        int numdofs = tagToIdCompact[1][edgeids[i]].size();
+        for (int j=0; j<numdofs; ++j) {
+          bdrydofs.push_back(tagToIdCompact[1][edgeids[i]][j]);
+        }
+      }
+    }
+
+    int numFaceIds = faceids.size();
+    if (tagToIdCompact.size() > 2) {
+      for (int i=0; i<numFaceIds; ++i) {
+        int numdofs = tagToIdCompact[2][faceids[i]].size();
+        for (int j=0; j<numdofs; ++j) {
+          bdrydofs.push_back(tagToIdCompact[2][faceids[i]][j]);
+        }
+      }
+    }
+
+    //for (unsigned i=0; i<bdrydofs.size(); ++i) {
+    //  std::cout << "\ndofid = " << bdrydofs[i];
+    //}
+
+    return bdrydofs;
+
+  }
+
+  /** \brief Returns the degrees of freedom on reference cell sides.
+  */
+  const std::vector<std::vector<int> > & getBoundaryDofs() const {
+    return sideDofs_;
+  }
+
+  /** \brief Computes coordinates of degrees of freedom on cells.
+  */
+  void computeDofCoords(scalar_view dofCoords,
+                        const scalar_view cellNodes) const {
+    // Map reference DOF locations to physical space.
+    ct::mapToPhysicalFrame(dofCoords, dofPoints_, cellNodes, *cellTopo_);
+  }
+
+}; // FE
+
+#endif

--- a/packages/rol/example/PDE-OPT/TOOLS/feK_curl.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/feK_curl.hpp
@@ -1,0 +1,441 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  feK_curl.hpp
+    \brief Given a set of cells with geometric node information, sets up
+           data structures used in finite element integration in HCURL.
+*/
+
+#ifndef PDEOPT_FE_CURL_HPP
+#define PDEOPT_FE_CURL_HPP
+
+#include "ROL_Ptr.hpp"
+
+#include "Teuchos_ParameterList.hpp"
+#include "Intrepid2_Basis.hpp"
+#include "Intrepid2_Cubature.hpp"
+#include "Intrepid2_CellTools.hpp"
+#include "Intrepid2_FunctionSpaceTools.hpp"
+
+template <class Real, class DeviceType>
+class FE_CURL {
+
+public:
+  using scalar_view = Kokkos::DynRankView<Real,DeviceType>;
+  using fst = Intrepid2::FunctionSpaceTools<DeviceType>;
+  using ct = Intrepid2::CellTools<DeviceType>;
+  using rst = Intrepid2::RealSpaceTools<DeviceType>;
+
+private:
+
+  const scalar_view cellNodes_;                                 // coordinates of the cell nodes
+  Intrepid2::BasisPtr<DeviceType, Real, Real> basis_;           // Intrepid basis
+  const ROL::Ptr<Intrepid2::Cubature<DeviceType, Real, Real>> cubature_;  // Intrepid cubature (quadrature, integration) rule
+  const int sideId_;                                                                         // local side id for boundary integration
+
+  int c_;    // number of cells in the FE object
+  int f_;    // number of basis functions per cell
+  int p_;    // number of cubature points per cell
+  int d_;    // space dimension of the (parent) cells
+  int sd_;   // space dimension of the side cells
+
+  ROL::Ptr<shards::CellTopology> cellTopo_;   // base (parent) cell topology
+  ROL::Ptr<shards::CellTopology> sideTopo_;   // side (subcell) topology; assumed uniform
+
+  std::vector<std::vector<int> > sideDofs_;       // local dofs on cell sides; 1st index: side number; 2nd index: dof number
+
+  // Containers for local finite element data.
+  scalar_view cubPoints_;             // points of the cubature rule on the reference cell
+  scalar_view cubWeights_;            // weights of the cubature rule on the reference cell
+  scalar_view cubPointsSubcell_;      // cubature points on the side reference cell
+  scalar_view cubWeightsSubcell_;     // cubature weights on the side reference cell
+  scalar_view cellJac_;               // cell Jacobian matrices
+  scalar_view cellJacInv_;            // inverses of cell Jacobians
+  scalar_view cellJacDet_;            // determinants of cell Jacobians
+  scalar_view cellWeightedMeasure_;   // cell measure (Jacobian determinant) multiplied by the cubature weights
+  scalar_view valReference_;          // value of FE basis in reference space
+  scalar_view curlReference_;         // curl of FE basis in reference space
+  scalar_view valPhysical_;           // value of FE basis in physical space
+  scalar_view curlPhysical_;          // curl of FE basis in physical space
+  scalar_view valPhysicalWeighted_;   // value of FE basis in physical space multiplied by weighted cell measure
+  scalar_view curlPhysicalWeighted_;  // curl of FE basis in physical space multiplied by weighted cell measure
+  scalar_view curlcurlMats_;          // cell curl-curl matrices
+  scalar_view valvalMats_;            // cell val-val matrices
+  scalar_view cubPointsPhysical_;     // cubature points on the physical cells
+  scalar_view dofPoints_;             // degree of freedom points on the reference cell
+
+public:
+
+  FE_CURL(const scalar_view                                           cellNodes,
+          const Intrepid2::BasisPtr<DeviceType, Real, Real>           basis,
+          const ROL::Ptr<Intrepid2::Cubature<DeviceType, Real, Real>> cubature) :
+    cellNodes_(cellNodes), basis_(basis), cubature_(cubature), sideId_(-1) {
+
+    // Get base cell topology from basis.
+    cellTopo_ = ROL::makePtr<shards::CellTopology>(basis_->getBaseCellTopology());
+
+    // Compute dimensions of multidimensional array members.
+    c_  = cellNodes_->extent_int(0);
+    f_  = basis_->getCardinality();
+    p_  = cubature_->getNumPoints();
+    d_  = cellTopo_->getDimension();
+    sd_ = d_ - 1;
+
+    // Get side subcell topology.
+    sideTopo_ = ROL::nullPtr;
+
+    // Allocate multidimensional arrays.
+    cubPoints_               = scalar_view("cubPoints_", p_, d_);
+    cubWeights_              = scalar_view("cubWeights_", p_);
+    cellJac_                 = scalar_view("cellJac_", c_, p_, d_, d_);
+    cellJacInv_              = scalar_view("cellJacInv_", c_, p_, d_, d_);
+    cellJacDet_              = scalar_view("cellJacDet_", c_, p_);
+    cellWeightedMeasure_     = scalar_view("cellWeightedMeasure_", c_, p_);
+    valReference_            = scalar_view("valReference_", f_, p_, d_);
+    curlReference_           = scalar_view("curlReference_", f_, p_, d_);
+    valPhysical_             = scalar_view("valPhysical_", c_, f_, p_, d_);
+    curlPhysical_            = scalar_view("curlPhysical_", c_, f_, p_, d_);
+    valPhysicalWeighted_     = scalar_view("valPhysicalWeighted_", c_, f_, p_, d_);
+    curlPhysicalWeighted_    = scalar_view("curlPhysicalWeighted_", c_, f_, p_, d_);
+    curlcurlMats_            = scalar_view("curlcurlMats_", c_, f_, f_);
+    valvalMats_              = scalar_view("valvalMats_", c_, f_, f_);
+    cubPointsPhysical_       = scalar_view("cubPointsPhysical_", c_, p_, d_);
+    dofPoints_               = scalar_view("dofPoints_", f_, d_);
+
+    /*** START: Fill multidimensional arrays. ***/
+
+    // Compute cubature points and weights.
+    cubature_->getCubature(cubPoints_, cubWeights_);
+
+    // Compute reference basis value and curl.
+    basis_->getValues(curlReference_, cubPoints_, Intrepid2::OPERATOR_CURL);       // evaluate curl operator at cubature points
+    basis_->getValues(valReference_, cubPoints_, Intrepid2::OPERATOR_VALUE);       // evaluate value operator at cubature points
+
+    // Compute cell Jacobian matrices, its inverses and determinants.
+    ct::setJacobian(cellJac_, cubPoints_, cellNodes_, *cellTopo_);  // compute cell Jacobians
+    ct::setJacobianInv(cellJacInv_, cellJac_);                       // compute inverses of cell Jacobians
+    ct::setJacobianDet(cellJacDet_, cellJac_);                       // compute determinants of cell Jacobians
+
+    // Compute weighted cell measure, i.e., det(J)*(cubature weight).
+    fst::computeCellMeasure(cellWeightedMeasure_, cellJacDet_, cubWeights_);
+
+    // Transform reference values into physical space.
+    fst::HCURLtransformVALUE(valPhysical_, valReference_);
+
+    // Multiply with weighted measure to get weighted values in physical space.
+    fst::multiplyMeasure(valPhysicalWeighted_, cellWeightedMeasure_, valPhysical_);
+
+    // Transform reference curls into physical space.
+    fst::HCURLtransformCURL(curlPhysical_, cellJac_, cellJacDet_, curlReference_);
+
+    // Multiply with weighted measure to get weighted curls in physical space.
+    fst::multiplyMeasure::multiplyMeasure(curlPhysicalWeighted_, cellWeightedMeasure_, curlPhysical_);
+
+    // Compute curl-curl matrices.
+    fst::integrate(curlcurlMats_, curlPhysical_, curlPhysicalWeighted_);
+
+    // Compute val-val matrices.
+    fst::integrate(valvalMats_, valPhysical_, valPhysicalWeighted_);
+
+    // Map reference cubature points to cells in physical space.
+    ct::mapToPhysicalFrame(cubPointsPhysical_, cubPoints_, cellNodes_, *cellTopo_);
+
+    // Compute local degrees of freedom on reference cell sides.
+    int numSides = cellTopo_->getSideCount();
+    if (cellTopo_->getDimension() == 1) {
+      numSides = 2;
+    }
+    if ( numSides ) {
+      for (int i=0; i<numSides; ++i) {
+        sideDofs_.push_back(computeBoundaryDofs(i));
+      }
+    }
+    else {
+      sideDofs_.push_back(computeBoundaryDofs(0));
+    }
+
+    // Get coordinates of DOFs in reference cell.
+    basis->getDofCoords(dofPoints_);
+
+    /*** END: Fill multidimensional arrays. ***/
+
+  }
+
+  /** \brief  Returns cell Jacobian matrices at cubature points.
+  */
+  scalar_view J() const {
+    return cellJac_;
+  }
+
+  /** \brief  Returns inverses of cell Jacobians at cubature points.
+  */
+  scalar_view invJ() const {
+    return cellJacInv_;
+  }
+
+  /** \brief  Returns determinants of cell Jacobians at cubature points.
+  */
+  scalar_view detJ() const {
+    return cellJacDet_;
+  }
+
+  /** \brief  Returns values of FE basis at cubature points in reference space.
+  */
+  scalar_view Nref() const {
+    return valReference_;
+  }
+
+  /** \brief  Returns curls of FE basis at cubature points in reference space.
+  */
+  scalar_view curlNref() const {
+    return curlReference_;
+  }
+
+  /** \brief  Returns value of FE basis at cubature points in physical space.
+  */
+  scalar_view N() const {
+    return valPhysical_;
+  }
+
+  /** \brief  Returns value of FE basis at cubature points in physical space,
+              multiplied by weighted cell measures.
+  */
+  scalar_view NdetJ() const {
+    return valPhysicalWeighted_;
+  }
+
+  /** \brief  Returns curl of FE basis at cubature points in physical space.
+  */
+  scalar_view curlN() const {
+    return curlPhysical_;
+  }
+
+  /** \brief  Returns curl of FE basis at cubature points in physical space,
+              multiplied by weighted cell measures.
+  */
+  scalar_view curlNdetJ() const {
+    return curlPhysicalWeighted_;
+  }
+
+  /** \brief  Returns curl-curl matrices on cells.
+  */
+  scalar_view curlcurlMat() const {
+    return curlcurlMats_;
+  }
+
+  /** \brief  Returns val-val matrices on cells.
+  */
+  scalar_view valvalMat() const {
+    return valvalMats_;
+  }
+
+  /** \brief Returns cubature points on cells in physical space.
+  */
+  scalar_view cubPts() const {
+    return cubPointsPhysical_;
+  }
+
+  /** \brief Builds FE value interpolant and evaluates it at cubature
+             points in physical space.  The input coefficients are
+             assumed to be 'signed' (with +/- 1 multiplying the
+             coefficient depending on the alignment with the reference
+             edge direction).
+  */
+  void evaluateValue(scalar_view fVals,
+                     const scalar_view inCoeffs) const {
+    fst::evaluate(fVals, inCoeffs, valPhysical_);
+  }
+
+  /** \brief Builds FE value interpolant and evaluates it at cubature
+             points in physical space.  The input coefficients are
+             combined with edge signs (with +/- 1 multiplying the
+             coefficient depending on the alignment with the reference
+             edge direction).
+  */
+  void evaluateValue(scalar_view fVals,
+                     const scalar_view inCoeffs,
+                     const scalar_view inSigns) const {
+    scalar_view coeffsSigned("coeffsSigned", inCoeffs.extent(0), inCoeffs.extent(3), inCoeffs.extent(2));
+    Kokkos::deep_copy(coeffsSigned, inCoeffs);
+    fst::applyFieldSigns(coeffsSigned, inSigns);
+    fst::evaluate(fVals, coeffsSigned, valPhysical_);
+  }
+
+  /** \brief Builds FE curl interpolant and evaluates it at cubature
+             points in physical space.  The input coefficients are
+             assumed to be 'signed' (with +/- 1 multiplying the
+             coefficient depending on the alignment with the reference
+             edge direction).
+  */
+  void evaluateCurl(scalar_view fCurls,
+                    const scalar_view inCoeffs) const {
+    fst::evaluate(fCurls, inCoeffs, curlPhysical_);
+  }
+
+  /** \brief Builds FE value interpolant and evaluates it at cubature
+             points in physical space.  The input coefficients are
+             combined with edge signs (with +/- 1 multiplying the
+             coefficient depending on the alignment with the reference
+             edge direction).
+  */
+  void evaluateCurl(scalar_view fCurls,
+                    const scalar_view inCoeffs,
+                    const scalar_view inSigns) const {
+    scalar_view coeffsSigned("coeffsSigned", inCoeffs.extent(0), inCoeffs.extent(3), inCoeffs.extent(2));
+    Kokkos::deep_copy(coeffsSigned, inCoeffs);
+    fst::applyFieldSigns(coeffsSigned, inSigns);
+    fst::evaluate(fCurls, coeffsSigned, curlPhysical_);
+  }
+
+  /** \brief Computes integral of the dot product of values or curls of interpolated
+             FE fields f1 and f2, indexed by (C,P,D).
+  */
+  void computeIntegral(scalar_view integral,
+                       const scalar_view f1,
+                       const scalar_view f2,
+                       const bool sumInto = false) const {
+    scalar_view f2Weighted;
+    if(f2.rank() == 3) {
+      f2Weighted = scalar_view("f2Weighted", f2.extent(0), f2.extent(1), f2.extent(2));
+    } else { //rank = 2
+      f2Weighted = scalar_view("f2Weighted", f2.extent(0), f2.extent(1));
+    }
+    fst::scalarMultiplyDataData(f2Weighted, cellWeightedMeasure_, f2);  // multiply with weighted measure
+                                                              
+    fst::integrate(integral, f1, f2Weighted, sumInto);                  // compute integral of f1*f2
+  }
+
+  /** \brief Computes the degrees of freedom on a side.
+  */
+  std::vector<int> computeBoundaryDofs(const int & locSideId) const {
+
+    std::vector<int> bdrydofs;
+    std::vector<int> nodeids, edgeids, faceids;
+
+    if (cellTopo_->getDimension() == 1) {
+      nodeids.push_back(locSideId);
+    }
+    else if (cellTopo_->getDimension() == 2) {
+      edgeids.push_back(locSideId);
+      int numVertices = 2;
+      for (int i=0; i<numVertices; ++i) {
+        nodeids.push_back(cellTopo_->getNodeMap(1, locSideId, i));
+      }
+      //for (unsigned i=0; i<nodeids.size(); ++i) {
+      //  std::cout << "\nnodeid = " << nodeids[i];
+      //}
+      //for (unsigned i=0; i<edgeids.size(); ++i) {
+      //  std::cout << "\nedgeid = " << edgeids[i];
+      //}
+    }
+    else if (cellTopo_->getDimension() == 3) {
+      faceids.push_back(locSideId);
+      CellTopologyData_Subcell face = cellTopo_->getCellTopologyData()->subcell[2][locSideId];
+      shards::CellTopology face_topo(face.topology);
+      int numVertices = face_topo.getVertexCount();
+      for (int i=0; i<numVertices; ++i) {
+        nodeids.push_back(cellTopo_->getNodeMap(2, locSideId, i));
+      }
+      int numEdges = face_topo.getEdgeCount();
+      for (int i=0; i<numEdges; ++i) {
+        edgeids.push_back(mapCellFaceEdge(cellTopo_->getCellTopologyData(), locSideId, i));
+      }
+      //for (unsigned i=0; i<nodeids.size(); ++i) {
+      //  std::cout << "\nnodeid = " << nodeids[i];
+      //}
+      //for (unsigned i=0; i<edgeids.size(); ++i) {
+      //  std::cout << "\nedgeid = " << edgeids[i];
+      //}
+      //for (unsigned i=0; i<faceids.size(); ++i) {
+      //  std::cout << "\nfaceid = " << faceids[i];
+      //}
+    }
+
+    auto tagToId = basis_->getAllDofOrdinal();
+    std::vector<std::vector<std::vector<int> > > tagToIdCompact;
+    int scdim = tagToId.extent_int(0);
+    tagToIdCompact.resize(scdim);
+    for (int i=0; i<scdim; ++i) {
+      for (int j=0; j<tagToId.extent_int(1); ++j) {
+        std::vector<int> ids;
+        for (int k=0; k<tagToId.extent_int(2); ++k) {
+          //std::cout << "\n  i=" << i << "  j=" << j << "  k=" << k << "  id=" << tagToId[i][j][k];
+          if (tagToId(i,j,k) != -1) {
+            ids.push_back(tagToId(i,j,k));
+          }
+        }
+        tagToIdCompact[i].push_back(ids);
+        //int dofordcompact = tagToIdCompact[i][j].size();
+        //for (int k=0; k<dofordcompact; ++k) {
+        //  std::cout << "\n  i=" << i << "  j=" << j << "  k=" << k << "  id=" << tagToIdCompact[i][j][k];
+        //}
+      }
+    }
+
+    int numNodeIds = nodeids.size();
+    if (tagToIdCompact.size() > 0) {
+      for (int i=0; i<numNodeIds; ++i) {
+        int numdofs = tagToIdCompact[0][nodeids[i]].size();
+        for (int j=0; j<numdofs; ++j) {
+          bdrydofs.push_back(tagToIdCompact[0][nodeids[i]][j]);
+        }
+      }
+    }
+
+    int numEdgeIds = edgeids.size();
+    if (tagToIdCompact.size() > 1) {
+      for (int i=0; i<numEdgeIds; ++i) {
+        int numdofs = tagToIdCompact[1][edgeids[i]].size();
+        for (int j=0; j<numdofs; ++j) {
+          bdrydofs.push_back(tagToIdCompact[1][edgeids[i]][j]);
+        }
+      }
+    }
+
+    int numFaceIds = faceids.size();
+    if (tagToIdCompact.size() > 2) {
+      for (int i=0; i<numFaceIds; ++i) {
+        int numdofs = tagToIdCompact[2][faceids[i]].size();
+        for (int j=0; j<numdofs; ++j) {
+          bdrydofs.push_back(tagToIdCompact[2][faceids[i]][j]);
+        }
+      }
+    }
+
+    //for (unsigned i=0; i<bdrydofs.size(); ++i) {
+    //  std::cout << "\ndofid = " << bdrydofs[i];
+    //}
+
+    return bdrydofs;
+
+  }
+
+  /** \brief Returns the degrees of freedom on reference cell sides.
+  */
+  const std::vector<std::vector<int> > & getBoundaryDofs() const {
+    return sideDofs_;
+  }
+
+  /** \brief Computes coordinates of degrees of freedom on cells.
+  */
+  void computeDofCoords(scalar_view dofCoords,
+                        const scalar_view cellNodes) const {
+    // Map reference DOF locations to physical space.
+    ct::mapToPhysicalFrame(dofCoords, dofPoints_, cellNodes, *cellTopo_);
+  }
+
+  void mapRefPointsToPhysical(scalar_view px,
+                              const scalar_view rx) const {
+    // Map input reference cell points to cells in physical space.
+    ct::mapToPhysicalFrame(px, rx, cellNodes_, *cellTopo_);
+  }
+
+}; // FE_CURL
+
+#endif

--- a/packages/rol/example/PDE-OPT/TOOLS/fieldhelperK.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/fieldhelperK.hpp
@@ -1,0 +1,207 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  fieldhelperK.hpp
+    \brief
+*/
+
+#ifndef FIELDHELPERK_HPP
+#define FIELDHELPERK_HPP
+
+#include "Kokkos_DynRankView.hpp"
+#include "ROL_Ptr.hpp"
+
+namespace FieldUtils {
+
+struct FieldInfo {
+  const int numFields, numDofs;
+  const std::vector<int> numFieldDofs;
+  const std::vector<std::vector<int>> fieldPattern;
+
+  FieldInfo(const int numFields_, const int numDofs_,
+            const std::vector<int> &numFieldDofs_,
+            const std::vector<std::vector<int>> &fieldPattern_)
+    : numFields(numFields_), numDofs(numDofs_),
+      numFieldDofs(numFieldDofs_), fieldPattern(fieldPattern_) {}
+};
+
+template<typename Real, typename DeviceType>
+inline void splitFieldCoeff(std::vector<Kokkos::DynRankView<Real,DeviceType>> &U,
+                            const Kokkos::DynRankView<Real,DeviceType>        u_coeff,
+                            const ROL::Ptr<const FieldInfo>                   &info) {
+  const int numFields = info->numFields;
+  U.resize(numFields);
+  const int c = u_coeff.extent_int(0);
+  for (int i=0; i<numFields; ++i) {
+    const int numFieldDofs = info->numFieldDofs[i];
+    U[i] = Kokkos::DynRankView<Real,DeviceType>("U",c,numFieldDofs);
+    for (int j=0; j<c; ++j) {
+      for (int k=0; k<numFieldDofs; ++k) {
+        U[i](j,k) = u_coeff(j,info->fieldPattern[i][k]);
+      }
+    }
+  }
+}
+
+template<typename Real, typename DeviceType>
+inline void splitFieldCoeff(std::vector<std::vector<Kokkos::DynRankView<Real,DeviceType>>> &J,
+                            const Kokkos::DynRankView<Real,DeviceType>                     jac,
+                            const ROL::Ptr<const FieldInfo>                                &rowInfo,
+                            const ROL::Ptr<const FieldInfo>                                &colInfo) {
+  const int rowNumFields = rowInfo->numFields;
+  const int colNumFields = colInfo->numFields;
+  J.resize(rowNumFields);
+  const int c = jac.extent_int(0);
+  for (int i=0; i<rowNumFields; ++i) {
+    const int rowNumFieldDofs = rowInfo->numFieldDofs[i];
+    J[i].resize(colNumFields,ROL::nullPtr);
+    for (int j=0; j<colNumFields; ++j) {
+      const int colNumFieldDofs = colInfo->numFieldDofs[j];
+      J[i][j] = Kokkos::DynRankView<Real,DeviceType>("J",c,rowNumFieldDofs,colNumFieldDofs);
+      for (int k=0; k<c; ++k) {
+        for (int l=0; l<rowNumFieldDofs; ++l) {
+          for (int m=0; m<colNumFieldDofs; ++m) {
+            J[i][j](k,l,m) = jac(k,rowInfo->fieldPattern[i][l],colInfo->fieldPattern[j][m]);
+          }
+        }
+      }
+    }
+  }
+}
+
+template<typename Real, typename DeviceType>
+inline void combineFieldCoeff(Kokkos::DynRankView<Real,DeviceType>                     &res,
+                              const std::vector<Kokkos::DynRankView<Real,DeviceType>>  &R,
+                              const ROL::Ptr<const FieldInfo>                          &info) {
+  const int numFields = info->numFields;
+  const int c = R[0].extent_int(0);  // number of cells
+  res = Kokkos::DynRankView<Real,DeviceType>("res", c, info->numDofs);
+  for (int i=0; i<numFields; ++i) {
+    const int numFieldDofs = info->numFieldDofs[i];
+    for (int j=0; j<c; ++j) {
+      for (int k=0; k<numFieldDofs; ++k) {
+        res(j,info->fieldPattern[i][k]) = R[i](j,k);
+      }
+    }
+  }
+}
+
+template<typename Real, typename DeviceType>
+inline void combineFieldCoeff(Kokkos::DynRankView<Real,DeviceType>                                 &jac,
+                              const std::vector<std::vector<Kokkos::DynRankView<Real,DeviceType>>> &J,
+                              const ROL::Ptr<const FieldInfo>                                      &rowInfo,
+                              const ROL::Ptr<const FieldInfo>                                      &colInfo) {
+  const int rowNumFields = rowInfo->numFields;
+  const int colNumFields = colInfo->numFields;
+  const int c = J[0][0].extent_int(0);  // number of cells
+  jac = Kokkos::DynRankView<Real,DeviceType>("jac", c, rowInfo->numDofs, colInfo->numDofs);
+  for (int i=0; i<rowNumFields; ++i) {
+    const int rowNumFieldDofs = rowInfo->numFieldDofs[i];
+    for (int j=0; j<colNumFields; ++j) {
+      const int colNumFieldDofs = colInfo->numFieldDofs[j];
+      for (int k=0; k<c; ++k) {
+        for (int l=0; l<rowNumFieldDofs; ++l) {
+          for (int m=0; m<colNumFieldDofs; ++m) {
+            jac(k,rowInfo->fieldPattern[i][l],colInfo->fieldPattern[j][m]) = J[i][j](k,l,m);
+          }
+        }
+      }
+    }
+  }
+}
+
+}
+
+template<class Real, class DeviceType>
+class FieldHelper {
+  private:
+  const int numFields_, numDofs_;
+  const std::vector<int> numFieldDofs_;
+  const std::vector<std::vector<int>> fieldPattern_;
+
+  public:
+  using scalar_view =  Kokkos::DynRankView<Real,DeviceType>;
+
+  FieldHelper(const int numFields, const int numDofs,
+              const std::vector<int> &numFieldDofs,
+              const std::vector<std::vector<int>> &fieldPattern)
+    : numFields_(numFields), numDofs_(numDofs),
+      numFieldDofs_(numFieldDofs), fieldPattern_(fieldPattern) {}
+
+  void splitFieldCoeff(std::vector<scalar_view> & U,
+                       const scalar_view u_coeff) const {
+    U.resize(numFields_);
+    int  c = u_coeff.extent_int(0);
+    for (int i=0; i<numFields_; ++i) {
+      U[i] = scalar_view("U",c,numFieldDofs_[i]);
+      for (int j=0; j<c; ++j) {
+        for (int k=0; k<numFieldDofs_[i]; ++k) {
+          //U[i](j,k) = u_coeff(j,offset[i]+k);
+          U[i](j,k) = u_coeff(j,fieldPattern_[i][k]);
+        }
+      }
+    }
+  }
+
+  void splitFieldCoeff(std::vector<std::vector<scalar_view>> & J,
+                       const scalar_view jac) const {
+    J.resize(numFields_);
+    int  c = jac.extent_int(0);
+    for (int i=0; i<numFields_; ++i) {
+      J[i].resize(numFields_,ROL::nullPtr);
+      for (int j=0; j<numFields_; ++j) {
+        J[i][j] = scalar_view("J",c,numFieldDofs_[i],numFieldDofs_[j]);
+        for (int k=0; k<c; ++k) {
+          for (int l=0; l<numFieldDofs_[i]; ++l) {
+            for (int m=0; m<numFieldDofs_[j]; ++m) {
+              J[i][j](k,l,m) = jac(k,fieldPattern_[i][l],fieldPattern_[j][m]);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  void combineFieldCoeff(scalar_view & res,
+                         const std::vector<scalar_view> & R) const {
+    int c = R[0].extent_int(0);  // number of cells
+    res = scalar_view("res",c, numDofs_);        
+    for (int i=0; i<numFields_; ++i) {
+      for (int j=0; j<c; ++j) {
+        for (int k=0; k<numFieldDofs_[i]; ++k) {
+          res(j,fieldPattern_[i][k]) = R[i](j,k);
+        }
+      }
+    }
+  }
+
+  void combineFieldCoeff(scalar_view & jac,
+                         const std::vector<std::vector<scalar_view>> & J) const {
+    int c = J[0][0].extent_int(0);  // number of cells
+    jac = scalar_view("jac",c, numDofs_, numDofs_);        
+    for (int i=0; i<numFields_; ++i) {
+      for (int j=0; j<numFields_; ++j) {
+        for (int k=0; k<c; ++k) {
+          for (int l=0; l<numFieldDofs_[i]; ++l) {
+            for (int m=0; m<numFieldDofs_[j]; ++m) {
+              jac(k,fieldPattern_[i][l],fieldPattern_[j][m]) = J[i][j](k,l,m);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  int numFields(void) const {
+    return numFields_;
+  }
+
+};
+
+#endif

--- a/packages/rol/example/PDE-OPT/TOOLS/integralobjectiveK.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/integralobjectiveK.hpp
@@ -1,0 +1,1022 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef PDE_INTEGRALOBJECTIVEK_HPP
+#define PDE_INTEGRALOBJECTIVEK_HPP
+
+#include "ROL_Objective_SimOpt.hpp"
+#include "qoiK.hpp"
+#include "assemblerK.hpp"
+#include "pdevectorK.hpp"
+
+// Do not instantiate the template in this translation unit.
+extern template class Assembler<double, Kokkos::HostSpace>;
+
+template<class Real, class DeviceType>
+class IntegralObjective : public ROL::Objective_SimOpt<Real> {
+public:
+  using QoI_type = QoI<Real, DeviceType>;
+  using Assembler_type = Assembler<Real, DeviceType>;
+private:
+  const ROL::Ptr<QoI_type> qoi_;
+  const ROL::Ptr<Assembler_type> assembler_;
+
+  ROL::Ptr<Tpetra::MultiVector<> > vecG1_;
+  ROL::Ptr<Tpetra::MultiVector<> > vecG2_;
+  ROL::Ptr<std::vector<Real> >     vecG3_;
+  ROL::Ptr<Tpetra::MultiVector<> > vecH11_;
+  ROL::Ptr<Tpetra::MultiVector<> > vecH12_;
+  ROL::Ptr<Tpetra::MultiVector<> > vecH13_;
+  ROL::Ptr<Tpetra::MultiVector<> > vecH21_;
+  ROL::Ptr<Tpetra::MultiVector<> > vecH22_;
+  ROL::Ptr<Tpetra::MultiVector<> > vecH23_;
+  ROL::Ptr<std::vector<Real> >     vecH31_;
+  ROL::Ptr<std::vector<Real> >     vecH32_;
+  ROL::Ptr<std::vector<Real> >     vecH33_;
+
+public:
+  IntegralObjective(const ROL::Ptr<QoI_type > &qoi,
+                    const ROL::Ptr<Assembler_type> &assembler)
+    : qoi_(qoi), assembler_(assembler) {}
+
+  void setParameter(const std::vector<Real> &param) {
+    ROL::Objective_SimOpt<Real>::setParameter(param);
+    qoi_->setParameter(param);
+  }
+
+  Real value(const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol) override {
+    ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+    ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+    ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+    return assembler_->assembleQoIValue(qoi_,uf,zf,zp);
+  }
+
+  void gradient_1(ROL::Vector<Real> &g, const ROL::Vector<Real> &u,
+                  const ROL::Vector<Real> &z, Real &tol ) override {
+    g.zero();
+    try {
+      ROL::Ptr<Tpetra::MultiVector<> >       gf = getField(g);
+      ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      assembler_->assembleQoIGradient1(vecG1_,qoi_,uf,zf,zp);
+      gf->scale(static_cast<Real>(1),*vecG1_);
+    }
+    catch ( Exception::Zero & ez ) {
+      g.zero();
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      ROL::Objective_SimOpt<Real>::gradient_1(g,u,z,tol);
+    }
+  }
+
+  void gradient_2(ROL::Vector<Real> &g, const ROL::Vector<Real> &u,
+                  const ROL::Vector<Real> &z, Real &tol ) override {
+    int NotImplemented(0), IsZero(0);
+    g.zero();
+    // Compute control field gradient
+    try {
+      // Get state and control vectors
+      ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      ROL::Ptr<Tpetra::MultiVector<> >       gf = getField(g);
+      assembler_->assembleQoIGradient2(vecG2_,qoi_,uf,zf,zp);
+      gf->scale(static_cast<Real>(1),*vecG2_);
+    }
+    catch ( Exception::Zero & ez ) {
+      IsZero++;
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      NotImplemented++;
+    }
+    // Compute control parameter gradient
+    try {
+      // Get state and control vectors
+      ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      ROL::Ptr<std::vector<Real> >           gp = getParameter(g);
+      assembler_->assembleQoIGradient3(vecG3_,qoi_,uf,zf,zp);
+      gp->assign(vecG3_->begin(),vecG3_->end());
+    }
+    catch ( Exception::Zero & ez ) {
+      IsZero++;
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      NotImplemented++;
+    }
+    // Zero gradient
+    if ( IsZero == 2 || (IsZero == 1 && NotImplemented == 1) ) {
+      g.zero();
+    }
+    // Not Implemented
+    if ( NotImplemented == 2 ) {
+      ROL::Objective_SimOpt<Real>::gradient_2(g,u,z,tol);
+    }
+  }
+
+  void hessVec_11( ROL::Vector<Real> &hv, const ROL::Vector<Real> &v, 
+             const ROL::Vector<Real> &u,  const ROL::Vector<Real> &z, Real &tol ) override {
+    hv.zero();
+    try {
+      ROL::Ptr<Tpetra::MultiVector<> >      hvf = getField(hv);
+      ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+      ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      assembler_->assembleQoIHessVec11(vecH11_,qoi_,vf,uf,zf,zp);
+      hvf->scale(static_cast<Real>(1),*vecH11_);
+    }
+    catch (Exception::Zero &ez) {
+      hv.zero();
+    }
+    catch (Exception::NotImplemented &eni) {
+      ROL::Objective_SimOpt<Real>::hessVec_11(hv,v,u,z,tol);
+    }
+  }
+
+  void hessVec_12( ROL::Vector<Real> &hv, const ROL::Vector<Real> &v, 
+                   const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol ) override {
+    int NotImplemented(0), IsZero(0);
+    hv.zero();
+    // Compute state field/control field hessvec
+    try {
+      ROL::Ptr<Tpetra::MultiVector<> >      hvf = getField(hv);
+      ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+      ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      assembler_->assembleQoIHessVec12(vecH12_,qoi_,vf,uf,zf,zp);
+      hvf->scale(static_cast<Real>(1),*vecH12_);
+    }
+    catch (Exception::Zero &ez) {
+      hv.zero();
+      IsZero++;
+    }
+    catch (Exception::NotImplemented &eni) {
+      hv.zero();
+      NotImplemented++;
+    }
+    // Compute state field/control parameter hessvec
+    try {
+      // Get state and control vectors
+      ROL::Ptr<Tpetra::MultiVector<> >      hvf = getField(hv);
+      ROL::Ptr<const std::vector<Real> >     vp = getConstParameter(v);
+      ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      assembler_->assembleQoIHessVec13(vecH13_,qoi_,vp,uf,zf,zp);
+      hvf->update(static_cast<Real>(1),*vecH13_,static_cast<Real>(1));
+    }
+    catch ( Exception::Zero & ez ) {
+      IsZero++;
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      NotImplemented++;
+    }
+    // Zero hessvec
+    if ( IsZero == 2 || (IsZero == 1 && NotImplemented == 1) ) {
+      hv.zero();
+    }
+    // Not Implemented
+    if ( NotImplemented == 2 ) {
+      ROL::Objective_SimOpt<Real>::hessVec_12(hv,v,u,z,tol);
+    }
+  }
+
+  void hessVec_21( ROL::Vector<Real> &hv, const ROL::Vector<Real> &v, 
+                   const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol ) override {
+    int NotImplemented(0), IsZero(0);
+    hv.zero();
+    // Compute control field/state field hessvec
+    try {
+      // Get state and control vectors
+      ROL::Ptr<Tpetra::MultiVector<> >      hvf = getField(hv);
+      ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+      ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      assembler_->assembleQoIHessVec21(vecH21_,qoi_,vf,uf,zf,zp);
+      hvf->scale(static_cast<Real>(1),*vecH21_);
+    }
+    catch ( Exception::Zero & ez ) {
+      hv.zero();
+      IsZero++;
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      hv.zero();
+      NotImplemented++;
+    }
+    // Compute control parameter/state field hessvec
+    try {
+      // Get state and control vectors
+      ROL::Ptr<std::vector<Real> >          hvp = getParameter(hv);
+      ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+      ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      assembler_->assembleQoIHessVec31(vecH31_,qoi_,vf,uf,zf,zp);
+      hvp->assign(vecH31_->begin(),vecH31_->end());
+    }
+    catch ( Exception::Zero & ez ) {
+      IsZero++;
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      NotImplemented++;
+    }
+    // Zero hessvec
+    if ( IsZero == 2 || (IsZero == 1 && NotImplemented == 1) ) {
+      hv.zero();
+    }
+    // Not Implemented
+    if ( NotImplemented == 2 ) {
+      ROL::Objective_SimOpt<Real>::hessVec_21(hv,v,u,z,tol);
+    }
+  }
+
+  void hessVec_22( ROL::Vector<Real> &hv, const ROL::Vector<Real> &v, 
+             const ROL::Vector<Real> &u,  const ROL::Vector<Real> &z, Real &tol ) override {
+    int NotImplemented(0), IsZero(0);
+    hv.zero();
+    // Compute control field/field hessvec
+    try {
+      ROL::Ptr<Tpetra::MultiVector<> >      hvf = getField(hv);
+      ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+      ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      assembler_->assembleQoIHessVec22(vecH22_,qoi_,vf,uf,zf,zp);
+      hvf->scale(static_cast<Real>(1),*vecH22_);
+    }
+    catch (Exception::Zero &ez) {
+      hv.zero();
+      IsZero++;
+    }
+    catch (Exception::NotImplemented &eni) {
+      hv.zero();
+      NotImplemented++;
+    }
+    // Compute control field/parameter hessvec
+    try {
+      // Get state and control vectors
+      ROL::Ptr<Tpetra::MultiVector<> >      hvf = getField(hv);
+      ROL::Ptr<const std::vector<Real> >     vp = getConstParameter(v);
+      ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      assembler_->assembleQoIHessVec23(vecH23_,qoi_,vp,uf,zf,zp);
+      hvf->update(static_cast<Real>(1),*vecH23_,static_cast<Real>(1));
+    }
+    catch ( Exception::Zero & ez ) {
+      IsZero++;
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      NotImplemented++;
+    }
+    // Compute control parameter/field hessvec
+    try {
+      ROL::Ptr<std::vector<Real> >          hvp = getParameter(hv);
+      ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+      ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      assembler_->assembleQoIHessVec32(vecH32_,qoi_,vf,uf,zf,zp);
+      hvp->assign(vecH32_->begin(),vecH32_->end());
+    }
+    catch (Exception::Zero &ez) {
+      ROL::Ptr<std::vector<Real> > hvp = getParameter(hv);
+      if ( hvp != ROL::nullPtr ) {
+        const int size = hvp->size();
+        hvp->assign(size,static_cast<Real>(0));
+      }
+      IsZero++;
+    }
+    catch (Exception::NotImplemented &eni) {
+      ROL::Ptr<std::vector<Real> > hvp = getParameter(hv);
+      if ( hvp != ROL::nullPtr ) {
+        const int size = hvp->size();
+        hvp->assign(size,static_cast<Real>(0));
+      }
+      NotImplemented++;
+    }
+    // Compute control parameter/parameter hessvec
+    try {
+      ROL::Ptr<std::vector<Real> >          hvp = getParameter(hv);
+      ROL::Ptr<const std::vector<Real> >     vp = getConstParameter(v);
+      ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      assembler_->assembleQoIHessVec33(vecH33_,qoi_,vp,uf,zf,zp);
+      const int size = hvp->size();
+      for (int i = 0; i < size; ++i) {
+        (*hvp)[i] += (*vecH33_)[i];
+      }
+    }
+    catch (Exception::Zero &ez) {
+      IsZero++;
+    }
+    catch (Exception::NotImplemented &eni) {
+      NotImplemented++;
+    }
+
+    // Zero hessvec
+    if ( IsZero > 0 && (IsZero + NotImplemented == 4) ) {
+      hv.zero();
+    }
+    // Not Implemented
+    if ( NotImplemented == 4 ) {
+      ROL::Objective_SimOpt<Real>::hessVec_22(hv,v,u,z,tol);
+    }
+  }
+
+private: // Vector accessor functions
+
+  ROL::Ptr<const Tpetra::MultiVector<> > getConstField(const ROL::Vector<Real> &x) const {
+    ROL::Ptr<const Tpetra::MultiVector<> > xp;
+    try {
+      xp = dynamic_cast<const ROL::TpetraMultiVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<const ROL::TpetraMultiVector<Real> > xvec
+          = dynamic_cast<const PDE_OptVector<Real>&>(x).getField();
+        if (xvec == ROL::nullPtr) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+
+  ROL::Ptr<Tpetra::MultiVector<> > getField(ROL::Vector<Real> &x) const {
+    ROL::Ptr<Tpetra::MultiVector<> > xp;
+    try {
+      xp = dynamic_cast<ROL::TpetraMultiVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<ROL::TpetraMultiVector<Real> > xvec
+          = dynamic_cast<PDE_OptVector<Real>&>(x).getField();
+        if ( xvec == ROL::nullPtr ) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+
+  ROL::Ptr<const std::vector<Real> > getConstParameter(const ROL::Vector<Real> &x) const {
+    ROL::Ptr<const std::vector<Real> > xp;
+    try {
+      xp = dynamic_cast<const ROL::StdVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<const ROL::StdVector<Real> > xvec
+          = dynamic_cast<const PDE_OptVector<Real>&>(x).getParameter();
+        if ( xvec == ROL::nullPtr ) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+
+  ROL::Ptr<std::vector<Real> > getParameter(ROL::Vector<Real> &x) const {
+    ROL::Ptr<std::vector<Real> > xp;
+    try {
+      xp = dynamic_cast<ROL::StdVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<ROL::StdVector<Real> > xvec
+          = dynamic_cast<PDE_OptVector<Real>&>(x).getParameter();
+        if ( xvec == ROL::nullPtr ) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+};
+
+
+template<class Real, class DeviceType>
+class IntegralSimObjective : public ROL::Objective<Real> {
+public:
+  using QoI_type = QoI<Real, DeviceType>;
+  using Assembler_type = Assembler<Real, DeviceType>;
+private:
+  const ROL::Ptr<QoI_type> qoi_;
+  const ROL::Ptr<Assembler_type> assembler_;
+
+  ROL::Ptr<Tpetra::MultiVector<>> vecG1_;
+  ROL::Ptr<Tpetra::MultiVector<>> vecH11_;
+
+public:
+  IntegralSimObjective(const ROL::Ptr<QoI_type> &qoi,
+                       const ROL::Ptr<Assembler_type> &assembler)
+    : qoi_(qoi), assembler_(assembler) {}
+
+  void setParameter(const std::vector<Real> &param) {
+    ROL::Objective<Real>::setParameter(param);
+    qoi_->setParameter(param);
+  }
+
+  Real value(const ROL::Vector<Real> &u, Real &tol) override {
+    ROL::Ptr<const Tpetra::MultiVector<>> uf = getConstField(u);
+    return assembler_->assembleQoIValue(qoi_,uf,ROL::nullPtr,ROL::nullPtr);
+  }
+
+  void gradient(ROL::Vector<Real> &g,
+                const ROL::Vector<Real> &u, Real &tol ) override {
+    int NotImplemented(0), IsZero(0);
+    g.zero();
+    // Compute control field gradient
+    try {
+      // Get state and control vectors
+      ROL::Ptr<const Tpetra::MultiVector<>> uf = getConstField(u);
+      ROL::Ptr<Tpetra::MultiVector<>>       gf = getField(g);
+      assembler_->assembleQoIGradient1(vecG1_,qoi_,uf,ROL::nullPtr,ROL::nullPtr);
+      gf->scale(static_cast<Real>(1),*vecG1_);
+    }
+    catch ( Exception::Zero & ez ) {
+      IsZero++;
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      NotImplemented++;
+    }
+    // Zero gradient
+    if ( IsZero == 1 ) {
+      g.zero();
+    }
+    // Not Implemented
+    if ( NotImplemented == 1 ) {
+      ROL::Objective<Real>::gradient(g,u,tol);
+    }
+  }
+
+  void hessVec(ROL::Vector<Real> &hv, const ROL::Vector<Real> &v, 
+               const ROL::Vector<Real> &u, Real &tol ) override {
+    int NotImplemented(0), IsZero(0);
+    hv.zero();
+    // Compute control field/field hessvec
+    try {
+      ROL::Ptr<Tpetra::MultiVector<> >      hvf = getField(hv);
+      ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+      ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+      assembler_->assembleQoIHessVec11(vecH11_,qoi_,vf,uf,ROL::nullPtr,ROL::nullPtr);
+      hvf->scale(static_cast<Real>(1),*vecH11_);
+    }
+    catch (Exception::Zero &ez) {
+      hv.zero();
+      IsZero++;
+    }
+    catch (Exception::NotImplemented &eni) {
+      hv.zero();
+      NotImplemented++;
+    }
+    // Zero hessvec
+    if ( IsZero == 1 ) {
+      hv.zero();
+    }
+    // Not Implemented
+    if ( NotImplemented == 1 ) {
+      ROL::Objective<Real>::hessVec(hv,v,u,tol);
+    }
+  }
+
+private: // Vector accessor functions
+
+  ROL::Ptr<const Tpetra::MultiVector<> > getConstField(const ROL::Vector<Real> &x) const {
+    ROL::Ptr<const Tpetra::MultiVector<> > xp;
+    try {
+      xp = dynamic_cast<const ROL::TpetraMultiVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<const ROL::TpetraMultiVector<Real> > xvec
+          = dynamic_cast<const PDE_OptVector<Real>&>(x).getField();
+        if (xvec == ROL::nullPtr) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+
+  ROL::Ptr<Tpetra::MultiVector<> > getField(ROL::Vector<Real> &x) const {
+    ROL::Ptr<Tpetra::MultiVector<> > xp;
+    try {
+      xp = dynamic_cast<ROL::TpetraMultiVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<ROL::TpetraMultiVector<Real> > xvec
+          = dynamic_cast<PDE_OptVector<Real>&>(x).getField();
+        if ( xvec == ROL::nullPtr ) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+};
+
+template<class Real, class DeviceType>
+class IntegralOptObjective : public ROL::Objective<Real> {
+public:
+  using QoI_type = QoI<Real, DeviceType>;
+  using Assembler_type = Assembler<Real, DeviceType>;
+private:
+  const ROL::Ptr<QoI_type> qoi_;
+  const ROL::Ptr<Assembler_type> assembler_;
+
+  ROL::Ptr<Tpetra::MultiVector<> > vecG2_;
+  ROL::Ptr<std::vector<Real> >     vecG3_;
+  ROL::Ptr<Tpetra::MultiVector<> > vecH22_;
+  ROL::Ptr<Tpetra::MultiVector<> > vecH23_;
+  ROL::Ptr<std::vector<Real> >     vecH32_;
+  ROL::Ptr<std::vector<Real> >     vecH33_;
+
+public:
+  IntegralOptObjective(const ROL::Ptr<QoI_type > &qoi,
+                       const ROL::Ptr<Assembler_type> &assembler)
+    : qoi_(qoi), assembler_(assembler) {}
+
+  void setParameter(const std::vector<Real> &param) {
+    ROL::Objective<Real>::setParameter(param);
+    qoi_->setParameter(param);
+  }
+
+  Real value(const ROL::Vector<Real> &z, Real &tol) override {
+    ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+    ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+    return assembler_->assembleQoIValue(qoi_,ROL::nullPtr,zf,zp);
+  }
+
+  void gradient(ROL::Vector<Real> &g,
+                const ROL::Vector<Real> &z, Real &tol ) override {
+    int NotImplemented(0), IsZero(0);
+    g.zero();
+    // Compute control field gradient
+    try {
+      // Get state and control vectors
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      ROL::Ptr<Tpetra::MultiVector<> >       gf = getField(g);
+      assembler_->assembleQoIGradient2(vecG2_,qoi_,ROL::nullPtr,zf,zp);
+      gf->scale(static_cast<Real>(1),*vecG2_);
+    }
+    catch ( Exception::Zero & ez ) {
+      IsZero++;
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      NotImplemented++;
+    }
+    // Compute control parameter gradient
+    try {
+      // Get state and control vectors
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      ROL::Ptr<std::vector<Real> >           gp = getParameter(g);
+      assembler_->assembleQoIGradient3(vecG3_,qoi_,ROL::nullPtr,zf,zp);
+      gp->assign(vecG3_->begin(),vecG3_->end());
+    }
+    catch ( Exception::Zero & ez ) {
+      IsZero++;
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      NotImplemented++;
+    }
+    // Zero gradient
+    if ( IsZero == 2 || (IsZero == 1 && NotImplemented == 1) ) {
+      g.zero();
+    }
+    // Not Implemented
+    if ( NotImplemented == 2 ) {
+      ROL::Objective<Real>::gradient(g,z,tol);
+    }
+  }
+
+  void hessVec(ROL::Vector<Real> &hv, const ROL::Vector<Real> &v, 
+               const ROL::Vector<Real> &z, Real &tol ) override {
+    int NotImplemented(0), IsZero(0);
+    hv.zero();
+    // Compute control field/field hessvec
+    try {
+      ROL::Ptr<Tpetra::MultiVector<> >      hvf = getField(hv);
+      ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      assembler_->assembleQoIHessVec22(vecH22_,qoi_,vf,ROL::nullPtr,zf,zp);
+      hvf->scale(static_cast<Real>(1),*vecH22_);
+    }
+    catch (Exception::Zero &ez) {
+      hv.zero();
+      IsZero++;
+    }
+    catch (Exception::NotImplemented &eni) {
+      hv.zero();
+      NotImplemented++;
+    }
+    // Compute control field/parameter hessvec
+    try {
+      // Get state and control vectors
+      ROL::Ptr<Tpetra::MultiVector<> >      hvf = getField(hv);
+      ROL::Ptr<const std::vector<Real> >     vp = getConstParameter(v);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      assembler_->assembleQoIHessVec23(vecH23_,qoi_,vp,ROL::nullPtr,zf,zp);
+      hvf->update(static_cast<Real>(1),*vecH23_,static_cast<Real>(1));
+    }
+    catch ( Exception::Zero & ez ) {
+      IsZero++;
+    }
+    catch ( Exception::NotImplemented & eni ) {
+      NotImplemented++;
+    }
+    // Compute control parameter/field hessvec
+    try {
+      ROL::Ptr<std::vector<Real> >          hvp = getParameter(hv);
+      ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      assembler_->assembleQoIHessVec32(vecH32_,qoi_,vf,ROL::nullPtr,zf,zp);
+      hvp->assign(vecH32_->begin(),vecH32_->end());
+    }
+    catch (Exception::Zero &ez) {
+      ROL::Ptr<std::vector<Real> > hvp = getParameter(hv);
+      if ( hvp != ROL::nullPtr ) {
+        const int size = hvp->size();
+        hvp->assign(size,static_cast<Real>(0));
+      }
+      IsZero++;
+    }
+    catch (Exception::NotImplemented &eni) {
+      ROL::Ptr<std::vector<Real> > hvp = getParameter(hv);
+      if ( hvp != ROL::nullPtr ) {
+        const int size = hvp->size();
+        hvp->assign(size,static_cast<Real>(0));
+      }
+      NotImplemented++;
+    }
+    // Compute control parameter/parameter hessvec
+    try {
+      ROL::Ptr<std::vector<Real> >          hvp = getParameter(hv);
+      ROL::Ptr<const std::vector<Real> >     vp = getConstParameter(v);
+      ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+      ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+      assembler_->assembleQoIHessVec33(vecH33_,qoi_,vp,ROL::nullPtr,zf,zp);
+      const int size = hvp->size();
+      for (int i = 0; i < size; ++i) {
+        (*hvp)[i] += (*vecH33_)[i];
+      }
+    }
+    catch (Exception::Zero &ez) {
+      IsZero++;
+    }
+    catch (Exception::NotImplemented &eni) {
+      NotImplemented++;
+    }
+
+    // Zero hessvec
+    if ( IsZero > 0 && (IsZero + NotImplemented == 4) ) {
+      hv.zero();
+    }
+    // Not Implemented
+    if ( NotImplemented == 4 ) {
+      ROL::Objective<Real>::hessVec(hv,v,z,tol);
+    }
+  }
+
+private: // Vector accessor functions
+
+  ROL::Ptr<const Tpetra::MultiVector<> > getConstField(const ROL::Vector<Real> &x) const {
+    ROL::Ptr<const Tpetra::MultiVector<> > xp;
+    try {
+      xp = dynamic_cast<const ROL::TpetraMultiVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<const ROL::TpetraMultiVector<Real> > xvec
+          = dynamic_cast<const PDE_OptVector<Real>&>(x).getField();
+        if (xvec == ROL::nullPtr) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+
+  ROL::Ptr<Tpetra::MultiVector<> > getField(ROL::Vector<Real> &x) const {
+    ROL::Ptr<Tpetra::MultiVector<> > xp;
+    try {
+      xp = dynamic_cast<ROL::TpetraMultiVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<ROL::TpetraMultiVector<Real> > xvec
+          = dynamic_cast<PDE_OptVector<Real>&>(x).getField();
+        if ( xvec == ROL::nullPtr ) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+
+  ROL::Ptr<const std::vector<Real> > getConstParameter(const ROL::Vector<Real> &x) const {
+    ROL::Ptr<const std::vector<Real> > xp;
+    try {
+      xp = dynamic_cast<const ROL::StdVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<const ROL::StdVector<Real> > xvec
+          = dynamic_cast<const PDE_OptVector<Real>&>(x).getParameter();
+        if ( xvec == ROL::nullPtr ) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+
+  ROL::Ptr<std::vector<Real> > getParameter(ROL::Vector<Real> &x) const {
+    ROL::Ptr<std::vector<Real> > xp;
+    try {
+      xp = dynamic_cast<ROL::StdVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<ROL::StdVector<Real> > xvec
+          = dynamic_cast<PDE_OptVector<Real>&>(x).getParameter();
+        if ( xvec == ROL::nullPtr ) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+};
+
+template<class Real, class DeviceType>
+class IntegralAffineSimObjective : public ROL::Objective_SimOpt<Real> {
+public:
+  using QoI_type = QoI<Real, DeviceType>;
+  using Assembler_type = Assembler<Real, DeviceType>;
+private:
+  const ROL::Ptr<QoI_type > qoi_;
+  const ROL::Ptr<Assembler_type> assembler_;
+
+  Real shift_;
+  ROL::Ptr<Tpetra::MultiVector<> > vecG1_;
+  ROL::Ptr<Tpetra::MultiVector<> > ufield_;
+  ROL::Ptr<Tpetra::MultiVector<> > zfield_;
+  ROL::Ptr<std::vector<Real> >     zparam_;
+
+  bool isAssembled_;
+
+  void assemble(const ROL::Ptr<const Tpetra::MultiVector<> > &zf,
+                const ROL::Ptr<const std::vector<Real> >     &zp) {
+    if ( !isAssembled_ ) {
+      ufield_ = assembler_->createStateVector();
+      ufield_->putScalar(static_cast<Real>(0));
+      if ( zf != ROL::nullPtr ) {
+        zfield_ = assembler_->createControlVector();
+        zfield_->putScalar(static_cast<Real>(0));
+      }
+      if ( zp != ROL::nullPtr ) {
+       zparam_ = ROL::makePtr<std::vector<Real>>(zp->size(),static_cast<Real>(0));
+      }
+      shift_ = assembler_->assembleQoIValue(qoi_,ufield_,zfield_,zparam_);
+      assembler_->assembleQoIGradient1(vecG1_,qoi_,ufield_,zfield_,zparam_);
+      isAssembled_ = true;
+    }
+  }
+
+public:
+  IntegralAffineSimObjective(const ROL::Ptr<QoI_type> &qoi,
+                             const ROL::Ptr<Assembler_type> &assembler)
+    : qoi_(qoi), assembler_(assembler), isAssembled_(false) {}
+
+  void setParameter(const std::vector<Real> &param) {
+    ROL::Objective_SimOpt<Real>::setParameter(param);
+    qoi_->setParameter(param);
+    isAssembled_ = false;
+  }
+
+  Real value(const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol) override {
+    ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+    ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+    ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+
+    assemble(zf,zp);
+
+    const size_t n = uf->getNumVectors();
+    Teuchos::Array<Real> val(n,0);
+    vecG1_->dot(*uf, val.view(0,n));
+    
+    return val[0] + shift_;
+  }
+
+  void gradient_1(ROL::Vector<Real> &g, const ROL::Vector<Real> &u,
+                  const ROL::Vector<Real> &z, Real &tol ) override {
+    ROL::Ptr<Tpetra::MultiVector<> >       gf = getField(g);
+    ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+    ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+
+    assemble(zf,zp);
+
+    gf->scale(static_cast<Real>(1),*vecG1_);
+  }
+
+  void gradient_2(ROL::Vector<Real> &g, const ROL::Vector<Real> &u,
+                  const ROL::Vector<Real> &z, Real &tol ) override {
+    g.zero();
+  }
+
+  void hessVec_11( ROL::Vector<Real> &hv, const ROL::Vector<Real> &v, 
+             const ROL::Vector<Real> &u,  const ROL::Vector<Real> &z, Real &tol ) override {
+    hv.zero();
+  }
+
+  void hessVec_12( ROL::Vector<Real> &hv, const ROL::Vector<Real> &v, 
+                   const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol ) override {
+    hv.zero();
+  }
+
+  void hessVec_21( ROL::Vector<Real> &hv, const ROL::Vector<Real> &v, 
+                   const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol ) override {
+    hv.zero();
+  }
+
+  void hessVec_22( ROL::Vector<Real> &hv, const ROL::Vector<Real> &v, 
+             const ROL::Vector<Real> &u,  const ROL::Vector<Real> &z, Real &tol ) override {
+    hv.zero();
+  }
+
+private: // Vector accessor functions
+
+  ROL::Ptr<const Tpetra::MultiVector<> > getConstField(const ROL::Vector<Real> &x) const {
+    ROL::Ptr<const Tpetra::MultiVector<> > xp;
+    try {
+      xp = dynamic_cast<const ROL::TpetraMultiVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<const ROL::TpetraMultiVector<Real> > xvec
+          = dynamic_cast<const PDE_OptVector<Real>&>(x).getField();
+        if (xvec == ROL::nullPtr) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+
+  ROL::Ptr<Tpetra::MultiVector<> > getField(ROL::Vector<Real> &x) const {
+    ROL::Ptr<Tpetra::MultiVector<> > xp;
+    try {
+      xp = dynamic_cast<ROL::TpetraMultiVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<ROL::TpetraMultiVector<Real> > xvec
+          = dynamic_cast<PDE_OptVector<Real>&>(x).getField();
+        if ( xvec == ROL::nullPtr ) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+
+  ROL::Ptr<const std::vector<Real> > getConstParameter(const ROL::Vector<Real> &x) const {
+    ROL::Ptr<const std::vector<Real> > xp;
+    try {
+      xp = dynamic_cast<const ROL::StdVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<const ROL::StdVector<Real> > xvec
+          = dynamic_cast<const PDE_OptVector<Real>&>(x).getParameter();
+        if ( xvec == ROL::nullPtr ) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+
+  ROL::Ptr<std::vector<Real> > getParameter(ROL::Vector<Real> &x) const {
+    ROL::Ptr<std::vector<Real> > xp;
+    try {
+      xp = dynamic_cast<ROL::StdVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<ROL::StdVector<Real> > xvec
+          = dynamic_cast<PDE_OptVector<Real>&>(x).getParameter();
+        if ( xvec == ROL::nullPtr ) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+};
+
+#endif

--- a/packages/rol/example/PDE-OPT/TOOLS/linearpdeconstraintK.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/linearpdeconstraintK.hpp
@@ -1,0 +1,592 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  constraint.hpp
+    \brief Defines the SimOpt constraint for the 'poisson' example.
+*/
+
+#ifndef ROL_PDEOPT_LINEARPDECONSTRAINTK_H
+#define ROL_PDEOPT_LINEARPDECONSTRAINTK_H
+
+#include "ROL_Constraint_SimOpt.hpp"
+#include "pdeK.hpp"
+#include "assemblerK.hpp"
+#include "solver.hpp"
+#include "pdevectorK.hpp"
+
+// Do not instantiate the template in this translation unit.
+extern template class Assembler<double,Kokkos::HostSpace>;
+
+//// Global Timers.
+#ifdef ROL_TIMERS
+namespace ROL {
+  namespace PDEOPT {
+    ROL::Ptr<Teuchos::Time> LinearPDEConstraintSolverConstruct_Jacobian1        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Linear PDE Constraint Solver Construction Time for Jacobian1");
+    ROL::Ptr<Teuchos::Time> LinearPDEConstraintSolverConstruct_AdjointJacobian1 = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Linear PDE Constraint Solver Construction Time for Adjoint Jacobian1");
+    ROL::Ptr<Teuchos::Time> LinearPDEConstraintSolverSolve_Jacobian1            = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Linear PDE Constraint Solver Solution Time for Jacobian1");
+    ROL::Ptr<Teuchos::Time> LinearPDEConstraintSolverSolve_AdjointJacobian1     = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Linear PDE Constraint Solver Solution Time for Adjoint Jacobian1");
+    ROL::Ptr<Teuchos::Time> LinearPDEConstraintApplyJacobian1                   = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Linear PDE Constraint Apply Jacobian1");
+    ROL::Ptr<Teuchos::Time> LinearPDEConstraintApplyJacobian2                   = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Linear PDE Constraint Apply Jacobian2");
+    ROL::Ptr<Teuchos::Time> LinearPDEConstraintApplyJacobian3                   = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Linear PDE Constraint Apply Jacobian3");
+    ROL::Ptr<Teuchos::Time> LinearPDEConstraintApplyAdjointJacobian1            = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Linear PDE Constraint Apply Adjoint Jacobian1");
+    ROL::Ptr<Teuchos::Time> LinearPDEConstraintApplyAdjointJacobian2            = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Linear PDE Constraint Apply Adjoint Jacobian2");
+    ROL::Ptr<Teuchos::Time> LinearPDEConstraintApplyAdjointJacobian3            = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: Linear PDE Constraint Apply Adjoint Jacobian3");
+  }
+}
+#endif
+
+
+template<class Real, class DeviceType>
+class Linear_PDE_Constraint : public ROL::Constraint_SimOpt<Real> {
+public:
+  using Assembler_type = Assembler<Real,DeviceType>;
+  using PDE_type = PDE<Real,DeviceType>;
+private:
+  const ROL::Ptr<PDE_type> pde_;
+  ROL::Ptr<Assembler_type> assembler_;
+  ROL::Ptr<Solver<Real> >    solver_;
+  bool initZvec_, initZpar_, isStochastic_;
+  bool assembleRHS_, assembleJ1_, assembleJ2_, assembleJ3_, setSolver_;
+
+  ROL::Ptr<Tpetra::MultiVector<> > cvec_;
+  ROL::Ptr<Tpetra::MultiVector<> > uvec_;
+  ROL::Ptr<Tpetra::MultiVector<> > zvec_;
+  ROL::Ptr<std::vector<Real> >     zpar_;
+
+  ROL::Ptr<Tpetra::MultiVector<> > vecR_;
+  ROL::Ptr<Tpetra::CrsMatrix<> >   matJ1_;
+  ROL::Ptr<Tpetra::CrsMatrix<> >   matJ2_;
+  ROL::Ptr<Tpetra::MultiVector<> > vecJ3_;
+
+  void assemble(const ROL::Ptr<const Tpetra::MultiVector<> > &zf,
+                const ROL::Ptr<const std::vector<Real> > &zp) {
+    // Initialize field component of z.
+    if (initZvec_ && zf != ROL::nullPtr) {
+      zvec_ = assembler_->createControlVector();
+      zvec_->putScalar(static_cast<Real>(0));
+    }
+    initZvec_ = false;
+    // Initialize parameter component of z.
+    if (initZpar_ && zp != ROL::nullPtr) {
+      zpar_ = ROL::makePtr<std::vector<Real>>(zp->size(),static_cast<Real>(0));
+    }
+    initZpar_ = false;
+    // Assemble affine term.
+    if (assembleRHS_) {
+      assembler_->assemblePDEResidual(vecR_,pde_,uvec_,zvec_,zpar_);
+    }
+    assembleRHS_ = false;
+    // Assemble jacobian_1.
+    if (assembleJ1_) {
+      assembler_->assemblePDEJacobian1(matJ1_,pde_,uvec_,zvec_,zpar_);
+    }
+    assembleJ1_ = false;
+    // Assemble jacobian_2.
+    if (assembleJ2_ && zf != ROL::nullPtr) {
+      assembler_->assemblePDEJacobian2(matJ2_,pde_,uvec_,zvec_,zpar_);
+    }
+    assembleJ2_ = false;
+    // Assemble jacobian_3.
+    if (assembleJ3_ && zp != ROL::nullPtr) {
+      assembler_->assemblePDEJacobian3(vecJ3_,pde_,uvec_,zvec_,zpar_);
+    }
+    assembleJ3_ = false;
+  }
+
+  void setSolver(void) {
+    solver_->setA(matJ1_);
+    setSolver_ = false;
+  }
+
+  void solveForward(ROL::Ptr<Tpetra::MultiVector<> > &x,
+                    const ROL::Ptr<const Tpetra::MultiVector<> > &b) {
+    if (setSolver_) {
+      #ifdef ROL_TIMERS
+        Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::LinearPDEConstraintSolverConstruct_Jacobian1);
+      #endif
+      setSolver();
+    }
+
+    #ifdef ROL_TIMERS
+      Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::LinearPDEConstraintSolverSolve_Jacobian1);
+    #endif
+    solver_->solve(x,b,false);
+  }
+
+  void solveAdjoint(ROL::Ptr<Tpetra::MultiVector<> > &x,
+                    const ROL::Ptr<const Tpetra::MultiVector<> > &b) {
+    if (setSolver_) {
+      #ifdef ROL_TIMERS
+        Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::LinearPDEConstraintSolverConstruct_AdjointJacobian1);
+      #endif
+      setSolver();
+    }
+
+    #ifdef ROL_TIMERS
+      Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::LinearPDEConstraintSolverSolve_AdjointJacobian1);
+    #endif
+    solver_->solve(x,b,true);
+  }
+
+  void applyJacobian1(const ROL::Ptr<Tpetra::MultiVector<> > &Jv,
+                      const ROL::Ptr<const Tpetra::MultiVector<> > &v) {
+    #ifdef ROL_TIMERS
+      Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::LinearPDEConstraintApplyJacobian1);
+    #endif
+    matJ1_->apply(*v,*Jv);
+  }
+
+  void applyAdjointJacobian1(const ROL::Ptr<Tpetra::MultiVector<> > &Jv,
+                             const ROL::Ptr<const Tpetra::MultiVector<> > &v) {
+    #ifdef ROL_TIMERS
+      Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::LinearPDEConstraintApplyAdjointJacobian1);
+    #endif
+    matJ1_->apply(*v,*Jv,Teuchos::TRANS);
+  }
+
+  void applyJacobian2(const ROL::Ptr<Tpetra::MultiVector<> > &Jv,
+                      const ROL::Ptr<const Tpetra::MultiVector<> > &v) {
+    #ifdef ROL_TIMERS
+      Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::LinearPDEConstraintApplyJacobian2);
+    #endif
+    matJ2_->apply(*v,*Jv);
+  }
+
+  void applyAdjointJacobian2(const ROL::Ptr<Tpetra::MultiVector<> > &Jv,
+                             const ROL::Ptr<const Tpetra::MultiVector<> > &v) {
+    #ifdef ROL_TIMERS
+      Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::LinearPDEConstraintApplyAdjointJacobian2);
+    #endif
+    matJ2_->apply(*v,*Jv,Teuchos::TRANS);
+  }
+
+  // Application routines
+  void applyJacobian3(const ROL::Ptr<Tpetra::MultiVector<> > &Jv,
+                      const ROL::Ptr<const std::vector<Real> > &v,
+                      const bool zeroOut = true) const {
+    #ifdef ROL_TIMERS
+      Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::LinearPDEConstraintApplyJacobian3);
+    #endif
+    if ( zeroOut ) {
+      Jv->putScalar(static_cast<Real>(0));
+    }
+    const size_t size = static_cast<size_t>(v->size());
+    for (size_t i = 0; i < size; ++i) {
+      Teuchos::ArrayView<const size_t> col(&i,1);
+      Jv->update((*v)[i],*(vecJ3_->subView(col)),static_cast<Real>(1));
+    }
+  }
+
+  void applyAdjointJacobian3(const ROL::Ptr<std::vector<Real> > &Jv,
+                             const ROL::Ptr<const Tpetra::MultiVector<> > &v) const {
+    #ifdef ROL_TIMERS
+      Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::LinearPDEConstraintApplyAdjointJacobian3);
+    #endif
+    Teuchos::Array<Real> val(1,0);
+    const size_t size = static_cast<size_t>(Jv->size());
+    for (size_t i = 0; i < size; ++i) {
+      Teuchos::ArrayView<const size_t> col(&i,1);
+      vecJ3_->subView(col)->dot(*v, val.view(0,1));
+      (*Jv)[i] = val[0];
+    }
+  }
+
+public:
+  virtual ~Linear_PDE_Constraint() {}
+
+  Linear_PDE_Constraint(const ROL::Ptr<PDE_type> &pde,
+                        const ROL::Ptr<MeshManager<Real,DeviceType> > &meshMgr,
+                        const ROL::Ptr<const Teuchos::Comm<int> > &comm,
+                        Teuchos::ParameterList &parlist,
+                        std::ostream &outStream = std::cout,
+                        const bool isStochastic = false)
+    : ROL::Constraint_SimOpt<Real>(), pde_(pde),
+      initZvec_(true), initZpar_(true), isStochastic_(isStochastic),
+      assembleRHS_(true), assembleJ1_(true), assembleJ2_(true), assembleJ3_(true), setSolver_(true) {
+    // Construct assembler.
+    assembler_ = ROL::makePtr<Assembler_type>(pde_->getFields(),meshMgr,comm,parlist,outStream);
+    assembler_->setCellNodes(*pde_);
+    // Construct solver.
+    solver_ = ROL::makePtr<Solver<Real>>(parlist.sublist("Solver"));
+    // Initialize zero vectors.
+    cvec_ = assembler_->createResidualVector();
+    uvec_ = assembler_->createStateVector();
+    uvec_->putScalar(static_cast<Real>(0));
+  }
+
+  void setParameter(const std::vector<Real> &param) {
+    if (isStochastic_) {
+      ROL::Constraint_SimOpt<Real>::setParameter(param);
+      pde_->setParameter(param);
+      assembleRHS_ = true;
+      assembleJ1_  = true;
+      assembleJ2_  = true;
+      assembleJ3_  = true;
+      setSolver_   = true;
+    }
+  }
+
+  const ROL::Ptr<Assembler_type> getAssembler(void) const {
+    return assembler_;
+  }
+
+  const ROL::Ptr<PDE_type> getPDE(void) const {
+    return pde_;
+  }
+
+  using ROL::Constraint_SimOpt<Real>::update_1;
+  void update_1(const ROL::Vector<Real> &u, bool flag = true, int iter = -1) {}
+
+  using ROL::Constraint_SimOpt<Real>::update_2;
+  void update_2(const ROL::Vector<Real> &z, bool flag = true, int iter = -1) {}
+
+  using ROL::Constraint_SimOpt<Real>::update;
+  void update(const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, bool flag = true, int iter = -1) {
+    update_1(u,flag,iter);
+    update_2(z,flag,iter);
+  }
+
+  void update_1(const ROL::Vector<Real> &u, ROL::UpdateType type, int iter = -1) {}
+  void update_2(const ROL::Vector<Real> &z, ROL::UpdateType type, int iter = -1) {}
+  void update(const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, ROL::UpdateType type, int iter = -1) {
+    update_1(u,type,iter);
+    update_2(z,type,iter);
+  }
+
+  using ROL::Constraint_SimOpt<Real>::value;
+  void value(ROL::Vector<Real> &c, const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol) {
+    ROL::Ptr<Tpetra::MultiVector<> >       cf = getField(c);
+    ROL::Ptr<const Tpetra::MultiVector<> > uf = getConstField(u);
+    ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+    ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+
+    assemble(zf,zp);
+    c.zero();
+    cvec_->putScalar(static_cast<Real>(0));
+
+    const Real one(1);
+    cf->scale(one,*vecR_);
+    if (zf != ROL::nullPtr) {
+      applyJacobian2(cvec_,zf);
+      cf->update(one,*cvec_,one);
+    }
+    if (zp != ROL::nullPtr) {
+      applyJacobian3(cvec_,zp,false);
+      cf->update(one,*cvec_,one);
+    }
+    applyJacobian1(cvec_,uf);
+    cf->update(one,*cvec_,one);
+  }
+
+  void solve(ROL::Vector<Real> &c, ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol) {
+    ROL::Ptr<Tpetra::MultiVector<> >       cf = getField(c);
+    ROL::Ptr<Tpetra::MultiVector<> >       uf = getField(u);
+    ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+    ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+
+    assemble(zf,zp);
+    c.zero();
+    cvec_->putScalar(static_cast<Real>(0));
+
+    const Real one(1);
+    cf->scale(one,*vecR_);
+    if (zf != ROL::nullPtr) {
+      applyJacobian2(cvec_,zf);
+      cf->update(one,*cvec_,one);
+    }
+    if (zp != ROL::nullPtr) {
+      applyJacobian3(cvec_,zp,false);
+      cf->update(one,*cvec_,one);
+    }
+
+    solveForward(uf,cf);
+    uf->scale(-one);
+
+    applyJacobian1(cvec_,uf);
+    cf->update(one,*cvec_,one);
+  }
+
+  void applyJacobian_1(ROL::Vector<Real> &jv,
+                 const ROL::Vector<Real> &v,
+                 const ROL::Vector<Real> &u,
+                 const ROL::Vector<Real> &z, Real &tol) {
+    ROL::Ptr<Tpetra::MultiVector<> >      jvf = getField(jv);
+    ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+    ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+    ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+
+    assemble(zf,zp);
+    applyJacobian1(jvf,vf);
+  }
+
+
+  void applyJacobian_2(ROL::Vector<Real> &jv,
+                 const ROL::Vector<Real> &v,
+                 const ROL::Vector<Real> &u,
+                 const ROL::Vector<Real> &z, Real &tol) {
+    jv.zero();
+    ROL::Ptr<Tpetra::MultiVector<> >      jvf = getField(jv);
+    ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+    ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+
+    assemble(zf,zp);
+
+    const Real one(1);
+    ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+    if (vf != ROL::nullPtr) {
+      applyJacobian2(cvec_,vf);
+      jvf->update(one,*cvec_,one);
+    }
+    ROL::Ptr<const std::vector<Real> >     vp = getConstParameter(v);
+    bool zeroOut = (vf == ROL::nullPtr);
+    if (vp != ROL::nullPtr) {
+      applyJacobian3(cvec_,vp,zeroOut);
+      jvf->update(one,*cvec_,one);
+    }
+  }
+
+
+  void applyAdjointJacobian_1(ROL::Vector<Real> &ajv,
+                        const ROL::Vector<Real> &v,
+                        const ROL::Vector<Real> &u,
+                        const ROL::Vector<Real> &z, Real &tol) {
+    ROL::Ptr<Tpetra::MultiVector<> >     ajvf = getField(ajv);
+    ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+    ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+    ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+
+    assemble(zf,zp);
+    applyAdjointJacobian1(ajvf,vf);
+  }
+
+
+  void applyAdjointJacobian_2(ROL::Vector<Real> &ajv,
+                        const ROL::Vector<Real> &v,
+                        const ROL::Vector<Real> &u,
+                        const ROL::Vector<Real> &z, Real &tol) {
+    ROL::Ptr<Tpetra::MultiVector<> >     ajvf = getField(ajv);
+    ROL::Ptr<std::vector<Real> >         ajvp = getParameter(ajv);
+    ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+    ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+    ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+
+    assemble(zf,zp);
+
+    if (zf != ROL::nullPtr) {
+      applyAdjointJacobian2(ajvf,vf);
+    }
+    if (zp != ROL::nullPtr) {
+      applyAdjointJacobian3(ajvp,vf);
+    }
+  }
+
+
+  void applyInverseJacobian_1(ROL::Vector<Real> &ijv,
+                        const ROL::Vector<Real> &v,
+                        const ROL::Vector<Real> &u,
+                        const ROL::Vector<Real> &z, Real &tol) {
+    ROL::Ptr<Tpetra::MultiVector<> >     ijvf = getField(ijv);
+    ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+    ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+    ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+
+    assemble(zf,zp);
+    solveForward(ijvf,vf);
+  }
+
+
+  void applyInverseAdjointJacobian_1(ROL::Vector<Real> &iajv,
+                               const ROL::Vector<Real> &v,
+                               const ROL::Vector<Real> &u,
+                               const ROL::Vector<Real> &z, Real &tol) {
+    ROL::Ptr<Tpetra::MultiVector<> >    iajvf = getField(iajv);
+    ROL::Ptr<const Tpetra::MultiVector<> > vf = getConstField(v);
+    ROL::Ptr<const Tpetra::MultiVector<> > zf = getConstField(z);
+    ROL::Ptr<const std::vector<Real> >     zp = getConstParameter(z);
+
+    assemble(zf,zp);
+    solveAdjoint(iajvf,vf);
+  }
+
+
+  void applyAdjointHessian_11(ROL::Vector<Real> &ahwv,
+                        const ROL::Vector<Real> &w,
+                        const ROL::Vector<Real> &v,
+                        const ROL::Vector<Real> &u,
+                        const ROL::Vector<Real> &z, Real &tol) {
+    ahwv.zero();
+  }
+
+
+  void applyAdjointHessian_12(ROL::Vector<Real> &ahwv,
+                        const ROL::Vector<Real> &w,
+                        const ROL::Vector<Real> &v,
+                        const ROL::Vector<Real> &u,
+                        const ROL::Vector<Real> &z, Real &tol) {
+    ahwv.zero();
+  }
+
+
+  void applyAdjointHessian_21(ROL::Vector<Real> &ahwv,
+                        const ROL::Vector<Real> &w,
+                        const ROL::Vector<Real> &v,
+                        const ROL::Vector<Real> &u,
+                        const ROL::Vector<Real> &z, Real &tol) {
+    ahwv.zero();
+  }
+
+
+  void applyAdjointHessian_22(ROL::Vector<Real> &ahwv,
+                        const ROL::Vector<Real> &w,
+                        const ROL::Vector<Real> &v,
+                        const ROL::Vector<Real> &u,
+                        const ROL::Vector<Real> &z, Real &tol) {
+    ahwv.zero();
+  }
+
+  /***************************************************************************/
+  /* Output routines.                                                        */
+  /***************************************************************************/
+  void printMeshData(std::ostream &outStream) const {
+    assembler_->printMeshData(outStream);
+  }
+
+  void outputTpetraData() const {
+    Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix<> > matWriter;
+    if (matJ1_ != ROL::nullPtr) {
+      matWriter.writeSparseFile("jacobian1.txt", matJ1_);
+    }
+    else {
+      std::ofstream emptyfile;
+      emptyfile.open("jacobian1.txt");
+      emptyfile.close();
+    }
+    if (matJ2_ != ROL::nullPtr) {
+      matWriter.writeSparseFile("jacobian2.txt", matJ2_);
+    }
+    else {
+      std::ofstream emptyfile;
+      emptyfile.open("jacobian2.txt");
+      emptyfile.close();
+    }
+    if (vecR_ != ROL::nullPtr) {
+      matWriter.writeDenseFile("residual.txt", vecR_);
+    }
+    else {
+      std::ofstream emptyfile;
+      emptyfile.open("residual.txt");
+      emptyfile.close();
+    }
+  }
+
+  void outputTpetraVector(const ROL::Ptr<const Tpetra::MultiVector<> > &vec,
+                          const std::string &filename) const {
+    Tpetra::MatrixMarket::Writer< Tpetra::CrsMatrix<> > vecWriter;
+    vecWriter.writeDenseFile(filename, vec);
+  }
+  /***************************************************************************/
+  /* End of output routines.                                                 */
+  /***************************************************************************/
+
+private: // Vector accessor functions
+
+  ROL::Ptr<const Tpetra::MultiVector<> > getConstField(const ROL::Vector<Real> &x) const {
+    ROL::Ptr<const Tpetra::MultiVector<> > xp;
+    try {
+      xp = dynamic_cast<const ROL::TpetraMultiVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<const ROL::TpetraMultiVector<Real> > xvec
+          = dynamic_cast<const PDE_OptVector<Real>&>(x).getField();
+        if (xvec == ROL::nullPtr) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+
+  ROL::Ptr<Tpetra::MultiVector<> > getField(ROL::Vector<Real> &x) const {
+    ROL::Ptr<Tpetra::MultiVector<> > xp;
+    try {
+      xp = dynamic_cast<ROL::TpetraMultiVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<ROL::TpetraMultiVector<Real> > xvec
+          = dynamic_cast<PDE_OptVector<Real>&>(x).getField();
+        if ( xvec == ROL::nullPtr ) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+
+  ROL::Ptr<const std::vector<Real> > getConstParameter(const ROL::Vector<Real> &x) const {
+    ROL::Ptr<const std::vector<Real> > xp;
+    try {
+      xp = dynamic_cast<const ROL::StdVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<const ROL::StdVector<Real> > xvec
+          = dynamic_cast<const PDE_OptVector<Real>&>(x).getParameter();
+        if ( xvec == ROL::nullPtr ) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+
+  ROL::Ptr<std::vector<Real> > getParameter(ROL::Vector<Real> &x) const {
+    ROL::Ptr<std::vector<Real> > xp;
+    try {
+      xp = dynamic_cast<ROL::StdVector<Real>&>(x).getVector();
+    }
+    catch (std::exception &e) {
+      try {
+        ROL::Ptr<ROL::StdVector<Real> > xvec
+          = dynamic_cast<PDE_OptVector<Real>&>(x).getParameter();
+        if ( xvec == ROL::nullPtr ) {
+          xp = ROL::nullPtr;
+        }
+        else {
+          xp = xvec->getVector();
+        }
+      }
+      catch (std::exception &ee) {
+        xp = ROL::nullPtr;
+      }
+    }
+    return xp;
+  }
+};
+
+#endif

--- a/packages/rol/example/PDE-OPT/TOOLS/meshmanagerK.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/meshmanagerK.hpp
@@ -1,0 +1,1147 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  MeshManager.hpp
+    \brief Defines the MeshManager classes.
+*/
+
+#ifndef MESHMANAGERK_HPP
+#define MESHMANAGERK_HPP
+
+#include "Teuchos_ParameterList.hpp"
+#include "Kokkos_DynRankView.hpp"
+#include "ROL_Ptr.hpp"
+
+/** \class  MeshManager
+    \brief  This is the pure virtual parent class for mesh construction
+            and management; it enables the generation of a few select
+            meshes and the setup of data structures for computing
+            cell/subcell adjacencies, for example, the cell-to-node
+            adjacency map and the cell-to-edge adjacency map.
+*/
+template <class Real, class DeviceType>
+class MeshManager {
+
+public:
+  using scalar_view = Kokkos::DynRankView<Real,DeviceType>;
+  using int_view = Kokkos::DynRankView<int,DeviceType>;
+
+
+  /** \brief  Destructor
+   */
+  virtual ~MeshManager() {}
+
+  /** \brief Returns node coordinates.
+             Format: number_of_nodes x 2 (Real)
+                     (node_index)  x, y coordinates
+  */
+  virtual scalar_view getNodes() const = 0;
+
+  /** \brief Returns cell to node adjacencies.
+             Format: number_of_cells x number_of_nodes_per_cell (int)
+                     (cell_index)  node_index1  node_index2  ...
+  */
+  virtual int_view getCellToNodeMap() const = 0;
+
+  /** \brief Returns cell to edge adjacencies.
+             Format: number_of_cells x number_of_edges_per_cell (int)
+                     (cell_index)  edge_index1  edge_index2  ...
+  */
+  virtual int_view getCellToEdgeMap() const {
+    return int_view(); // default due to lack of edges in 1D
+  }
+
+  /** \brief Returns cell to face adjacencies.
+             Format: number_of_cells x number_of_faces_per_cell (int)
+                     (cell_index)  face_index1  face_index2  ...
+  */
+  virtual int_view getCellToFaceMap() const {
+    return int_view(); // default due to lack of faces in 1D and 2D
+  }
+
+  /** \brief Returns cell IDs per processor.
+             Format: number_of_procs vectors, each with number_of_cells cell IDs (ints)
+  */
+  virtual ROL::Ptr<std::vector<std::vector<int>>> getProcCellIds() const {
+    return ROL::makePtr<std::vector<std::vector<int>>>();
+    // default due to support for in-line partitioning,
+    // where this functionality is bypassed
+  }
+
+  /** \brief Returns sideset information.
+             Format: The std::vector components are indexed by the local side number (0, 1, 2, ...);
+                     the FieldConTainer is a 1D array of cell indices.
+             Input:  Sideset number.  Its meaning is context-dependent.
+  */
+  //virtual ROL::Ptr<std::vector<std::vector<Intrepid::FieldContainer<int> > > > getSideSets(
+  //            std::ostream & outStream = std::cout,
+  //            const bool verbose = false) const = 0;
+  virtual ROL::Ptr<std::vector<std::vector<std::vector<int> > > > getSideSets(
+              const bool verbose = false,
+              std::ostream & outStream = std::cout) const = 0;
+
+  /** \brief Returns number of cells.
+  */
+  virtual int getNumCells() const = 0;
+
+  /** \brief Returns number of nodes.
+  */
+  virtual int getNumNodes() const = 0;
+
+  /** \brief Returns number of edges.
+  */
+  virtual int getNumEdges() const {
+    return 0; // default due to lack of edges in 1D
+  }
+
+  /** \brief Returns number of faces.
+  */
+  virtual int getNumFaces() const {
+    return 0; // default due to lack of faces in 1D and 2D
+  }
+
+}; // MeshManager
+
+
+
+/** \class  MeshManager_BackwardFacingStepChannel
+    \brief  Mesh construction and mesh management for the
+            backward-facing step channel geometry, on
+            quadrilateral grids.
+*/
+template <class Real, class DeviceType>
+class MeshManager_BackwardFacingStepChannel : public MeshManager<Real,DeviceType> {
+
+/* Backward-facing step geometry.
+
+  ***************************************************
+  *        *           *                            *
+  *   3    *     4     *             5              *
+  *        *           *                            *
+  ********** * * * * * * * * * * * * * * * * * * * **
+           *     1     *             2              *
+           *           *                            *
+           ******************************************
+
+*/
+
+public:
+  using scalar_view = typename MeshManager<Real,DeviceType>::scalar_view;
+  using int_view = typename MeshManager<Real,DeviceType>::int_view;
+
+private:
+  Real channelH_;   // channel height (height of regions 1+4)
+  Real channelW_;   // channel width (width of regions 3+4+5)
+  Real stepH_;      // step height (height of region 1)
+  Real stepW_;      // step width (width of region 3)
+  Real observeW_;   // width of observation region (width of region 1)
+  
+  int ref_;          // mesh refinement level
+
+  int nx1_;
+  int nx2_;
+  int nx3_;
+  int nx4_;
+  int nx5_;
+  int ny1_;
+  int ny2_;
+  int ny3_;
+  int ny4_;
+  int ny5_;
+
+  int numCells_;
+  int numNodes_;
+  int numEdges_;
+
+  scalar_view meshNodes_;
+  int_view    meshCellToNodeMap_;
+  int_view    meshCellToEdgeMap_;
+  ROL::Ptr<std::vector<std::vector<std::vector<int> > > >  meshSideSets_;
+
+public:
+
+  MeshManager_BackwardFacingStepChannel(Teuchos::ParameterList &parlist) {
+    // Geometry data.
+    channelH_ = parlist.sublist("Geometry").get(   "Channel height", 1.0);
+    channelW_ = parlist.sublist("Geometry").get(    "Channel width", 8.0);
+    stepH_    = parlist.sublist("Geometry").get(      "Step height", 0.5);
+    stepW_    = parlist.sublist("Geometry").get(       "Step width", 1.0);
+    observeW_ = parlist.sublist("Geometry").get("Observation width", 3.0);
+    // Mesh data.
+    ref_   = parlist.sublist("Geometry").get(      "Refinement level", 1);
+    /*nx1_   = parlist.sublist("Geometry").get( "Observation region NX", 3*2*ref_);
+    ny1_   = parlist.sublist("Geometry").get( "Observation region NY", 1*ref_);
+    nx2_   = parlist.sublist("Geometry").get("Laminar flow region NX", 4*2*ref_);
+    ny2_   = ny1_;
+    nx3_   = parlist.sublist("Geometry").get(      "Inflow region NX", 1*2*ref_);
+    ny3_   = parlist.sublist("Geometry").get(      "Inflow region NY", 1*ref_);*/
+    nx1_   = parlist.sublist("Geometry").get( "Observation region NX", 4*ref_);
+    ny1_   = parlist.sublist("Geometry").get( "Observation region NY", 5*ref_);
+    nx2_   = parlist.sublist("Geometry").get("Laminar flow region NX", 2*ref_);
+    ny2_   = ny1_;
+    nx3_   = parlist.sublist("Geometry").get(      "Inflow region NX", 1*ref_);
+    ny3_   = parlist.sublist("Geometry").get(      "Inflow region NY", 2*ref_);
+    nx4_   = nx1_;
+    ny4_   = ny3_;
+    nx5_   = nx2_;
+    ny5_   = ny3_;
+    numCells_ = (nx1_ + nx2_)*ny1_  +  (nx3_ + nx1_ + nx2_)*ny3_;
+    numNodes_ = (nx1_ + nx2_ + 1)*ny1_  +  (nx3_ + nx1_ + nx2_ + 1)*(ny3_ + 1);
+    numEdges_ = (2*(nx1_ + nx2_)+1)*ny1_ + (2*(nx3_ + nx1_ + nx2_)+1)*ny3_ + (nx3_ + nx1_ + nx2_);
+    // Compute mesh data structures.
+    computeNodes();
+    computeCellToNodeMap();
+    computeCellToEdgeMap();
+    computeSideSets();
+  }
+
+
+  scalar_view getNodes() const override {
+    return meshNodes_;
+  }
+
+
+  int_view getCellToNodeMap() const override {
+    return meshCellToNodeMap_;
+  }
+
+
+  int_view getCellToEdgeMap() const override {
+    return meshCellToEdgeMap_;
+  }
+
+
+  ROL::Ptr<std::vector<std::vector<std::vector<int> > > > getSideSets(
+              const bool verbose = false,
+              std::ostream & outStream = std::cout) const override { 
+    return meshSideSets_;
+  }
+
+
+  int getNumCells() const override {
+    return numCells_;
+  } // getNumCells
+
+
+  int getNumNodes() const override {
+    return numNodes_;
+  } // getNumNodes
+
+
+  int getNumEdges() const override {
+    return numEdges_;
+  } // getNumEdges
+
+
+private:
+
+  void computeNodes() {
+
+    meshNodes_ = scalar_view("meshNodes_", numNodes_, 2);
+    auto nodes = meshNodes_;
+
+    Real dy1 = stepH_ / ny1_;
+    Real dy3 = (channelH_ - stepH_) / ny3_;
+    Real dx1 = observeW_ / nx1_;
+    Real dx2 = (channelW_ - stepW_ - observeW_) / nx2_;
+    Real dx3 = stepW_ / nx3_;
+    int nodeCt = 0;
+
+    // bottom region
+    for (int j=0; j<ny1_; ++j) {
+      for (int i=0; i<=nx1_; ++i) {
+        nodes(nodeCt, 0) = stepW_ + i*dx1;
+        nodes(nodeCt, 1) = j*dy1;
+        ++nodeCt;
+      }
+      for (int i=0; i<nx2_; ++i) {
+        nodes(nodeCt, 0) = stepW_ + observeW_ + (i+1)*dx2;
+        nodes(nodeCt, 1) = j*dy1;
+        ++nodeCt;
+      }
+    }
+
+    // top region
+    for (int j=0; j<=ny3_; ++j) {
+      for (int i=0; i<=nx3_; ++i) {
+        nodes(nodeCt, 0) = i*dx3;
+        nodes(nodeCt, 1) = stepH_ + j*dy3;
+        ++nodeCt;
+      }
+      for (int i=0; i<nx1_; ++i) {
+        nodes(nodeCt, 0) = stepW_ + (i+1)*dx1;
+        nodes(nodeCt, 1) = stepH_ + j*dy3;
+        ++nodeCt;
+      }
+      for (int i=0; i<nx2_; ++i) {
+        nodes(nodeCt, 0) = stepW_ + observeW_ + (i+1)*dx2;
+        nodes(nodeCt, 1) = stepH_ + j*dy3;
+        ++nodeCt;
+      }
+    }
+
+  }  // computeNodes
+
+
+  void computeCellToNodeMap() {
+
+    meshCellToNodeMap_ = int_view("meshCellToNodeMap_", numCells_, 4);
+    auto ctn = meshCellToNodeMap_;
+
+    int cellCt = 0;
+
+    // bottom region
+    for (int j=0; j<ny1_-1; ++j) {
+      for (int i=0; i<nx1_+nx2_; ++i) {
+        ctn(cellCt, 0) = j*(nx1_+nx2_+1) + i;
+        ctn(cellCt, 1) = j*(nx1_+nx2_+1) + (i+1);
+        ctn(cellCt, 2) = (j+1)*(nx1_+nx2_+1) + (i+1);
+        ctn(cellCt, 3) = (j+1)*(nx1_+nx2_+1) + i;
+        ++cellCt;
+      }
+    }
+
+    // transition region
+    for (int i=0; i<nx1_+nx2_; ++i) {
+      ctn(cellCt, 0) = (ny1_-1)*(nx1_+nx2_+1) + i;
+      ctn(cellCt, 1) = (ny1_-1)*(nx1_+nx2_+1) + (i+1);
+      ctn(cellCt, 2) = ny1_*(nx1_+nx2_+1) + nx3_ + (i+1);
+      ctn(cellCt, 3) = ny1_*(nx1_+nx2_+1) + nx3_ + i;
+      ++cellCt;
+    }
+
+    // top region
+    for (int j=0; j<ny3_; ++j) {
+      for (int i=0; i<nx3_+nx1_+nx2_; ++i) {
+        ctn(cellCt, 0) = ny1_*(nx1_+nx2_+1) + j*(nx3_+nx1_+nx2_+1) + i;
+        ctn(cellCt, 1) = ny1_*(nx1_+nx2_+1) + j*(nx3_+nx1_+nx2_+1) + (i+1);
+        ctn(cellCt, 2) = ny1_*(nx1_+nx2_+1) + (j+1)*(nx3_+nx1_+nx2_+1) + (i+1);
+        ctn(cellCt, 3) = ny1_*(nx1_+nx2_+1) + (j+1)*(nx3_+nx1_+nx2_+1) + i;
+        ++cellCt;
+      }
+    }
+
+  } // computeCellToNodeMap
+
+
+  void computeCellToEdgeMap() {
+
+    meshCellToEdgeMap_ = int_view("meshCellToEdgeMap_", numCells_, 4);
+    auto cte = meshCellToEdgeMap_;
+
+    int cellCt = 0;
+
+    // bottom region
+    for (int j=0; j<ny1_-1; ++j) {
+      for (int i=0; i<nx1_+nx2_; ++i) {
+        cte(cellCt, 0) = j*(2*(nx1_+nx2_)+1) + i;
+        cte(cellCt, 1) = j*(2*(nx1_+nx2_)+1) + (nx1_+nx2_) + (i+1);
+        cte(cellCt, 2) = (j+1)*(2*(nx1_+nx2_)+1) + i;
+        cte(cellCt, 3) = j*(2*(nx1_+nx2_)+1) + (nx1_+nx2_) + i;
+        ++cellCt;
+      }
+    }
+
+    // transition region
+    for (int i=0; i<nx1_+nx2_; ++i) {
+      cte(cellCt, 0) = (ny1_-1)*(2*(nx1_+nx2_)+1) + i;
+      cte(cellCt, 1) = (ny1_-1)*(2*(nx1_+nx2_)+1) + (nx1_+nx2_) + (i+1);
+      cte(cellCt, 2) = ny1_*(2*(nx1_+nx2_)+1) + nx3_ + i;
+      cte(cellCt, 3) = (ny1_-1)*(2*(nx1_+nx2_)+1) + (nx1_+nx2_) + i;
+      ++cellCt;
+    }
+
+    // top region
+    for (int j=0; j<ny3_; ++j) {
+      for (int i=0; i<nx3_+nx1_+nx2_; ++i) {
+        cte(cellCt, 0) = ny1_*(2*(nx1_+nx2_)+1) + j*(2*(nx3_+nx1_+nx2_)+1) + i;
+        cte(cellCt, 1) = ny1_*(2*(nx1_+nx2_)+1) + j*(2*(nx3_+nx1_+nx2_)+1) + (nx3_+nx1_+nx2_) + (i+1);
+        cte(cellCt, 2) = ny1_*(2*(nx1_+nx2_)+1) + (j+1)*(2*(nx3_+nx1_+nx2_)+1) + i;
+        cte(cellCt, 3) = ny1_*(2*(nx1_+nx2_)+1) + j*(2*(nx3_+nx1_+nx2_)+1) + (nx3_+nx1_+nx2_) + i;
+        ++cellCt;
+      }
+    }
+
+  } // computeCellToEdgeMap
+
+
+  void setRefinementLevel(const int &refLevel) {
+    ref_ = refLevel;
+    computeNodes();
+    computeCellToNodeMap();
+    computeCellToEdgeMap();
+  } // setRefinementLevel
+
+
+  virtual void computeSideSets() {
+
+    meshSideSets_ = ROL::makePtr<std::vector<std::vector<std::vector<int> > >>(11);
+    int numSides = 4;
+    (*meshSideSets_)[0].resize(numSides); // bottom
+    (*meshSideSets_)[1].resize(numSides); // right lower
+    (*meshSideSets_)[2].resize(numSides); // right upper
+    (*meshSideSets_)[3].resize(numSides); // top
+    (*meshSideSets_)[4].resize(numSides); // left upper
+    (*meshSideSets_)[5].resize(numSides); // middle
+    (*meshSideSets_)[6].resize(numSides); // left lower
+    (*meshSideSets_)[7].resize(1); // L-corner cell
+    (*meshSideSets_)[8].resize(numSides); // top corner cell
+    (*meshSideSets_)[9].resize(1); // between side 2 and 3
+    (*meshSideSets_)[10].resize(numSides); // top corner cell
+    (*meshSideSets_)[0][0].resize(nx1_+nx2_);
+    (*meshSideSets_)[1][1].resize(ny2_);
+    (*meshSideSets_)[2][1].resize(ny5_);
+    (*meshSideSets_)[3][2].resize(nx3_+nx4_+nx5_);
+    (*meshSideSets_)[4][3].resize(ny3_);
+    (*meshSideSets_)[5][0].resize(nx3_);
+    (*meshSideSets_)[6][3].resize(ny1_-1);
+    (*meshSideSets_)[7][0].resize(1);
+    (*meshSideSets_)[8][3].resize(1);
+    (*meshSideSets_)[9][0].resize(1);
+    (*meshSideSets_)[10][3].resize(ny1_);
+
+    for (int i=0; i<nx1_+nx2_; ++i) {
+      (*meshSideSets_)[0][0][i] = i;
+    }
+    for (int i=0; i<ny2_; ++i) {
+      (*meshSideSets_)[1][1][i] = (i+1)*(nx1_+nx2_) - 1;
+    }
+    int offset = nx1_*ny1_+nx2_*ny2_;
+    for (int i=0; i<ny5_; ++i) {
+      (*meshSideSets_)[2][1][i] = offset + (i+1)*(nx3_+nx4_+nx5_) - 1;
+    }
+    for (int i=0; i<nx3_+nx4_+nx5_; ++i) {
+      (*meshSideSets_)[3][2][i] = offset + (ny3_-1)*(nx3_+nx4_+nx5_) + i;
+    }
+    for (int i=0; i<ny3_; ++i) {
+      (*meshSideSets_)[4][3][i] = offset + i*(nx3_+nx4_+nx5_);
+    }
+    for (int i=0; i<nx3_; ++i) {
+      (*meshSideSets_)[5][0][i] = offset + i;
+    }
+    for (int i=0; i<ny1_-1; ++i) {
+      (*meshSideSets_)[6][3][i] = i*(nx1_+nx2_);
+    }
+    (*meshSideSets_)[7][0][0] = offset + nx3_;
+    (*meshSideSets_)[8][3][0] = (ny1_-1)*(nx1_+nx2_);
+    (*meshSideSets_)[9][0][0] = offset + ny5_*(nx3_+nx4_+nx5_) - 1;
+    for (int i=0; i<ny1_; ++i) {
+      (*meshSideSets_)[10][3][i] = i*(nx1_+nx2_);
+    }
+
+  } // computeSideSets
+
+}; // MeshManager_BackwardFacingStepChannel
+
+
+
+/** \class  MeshManager_Rectangle
+    \brief  Mesh construction and mesh management for the
+            rectangle geometry, on quadrilateral grids.
+*/
+template <class Real, class DeviceType>
+class MeshManager_Rectangle : public MeshManager<Real, DeviceType> {
+
+/* Rectangle geometry.
+ 
+      ***********************
+      *                     *   :
+      *                     *   |
+      *                     * height
+      *                     *   |
+      *                     *   :
+      *                     *
+      ***********************
+  (X0,Y0)   :--width--:
+
+*/
+
+public:
+  using scalar_view = typename MeshManager<Real,DeviceType>::scalar_view;
+  using int_view = typename MeshManager<Real,DeviceType>::int_view;
+
+private:
+  Real width_;   // rectangle height
+  Real height_;  // rectangle width
+  Real X0_;      // x coordinate of bottom left corner
+  Real Y0_;      // y coordinate of bottom left corner
+
+  int nx_;
+  int ny_;
+
+  int numCells_;
+  int numNodes_;
+  int numEdges_;
+
+  scalar_view meshNodes_;
+  int_view    meshCellToNodeMap_;
+  int_view    meshCellToEdgeMap_;
+
+  ROL::Ptr<std::vector<std::vector<std::vector<int> > > >  meshSideSets_;
+
+public:
+
+  MeshManager_Rectangle(Teuchos::ParameterList &parlist) {
+    // Geometry data.
+    width_  = parlist.sublist("Geometry").get( "Width", 3.0);
+    height_ = parlist.sublist("Geometry").get("Height", 1.0);
+    X0_     = parlist.sublist("Geometry").get(    "X0", 0.0);
+    Y0_     = parlist.sublist("Geometry").get(    "Y0", 0.0);
+    // Mesh data.
+    nx_ = parlist.sublist("Geometry").get("NX", 3);
+    ny_ = parlist.sublist("Geometry").get("NY", 1);
+    numCells_ = nx_ * ny_;
+    numNodes_ = (nx_+1) * (ny_+1);
+    numEdges_ = (nx_+1)*ny_ + (ny_+1)*nx_;
+    // Compute and store mesh data structures.
+    computeNodes();
+    computeCellToNodeMap();
+    computeCellToEdgeMap();
+    computeSideSets();
+  }
+
+
+  scalar_view getNodes() const override {
+    return meshNodes_;
+  }
+
+
+  int_view getCellToNodeMap() const override {
+    return meshCellToNodeMap_;
+  }
+
+
+  int_view getCellToEdgeMap() const override {
+    return meshCellToEdgeMap_;
+  }
+
+
+  virtual ROL::Ptr<std::vector<std::vector<std::vector<int> > > > getSideSets(
+              const bool verbose = false,
+              std::ostream & outStream = std::cout) const override { 
+    return meshSideSets_;
+  }
+
+
+  int getNumCells() const override {
+    return numCells_;
+  } // getNumCells
+
+
+  int getNumNodes() const override {
+    return numNodes_;
+  } // getNumNodes
+
+
+  int getNumEdges() const override {
+    return numEdges_;
+  } // getNumEdges
+
+private:
+
+  void computeNodes() {
+
+    meshNodes_ = scalar_view("meshNodes_", numNodes_, 2);
+    auto nodes = meshNodes_;
+
+    Real dx = width_ / nx_;
+    Real dy = height_ / ny_;
+    int nodeCt = 0;
+
+    for (int j=0; j<=ny_; ++j) {
+      Real ycoord = Y0_ + j*dy;
+      for (int i=0; i<=nx_; ++i) {
+        nodes(nodeCt, 0) = X0_ + i*dx;
+        nodes(nodeCt, 1) = ycoord; 
+        ++nodeCt;
+      }
+    }
+
+  } // computeNodes
+
+
+  void computeCellToNodeMap() {
+
+    meshCellToNodeMap_ = int_view("meshCellToNodeMap_", numCells_, 4);
+    auto ctn = meshCellToNodeMap_;
+
+    int cellCt = 0;
+
+    for (int j=0; j<ny_; ++j) {
+      for (int i=0; i<nx_; ++i) {
+        ctn(cellCt, 0) = j*(nx_+1) + i;
+        ctn(cellCt, 1) = j*(nx_+1) + (i+1);
+        ctn(cellCt, 2) = (j+1)*(nx_+1) + (i+1);
+        ctn(cellCt, 3) = (j+1)*(nx_+1) + i;
+        ++cellCt;
+      }
+    }
+
+  } // computeCellToNodeMap
+
+
+  void computeCellToEdgeMap() {
+
+    meshCellToEdgeMap_ = int_view("meshCellToEdgeMap_", numCells_, 4);
+    auto cte = meshCellToEdgeMap_;
+
+    int cellCt = 0;
+
+    for (int j=0; j<ny_; ++j) {
+      for (int i=0; i<nx_; ++i) {
+        cte(cellCt, 0) = j*(2*nx_+1) + i;
+        cte(cellCt, 1) = j*(2*nx_+1) + nx_ + (i+1);
+        cte(cellCt, 2) = (j+1)*(2*nx_+1) + i;
+        cte(cellCt, 3) = j*(2*nx_+1) + nx_ + i;
+        ++cellCt;
+      }
+    }
+
+  } // computeCellToEdgeMap
+
+
+  virtual void computeSideSets() {
+
+    meshSideSets_ = ROL::makePtr<std::vector<std::vector<std::vector<int> > >>(1);
+    int numSides = 4;
+    (*meshSideSets_)[0].resize(numSides);
+    (*meshSideSets_)[0][0].resize(nx_);
+    (*meshSideSets_)[0][1].resize(ny_);
+    (*meshSideSets_)[0][2].resize(nx_);
+    (*meshSideSets_)[0][3].resize(ny_);
+
+    for (int i=0; i<nx_; ++i) {
+      (*meshSideSets_)[0][0][i] = i;
+    }
+    for (int i=0; i<ny_; ++i) {
+      (*meshSideSets_)[0][1][i] = (i+1)*nx_-1;
+    }
+    for (int i=0; i<nx_; ++i) {
+      (*meshSideSets_)[0][2][i] = i + nx_*(ny_-1);
+    }
+    for (int i=0; i<ny_; ++i) {
+      (*meshSideSets_)[0][3][i] = i*nx_;
+    }
+
+  } // computeSideSets
+
+
+}; // MeshManager_Rectangle
+
+
+template<class Real, class DeviceType>
+class MeshManager_Interval : public MeshManager<Real, DeviceType> {
+
+/* Interval geometry [X0,X0+width] */
+
+public:
+  using scalar_view = typename MeshManager<Real,DeviceType>::scalar_view;
+  using int_view = typename MeshManager<Real,DeviceType>::int_view;
+
+private:
+  Real width_;    // Interval width
+  Real X0_;       // x coordinate left corner
+
+  int nx_;
+
+  int numCells_;
+  int numNodes_;
+
+  scalar_view meshNodes_;
+  int_view meshCellToNodeMap_;
+
+  ROL::Ptr<std::vector<std::vector<std::vector<int> > > > meshSideSets_;
+
+public:
+
+  MeshManager_Interval(Teuchos::ParameterList &parlist) {
+
+    // Geometry data
+    width_    = parlist.sublist("Geometry").get("Width", 1.0);
+    X0_       = parlist.sublist("Geometry").get("X0", 0.0);
+
+    // Mesh data
+    nx_       = parlist.sublist("Geometry").get("NX",10);
+
+    numCells_ = nx_;
+    numNodes_ = nx_+1;
+
+    // Compute and store mesh data structures
+    computeNodes();
+    computeCellToNodeMap();
+    computeSideSets();
+
+  }
+
+  scalar_view getNodes() const override {
+    return meshNodes_;
+  }
+
+  int_view getCellToNodeMap() const override {
+    return meshCellToNodeMap_;
+  }
+
+  ROL::Ptr<std::vector<std::vector<std::vector<int> > > > getSideSets(
+              const bool verbose = false,
+              std::ostream & outStream = std::cout) const override {
+    return meshSideSets_;
+  }
+
+  int getNumCells() const override {
+    return numCells_;
+  }
+
+  int getNumNodes() const override {
+    return numNodes_;
+  } // getNumNodes
+
+
+private:
+
+  void computeNodes() {
+
+    meshNodes_ = scalar_view("meshNodes_", numNodes_,1);
+    auto nodes = meshNodes_;
+
+    Real dx = width_ / nx_;
+
+    for( int i=0; i<nx_+1; ++i ) {
+      nodes(i, 0) = X0_ + i*dx;
+    }
+  } // computeNodes
+
+
+  void computeCellToNodeMap() {
+
+    meshCellToNodeMap_ = int_view("meshCellToNodeMap_", numCells_,2);
+    auto ctn = meshCellToNodeMap_;
+
+    for( int i=0; i<nx_; ++i ) {
+      ctn(i,0) = i;
+      ctn(i,1) = i+1;
+    }
+  } // computeCellToNodeMap
+
+
+  virtual void computeSideSets() {
+    int numSideSets = 2;
+    int numSides = 2;
+    meshSideSets_
+      = ROL::makePtr<std::vector<std::vector<std::vector<int> > >>(numSideSets);
+
+    (*meshSideSets_)[0].resize(numSides);
+    (*meshSideSets_)[0][0].resize(1);
+    (*meshSideSets_)[0][0][0] = 0;
+    (*meshSideSets_)[0][1].resize(0);
+
+    (*meshSideSets_)[1].resize(numSides);
+    (*meshSideSets_)[1][0].resize(0);
+    (*meshSideSets_)[1][1].resize(1);
+    (*meshSideSets_)[1][1][0] = numCells_-1;
+
+  } // computeSideSets
+
+}; // MeshManager_Interval
+
+
+template<class Real, class DeviceType>
+class MeshManager_Fractional_Cylinder : public MeshManager<Real, DeviceType> {
+
+/* Line geometry [X0,X0+width] */
+
+public:
+  using scalar_view = typename MeshManager<Real,DeviceType>::scalar_view;
+  using int_view = typename MeshManager<Real,DeviceType>::int_view;
+
+private:
+  Real width_;    // Interval width
+  Real X0_;       // x coordinate left corner
+
+  int nx_;
+
+  Real gamma_;
+
+  int numCells_;
+  int numNodes_;
+  int numEdges_;
+
+  scalar_view meshNodes_;
+  int_view    meshCellToNodeMap_;
+  int_view    meshCellToEdgeMap_;
+
+  ROL::Ptr<std::vector<std::vector<std::vector<int> > > > meshSideSets_;
+
+public:
+
+  MeshManager_Fractional_Cylinder(Teuchos::ParameterList &parlist) : X0_(0) {
+    // Mesh data
+    gamma_ = parlist.sublist("Geometry").sublist("Cylinder").get("Grading Parameter",0.5);
+    nx_    = parlist.sublist("Geometry").sublist("Cylinder").get("NI",10);
+    width_ = parlist.sublist("Geometry").sublist("Cylinder").get("Height",2.0);
+
+    std::cout << "GAMMA: " << gamma_ << "  NX: " << nx_ << "  WIDTH: " << width_ << std::endl;
+
+    numCells_ = nx_;
+    numNodes_ = nx_+1;
+    numEdges_ = 2;
+
+    std::cout << "NUMCELLS: " << numCells_ << "  NUMNODES: " << numNodes_ << "  NUMEDGES: " << numEdges_ << std::endl;
+
+    // Compute and store mesh data structures
+    computeNodes();
+    computeCellToNodeMap();
+    computeCellToEdgeMap();
+    computeSideSets();
+  }
+
+  scalar_view getNodes() const override {
+    return meshNodes_;
+  }
+
+  int_view getCellToNodeMap() const override {
+    return meshCellToNodeMap_; 
+  }
+
+  int_view getCellToEdgeMap() const override {
+    return meshCellToEdgeMap_;
+  }
+
+  ROL::Ptr<std::vector<std::vector<std::vector<int> > > > getSideSets(
+              const bool verbose = false,
+              std::ostream & outStream = std::cout) const override { 
+    return meshSideSets_;
+  }
+
+  int getNumCells() const override {
+    return numCells_;
+  }
+
+  int getNumNodes() const override {
+    return numNodes_;
+  } // getNumNodes
+
+
+  int getNumEdges() const override {
+    return numEdges_;
+  } // getNumEdges
+
+
+private:
+
+  void computeNodes() {
+    meshNodes_ = scalar_view("meshNodes_", numNodes_,1);
+
+    for( int i=0; i<nx_+1; ++i ) {
+      meshNodes_(i, 0) = X0_ + std::pow(static_cast<Real>(i)/nx_,gamma_) * width_;
+    }
+  } // computeNodes
+
+
+  void computeCellToNodeMap() {
+    meshCellToNodeMap_ = int_view("meshCellToNodeMap_", numCells_,2);
+
+    for( int i=0; i<nx_; ++i ) {
+      meshCellToNodeMap_(i,0) = i;
+      meshCellToNodeMap_(i,1) = i+1;
+    }
+  } // computeCellToNodeMap
+
+
+  void computeCellToEdgeMap() {
+    meshCellToEdgeMap_ = int_view("meshCellToEdgeMap_", numCells_,1);
+
+    for( int i=0; i<nx_; ++i ) {
+      meshCellToEdgeMap_(i,0) = i;
+    }
+  } // computeCellToEdgeMap
+
+
+  virtual void computeSideSets() {
+    int numSideSets = 2;
+    int numSides = 2;
+    meshSideSets_
+      = ROL::makePtr<std::vector<std::vector<std::vector<int> > >>(numSideSets);
+
+    (*meshSideSets_)[0].resize(numSides);
+    (*meshSideSets_)[0][0].resize(1);
+    (*meshSideSets_)[0][0][0] = 0;
+    (*meshSideSets_)[0][1].resize(0);
+
+    (*meshSideSets_)[1].resize(numSides);
+    (*meshSideSets_)[1][0].resize(0);
+    (*meshSideSets_)[1][1].resize(1);
+    (*meshSideSets_)[1][1][0] = numCells_-1;
+
+  } // computeSideSets
+
+}; // MeshManager_Fractional_Cylinder
+
+
+/** \class  MeshManager_Brick
+    \brief  Mesh construction and mesh management for the
+            brick geometry, on hexahedral grids.
+*/
+template <class Real, class DeviceType>
+class MeshManager_Brick : public MeshManager<Real, DeviceType> {
+
+/* Brick geometry.
+
+                   ***********************
+                 *                     * *
+  :--depth--:  *                     *   *
+             *                     *     *
+           ***********************       *
+           *                     *   :   *
+           *                     *   |   *
+           *                     * height
+           *                     *   |
+           *                     *   :
+           *                     * *
+           ***********************
+      (X0,Y0,Z0) :--width--:
+
+  (X0,Y0,Z0) denote the *smallest* values of each coordinate.
+
+*/
+
+public:
+  using scalar_view = typename MeshManager<Real,DeviceType>::scalar_view;
+  using int_view = typename MeshManager<Real,DeviceType>::int_view;
+
+private:
+  Real width_;   // rectangle width
+  Real depth_;   // rectangle depth
+  Real height_;  // rectangle height
+  Real X0_;      // x coordinate of bottom left front corner
+  Real Y0_;      // y coordinate of bottom left front corner
+  Real Z0_;      // z coordinate of bottom left front corner
+
+  int nx_;
+  int ny_;
+  int nz_;
+
+  int numCells_;
+  int numNodes_;
+  int numEdges_;
+
+  scalar_view meshNodes_;
+  int_view  meshCellToNodeMap_;
+  int_view  meshCellToEdgeMap_;
+
+  ROL::Ptr<std::vector<std::vector<std::vector<int> > > >  meshSideSets_;
+
+public:
+
+  MeshManager_Brick(Teuchos::ParameterList &parlist) {
+    // Geometry data.
+    width_  = parlist.sublist("Geometry").get( "Width", 3.0);
+    depth_  = parlist.sublist("Geometry").get( "Depth", 2.0);
+    height_ = parlist.sublist("Geometry").get("Height", 1.0);
+    X0_     = parlist.sublist("Geometry").get(    "X0", 0.0);
+    Y0_     = parlist.sublist("Geometry").get(    "Y0", 0.0);
+    Z0_     = parlist.sublist("Geometry").get(    "Z0", 0.0);
+    // Mesh data.
+    nx_ = parlist.sublist("Geometry").get("NX", 3);
+    ny_ = parlist.sublist("Geometry").get("NY", 2);
+    nz_ = parlist.sublist("Geometry").get("NZ", 1);
+    numCells_ = nx_ * ny_ * nz_;
+    numNodes_ = (nx_+1) * (ny_+1) * (nz_+1);
+    numEdges_ = ((nx_+1)*ny_ + (ny_+1)*nx_)*(nz_+1) + (nx_+1)*(ny_+1)*nz_;
+    // Compute and store mesh data structures.
+    computeNodes(); 
+    computeCellToNodeMap(); 
+    computeCellToEdgeMap();
+    computeSideSets();
+  }
+
+
+  scalar_view getNodes() const override {
+    return meshNodes_;
+  }
+
+
+  int_view getCellToNodeMap() const override {
+    return meshCellToNodeMap_;
+  }
+
+
+  int_view getCellToEdgeMap() const override {
+    return meshCellToEdgeMap_;
+  }
+
+
+  ROL::Ptr<std::vector<std::vector<std::vector<int> > > > getSideSets(
+              const bool verbose = false,
+              std::ostream & outStream = std::cout) const override { 
+    return meshSideSets_;
+  }
+
+
+  int getNumCells() const override {
+    return numCells_;
+  } // getNumCells
+
+
+  int getNumNodes() const override {
+    return numNodes_;
+  } // getNumNodes
+
+
+  int getNumEdges() const override {
+    return numEdges_;
+  } // getNumEdges
+
+private:
+
+  void computeNodes() {
+
+    meshNodes_ = scalar_view("meshNodes_", numNodes_, 3);
+
+    Real dx = width_ / nx_;
+    Real dy = depth_ / ny_;
+    Real dz = height_ / nz_;
+    int nodeCt = 0;
+
+    for (int k=0; k<=nz_; ++k) {
+      Real zcoord = Z0_ + k*dz;
+      for (int j=0; j<=ny_; ++j) {
+        Real ycoord = Y0_ + j*dy;
+        for (int i=0; i<=nx_; ++i) {
+          meshNodes_(nodeCt, 0) = X0_ + i*dx;
+          meshNodes_(nodeCt, 1) = ycoord; 
+          meshNodes_(nodeCt, 2) = zcoord; 
+          ++nodeCt;
+        }
+      }
+    }
+
+  } // computeNodes
+
+
+  void computeCellToNodeMap() {
+
+    meshCellToNodeMap_ = int_view("meshCellToNodeMap_", numCells_, 8);
+    auto ctn = meshCellToNodeMap_;
+
+    int cellCt = 0;
+
+    int numNodesXY = (nx_+1)*(ny_+1);
+
+    for (int k=0; k<nz_; ++k) {
+      for (int j=0; j<ny_; ++j) {
+        for (int i=0; i<nx_; ++i) {
+          //
+          ctn(cellCt, 0) = k*numNodesXY + j*(nx_+1) + i;
+          ctn(cellCt, 1) = k*numNodesXY + j*(nx_+1) + (i+1);
+          ctn(cellCt, 2) = k*numNodesXY + (j+1)*(nx_+1) + (i+1);
+          ctn(cellCt, 3) = k*numNodesXY + (j+1)*(nx_+1) + i;
+          //
+          ctn(cellCt, 4) = (k+1)*numNodesXY + j*(nx_+1) + i;
+          ctn(cellCt, 5) = (k+1)*numNodesXY + j*(nx_+1) + (i+1);
+          ctn(cellCt, 6) = (k+1)*numNodesXY + (j+1)*(nx_+1) + (i+1);
+          ctn(cellCt, 7) = (k+1)*numNodesXY + (j+1)*(nx_+1) + i;
+          //
+          ++cellCt;
+        }
+      }
+    }
+
+  } // computeCellToNodeMap
+
+
+  void computeCellToEdgeMap() {
+
+    meshCellToEdgeMap_ = int_view("meshCellToEdgeMap_", numCells_, 12);
+    auto cte = meshCellToEdgeMap_;
+
+    int cellCt = 0;
+
+    int numEdgesXY  = ((nx_+1)*ny_ + (ny_+1)*nx_);
+    int numEdgesZ   = (nx_+1)*(ny_+1);
+    int numEdgesXYZ = numEdgesXY + numEdgesZ;
+
+    for (int k=0; k<nz_; ++k) {
+      for (int j=0; j<ny_; ++j) {
+        for (int i=0; i<nx_; ++i) {
+          // bottom
+          cte(cellCt,  0) = k*numEdgesXYZ + j*(2*nx_+1) + i;
+          cte(cellCt,  1) = k*numEdgesXYZ + j*(2*nx_+1) + nx_ + (i+1);
+          cte(cellCt,  2) = k*numEdgesXYZ + (j+1)*(2*nx_+1) + i;
+          cte(cellCt,  3) = k*numEdgesXYZ + j*(2*nx_+1) + nx_ + i;
+          // verticals
+          cte(cellCt,  8) = k*numEdgesXYZ + numEdgesXY + j*(nx_+1) + i;
+          cte(cellCt,  9) = k*numEdgesXYZ + numEdgesXY + j*(nx_+1) + (i+1);
+          cte(cellCt, 10) = k*numEdgesXYZ + numEdgesXY + (j+1)*(nx_+1) + (i+1);
+          cte(cellCt, 11) = k*numEdgesXYZ + numEdgesXY + (j+1)*(nx_+1) + i;
+          // top
+          cte(cellCt,  4) = (k+1)*numEdgesXYZ + j*(2*nx_+1) + i;
+          cte(cellCt,  5) = (k+1)*numEdgesXYZ + j*(2*nx_+1) + nx_ + (i+1);
+          cte(cellCt,  6) = (k+1)*numEdgesXYZ + (j+1)*(2*nx_+1) + i;
+          cte(cellCt,  7) = (k+1)*numEdgesXYZ + j*(2*nx_+1) + nx_ + i;
+          ++cellCt;
+        }
+      }
+    }
+
+  } // computeCellToEdgeMap
+
+
+  virtual void computeSideSets() {
+
+    // single sideset (all of the boundary)
+    meshSideSets_ = ROL::makePtr<std::vector<std::vector<std::vector<int> > >>(1);
+    // the sideset has six sides with local side ids from 0 to 5
+    int numSides = 6;
+    (*meshSideSets_)[0].resize(numSides);
+    (*meshSideSets_)[0][0].resize(nx_*nz_);
+    (*meshSideSets_)[0][1].resize(ny_*nz_);
+    (*meshSideSets_)[0][2].resize(nx_*nz_);
+    (*meshSideSets_)[0][3].resize(ny_*nz_);
+    (*meshSideSets_)[0][4].resize(nx_*ny_);
+    (*meshSideSets_)[0][5].resize(nx_*ny_);
+
+    int nxny = nx_*ny_;
+
+    for (int j=0; j<nz_; ++j) {
+      for (int i=0; i<nx_; ++i) {
+        (*meshSideSets_)[0][0][i+nx_*j] = i+nxny*j;
+      }
+    }
+    for (int j=0; j<nz_; ++j) {
+      for (int i=0; i<ny_; ++i) {
+        (*meshSideSets_)[0][1][i+ny_*j] = (i+1)*nx_-1 + nxny*j;
+      }
+    }
+    for (int j=0; j<nz_; ++j) {
+      for (int i=0; i<nx_; ++i) {
+        (*meshSideSets_)[0][2][i+nx_*j] = nx_*(ny_-1) + i + nxny*j;
+      }
+    }
+    for (int j=0; j<nz_; ++j) {
+      for (int i=0; i<ny_; ++i) {
+        (*meshSideSets_)[0][3][i+ny_*j] = i*nx_ + nxny*j;
+      }
+    }
+    for (int j=0; j<ny_; ++j) {
+      for (int i=0; i<nx_; ++i) {
+        (*meshSideSets_)[0][4][i+nx_*j] = i + nx_*j;
+      }
+    }
+    for (int j=0; j<ny_; ++j) {
+      for (int i=0; i<nx_; ++i) {
+        (*meshSideSets_)[0][5][i+nx_*j] = i + nx_*j + nxny*(nz_-1);
+      }
+    }
+
+  } // computeSideSets
+
+
+}; // MeshManager_Brick
+
+#endif

--- a/packages/rol/example/PDE-OPT/TOOLS/meshreaderK.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/meshreaderK.hpp
@@ -1,0 +1,617 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  meshreaderK.hpp
+    \brief Defines the MeshReader class.
+*/
+
+#ifndef MESHREADERK_HPP
+#define MESHREADERK_HPP
+
+#include "Shards_CellTopology.hpp"
+#include "ROL_Types.hpp"
+
+#include <iostream>
+#include <fstream>
+#include <cstring>
+#include "meshmanagerK.hpp"
+
+
+/** \class  MeshReader
+    \brief  This class implements the pure virtual MeshManager interface,
+            through methods that read in text (ASCII) files generated
+            from Exodus mesh files using the 'ncdump' tool.
+*/
+template <class Real, class DeviceType>
+class MeshReader : public MeshManager<Real, DeviceType> {
+
+public:
+  using scalar_view = Kokkos::DynRankView<Real, DeviceType>;
+  using int_view = Kokkos::DynRankView<int, DeviceType>;
+
+
+private:
+
+  Teuchos::ParameterList parlist_;
+
+  int spaceDim_;
+  int numNodes_;
+  int numCells_;
+  int numEdges_;
+  int numFaces_;
+  int numSideSets_;
+  int numNodesPerCell_;
+  int numEdgesPerCell_;
+  int numFacesPerCell_;
+  int numNodesPerFace_;
+  int numProcs_;
+
+  ROL::Ptr<shards::CellTopology> cellTopo_;
+
+  scalar_view meshNodes_;
+  int_view  meshCellToNodeMap_;
+  int_view  meshCellToEdgeMap_;
+  int_view  meshCellToFaceMap_;
+
+  ROL::Ptr<std::vector<std::vector<std::vector<int>>>>  meshSideSets_;
+
+  ROL::Ptr<std::vector<std::vector<int>>>  procCellIds_;
+
+public:
+
+  /** \brief Constructor.  Parses the mesh file, and fills all data structures.
+  */
+  MeshReader(Teuchos::ParameterList & parlist, int numProcs = 0) : parlist_(parlist),
+      spaceDim_(0), numNodes_(0), numCells_(0), numEdges_(0), numFaces_(0),
+      numSideSets_(0), numNodesPerCell_(0), numEdgesPerCell_(0), numFacesPerCell_(0),
+      numNodesPerFace_(0) {
+    std::string   filename = parlist.sublist("Mesh").get("File Name", "mesh.txt");
+    std::ifstream inputfile;
+    std::string   line;
+    std::string   token;
+    std::string   shape;
+
+    inputfile.open(filename);
+
+    // Check if file readable.
+    if (!inputfile.good()) {
+      throw std::runtime_error("\nMeshReader: Could not open mesh file!\n");
+    }
+
+    // Parse file header.
+    bool processHeader = true;
+    while (processHeader) {
+
+      std::getline(inputfile, line);    // consider: while (getline(inputfile, line).good())
+      std::stringstream ssline(line);
+
+      while (ssline >> token) {
+
+        // Get space dimension.
+        if (token == "num_dim") {
+          ssline >> token;  // skip "="
+          ssline >> spaceDim_;
+          break;
+        }
+
+        // Get number of nodes.
+        if (token == "num_nodes") {
+          ssline >> token;  // skip "="
+          ssline >> numNodes_;
+          break;
+        }
+
+        // Get number of cells.
+        if (token == "num_elem") {
+          ssline >> token;  // skip "="
+          ssline >> numCells_;
+          break;
+        }
+
+        // Get number of sidesets.
+        if (token == "num_side_sets") {
+          ssline >> token;  // skip "="
+          ssline >> numSideSets_;
+          break;
+        }
+
+        // Get cell shape.
+        if (token == "connect1:elem_type") {
+          ssline >> token;  // skip "="
+          ssline >> shape;
+          processHeader = false;
+          break;
+        }
+
+      } // end tokenizing
+
+    } // end parse header
+
+    if (shape.find("TRI") != std::string::npos) {
+      cellTopo_ = ROL::makePtr<shards::CellTopology>( shards::getCellTopologyData<shards::Triangle<3>>() );
+    }
+    else if (shape.find("QUAD") != std::string::npos) {
+      cellTopo_ = ROL::makePtr<shards::CellTopology>( shards::getCellTopologyData<shards::Quadrilateral<4>>() );
+    }
+    else if (shape.find("TET") != std::string::npos) {
+      cellTopo_ = ROL::makePtr<shards::CellTopology>( shards::getCellTopologyData<shards::Tetrahedron<4>>() );
+    }
+    else if (shape.find("HEX") != std::string::npos) {
+      cellTopo_ = ROL::makePtr<shards::CellTopology>( shards::getCellTopologyData<shards::Hexahedron<8>>() );
+    }
+    else {
+      std::cout << shape << std::endl;
+      throw ROL::Exception::NotImplemented(">>> Cell shape not recognized!");
+    }
+
+    // Set up internal storage.
+    numNodesPerCell_ = cellTopo_->getVertexCount();
+    numFacesPerCell_ = cellTopo_->getFaceCount();
+    numEdgesPerCell_ = cellTopo_->getEdgeCount();
+    numNodesPerFace_ = cellTopo_->getVertexCount(2,0);
+    meshNodes_ = scalar_view("meshNodes_", numNodes_, spaceDim_);
+    meshCellToNodeMap_ = int_view("meshCellToNodeMap_", numCells_, numNodesPerCell_);
+
+    // Parse node coordinates.
+    std::vector<int> coordCount(3, 0);
+    std::vector<std::string> coordLabel(3);
+    coordLabel[0] = "coordx";
+    coordLabel[1] = "coordy";
+    coordLabel[2] = "coordz";
+    char semicolon = ';';
+
+    for (int d=0; d<spaceDim_; ++d) {
+
+      bool processCoordsHeader = true;
+      while (processCoordsHeader) {
+
+        std::getline(inputfile, line);
+        std::stringstream ssline(line);
+
+        while (ssline >> token) {
+
+          // Get node coordinates.
+          if (token == coordLabel[d]) {
+            ssline >> token;  // skip "="
+            while (std::getline(ssline, token, ',')) {
+              if (token != " ") {
+                meshNodes_(coordCount[d]++, d) = atof(token.c_str());
+              }
+            }
+            processCoordsHeader = false;
+          }
+        }
+
+      }
+
+      bool processCoords = true;
+      if (token.find(semicolon) != std::string::npos) {
+        processCoords = false;
+      }
+      while (processCoords) {
+
+        std::getline(inputfile, line);
+        std::stringstream ssline(line);
+
+        while (std::getline(ssline, token, ',')) {
+          // Get node coordinates.
+          if (token.find(semicolon) == std::string::npos) {
+            if (token != " ") {
+              meshNodes_(coordCount[d]++, d) = atof(token.c_str());
+            }
+          }
+          else { // encountered "some-number ;"
+            std::string onlyNumber = token.substr(0, token.size()-1);
+            meshNodes_(coordCount[d]++, d) = atof(onlyNumber.c_str());
+            processCoords = false;
+          }
+        }
+      } // end process coords
+
+    } // end dimension loop
+
+
+    // Find connectivity information.
+    bool searchConnect = true;
+    while (searchConnect) {
+
+      std::getline(inputfile, line);
+      std::stringstream ssline(line);
+
+      while (ssline >> token) {
+        if (token == "connect1") { // found connectivity, cell-to-node map
+          searchConnect = false;
+          break;
+        }
+      }
+    }
+
+    // Process connectivity information.
+    bool processConnectivity = true;
+    int  cellCount = 0;
+    int  nodeId = 0;
+    while (processConnectivity) {
+
+      std::getline(inputfile, line);
+      std::stringstream ssline(line);
+
+      while (std::getline(ssline, token, ',')) {
+        // Get node ids.
+        if (token.find(semicolon) == std::string::npos) {
+          if (token != " ") {
+            meshCellToNodeMap_(cellCount, nodeId++) = atoi(token.c_str())-1;
+            if (nodeId == numNodesPerCell_) {
+              nodeId = 0;
+              cellCount++;
+            }
+          }
+        }
+        else { // encountered "some-number ;"
+          std::string onlyNumber = token.substr(0, token.size()-1);
+          meshCellToNodeMap_(cellCount, numNodesPerCell_-1) = atoi(onlyNumber.c_str())-1;
+          processConnectivity = false;
+        }
+      }
+    } // end process connectivity
+
+
+    // Parse side sets.
+    meshSideSets_ = ROL::makePtr<std::vector<std::vector<std::vector<int>>>>(numSideSets_);
+    for (int ss=0; ss<numSideSets_; ++ss) {
+      if (spaceDim_ == 2) {
+        (*meshSideSets_)[ss].resize(numEdgesPerCell_);
+      }
+      else if (spaceDim_ == 3) {
+        (*meshSideSets_)[ss].resize(numFacesPerCell_);
+      }
+    }
+    std::vector<int> ssCellIds;
+
+    for (int ss=0; ss<numSideSets_; ++ss) {
+
+      ssCellIds.clear();
+
+      bool processSSHeaderCell = true;
+      while (processSSHeaderCell) {
+
+        std::getline(inputfile, line);
+        std::stringstream ssline(line);
+
+        while (ssline >> token) {
+
+          // Get cell ids.
+          if (token.substr(0,7) == "elem_ss") {
+            ssline >> token;  // skip "="
+            while (std::getline(ssline, token, ',')) {
+              if (token != " ") {
+                ssCellIds.push_back(atoi(token.c_str())-1);
+              }
+            }
+            processSSHeaderCell = false;
+          }
+        }
+
+      }
+
+      bool processSSCell = true;
+      if (token.find(semicolon) != std::string::npos) {
+        processSSCell = false;
+      }
+      while (processSSCell) {
+
+        std::getline(inputfile, line);
+        std::stringstream ssline(line);
+
+        while (std::getline(ssline, token, ',')) {
+          // Get cell ids.
+          if (token.find(semicolon) == std::string::npos) {
+            if (token != " ") {
+              ssCellIds.push_back(atoi(token.c_str())-1);
+            }
+          }
+          else { // encountered "some-number ;"
+            std::string onlyNumber = token.substr(0, token.size()-1);
+            ssCellIds.push_back(atoi(token.c_str())-1);
+            processSSCell = false;
+          }
+        }
+      } // end process side set cells
+
+      bool processSSHeaderSide = true;
+      int cellIdx = 0;
+      while (processSSHeaderSide) {
+
+        std::getline(inputfile, line);
+        std::stringstream ssline(line);
+
+        while (ssline >> token) {
+
+          // Get local side ids.
+          if (token.substr(0,7) == "side_ss") {
+            ssline >> token;  // skip "="
+            while (std::getline(ssline, token, ',')) {
+              if (token != " ") {
+                (*meshSideSets_)[ss][atoi(token.c_str())-1].push_back(ssCellIds[cellIdx]);
+                cellIdx++;
+              }
+            }
+            processSSHeaderSide = false;
+          }
+        }
+
+      }
+
+      bool processSSSide = true;
+      if (token.find(semicolon) != std::string::npos) {
+        processSSSide = false;
+      }
+      while (processSSSide) {
+
+        std::getline(inputfile, line);
+        std::stringstream ssline(line);
+
+        while (std::getline(ssline, token, ',')) {
+          // Get cell ids.
+          if (token.find(semicolon) == std::string::npos) {
+            if (token != " ") {
+              (*meshSideSets_)[ss][atoi(token.c_str())-1].push_back(ssCellIds[cellIdx]);
+              cellIdx++;
+            }
+          }
+          else { // encountered "some-number ;"
+            std::string onlyNumber = token.substr(0, token.size()-1);
+            (*meshSideSets_)[ss][atoi(token.c_str())-1].push_back(ssCellIds[cellIdx]);
+            ssCellIds.clear();
+            processSSSide = false;
+          }
+        }
+      } // end process side set sides
+
+
+    } // end dimension loop
+
+    inputfile.close();
+
+    computeCellToEdgeMap();
+
+    computeCellToFaceMap();
+
+
+    // Parse parallel partitions.
+
+    if ((numProcs != 0) && (numProcs < 2)) {
+      throw std::runtime_error("\n>>> The number of processors is either zero (serial execution, by convention) or at least 2 (parallel execution)!\n");
+    }
+    numProcs_ = numProcs;
+    procCellIds_ = ROL::makePtr<std::vector<std::vector<int>>>(numProcs_);
+
+    for (int proc=0; proc<numProcs_; ++proc) {
+      std::string procfile = filename + "." + std::to_string(numProcs_) + "." + std::to_string(proc);
+      inputfile.open(procfile);
+      int procNumCells;
+      int cellCt = 0;
+
+      // Check if file readable.
+      if (!inputfile.good()) {
+        throw std::runtime_error("\nMeshReader: Could not open mesh file!\n");
+      }
+
+      // Parse file header.
+      bool processPartitionHeader = true;
+      while (processPartitionHeader) {
+
+        std::getline(inputfile, line);    // consider: while (getline(inputfile, line).good())
+        std::stringstream ssline(line);
+
+        while (ssline >> token) {
+
+          // Get number of cells.
+          if (token == "num_elem") {
+            ssline >> token;  // skip "="
+            ssline >> procNumCells;
+            processPartitionHeader = false;
+            break;
+          }
+
+        } // end tokenizing
+
+      } // end parse header
+
+      (*procCellIds_)[proc].resize(procNumCells, 0);
+
+      bool processCellsHeader = true;
+      while (processCellsHeader) {
+
+        std::getline(inputfile, line);
+        std::stringstream ssline(line);
+
+        while (ssline >> token) {
+
+          // Get cell ids.
+          if (token == "elem_num_map") {
+            ssline >> token;  // skip "="
+            while (std::getline(ssline, token, ',')) {
+              if (token != " ") {
+                (*procCellIds_)[proc][cellCt++] = atoi(token.c_str())-1;
+              }
+            }
+            processCellsHeader = false;
+          }
+        }
+
+      }
+
+      bool processCells = true;
+      if (token.find(semicolon) != std::string::npos) {
+        processCells = false;
+      }
+      while (processCells) {
+
+        std::getline(inputfile, line);
+        std::stringstream ssline(line);
+
+        while (std::getline(ssline, token, ',')) {
+          // Get cell ids.
+          if (token.find(semicolon) == std::string::npos) {
+            if (token != " ") {
+              (*procCellIds_)[proc][cellCt++] = atoi(token.c_str())-1;
+            }
+          }
+          else { // encountered "some-number ;"
+            std::string onlyNumber = token.substr(0, token.size()-1);
+            (*procCellIds_)[proc][cellCt++] = atoi(onlyNumber.c_str())-1;
+            processCells = false;
+          }
+        }
+      } // end process cells
+
+      inputfile.close();
+    }
+
+  }
+
+
+  scalar_view getNodes() const override {
+    return meshNodes_;
+  }
+
+
+  int_view getCellToNodeMap() const override {
+    return meshCellToNodeMap_;
+  }
+
+
+  int_view getCellToEdgeMap() const override {
+    return meshCellToEdgeMap_;
+  }
+
+
+  int_view getCellToFaceMap() const override {
+    return meshCellToFaceMap_;
+  }
+
+
+  ROL::Ptr<std::vector<std::vector<std::vector<int> > > > getSideSets (
+      const bool verbose = false,
+      std::ostream & outStream = std::cout) const {
+    if (verbose) {
+      for (int i=0; i<numSideSets_; ++i) {
+        outStream << "\nSideset " << i << std::endl;
+        for (int j=0; j<numFacesPerCell_; ++j) {
+          outStream << "    Local side " << j << ":";
+          for (int k=0; k<static_cast<int>((*meshSideSets_)[i][j].size()); ++k) {
+            outStream << " " << (*meshSideSets_)[i][j][k];
+          }
+          outStream << std::endl;
+        }
+      }
+    }
+    return meshSideSets_;
+  }
+
+
+  ROL::Ptr<std::vector<std::vector<int>>> getProcCellIds() const override {
+    return procCellIds_;
+  }
+
+
+  int getNumCells() const override {
+    return numCells_;
+  } // getNumCells
+
+
+  int getNumNodes() const override {
+    return numNodes_;
+  } // getNumNodes
+
+
+  int getNumEdges() const override {
+    return numEdges_;
+  } // getNumEdges
+
+  int getNumFaces() const override {
+    return numFaces_;
+  } // getNumEdges
+
+  int getNumSideSets() const {
+    return numSideSets_;
+  } // getNumSideSets
+
+  void computeCellToEdgeMap() {
+    meshCellToEdgeMap_ = int_view("meshCellToEdgeMap_", numCells_, numEdgesPerCell_);
+    std::set<int> edgenodes;
+    std::map<std::set<int>,int> edgemap;
+    int edgeCt = 0;
+
+    /* Build edge map. */
+    for (int i=0; i<numCells_; ++i) { // loop over cells
+      for (int j=0; j<numEdgesPerCell_; ++j) { // loop over local edges
+        edgenodes.insert(meshCellToNodeMap_(i, cellTopo_->getNodeMap(1, j, 0)));
+        edgenodes.insert(meshCellToNodeMap_(i, cellTopo_->getNodeMap(1, j, 1)));
+        //std::pair<std::map<std::set<int>,int>::iterator,bool> ret;
+        auto ret = edgemap.insert(std::pair<std::set<int>,int>(edgenodes, edgeCt++));
+        meshCellToEdgeMap_(i, j) = edgemap[edgenodes];
+        if (ret.second == false) {
+          edgeCt--;
+        }
+        edgenodes.clear();
+      }
+    }
+
+    numEdges_ = edgemap.size();
+
+    /* Print edges and cell-to-edge map, for debugging. */
+    /*for (auto it_em=edgemap.begin(); it_em != edgemap.end(); ++it_em) {
+      for (auto it_ns=(it_em->first).begin(); it_ns != (it_em->first).end(); ++it_ns) {
+        std::cout << *it_ns << " , ";
+      }
+      std::cout << " => " << it_em->second << std::endl;
+    }
+    std::cout << cte;*/
+
+  }
+
+  void computeCellToFaceMap() {
+    meshCellToFaceMap_ = int_view("meshCellToFaceMap_", numCells_, numFacesPerCell_);
+    std::set<int> facenodes;
+    std::map<std::set<int>,int> facemap;
+    int faceCt = 0;
+
+    /* Build face map. */
+    for (int i=0; i<numCells_; ++i) { // loop over cells
+      for (int j=0; j<numFacesPerCell_; ++j) { // loop over local faces
+        for (int k=0; k<numNodesPerFace_; ++k) { // loop over nodes to insert in sorted order
+          facenodes.insert(meshCellToNodeMap_(i, cellTopo_->getNodeMap(2, j, k)));
+        }
+        //std::pair<std::map<std::set<int>,int>::iterator,bool> ret;
+        auto ret = facemap.insert(std::pair<std::set<int>,int>(facenodes, faceCt++));
+        meshCellToFaceMap_(i, j) = facemap[facenodes];
+        if (ret.second == false) {
+          faceCt--;
+        }
+        facenodes.clear();
+      }
+    }
+
+    numFaces_ = facemap.size();
+
+    /* Print faces and cell-to-face map, for debugging. */
+    /*for (auto it_fm=facemap.begin(); it_fm != facemap.end(); ++it_fm) {
+      for (auto it_ns=(it_fm->first).begin(); it_ns != (it_fm->first).end(); ++it_ns) {
+        std::cout << *it_ns << " , ";
+      }
+      std::cout << " => " << it_fm->second << std::endl;
+    }
+    std::cout << ctf;*/
+
+  }
+
+}; // MeshReader
+
+#endif

--- a/packages/rol/example/PDE-OPT/TOOLS/pdeK.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/pdeK.hpp
@@ -1,0 +1,265 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  pde.hpp
+    \brief Provides the interface for local (cell-based) PDE residual computations.
+*/
+
+#ifndef PDEOPT_PDEK_HPP
+#define PDEOPT_PDEK_HPP
+
+#include "Intrepid2_Basis.hpp"
+#include "ROL_Ptr.hpp"
+
+namespace Exception {
+
+  class NotImplemented : public Teuchos::ExceptionBase {
+    public:
+      NotImplemented(const std::string & what_arg) : Teuchos::ExceptionBase(what_arg) {}
+  }; // NotImplemented
+
+  class Zero : public Teuchos::ExceptionBase {
+    public:
+      Zero(const std::string & what_arg) : Teuchos::ExceptionBase(what_arg) {}
+  }; // Zero
+
+} // Exception
+
+template <class Real, class DeviceType>
+class PDE {
+public:
+  using scalar_view = Kokkos::DynRankView<Real,DeviceType>;
+  using basis_ptr = Intrepid2::BasisPtr<DeviceType, Real, Real>;
+
+  virtual ~PDE() {}
+
+  virtual void residual(scalar_view & res,
+                        const scalar_view u_coeff,
+                        const scalar_view z_coeff = scalar_view(),
+                        const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) = 0;
+
+  virtual void Jacobian_1(scalar_view & jac,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Jacobian_1 not implemented.");
+  }
+
+  virtual void Jacobian_2(scalar_view & jac,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Jacobian_2 not implemented.");
+  }
+
+  virtual void Jacobian_3(std::vector<scalar_view > & jac,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Jacobian_3 not implemented.");
+  }
+
+  virtual void applyJacobian_1(scalar_view &jv,
+                               const scalar_view v_coeff,
+                               const scalar_view u_coeff,
+                               const scalar_view z_coeff,
+                               const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> applyJacobian_1 not implemented.");
+  }
+
+  virtual void applyAdjointJacobian_1(scalar_view &jv,
+                                      const scalar_view v_coeff,
+                                      const scalar_view u_coeff,
+                                      const scalar_view z_coeff,
+                                      const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> applyAdjointJacobian_1 not implemented.");
+  }
+
+  virtual void applyJacobian_2(scalar_view &jv,
+                               const scalar_view v_coeff,
+                               const scalar_view u_coeff,
+                               const scalar_view z_coeff,
+                               const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> applyJacobian_2 not implemented.");
+  }
+
+  virtual void applyAdjointJacobian_2(scalar_view &jv,
+                                      const scalar_view v_coeff,
+                                      const scalar_view u_coeff,
+                                      const scalar_view z_coeff,
+                                      const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> applyAdjointJacobian_2 not implemented.");
+  }
+
+  virtual void Hessian_11(scalar_view & hess,
+                          const scalar_view l_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_11 not implemented.");
+  }
+
+  virtual void Hessian_12(scalar_view & hess,
+                          const scalar_view l_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_12 not implemented.");
+  }
+
+  virtual void Hessian_13(std::vector<scalar_view > & hess,
+                          const scalar_view l_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_13 not implemented.");
+  }
+
+  virtual void Hessian_21(scalar_view & hess,
+                          const scalar_view l_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_21 not implemented.");
+  }
+
+  virtual void Hessian_22(scalar_view & hess,
+                          const scalar_view l_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_22 not implemented.");
+  }
+
+  virtual void Hessian_23(std::vector<scalar_view > & hess,
+                          const scalar_view l_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_23 not implemented.");
+  }
+
+  virtual void Hessian_31(std::vector<scalar_view > & hess,
+                          const scalar_view l_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_31 not implemented.");
+  }
+
+  virtual void Hessian_32(std::vector<scalar_view > & hess,
+                          const scalar_view l_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_32 not implemented.");
+  }
+
+  virtual void Hessian_33(std::vector<std::vector<scalar_view > > & hess,
+                          const scalar_view l_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_33 not implemented.");
+  }
+
+  virtual void applyHessian_11(scalar_view & hess,
+                               const scalar_view v_coeff,
+                               const scalar_view l_coeff,
+                               const scalar_view u_coeff,
+                               const scalar_view z_coeff = scalar_view(),
+                               const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> applyHessian_11 not implemented.");
+  }
+
+  virtual void applyHessian_12(scalar_view & hess,
+                               const scalar_view v_coeff,
+                               const scalar_view l_coeff,
+                               const scalar_view u_coeff,
+                               const scalar_view z_coeff = scalar_view(),
+                               const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> applyHessian_12 not implemented.");
+  }
+
+  virtual void applyHessian_21(scalar_view & hess,
+                               const scalar_view v_coeff,
+                               const scalar_view l_coeff,
+                               const scalar_view u_coeff,
+                               const scalar_view z_coeff = scalar_view(),
+                               const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> applyHessian_21 not implemented.");
+  }
+
+  virtual void applyHessian_22(scalar_view & hess,
+                               const scalar_view v_coeff,
+                               const scalar_view l_coeff,
+                               const scalar_view u_coeff,
+                               const scalar_view z_coeff = scalar_view(),
+                               const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> applyHessian_22 not implemented.");
+  }
+
+  virtual void RieszMap_1(scalar_view &riesz) {
+    throw Exception::NotImplemented(">>> RieszMap_1 not implemented.");
+  }
+
+  virtual void RieszMap_2(scalar_view &riesz) {
+    throw Exception::NotImplemented(">>> RieszMap_2 not implemented.");
+  }
+
+  virtual std::vector<basis_ptr> getFields() = 0;
+  //virtual std::vector<basis_ptr> getFields2() {
+  //  return getFields();
+  // }
+
+  virtual void setCellNodes(const scalar_view &cellNodes,
+                            const std::vector<std::vector<scalar_view>> &bdryCellNodes,
+                            const std::vector<std::vector<std::vector<int>>> &bdryCellLocIds) = 0;
+
+  virtual void setFieldPattern(const std::vector<std::vector<int>> &fieldPattern) {}
+  virtual void setFieldPattern(const std::vector<std::vector<int>> &fieldPattern1,
+                               const std::vector<std::vector<int>> &fieldPattern2) {
+    setFieldPattern(fieldPattern1);
+  }
+
+  virtual void printData(std::string tag,
+                         const scalar_view u_coeff,
+                         const scalar_view z_coeff = scalar_view(),
+                         const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {}
+
+  virtual void printCellAverages(std::string tag,
+                                 const scalar_view u_coeff,
+                                 const scalar_view z_coeff = scalar_view(),
+                                 const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) {}
+
+private:
+  Real time_;
+  std::vector<Real> param_;
+
+protected:
+  Real getTime(void) const {
+    return time_;
+  }
+
+  std::vector<Real> getParameter(void) const {
+    return param_;
+  }
+
+public:
+  void setTime(const Real time) {
+    time_ = time;
+  }
+
+  void setParameter(const std::vector<Real> &param) {
+    param_.assign(param.begin(),param.end());
+  }
+
+}; // PDE
+
+#endif

--- a/packages/rol/example/PDE-OPT/TOOLS/pdeobjectiveK.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/pdeobjectiveK.hpp
@@ -1,0 +1,128 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef PDE_PDEOBJECTIVE_HPP
+#define PDE_PDEOBJECTIVE_HPP
+
+#include "ROL_Objective_SimOpt.hpp"
+#include "ROL_CompositeObjective_SimOpt.hpp"
+#include "ROL_LinearCombinationObjective_SimOpt.hpp"
+#include "ROL_StdObjective.hpp"
+#include "integralobjectiveK.hpp"
+#include "qoiK.hpp"
+#include "assemblerK.hpp"
+
+// Do not instantiate the template in this translation unit.
+extern template class Assembler<double,Kokkos::HostSpace>;
+
+template <class Real, class DeviceType>
+class PDE_Objective : public ROL::Objective_SimOpt<Real> {
+public:
+  using QoI_type = QoI<Real, DeviceType>;
+  using Assembler_type = Assembler<Real, DeviceType>;
+  using IntegralObjective_type = IntegralObjective<Real,DeviceType>;
+private:
+  std::vector<ROL::Ptr<QoI_type> > qoi_vec_;
+  const ROL::Ptr<ROL::StdObjective<Real> > std_obj_;
+  const ROL::Ptr<Assembler_type> assembler_;
+
+  std::vector<ROL::Ptr<ROL::Objective_SimOpt<Real> > > obj_vec_;
+  ROL::Ptr<ROL::Objective_SimOpt<Real> > obj_;
+
+public:
+  PDE_Objective(const std::vector<ROL::Ptr<QoI_type> > &qoi_vec,
+                const ROL::Ptr<ROL::StdObjective<Real> > &std_obj,
+                const ROL::Ptr<Assembler_type> &assembler)
+    : qoi_vec_(qoi_vec), std_obj_(std_obj), assembler_(assembler) {
+    int size = qoi_vec_.size();
+    obj_vec_.clear(); obj_vec_.resize(size,ROL::nullPtr);
+    for (int i = 0; i < size; ++i) {
+      obj_vec_[i] = ROL::makePtr<IntegralObjective_type>(qoi_vec[i],assembler);
+    }
+    obj_ = ROL::makePtr<ROL::CompositeObjective_SimOpt<Real>>(obj_vec_,std_obj_);
+  }
+
+  PDE_Objective(const std::vector<ROL::Ptr<QoI_type> > &qoi_vec,
+                const ROL::Ptr<Assembler_type> &assembler)
+    : qoi_vec_(qoi_vec), std_obj_(ROL::nullPtr), assembler_(assembler) {
+    int size = qoi_vec_.size();
+    obj_vec_.clear(); obj_vec_.resize(size,ROL::nullPtr);
+    for (int i = 0; i < size; ++i) {
+      obj_vec_[i] = ROL::makePtr<IntegralObjective_type>(qoi_vec[i],assembler);
+    }
+    obj_ = ROL::makePtr<ROL::LinearCombinationObjective_SimOpt<Real>>(obj_vec_);
+  }
+
+  PDE_Objective(const std::vector<ROL::Ptr<QoI_type> > &qoi_vec,
+                const std::vector<Real> &weights,
+                const ROL::Ptr<Assembler_type> &assembler)
+    : qoi_vec_(qoi_vec), std_obj_(ROL::nullPtr), assembler_(assembler) {
+    int size = qoi_vec_.size();
+    obj_vec_.clear(); obj_vec_.resize(size,ROL::nullPtr);
+    for (int i = 0; i < size; ++i) {
+      obj_vec_[i] = ROL::makePtr<IntegralObjective_type>(qoi_vec[i],assembler);
+    }
+    obj_ = ROL::makePtr<ROL::LinearCombinationObjective_SimOpt<Real>>(weights,obj_vec_);
+  }
+
+  PDE_Objective(const ROL::Ptr<QoI_type> &qoi,
+                const ROL::Ptr<Assembler_type> &assembler)
+    : std_obj_(ROL::nullPtr), assembler_(assembler) {
+    int size = 1;
+    qoi_vec_.clear(); qoi_vec_.resize(size,ROL::nullPtr);
+    obj_vec_.clear(); obj_vec_.resize(size,ROL::nullPtr);
+    qoi_vec_[0] = qoi;
+    obj_vec_[0] = ROL::makePtr<IntegralObjective_type>(qoi_vec_[0],assembler);
+    obj_ = obj_vec_[0];
+  }
+
+  void setParameter(const std::vector<Real> &param) {
+    ROL::Objective_SimOpt<Real>::setParameter(param);
+    obj_->setParameter(param);
+  }
+
+  void update( const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, bool flag = true, int iter = -1 ) override {
+    obj_->update(u,z,flag,iter);
+  }
+
+  void update( const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, ROL::UpdateType type, int iter = -1 ) override {
+    obj_->update(u,z,type,iter);
+  }
+
+  Real value( const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol ) override {
+    return obj_->value(u,z,tol);
+  }
+
+  void gradient_1( ROL::Vector<Real> &g, const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol ) override {
+    obj_->gradient_1(g,u,z,tol);
+  }
+
+  void gradient_2( ROL::Vector<Real> &g, const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol ) override {
+    obj_->gradient_2(g,u,z,tol);
+  }
+
+  void hessVec_11( ROL::Vector<Real> &hv, const ROL::Vector<Real> &v, const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol ) override {
+    obj_->hessVec_11(hv,v,u,z,tol);
+  }
+
+  void hessVec_12( ROL::Vector<Real> &hv, const ROL::Vector<Real> &v, const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol ) override {
+    obj_->hessVec_12(hv,v,u,z,tol);
+  }
+
+  void hessVec_21( ROL::Vector<Real> &hv, const ROL::Vector<Real> &v, const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol ) override {
+    obj_->hessVec_21(hv,v,u,z,tol);
+  }
+
+  void hessVec_22( ROL::Vector<Real> &hv, const ROL::Vector<Real> &v, const ROL::Vector<Real> &u, const ROL::Vector<Real> &z, Real &tol ) override {
+    obj_->hessVec_22(hv,v,u,z,tol);
+  }
+
+}; // class PDE_Objective
+
+#endif

--- a/packages/rol/example/PDE-OPT/TOOLS/pdevectorK.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/pdevectorK.hpp
@@ -1,0 +1,1053 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef ROL_PDEOPT_PDEVECTORK_HPP
+#define ROL_PDEOPT_PDEVECTORK_HPP
+
+#include "ROL_TpetraMultiVector.hpp"
+#include "ROL_StdVector.hpp"
+
+#include "assemblerK.hpp"
+#include "solver.hpp"
+
+// Do not instantiate the template in this translation unit.
+extern template class Assembler<double, Kokkos::HostSpace>;
+
+//// Global Timers.
+#ifdef ROL_TIMERS
+namespace ROL {
+  namespace PDEOPT {
+    ROL::Ptr<Teuchos::Time> PDEVectorSimRieszConstruct    = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: PDE Vector Sim Riesz Construction Time");
+    ROL::Ptr<Teuchos::Time> PDEVectorSimRieszApply        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: PDE Vector Sim Riesz Application Time");
+    ROL::Ptr<Teuchos::Time> PDEVectorSimRieszSolve        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: PDE Vector Sim Riesz Solver Solution Time");
+    ROL::Ptr<Teuchos::Time> PDEVectorOptRieszConstruct    = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: PDE Vector Opt Riesz Construction Time");
+    ROL::Ptr<Teuchos::Time> PDEVectorOptRieszApply        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: PDE Vector Opt Riesz Application Time");
+    ROL::Ptr<Teuchos::Time> PDEVectorOptRieszSolve        = Teuchos::TimeMonitor::getNewCounter("ROL::PDEOPT: PDE Vector Opt Riesz Solver Solution Time");
+  }
+}
+#endif
+
+
+template <class Real, class DeviceType,
+          class LO=Tpetra::Map<>::local_ordinal_type, 
+          class GO=Tpetra::Map<>::global_ordinal_type,
+          class Node=Tpetra::Map<>::node_type >
+class PDE_PrimalSimVector;
+
+template <class Real, class DeviceType,
+          class LO=Tpetra::Map<>::local_ordinal_type, 
+          class GO=Tpetra::Map<>::global_ordinal_type,
+          class Node=Tpetra::Map<>::node_type >
+class PDE_DualSimVector;
+
+template <class Real, class DeviceType, class LO, class GO, class Node>
+class PDE_PrimalSimVector : public ROL::TpetraMultiVector<Real,LO,GO,Node> {
+  private:
+    ROL::Ptr<Tpetra::CrsMatrix<> > RieszMap_;
+    ROL::Ptr<Tpetra::MultiVector<> > lumpedRiesz_;
+    ROL::Ptr<Solver<Real> > solver_;
+
+    bool useRiesz_;
+    bool useLumpedRiesz_;
+
+    mutable ROL::Ptr<PDE_DualSimVector<Real,DeviceType> > dual_vec_;
+    mutable bool isDualInitialized_;
+
+    void lumpRiesz(void) {
+      lumpedRiesz_ = ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(),1);
+      Tpetra::MultiVector<Real,LO,GO,Node> ones(ROL::TpetraMultiVector<Real>::getMap(),1);
+      ones.putScalar(static_cast<Real>(1));
+      RieszMap_->apply(ones, *lumpedRiesz_);
+    }
+
+    void applyRiesz(const ROL::Ptr<Tpetra::MultiVector<> > &out,
+                    const ROL::Ptr<const Tpetra::MultiVector<> > &in) const {
+      #ifdef ROL_TIMERS
+        Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::PDEVectorSimRieszApply);
+      #endif
+      if ( useRiesz_ ) {
+        if (useLumpedRiesz_) {
+          out->elementWiseMultiply(static_cast<Real>(1), *(lumpedRiesz_->getVector(0)), *in, static_cast<Real>(0));
+        }
+        else {
+          RieszMap_->apply(*in,*out);
+        }
+      }
+      else {
+        out->scale(static_cast<Real>(1),*in);
+      }
+    }
+
+  public:
+    virtual ~PDE_PrimalSimVector() {}
+
+    using Assembler_type = Assembler<Real,DeviceType>;
+    using PDE_type = PDE<Real,DeviceType>;
+    using DynamicPDE_type = DynamicPDE<Real,DeviceType>;
+
+    PDE_PrimalSimVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                        const ROL::Ptr<PDE_type> &pde,
+                        const ROL::Ptr<Assembler_type> &assembler)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec), solver_(ROL::nullPtr),
+        useRiesz_(false), useLumpedRiesz_(false), isDualInitialized_(false) {}
+
+    PDE_PrimalSimVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                        const ROL::Ptr<PDE_type> &pde,
+                        const ROL::Ptr<Assembler_type> &assembler,
+                        Teuchos::ParameterList &parlist)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec),
+        isDualInitialized_(false) {
+      #ifdef ROL_TIMERS
+        Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::PDEVectorSimRieszConstruct);
+      #endif
+      useRiesz_       = parlist.sublist("Vector").sublist("Sim").get("Use Riesz Map", false);
+      useLumpedRiesz_ = parlist.sublist("Vector").sublist("Sim").get("Lump Riesz Map", false);
+      if (useRiesz_) assembler->assemblePDERieszMap1(RieszMap_, pde);
+      useRiesz_ = useRiesz_ && (RieszMap_ != ROL::nullPtr);
+      if (useRiesz_) {
+        if (useLumpedRiesz_) {
+          lumpRiesz();
+        }
+        else {
+          solver_ = ROL::makePtr<Solver<Real>>(parlist.sublist("Solver"));
+          solver_->setA(RieszMap_);
+        }
+      }
+    }
+
+    PDE_PrimalSimVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                        const ROL::Ptr<DynamicPDE_type> &pde,
+                        Assembler_type &assembler)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec), solver_(ROL::nullPtr),
+        useRiesz_(false), useLumpedRiesz_(false), isDualInitialized_(false) {}
+
+    PDE_PrimalSimVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                        const ROL::Ptr<DynamicPDE_type> &pde,
+                        Assembler_type &assembler,
+                        Teuchos::ParameterList &parlist)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec),
+        isDualInitialized_(false) {
+      #ifdef ROL_TIMERS
+        Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::PDEVectorSimRieszConstruct);
+      #endif
+      useRiesz_       = parlist.sublist("Vector").sublist("Sim").get("Use Riesz Map", false);
+      useLumpedRiesz_ = parlist.sublist("Vector").sublist("Sim").get("Lump Riesz Map", false);
+      if (useRiesz_) assembler.assembleDynPDERieszMap1(RieszMap_, pde);
+      useRiesz_ = useRiesz_ && (RieszMap_ != ROL::nullPtr);
+      if (useRiesz_) {
+        if (useLumpedRiesz_) {
+          lumpRiesz();
+        }
+        else {
+          solver_ = ROL::makePtr<Solver<Real>>(parlist.sublist("Solver"));
+          solver_->setA(RieszMap_);
+        }
+      }
+    }
+
+    PDE_PrimalSimVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                        const ROL::Ptr<Tpetra::CrsMatrix<> > &RieszMap,
+                        const ROL::Ptr<Solver<Real> > &solver,
+                        const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &lumpedRiesz)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec), RieszMap_(RieszMap),
+        lumpedRiesz_(lumpedRiesz), solver_(solver), isDualInitialized_(false) {
+      if (RieszMap_ != ROL::nullPtr) {
+        useLumpedRiesz_ = (lumpedRiesz_ != ROL::nullPtr);
+        useRiesz_ = (solver_ != ROL::nullPtr) || useLumpedRiesz_;
+      }
+      else {
+        useLumpedRiesz_ = false;
+        useRiesz_ = false;
+      }
+    }
+
+    Real dot( const ROL::Vector<Real> &x ) const {
+      TEUCHOS_TEST_FOR_EXCEPTION( (ROL::TpetraMultiVector<Real,LO,GO,Node>::dimension() != x.dimension()),
+                                  std::invalid_argument,
+                                  "Error: Vectors must have the same dimension." );
+      const ROL::Ptr<const Tpetra::MultiVector<Real,LO,GO,Node> > ex
+        = dynamic_cast<const ROL::TpetraMultiVector<Real,LO,GO,Node>&>(x).getVector();
+      const Tpetra::MultiVector<Real,LO,GO,Node> &ey
+        = *(ROL::TpetraMultiVector<Real,LO,GO,Node>::getVector());
+      size_t n = ey.getNumVectors();
+      // Scale x with scale_vec_
+      ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > wex
+        = ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(), n);
+      applyRiesz(wex,ex);
+      // Perform Euclidean dot between *this and scaled x for each vector
+      Teuchos::Array<Real> val(n,0);
+      ey.dot( *wex, val.view(0,n) );
+      // Combine dots for each vector to get a scalar
+      Real xy(0);
+      for (size_t i = 0; i < n; ++i) {
+        xy += val[i];
+      }
+      return xy;
+    }
+
+    ROL::Ptr<ROL::Vector<Real> > clone() const {
+      const Tpetra::MultiVector<Real,LO,GO,Node> &ey
+        = *(ROL::TpetraMultiVector<Real,LO,GO,Node>::getVector());
+      size_t n = ey.getNumVectors();
+      return ROL::makePtr<PDE_PrimalSimVector<Real,DeviceType,LO,GO,Node>>(
+             ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(),n),
+             RieszMap_, solver_, lumpedRiesz_);
+    }
+
+    const ROL::Vector<Real> & dual() const {
+      if ( !isDualInitialized_ ) {
+        // Create new memory for dual vector
+        size_t n = ROL::TpetraMultiVector<Real,LO,GO,Node>::getVector()->getNumVectors();
+        dual_vec_ = ROL::makePtr<PDE_DualSimVector<Real,DeviceType,LO,GO,Node>>(
+                    ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(),n),
+                    RieszMap_, solver_, lumpedRiesz_);
+        isDualInitialized_ = true;
+      }
+      // Scale *this with scale_vec_ and place in dual vector
+      applyRiesz(dual_vec_->getVector(),ROL::TpetraMultiVector<Real,LO,GO,Node>::getVector());
+      return *dual_vec_;
+    }
+
+    Real apply(const ROL::Vector<Real> &x) const {
+      const PDE_DualSimVector<Real,DeviceType,LO,GO,Node> &ex = dynamic_cast<const PDE_DualSimVector<Real,DeviceType,LO,GO,Node>&>(x);
+      return ROL::TpetraMultiVector<Real,LO,GO,Node>::dot(ex);
+    }
+}; // class PDE_PrimalSimVector
+
+template <class Real, class DeviceType, class LO, class GO, class Node>
+class PDE_DualSimVector : public ROL::TpetraMultiVector<Real,LO,GO,Node> {
+  private:
+    ROL::Ptr<Tpetra::CrsMatrix<Real> > RieszMap_;
+    ROL::Ptr<Tpetra::MultiVector<> > lumpedRiesz_;
+    ROL::Ptr<Tpetra::MultiVector<> > recipLumpedRiesz_;
+    ROL::Ptr<Solver<Real> > solver_;
+
+    bool useRiesz_;
+    bool useLumpedRiesz_;
+
+    mutable ROL::Ptr<PDE_PrimalSimVector<Real,DeviceType> > primal_vec_;
+    mutable bool isDualInitialized_;
+
+    void lumpRiesz(void) {
+      lumpedRiesz_ = ROL::makePtr<Tpetra::Vector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap());
+      Tpetra::MultiVector<Real,LO,GO,Node> ones(ROL::TpetraMultiVector<Real>::getMap(),1);
+      ones.putScalar(static_cast<Real>(1));
+      RieszMap_->apply(ones, *lumpedRiesz_);
+    }
+
+    void invertLumpedRiesz(void) {
+      recipLumpedRiesz_ = ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(),1);
+      recipLumpedRiesz_->reciprocal(*lumpedRiesz_);
+    }
+
+    void applyRiesz(const ROL::Ptr<Tpetra::MultiVector<> > &out,
+                    const ROL::Ptr<const Tpetra::MultiVector<> > &in) const {
+      #ifdef ROL_TIMERS
+        Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::PDEVectorSimRieszSolve);
+      #endif
+      if ( useRiesz_ ) {
+        if (useLumpedRiesz_) {
+          out->elementWiseMultiply(static_cast<Real>(1), *(recipLumpedRiesz_->getVector(0)), *in, static_cast<Real>(0));
+        }
+        else {
+          solver_->solve(out,in,false);
+        }
+      }
+      else {
+        out->scale(static_cast<Real>(1),*in);
+      }
+    }
+
+  public:
+    virtual ~PDE_DualSimVector() {}
+
+    using Assembler_type = Assembler<Real,DeviceType>;
+    using PDE_type = PDE<Real,DeviceType>;
+    using DynamicPDE_type = DynamicPDE<Real,DeviceType>;
+
+    PDE_DualSimVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                      const ROL::Ptr<PDE_type> &pde,
+                      const ROL::Ptr<Assembler_type> &assembler)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec), solver_(ROL::nullPtr),
+        useRiesz_(false), useLumpedRiesz_(false), isDualInitialized_(false) {}
+
+    PDE_DualSimVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                      const ROL::Ptr<PDE_type> &pde,
+                      const ROL::Ptr<Assembler_type> &assembler,
+                      Teuchos::ParameterList &parlist)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec),
+        isDualInitialized_(false) {
+      #ifdef ROL_TIMERS
+        Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::PDEVectorSimRieszConstruct);
+      #endif
+      useRiesz_       = parlist.sublist("Vector").sublist("Sim").get("Use Riesz Map", false);
+      useLumpedRiesz_ = parlist.sublist("Vector").sublist("Sim").get("Lump Riesz Map", false);
+      if (useRiesz_) assembler->assemblePDERieszMap1(RieszMap_, pde);
+      useRiesz_ = useRiesz_ && (RieszMap_ != ROL::nullPtr);
+      if (useRiesz_) {
+        if (useLumpedRiesz_) {
+          lumpRiesz();
+          invertLumpedRiesz();
+        }
+        else {
+          solver_ = ROL::makePtr<Solver<Real>>(parlist.sublist("Solver"));
+          solver_->setA(RieszMap_);
+        }
+      }
+    }
+
+    PDE_DualSimVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                      const ROL::Ptr<DynamicPDE_type> &pde,
+                      Assembler_type &assembler)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec), solver_(ROL::nullPtr),
+        useRiesz_(false), useLumpedRiesz_(false), isDualInitialized_(false) {}
+
+    PDE_DualSimVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                      const ROL::Ptr<DynamicPDE_type> &pde,
+                      Assembler_type &assembler,
+                      Teuchos::ParameterList &parlist)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec),
+        isDualInitialized_(false) {
+      #ifdef ROL_TIMERS
+        Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::PDEVectorSimRieszConstruct);
+      #endif
+      useRiesz_       = parlist.sublist("Vector").sublist("Sim").get("Use Riesz Map", false);
+      useLumpedRiesz_ = parlist.sublist("Vector").sublist("Sim").get("Lump Riesz Map", false);
+      assembler.assembleDynPDERieszMap1(RieszMap_, pde);
+      useRiesz_ = useRiesz_ && (RieszMap_ != ROL::nullPtr);
+      if (useRiesz_) {
+        if (useLumpedRiesz_) {
+          lumpRiesz();
+          invertLumpedRiesz();
+        }
+        else {
+          solver_ = ROL::makePtr<Solver<Real>>(parlist.sublist("Solver"));
+          solver_->setA(RieszMap_);
+        }
+      }
+    }
+
+    PDE_DualSimVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                      const ROL::Ptr<Tpetra::CrsMatrix<> > &RieszMap,
+                      const ROL::Ptr<Solver<Real> > &solver,
+                      const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &lumpedRiesz)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec), RieszMap_(RieszMap),
+        lumpedRiesz_(lumpedRiesz), solver_(solver), isDualInitialized_(false) {
+      if (RieszMap_ != ROL::nullPtr) {
+        useLumpedRiesz_ = (lumpedRiesz_ != ROL::nullPtr);
+        useRiesz_ = (solver_ != ROL::nullPtr) || useLumpedRiesz_;
+        if (useLumpedRiesz_) {
+          invertLumpedRiesz();
+        }
+      }
+      else {
+        useLumpedRiesz_ = false;
+        useRiesz_ = false;
+      }
+    }
+
+    Real dot( const ROL::Vector<Real> &x ) const {
+      TEUCHOS_TEST_FOR_EXCEPTION( (ROL::TpetraMultiVector<Real,LO,GO,Node>::dimension() != x.dimension()),
+                                  std::invalid_argument,
+                                  "Error: Vectors must have the same dimension." );
+      const ROL::Ptr<const Tpetra::MultiVector<Real,LO,GO,Node> > &ex
+        = dynamic_cast<const ROL::TpetraMultiVector<Real,LO,GO,Node>&>(x).getVector();
+      const Tpetra::MultiVector<Real,LO,GO,Node> &ey
+        = *(ROL::TpetraMultiVector<Real>::getVector());
+      size_t n = ey.getNumVectors();
+      // Scale x with 1/scale_vec_
+      ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > wex
+        = ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(), n);
+      applyRiesz(wex,ex);
+      // Perform Euclidean dot between *this and scaled x for each vector
+      Teuchos::Array<Real> val(n,0);
+      ey.dot( *wex, val.view(0,n) );
+      // Combine dots for each vector to get a scalar
+      Real xy(0);
+      for (size_t i = 0; i < n; ++i) {
+        xy += val[i];
+      }
+      return xy;
+    }
+
+    ROL::Ptr<ROL::Vector<Real> > clone() const {
+      const Tpetra::MultiVector<Real,LO,GO,Node> &ey
+        = *(ROL::TpetraMultiVector<Real,LO,GO,Node>::getVector());
+      size_t n = ey.getNumVectors();  
+      return ROL::makePtr<PDE_DualSimVector<Real,DeviceType,LO,GO,Node>>(
+             ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(),n),
+             RieszMap_, solver_, lumpedRiesz_);
+    }
+
+    const ROL::Vector<Real> & dual() const {
+      if ( !isDualInitialized_ ) {
+        // Create new memory for dual vector
+        size_t n = ROL::TpetraMultiVector<Real,LO,GO,Node>::getVector()->getNumVectors();
+        primal_vec_ = ROL::makePtr<PDE_PrimalSimVector<Real,DeviceType,LO,GO,Node>>(
+                      ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(),n),
+                      RieszMap_, solver_, lumpedRiesz_);
+        isDualInitialized_ = true;
+      }
+      // Scale *this with scale_vec_ and place in dual vector
+      applyRiesz(primal_vec_->getVector(),ROL::TpetraMultiVector<Real,LO,GO,Node>::getVector());
+      return *primal_vec_;
+    }
+
+    Real apply(const ROL::Vector<Real> &x) const {
+      const PDE_PrimalSimVector<Real,DeviceType,LO,GO,Node> &ex = dynamic_cast<const PDE_PrimalSimVector<Real,DeviceType,LO,GO,Node>&>(x);
+      return ROL::TpetraMultiVector<Real,LO,GO,Node>::dot(ex);
+    }
+}; // class PDE_DualSimVector
+
+template <class Real, class DeviceType,
+          class LO=Tpetra::Map<>::local_ordinal_type, 
+          class GO=Tpetra::Map<>::global_ordinal_type,
+          class Node=Tpetra::Map<>::node_type >
+class PDE_PrimalOptVector;
+
+template <class Real, class DeviceType,
+          class LO=Tpetra::Map<>::local_ordinal_type, 
+          class GO=Tpetra::Map<>::global_ordinal_type,
+          class Node=Tpetra::Map<>::node_type >
+class PDE_DualOptVector;
+
+template <class Real, class DeviceType, class LO, class GO, class Node>
+class PDE_PrimalOptVector : public ROL::TpetraMultiVector<Real,LO,GO,Node> {
+  private:
+    ROL::Ptr<Tpetra::CrsMatrix<> > RieszMap_;
+    ROL::Ptr<Tpetra::MultiVector<> > lumpedRiesz_;
+    ROL::Ptr<Solver<Real> > solver_;
+
+    bool useRiesz_;
+    bool useLumpedRiesz_;
+
+    mutable ROL::Ptr<PDE_DualOptVector<Real, DeviceType> > dual_vec_;
+    mutable bool isDualInitialized_;
+
+    void lumpRiesz(void) {
+      lumpedRiesz_ = ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(),1);
+      Tpetra::MultiVector<Real,LO,GO,Node> ones(ROL::TpetraMultiVector<Real>::getMap(),1);
+      ones.putScalar(static_cast<Real>(1));
+      RieszMap_->apply(ones, *lumpedRiesz_);
+    }
+
+    void applyRiesz(const ROL::Ptr<Tpetra::MultiVector<> > &out,
+                    const ROL::Ptr<const Tpetra::MultiVector<> > &in) const {
+      #ifdef ROL_TIMERS
+        Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::PDEVectorOptRieszApply);
+      #endif
+      if ( useRiesz_ ) {
+        if (useLumpedRiesz_) {
+          out->elementWiseMultiply(static_cast<Real>(1), *(lumpedRiesz_->getVector(0)), *in, static_cast<Real>(0));
+        }
+        else {
+          RieszMap_->apply(*in,*out);
+        }
+      }
+      else {
+        out->scale(static_cast<Real>(1),*in);
+      }
+    }
+
+  public:
+
+    using Assembler_type = Assembler<Real,DeviceType>;
+    using PDE_type = PDE<Real,DeviceType>;
+    using DynamicPDE_type = DynamicPDE<Real,DeviceType>;
+
+    virtual ~PDE_PrimalOptVector() {}
+
+    PDE_PrimalOptVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                        const ROL::Ptr<PDE_type> &pde,
+                        const ROL::Ptr<Assembler_type> &assembler)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec), solver_(ROL::nullPtr),
+        useRiesz_(false), useLumpedRiesz_(false), isDualInitialized_(false) {}
+
+    PDE_PrimalOptVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                        const ROL::Ptr<PDE_type> &pde,
+                        const ROL::Ptr<Assembler_type> &assembler,
+                        Teuchos::ParameterList &parlist)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec),
+        isDualInitialized_(false) {
+      #ifdef ROL_TIMERS
+        Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::PDEVectorOptRieszConstruct);
+      #endif
+      useRiesz_       = parlist.sublist("Vector").sublist("Opt").get("Use Riesz Map", false);
+      useLumpedRiesz_ = parlist.sublist("Vector").sublist("Opt").get("Lump Riesz Map", false);
+      if (useRiesz_) assembler->assemblePDERieszMap2(RieszMap_, pde);
+      useRiesz_ = useRiesz_ && (RieszMap_ != ROL::nullPtr);
+      if (useRiesz_) {
+        if (useLumpedRiesz_) {
+          lumpRiesz();
+        }
+        else {
+          solver_ = ROL::makePtr<Solver<Real>>(parlist.sublist("Solver"));
+          solver_->setA(RieszMap_);
+        }
+      }
+    }
+
+    PDE_PrimalOptVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                        const ROL::Ptr<DynamicPDE_type> &pde,
+                        Assembler_type &assembler)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec), solver_(ROL::nullPtr),
+        useRiesz_(false), useLumpedRiesz_(false), isDualInitialized_(false) {}
+
+    PDE_PrimalOptVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                        const ROL::Ptr<DynamicPDE_type> &pde,
+                        Assembler_type &assembler,
+                        Teuchos::ParameterList &parlist)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec),
+        isDualInitialized_(false) {
+      #ifdef ROL_TIMERS
+        Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::PDEVectorOptRieszConstruct);
+      #endif
+      useRiesz_       = parlist.sublist("Vector").sublist("Opt").get("Use Riesz Map", false);
+      useLumpedRiesz_ = parlist.sublist("Vector").sublist("Opt").get("Lump Riesz Map", false);
+      assembler.assembleDynPDERieszMap2(RieszMap_, pde);
+      useRiesz_ = useRiesz_ && (RieszMap_ != ROL::nullPtr);
+      if (useRiesz_) {
+        if (useLumpedRiesz_) {
+          lumpRiesz();
+        }
+        else {
+          solver_ = ROL::makePtr<Solver<Real>>(parlist.sublist("Solver"));
+          solver_->setA(RieszMap_);
+        }
+      }
+    }
+
+    PDE_PrimalOptVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                        const ROL::Ptr<Tpetra::CrsMatrix<> > &RieszMap,
+                        const ROL::Ptr<Solver<Real> > &solver,
+                        const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &lumpedRiesz)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec), RieszMap_(RieszMap),
+        lumpedRiesz_(lumpedRiesz), solver_(solver), isDualInitialized_(false) {
+      if (RieszMap_ != ROL::nullPtr) {
+        useLumpedRiesz_ = (lumpedRiesz_ != ROL::nullPtr);
+        useRiesz_ = (solver_ != ROL::nullPtr) || useLumpedRiesz_;
+      }
+      else {
+        useLumpedRiesz_ = false;
+        useRiesz_ = false;
+      }
+    }
+
+    Real dot( const ROL::Vector<Real> &x ) const {
+      TEUCHOS_TEST_FOR_EXCEPTION( (ROL::TpetraMultiVector<Real,LO,GO,Node>::dimension() != x.dimension()),
+                                  std::invalid_argument,
+                                  "Error: Vectors must have the same dimension." );
+      const ROL::Ptr<const Tpetra::MultiVector<Real,LO,GO,Node> > ex
+        = dynamic_cast<const ROL::TpetraMultiVector<Real,LO,GO,Node>&>(x).getVector();
+      const Tpetra::MultiVector<Real,LO,GO,Node> &ey
+        = *(ROL::TpetraMultiVector<Real,LO,GO,Node>::getVector());
+      size_t n = ey.getNumVectors();
+      // Scale x with scale_vec_
+      ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > wex
+        = ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(), n);
+      applyRiesz(wex,ex);
+      // Perform Euclidean dot between *this and scaled x for each vector
+      Teuchos::Array<Real> val(n,0);
+      ey.dot( *wex, val.view(0,n) );
+      // Combine dots for each vector to get a scalar
+      Real xy(0);
+      for (size_t i = 0; i < n; ++i) {
+        xy += val[i];
+      }
+      return xy;
+    }
+
+    ROL::Ptr<ROL::Vector<Real> > clone() const {
+      const Tpetra::MultiVector<Real,LO,GO,Node> &ey
+        = *(ROL::TpetraMultiVector<Real,LO,GO,Node>::getVector());
+      size_t n = ey.getNumVectors();
+      return ROL::makePtr<PDE_PrimalOptVector<Real,DeviceType,LO,GO,Node>>(
+             ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(),n),
+             RieszMap_, solver_, lumpedRiesz_);
+    }
+
+    const ROL::Vector<Real> & dual() const {
+      if ( !isDualInitialized_ ) {
+        // Create new memory for dual vector
+        size_t n = ROL::TpetraMultiVector<Real,LO,GO,Node>::getVector()->getNumVectors();
+        dual_vec_ = ROL::makePtr<PDE_DualOptVector<Real,DeviceType,LO,GO,Node>>(
+                    ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(),n),
+                    RieszMap_, solver_, lumpedRiesz_);
+        isDualInitialized_ = true;
+      }
+      // Scale *this with scale_vec_ and place in dual vector
+      applyRiesz(dual_vec_->getVector(),ROL::TpetraMultiVector<Real,LO,GO,Node>::getVector());
+      return *dual_vec_;
+    }
+
+    Real apply(const ROL::Vector<Real> &x) const {
+      const PDE_DualOptVector<Real,DeviceType,LO,GO,Node> &ex = dynamic_cast<const PDE_DualOptVector<Real,DeviceType,LO,GO,Node>&>(x);
+      return ROL::TpetraMultiVector<Real,LO,GO,Node>::dot(ex);
+    }
+}; // class PDE_PrimalOptVector
+
+template <class Real, class DeviceType, class LO, class GO, class Node>
+class PDE_DualOptVector : public ROL::TpetraMultiVector<Real,LO,GO,Node> {
+  private:
+    ROL::Ptr<Tpetra::CrsMatrix<Real> > RieszMap_;
+    ROL::Ptr<Tpetra::MultiVector<> > lumpedRiesz_;
+    ROL::Ptr<Tpetra::MultiVector<> > recipLumpedRiesz_;
+    ROL::Ptr<Solver<Real> > solver_;
+
+    bool useRiesz_;
+    bool useLumpedRiesz_;
+
+    mutable ROL::Ptr<PDE_PrimalOptVector<Real,DeviceType> > primal_vec_;
+    mutable bool isDualInitialized_;
+
+    void lumpRiesz(void) {
+      lumpedRiesz_ = ROL::makePtr<Tpetra::Vector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap());
+      Tpetra::MultiVector<Real,LO,GO,Node> ones(ROL::TpetraMultiVector<Real>::getMap(),1);
+      ones.putScalar(static_cast<Real>(1));
+      RieszMap_->apply(ones, *lumpedRiesz_);
+    }
+
+    void invertLumpedRiesz(void) {
+      recipLumpedRiesz_ = ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(),1);
+      recipLumpedRiesz_->reciprocal(*lumpedRiesz_);
+    }
+
+    void applyRiesz(const ROL::Ptr<Tpetra::MultiVector<> > &out,
+                    const ROL::Ptr<const Tpetra::MultiVector<> > &in) const {
+      #ifdef ROL_TIMERS
+        Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::PDEVectorOptRieszSolve);
+      #endif
+      if ( useRiesz_ ) {
+        if (useLumpedRiesz_) {
+          out->elementWiseMultiply(static_cast<Real>(1), *(recipLumpedRiesz_->getVector(0)), *in, static_cast<Real>(0));
+        }
+        else {
+          solver_->solve(out,in,false);
+        }
+      }
+      else {
+        out->scale(static_cast<Real>(1),*in);
+      }
+    }
+
+  public:
+    virtual ~PDE_DualOptVector() {}
+
+    using Assembler_type = Assembler<Real,DeviceType>;
+    using PDE_type = PDE<Real,DeviceType>;
+    using DynamicPDE_type = DynamicPDE<Real,DeviceType>;
+
+    PDE_DualOptVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                      const ROL::Ptr<PDE_type> &pde,
+                      const ROL::Ptr<Assembler_type> &assembler)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec), solver_(ROL::nullPtr),
+        useRiesz_(false), useLumpedRiesz_(false), isDualInitialized_(false) {}
+
+    PDE_DualOptVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                      const ROL::Ptr<PDE_type> &pde,
+                      const ROL::Ptr<Assembler_type> &assembler,
+                      Teuchos::ParameterList &parlist)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec),
+        isDualInitialized_(false) {
+      #ifdef ROL_TIMERS
+        Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::PDEVectorOptRieszConstruct);
+      #endif
+      useRiesz_       = parlist.sublist("Vector").sublist("Opt").get("Use Riesz Map", false);
+      useLumpedRiesz_ = parlist.sublist("Vector").sublist("Opt").get("Lump Riesz Map", false);
+      if (useRiesz_) assembler->assemblePDERieszMap2(RieszMap_, pde);
+      useRiesz_ = useRiesz_ && (RieszMap_ != ROL::nullPtr);
+      if (useRiesz_) {
+        if (useLumpedRiesz_) {
+          lumpRiesz();
+          invertLumpedRiesz();
+        }
+        else {
+          solver_ = ROL::makePtr<Solver<Real>>(parlist.sublist("Solver"));
+          solver_->setA(RieszMap_);
+        }
+      }
+    }
+
+    PDE_DualOptVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                      const ROL::Ptr<DynamicPDE_type> &pde,
+                      Assembler_type &assembler)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec), solver_(ROL::nullPtr),
+        useRiesz_(false), useLumpedRiesz_(false), isDualInitialized_(false) {}
+
+    PDE_DualOptVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                      const ROL::Ptr<DynamicPDE_type> &pde,
+                      Assembler_type &assembler,
+                      Teuchos::ParameterList &parlist)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec),
+        isDualInitialized_(false) {
+      #ifdef ROL_TIMERS
+        Teuchos::TimeMonitor LocalTimer(*ROL::PDEOPT::PDEVectorOptRieszConstruct);
+      #endif
+      useRiesz_       = parlist.sublist("Vector").sublist("Opt").get("Use Riesz Map", false);
+      useLumpedRiesz_ = parlist.sublist("Vector").sublist("Opt").get("Lump Riesz Map", false);
+      assembler.assembleDynPDERieszMap2(RieszMap_, pde);
+      useRiesz_ = useRiesz_ && (RieszMap_ != ROL::nullPtr);
+      if (useRiesz_) {
+        if (useLumpedRiesz_) {
+          lumpRiesz();
+          invertLumpedRiesz();
+        }
+        else {
+          solver_ = ROL::makePtr<Solver<Real>>(parlist.sublist("Solver"));
+          solver_->setA(RieszMap_);
+        }
+      }
+    }
+
+    PDE_DualOptVector(const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &tpetra_vec,
+                      const ROL::Ptr<Tpetra::CrsMatrix<> > &RieszMap,
+                      const ROL::Ptr<Solver<Real> > &solver,
+                      const ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > &lumpedRiesz)
+      : ROL::TpetraMultiVector<Real,LO,GO,Node>(tpetra_vec), RieszMap_(RieszMap),
+        lumpedRiesz_(lumpedRiesz), solver_(solver), isDualInitialized_(false) {
+      if (RieszMap_ != ROL::nullPtr) {
+        useLumpedRiesz_ = (lumpedRiesz_ != ROL::nullPtr);
+        useRiesz_ = (solver_ != ROL::nullPtr) || useLumpedRiesz_;
+        if (useLumpedRiesz_) {
+          invertLumpedRiesz();
+        }
+      }
+      else {
+        useLumpedRiesz_ = false;
+        useRiesz_ = false;
+      }
+    }
+
+    Real dot( const ROL::Vector<Real> &x ) const {
+      TEUCHOS_TEST_FOR_EXCEPTION( (ROL::TpetraMultiVector<Real,LO,GO,Node>::dimension() != x.dimension()),
+                                  std::invalid_argument,
+                                  "Error: Vectors must have the same dimension." );
+      const ROL::Ptr<const Tpetra::MultiVector<Real,LO,GO,Node> > &ex
+        = dynamic_cast<const ROL::TpetraMultiVector<Real,LO,GO,Node>&>(x).getVector();
+      const Tpetra::MultiVector<Real,LO,GO,Node> &ey
+        = *(ROL::TpetraMultiVector<Real>::getVector());
+      size_t n = ey.getNumVectors();
+      // Scale x with 1/scale_vec_
+      ROL::Ptr<Tpetra::MultiVector<Real,LO,GO,Node> > wex
+        = ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(), n);
+      applyRiesz(wex,ex);
+      // Perform Euclidean dot between *this and scaled x for each vector
+      Teuchos::Array<Real> val(n,0);
+      ey.dot( *wex, val.view(0,n) );
+      // Combine dots for each vector to get a scalar
+      Real xy(0);
+      for (size_t i = 0; i < n; ++i) {
+        xy += val[i];
+      }
+      return xy;
+    }
+
+    ROL::Ptr<ROL::Vector<Real> > clone() const {
+      const Tpetra::MultiVector<Real,LO,GO,Node> &ey
+        = *(ROL::TpetraMultiVector<Real,LO,GO,Node>::getVector());
+      size_t n = ey.getNumVectors();  
+      return ROL::makePtr<PDE_DualOptVector<Real,DeviceType,LO,GO,Node>>(
+             ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(),n),
+             RieszMap_, solver_, lumpedRiesz_);
+    }
+
+    const ROL::Vector<Real> & dual() const {
+      if ( !isDualInitialized_ ) {
+        // Create new memory for dual vector
+        size_t n = ROL::TpetraMultiVector<Real,LO,GO,Node>::getVector()->getNumVectors();
+        primal_vec_ = ROL::makePtr<PDE_PrimalOptVector<Real,DeviceType,LO,GO,Node>>(
+                      ROL::makePtr<Tpetra::MultiVector<Real,LO,GO,Node>>(ROL::TpetraMultiVector<Real>::getMap(),n),
+                      RieszMap_, solver_, lumpedRiesz_);
+        isDualInitialized_ = true;
+      }
+      // Scale *this with scale_vec_ and place in dual vector
+      applyRiesz(primal_vec_->getVector(),ROL::TpetraMultiVector<Real,LO,GO,Node>::getVector());
+      return *primal_vec_;
+    }
+
+    Real apply(const ROL::Vector<Real> &x) const {
+      const PDE_PrimalOptVector<Real,DeviceType,LO,GO,Node> &ex = dynamic_cast<const PDE_PrimalOptVector<Real,DeviceType,LO,GO,Node>&>(x);
+      return ROL::TpetraMultiVector<Real,LO,GO,Node>::dot(ex);
+    }
+}; // class PDE_DualOptVector
+
+template <class Real,
+          class LO=Tpetra::Map<>::local_ordinal_type, 
+          class GO=Tpetra::Map<>::global_ordinal_type,
+          class Node=Tpetra::Map<>::node_type >
+class PDE_OptVector : public ROL::Vector<Real> {
+private:
+  ROL::Ptr<ROL::TpetraMultiVector<Real,LO,GO,Node> > vec1_;
+  ROL::Ptr<ROL::StdVector<Real> >                    vec2_;
+  const int rank_;
+  mutable ROL::Ptr<ROL::TpetraMultiVector<Real,LO,GO,Node> > dual_vec1_;
+  mutable ROL::Ptr<ROL::StdVector<Real> >                    dual_vec2_;
+  mutable ROL::Ptr<PDE_OptVector<Real,LO,GO,Node> >          dual_vec_;
+  mutable bool isDualInitialized_;
+
+public:
+  PDE_OptVector(const ROL::Ptr<ROL::TpetraMultiVector<Real,LO,GO,Node> > &vec1,
+                const ROL::Ptr<ROL::StdVector<Real> >                    &vec2,
+                const int rank = 0 ) 
+    : vec1_(vec1), vec2_(vec2), rank_(rank), isDualInitialized_(false) {
+
+    dual_vec1_ = ROL::dynamicPtrCast<ROL::TpetraMultiVector<Real,LO,GO,Node> >(vec1_->dual().clone());
+    dual_vec2_ = ROL::dynamicPtrCast<ROL::StdVector<Real> >(vec2_->dual().clone());
+  }
+
+  PDE_OptVector(const ROL::Ptr<ROL::TpetraMultiVector<Real,LO,GO,Node> > &vec)
+    : vec1_(vec), vec2_(ROL::nullPtr), rank_(0), dual_vec2_(ROL::nullPtr), isDualInitialized_(false) {
+    dual_vec1_ = ROL::dynamicPtrCast<ROL::TpetraMultiVector<Real,LO,GO,Node> >(vec1_->dual().clone());
+  }
+
+  PDE_OptVector(const ROL::Ptr<ROL::StdVector<Real> > &vec,
+                const int rank = 0)
+    : vec1_(ROL::nullPtr), vec2_(vec), rank_(rank), dual_vec1_(ROL::nullPtr), isDualInitialized_(false) {
+    dual_vec2_ = ROL::dynamicPtrCast<ROL::StdVector<Real> >(vec2_->dual().clone());
+  }
+
+  void set( const ROL::Vector<Real> &x ) {
+    const PDE_OptVector<Real> &xs = dynamic_cast<const PDE_OptVector<Real>&>(x);
+    if ( vec1_ != ROL::nullPtr ) {
+      vec1_->set(*(xs.getField()));
+    }
+    if ( vec2_ != ROL::nullPtr ) {
+      vec2_->set(*(xs.getParameter()));
+    }
+  }
+
+  void plus( const ROL::Vector<Real> &x ) {
+    const PDE_OptVector<Real> &xs = dynamic_cast<const PDE_OptVector<Real>&>(x);
+    if ( vec1_ != ROL::nullPtr ) {
+      vec1_->plus(*(xs.getField()));
+    }
+    if ( vec2_ != ROL::nullPtr ) {
+      vec2_->plus(*(xs.getParameter()));
+    }
+  }
+
+  void scale( const Real alpha ) {
+    if ( vec1_ != ROL::nullPtr ) {
+      vec1_->scale(alpha);
+    }
+    if ( vec2_ != ROL::nullPtr ) {
+      vec2_->scale(alpha);
+    }
+  }
+
+  void axpy( const Real alpha, const ROL::Vector<Real> &x ) {
+    const PDE_OptVector<Real> &xs = dynamic_cast<const PDE_OptVector<Real>&>(x);
+    if ( vec1_ != ROL::nullPtr ) {
+      vec1_->axpy(alpha,*(xs.getField()));
+    }
+    if ( vec2_ != ROL::nullPtr ) {
+      vec2_->axpy(alpha,*(xs.getParameter()));
+    }
+  }
+
+  Real dot( const ROL::Vector<Real> &x ) const {
+    const PDE_OptVector<Real> &xs = dynamic_cast<const PDE_OptVector<Real>&>(x);
+    Real val(0);
+    if ( vec1_ != ROL::nullPtr ) {
+      val += vec1_->dot(*(xs.getField()));
+    }
+    if ( vec2_ != ROL::nullPtr ) {
+      val += vec2_->dot(*(xs.getParameter()));
+    }
+    return val;
+  }
+
+  Real norm() const {
+    Real val(0);
+    if ( vec1_ != ROL::nullPtr ) {
+      Real norm1 = vec1_->norm();
+      val += norm1*norm1;
+    }
+    if ( vec2_ != ROL::nullPtr ) {
+      Real norm2 = vec2_->norm();
+      val += norm2*norm2;
+    }
+    return std::sqrt(val);
+  } 
+
+  ROL::Ptr<ROL::Vector<Real> > clone(void) const {
+    if ( vec2_ == ROL::nullPtr ) {
+      return ROL::makePtr<PDE_OptVector<Real,LO,GO,Node>>(
+             ROL::dynamicPtrCast<ROL::TpetraMultiVector<Real,LO,GO,Node> >(vec1_->clone()));
+    }
+    if ( vec1_ == ROL::nullPtr ) {
+      return ROL::makePtr<PDE_OptVector<Real,LO,GO,Node>>(
+             ROL::dynamicPtrCast<ROL::StdVector<Real> >(vec2_->clone()));
+    }
+    return ROL::makePtr<PDE_OptVector<Real,LO,GO,Node>>(
+           ROL::dynamicPtrCast<ROL::TpetraMultiVector<Real,LO,GO,Node> >(vec1_->clone()),
+           ROL::dynamicPtrCast<ROL::StdVector<Real> >(vec2_->clone()));
+  }
+
+  const ROL::Vector<Real> & dual(void) const {
+    if ( !isDualInitialized_ ) {
+      if ( vec1_ == ROL::nullPtr ) {
+        dual_vec_ = ROL::makePtr<PDE_OptVector<Real>>(dual_vec2_);
+      }
+      else if ( vec2_ == ROL::nullPtr ) {
+        dual_vec_ = ROL::makePtr<PDE_OptVector<Real>>(dual_vec1_);
+      }
+      else {
+        dual_vec_ = ROL::makePtr<PDE_OptVector<Real>>(dual_vec1_,dual_vec2_);
+      }
+      isDualInitialized_ = true;
+    }
+    if ( vec1_ != ROL::nullPtr ) {
+      dual_vec1_->set(vec1_->dual());
+    }
+    if ( vec2_ != ROL::nullPtr ) {
+      dual_vec2_->set(vec2_->dual());
+    }
+    return *dual_vec_;
+  }
+
+  Real apply(const ROL::Vector<Real> &x) const {
+    const PDE_OptVector<Real> &xs = dynamic_cast<const PDE_OptVector<Real>&>(x);
+    Real val(0);
+    if ( vec1_ != ROL::nullPtr ) val += vec1_->apply(*(xs.getField()));
+    if ( vec2_ != ROL::nullPtr ) val += vec2_->apply(*(xs.getParameter()));
+    return val;
+  }
+
+  ROL::Ptr<ROL::Vector<Real> > basis( const int i )  const {
+    ROL::Ptr<ROL::Vector<Real> > e;
+    if ( vec1_ != ROL::nullPtr && vec2_ != ROL::nullPtr ) {
+      int n1 = vec1_->dimension();
+      ROL::Ptr<ROL::Vector<Real> > e1, e2;
+      if ( i < n1 ) {
+        e1 = vec1_->basis(i);
+        e2 = vec2_->clone(); e2->zero();
+      }
+      else {
+        e1 = vec1_->clone(); e1->zero();
+        e2 = vec2_->basis(i-n1);
+      }
+      e = ROL::makePtr<PDE_OptVector>(
+        ROL::dynamicPtrCast<ROL::TpetraMultiVector<Real> >(e1),
+        ROL::dynamicPtrCast<ROL::StdVector<Real> >(e2));
+    }
+    if ( vec1_ != ROL::nullPtr && vec2_ == ROL::nullPtr ) {
+      int n1 = vec1_->dimension();
+      ROL::Ptr<ROL::Vector<Real> > e1;
+      if ( i < n1 ) {
+        e1 = vec1_->basis(i);
+      }
+      else {
+        e1->zero();
+      }
+      e = ROL::makePtr<PDE_OptVector>(
+        ROL::dynamicPtrCast<ROL::TpetraMultiVector<Real> >(e1));
+    }
+    if ( vec1_ == ROL::nullPtr && vec2_ != ROL::nullPtr ) {
+      int n2 = vec2_->dimension();
+      ROL::Ptr<ROL::Vector<Real> > e2;
+      if ( i < n2 ) {
+        e2 = vec2_->basis(i);
+      }
+      else {
+        e2->zero();
+      }
+      e = ROL::makePtr<PDE_OptVector>(
+        ROL::dynamicPtrCast<ROL::StdVector<Real> >(e2));
+    }
+    return e;
+  }
+
+  void applyUnary( const ROL::Elementwise::UnaryFunction<Real> &f ) {
+    if ( vec1_ != ROL::nullPtr ) {
+      vec1_->applyUnary(f);
+    }
+    if ( vec2_ != ROL::nullPtr ) {
+      vec2_->applyUnary(f);
+    }
+  }
+
+  void applyBinary( const ROL::Elementwise::BinaryFunction<Real> &f, const ROL::Vector<Real> &x ) {
+    const PDE_OptVector<Real> &xs = dynamic_cast<const PDE_OptVector<Real>&>(x);
+    if ( vec1_ != ROL::nullPtr ) {
+      vec1_->applyBinary(f,*xs.getField());
+    }
+    if ( vec2_ != ROL::nullPtr ) {
+      vec2_->applyBinary(f,*xs.getParameter());
+    }
+  }
+
+  Real reduce( const ROL::Elementwise::ReductionOp<Real> &r ) const {
+    Real result = r.initialValue();
+    if ( vec1_ != ROL::nullPtr ) {
+      r.reduce(vec1_->reduce(r),result);
+    }
+    if ( vec2_ != ROL::nullPtr ) {
+      r.reduce(vec2_->reduce(r),result);
+    }
+    return result;
+  }
+
+  int dimension() const {
+    int dim(0);
+    if ( vec1_ != ROL::nullPtr ) {
+      dim += vec1_->dimension();
+    }
+    if ( vec2_ != ROL::nullPtr ) {
+      dim += vec2_->dimension();
+    }
+    return dim;
+  }
+
+  void randomize(const Real l = 0.0, const Real u = 1.0) {
+    if (vec1_ != ROL::nullPtr) {
+      vec1_->randomize(l,u);
+    }
+    if (vec2_ != ROL::nullPtr) {
+      vec2_->randomize(l,u);
+    }
+  }
+
+  void print(std::ostream &outStream) const {
+    if (vec1_ != ROL::nullPtr) {
+      vec1_->print(outStream);
+    }
+    if (vec2_ != ROL::nullPtr) {
+      if (rank_ == 0) {
+        vec2_->print(outStream);
+      }
+    }
+  }
+
+  ROL::Ptr<const ROL::TpetraMultiVector<Real> > getField(void) const { 
+    return vec1_;
+  }
+
+  ROL::Ptr<const ROL::StdVector<Real> > getParameter(void) const { 
+    return vec2_; 
+  }
+
+  ROL::Ptr<ROL::TpetraMultiVector<Real> > getField(void) { 
+    return vec1_;
+  }
+
+  ROL::Ptr<ROL::StdVector<Real> > getParameter(void) { 
+    return vec2_; 
+  }
+
+  void setField(const ROL::Vector<Real>& vec) { 
+    vec1_->set(vec);
+  }
+  
+  void setParameter(const ROL::Vector<Real>& vec) { 
+    vec2_->set(vec); 
+  }
+}; // class PDE_OptVector
+
+#endif

--- a/packages/rol/example/PDE-OPT/TOOLS/qoiK.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/qoiK.hpp
@@ -1,0 +1,203 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  qoi.hpp
+    \brief Provides the interface for local (cell-based) quantities of interest.
+*/
+
+#ifndef ROL_PDEOPT_QOIK_HPP
+#define ROL_PDEOPT_QOIK_HPP
+
+#include "pdeK.hpp"
+
+template <class Real, class DeviceType>
+class QoI {
+public:
+  
+  using scalar_view = Kokkos::DynRankView<Real,DeviceType>;
+
+  virtual ~QoI() {}
+
+  virtual Real value(scalar_view & val,
+                     const scalar_view u_coeff,
+                     const scalar_view z_coeff = scalar_view(),
+                     const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) = 0;
+
+  virtual void gradient_1(scalar_view & grad,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> gradient_1 not implemented.");
+  }
+
+  virtual void gradient_2(scalar_view & grad,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> gradient_2 not implemented.");
+  }
+
+  virtual std::vector<Real> gradient_3(std::vector<scalar_view > & grad,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> gradient_3 not implemented.");
+  }
+
+  virtual void HessVec_11(scalar_view & hess,
+                          const scalar_view v_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> HessVec_11 not implemented.");
+  }
+
+  virtual void HessVec_12(scalar_view & hess,
+                          const scalar_view v_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> HessVec_12 not implemented.");
+  }
+
+  virtual void HessVec_13(scalar_view & hess,
+                          const ROL::Ptr<const std::vector<Real> > & v_param,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> HessVec_13 not implemented.");
+  }
+
+  virtual void HessVec_21(scalar_view & hess,
+                          const scalar_view v_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> HessVec_21 not implemented.");
+  }
+
+  virtual void HessVec_22(scalar_view & hess,
+                          const scalar_view v_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> HessVec_22 not implemented.");
+  }
+
+  virtual void HessVec_23(scalar_view & hess,
+                          const ROL::Ptr<const std::vector<Real> > & v_param,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> HessVec_23 not implemented.");
+  }
+
+  virtual std::vector<Real> HessVec_31(std::vector<scalar_view > & hess,
+                          const scalar_view v_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> HessVec_31 not implemented.");
+  }
+
+  virtual std::vector<Real> HessVec_32(std::vector<scalar_view > & hess,
+                          const scalar_view v_coeff,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> HessVec_32 not implemented.");
+  }
+
+  virtual std::vector<Real> HessVec_33(std::vector<scalar_view > & hess,
+                          const ROL::Ptr<const std::vector<Real> > & v_param,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> HessVec_33 not implemented.");
+  }
+
+  virtual void Hessian_11(scalar_view & hess,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_11 not implemented.");
+  }
+
+  virtual void Hessian_12(scalar_view & hess,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_12 not implemented.");
+  }
+
+  virtual void Hessian_13(std::vector<scalar_view > & hess,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_13 not implemented.");
+  }
+
+  virtual void Hessian_21(scalar_view & hess,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_21 not implemented.");
+  }
+
+  virtual void Hessian_22(scalar_view & hess,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_22 not implemented.");
+  }
+
+  virtual void Hessian_23(std::vector<scalar_view > & hess,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_23 not implemented.");
+  }
+
+  virtual void Hessian_31(std::vector<scalar_view > & hess,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_31 not implemented.");
+  }
+
+  virtual void Hessian_32(std::vector<scalar_view > & hess,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_32 not implemented.");
+  }
+
+  virtual void Hessian_33(std::vector<std::vector<Real> > & hess,
+                          const scalar_view u_coeff,
+                          const scalar_view z_coeff = scalar_view(),
+                          const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) {
+    throw Exception::NotImplemented(">>> Hessian_33 not implemented.");
+  }
+
+private:
+  std::vector<Real> param_;
+
+protected:
+  std::vector<Real> getParameter(void) const {
+    return param_;
+  }
+
+public:
+  void setParameter(const std::vector<Real> &param) {
+    param_.assign(param.begin(),param.end());
+  }
+
+}; // QOI
+
+#endif

--- a/packages/rol/example/PDE-OPT/poisson/CMakeLists.txt
+++ b/packages/rol/example/PDE-OPT/poisson/CMakeLists.txt
@@ -28,3 +28,33 @@ IF(${PROJECT_NAME}_ENABLE_Intrepid AND
 
 
 ENDIF()
+
+IF(${PROJECT_NAME}_ENABLE_Intrepid2 AND
+   ${PROJECT_NAME}_ENABLE_Ifpack2  AND
+   ${PROJECT_NAME}_ENABLE_MueLu    AND
+   ${PROJECT_NAME}_ENABLE_Amesos2  AND
+   ${PROJECT_NAME}_ENABLE_Tpetra )
+
+  # Need ROL_TpetraMultiVector.hpp
+  TRIBITS_INCLUDE_DIRECTORIES(${${PACKAGE_NAME}_SOURCE_DIR}/adapters/tpetra/src/vector)
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    example_01_Kokkoos
+    SOURCES example_01_K.cpp
+    ARGS PrintItAll
+    NUM_MPI_PROCS 4
+    NUM_TOTAL_CORES_USED 4
+    PASS_REGULAR_EXPRESSION "TEST PASSED"
+    ADD_DIR_TO_NAME
+  )
+
+  TRIBITS_COPY_FILES_TO_BINARY_DIR(
+    PoissonDataCopyK
+    SOURCE_FILES
+      input.xml plotresults.m p-cube-4x4x4.txt p-cube-4x4x4.e p-cube-8x8x8.txt p-cube-8x8x8.e
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+    DEST_DIR "${CMAKE_CURRENT_BINARY_DIR}"
+  )
+
+
+ENDIF()

--- a/packages/rol/example/PDE-OPT/poisson/example_01_K.cpp
+++ b/packages/rol/example/PDE-OPT/poisson/example_01_K.cpp
@@ -1,0 +1,196 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  example_01.cpp
+    \brief Shows how to solve the Poisson control problem.
+*/
+
+#include "Teuchos_Comm.hpp"
+#include "ROL_Stream.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+
+#include "Tpetra_Core.hpp"
+#include "Tpetra_Version.hpp"
+
+#include <iostream>
+#include <algorithm>
+
+#include "ROL_Reduced_Objective_SimOpt.hpp"
+#include "ROL_Solver.hpp"
+
+#include "../TOOLS/meshreaderK.hpp"
+#include "../TOOLS/linearpdeconstraintK.hpp"
+#include "../TOOLS/pdeobjectiveK.hpp"
+#include "../TOOLS/pdevectorK.hpp"
+#include "pde_poissonK.hpp"
+#include "obj_poissonK.hpp"
+
+using RealT = double;
+using DeviceT = Kokkos::HostSpace;
+
+template<class Real>
+class stateSolution : public Solution<Real> {
+public:
+  stateSolution(void) {}
+  Real evaluate(const std::vector<Real> &x, const int fieldNumber) const {
+    const Real pi(M_PI);
+    Real u(1);
+    int dim = x.size();
+    for (int i=0; i<dim; ++i) {
+      u *= std::sin(pi*x[i]);
+    }
+    return u;
+  }
+};
+
+template<class Real>
+class controlSolution : public Solution<Real> {
+private:
+  const Real alpha_;
+public:
+  controlSolution(const Real alpha) : alpha_(alpha) {}
+  Real evaluate(const std::vector<Real> &x, const int fieldNumber) const {
+    const Real eight(8), pi(M_PI);
+    Real z(1);
+    int dim = x.size();
+    for (int i=0; i<dim; ++i) {
+      z *= std::sin(eight*pi*x[i]);
+    }
+    Real coeff1(64), coeff2(dim);
+    return -z/(alpha_*coeff1*coeff2*pi*pi);
+  }
+};
+
+int main(int argc, char *argv[]) {
+  // This little trick lets us print to std::cout only if a (dummy) command-line argument is provided.
+  int iprint     = argc - 1;
+  ROL::Ptr<std::ostream> outStream;
+  ROL::nullstream bhs; // outputs nothing
+
+  /*** Initialize communicator. ***/
+  Teuchos::GlobalMPISession mpiSession (&argc, &argv, &bhs);
+  Kokkos::ScopeGuard kokkosScope (argc, argv);
+  
+  ROL::Ptr<const Teuchos::Comm<int>> comm
+    = Tpetra::getDefaultComm();
+  const int myRank = comm->getRank();
+  if ((iprint > 0) && (myRank == 0)) {
+    outStream = ROL::makePtrFromRef(std::cout);
+  }
+  else {
+    outStream = ROL::makePtrFromRef(bhs);
+  }
+  int errorFlag  = 0;
+
+  // *** Example body.
+  try {
+
+    /*** Read in XML input ***/
+    std::string filename = "input.xml";
+    Teuchos::RCP<Teuchos::ParameterList> parlist = Teuchos::rcp( new Teuchos::ParameterList() );
+    Teuchos::updateParametersFromXmlFile( filename, parlist.ptr() );
+
+    /*** Initialize main data structure. ***/
+    int probDim = parlist->sublist("Problem").get("Problem Dimension",2);
+    ROL::Ptr<MeshManager<RealT,DeviceT>> meshMgr;
+    if (probDim == 1) {
+      meshMgr = ROL::makePtr<MeshManager_Interval<RealT,DeviceT>>(*parlist);
+    } else if (probDim == 2) {
+      meshMgr = ROL::makePtr<MeshManager_Rectangle<RealT,DeviceT>>(*parlist);
+    } else if (probDim == 3) {
+      meshMgr = ROL::makePtr<MeshReader<RealT,DeviceT>>(*parlist);
+    }
+    else {
+      TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
+        ">>> PDE-OPT/poisson/example_01.cpp: Problem dim is not 1, 2 or 3!");
+    }
+    // Initialize PDE describe Poisson's equation
+    ROL::Ptr<PDE_Poisson<RealT,DeviceT>>
+      pde = ROL::makePtr<PDE_Poisson<RealT,DeviceT>>(*parlist);
+    ROL::Ptr<ROL::Constraint_SimOpt<RealT>>
+      con = ROL::makePtr<Linear_PDE_Constraint<RealT,DeviceT>>(pde,meshMgr,comm,*parlist,*outStream);
+    // Cast the constraint and get the assembler.
+    ROL::Ptr<Linear_PDE_Constraint<RealT,DeviceT>>
+      pdecon = ROL::dynamicPtrCast<Linear_PDE_Constraint<RealT,DeviceT>>(con);
+    ROL::Ptr<Assembler<RealT,DeviceT>> assembler = pdecon->getAssembler();
+    // Initialize quadratic objective function
+    std::vector<ROL::Ptr<QoI<RealT,DeviceT>>> qoi_vec(2,ROL::nullPtr);
+    qoi_vec[0] = ROL::makePtr<QoI_L2Tracking_Poisson<RealT,DeviceT>>(pde->getFE());
+    qoi_vec[1] = ROL::makePtr<QoI_L2Penalty_Poisson<RealT,DeviceT>>(pde->getFE());
+    RealT alpha = parlist->sublist("Problem").get("Control penalty parameter",1e-2);
+    std::vector<RealT> wt(2); wt[0] = static_cast<RealT>(1); wt[1] = alpha;
+    ROL::Ptr<ROL::Objective_SimOpt<RealT>>
+      obj = ROL::makePtr<PDE_Objective<RealT,DeviceT>>(qoi_vec,wt,assembler);
+
+    // Create state vector and set to zeroes
+    ROL::Ptr<Tpetra::MultiVector<>> u_ptr, z_ptr, p_ptr, r_ptr;
+    ROL::Ptr<ROL::Vector<RealT>> up, zp, pp, rp;
+    u_ptr  = assembler->createStateVector();   u_ptr->putScalar(0.0);
+    z_ptr  = assembler->createControlVector(); z_ptr->putScalar(0.0);
+    p_ptr  = assembler->createStateVector();   p_ptr->putScalar(0.0);
+    r_ptr  = assembler->createStateVector();   r_ptr->putScalar(0.0);
+    up  = ROL::makePtr<PDE_PrimalSimVector<RealT,DeviceT>>(u_ptr,pde,assembler);
+    zp  = ROL::makePtr<PDE_PrimalOptVector<RealT,DeviceT>>(z_ptr,pde,assembler);
+    pp  = ROL::makePtr<PDE_PrimalSimVector<RealT,DeviceT>>(p_ptr,pde,assembler);
+    rp  = ROL::makePtr<PDE_DualSimVector<RealT,DeviceT>>(r_ptr,pde,assembler);
+
+    // Initialize reduced objective function
+    ROL::Ptr<ROL::Reduced_Objective_SimOpt<RealT>>
+      robj = ROL::makePtr<ROL::Reduced_Objective_SimOpt<RealT>>(obj, con, up, zp, pp);
+
+    // Build optimization problem and check derivatives
+    ROL::Ptr<ROL::Problem<RealT>>
+      optProb = ROL::makePtr<ROL::Problem<RealT>>(robj,zp);
+    optProb->check(true,*outStream);
+
+    // Build optimization solver and solve
+    zp->zero(); up->zero(); pp->zero();
+    ROL::Solver<RealT> optSolver(optProb,*parlist);
+    std::clock_t timerTR = std::clock();
+    optSolver.solve(*outStream);
+    *outStream << "Trust Region Time: "
+               << static_cast<RealT>(std::clock()-timerTR)/static_cast<RealT>(CLOCKS_PER_SEC)
+               << " seconds." << std::endl << std::endl;
+
+    // Compute solution error
+    RealT tol(1.e-8);
+    con->solve(*rp,*up,*zp,tol);
+    ROL::Ptr<Solution<RealT>>
+      usol = ROL::makePtr<stateSolution<RealT>>();
+    RealT uerr = assembler->computeStateError(u_ptr,usol);
+    *outStream << "State Error: " << uerr << std::endl;
+    ROL::Ptr<Solution<RealT>>
+      zsol = ROL::makePtr<controlSolution<RealT>>(alpha);
+    RealT zerr = assembler->computeControlError(z_ptr,zsol);
+    *outStream << "Control Error: " << zerr << std::endl;
+
+    // Output.
+    pdecon->outputTpetraVector(u_ptr,"state.txt");
+    pdecon->outputTpetraVector(z_ptr,"control.txt");
+    pdecon->outputTpetraData();
+    assembler->printMeshData(*outStream);
+
+    errorFlag += (uerr > 10. ? 1 : 0);
+
+    // Get a summary from the time monitor.
+    Teuchos::TimeMonitor::summarize();
+  }
+  catch (std::logic_error& err) {
+    *outStream << err.what() << "\n";
+    errorFlag = -1000;
+  }; // end try
+
+  if (errorFlag != 0)
+    std::cout << "End Result: TEST FAILED\n";
+  else
+    std::cout << "End Result: TEST PASSED\n";
+
+  return 0;
+}

--- a/packages/rol/example/PDE-OPT/poisson/obj_poissonK.hpp
+++ b/packages/rol/example/PDE-OPT/poisson/obj_poissonK.hpp
@@ -1,0 +1,240 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  obj.hpp
+    \brief Provides the interface for local (cell-based) objective function computations.
+*/
+
+#ifndef PDEOPT_QOI_L2TRACKING_POISSONK_HPP
+#define PDEOPT_QOI_L2TRACKING_POISSONK_HPP
+
+#include "../TOOLS/qoiK.hpp"
+#include "pde_poissonK.hpp"
+
+template <class Real,class DeviceType>
+class QoI_L2Tracking_Poisson : public QoI<Real,DeviceType> {
+public:
+  using scalar_view = Kokkos::DynRankView<Real, DeviceType>;
+  using fe_type = FE<Real,DeviceType>;
+  using fst = Intrepid2::FunctionSpaceTools<DeviceType>;
+  using rst = Intrepid2::RealSpaceTools<DeviceType>;
+private:
+  ROL::Ptr<fe_type> fe_;
+
+  scalar_view target_;
+
+  Real targetFunc(const std::vector<Real> & x) const {
+    int size = x.size();
+    const Real eight(8), pi(M_PI);
+    Real s1(1), s2(1);
+    for (int i = 0; i < size; ++i) {
+      s1 *= std::sin(eight*pi*x[i]);
+      s2 *= std::sin(pi*x[i]);
+    }
+    return -s1 + s2;
+  }
+
+public:
+  QoI_L2Tracking_Poisson(const ROL::Ptr<fe_type> &fe) : fe_(fe) {
+    int c = fe_->cubPts().extent_int(0);
+    int p = fe_->cubPts().extent_int(1);
+    int d = fe_->cubPts().extent_int(2);
+    std::vector<Real> pt(d);
+    target_ = scalar_view("target_",c,p);
+    for (int i = 0; i < c; ++i) {
+      for (int j = 0; j < p; ++j) {
+        for (int k = 0; k < d; ++k) {
+          pt[k] = fe_->cubPts()(i,j,k);
+        }
+        target_(i,j) = targetFunc(pt);
+      }
+    }
+  }
+
+  Real value(scalar_view & val,
+             const scalar_view u_coeff,
+             const scalar_view z_coeff = scalar_view(),
+             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    // Get relevant dimensions
+    int c = u_coeff.extent_int(0);
+    int p = fe_->cubPts().extent_int(1);
+    // Initialize output val
+    val = scalar_view("val",c);
+    // Evaluate state on FE basis
+    scalar_view valU_eval("valU_eval", c, p);
+    fe_->evaluateValue(valU_eval, u_coeff);
+    // Compute difference between state and target
+    rst::subtract(valU_eval,target_);
+    // Compute squared L2-norm of diff
+    fe_->computeIntegral(val,valU_eval,valU_eval);
+    // Scale by one half
+    rst::scale(val,static_cast<Real>(0.5));
+    return static_cast<Real>(0);
+  }
+
+  void gradient_1(scalar_view & grad,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr)  override {
+    // Get relevant dimensions
+    int c = u_coeff.extent_int(0);
+    int p = fe_->cubPts().extent_int(1);
+    int f = fe_->N().extent_int(1);
+    // Initialize output grad
+    grad = scalar_view("grad", c, f);
+    // Evaluate state on FE basis
+    scalar_view valU_eval("valU_eval", c, p);
+    fe_->evaluateValue(valU_eval, u_coeff);
+    // Compute difference between state and target
+    rst::subtract(valU_eval,target_);
+    // Compute gradient of squared L2-norm of diff
+    fst::integrate(grad,valU_eval,fe_->NdetJ(), false);
+  }
+
+  void gradient_2(scalar_view & grad,
+                  scalar_view u_coeff,
+                  scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    throw Exception::Zero(">>> QoI_L2Tracking_Poisson::gradient_2 is zero.");
+  }
+
+  void HessVec_11(scalar_view & hess,
+                  const scalar_view v_coeff,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    int c = v_coeff.extent_int(0);
+    int p = fe_->cubPts().extent_int(1);
+    int f = fe_->N().extent_int(1);
+    scalar_view valV_eval("valV_eval",c, p);
+    hess = scalar_view("hess", c, f);
+    fe_->evaluateValue(valV_eval, v_coeff);
+    fst::integrate(hess,valV_eval,fe_->NdetJ(), false);
+  }
+
+  void HessVec_12(scalar_view & hess,
+                  const scalar_view v_coeff,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    throw Exception::Zero(">>> QoI_L2Tracking_Poisson::HessVec_12 is zero.");
+  }
+
+  void HessVec_21(scalar_view & hess,
+                  const scalar_view v_coeff,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    throw Exception::Zero(">>> QoI_L2Tracking_Poisson::HessVec_21 is zero.");
+  }
+
+  void HessVec_22(scalar_view & hess,
+                  const scalar_view v_coeff,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    throw Exception::Zero(">>> QoI_L2Tracking_Poisson::HessVec_22 is zero.");
+  }
+
+}; // QoI_L2Tracking
+
+template <class Real, class DeviceType>
+class QoI_L2Penalty_Poisson : public QoI<Real,DeviceType> {
+public:
+  using scalar_view = Kokkos::DynRankView<Real, DeviceType>;
+  using fe_type = FE<Real,DeviceType>;
+  using fst = Intrepid2::FunctionSpaceTools<DeviceType>;
+  using rst = Intrepid2::RealSpaceTools<DeviceType>;
+private:
+  ROL::Ptr<fe_type> fe_;
+
+public:
+  QoI_L2Penalty_Poisson(const ROL::Ptr<fe_type> &fe) : fe_(fe) {}
+
+  Real value(scalar_view & val,
+             const scalar_view u_coeff,
+             const scalar_view z_coeff = scalar_view(),
+             const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    // Get relevant dimensions
+    int c = z_coeff.extent_int(0);
+    int p = fe_->cubPts().extent_int(1);
+    // Initialize output val
+    val = scalar_view("val",c);
+    // Build local state tracking term
+    scalar_view valZ_eval("valZ", c, p);
+    fe_->evaluateValue(valZ_eval, z_coeff);
+    fe_->computeIntegral(val,valZ_eval,valZ_eval);
+    rst::scale(val,static_cast<Real>(0.5));
+    return static_cast<Real>(0);
+  }
+
+  void gradient_1(scalar_view & grad,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    throw Exception::Zero(">>> QoI_L2Tracking_Poisson::gradient_1 is zero.");
+  }
+
+  void gradient_2(scalar_view & grad,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    // Get relevant dimensions
+    int c = z_coeff.extent_int(0);
+    int p = fe_->cubPts().extent_int(1);
+    int f = fe_->N().extent_int(1);
+    // Initialize output grad
+    grad = scalar_view("grad", c, f);
+    // Build local gradient of state tracking term
+    scalar_view valZ_eval("valZ_eval", c, p);
+    fe_->evaluateValue(valZ_eval, z_coeff);
+    fst::integrate(grad, valZ_eval, fe_->NdetJ(), false);
+  }
+
+  void HessVec_11(scalar_view & hess,
+                  const scalar_view v_coeff,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    throw Exception::Zero(">>> QoI_L2Penalty_Poisson::HessVec_11 is zero.");
+  }
+
+  void HessVec_12(scalar_view & hess,
+                  const scalar_view v_coeff,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    throw Exception::Zero(">>> QoI_L2Penalty_Poisson::HessVec_12 is zero.");
+  }
+
+  void HessVec_21(scalar_view & hess,
+                  const scalar_view v_coeff,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    throw Exception::Zero(">>> QoI_L2Penalty_Poisson::HessVec_21 is zero.");
+  }
+
+  void HessVec_22(scalar_view & hess,
+                  const scalar_view v_coeff,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    int c = v_coeff.extent_int(0);
+    int p = fe_->cubPts().extent_int(1);
+    int f = fe_->N().extent_int(1);
+    scalar_view valV_eval("valV", c, p);
+    hess = scalar_view("hess", c, f);
+    fe_->evaluateValue(valV_eval, v_coeff);
+    fst::integrate(hess, valV_eval, fe_->NdetJ(), false);
+  }
+
+}; // QoI_L2Penalty
+
+#endif

--- a/packages/rol/example/PDE-OPT/poisson/pde_poissonK.hpp
+++ b/packages/rol/example/PDE-OPT/poisson/pde_poissonK.hpp
@@ -1,0 +1,367 @@
+// @HEADER
+// *****************************************************************************
+//               Rapid Optimization Library (ROL) Package
+//
+// Copyright 2014 NTESS and the ROL contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file  pde.hpp
+    \brief Implements the local PDE interface for the Poisson control problem.
+*/
+
+#ifndef PDE_POISSONK_HPP
+#define PDE_POISSONK_HPP
+
+#include "../TOOLS/pdeK.hpp"
+#include "../TOOLS/feK.hpp"
+
+#include "Intrepid2_HGRAD_LINE_Cn_FEM.hpp"
+#include "Intrepid2_HGRAD_QUAD_C1_FEM.hpp"
+#include "Intrepid2_HGRAD_QUAD_C2_FEM.hpp"
+#include "Intrepid2_HGRAD_HEX_C1_FEM.hpp"
+#include "Intrepid2_HGRAD_HEX_C2_FEM.hpp"
+#include "Intrepid2_DefaultCubatureFactory.hpp"
+#include "Intrepid2_FunctionSpaceTools.hpp"
+#include "Intrepid2_CellTools.hpp"
+
+#include "ROL_Ptr.hpp"
+
+template <class Real, class DeviceType>
+class PDE_Poisson : public PDE<Real, DeviceType> {
+public:
+  using scalar_view = Kokkos::DynRankView<Real, DeviceType>;
+  using basis_ptr = Intrepid2::BasisPtr<DeviceType, Real, Real>;
+  using fe_type = FE<Real,DeviceType>;
+  using fst = Intrepid2::FunctionSpaceTools<DeviceType>;
+  using ct = Intrepid2::CellTools<DeviceType>;
+  using rst = Intrepid2::RealSpaceTools<DeviceType>;
+private:
+  // Finite element basis information
+  basis_ptr basisPtr_;
+  std::vector<basis_ptr> basisPtrs_;
+  // Cell cubature information
+  ROL::Ptr<Intrepid2::Cubature<DeviceType, Real, Real>> cellCub_;
+  // Cell node information
+  scalar_view volCellNodes_;
+  std::vector<std::vector<scalar_view>> bdryCellNodes_;
+  std::vector<std::vector<std::vector<int>>> bdryCellLocIds_;
+  // Finite element definition
+  ROL::Ptr<fe_type> fe_vol_;
+  // Local degrees of freedom on boundary, for each side of the reference cell (first index).
+  std::vector<std::vector<int>> fidx_;
+  // Coordinates of degrees freedom on boundary cells.
+  // Indexing:  [sideset number][local side id](cell number, value at dof)
+  std::vector<std::vector<scalar_view>> bdryCellDofValues_;
+
+  bool useStateRiesz_;
+  bool useControlRiesz_;
+  Real alpha_;
+
+  Real DirichletFunc(const std::vector<Real> & coords, int sideset, int locSideId) const {
+    return 0;
+  }
+
+  Real evaluateRHS(const std::vector<Real> &x) const {
+    const Real pi(M_PI), eight(8);
+    Real s1(1), s2(1);
+    int dim = x.size();
+    for (int i=0; i<dim; ++i) {
+      s1 *= std::sin(eight*pi*x[i]);
+      s2 *= std::sin(pi*x[i]);
+    }
+    Real coeff1(64), coeff2(dim);
+    return s1/(alpha_*coeff1*coeff2*pi*pi) + coeff2*pi*pi*s2;
+  }
+
+  void computeRHS(scalar_view rhs) const {
+    // GET DIMENSIONS
+    int c = fe_vol_->gradN().extent_int(0);
+    int p = fe_vol_->gradN().extent_int(2);
+    int d = fe_vol_->gradN().extent_int(3);
+    std::vector<Real> pt(d);
+    for (int i = 0; i < c; ++i) {
+      for (int j = 0; j < p; ++j) {
+        for ( int k = 0; k < d; ++k) {
+          pt[k] = fe_vol_->cubPts()(i,j,k);
+        }
+        // Compute forcing term f
+        rhs(i,j) = -evaluateRHS(pt);
+      }
+    }
+  }
+
+public:
+  PDE_Poisson(Teuchos::ParameterList &parlist) {
+    // Finite element fields.
+    int basisOrder = parlist.sublist("Problem").get("Basis Order",1);
+    int cubDegree  = parlist.sublist("Problem").get("Cubature Degree",4);
+    int probDim    = parlist.sublist("Problem").get("Problem Dimension",2);
+    if (probDim > 3 || probDim < 1) {
+      TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
+        ">>> PDE-OPT/poisson/pde_poisson.hpp: Problem dimension is not 1, 2 or 3!");
+    }
+    if (basisOrder > 2 || basisOrder < 1) {
+      TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument,
+        ">>> PDE-OPT/poisson/pde_poisson.hpp: Basis order is not 1 or 2!");
+    }
+    if (probDim == 1) {
+      basisPtr_ = Teuchos::rcp(new Intrepid2::Basis_HGRAD_LINE_Cn_FEM<DeviceType, Real, Real>(basisOrder,Intrepid2::POINTTYPE_EQUISPACED));
+    } else if (probDim == 2) {
+      if (basisOrder == 1) {
+        basisPtr_ = Teuchos::rcp(new Intrepid2::Basis_HGRAD_QUAD_C1_FEM<DeviceType, Real, Real>);
+      }
+      else if (basisOrder == 2) {
+        basisPtr_ = Teuchos::rcp(new Intrepid2::Basis_HGRAD_QUAD_C2_FEM<DeviceType, Real, Real>);
+      }
+    } else if (probDim == 3) {
+      if (basisOrder == 1) {
+        basisPtr_ = Teuchos::rcp(new Intrepid2::Basis_HGRAD_HEX_C1_FEM<DeviceType, Real, Real>);
+      }
+      else if (basisOrder == 2) {
+        basisPtr_ = Teuchos::rcp(new Intrepid2::Basis_HGRAD_HEX_C2_FEM<DeviceType, Real, Real>);
+      }
+    }
+    basisPtrs_.clear(); basisPtrs_.push_back(basisPtr_);
+    // Quadrature rules.
+    shards::CellTopology cellType = basisPtr_->getBaseCellTopology();
+    Intrepid2::DefaultCubatureFactory cubFactory;
+    cellCub_ = cubFactory.create<DeviceType, Real, Real>(cellType, cubDegree);
+    // Problem data.
+    useStateRiesz_   = parlist.sublist("Problem").get("Use State Riesz Map", true);      // use Riesz map for state variables?
+    useControlRiesz_ = parlist.sublist("Problem").get("Use Control Riesz Map", true);    // use Riesz map for control variables?
+    alpha_           = parlist.sublist("Problem").get("Control penalty parameter",1e-2);
+  }
+
+  void residual(scalar_view & res,
+                const scalar_view u_coeff,
+                const scalar_view z_coeff = ROL::nullPtr,
+                const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    // GET DIMENSIONS
+    int c = u_coeff.extent_int(0);
+    int p = cellCub_->getNumPoints();
+    int f = basisPtr_->getCardinality();
+    int d = cellCub_->getDimension();
+    // INITIALIZE RESIDUAL
+    res = scalar_view("res", c, f);
+    // COMPUTE STIFFNESS TERM
+    scalar_view gradU_eval("gradU_eval", c, p, d);
+    fe_vol_->evaluateGradient(gradU_eval, u_coeff);
+    fst::integrate(res, gradU_eval, fe_vol_->gradNdetJ(), false);
+    // COMPUTE RHS
+    scalar_view rhs("rhs", c, p);
+    computeRHS(rhs);
+    fst::integrate(res, rhs, fe_vol_->NdetJ(), true);
+    // ADD CONTROL TERM TO RESIDUAL
+    if ( z_coeff.is_allocated()) {
+      scalar_view valZ_eval("valZ_eval", c, p);
+      fe_vol_->evaluateValue(valZ_eval, z_coeff);
+      rst::scale(valZ_eval,static_cast<Real>(-1));
+      fst::integrate(res, valZ_eval, fe_vol_->NdetJ(), true);
+    }
+    // APPLY DIRICHLET CONDITIONS
+    int numSideSets = bdryCellLocIds_.size();
+    if (numSideSets > 0) {
+      for (int i = 0; i < numSideSets; ++i) {
+        int numLocalSideIds = bdryCellLocIds_[i].size();
+        for (int j = 0; j < numLocalSideIds; ++j) {
+          int numCellsSide = bdryCellLocIds_[i][j].size();
+          int numBdryDofs = fidx_[j].size();
+          for (int k = 0; k < numCellsSide; ++k) {
+            int cidx = bdryCellLocIds_[i][j][k];
+            for (int l = 0; l < numBdryDofs; ++l) {
+              //std::cout << "\n   j=" << j << "  l=" << l << "  " << fidx_[j][l];
+              res(cidx,fidx_[j][l]) = u_coeff(cidx,fidx_[j][l]) - (bdryCellDofValues_[i][j])(k,fidx_[j][l]);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  void Jacobian_1(scalar_view & jac,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) override {
+    // GET DIMENSIONS
+    int c = u_coeff.extent_int(0);
+    int f = basisPtr_->getCardinality();
+    // INITILAIZE JACOBIAN
+    jac = scalar_view("jac", c, f, f);
+    // COMPUTE STIFFNESS TERM
+    fst::integrate(jac, fe_vol_->gradN(), fe_vol_->gradNdetJ(), false);
+    // APPLY DIRICHLET CONDITIONS
+    int numSideSets = bdryCellLocIds_.size();
+    if (numSideSets > 0) {
+      for (int i = 0; i < numSideSets; ++i) {
+        int numLocalSideIds = bdryCellLocIds_[i].size();
+        for (int j = 0; j < numLocalSideIds; ++j) {
+          int numCellsSide = bdryCellLocIds_[i][j].size();
+          int numBdryDofs = fidx_[j].size();
+          for (int k = 0; k < numCellsSide; ++k) {
+            int cidx = bdryCellLocIds_[i][j][k];
+            for (int l = 0; l < numBdryDofs; ++l) {
+              //std::cout << "\n   j=" << j << "  l=" << l << "  " << fidx[j][l];
+              for (int m = 0; m < f; ++m) {
+                jac(cidx,fidx_[j][l],m) = static_cast<Real>(0);
+              }
+              jac(cidx,fidx_[j][l],fidx_[j][l]) = static_cast<Real>(1);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  void Jacobian_2(scalar_view & jac,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real> > & z_param = ROL::nullPtr) override {
+    if ( z_coeff.is_allocated() ) {
+      // GET DIMENSIONS
+      int c = u_coeff.extent_int(0);
+      int f = basisPtr_->getCardinality();
+      // INITIALIZE JACOBIAN
+      jac = scalar_view("jac", c, f, f);
+      // ADD CONTROL TERM
+      fst::integrate(jac, fe_vol_->N(), fe_vol_->NdetJ(), false);
+      rst::scale(jac, static_cast<Real>(-1));
+      // APPLY DIRICHLET CONDITIONS
+      int numSideSets = bdryCellLocIds_.size();
+      if (numSideSets > 0) {
+        for (int i = 0; i < numSideSets; ++i) {
+          int numLocalSideIds = bdryCellLocIds_[i].size();
+          for (int j = 0; j < numLocalSideIds; ++j) {
+            int numCellsSide = bdryCellLocIds_[i][j].size();
+            int numBdryDofs = fidx_[j].size();
+            for (int k = 0; k < numCellsSide; ++k) {
+              int cidx = bdryCellLocIds_[i][j][k];
+              for (int l = 0; l < numBdryDofs; ++l) {
+                //std::cout << "\n   j=" << j << "  l=" << l << "  " << fidx[j][l];
+                for (int m = 0; m < f; ++m) {
+                  jac(cidx,fidx_[j][l],m) = static_cast<Real>(0);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    else {
+      throw Exception::Zero(">>> (PDE_Poisson::Jacobian_2): Jacobian is zero.");
+    }
+  }
+
+  void Hessian_11(scalar_view & hess,
+                  const scalar_view l_coeff,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    throw Exception::Zero(">>> (PDE_Poisson::Hessian_11): Hessian is zero.");
+  }
+
+  void Hessian_12(scalar_view & hess,
+                  const scalar_view l_coeff,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    throw Exception::Zero(">>> (PDE_Poisson::Hessian_12): Hessian is zero.");
+  }
+
+  void Hessian_21(scalar_view & hess,
+                  const scalar_view l_coeff,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    throw Exception::Zero(">>> (PDE_Poisson::Hessian_21): Hessian is zero.");
+  }
+
+  void Hessian_22(scalar_view & hess,
+                  const scalar_view l_coeff,
+                  const scalar_view u_coeff,
+                  const scalar_view z_coeff = scalar_view(),
+                  const ROL::Ptr<const std::vector<Real>> & z_param = ROL::nullPtr) override {
+    throw Exception::Zero(">>> (PDE_Poisson::Hessian_22): Hessian is zero.");
+  }
+
+  void RieszMap_1(scalar_view & riesz) override {
+    // Optionally disable Riesz map ...
+    if (!useStateRiesz_) {
+      throw Exception::NotImplemented(">>> (PDE_Poisson::RieszMap_1): Not implemented.");
+    }
+
+    // ...otherwise ...
+
+    int c = fe_vol_->N().extent_int(0);
+    int f = fe_vol_->N().extent_int(1);
+    // INITILAIZE JACOBIAN
+    riesz = scalar_view("riesz", c, f, f);
+    Kokkos::deep_copy(riesz,fe_vol_->stiffMat());
+    rst::add(riesz,fe_vol_->massMat());
+  }
+
+  void RieszMap_2(scalar_view & riesz) override {
+    // Optionally disable Riesz map ...
+    if (!useControlRiesz_) {
+      throw Exception::NotImplemented(">>> (PDE_Poisson::RieszMap_2): Not implemented.");
+    }
+
+    // ...otherwise ...
+
+    int c = fe_vol_->N().extent_int(0);
+    int f = fe_vol_->N().extent_int(1);
+    // INITILAIZE JACOBIAN
+    riesz = scalar_view("riesz", c, f, f);
+    Kokkos::deep_copy(riesz, fe_vol_->massMat());
+  }
+
+  std::vector<basis_ptr> getFields() override   {
+    return basisPtrs_;
+  }
+
+  void setCellNodes(const scalar_view &volCellNodes,
+                    const std::vector<std::vector<scalar_view>> &bdryCellNodes,
+                    const std::vector<std::vector<std::vector<int>>> &bdryCellLocIds) override {
+    volCellNodes_ = volCellNodes;
+    bdryCellNodes_ = bdryCellNodes;
+    bdryCellLocIds_ = bdryCellLocIds;
+    // Finite element definition.
+    fe_vol_ = ROL::makePtr<fe_type>(volCellNodes_,basisPtr_,cellCub_);
+    // Set local boundary DOFs.
+    fidx_ = fe_vol_->getBoundaryDofs();
+    // Compute Dirichlet values at DOFs.
+    int d = basisPtr_->getBaseCellTopology().getDimension();
+    int numSidesets = bdryCellLocIds_.size();
+    bdryCellDofValues_.resize(numSidesets);
+    for (int i=0; i<numSidesets; ++i) {
+      int numLocSides = bdryCellLocIds_[i].size();
+      bdryCellDofValues_[i].resize(numLocSides);
+      for (int j=0; j<numLocSides; ++j) {
+        int c = bdryCellLocIds_[i][j].size();
+        int f = basisPtr_->getCardinality();
+        bdryCellDofValues_[i][j] = scalar_view("bdryVals", c, f);
+        scalar_view coords("coords", c, f, d);
+        if (c > 0) {
+          fe_vol_->computeDofCoords(coords, bdryCellNodes_[i][j]);
+        }
+        for (int k=0; k<c; ++k) {
+          for (int l=0; l<f; ++l) {
+            std::vector<Real> dofpoint(d);
+            for (int m=0; m<d; ++m) {
+              dofpoint[m] = coords(k, l, m);
+            }
+            bdryCellDofValues_[i][j](k, l) = DirichletFunc(dofpoint, i, j);
+          }
+        }
+      }
+    }
+  }
+
+  const ROL::Ptr<fe_type> getFE(void) const {
+    return fe_vol_;
+  }
+
+}; // PDE_Poisson
+
+#endif


### PR DESCRIPTION
In this PR we start the transition of ROL PDE-OPT examples to Intrepid2.
Changes: 
- Added `PDE-OPT/poisson/example_01_K.cpp` as part of the transition to Intrepid2.
- Replicated several files in the PDE-OPT directory to use Intrepid2 instead of Intrepid.
- New files using Intrepid2 are suffixed with K to indicate Kokkos compatibility.

Intrepid Field Containers have been replaced with Kokkos Dynamic Rank Views. The new classes are templated with the DeviceType. However, at the moment the code is executable only on host, and additional modifications are required for the code to build and run on devices. 

At this stage, only one example has been migrated to Intrepid2. As a result, much of the code in the new files remains untested, partially uncompiled, and may contain errors. 

@dridzal  Except for essential or trivial modifications, I tried to keep the design as close as possible to the original implementation. However, there is room for improvement. As an example, Intrepid2 has functionality for handling the orientation of basis functions for high-order finite elements. For now, I have retained the ad-hoc orientation handling implemented in ROL. We may consider transitioning to Intrepid2's orientation capabilities in the future.

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/rol 

## Motivation
Intrepid archival
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->




## Testing
Only one example, `PDE-OPT/poisson/example_01_K.cpp` ,  has been migrated to Intrepid2. 
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
