### PR TITLE
Treat shadow warnings as errors

### DIFF
--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -70,7 +70,6 @@ set(upcoming_warnings
     overloaded-virtual=1
     pessimizing-move
     range-loop-construct
-    shadow
     unused-but-set-variable
     uninitialized
     ${Trilinos_ADDITIONAL_WARNINGS}
@@ -133,6 +132,7 @@ set(promoted_warnings
     return-type
     self-move
     sequence-point
+    shadow
     sign-compare
     sizeof-array-div
     sizeof-pointer-div


### PR DESCRIPTION
@trilinos/framework 

## Motivation
We should be pretty close to flip the switch and treat shadow warnings as errors. Let's see if the AT agrees.