### PR TITLE
Adelus: Guard showtime statements with GET_TIMING and fix missing value_type

### DIFF
--- a/packages/adelus/src/Adelus_x_factor.hpp
+++ b/packages/adelus/src/Adelus_x_factor.hpp
@@ -121,8 +121,10 @@ void lu_(HandleType& ahandle, ZViewType& Z, PViewType& permute, double *secs)
   run_secs = (double) tsecs;
 
   *secs = run_secs;
+#ifdef GET_TIMING
   showtime(ahandle.get_comm_id(), ahandle.get_comm(), ahandle.get_myrank(), ahandle.get_nprocs_cube(),
            "Total time in Factor (inl. matrix permutation)", &run_secs );
+#endif
   }
 }
 

--- a/packages/adelus/src/Adelus_x_solve.hpp
+++ b/packages/adelus/src/Adelus_x_solve.hpp
@@ -41,6 +41,7 @@ void solve_(HandleType& ahandle, ZViewType& Z, RHSViewType& RHS, PViewType& perm
 #endif
 
 #ifdef PRINT_STATUS
+  using value_type      = typename ZViewType::value_type;
   using execution_space = typename ZViewType::device_type::execution_space;
   using memory_space    = typename ZViewType::device_type::memory_space;
 #endif
@@ -126,8 +127,10 @@ void solve_(HandleType& ahandle, ZViewType& Z, RHSViewType& RHS, PViewType& perm
     run_secs = (double) tsecs;
 
     *secs = run_secs;
+#ifdef GET_TIMING
     showtime(ahandle.get_comm_id(), ahandle.get_comm(), ahandle.get_myrank(), ahandle.get_nprocs_cube(),
               "Total time in Solve", &run_secs );
+#endif
   }
 }
 

--- a/packages/adelus/src/Adelus_xlu_solve.hpp
+++ b/packages/adelus/src/Adelus_xlu_solve.hpp
@@ -140,8 +140,10 @@ void lusolve_(HandleType& ahandle, ZRHSViewType& ZRHS, double *secs)
   // Solve time secs
 
   *secs = run_secs;
+#ifdef GET_TIMING
   showtime(ahandle.get_comm_id(), ahandle.get_comm(), ahandle.get_myrank(), ahandle.get_nprocs_cube(),
            "Total time in Factor and Solve", &run_secs);
+#endif
   }
 }
 


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/adelus 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
This PR is to
- move ```showtime``` statements into ```#ifdef GET_TIMING``` for less timing outputs, and
- declare ```value_type``` when ```PRINT_STATUS``` is defined.


<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->



<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
