### PR TITLE
MueLu: shrink anisotropic elasticity tests

### DIFF
--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -631,7 +631,7 @@ IF (${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK)
   MUELU_ADD_SERIAL_AND_MPI_TEST(
       Driver
       NAME "AnisotropicElasticityEmin"
-      ARGS "--linAlgebra=Tpetra --xml=emin_with_dl_elasticity3D.xml  --matrixType=Elasticity3D --nx=20 --ny=20 --stretchx=3. --its=25 --belosType=cg --tol=1.0e-8  --muelu-computed-nullspace"
+      ARGS "--linAlgebra=Tpetra --xml=emin_with_dl_elasticity3D.xml  --matrixType=Elasticity3D --nx=20 --ny=20 --nz=25 --stretchx=3. --its=25 --belosType=cg --tol=1.0e-8  --muelu-computed-nullspace"
       NUM_MPI_PROCS 4
       COMM serial mpi
       PASS_REGULAR_EXPRESSION "Belos converged"
@@ -639,8 +639,8 @@ IF (${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK)
   MUELU_ADD_SERIAL_AND_MPI_TEST(
       Driver
       NAME "MaterialAnisotropicElasticityEmin"
-      POSTFIX_AND_ARGS_0 "ConstantScalar" --linAlgebra=Tpetra --xml=emin_with_dl_material_elasticity3D.xml --matrixType=Elasticity3D --nx=20 --ny=20 --stretchx=3. --its=25 --belosType=cg --tol=1.0e-8  --muelu-computed-nullspace --scalarCoefficient
-      POSTFIX_AND_ARGS_1 "ConstantTensor" --linAlgebra=Tpetra --xml=emin_with_dl_material_elasticity3D.xml --matrixType=Elasticity3D --nx=20 --ny=20 --stretchx=3. --its=25 --belosType=cg --tol=1.0e-8  --muelu-computed-nullspace --tensorCoefficient
+      POSTFIX_AND_ARGS_0 "ConstantScalar" --linAlgebra=Tpetra --xml=emin_with_dl_material_elasticity3D.xml --matrixType=Elasticity3D --nx=20 --ny=20 --nz=25 --stretchx=3. --its=25 --belosType=cg --tol=1.0e-8  --muelu-computed-nullspace --scalarCoefficient
+      POSTFIX_AND_ARGS_1 "ConstantTensor" --linAlgebra=Tpetra --xml=emin_with_dl_material_elasticity3D.xml --matrixType=Elasticity3D --nx=20 --ny=20 --nz=25 --stretchx=3. --its=25 --belosType=cg --tol=1.0e-8  --muelu-computed-nullspace --tensorCoefficient
       NUM_MPI_PROCS 4
       COMM serial mpi
       PASS_REGULAR_EXPRESSION "Belos converged"


### PR DESCRIPTION
Shrink z dimension of MueLu anisotropic elasticity tests from 100 (default) to 25.
One of these tests in particular (``MueLu_MaterialAnisotropicElasticityEmin_ConstantScalar_MPI_4``) is timing out often in the AT2/cuda11 build, so this should help with that.

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
