### PR TITLE
Use pre-commit

### DIFF
--- a/.github/workflows/pre_commit_comment.yml
+++ b/.github/workflows/pre_commit_comment.yml
@@ -1,0 +1,58 @@
+# This file needs to be on the default branch for the workflow to run.
+
+name: pre-commit-comment
+
+on:
+  workflow_run:
+    workflows: [pre-commit-run]
+    types:
+      - completed
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  pre-commit-comment:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+
+    steps:
+    - name: 'Download artifact'
+      uses: actions/github-script@v8
+      with:
+        script: |
+          let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             run_id: context.payload.workflow_run.id,
+          });
+          let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "format_patch_message"
+          })[0];
+          let download = await github.rest.actions.downloadArtifact({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             artifact_id: matchArtifact.id,
+             archive_format: 'zip',
+          });
+          const fs = require('fs');
+          const path = require('path');
+          const temp = '${{ runner.temp }}/artifacts';
+          if (!fs.existsSync(temp)){
+            fs.mkdirSync(temp);
+          }
+          fs.writeFileSync(path.join(temp, 'format_patch_message.zip'), Buffer.from(download.data));
+
+    - run: |
+        cd ${{ runner.temp }}/artifacts
+        unzip format_patch_message.zip
+        MY_PR_NUMBER=$(cat pr_number)
+        echo "PR_NUMBER=$MY_PR_NUMBER" >> $GITHUB_ENV
+
+    - name: Post artifact in issue comment
+      uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
+      with:
+        message-id: format-patch
+        issue:  ${{ env.PR_NUMBER }}
+        refresh-message-position: true
+        message-path: ${{ runner.temp }}/artifacts/format_patch_message.txt

--- a/.github/workflows/pre_commit_run.yml
+++ b/.github/workflows/pre_commit_run.yml
@@ -1,0 +1,66 @@
+name: pre-commit-run
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit-run:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        ref: "${{ github.event.pull_request.head.sha }}"
+
+    - uses: actions/setup-python@v3
+
+    - uses: pre-commit/action@v3.0.1
+      continue-on-error: true
+
+    - run: git diff HEAD > format_patch.txt
+
+    - run: if [ "$(cat format_patch.txt)" == "" ] ; then rm format_patch.txt ; else cat format_patch.txt; fi
+
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      id: upload-artf
+      if: ${{ hashFiles('format_patch.txt') != '' }}
+      with:
+        name: format patch
+        path: format_patch.txt
+
+    - if: ${{ hashFiles('format_patch.txt') != '' }}
+      run: |
+        echo "Your PR updated files that did not respect package formatting settings." >> format_patch_message.txt
+        echo "Please apply the patch given below. Alternatively you can download a patch file [here](${{ steps.upload-artf.outputs.artifact-url }})." >> format_patch_message.txt
+        echo "<details>" >> format_patch_message.txt
+        echo "<summary>Patch</summary>" >> format_patch_message.txt
+        echo "" >> format_patch_message.txt
+        echo "\`\`\`diff" >> format_patch_message.txt
+        cat format_patch.txt >> format_patch_message.txt
+        echo "\`\`\`" >> format_patch_message.txt
+        echo "</details>" >> format_patch_message.txt
+        echo "" >> format_patch_message.txt
+        echo "More details about our use of clang-format and other tools can be found in the [wiki](https://github.com/trilinos/Trilinos/wiki/Clang\%E2\%80\%90format)." >> format_patch_message.txt
+
+    - name: Save PR number
+      env:
+        PR_NUMBER: ${{ github.event.number }}
+      run: |
+        echo $PR_NUMBER > pr_number
+
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      id: upload-artf-msg
+      if: ${{ hashFiles('format_patch_message.txt') != '' }}
+      with:
+        name: format_patch_message
+        path: |
+          format_patch_message.txt
+          pr_number
+
+    - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      if: ${{ hashFiles('format_patch.txt') != '' }}
+      with:
+        script: |
+          core.setFailed('Your PR updated files that did not respect package formatting settings. Please download and apply the formatting patch! It is located at the bottom of the summary tab for this workflow and at this link: ${{ steps.upload-artf.outputs.artifact-url }}')

--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,6 @@ doxygen_objdb_*.tmp
 # Ignore local gitdist config file (.gitdis.default is in git repo)
 /.gitdist
 
-# Ignore user-specific pre-commit files
-/.pre-commit-config.yaml
-
 # Allow github Kokkos to be cloned under Trilinos
 /kokkos/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+ repos:
+
+ - repo: https://github.com/pre-commit/mirrors-clang-format
+   rev: v14.0.1
+   hooks:
+   - id: clang-format
+     name: clang-format Galeri
+     types_or: [c++, c, cuda]
+     files: "packages/galeri/(src-xpetra|example-tpetra|example-xpetra|test)/.*pp"
+   - id: clang-format
+     name: clang-format Ifpack2
+     types_or: [c++, c, cuda]
+     files: "packages/ifpack2/.*pp"
+   - id: clang-format
+     name: clang-format MueLu
+     types_or: [c++, c, cuda]
+     files: "packages/muelu/.*pp"
+   - id: clang-format
+     name: clang-format Teko
+     types_or: [c++, c, cuda]
+     files: "packages/teko/.*pp"
+   - id: clang-format
+     name: clang-format Tempus
+     types_or: [c++, c, cuda]
+     files: "packages/tempus/.*pp"
+     exclude: "packages/tempus/examples/.*"
+   - id: clang-format
+     name: clang-format Tpetra
+     types_or: [c++, c, cuda]
+     files: "packages/tpetra/.*pp"
+   - id: clang-format
+     name: clang-format Xpetra
+     types_or: [c++, c, cuda]
+     files: "packages/xpetra/.*pp"
+
+ - repo: https://github.com/pre-commit/pre-commit-hooks
+   rev: v4.5.0
+   hooks:
+   - id: check-xml
+     files: ".*xml"
+     exclude: "(packages/teuchos/parameterlist/.*|packages/ifpack2/test/belos/test_2_RILUK_Experimental_nos1_hb.xml|packages/anasazi/epetra/example/.*)"
+   - id: check-yaml
+     files: "(.*yaml|.*yml)"
+     exclude: "packages/teuchos/.*"


### PR DESCRIPTION
@trilinos/framework 

## Motivation
This PR adds a replacement for the clang-format workflow.
- It splits the workflow into two. One workflow checks the PR with read permissions. The second workflow posts results.
- The formatting check now uses pre-commit. This simplifies adding additional code checks and also allows to run checks locally before pushing them.
- I have tested the workflow in a fork. The `pre_commit_comment` workflow file needs to be on the default branch. So it won't work until then. Once we can see the new system working, I will remove the old clang_format workflow.