### PR TITLE
Tpetra: Removing ifdefs for no-long-supported Kokkos/KokkosKernels versions

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_KokkosCounter.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_KokkosCounter.cpp
@@ -36,7 +36,6 @@ void kokkosp_begin_deep_copy(Kokkos::Tools::SpaceHandle dst_handle, const char *
   }
 }
 
-
 }  // namespace DeepCopyCounterDetails
 
 void DeepCopyCounter::start() {

--- a/packages/tpetra/core/src/Tpetra_Details_KokkosCounter.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_KokkosCounter.cpp
@@ -7,7 +7,6 @@
 // *****************************************************************************
 // @HEADER
 
-// clang-format off
 #include "Tpetra_Details_KokkosCounter.hpp"
 #include "TpetraCore_config.h"
 #include "Kokkos_Core.hpp"
@@ -18,163 +17,156 @@
 namespace Tpetra {
 namespace Details {
 
+/***************************** Deep Copy *****************************/
+namespace DeepCopyCounterDetails {
+// Static variables
+bool is_initialized    = true;
+size_t count_same      = 0;
+size_t count_different = 0;
+bool count_active      = false;
 
-  /***************************** Deep Copy *****************************/
-  namespace DeepCopyCounterDetails {
-    // Static variables
-    bool is_initialized=true;
-    size_t count_same=0;
-    size_t count_different=0;
-    bool count_active=false;
-       
-    void kokkosp_begin_deep_copy(Kokkos::Tools::SpaceHandle dst_handle, const char* dst_name, const void* dst_ptr,                                 
-                                 Kokkos::Tools::SpaceHandle src_handle, const char* src_name, const void* src_ptr,
-                                 uint64_t size) {
-
-      if(count_active) {
-        if(strcmp(dst_handle.name,src_handle.name))
-          count_different++;
-        else
-          count_same++;        
-      }
-    }
-
-  }// end DeepCopyCounterDetails
-
-
-  void DeepCopyCounter::start() {
-    DeepCopyCounterDetails::count_active=true;
-    Kokkos::Tools::Experimental::set_begin_deep_copy_callback(DeepCopyCounterDetails::kokkosp_begin_deep_copy);
+void kokkosp_begin_deep_copy(Kokkos::Tools::SpaceHandle dst_handle, const char *dst_name, const void *dst_ptr,
+                             Kokkos::Tools::SpaceHandle src_handle, const char *src_name, const void *src_ptr,
+                             uint64_t size) {
+  if (count_active) {
+    if (strcmp(dst_handle.name, src_handle.name))
+      count_different++;
+    else
+      count_same++;
   }
+}
 
-  void DeepCopyCounter::reset() {
-    DeepCopyCounterDetails::count_same=0;
-    DeepCopyCounterDetails::count_different=0;
-  }
+}  // namespace DeepCopyCounterDetails
 
-  void DeepCopyCounter::stop() {
-    DeepCopyCounterDetails::count_active=false;
-  }
+void DeepCopyCounter::start() {
+  DeepCopyCounterDetails::count_active = true;
+  Kokkos::Tools::Experimental::set_begin_deep_copy_callback(DeepCopyCounterDetails::kokkosp_begin_deep_copy);
+}
 
-  size_t DeepCopyCounter::get_count_same_space() {
-    return DeepCopyCounterDetails::count_same;
-  }
+void DeepCopyCounter::reset() {
+  DeepCopyCounterDetails::count_same      = 0;
+  DeepCopyCounterDetails::count_different = 0;
+}
 
-  size_t DeepCopyCounter::get_count_different_space() {
-    return DeepCopyCounterDetails::count_different;
-  }
+void DeepCopyCounter::stop() {
+  DeepCopyCounterDetails::count_active = false;
+}
 
+size_t DeepCopyCounter::get_count_same_space() {
+  return DeepCopyCounterDetails::count_same;
+}
 
+size_t DeepCopyCounter::get_count_different_space() {
+  return DeepCopyCounterDetails::count_different;
+}
 
-  /***************************** Fence *****************************/
+/***************************** Fence *****************************/
 
+namespace FenceCounterDetails {
 
-  namespace FenceCounterDetails {
+// Static variables
+bool is_initialized = false;
+bool count_active   = false;
+std::vector<size_t> count_instance;
+std::vector<size_t> count_global;
+int num_devices = 0;
 
-    // Static variables
-    bool is_initialized=false;
-    bool count_active=false;
-    std::vector<size_t> count_instance;
-    std::vector<size_t> count_global;
-    int num_devices=0;
-
-
-    void kokkosp_begin_fence(const char* name, const uint32_t deviceId,
-                             uint64_t* handle) {
-
-      if(count_active) {
-        using namespace Kokkos::Tools::Experimental;
-        ExecutionSpaceIdentifier eid = identifier_from_devid(deviceId);
-        
-        // Figure out what count bin to stick this in
-        int idx = (int) eid.type;
-#if KOKKOS_VERSION >= 40499
-        if(eid.instance_id == int_for_synchronization_reason(SpecialSynchronizationCases::GlobalDeviceSynchronization))
-#else
-        if(eid.instance_id == Impl::int_for_synchronization_reason(SpecialSynchronizationCases::GlobalDeviceSynchronization))
-#endif
-          count_global[idx]++;
-        else
-          count_instance[idx]++;
-      }
-    }
-
-
-    std::string get_label(int i) {
-      using namespace Kokkos::Tools::Experimental;
-      DeviceType i_type = devicetype_from_uint32t(i);
-      std::string device_label;
-      if      (i_type == DeviceType::Serial)       device_label="Serial";
-      else if (i_type == DeviceType::OpenMP)       device_label="OpenMP";
-      else if (i_type == DeviceType::Cuda)         device_label="Cuda";
-      else if (i_type == DeviceType::HIP)          device_label="HIP";
-      else if (i_type == DeviceType::OpenMPTarget) device_label="OpenMPTarget";
-      else if (i_type == DeviceType::HPX)          device_label="HPX";
-      else if (i_type == DeviceType::Threads)      device_label="Threats";
-      else if (i_type == DeviceType::SYCL)         device_label="SYCL";
-      else if (i_type == DeviceType::OpenACC)      device_label="OpenACC";
-      else if (i_type == DeviceType::Unknown)      device_label="Unknown";
-      
-      return device_label;
-    }
-
-    void initialize() {
-      using namespace Kokkos::Tools::Experimental;
-      num_devices = (int) DeviceType::Unknown;
-      count_instance.resize(num_devices);
-      count_instance.assign(num_devices,0);
-      count_global.resize(num_devices);
-      count_global.assign(num_devices,0);
-      is_initialized=true;
-    }
-
-  }// end FenceCounterDetails
-
-
-  
-
-  void FenceCounter::start() {
-    if(!FenceCounterDetails::is_initialized) 
-      FenceCounterDetails::initialize();
-    FenceCounterDetails::count_active=true;
-    Kokkos::Tools::Experimental::set_begin_fence_callback(FenceCounterDetails::kokkosp_begin_fence);
-  }
-
-  void FenceCounter::reset() {
-    FenceCounterDetails::count_instance.assign(FenceCounterDetails::num_devices,0);
-    FenceCounterDetails::count_global.assign(FenceCounterDetails::num_devices,0);
-  }
-  
-  void FenceCounter::stop() {
-    FenceCounterDetails::count_active=false;
-  }
-
-  size_t FenceCounter::get_count_global(const std::string & device) {
+void kokkosp_begin_fence(const char *name, const uint32_t deviceId,
+                         uint64_t *handle) {
+  if (count_active) {
     using namespace Kokkos::Tools::Experimental;
-    for(int i=0;i<FenceCounterDetails::num_devices; i++) {
-      std::string device_label = FenceCounterDetails::get_label(i);      
+    ExecutionSpaceIdentifier eid = identifier_from_devid(deviceId);
 
-      if(device == device_label)
-        return FenceCounterDetails::count_global[i];
-    }
+    // Figure out what count bin to stick this in
+    int idx = (int)eid.type;
+    if (eid.instance_id == int_for_synchronization_reason(SpecialSynchronizationCases::GlobalDeviceSynchronization))
+      count_global[idx]++;
+    else
+      count_instance[idx]++;
+  }
+}
 
-    // Haven't found a device by this name
-    TEUCHOS_TEST_FOR_EXCEPTION(1,std::runtime_error,std::string("Error: ") + device + std::string(" is not a device known to Tpetra"));
+std::string get_label(int i) {
+  using namespace Kokkos::Tools::Experimental;
+  DeviceType i_type = devicetype_from_uint32t(i);
+  std::string device_label;
+  if (i_type == DeviceType::Serial)
+    device_label = "Serial";
+  else if (i_type == DeviceType::OpenMP)
+    device_label = "OpenMP";
+  else if (i_type == DeviceType::Cuda)
+    device_label = "Cuda";
+  else if (i_type == DeviceType::HIP)
+    device_label = "HIP";
+  else if (i_type == DeviceType::OpenMPTarget)
+    device_label = "OpenMPTarget";
+  else if (i_type == DeviceType::HPX)
+    device_label = "HPX";
+  else if (i_type == DeviceType::Threads)
+    device_label = "Threats";
+  else if (i_type == DeviceType::SYCL)
+    device_label = "SYCL";
+  else if (i_type == DeviceType::OpenACC)
+    device_label = "OpenACC";
+  else if (i_type == DeviceType::Unknown)
+    device_label = "Unknown";
+
+  return device_label;
+}
+
+void initialize() {
+  using namespace Kokkos::Tools::Experimental;
+  num_devices = (int)DeviceType::Unknown;
+  count_instance.resize(num_devices);
+  count_instance.assign(num_devices, 0);
+  count_global.resize(num_devices);
+  count_global.assign(num_devices, 0);
+  is_initialized = true;
+}
+
+}  // namespace FenceCounterDetails
+
+void FenceCounter::start() {
+  if (!FenceCounterDetails::is_initialized)
+    FenceCounterDetails::initialize();
+  FenceCounterDetails::count_active = true;
+  Kokkos::Tools::Experimental::set_begin_fence_callback(FenceCounterDetails::kokkosp_begin_fence);
+}
+
+void FenceCounter::reset() {
+  FenceCounterDetails::count_instance.assign(FenceCounterDetails::num_devices, 0);
+  FenceCounterDetails::count_global.assign(FenceCounterDetails::num_devices, 0);
+}
+
+void FenceCounter::stop() {
+  FenceCounterDetails::count_active = false;
+}
+
+size_t FenceCounter::get_count_global(const std::string &device) {
+  using namespace Kokkos::Tools::Experimental;
+  for (int i = 0; i < FenceCounterDetails::num_devices; i++) {
+    std::string device_label = FenceCounterDetails::get_label(i);
+
+    if (device == device_label)
+      return FenceCounterDetails::count_global[i];
   }
 
+  // Haven't found a device by this name
+  TEUCHOS_TEST_FOR_EXCEPTION(1, std::runtime_error, std::string("Error: ") + device + std::string(" is not a device known to Tpetra"));
+}
 
-  size_t FenceCounter::get_count_instance(const std::string & device) {
-    using namespace Kokkos::Tools::Experimental;
-    for(int i=0;i<FenceCounterDetails::num_devices; i++) {
-      std::string device_label = FenceCounterDetails::get_label(i);      
+size_t FenceCounter::get_count_instance(const std::string &device) {
+  using namespace Kokkos::Tools::Experimental;
+  for (int i = 0; i < FenceCounterDetails::num_devices; i++) {
+    std::string device_label = FenceCounterDetails::get_label(i);
 
-      if(device == device_label)
-        return FenceCounterDetails::count_instance[i];
-    }
-
-    // Haven't found a device by this name
-    TEUCHOS_TEST_FOR_EXCEPTION(1,std::runtime_error,std::string("Error: ") + device + std::string(" is not a device known to Tpetra"));
+    if (device == device_label)
+      return FenceCounterDetails::count_instance[i];
   }
+
+  // Haven't found a device by this name
+  TEUCHOS_TEST_FOR_EXCEPTION(1, std::runtime_error, std::string("Error: ") + device + std::string(" is not a device known to Tpetra"));
+}
 
 // clang-format on
 namespace KokkosRegionCounterDetails {
@@ -227,4 +219,3 @@ void KokkosRegionCounter::dump_regions(std::ostream &os) {
 
 } // namespace Details
 } // namespace Tpetra
-

--- a/packages/tpetra/core/src/Tpetra_Details_KokkosTeuchosTimerInjection.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_KokkosTeuchosTimerInjection.cpp
@@ -51,17 +51,10 @@ std::string deviceIdToString(const uint32_t deviceId) {
     device_label += "Unknown";
   else
     device_label += "Unknown to Tpetra";
-#if KOKKOS_VERSION >= 40499
   if (eid.instance_id == int_for_synchronization_reason(SpecialSynchronizationCases::GlobalDeviceSynchronization))
     device_label += " All Instances)";
   else if (eid.instance_id == int_for_synchronization_reason(SpecialSynchronizationCases::DeepCopyResourceSynchronization))
     device_label += " DeepCopyResource)";
-#else
-  if (eid.instance_id == Impl::int_for_synchronization_reason(SpecialSynchronizationCases::GlobalDeviceSynchronization))
-    device_label += " All Instances)";
-  else if (eid.instance_id == Impl::int_for_synchronization_reason(SpecialSynchronizationCases::DeepCopyResourceSynchronization))
-    device_label += " DeepCopyResource)";
-#endif
   else
     device_label += " Instance " + std::to_string(eid.instance_id) + ")";
 

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ApplyUsesTPLs.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ApplyUsesTPLs.cpp
@@ -267,13 +267,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, NonSquare, LO, GO, Scalar, Node) {
       const size_t numTplCalls =
           Tpetra::Details::KokkosRegionCounter::get_count_region_contains("spmv[TPL_") +
           Tpetra::Details::KokkosRegionCounter::get_count_region_contains("spmv_mv[TPL_");  // added in Kernels 4.3.1, okay to look for before
-#if (KOKKOSKERNELS_VERSION >= 40399)
       // rocSparse spmv_mv has been added to KokkosKernels develop
       // Delete the #else branch at the next release
       TEST_COMPARE(numTplCalls, ==, 1);
-#else
-      TEST_COMPARE(numTplCalls, ==, 0);
-#endif
     }
 #endif  // HIP
   }

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_MatvecFence.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_MatvecFence.cpp
@@ -195,17 +195,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, MatvecFence, LO, GO, Scalar, Node) 
       // Did not test the case of Serial node in build with Serial and OpenMP and GPU-aware
       expectedGlobalCount = iter_num;
       if (Tpetra::Details::Behavior::debug()) {
-#if KOKKOS_VERSION >= 40499
         expectedInstanceCount = 3 * iter_num;
-#else
-        expectedInstanceCount = 4 * iter_num;
-#endif
       } else {
-#if KOKKOS_VERSION >= 40499
         expectedInstanceCount = 2 * iter_num;
-#else
-        expectedInstanceCount = 3 * iter_num;
-#endif
       }
     }
 #endif


### PR DESCRIPTION
Issue: #14419
Test: n/a
Stakeholder feedback: n/a

I also re-enabled clang-format for one file and it totally got rearranged.