### PR TITLE
Tacho : avoid the use of Kokkos:reduction_identity

### DIFF
--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_SupernodeInfo.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_SupernodeInfo.hpp
@@ -69,11 +69,11 @@ struct SuperNodeInfoInitReducer {
   }
 
   KOKKOS_INLINE_FUNCTION void init(value_type &val) const {
-    val.max_nchildren = Kokkos::reduction_identity<ordinal_type>::max();
-    val.max_supernode_size = Kokkos::reduction_identity<ordinal_type>::max();
-    val.max_num_cols = Kokkos::reduction_identity<ordinal_type>::max();
-    val.max_schur_size = Kokkos::reduction_identity<ordinal_type>::max();
-    val.nnz = Kokkos::reduction_identity<size_type>::sum();
+    val.max_nchildren = Kokkos::Experimental::finite_min_v<ordinal_type>;
+    val.max_supernode_size = Kokkos::Experimental::finite_min_v<ordinal_type>;
+    val.max_num_cols = Kokkos::Experimental::finite_min_v<ordinal_type>;
+    val.max_schur_size = Kokkos::Experimental::finite_min_v<ordinal_type>;
+    val.nnz = 0;
   }
 
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION

@trilinos/shylu 

## Motivation

Trying to avoid the use of Kokkos:reduction_identity in Tacho.

## Related Issues

[Issue 14416](https://github.com/trilinos/Trilinos/issues/14416)


## Additional Information

Thank you @ndellingwood 

