### PR TITLE
Teuchos: Adds missing template instantiation for unsigned long long

### DIFF
--- a/packages/teuchos/core/src/Teuchos_EnvVariables.cpp
+++ b/packages/teuchos/core/src/Teuchos_EnvVariables.cpp
@@ -194,5 +194,6 @@ template std::string idempotentlyGetEnvironmentVariable<std::string>(std::string
 template int idempotentlyGetEnvironmentVariable<int>(int&, bool&, const std::string_view, const int);
 template unsigned long idempotentlyGetEnvironmentVariable<unsigned long>(unsigned long&, bool&, const std::string_view, const unsigned long);
 template bool idempotentlyGetEnvironmentVariable<bool>(bool&, bool&, const std::string_view, const bool);
+template unsigned long long idempotentlyGetEnvironmentVariable<unsigned long long>(unsigned long long&, bool&, const std::string_view, const unsigned long long);
 
 } // namespace Teuchos


### PR DESCRIPTION

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 

## Motivation
The idempotentlyGetEnvironmentVariable<> template, which is used in Tpetra_Details_Behavior.cpp, there is a missing template instantiation for unsigned long long which is size_t on Windows machines.

<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes #14397 

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
This change allows Trilinos to compile on the Xyce Windows development and test machine.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
