### PR TITLE
Ifpack2, MueLu: alloc changes

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_ChebyshevKernel_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_ChebyshevKernel_decl.hpp
@@ -61,6 +61,8 @@ class ChebyshevKernel {
   void
   setMatrix(const Teuchos::RCP<const operator_type>& A);
 
+  void setAuxiliaryVectors(size_t numVectors);
+
   void
   compute(multivector_type& W,
           const SC& alpha,

--- a/packages/ifpack2/src/Ifpack2_Details_ChebyshevKernel_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_ChebyshevKernel_def.hpp
@@ -300,6 +300,15 @@ void ChebyshevKernel<TpetraOperatorType>::
 
 template <class TpetraOperatorType>
 void ChebyshevKernel<TpetraOperatorType>::
+    setAuxiliaryVectors(size_t numVectors) {
+  if ((V1_.get() == nullptr) || V1_->getNumVectors() != numVectors) {
+    using MV = multivector_type;
+    V1_      = std::unique_ptr<MV>(new MV(A_op_->getRangeMap(), numVectors));
+  }
+}
+
+template <class TpetraOperatorType>
+void ChebyshevKernel<TpetraOperatorType>::
     compute(multivector_type& W,
             const SC& alpha,
             vector_type& D_inv,
@@ -357,11 +366,8 @@ void ChebyshevKernel<TpetraOperatorType>::
                 multivector_type& X,
                 const SC& beta) {
   using STS = Teuchos::ScalarTraits<SC>;
-  if (V1_.get() == nullptr) {
-    using MV             = multivector_type;
-    const size_t numVecs = B.getNumVectors();
-    V1_                  = std::unique_ptr<MV>(new MV(B.getMap(), numVecs));
-  }
+  setAuxiliaryVectors(B.getNumVectors());
+
   const SC one = Teuchos::ScalarTraits<SC>::one();
 
   // V1 = B - A*X

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
@@ -493,6 +493,11 @@ class Chebyshev : public Teuchos::Describable {
   /// and insead use native blas/SpMV operators
   bool ckUseNativeSpMV_;
 
+  /// Whether the temporary multivector should be pre-allocated (for a single vector)
+  /// in compute(). Otherwise this will happen the first time apply is called,
+  /// slowing it down.
+  bool preAllocateTempVector_;
+
   /// \brief Output stream for debug output ONLY.
   ///
   /// This is ONLY valid if debug_ is true.

--- a/packages/ifpack2/src/Ifpack2_Parameters.cpp
+++ b/packages/ifpack2/src/Ifpack2_Parameters.cpp
@@ -46,6 +46,7 @@ void getValidParameters(Teuchos::ParameterList &params) {
   params.set("chebyshev: min diagonal value", STS::eps());
   params.set("chebyshev: zero starting solution", true);
   params.set("chebyshev: use native spmv", true);
+  params.set("chebyshev: pre-allocate temp vector", true);
   params.set("chebyshev: algorithm", "first");
 
   // Ifpack2_Amesos.cpp

--- a/packages/muelu/test/scaling/Driver.cpp
+++ b/packages/muelu/test/scaling/Driver.cpp
@@ -303,8 +303,10 @@ int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib& lib, int ar
   std::string levelPerformanceModel = "no";
   clp.setOption("performance-model", &levelPerformanceModel, "runs the level-by-level performance mode options- 'no', 'yes' or 'verbose'");
 
-  bool performSacrifice = Node::is_gpu;
-  clp.setOption("sacrificial-solve", "no-sacrificial-solve", &performSacrifice, "Warm up the solver using a sacrificial solve");
+  bool performSacrificeSetup = Node::is_gpu;
+  clp.setOption("sacrificial-setup", "no-sacrificial-setup", &performSacrificeSetup, "Warm up using a sacrificial setup");
+  bool performSacrificeSolve = Node::is_gpu;
+  clp.setOption("sacrificial-solve", "no-sacrificial-solve", &performSacrificeSolve, "Warm up the solver using a sacrificial solve");
 
   bool kokkosTuning = false;
 #ifdef KOKKOS_ENABLE_TUNING
@@ -583,9 +585,7 @@ int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib& lib, int ar
         RCP<Operator> Prec;
         // Build the preconditioner numRebuilds+1 times
         if (solvePreconditioned) {
-          MUELU_SWITCH_TIME_MONITOR(tm, "Driver: 2 - MueLu Setup");
-
-          PreconditionerSetup(A, coordinates, nullspace, material, blocknumber, mueluList, profileSetup, useAMGX, useML, setNullSpace, numRebuilds, H, Prec);
+          PreconditionerSetup(A, coordinates, nullspace, material, blocknumber, mueluList, profileSetup, useAMGX, useML, setNullSpace, numRebuilds, H, Prec, performSacrificeSetup);
         }
         comm->barrier();
         tm = Teuchos::null;
@@ -610,7 +610,7 @@ int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib& lib, int ar
         // =========================================================================
         // Solve the system numResolves+1 times
         try {
-          SystemSolve(A, X, B, H, Prec, out2, solveType, belosType, profileSolve, useAMGX, useML, cacheSize, numResolves, scaleResidualHist, solvePreconditioned, maxIts, tol, computeCondEst, enforceBoundaryConditionsOnInitialGuess, performSacrifice);
+          SystemSolve(A, X, B, H, Prec, out2, solveType, belosType, profileSolve, useAMGX, useML, cacheSize, numResolves, scaleResidualHist, solvePreconditioned, maxIts, tol, computeCondEst, enforceBoundaryConditionsOnInitialGuess, performSacrificeSolve);
 
           comm->barrier();
         } catch (const std::exception& e) {

--- a/packages/muelu/test/scaling/DriverCore.hpp
+++ b/packages/muelu/test/scaling/DriverCore.hpp
@@ -126,9 +126,11 @@ void PreconditionerSetup(Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, Globa
                          bool setNullSpace,
                          int numRebuilds,
                          Teuchos::RCP<MueLu::Hierarchy<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& H,
-                         Teuchos::RCP<Xpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& Prec) {
+                         Teuchos::RCP<Xpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& Prec,
+                         bool sacrifice = false) {
 #include <MueLu_UseShortNames.hpp>
   using Teuchos::RCP;
+  using Teuchos::TimeMonitor;
   Xpetra::UnderlyingLib lib = A->getRowMap()->lib();
   typedef typename Teuchos::ScalarTraits<SC>::coordinateType coordinate_type;
   typedef Xpetra::MultiVector<coordinate_type, LO, GO, NO> CoordinateMultiVector;
@@ -140,9 +142,13 @@ void PreconditionerSetup(Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, Globa
   if (profileSetup) cudaProfilerStart();
 #endif
 
+  if (sacrifice)
+    ++numRebuilds;
+
   if (useML && lib != Xpetra::UseEpetra) throw std::runtime_error("Error: Cannot use ML on non-epetra matrices");
 
   for (int i = 0; i <= numRebuilds; i++) {
+    auto tm = Teuchos::rcp(new TimeMonitor(*TimeMonitor::getNewTimer((!sacrifice || (i > 0)) ? "Driver: 2 - MueLu Setup" : "Driver: 2 - MueLu Setup (sacrifice)")));
     A->SetMaxEigenvalueEstimate(-Teuchos::ScalarTraits<SC>::one());
     if (useAMGX) {
 #if defined(HAVE_MUELU_AMGX)


### PR DESCRIPTION
@trilinos/ifpack2 @trilinos/muelu 

## Motivation
- Ifpack2 Chebyshev: Allocate auxiliary vectors during `compute`.
- MueLu Driver: Hook up RCM reordering
- MueLu: Refactor `EnforceInitialCondition` so that it avoids an allocation 
- MueLu Driver: add option for sacrificial setup