### PR TITLE
MueLu: Do not recompute valid PL

### DIFF
--- a/packages/muelu/src/Graph/BrickAggregation/MueLu_BrickAggregationFactory_decl.hpp
+++ b/packages/muelu/src/Graph/BrickAggregation/MueLu_BrickAggregationFactory_decl.hpp
@@ -84,7 +84,9 @@ class BrickAggregationFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~BrickAggregationFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Graph/BrickAggregation/MueLu_BrickAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/BrickAggregation/MueLu_BrickAggregationFactory_def.hpp
@@ -37,7 +37,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> BrickAggregationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> BrickAggregationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Graph/HybridAggregation/MueLu_HybridAggregationFactory_decl.hpp
+++ b/packages/muelu/src/Graph/HybridAggregation/MueLu_HybridAggregationFactory_decl.hpp
@@ -107,7 +107,9 @@ class HybridAggregationFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~HybridAggregationFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Graph/HybridAggregation/MueLu_HybridAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/HybridAggregation/MueLu_HybridAggregationFactory_def.hpp
@@ -50,7 +50,7 @@ HybridAggregationFactory<LocalOrdinal, GlobalOrdinal, Node>::
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 RCP<const ParameterList> HybridAggregationFactory<LocalOrdinal, GlobalOrdinal, Node>::
-    GetValidParameterList() const {
+    GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_decl.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_decl.hpp
@@ -53,7 +53,9 @@ class AmalgamationFactory : public SingleLevelFactoryBase {
   //! Destructor
   virtual ~AmalgamationFactory();
 
-  RCP<const ParameterList> GetValidParameterList() const override;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_AmalgamationFactory_def.hpp
@@ -27,7 +27,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 AmalgamationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~AmalgamationFactory() = default;
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> AmalgamationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> AmalgamationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Generating factory of the matrix A");
   return validParamList;

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_decl.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_decl.hpp
@@ -109,7 +109,9 @@ class CoalesceDropFactory : public SingleLevelFactoryBase {
   //! Destructor
   virtual ~CoalesceDropFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_def.hpp
@@ -85,7 +85,7 @@ enum decisionAlgoType { defaultAlgo,
                         scaled_cut_symmetric };
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> CoalesceDropFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> CoalesceDropFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_decl.hpp
@@ -119,7 +119,9 @@ class CoalesceDropFactory_kokkos
   //! Destructor
   virtual ~CoalesceDropFactory_kokkos() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
@@ -43,7 +43,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> CoalesceDropFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> CoalesceDropFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_SmooVecCoalesceDropFactory_decl.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_SmooVecCoalesceDropFactory_decl.hpp
@@ -96,7 +96,9 @@ class SmooVecCoalesceDropFactory : public SingleLevelFactoryBase {
   //! Destructor
   virtual ~SmooVecCoalesceDropFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_SmooVecCoalesceDropFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_SmooVecCoalesceDropFactory_def.hpp
@@ -56,7 +56,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> SmooVecCoalesceDropFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> SmooVecCoalesceDropFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_UnsmooshFactory_decl.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_UnsmooshFactory_decl.hpp
@@ -71,7 +71,9 @@ class UnsmooshFactory : public PFactory {
   //! Destructor
   virtual ~UnsmooshFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_UnsmooshFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_UnsmooshFactory_def.hpp
@@ -20,7 +20,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 UnsmooshFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::UnsmooshFactory() {}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> UnsmooshFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> UnsmooshFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Generating factory for unamalgamated matrix. Row map of (unamalgamted) output prolongation operator should match row map of this A.");
   validParamList->set<RCP<const FactoryBase> >("P", Teuchos::null, "Generating factory of the (amalgamated) prolongator P");

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_VariableDofLaplacianFactory_decl.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_VariableDofLaplacianFactory_decl.hpp
@@ -77,7 +77,9 @@ class VariableDofLaplacianFactory : public SingleLevelFactoryBase {
   //! Destructor
   virtual ~VariableDofLaplacianFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_VariableDofLaplacianFactory_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_VariableDofLaplacianFactory_def.hpp
@@ -17,7 +17,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> VariableDofLaplacianFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> VariableDofLaplacianFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<double>("Advanced Dirichlet: threshold", 1e-5, "Drop tolerance for Dirichlet detection");

--- a/packages/muelu/src/Graph/PairwiseAggregation/MueLu_NotayAggregationFactory_decl.hpp
+++ b/packages/muelu/src/Graph/PairwiseAggregation/MueLu_NotayAggregationFactory_decl.hpp
@@ -58,7 +58,9 @@ class NotayAggregationFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~NotayAggregationFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Graph/PairwiseAggregation/MueLu_NotayAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/PairwiseAggregation/MueLu_NotayAggregationFactory_def.hpp
@@ -49,7 +49,7 @@ void RandomReorder(Teuchos::Array<LocalOrdinal>& list) {
 }  // namespace NotayUtils
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> NotayAggregationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> NotayAggregationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_decl.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_decl.hpp
@@ -80,7 +80,9 @@ class StructuredAggregationFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~StructuredAggregationFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_def.hpp
@@ -34,7 +34,7 @@ StructuredAggregationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RCP<const ParameterList> StructuredAggregationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-    GetValidParameterList() const {
+    GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_kokkos_decl.hpp
@@ -84,7 +84,9 @@ class StructuredAggregationFactory_kokkos : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~StructuredAggregationFactory_kokkos() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_kokkos_def.hpp
@@ -36,7 +36,7 @@ StructuredAggregationFactory_kokkos<LocalOrdinal, GlobalOrdinal, Node>::
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 RCP<const ParameterList> StructuredAggregationFactory_kokkos<LocalOrdinal, GlobalOrdinal, Node>::
-    GetValidParameterList() const {
+    GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_decl.hpp
@@ -115,7 +115,9 @@ class UncoupledAggregationFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~UncoupledAggregationFactory();
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DoGraphColoring(Level& currentLevel,
                        const std::string& aggAlgo,

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_def.hpp
@@ -50,7 +50,7 @@ template <class LocalOrdinal, class GlobalOrdinal, class Node>
 UncoupledAggregationFactory<LocalOrdinal, GlobalOrdinal, Node>::~UncoupledAggregationFactory() = default;
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> UncoupledAggregationFactory<LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> UncoupledAggregationFactory<LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   // Aggregation parameters (used in aggregation algorithms)

--- a/packages/muelu/src/Graph/UserAggregation/MueLu_UserAggregationFactory_decl.hpp
+++ b/packages/muelu/src/Graph/UserAggregation/MueLu_UserAggregationFactory_decl.hpp
@@ -40,7 +40,9 @@ class UserAggregationFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~UserAggregationFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Graph/UserAggregation/MueLu_UserAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/UserAggregation/MueLu_UserAggregationFactory_def.hpp
@@ -25,7 +25,7 @@
 namespace MueLu {
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> UserAggregationFactory<LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> UserAggregationFactory<LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   // input parameters

--- a/packages/muelu/src/Misc/MueLu_BlockedCoordinatesTransferFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_BlockedCoordinatesTransferFactory_decl.hpp
@@ -75,7 +75,9 @@ class BlockedCoordinatesTransferFactory : public TwoLevelFactoryBase {
   //! Destructor.
   virtual ~BlockedCoordinatesTransferFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Misc/MueLu_BlockedCoordinatesTransferFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_BlockedCoordinatesTransferFactory_def.hpp
@@ -23,7 +23,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> BlockedCoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> BlockedCoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("Coordinates", Teuchos::null, "Factory for coordinates generation");

--- a/packages/muelu/src/Misc/MueLu_BlockedRAPFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_BlockedRAPFactory_decl.hpp
@@ -48,7 +48,9 @@ class BlockedRAPFactory : public TwoLevelFactoryBase {
   //! @name Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const override;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level &fineLevel, Level &coarseLevel) const override;
 

--- a/packages/muelu/src/Misc/MueLu_BlockedRAPFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_BlockedRAPFactory_def.hpp
@@ -30,7 +30,7 @@ BlockedRAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BlockedRAPFactory(
   , repairZeroDiagonals_(false) {}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> BlockedRAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> BlockedRAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Misc/MueLu_CoordinatesTransferFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_CoordinatesTransferFactory_decl.hpp
@@ -90,7 +90,9 @@ class CoordinatesTransferFactory : public TwoLevelFactoryBase {
   //! Destructor.
   virtual ~CoordinatesTransferFactory();
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Misc/MueLu_CoordinatesTransferFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_CoordinatesTransferFactory_def.hpp
@@ -32,7 +32,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 CoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~CoordinatesTransferFactory() = default;
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> CoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> CoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("Coordinates", Teuchos::null, "Factory for coordinates generation");

--- a/packages/muelu/src/Misc/MueLu_DropNegativeEntriesFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_DropNegativeEntriesFactory_decl.hpp
@@ -43,7 +43,9 @@ class DropNegativeEntriesFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~DropNegativeEntriesFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Misc/MueLu_DropNegativeEntriesFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_DropNegativeEntriesFactory_def.hpp
@@ -24,7 +24,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> DropNegativeEntriesFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> DropNegativeEntriesFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Misc/MueLu_FilteredAFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_FilteredAFactory_decl.hpp
@@ -44,7 +44,9 @@ class FilteredAFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~FilteredAFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Misc/MueLu_FilteredAFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_FilteredAFactory_def.hpp
@@ -36,7 +36,7 @@ void sort_and_unique(T& array) {
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> FilteredAFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> FilteredAFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Misc/MueLu_FineLevelInputDataFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_FineLevelInputDataFactory_decl.hpp
@@ -52,7 +52,9 @@ class FineLevelInputDataFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~FineLevelInputDataFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Misc/MueLu_FineLevelInputDataFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_FineLevelInputDataFactory_def.hpp
@@ -19,7 +19,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> FineLevelInputDataFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> FineLevelInputDataFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   // Variable name (e.g. A or P or Coordinates)

--- a/packages/muelu/src/Misc/MueLu_InitialBlockNumberFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_InitialBlockNumberFactory_decl.hpp
@@ -44,7 +44,9 @@ class InitialBlockNumberFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~InitialBlockNumberFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Misc/MueLu_InitialBlockNumberFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InitialBlockNumberFactory_def.hpp
@@ -24,7 +24,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> InitialBlockNumberFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> InitialBlockNumberFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Misc/MueLu_InterfaceAggregationFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_InterfaceAggregationFactory_decl.hpp
@@ -93,7 +93,9 @@ class InterfaceAggregationFactory : public SingleLevelFactoryBase {
   //! Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const override;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level& currentLevel) const override;
 

--- a/packages/muelu/src/Misc/MueLu_InterfaceAggregationFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InterfaceAggregationFactory_def.hpp
@@ -25,7 +25,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> InterfaceAggregationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> InterfaceAggregationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase>>("A", Teuchos::null, "Generating factory of A (matrix block related to dual DOFs)");

--- a/packages/muelu/src/Misc/MueLu_InterfaceMappingTransferFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_InterfaceMappingTransferFactory_decl.hpp
@@ -50,7 +50,9 @@ class InterfaceMappingTransferFactory : public TwoLevelFactoryBase {
   //! Destructor.
   ~InterfaceMappingTransferFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const override;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
   void DeclareInput(Level &fineLevel, Level &coarseLevel) const override;
   void Build(Level &fineLevel, Level &coarseLevel) const override;
 };

--- a/packages/muelu/src/Misc/MueLu_InterfaceMappingTransferFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InterfaceMappingTransferFactory_def.hpp
@@ -15,7 +15,7 @@
 namespace MueLu {
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> InterfaceMappingTransferFactory<LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> InterfaceMappingTransferFactory<LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
   validParamList->set<RCP<const FactoryBase>>("CoarseDualNodeID2PrimalNodeID", Teuchos::null, "Generating factory of the CoarseDualNodeID2PrimalNodeID map");
   return validParamList;

--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_decl.hpp
@@ -76,7 +76,9 @@ class InverseApproximationFactory : public SingleLevelFactoryBase {
 
   void DeclareInput(Level& currentLevel) const;
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
@@ -34,7 +34,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> InverseApproximationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> InverseApproximationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
   using Magnitude                   = typename Teuchos::ScalarTraits<Scalar>::magnitudeType;
 

--- a/packages/muelu/src/Misc/MueLu_LineDetectionFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_LineDetectionFactory_decl.hpp
@@ -49,7 +49,9 @@ class LineDetectionFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~LineDetectionFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Misc/MueLu_LineDetectionFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_LineDetectionFactory_def.hpp
@@ -22,7 +22,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> LineDetectionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> LineDetectionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Misc/MueLu_LocalOrdinalTransferFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_LocalOrdinalTransferFactory_decl.hpp
@@ -87,7 +87,9 @@ class LocalOrdinalTransferFactory : public TwoLevelFactoryBase {
   //! Destructor.
   virtual ~LocalOrdinalTransferFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Misc/MueLu_LocalOrdinalTransferFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_LocalOrdinalTransferFactory_def.hpp
@@ -26,7 +26,7 @@
 namespace MueLu {
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> LocalOrdinalTransferFactory<LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> LocalOrdinalTransferFactory<LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >(TransferVecName_, Teuchos::null, "Factory for TransferVec generation");

--- a/packages/muelu/src/Misc/MueLu_LowPrecisionFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_LowPrecisionFactory_decl.hpp
@@ -39,7 +39,9 @@ class LowPrecisionFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~LowPrecisionFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 
@@ -80,7 +82,9 @@ class LowPrecisionFactory<double, LocalOrdinal, GlobalOrdinal, Node> : public Si
   //! Destructor.
   virtual ~LowPrecisionFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 
@@ -122,7 +126,9 @@ class LowPrecisionFactory<std::complex<double>, LocalOrdinal, GlobalOrdinal, Nod
   //! Destructor.
   virtual ~LowPrecisionFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Misc/MueLu_LowPrecisionFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_LowPrecisionFactory_def.hpp
@@ -23,7 +23,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> LowPrecisionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> LowPrecisionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<std::string>("matrix key", "A", "");
@@ -58,7 +58,7 @@ void LowPrecisionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level
 
 #if defined(HAVE_TPETRA_INST_DOUBLE) && defined(HAVE_TPETRA_INST_FLOAT)
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> LowPrecisionFactory<double, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> LowPrecisionFactory<double, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<std::string>("matrix key", "A", "");
@@ -105,7 +105,7 @@ void LowPrecisionFactory<double, LocalOrdinal, GlobalOrdinal, Node>::Build(Level
 
 #if defined(HAVE_TPETRA_INST_COMPLEX_DOUBLE) && defined(HAVE_TPETRA_INST_COMPLEX_FLOAT)
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> LowPrecisionFactory<std::complex<double>, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> LowPrecisionFactory<std::complex<double>, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<std::string>("matrix key", "A", "");

--- a/packages/muelu/src/Misc/MueLu_MapTransferFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_MapTransferFactory_decl.hpp
@@ -62,7 +62,9 @@ class MapTransferFactory : public TwoLevelFactoryBase {
   //! Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const override;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level& fineLevel, Level& coarseLevel) const override;
 

--- a/packages/muelu/src/Misc/MueLu_MapTransferFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_MapTransferFactory_def.hpp
@@ -23,7 +23,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> MapTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> MapTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->setEntry("map: name", Teuchos::ParameterEntry(std::string("")));

--- a/packages/muelu/src/Misc/MueLu_MergedBlockedMatrixFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_MergedBlockedMatrixFactory_decl.hpp
@@ -46,7 +46,9 @@ class MergedBlockedMatrixFactory : public SingleLevelFactoryBase {
   //! @name Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level &currentLevel) const;
 

--- a/packages/muelu/src/Misc/MueLu_MergedBlockedMatrixFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_MergedBlockedMatrixFactory_def.hpp
@@ -23,7 +23,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 MergedBlockedMatrixFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::MergedBlockedMatrixFactory() {}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> MergedBlockedMatrixFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> MergedBlockedMatrixFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", MueLu::NoFactory::getRCP() /*Teuchos::null*/, "Generating factory of the matrix A used for building SchurComplement (must be a 2x2 blocked operator, default = MueLu::NoFactory::getRCP())");

--- a/packages/muelu/src/Misc/MueLu_MultiVectorTransferFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_MultiVectorTransferFactory_decl.hpp
@@ -53,7 +53,9 @@ class MultiVectorTransferFactory : public TwoLevelFactoryBase {
   //! Destructor.
   virtual ~MultiVectorTransferFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Misc/MueLu_MultiVectorTransferFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_MultiVectorTransferFactory_def.hpp
@@ -24,7 +24,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> MultiVectorTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> MultiVectorTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<std::string>("Vector name", "undefined", "Name of the vector that will be transferred on the coarse grid (level key)");  // TODO: how to set a validator without default value?

--- a/packages/muelu/src/Misc/MueLu_RAPFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_RAPFactory_decl.hpp
@@ -52,7 +52,9 @@ class RAPFactory : public TwoLevelFactoryBase {
   //! @name Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level& fineLevel, Level& coarseLevel) const;
 

--- a/packages/muelu/src/Misc/MueLu_RAPFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_RAPFactory_def.hpp
@@ -34,7 +34,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~RAPFactory() = default;
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> RAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> RAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Misc/MueLu_RAPShiftFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_RAPShiftFactory_decl.hpp
@@ -54,7 +54,9 @@ class RAPShiftFactory : public TwoLevelFactoryBase {
   //! @name Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level &fineLevel, Level &coarseLevel) const;
 

--- a/packages/muelu/src/Misc/MueLu_RAPShiftFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_RAPShiftFactory_def.hpp
@@ -33,7 +33,7 @@ RAPShiftFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::RAPShiftFactory()
 
 /*********************************************************************************************************/
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> RAPShiftFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> RAPShiftFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Misc/MueLu_SchurComplementFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_SchurComplementFactory_decl.hpp
@@ -83,7 +83,9 @@ class SchurComplementFactory : public SingleLevelFactoryBase {
 
   void DeclareInput(Level& currentLevel) const;
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Misc/MueLu_SchurComplementFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_SchurComplementFactory_def.hpp
@@ -27,7 +27,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> SchurComplementFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> SchurComplementFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   const SC one = Teuchos::ScalarTraits<SC>::one();

--- a/packages/muelu/src/Misc/MueLu_SegregatedAFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_SegregatedAFactory_decl.hpp
@@ -80,7 +80,9 @@ class SegregatedAFactory : public SingleLevelFactoryBase {
   //! Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const override;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level& currentLevel) const override;
 

--- a/packages/muelu/src/Misc/MueLu_SegregatedAFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_SegregatedAFactory_def.hpp
@@ -22,7 +22,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> SegregatedAFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> SegregatedAFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase>>("A", Teuchos::null, "Generating factory of the matrix A to be filtered");

--- a/packages/muelu/src/Misc/MueLu_StructuredLineDetectionFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_StructuredLineDetectionFactory_decl.hpp
@@ -40,7 +40,9 @@ class StructuredLineDetectionFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~StructuredLineDetectionFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Misc/MueLu_StructuredLineDetectionFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_StructuredLineDetectionFactory_def.hpp
@@ -19,7 +19,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> StructuredLineDetectionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> StructuredLineDetectionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Generating factory of the matrix A");

--- a/packages/muelu/src/MueCentral/MueLu_Factory.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_Factory.cpp
@@ -65,7 +65,7 @@ RCP<ParameterList> Factory::RemoveFactoriesFromList(const ParameterList& list) c
   return paramList;
 }
 
-RCP<const ParameterList> Factory::GetValidParameterList() const {
+RCP<const ParameterList> Factory::GetValidParameterListImpl() const {
   return Teuchos::null;  // Teuchos::null == GetValidParameterList() not implemented == skip validation and no default values (dangerous)
 }
 

--- a/packages/muelu/src/MueCentral/MueLu_Factory.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Factory.hpp
@@ -58,7 +58,9 @@ class Factory : public FactoryBase, public FactoryAcceptor, public ParameterList
 
   //@}
 
-  virtual RCP<const ParameterList> GetValidParameterList() const;
+  virtual MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
  protected:
   void Input(Level& level, const std::string& varName) const;

--- a/packages/muelu/src/MueCentral/MueLu_ParameterListAcceptor.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_ParameterListAcceptor.hpp
@@ -129,6 +129,12 @@ class ParameterListAcceptorImpl : public ParameterListAcceptor {
   // Do we need that too?
 };
 
+#define MUELU_GETVALIDPARAMETERLIST()                                        \
+  Teuchos::RCP<const Teuchos::ParameterList> GetValidParameterList() const { \
+    static auto valid_pl = GetValidParameterListImpl();                      \
+    return valid_pl;                                                         \
+  }
+
 }  // namespace MueLu
 
 #endif  // MUELU_PARAMETERLISTACCEPTOR_HPP

--- a/packages/muelu/src/Rebalancing/MueLu_CloneRepartitionInterface_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_CloneRepartitionInterface_decl.hpp
@@ -72,7 +72,9 @@ class CloneRepartitionInterface : public SingleLevelFactoryBase {
   virtual ~CloneRepartitionInterface() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Rebalancing/MueLu_CloneRepartitionInterface_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_CloneRepartitionInterface_def.hpp
@@ -22,7 +22,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-Teuchos::RCP<const ParameterList> CloneRepartitionInterface<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+Teuchos::RCP<const ParameterList> CloneRepartitionInterface<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   Teuchos::RCP<ParameterList> validParamList = rcp(new ParameterList());
   validParamList->set<Teuchos::RCP<const FactoryBase> >("A", Teuchos::null, "Factory of the matrix A");
   validParamList->set<Teuchos::RCP<const FactoryBase> >("number of partitions", Teuchos::null, "Instance of RepartitionHeuristicFactory.");

--- a/packages/muelu/src/Rebalancing/MueLu_IsorropiaInterface_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_IsorropiaInterface_decl.hpp
@@ -91,7 +91,9 @@ class IsorropiaInterface : public SingleLevelFactoryBase {
   virtual ~IsorropiaInterface() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Rebalancing/MueLu_IsorropiaInterface_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_IsorropiaInterface_def.hpp
@@ -37,7 +37,7 @@
 namespace MueLu {
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> IsorropiaInterface<LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> IsorropiaInterface<LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Factory of the matrix A");

--- a/packages/muelu/src/Rebalancing/MueLu_NodePartitionInterface_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_NodePartitionInterface_decl.hpp
@@ -87,7 +87,9 @@ class NodePartitionInterface : public SingleLevelFactoryBase {
   virtual ~NodePartitionInterface() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Rebalancing/MueLu_NodePartitionInterface_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_NodePartitionInterface_def.hpp
@@ -30,7 +30,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 NodePartitionInterface<Scalar, LocalOrdinal, GlobalOrdinal, Node>::NodePartitionInterface() {}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> NodePartitionInterface<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> NodePartitionInterface<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))
   SET_VALID_ENTRY("repartition: node id");

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceAcFactory_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceAcFactory_decl.hpp
@@ -43,7 +43,9 @@ class RebalanceAcFactory : public TwoLevelFactoryBase {
 
   virtual ~RebalanceAcFactory();
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
   //@}
 
   //! @name Input

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceAcFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceAcFactory_def.hpp
@@ -31,7 +31,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RebalanceAcFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~RebalanceAcFactory() = default;
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> RebalanceAcFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> RebalanceAcFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceBlockAcFactory_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceBlockAcFactory_decl.hpp
@@ -68,7 +68,9 @@ class RebalanceBlockAcFactory : public TwoLevelFactoryBase {
   //! @name Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level &fineLevel, Level &coarseLevel) const;
 

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceBlockAcFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceBlockAcFactory_def.hpp
@@ -33,7 +33,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> RebalanceBlockAcFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> RebalanceBlockAcFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceBlockInterpolationFactory_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceBlockInterpolationFactory_decl.hpp
@@ -52,7 +52,9 @@ class RebalanceBlockInterpolationFactory : public TwoLevelFactoryBase {
   //! Destructor.
   virtual ~RebalanceBlockInterpolationFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceBlockInterpolationFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceBlockInterpolationFactory_def.hpp
@@ -36,7 +36,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> RebalanceBlockInterpolationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> RebalanceBlockInterpolationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("P", Teuchos::null, "Factory of the prolongation operator that need to be rebalanced (only used if type=Interpolation)");

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceBlockRestrictionFactory_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceBlockRestrictionFactory_decl.hpp
@@ -53,7 +53,9 @@ class RebalanceBlockRestrictionFactory : public TwoLevelFactoryBase {
   //! Destructor.
   virtual ~RebalanceBlockRestrictionFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceBlockRestrictionFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceBlockRestrictionFactory_def.hpp
@@ -37,7 +37,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> RebalanceBlockRestrictionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> RebalanceBlockRestrictionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceMapFactory_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceMapFactory_decl.hpp
@@ -48,7 +48,9 @@ class RebalanceMapFactory : public SingleLevelFactoryBase {
   virtual ~RebalanceMapFactory() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceMapFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceMapFactory_def.hpp
@@ -22,7 +22,7 @@
 namespace MueLu {
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> RebalanceMapFactory<LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> RebalanceMapFactory<LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceTransferFactory_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceTransferFactory_decl.hpp
@@ -53,7 +53,9 @@ class RebalanceTransferFactory : public TwoLevelFactoryBase {
   //! Destructor.
   virtual ~RebalanceTransferFactory();
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceTransferFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceTransferFactory_def.hpp
@@ -41,7 +41,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RebalanceTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~RebalanceTransferFactory() = default;
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> RebalanceTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> RebalanceTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionBlockDiagonalFactory_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionBlockDiagonalFactory_decl.hpp
@@ -44,7 +44,9 @@ class RepartitionBlockDiagonalFactory : public SingleLevelFactoryBase {
   virtual ~RepartitionBlockDiagonalFactory() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionBlockDiagonalFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionBlockDiagonalFactory_def.hpp
@@ -23,7 +23,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> RepartitionBlockDiagonalFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> RepartitionBlockDiagonalFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Factory of the matrix A");
 

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_decl.hpp
@@ -90,7 +90,9 @@ class RepartitionFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~RepartitionFactory();
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_def.hpp
@@ -52,7 +52,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RepartitionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~RepartitionFactory() = default;
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> RepartitionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> RepartitionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionHeuristicFactory_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionHeuristicFactory_decl.hpp
@@ -88,7 +88,9 @@ class RepartitionHeuristicFactory : public SingleLevelFactoryBase {
   //! Destructor.
   virtual ~RepartitionHeuristicFactory();
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionHeuristicFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionHeuristicFactory_def.hpp
@@ -39,7 +39,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RepartitionHeuristicFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~RepartitionHeuristicFactory() = default;
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> RepartitionHeuristicFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> RepartitionHeuristicFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionInterface_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionInterface_decl.hpp
@@ -93,7 +93,9 @@ class RepartitionInterface : public SingleLevelFactoryBase {
   virtual ~RepartitionInterface() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionInterface_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionInterface_def.hpp
@@ -26,7 +26,7 @@
 namespace MueLu {
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> RepartitionInterface<LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> RepartitionInterface<LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Factory of the matrix A");
   validParamList->set<RCP<const FactoryBase> >("number of partitions", Teuchos::null, "Instance of RepartitionHeuristicFactory.");

--- a/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_decl.hpp
@@ -91,7 +91,9 @@ class Zoltan2Interface : public SingleLevelFactoryBase {
   virtual ~Zoltan2Interface() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_def.hpp
@@ -43,7 +43,7 @@ Zoltan2Interface<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Zoltan2Interface() 
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> Zoltan2Interface<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> Zoltan2Interface<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Factory of the matrix A");

--- a/packages/muelu/src/Rebalancing/MueLu_ZoltanInterface_decl.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_ZoltanInterface_decl.hpp
@@ -89,7 +89,9 @@ class ZoltanInterface : public SingleLevelFactoryBase {
   virtual ~ZoltanInterface() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Rebalancing/MueLu_ZoltanInterface_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_ZoltanInterface_def.hpp
@@ -24,7 +24,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> ZoltanInterface<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> ZoltanInterface<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Factory of the matrix A");

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedDirectSolver_decl.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedDirectSolver_decl.hpp
@@ -63,7 +63,9 @@ class BlockedDirectSolver : public SmootherPrototype<Scalar, LocalOrdinal, Globa
 
   //! Input
   //@{
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level& currentLevel) const;
   //@}

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedDirectSolver_def.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedDirectSolver_def.hpp
@@ -42,7 +42,7 @@ BlockedDirectSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BlockedDirectSol
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> BlockedDirectSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> BlockedDirectSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", null, "Generating factory of the matrix A");

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedGaussSeidelSmoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedGaussSeidelSmoother_decl.hpp
@@ -94,7 +94,9 @@ class BlockedGaussSeidelSmoother : public SmootherPrototype<Scalar, LocalOrdinal
 
   //! Input
   //@{
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level &currentLevel) const;
 

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedGaussSeidelSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedGaussSeidelSmoother_def.hpp
@@ -41,7 +41,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 BlockedGaussSeidelSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~BlockedGaussSeidelSmoother() {}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> BlockedGaussSeidelSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> BlockedGaussSeidelSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Generating factory of the matrix A");

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedJacobiSmoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedJacobiSmoother_decl.hpp
@@ -96,7 +96,9 @@ class BlockedJacobiSmoother : public SmootherPrototype<Scalar, LocalOrdinal, Glo
 
   //! Input
   //@{
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level &currentLevel) const;
 

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedJacobiSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedJacobiSmoother_def.hpp
@@ -41,7 +41,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 BlockedJacobiSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~BlockedJacobiSmoother() {}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> BlockedJacobiSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> BlockedJacobiSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Generating factory of the matrix A");

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BraessSarazinSmoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BraessSarazinSmoother_decl.hpp
@@ -48,7 +48,9 @@ class BraessSarazinSmoother : public SmootherPrototype<Scalar, LocalOrdinal, Glo
   //! Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level &currentLevel) const;
 

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BraessSarazinSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BraessSarazinSmoother_def.hpp
@@ -39,7 +39,7 @@ void BraessSarazinSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::AddFactor
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> BraessSarazinSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> BraessSarazinSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   SC one = Teuchos::ScalarTraits<SC>::one();

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_IndefBlockedDiagonalSmoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_IndefBlockedDiagonalSmoother_decl.hpp
@@ -73,7 +73,9 @@ class IndefBlockedDiagonalSmoother : public SmootherPrototype<Scalar, LocalOrdin
   //! Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level &currentLevel) const;
 

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_IndefBlockedDiagonalSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_IndefBlockedDiagonalSmoother_def.hpp
@@ -51,7 +51,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 IndefBlockedDiagonalSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~IndefBlockedDiagonalSmoother() {}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> IndefBlockedDiagonalSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> IndefBlockedDiagonalSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Generating factory of the matrix A (must be a 2x2 block matrix)");

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_SimpleSmoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_SimpleSmoother_decl.hpp
@@ -63,7 +63,9 @@ class SimpleSmoother : public SmootherPrototype<Scalar, LocalOrdinal, GlobalOrdi
   //! Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level &currentLevel) const;
 

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_SimpleSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_SimpleSmoother_def.hpp
@@ -44,7 +44,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 SimpleSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~SimpleSmoother() {}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> SimpleSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> SimpleSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase>>("A", Teuchos::null, "Generating factory of the matrix A");

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_TekoSmoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_TekoSmoother_decl.hpp
@@ -66,7 +66,7 @@ class TekoSmoother : public SmootherPrototype<Scalar, LocalOrdinal, GlobalOrdina
 
   //! Input
   //@{
-  RCP<const ParameterList> GetValidParameterList() const {
+  RCP<const ParameterList> GetValidParameterListImpl() const {
     RCP<ParameterList> validParamList = rcp(new ParameterList());
     return validParamList;
   }
@@ -171,7 +171,7 @@ class TekoSmoother<double, int, GlobalOrdinal, Node> : public SmootherPrototype<
 
   //! Input
   //@{
-  RCP<const ParameterList> GetValidParameterList() const {
+  RCP<const ParameterList> GetValidParameterListImpl() const {
     RCP<ParameterList> validParamList = rcp(new ParameterList());
 
     validParamList->set<RCP<const FactoryBase> >("A", null, "Generating factory of the matrix A");

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_UzawaSmoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_UzawaSmoother_decl.hpp
@@ -51,7 +51,9 @@ class UzawaSmoother : public SmootherPrototype<Scalar, LocalOrdinal, GlobalOrdin
   //! Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level &currentLevel) const;
 

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_UzawaSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_UzawaSmoother_def.hpp
@@ -32,7 +32,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> UzawaSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> UzawaSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase>>("A", Teuchos::null, "Generating factory of the matrix A");

--- a/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_decl.hpp
@@ -72,7 +72,9 @@ class Amesos2Smoother : public SmootherPrototype<Scalar, LocalOrdinal, GlobalOrd
   //! Destructor
   virtual ~Amesos2Smoother();
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
@@ -138,7 +138,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 Amesos2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~Amesos2Smoother() {}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> Amesos2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> Amesos2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
   validParamList->set<RCP<const FactoryBase> >("A", null, "Factory of the coarse matrix");
   validParamList->set<RCP<const FactoryBase> >("Nullspace", null, "Factory of the nullspace");

--- a/packages/muelu/src/Smoothers/MueLu_SmootherFactory_decl.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_SmootherFactory_decl.hpp
@@ -128,7 +128,9 @@ class SmootherFactory : public SmootherFactoryBase {
   //! Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level& currentLevel) const;
 

--- a/packages/muelu/src/Smoothers/MueLu_SmootherFactory_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_SmootherFactory_def.hpp
@@ -47,7 +47,7 @@ void SmootherFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetSmootherProt
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> SmootherFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> SmootherFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<bool>("keep smoother data", false, "Keep constructed smoothers for later reuse");

--- a/packages/muelu/src/Transfers/BlackBox/MueLu_BlackBoxPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/BlackBox/MueLu_BlackBoxPFactory_decl.hpp
@@ -98,7 +98,9 @@ class BlackBoxPFactory : public PFactory {
   virtual ~BlackBoxPFactory() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Transfers/BlackBox/MueLu_BlackBoxPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/BlackBox/MueLu_BlackBoxPFactory_def.hpp
@@ -35,7 +35,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> BlackBoxPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> BlackBoxPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   // Coarsen can come in two forms, either a single char that will be interpreted as an integer

--- a/packages/muelu/src/Transfers/BlockedTransfers/MueLu_BlockedCoarseMapFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/BlockedTransfers/MueLu_BlockedCoarseMapFactory_decl.hpp
@@ -64,7 +64,9 @@ class BlockedCoarseMapFactory : public MueLu::CoarseMapFactory<Scalar, LocalOrdi
   //! @name Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const final;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   /*! @brief Specifies the data that this class needs, and the factories that generate that data.
 

--- a/packages/muelu/src/Transfers/BlockedTransfers/MueLu_BlockedCoarseMapFactory_def.hpp
+++ b/packages/muelu/src/Transfers/BlockedTransfers/MueLu_BlockedCoarseMapFactory_def.hpp
@@ -24,7 +24,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> BlockedCoarseMapFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> BlockedCoarseMapFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase>>("Aggregates", Teuchos::null, "Generating factory for aggregates.");

--- a/packages/muelu/src/Transfers/BlockedTransfers/MueLu_BlockedPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/BlockedTransfers/MueLu_BlockedPFactory_decl.hpp
@@ -99,7 +99,9 @@ class BlockedPFactory : public PFactory {
   //! Destructor.
   virtual ~BlockedPFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Transfers/BlockedTransfers/MueLu_BlockedPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/BlockedTransfers/MueLu_BlockedPFactory_def.hpp
@@ -31,7 +31,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> BlockedPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> BlockedPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", null, "Generating factory of the matrix A (block matrix)");

--- a/packages/muelu/src/Transfers/BlockedTransfers/MueLu_ReorderBlockAFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/BlockedTransfers/MueLu_ReorderBlockAFactory_decl.hpp
@@ -43,7 +43,9 @@ class ReorderBlockAFactory : public SingleLevelFactoryBase {
   //! Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level &currentLevel) const;
 

--- a/packages/muelu/src/Transfers/BlockedTransfers/MueLu_ReorderBlockAFactory_def.hpp
+++ b/packages/muelu/src/Transfers/BlockedTransfers/MueLu_ReorderBlockAFactory_def.hpp
@@ -26,7 +26,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> ReorderBlockAFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> ReorderBlockAFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", MueLu::NoFactory::getRCP(), "Generating factory for A.");

--- a/packages/muelu/src/Transfers/BlockedTransfers/MueLu_SubBlockAFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/BlockedTransfers/MueLu_SubBlockAFactory_decl.hpp
@@ -72,7 +72,9 @@ class SubBlockAFactory : public SingleLevelFactoryBase {
   //! Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const override;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level& currentLevel) const override;
 

--- a/packages/muelu/src/Transfers/BlockedTransfers/MueLu_SubBlockAFactory_def.hpp
+++ b/packages/muelu/src/Transfers/BlockedTransfers/MueLu_SubBlockAFactory_def.hpp
@@ -23,7 +23,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> SubBlockAFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> SubBlockAFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase>>("A", MueLu::NoFactory::getRCP(), "Generating factory for A.");

--- a/packages/muelu/src/Transfers/BlockedTransfers/MueLu_ZeroSubBlockAFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/BlockedTransfers/MueLu_ZeroSubBlockAFactory_decl.hpp
@@ -39,7 +39,9 @@ class ZeroSubBlockAFactory : public SingleLevelFactoryBase {
   //! Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const override;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level &currentLevel) const override;
 

--- a/packages/muelu/src/Transfers/BlockedTransfers/MueLu_ZeroSubBlockAFactory_def.hpp
+++ b/packages/muelu/src/Transfers/BlockedTransfers/MueLu_ZeroSubBlockAFactory_def.hpp
@@ -24,7 +24,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> ZeroSubBlockAFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> ZeroSubBlockAFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase>>("A", MueLu::NoFactory::getRCP(), "Generating factory for A.");

--- a/packages/muelu/src/Transfers/Classical/MueLu_ClassicalMapFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Classical/MueLu_ClassicalMapFactory_decl.hpp
@@ -73,7 +73,9 @@ class ClassicalMapFactory : public SingleLevelFactoryBase {
   //! @name Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const override;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   /*!
     @brief Specifies the data that this class needs, and the factories that generate that data.

--- a/packages/muelu/src/Transfers/Classical/MueLu_ClassicalMapFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Classical/MueLu_ClassicalMapFactory_def.hpp
@@ -46,7 +46,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> ClassicalMapFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> ClassicalMapFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))
   SET_VALID_ENTRY("aggregation: deterministic");

--- a/packages/muelu/src/Transfers/Classical/MueLu_ClassicalPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Classical/MueLu_ClassicalPFactory_decl.hpp
@@ -51,7 +51,9 @@ class ClassicalPFactory : public PFactory {
   virtual ~ClassicalPFactory() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Transfers/Classical/MueLu_ClassicalPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Classical/MueLu_ClassicalPFactory_def.hpp
@@ -54,7 +54,7 @@ int Sign(SC val) {
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> ClassicalPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> ClassicalPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))
   SET_VALID_ENTRY("aggregation: deterministic");

--- a/packages/muelu/src/Transfers/Energy-Minimization/MueLu_ConstraintFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/MueLu_ConstraintFactory_decl.hpp
@@ -49,7 +49,9 @@ class ConstraintFactory : public TwoLevelFactoryBase {
 
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Transfers/Energy-Minimization/MueLu_ConstraintFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/MueLu_ConstraintFactory_def.hpp
@@ -18,7 +18,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> ConstraintFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> ConstraintFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("FineNullspace", Teuchos::null, "Generating factory for the nullspace");

--- a/packages/muelu/src/Transfers/Energy-Minimization/MueLu_EminPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/MueLu_EminPFactory_decl.hpp
@@ -54,7 +54,9 @@ class EminPFactory : public PFactory {
 
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Transfers/Energy-Minimization/MueLu_EminPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/MueLu_EminPFactory_def.hpp
@@ -45,7 +45,7 @@ EminPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> EminPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> EminPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Transfers/Energy-Minimization/MueLu_NullspacePresmoothFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/MueLu_NullspacePresmoothFactory_decl.hpp
@@ -36,7 +36,9 @@ class NullspacePresmoothFactory : public SingleLevelFactoryBase {
 
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Transfers/Energy-Minimization/MueLu_NullspacePresmoothFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/MueLu_NullspacePresmoothFactory_def.hpp
@@ -22,7 +22,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> NullspacePresmoothFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> NullspacePresmoothFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Generating factory for A");

--- a/packages/muelu/src/Transfers/Energy-Minimization/MueLu_PatternFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/MueLu_PatternFactory_decl.hpp
@@ -44,7 +44,9 @@ class PatternFactory : public TwoLevelFactoryBase {
 
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Transfers/Energy-Minimization/MueLu_PatternFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/MueLu_PatternFactory_def.hpp
@@ -22,7 +22,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> PatternFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> PatternFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeneralGeometricPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeneralGeometricPFactory_decl.hpp
@@ -97,7 +97,9 @@ class GeneralGeometricPFactory : public PFactory {
   virtual ~GeneralGeometricPFactory() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeneralGeometricPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeneralGeometricPFactory_def.hpp
@@ -34,7 +34,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> GeneralGeometricPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> GeneralGeometricPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   // Coarsen can come in two forms, either a single char that will be interpreted as an integer

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_decl.hpp
@@ -43,7 +43,9 @@ class GeometricInterpolationPFactory : public PFactory {
   virtual ~GeometricInterpolationPFactory() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
@@ -24,7 +24,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> GeometricInterpolationPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> GeometricInterpolationPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_kokkos_decl.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_kokkos_decl.hpp
@@ -49,7 +49,9 @@ class GeometricInterpolationPFactory_kokkos : public PFactory {
   virtual ~GeometricInterpolationPFactory_kokkos() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_kokkos_def.hpp
@@ -25,7 +25,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> GeometricInterpolationPFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> GeometricInterpolationPFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_RegionRFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_RegionRFactory_decl.hpp
@@ -46,7 +46,9 @@ class RegionRFactory : public TwoLevelFactoryBase {
 
   //! Input
   //@{
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level& fineLevel, Level& coarseLevel) const;
 

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_RegionRFactory_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_RegionRFactory_def.hpp
@@ -22,7 +22,7 @@ namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RCP<const ParameterList> RegionRFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-    GetValidParameterList() const {
+    GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null,

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_RegionRFactory_kokkos_decl.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_RegionRFactory_kokkos_decl.hpp
@@ -55,7 +55,9 @@ class RegionRFactory_kokkos : public TwoLevelFactoryBase {
 
   //! Input
   //@{
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level& fineLevel, Level& coarseLevel) const;
 

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_RegionRFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_RegionRFactory_kokkos_def.hpp
@@ -23,7 +23,7 @@ namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RCP<const ParameterList> RegionRFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-    GetValidParameterList() const {
+    GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null,

--- a/packages/muelu/src/Transfers/Generic/MueLu_CombinePFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_CombinePFactory_decl.hpp
@@ -108,7 +108,9 @@ class CombinePFactory : public PFactory {
   virtual ~CombinePFactory() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Transfers/Generic/MueLu_CombinePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_CombinePFactory_def.hpp
@@ -36,7 +36,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> CombinePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> CombinePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
   validParamList->setEntry("combine: numBlks", ParameterEntry(1));
   validParamList->setEntry("combine: useMaxLevels", ParameterEntry(false));

--- a/packages/muelu/src/Transfers/Generic/MueLu_GenericRFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_GenericRFactory_decl.hpp
@@ -52,7 +52,9 @@ class GenericRFactory : public TwoLevelFactoryBase {
 
   //! Input
   //@{
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   void DeclareInput(Level &fineLevel, Level &coarseLevel) const;
 

--- a/packages/muelu/src/Transfers/Generic/MueLu_GenericRFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_GenericRFactory_def.hpp
@@ -23,7 +23,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> GenericRFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> GenericRFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
   validParamList->set<RCP<const FactoryBase> >("P", Teuchos::null, "Generating factory of the matrix P");
   return validParamList;

--- a/packages/muelu/src/Transfers/Generic/MueLu_ReplicatePFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_ReplicatePFactory_decl.hpp
@@ -89,7 +89,9 @@ class ReplicatePFactory : public PFactory {
   virtual ~ReplicatePFactory() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Transfers/Generic/MueLu_ReplicatePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_ReplicatePFactory_def.hpp
@@ -34,7 +34,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> ReplicatePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> ReplicatePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
   validParamList->setEntry("replicate: npdes", ParameterEntry(1));
 

--- a/packages/muelu/src/Transfers/Generic/MueLu_RfromP_Or_TransP_decl.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_RfromP_Or_TransP_decl.hpp
@@ -48,7 +48,9 @@ class RfromP_Or_TransP : public TwoLevelFactoryBase {
   //! Destructor.
   virtual ~RfromP_Or_TransP() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Transfers/Generic/MueLu_RfromP_Or_TransP_def.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_RfromP_Or_TransP_def.hpp
@@ -30,7 +30,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> RfromP_Or_TransP<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> RfromP_Or_TransP<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
   validParamList->set<RCP<const FactoryBase>>("P", Teuchos::null, "Generating factory of the matrix P");
   validParamList->set<RCP<const FactoryBase>>("RfromPfactory", Teuchos::null, "Generating factory of the matrix R");

--- a/packages/muelu/src/Transfers/Generic/MueLu_TransPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_TransPFactory_decl.hpp
@@ -48,7 +48,9 @@ class TransPFactory : public TwoLevelFactoryBase {
   //! Destructor.
   virtual ~TransPFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Transfers/Generic/MueLu_TransPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_TransPFactory_def.hpp
@@ -24,7 +24,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> TransPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> TransPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
   validParamList->set<RCP<const FactoryBase> >("P", Teuchos::null, "Generating factory of the matrix P");
 

--- a/packages/muelu/src/Transfers/Matrix-Free/MueLu_MatrixFreeTentativePFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Matrix-Free/MueLu_MatrixFreeTentativePFactory_decl.hpp
@@ -87,7 +87,9 @@ class MatrixFreeTentativePFactory : public PFactory {
   virtual ~MatrixFreeTentativePFactory() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Transfers/Matrix-Free/MueLu_MatrixFreeTentativePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Matrix-Free/MueLu_MatrixFreeTentativePFactory_def.hpp
@@ -22,7 +22,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> MatrixFreeTentativePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> MatrixFreeTentativePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase>>("A", Teuchos::null, "Generating factory of the matrix A");

--- a/packages/muelu/src/Transfers/PCoarsen/MueLu_IntrepidPCoarsenFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/PCoarsen/MueLu_IntrepidPCoarsenFactory_decl.hpp
@@ -94,7 +94,9 @@ class IntrepidPCoarsenFactory : public PFactory {
   //! Destructor.
   virtual ~IntrepidPCoarsenFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Transfers/PCoarsen/MueLu_IntrepidPCoarsenFactory_def.hpp
+++ b/packages/muelu/src/Transfers/PCoarsen/MueLu_IntrepidPCoarsenFactory_def.hpp
@@ -666,7 +666,7 @@ void IntrepidPCoarsenFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Generat
 
 /*********************************************************************************************************/
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> IntrepidPCoarsenFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> IntrepidPCoarsenFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Transfers/Petrov-Galerkin-SA/MueLu_PgPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Petrov-Galerkin-SA/MueLu_PgPFactory_decl.hpp
@@ -64,7 +64,9 @@ class PgPFactory : public PFactory {
   //! @name Set methods.
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Set minimization mode (L2NORM for cheapest, ANORM more expensive, DINVANORM = default)
   void SetMinimizationMode(MinimizationNorm minnorm);

--- a/packages/muelu/src/Transfers/Petrov-Galerkin-SA/MueLu_PgPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Petrov-Galerkin-SA/MueLu_PgPFactory_def.hpp
@@ -31,7 +31,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> PgPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> PgPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Generating factory of the matrix A used during the prolongator smoothing process");

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_decl.hpp
@@ -87,7 +87,9 @@ class SemiCoarsenPFactory : public PFactory {
   virtual ~SemiCoarsenPFactory() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_def.hpp
@@ -29,7 +29,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> SemiCoarsenPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> SemiCoarsenPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_kokkos_decl.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_kokkos_decl.hpp
@@ -82,7 +82,9 @@ class SemiCoarsenPFactory_kokkos : public PFactory {
   virtual ~SemiCoarsenPFactory_kokkos() = default;
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_kokkos_def.hpp
@@ -38,7 +38,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 
 RCP<const ParameterList>
 SemiCoarsenPFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-    GetValidParameterList() const {
+    GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   std::string name = "semicoarsen: coarsen rate";

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_ToggleCoordinatesTransferFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_ToggleCoordinatesTransferFactory_decl.hpp
@@ -48,7 +48,9 @@ class ToggleCoordinatesTransferFactory : public TwoLevelFactoryBase {
   //! Destructor.
   virtual ~ToggleCoordinatesTransferFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_ToggleCoordinatesTransferFactory_def.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_ToggleCoordinatesTransferFactory_def.hpp
@@ -18,7 +18,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> ToggleCoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> ToggleCoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("Chosen P", Teuchos::null, "Name of TogglePFactory this ToggleCoordinatesTransferFactory is connected to. Parameter provides information which execution path (prolongator) has been chosen.");

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_TogglePFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_TogglePFactory_decl.hpp
@@ -70,7 +70,9 @@ class TogglePFactory : public PFactory {
   //! Destructor.
   virtual ~TogglePFactory() {}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_TogglePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_TogglePFactory_def.hpp
@@ -21,7 +21,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> TogglePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> TogglePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_CoarseMapFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_CoarseMapFactory_decl.hpp
@@ -86,7 +86,9 @@ class CoarseMapFactory : public SingleLevelFactoryBase {
   //! @name Input
   //@{
 
-  RCP<const ParameterList> GetValidParameterList() const override;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   /*!
     @brief Specifies the data that this class needs, and the factories that generate that data.

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_CoarseMapFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_CoarseMapFactory_def.hpp
@@ -36,7 +36,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 CoarseMapFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~CoarseMapFactory() = default;
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> CoarseMapFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> CoarseMapFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("Aggregates", Teuchos::null, "Generating factory for aggregates.");

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_NullspaceFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_NullspaceFactory_decl.hpp
@@ -97,7 +97,9 @@ class NullspaceFactory : public SingleLevelFactoryBase {
   //@{
 
   /*! @brief Define valid parameters for internal factory parameters */
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   /*! @brief Specifies the data that this class needs, and the factories that generate that data.
 

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_NullspaceFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_NullspaceFactory_def.hpp
@@ -23,7 +23,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> NullspaceFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> NullspaceFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_decl.hpp
@@ -81,7 +81,9 @@ class ReitzingerPFactory : public PFactory {
   virtual ~ReitzingerPFactory() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_def.hpp
@@ -35,7 +35,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_decl.hpp
@@ -82,7 +82,9 @@ class SaPFactory : public PFactory {
   //! Destructor.
   virtual ~SaPFactory();
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //@}
 

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_def.hpp
@@ -35,7 +35,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 SaPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~SaPFactory() = default;
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> SaPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> SaPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ScaledNullspaceFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ScaledNullspaceFactory_decl.hpp
@@ -93,7 +93,9 @@ class ScaledNullspaceFactory : public SingleLevelFactoryBase {
   //@{
 
   /*! @brief Define valid parameters for internal factory parameters */
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   /*! @brief Specifies the data that this class needs, and the factories that generate that data.
 

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ScaledNullspaceFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ScaledNullspaceFactory_def.hpp
@@ -23,7 +23,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> ScaledNullspaceFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> ScaledNullspaceFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
   validParamList->set<std::string>("Fine level nullspace", "Nullspace", "Variable name which is used to store null space multi vector on the finest level (default=\"Nullspace\").");
 

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_decl.hpp
@@ -97,7 +97,9 @@ class TentativePFactory : public PFactory {
   virtual ~TentativePFactory() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_def.hpp
@@ -40,7 +40,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> TentativePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> TentativePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_decl.hpp
@@ -93,7 +93,9 @@ class TentativePFactory_kokkos : public PFactory {
   virtual ~TentativePFactory_kokkos() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
@@ -331,7 +331,7 @@ class LocalQRDecompFunctor {
 }  // namespace
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> TentativePFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> TentativePFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Transfers/User/MueLu_UserPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/User/MueLu_UserPFactory_decl.hpp
@@ -40,7 +40,9 @@ class UserPFactory : public PFactory {
   virtual ~UserPFactory() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Transfers/User/MueLu_UserPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/User/MueLu_UserPFactory_def.hpp
@@ -21,7 +21,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> UserPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> UserPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Generating factory of the matrix A");

--- a/packages/muelu/src/Utils/MueLu_AggregateQualityEstimateFactory_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_AggregateQualityEstimateFactory_decl.hpp
@@ -63,7 +63,9 @@ class AggregateQualityEstimateFactory : public TwoLevelFactoryBase {
 
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Utils/MueLu_AggregateQualityEstimateFactory_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_AggregateQualityEstimateFactory_def.hpp
@@ -41,7 +41,7 @@ void AggregateQualityEstimateFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>:
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> AggregateQualityEstimateFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> AggregateQualityEstimateFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
 #define SET_VALID_ENTRY(name) validParamList->setEntry(name, MasterList::getEntry(name))

--- a/packages/muelu/src/Utils/MueLu_AggregationExportFactory_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_AggregationExportFactory_decl.hpp
@@ -85,7 +85,9 @@ class AggregationExportFactory : public TwoLevelFactoryBase, public Visualizatio
   virtual ~AggregationExportFactory();
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Utils/MueLu_AggregationExportFactory_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_AggregationExportFactory_def.hpp
@@ -53,7 +53,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 AggregationExportFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~AggregationExportFactory() = default;
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> AggregationExportFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> AggregationExportFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   std::string output_msg =

--- a/packages/muelu/src/Utils/MueLu_AvatarInterface.cpp
+++ b/packages/muelu/src/Utils/MueLu_AvatarInterface.cpp
@@ -60,7 +60,7 @@ extern "C" {
 namespace MueLu {
 
 // ***********************************************************************
-RCP<const ParameterList> AvatarInterface::GetValidParameterList() const {
+RCP<const ParameterList> AvatarInterface::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   Teuchos::ParameterList pl_dummy;

--- a/packages/muelu/src/Utils/MueLu_CoarseningVisualizationFactory_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_CoarseningVisualizationFactory_decl.hpp
@@ -67,7 +67,9 @@ class CoarseningVisualizationFactory : public TwoLevelFactoryBase, public Visual
   virtual ~CoarseningVisualizationFactory() {}
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! Input
   //@{

--- a/packages/muelu/src/Utils/MueLu_CoarseningVisualizationFactory_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_CoarseningVisualizationFactory_def.hpp
@@ -19,8 +19,8 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> CoarseningVisualizationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
-  RCP<ParameterList> validParamList = VisualizationHelpers::GetValidParameterList();
+RCP<const ParameterList> CoarseningVisualizationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
+  RCP<ParameterList> validParamList = rcp(new Teuchos::ParameterList(*VisualizationHelpers::GetValidParameterList()));
 
   validParamList->set<int>("visualization: start level", 0, "visualize only levels with level ids greater or equal than start level");  // Remove me?
 

--- a/packages/muelu/src/Utils/MueLu_KokkosTuningInterface.cpp
+++ b/packages/muelu/src/Utils/MueLu_KokkosTuningInterface.cpp
@@ -51,7 +51,7 @@ KokkosTuningInterface::KokkosTuningInterface(const Teuchos::RCP<const Teuchos::C
 }
 
 // ***********************************************************************
-RCP<const Teuchos::ParameterList> KokkosTuningInterface::GetValidParameterList() const {
+RCP<const Teuchos::ParameterList> KokkosTuningInterface::GetValidParameterListImpl() const {
   RCP<ParameterList> topValidParamList = rcp(new ParameterList());
   ParameterList validParamList;
 

--- a/packages/muelu/src/Utils/MueLu_KokkosTuningInterface.hpp
+++ b/packages/muelu/src/Utils/MueLu_KokkosTuningInterface.hpp
@@ -32,7 +32,12 @@ class KokkosTuningInterface : public BaseClass {
 
   virtual ~KokkosTuningInterface() {}
 
-  Teuchos::RCP<const Teuchos::ParameterList> GetValidParameterList() const;
+  Teuchos::RCP<const Teuchos::ParameterList> GetValidParameterList() const {
+    static auto valid_pl = GetValidParameterListImpl();
+    return valid_pl;
+  }
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   // Sets the input parameters for the KokkosTuneInterface
   // NOTE: These are *not* the parameters which KokkosTuning is going to overwrite, rather the

--- a/packages/muelu/src/Utils/MueLu_MatrixAnalysisFactory_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_MatrixAnalysisFactory_decl.hpp
@@ -70,7 +70,9 @@ class MatrixAnalysisFactory : public TwoLevelFactoryBase {
 
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Utils/MueLu_MatrixAnalysisFactory_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_MatrixAnalysisFactory_def.hpp
@@ -30,7 +30,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 MatrixAnalysisFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~MatrixAnalysisFactory() {}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> MatrixAnalysisFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> MatrixAnalysisFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Generating factory of the matrix A to be permuted.");

--- a/packages/muelu/src/Utils/MueLu_PermutationFactory_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_PermutationFactory_decl.hpp
@@ -55,7 +55,9 @@ class PermutationFactory : public SingleLevelFactoryBase {
 
   //@}
 
-  RCP<const ParameterList> GetValidParameterList() const;
+  MUELU_GETVALIDPARAMETERLIST();
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
   //! @name Input
   //@{

--- a/packages/muelu/src/Utils/MueLu_PermutationFactory_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_PermutationFactory_def.hpp
@@ -49,7 +49,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 PermutationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~PermutationFactory() {}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<const ParameterList> PermutationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> PermutationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Generating factory of the matrix A to be permuted.");

--- a/packages/muelu/src/Utils/MueLu_VisualizationHelpers_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_VisualizationHelpers_decl.hpp
@@ -99,7 +99,12 @@ class VisualizationHelpers {
   virtual ~VisualizationHelpers() {}
   //@}
 
-  RCP<ParameterList> GetValidParameterList() const;
+  Teuchos::RCP<const Teuchos::ParameterList> GetValidParameterList() const {
+    static auto valid_pl = GetValidParameterListImpl();
+    return valid_pl;
+  }
+
+  RCP<const ParameterList> GetValidParameterListImpl() const;
 
  protected:
   void writeFileVTKOpening(std::ofstream& fout, std::vector<int>& uniqueFine, std::vector<int>& geomSizesFine) const;

--- a/packages/muelu/src/Utils/MueLu_VisualizationHelpers_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_VisualizationHelpers_def.hpp
@@ -25,7 +25,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-RCP<ParameterList> VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterList() const {
+RCP<const ParameterList> VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetValidParameterListImpl() const {
   RCP<ParameterList> validParamList = rcp(new ParameterList());
 
   validParamList->set<std::string>("visualization: output filename", "viz%LEVELID", "filename for VTK-style visualization output");


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Cache the valid parameter list for each factory in a static variable. This reduce runtime by ~25% for a unit test in an application code. The drawback is that this uses more memory.