### PR TITLE
Teuchos: Collect system information

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -8,6 +8,7 @@
 // @HEADER
 
 #include "Teuchos_StackedTimer.hpp"
+#include "Teuchos_SystemInformation.hpp"
 #include <limits>
 #include <ctime>
 #include <cctype>
@@ -832,6 +833,12 @@ StackedTimer::reportWatchrXML(const std::string& name, Teuchos::RCP<const Teucho
       if(gitSHA.length() > 10)
         gitSHA = gitSHA.substr(0, 10);
       os << "  <metadata key=\"Trilinos Version\" value=\"" << gitSHA << "\"/>\n";
+    }
+    auto systemInfo = SystemInformation::collectSystemInformation();
+    for (const auto &e : systemInfo) {
+      os << "  <metadata key=\"" << e.first << "\" value=\"";
+      printXMLEscapedString(os, e.second);
+      os << "\"/>\n";
     }
     printLevelXML("", 0, os, printed, 0.0, buildName + ": " + name);
     os << "</performance-report>\n";

--- a/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
+++ b/packages/teuchos/core/src/Teuchos_CommandLineProcessor.hpp
@@ -515,6 +515,7 @@ private:
   int   output_to_root_rank_only_;
   bool  print_rcpnode_statistics_on_exit_;
   bool  show_timer_summary_on_exit_;
+  bool  print_system_info_;
 
   bool printed_timer_summary_;
 
@@ -528,6 +529,7 @@ private:
   static const int   output_to_root_rank_only_default_;
   static const bool  print_rcpnode_statistics_on_exit_default_;
   static const bool  show_timer_summary_on_exit_default_;
+  static const bool  print_system_info_default_;
 
   // /////////////////////////////////
   // Private member functions

--- a/packages/teuchos/core/src/Teuchos_EnvVariables.hpp
+++ b/packages/teuchos/core/src/Teuchos_EnvVariables.hpp
@@ -14,6 +14,10 @@
 
 namespace Teuchos {
 
+template <typename T>
+T getEnvironmentVariable(const std::string_view environmentVariableName,
+                         const T defaultValue);
+
 bool idempotentlyGetNamedEnvironmentVariableAsBool(
     const char name[], bool &initialized, const char environmentVariableName[],
     const bool defaultValue);

--- a/packages/teuchos/core/src/Teuchos_SystemInformation.cpp
+++ b/packages/teuchos/core/src/Teuchos_SystemInformation.cpp
@@ -1,0 +1,270 @@
+// @HEADER
+// *****************************************************************************
+//                    Teuchos: Common Tools Package
+//
+// Copyright 2004 NTESS and the Teuchos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#include "Teuchos_SystemInformation.hpp"
+#include "Teuchos_EnvVariables.hpp"
+#include "Teuchos_StrUtils.hpp"
+#include "Teuchos_TestForException.hpp"
+
+#if !defined(__GNUC__) || (__GNUC__ >= 10)
+#include <filesystem>
+#endif
+#include <iostream>
+#include <stdexcept>
+#include <set>
+
+// environ should be available on posix platforms
+#if not(defined(WIN) && (_MSC_VER >= 1900))
+// needs to be in the global namespace
+extern char **environ;
+#endif
+
+namespace Teuchos::SystemInformation {
+
+namespace {
+
+std::map<std::string, std::pair<std::string, std::string>>& getCommandsMap() {
+  static std::map<std::string, std::pair<std::string, std::string>> commands;
+  return commands;
+}
+
+std::set<std::string>& getEnvironmentVariablesSet() {
+  static std::set<std::string> environmentVariables;
+  return environmentVariables;
+}
+
+}
+
+bool commandIsAvailable(const std::string &command) {
+  return !std::system(
+      std::string("command -v " + command + " > /dev/null 2>&1").c_str());
+}
+
+std::string runCommandAndCaptureOutput(const std::string &command) {
+  char buffer[128];
+  std::string result = "";
+  FILE *pipe = popen(command.c_str(), "r");
+  if (!pipe)
+    return "command \"" + command + "\"failed";
+  try {
+    while (fgets(buffer, sizeof buffer, pipe) != NULL) {
+      result += buffer;
+    }
+  } catch (...) {
+    pclose(pipe);
+    return "command \"" + command + "\"failed";
+  }
+  pclose(pipe);
+  return result;
+}
+
+RegistrationResult
+registerEnvironmentVariable(const std::string &variableName) {
+  auto &environmentVariables = getEnvironmentVariablesSet();
+
+  if (auto search = environmentVariables.find(variableName);
+      search != environmentVariables.end()) {
+    // variable is already present
+    return ALREADY_PRESENT;
+  } else {
+    // variable not found
+    environmentVariables.insert(variableName);
+    return REGISTERED;
+  }
+}
+
+void registerAllPrefixedVariables(const std::string &prefix) {
+  char **env;
+#if defined(WIN) && (_MSC_VER >= 1900)
+  env = *__p__environ();
+#else
+  env = environ; // defined at the top of this file as extern char **environ;
+#endif
+  for (; *env; ++env) {
+    // const std::string_view ev(*env);
+
+    // split name=value on the first =, everything before = is name
+    auto substrings = StrUtils::splitString(*env, '=');
+    std::string name = substrings[0];
+
+    if (name.size() >= prefix.size() &&
+        name.substr(0, prefix.size()) == prefix) {
+      Teuchos::SystemInformation::registerEnvironmentVariable(name);
+    }
+  }
+}
+
+RegistrationResult
+registerCommand(const std::string &commandLabel,
+                const std::string &commandToRunAndCapture,
+                const std::string &commandToCheckForExistence) {
+  auto &commands = getCommandsMap();
+
+  std::string myCommandToRunAndCapture = commandToRunAndCapture;
+  if (myCommandToRunAndCapture.empty())
+    myCommandToRunAndCapture = commandLabel;
+
+  std::string myCommandToCheckForExistence = commandToCheckForExistence;
+  if (myCommandToCheckForExistence.empty())
+    myCommandToCheckForExistence = myCommandToRunAndCapture;
+
+  if (auto search = commands.find(commandLabel); search != commands.end()) {
+    if ((commands[commandLabel].first == myCommandToCheckForExistence) &&
+        (commands[commandLabel].second == myCommandToRunAndCapture))
+      return ALREADY_PRESENT;
+    else {
+      std::cerr
+          << "Teuchos::SystemInformation: Attempted to register a command (\""
+          << commandLabel << "\", \"" << myCommandToRunAndCapture << "\", \""
+          << myCommandToCheckForExistence << "\") "
+          << "that clashes with already registered command: (" << commandLabel
+          << "\", \"" << commands[commandLabel].first << "\", \""
+          << commands[commandLabel].second << "\")." << std::endl;
+      return FAILURE;
+    }
+  } else {
+    // command not found
+    commands[commandLabel] = {myCommandToCheckForExistence, myCommandToRunAndCapture};
+    return REGISTERED;
+  }
+}
+
+void initializeCollection() {
+
+  std::string userProvidedEnvVariables =
+      Teuchos::getEnvironmentVariable<std::string>(
+          "TEUCHOS_USER_ENVIRONMENT_VARIABLES", "");
+  if (!userProvidedEnvVariables.empty()) {
+    auto strings = StrUtils::splitString(userProvidedEnvVariables, ';');
+    bool isValid = (strings.size() >= 1);
+    if (!isValid)
+      std::cerr
+          << "Teuchos::SystemInformation: The value of the environment "
+             "variable "
+             "TEUCHOS_USER_ENVIRONMENT_VARIABLES needs to be a semi-colon "
+             "seperated string. Value: "
+          << userProvidedEnvVariables << std::endl;
+    for (int itemNo = 0; itemNo < strings.size(); ++itemNo) {
+      std::string &variableName = strings[itemNo];
+      if (registerEnvironmentVariable(variableName) == FAILURE)
+        isValid = false;
+    }
+    TEUCHOS_TEST_FOR_EXCEPTION(
+        !isValid, std::runtime_error,
+        "Teuchos::SystemInformation: Invalid environment variable "
+        "TEUCHOS_USER_ENVIRONMENT_VARIABLES");
+  }
+
+  std::string userProvidedCommands =
+      Teuchos::getEnvironmentVariable<std::string>("TEUCHOS_USER_COMMANDS", "");
+  if (!userProvidedCommands.empty()) {
+    auto strings = StrUtils::splitString(userProvidedEnvVariables, ';');
+    bool isValid = (strings.size() % 3 == 0) && (strings.size() >= 3);
+    if (!isValid)
+      std::cerr << "Teuchos::SystemInformation: The value of the environment "
+                   "variable TEUCHOS_USER_COMMANDS "
+                   "needs to be a semi-colon seperated string with a number of "
+                   "elements that is a multiple of 3. Value: "
+                << userProvidedCommands << std::endl;
+    int tupleNo = 0;
+    while (isValid && (3 * tupleNo + 2 < strings.size())) {
+      std::string &commandLabel = strings[3 * tupleNo];
+      std::string &commandToRunAndCapture = strings[3 * tupleNo + 1];
+      std::string &commandToCheckForExistence = strings[3 * tupleNo + 2];
+      if (registerCommand(commandLabel, commandToRunAndCapture,
+                          commandToCheckForExistence) == FAILURE) {
+        isValid = false;
+      }
+      ++tupleNo;
+    }
+    TEUCHOS_TEST_FOR_EXCEPTION(!isValid, std::runtime_error,
+                               "Teuchos::SystemInformation: Invalid "
+                               "environment variable TEUCHOS_USER_COMMANDS");
+  }
+
+#if !defined(__GNUC__) || (__GNUC__ >= 10)
+  try {
+    const std::string executable = std::filesystem::canonical("/proc/self/exe");
+    if (!executable.empty()) {
+      registerCommand("ldd", "ldd " + executable, "ldd");
+    }
+  } catch (std::filesystem::filesystem_error &) {
+    // ignore
+  }
+#endif
+
+  // CPUs
+  registerCommand("lscpu");
+
+  // temperature sensore
+  registerCommand("sensors");
+
+  // OpenMP
+  registerAllPrefixedVariables("OMP");
+
+  // OpenMPI
+  registerCommand("ompi_info");
+  registerAllPrefixedVariables("OMPI");
+
+  // MPICH
+  registerCommand("mpichinfo");
+  registerAllPrefixedVariables("MPICH");
+
+  // CRAY
+  registerAllPrefixedVariables("CRAY");
+
+  // modules
+  registerCommand("module", "module list", "module");
+
+  // CUDA
+  registerCommand("nvidia-smi", "nvidia-smi --query", "nvidia-smi");
+  registerAllPrefixedVariables("CUDA");
+
+  // ROCm
+  registerCommand("rocm-smi", "rocm-smi --showallinfo", "rocm-smi");
+
+  // SYCL
+  registerCommand("sycl-ls", "sycl-ls --verbose", "sycl-ls");
+
+  // package namespaced environment variables
+  for (auto &prefix : {"TEUCHOS", "KOKKOS", "TPETRA", "STK"})
+    registerAllPrefixedVariables(prefix);
+}
+
+std::map<std::string, std::string> collectSystemInformation() {
+
+  std::map<std::string, std::string> data;
+
+  const std::string DATA_NOT_AVAILABLE = "NOT AVAILABLE";
+
+  auto &commands = getCommandsMap();
+  for (auto &command : commands) {
+    const bool isAvailable = commandIsAvailable(command.second.first);
+    if (isAvailable) {
+      data[command.first] = runCommandAndCaptureOutput(command.second.second);
+    } else {
+      data[command.first] = DATA_NOT_AVAILABLE;
+    }
+  }
+
+  auto &environmentVariables = getEnvironmentVariablesSet();
+  for (auto &envVariable : environmentVariables) {
+    const char *varVal = std::getenv(envVariable.c_str());
+    if (varVal == nullptr)
+      data[envVariable] = "NOT SET";
+    else {
+      data[envVariable] =
+          Teuchos::getEnvironmentVariable<std::string>(envVariable, "");
+    }
+  }
+
+  return data;
+}
+
+} // namespace Teuchos::SystemInformation

--- a/packages/teuchos/core/src/Teuchos_SystemInformation.hpp
+++ b/packages/teuchos/core/src/Teuchos_SystemInformation.hpp
@@ -1,0 +1,61 @@
+// @HEADER
+// *****************************************************************************
+//                    Teuchos: Common Tools Package
+//
+// Copyright 2004 NTESS and the Teuchos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef TEUCHOS_SYSTEMINFORMATION_HPP
+#define TEUCHOS_SYSTEMINFORMATION_HPP
+
+/// \file Teuchos_SystemInformation.hpp
+/// \brief Collect information about the runtime environment
+///
+/// This tool collects the values of environment variables and the output of
+/// commands for debugging purposes. Several useful variables and commands are
+/// pre-registered. Additional environment variables can be added by setting
+/// export
+/// TEUCHOS_USER_ENVIRONMENT_VARIABLES=MY_FANCY_VARIABLE;MY_LESS_FANCY_VARIABLE
+/// Additional commands can be added by setting
+/// export
+/// TEUCHOS_USER_COMMANDS=label_for_the_command;command_to_call;executable_that_is_checked_for_availabilty;....
+/// The collection of data can be triggered by passing a --print-system-info to
+/// any Teuchos::CommandLineProcessor
+
+#include <map>
+#include <string>
+
+namespace Teuchos::SystemInformation {
+
+/// Check whether a command is available on the system.
+bool commandIsAvailable(const std::string &command);
+
+/// Run a command and capture its output
+std::string runCommandAndCaptureOutput(const std::string &command);
+
+enum RegistrationResult { REGISTERED, ALREADY_PRESENT, FAILURE };
+
+/// Register an environment variable that should be tracked.
+RegistrationResult registerEnvironmentVariable(const std::string &variableName);
+
+/// Register all variables with a given prefix that can be found in the
+/// environment.
+void registerAllPrefixedVariables(const std::string &prefix);
+
+/// Register a command.
+RegistrationResult
+registerCommand(const std::string &commandLabel,
+                const std::string &commandToRunAndCapture = "",
+                const std::string &commandToCheckForExistence = "");
+
+/// Track commonly used environment variables and commands.
+void initializeCollection();
+
+/// Collect information about the system.
+std::map<std::string, std::string> collectSystemInformation();
+
+} // namespace Teuchos::SystemInformation
+
+#endif

--- a/packages/teuchos/core/test/UnitTest/CMakeLists.txt
+++ b/packages/teuchos/core/test/UnitTest/CMakeLists.txt
@@ -177,3 +177,17 @@ TRIBITS_ADD_TEST(
   COMM mpi
   STANDARD_PASS_OUTPUT
   )
+
+
+#
+# SystemInformation unit tests
+#
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  SystemInformation_UnitTests
+  SOURCES
+    SystemInformation_UnitTests.cpp
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  NUM_MPI_PROCS 1
+  STANDARD_PASS_OUTPUT
+  )

--- a/packages/teuchos/core/test/UnitTest/SystemInformation_UnitTests.cpp
+++ b/packages/teuchos/core/test/UnitTest/SystemInformation_UnitTests.cpp
@@ -1,0 +1,52 @@
+// @HEADER
+// *****************************************************************************
+//                    Teuchos: Common Tools Package
+//
+// Copyright 2004 NTESS and the Teuchos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_SystemInformation.hpp"
+#include <stdlib.h>
+
+namespace {
+
+
+TEUCHOS_UNIT_TEST( SystemInformation, Commands )
+{
+  if (Teuchos::SystemInformation::commandIsAvailable("ls")) {
+    auto output = Teuchos::SystemInformation::runCommandAndCaptureOutput("ls");
+    TEST_ASSERT(output.find("TeuchosCore_SystemInformation_UnitTests.exe") != std::string::npos);
+  }
+}
+
+
+TEUCHOS_UNIT_TEST( SystemInformation, EnvVariables ) {
+
+  Teuchos::SystemInformation::registerEnvironmentVariable("BLAH_BLAH");
+  {
+    auto values = Teuchos::SystemInformation::collectSystemInformation();
+    TEST_ASSERT(values.find("BLAH_BLAH") != values.end());
+    TEST_EQUALITY_CONST(values["BLAH_BLAH"], "NOT SET");
+  }
+
+  setenv("BLAH_BLAH", "test", 1);
+  {
+    auto values = Teuchos::SystemInformation::collectSystemInformation();
+    TEST_ASSERT(values.find("BLAH_BLAH") != values.end());
+    TEST_EQUALITY_CONST(values["BLAH_BLAH"], "test");
+  }
+  unsetenv("BLAH_BLAH");
+}
+
+
+TEUCHOS_UNIT_TEST( SystemInformation, CommonlyUsed ) {
+  Teuchos::SystemInformation::initializeCollection();
+  auto values = Teuchos::SystemInformation::collectSystemInformation();
+  TEST_ASSERT(values.find("lscpu") != values.end());
+  TEST_ASSERT(values.find("sensors") != values.end());
+}
+
+} // namespace


### PR DESCRIPTION
@trilinos/teuchos @trilinos/tpetra 

## Motivation

Information can be printed by passing "--print-system-info" to any CommandLineProcessor. The data also gets recorded in Watchr output.

I am not sure how robust this is: does this also work on Mac or Windows?

<details>
<summary>Example output</summary>

```
CUDA_LAUNCH_BLOCKING: NOT SET
KOKKOS_TOOLS_LIBS: /workspace/kokkos-tools/build/profiling/memory-hwm/libkp_hwm.so
MPICH_GPU_SUPPORT_ENABLED: NOT SET
TEUCHOS_FENCE_TIMERS: NOT SET
TPETRA_ASSUME_GPU_AWARE_MPI: NOT SET
TPETRA_DEFAULT_SEND_TYPE: NOT SET
TPETRA_GRANULAR_TRANSFERS: NOT SET
TPETRA_TIME_KOKKOS_DEEP_COPY: NOT SET
TPETRA_USE_KOKKOS_PROFILING: NOT SET
TPETRA_USE_TEUCHOS_TIMERS: NOT SET
executable: /workspace/trilinos/build/packages/muelu/test/scaling/MueLu_Driver.exe
ldd:    linux-vdso.so.1 (0x00007fff77cdf000)
        libmpi.so.40 => /home/runner/spack/opt/spack/linux-x86_64/openmpi-4.1.6-2atbcifi27x7uqe645a6tzhhe3vmrxwp/lib/libmpi.so.40 (0x00007f23f8648000)
        libmuelu-adapters.so.16 => /workspace/trilinos/build/packages/muelu/adapters/libmuelu-adapters.so.16 (0x00007f23f839b000)
        libmuelu.so.16 => /workspace/trilinos/build/packages/muelu/src/libmuelu.so.16 (0x00007f23f3ed9000)
        libteko.so.16 => /workspace/trilinos/build/packages/teko/src/libteko.so.16 (0x00007f23f34c4000)
        libTpetraModeLaplace.so.16 => /workspace/trilinos/build/packages/anasazi/tpetra/util/ModeLaplace/libTpetraModeLaplace.so.16 (0x00007f23f8623000)
        libanasazitpetra.so.16 => /workspace/trilinos/build/packages/anasazi/tpetra/src/libanasazitpetra.so.16 (0x00007f23f8604000)
        libanasazi.so.16 => /workspace/trilinos/build/packages/anasazi/src/libanasazi.so.16 (0x00007f23f85fb000)
        libintrepid2.so.16 => /workspace/trilinos/build/packages/intrepid2/src/libintrepid2.so.16 (0x00007f23f1b09000)
        libshards.so.16 => /workspace/trilinos/build/packages/shards/src/libshards.so.16 (0x00007f23f85ca000)
        libsacado.so.16 => /workspace/trilinos/build/packages/sacado/src/libsacado.so.16 (0x00007f23f8597000)
        libstratimikos.so.16 => /workspace/trilinos/build/packages/stratimikos/src/libstratimikos.so.16 (0x00007f23f1a18000)
        libstratimikosbelos.so.16 => /workspace/trilinos/build/packages/stratimikos/adapters/belos/src/libstratimikosbelos.so.16 (0x00007f23f1307000)
        libstratimikosamesos2.so.16 => /workspace/trilinos/build/packages/stratimikos/adapters/amesos2/src/libstratimikosamesos2.so.16 (0x00007f23f1232000)
        libifpack2-adapters.so.16 => /workspace/trilinos/build/packages/ifpack2/adapters/libifpack2-adapters.so.16 (0x00007f23f1095000)
        libifpack2.so.16 => /workspace/trilinos/build/packages/ifpack2/src/libifpack2.so.16 (0x00007f23ef374000)
        libamesos2.so.16 => /workspace/trilinos/build/packages/amesos2/src/libamesos2.so.16 (0x00007f23eecfd000)
        libtacho.so.16 => /workspace/trilinos/build/packages/shylu/shylu_node/tacho/src/libtacho.so.16 (0x00007f23edfdf000)
        libtrilinosss.so.16 => /workspace/trilinos/build/packages/common/auxiliarySoftware/SuiteSparse/src/libtrilinosss.so.16 (0x00007f23edf93000)
        libbelosxpetra.so.16 => /workspace/trilinos/build/packages/belos/xpetra/src/libbelosxpetra.so.16 (0x00007f23edab3000)
        libbelostpetra.so.16 => /workspace/trilinos/build/packages/belos/tpetra/src/libbelostpetra.so.16 (0x00007f23ed07d000)
        libbelos.so.16 => /workspace/trilinos/build/packages/belos/src/libbelos.so.16 (0x00007f23ec925000)
        libzoltan2.so.16 => /workspace/trilinos/build/packages/zoltan2/core/src/libzoltan2.so.16 (0x00007f23ec789000)
        libzoltan.so.16 => /workspace/trilinos/build/packages/zoltan/src/libzoltan.so.16 (0x00007f23ec62c000)
        libz.so.1 => /home/runner/spack/opt/spack/linux-x86_64/zlib-1.3.1-vyalowlmjzl4ydiui7fqnws5jzujtefm/lib/libz.so.1 (0x00007f23ec612000)
        libshylu_nodefastilu.so.16 => /workspace/trilinos/build/packages/shylu/shylu_node/fastilu/src/libshylu_nodefastilu.so.16 (0x00007f23ec60d000)
        libgaleri-xpetra.so.16 => /workspace/trilinos/build/packages/galeri/src-xpetra/libgaleri-xpetra.so.16 (0x00007f23ec608000)
        libxpetra.so.16 => /workspace/trilinos/build/packages/xpetra/src/libxpetra.so.16 (0x00007f23ebd3a000)
        libthyratpetra.so.16 => /workspace/trilinos/build/packages/thyra/adapters/tpetra/src/libthyratpetra.so.16 (0x00007f23ebcb5000)
        libtpetraext.so.16 => /workspace/trilinos/build/packages/tpetra/core/ext/libtpetraext.so.16 (0x00007f23eb32c000)
        libtpetrainout.so.16 => /workspace/trilinos/build/packages/tpetra/core/inout/libtpetrainout.so.16 (0x00007f23eb29a000)
        libtpetra.so.16 => /workspace/trilinos/build/packages/tpetra/core/src/libtpetra.so.16 (0x00007f23e8427000)
        libtpetraclassic.so.16 => /workspace/trilinos/build/packages/tpetra/core/compat/libtpetraclassic.so.16 (0x00007f23e8412000)
        libkokkostsqr.so.16 => /workspace/trilinos/build/packages/tpetra/tsqr/src/libkokkostsqr.so.16 (0x00007f23e826b000)
        libteuchosremainder.so.16 => /workspace/trilinos/build/packages/teuchos/remainder/src/libteuchosremainder.so.16 (0x00007f23e8252000)
        libteuchoskokkoscomm.so.16 => /workspace/trilinos/build/packages/teuchos/kokkoscomm/src/libteuchoskokkoscomm.so.16 (0x00007f23e824b000)
        libteuchoskokkoscompat.so.16 => /workspace/trilinos/build/packages/teuchos/kokkoscompat/src/libteuchoskokkoscompat.so.16 (0x00007f23e8246000)
        libthyracore.so.16 => /workspace/trilinos/build/packages/thyra/core/src/libthyracore.so.16 (0x00007f23e789a000)
        librtop.so.16 => /workspace/trilinos/build/packages/rtop/src/librtop.so.16 (0x00007f23e7775000)
        libteuchosnumerics.so.16 => /workspace/trilinos/build/packages/teuchos/numerics/src/libteuchosnumerics.so.16 (0x00007f23e7749000)
        libteuchoscomm.so.16 => /workspace/trilinos/build/packages/teuchos/comm/src/libteuchoscomm.so.16 (0x00007f23e7346000)
        libteuchosparameterlist.so.16 => /workspace/trilinos/build/packages/teuchos/parameterlist/src/libteuchosparameterlist.so.16 (0x00007f23e6714000)
        libteuchosparser.so.16 => /workspace/trilinos/build/packages/teuchos/parser/src/libteuchosparser.so.16 (0x00007f23e65c0000)
        libteuchoscore.so.16 => /workspace/trilinos/build/packages/teuchos/core/src/libteuchoscore.so.16 (0x00007f23e640d000)
        libkokkoskernels.so.16 => /workspace/trilinos/build/packages/kokkos-kernels/libkokkoskernels.so.16 (0x00007f23e4837000)
        libkokkoscontainers.so.4.7 => /workspace/trilinos/build/packages/kokkos/containers/src/libkokkoscontainers.so.4.7 (0x00007f23e4829000)
        libkokkosalgorithms.so.4.7 => /workspace/trilinos/build/packages/kokkos/algorithms/src/libkokkosalgorithms.so.4.7 (0x00007f23e4822000)
        libkokkoscore.so.4.7 => /workspace/trilinos/build/packages/kokkos/core/src/libkokkoscore.so.4.7 (0x00007f23e4688000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007f23e4481000)
        libkokkossimd.so.4.7 => /workspace/trilinos/build/packages/kokkos/simd/src/libkokkossimd.so.4.7 (0x00007f23e447c000)
        libopenblas.so.0 => /home/runner/spack/opt/spack/linux-x86_64/openblas-0.3.29-thw37oeebsluhrgw5fupnbtszotkctxm/lib/libopenblas.so.0 (0x00007f23e2376000)
        libpamgen_extras.so.16 => /workspace/trilinos/build/packages/pamgen/src/libpamgen_extras.so.16 (0x00007f23e2358000)
        libpamgen.so.16 => /workspace/trilinos/build/packages/pamgen/src/libpamgen.so.16 (0x00007f23e21bd000)
        libstdc++.so.6 => /home/runner/spack/opt/spack/linux-x86_64/gcc-12.3.0-rts5kliprfghtwrc4tvk4rsjqy6io46f/lib64/libstdc++.so.6 (0x00007f23e1f93000)
        libm.so.6 => /lib64/libm.so.6 (0x00007f23e1c11000)
        libgcc_s.so.1 => /home/runner/spack/opt/spack/linux-x86_64/gcc-12.3.0-rts5kliprfghtwrc4tvk4rsjqy6io46f/lib64/libgcc_s.so.1 (0x00007f23e1bf0000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f23e19d0000)
        libc.so.6 => /lib64/libc.so.6 (0x00007f23e15fa000)
        libopen-rte.so.40 => /home/runner/spack/opt/spack/linux-x86_64/openmpi-4.1.6-2atbcifi27x7uqe645a6tzhhe3vmrxwp/lib/libopen-rte.so.40 (0x00007f23e153d000)
        libopen-pal.so.40 => /home/runner/spack/opt/spack/linux-x86_64/openmpi-4.1.6-2atbcifi27x7uqe645a6tzhhe3vmrxwp/lib/libopen-pal.so.40 (0x00007f23e1485000)
        librt.so.1 => /lib64/librt.so.1 (0x00007f23e127d000)
        libutil.so.1 => /lib64/libutil.so.1 (0x00007f23e1079000)
        libhwloc.so.15 => /home/runner/spack/opt/spack/linux-x86_64/hwloc-2.11.1-ou2qxanhychbv5daa5ajigfflxpwhmkd/lib/libhwloc.so.15 (0x00007f23e1017000)
        libevent_core-2.1.so.7 => /home/runner/spack/opt/spack/linux-x86_64/libevent-2.1.12-qgf246jk2zcdhe4npa6fk6tpvfpks4j7/lib/libevent_core-2.1.so.7 (0x00007f23e0fe0000)
        libevent_pthreads-2.1.so.7 => /home/runner/spack/opt/spack/linux-x86_64/libevent-2.1.12-qgf246jk2zcdhe4npa6fk6tpvfpks4j7/lib/libevent_pthreads-2.1.so.7 (0x00007f23e0fd9000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f23f8560000)
        libgfortran.so.5 => /home/runner/spack/opt/spack/linux-x86_64/gcc-12.3.0-rts5kliprfghtwrc4tvk4rsjqy6io46f/lib64/libgfortran.so.5 (0x00007f23e0d05000)
        libpciaccess.so.0 => /home/runner/spack/opt/spack/linux-x86_64/libpciaccess-0.17-ignwkqlhlrtyjumuvr3ggbrkeid7rwhl/lib/libpciaccess.so.0 (0x00007f23e0cf7000)
        libxml2.so.2 => /home/runner/spack/opt/spack/linux-x86_64/libxml2-2.13.5-uby4l62wfdkely42l3qhvmwngvej6gdq/lib/libxml2.so.2 (0x00007f23e0ba3000)
        libquadmath.so.0 => /home/runner/spack/opt/spack/linux-x86_64/gcc-12.3.0-rts5kliprfghtwrc4tvk4rsjqy6io46f/lib/../lib64/libquadmath.so.0 (0x00007f23e0b5a000)
        liblzma.so.5 => /home/runner/spack/opt/spack/linux-x86_64/xz-5.6.3-q3yqcdtreaontgesgqel5jv6ktgfgruo/lib/liblzma.so.5 (0x00007f23e092c000)
        libiconv.so.2 => /home/runner/spack/opt/spack/linux-x86_64/libiconv-1.18-slvcmqv6tlvjt5fetskfrc2prbwuxjxp/lib/libiconv.so.2 (0x00007f23e061e000)

module: Currently Loaded Modulefiles:
 1) ccache/4.10.2                        20) netcdf-c/4.9.2
 2) valgrind/3.24.0                      21) parallel-netcdf/1.14.0
 3) gdb/16.2                             22) parmetis/4.0.3
 4) glibc/2.28-none-none-wklw66w         23) superlu/5.3.0
 5) gcc-runtime/8.5.0-none-none-yrsiwbg  24) superlu-dist/9.1.0
 6) zlib-ng/2.2.4-gcc-8.5.0-iz6y37p      25) zlib/1.3.1
 7) zstd/1.5.7-gcc-8.5.0-3rwf5af         26) matio/1.5.26
 8) binutils/2.44-gcc-8.5.0-hgkop2c      27) python/3.13.5
 9) gmp/6.3.0-gcc-8.5.0-lfri3dq          28) binder/1.4.2
10) mpfr/4.2.1-gcc-8.5.0-hwr5xu2         29) py-mpi4py/4.0.1
11) mpc/1.3.1-gcc-8.5.0-yqlkhdw          30) py-numpy/2.3.1
12) gcc/12.3.0-gcc-8.5.0-rts5kli         31) py-pybind11/2.13.6
13) openmpi/4.1.6                        32) openblas/0.3.29
14) cmake/3.31.8                         33) emacs/30.1
15) ninja/1.13.0                         34) gh/2.74.2
16) boost/1.88.0                         35) time/1.9
17) cgns/4.5.0                           36) unifdef/2.12
18) hdf5/1.14.6                          37) py-pip/25.1.1
19) metis/5.1.0

mpichinfo: NOT AVAILABLE
nvidia-smi: NOT AVAILABLE
ompi_info:                  Package: Open MPI runner@86cc88156961 Distribution
                Open MPI: 4.1.6
  Open MPI repo revision: v4.1.6
   Open MPI release date: Sep 30, 2023
                Open RTE: 4.1.6
  Open RTE repo revision: v4.1.6
   Open RTE release date: Sep 30, 2023
                    OPAL: 4.1.6
      OPAL repo revision: v4.1.6
       OPAL release date: Sep 30, 2023
                 MPI API: 3.1.0
            Ident string: 4.1.6
                  Prefix: /home/runner/spack/opt/spack/linux-x86_64/openmpi-4.1.6-2atbcifi27x7uqe645a6tzhhe3vmrxwp
 Configured architecture: x86_64-pc-linux-gnu
          Configure host: 86cc88156961
           Configured by: runner
           Configured on: Thu Jul 24 04:02:47 UTC 2025
          Configure host: 86cc88156961
  Configure command line: '--prefix=/home/runner/spack/opt/spack/linux-x86_64/openmpi-4.1.6-2atbcifi27x7uqe645a6tzhhe3vmrxwp' '--enable-shared' '--disable-silent-rules' '--disable-sphinx' '--enable-builtin-atomics' '--disable-static' '--enable-mpi1-compatibility' '--without-fca' '--without-cma' '--without-ofi' '--without-psm2' '--without-psm' '--without-mxm' '--without-xpmem' '--without-knem' '--without-ucx' '--without-hcoll' '--without-verbs' '--without-ucc' '--without-cray-xpmem' '--without-sge' '--without-tm' '--without-lsf' '--without-alps' '--without-slurm' '--without-loadleveler' '--disable-memchecker' '--with-libevent=/home/runner/spack/opt/spack/linux-x86_64/libevent-2.1.12-qgf246jk2zcdhe4npa6fk6tpvfpks4j7' '--with-pmix=/home/runner/spack/opt/spack/linux-x86_64/pmix-6.0.0-sov4zz4qb7tzw6crrqerpwz4euukc26s' '--with-prrte=/home/runner/spack/opt/spack/linux-x86_64/prrte-4.0.0-irkgcomfybd2txhsuetaqwkhbolrwcni' '--with-zlib=/home/runner/spack/opt/spack/linux-x86_64/zlib-1.3.1-vyalowlmjzl4ydiui7fqnws5jzujtefm' '--with-hwloc=/home/runner/spack/opt/spack/linux-x86_64/hwloc-2.11.1-ou2qxanhychbv5daa5ajigfflxpwhmkd' '--disable-java' '--disable-mpi-java' '--with-gpfs=no' '--without-cuda' '--enable-wrapper-rpath' '--disable-wrapper-runpath' '--disable-mpi-cxx' '--disable-cxx-exceptions' '--enable-mpi-fortran' '--disable-debug'
                Built by: runner
                Built on: Thu Jul 24 04:22:03 UTC 2025
              Built host: 86cc88156961
              C bindings: yes
            C++ bindings: no
             Fort mpif.h: yes (all)
            Fort use mpi: yes (full: ignore TKR)
       Fort use mpi size: deprecated-ompi-info-value
        Fort use mpi_f08: yes
 Fort mpi_f08 compliance: The mpi_f08 module is available, but due to limitations in the /home/runner/spack/opt/spack/linux-x86_64/compiler-wrapper-1.0-zqtnfi2nyhkn7337btiao6cb7d6o5ote/libexec/spack/gcc/gfortran compiler and/or Open MPI, does not support the following: array subsections, direct passthru (where possible) to underlying Open MPI's C functionality
  Fort mpi_f08 subarrays: no
           Java bindings: no
  Wrapper compiler rpath: rpath
              C compiler: /home/runner/spack/opt/spack/linux-x86_64/compiler-wrapper-1.0-zqtnfi2nyhkn7337btiao6cb7d6o5ote/libexec/spack/gcc/gcc
     C compiler absolute:
  C compiler family name: GNU
      C compiler version: 12.3.0
            C++ compiler: /home/runner/spack/opt/spack/linux-x86_64/compiler-wrapper-1.0-zqtnfi2nyhkn7337btiao6cb7d6o5ote/libexec/spack/gcc/g++
   C++ compiler absolute: none
           Fort compiler: /home/runner/spack/opt/spack/linux-x86_64/compiler-wrapper-1.0-zqtnfi2nyhkn7337btiao6cb7d6o5ote/libexec/spack/gcc/gfortran
       Fort compiler abs:
         Fort ignore TKR: yes (!GCC$ ATTRIBUTES NO_ARG_CHECK ::)
   Fort 08 assumed shape: yes
      Fort optional args: yes
          Fort INTERFACE: yes
    Fort ISO_FORTRAN_ENV: yes
       Fort STORAGE_SIZE: yes
      Fort BIND(C) (all): yes
      Fort ISO_C_BINDING: yes
 Fort SUBROUTINE BIND(C): yes
       Fort TYPE,BIND(C): yes
 Fort T,BIND(C,name="a"): yes
            Fort PRIVATE: yes
          Fort PROTECTED: yes
           Fort ABSTRACT: yes
       Fort ASYNCHRONOUS: yes
          Fort PROCEDURE: yes
         Fort USE...ONLY: yes
           Fort C_FUNLOC: yes
 Fort f08 using wrappers: yes
         Fort MPI_SIZEOF: yes
             C profiling: yes
           C++ profiling: no
   Fort mpif.h profiling: yes
  Fort use mpi profiling: yes
   Fort use mpi_f08 prof: yes
          C++ exceptions: no
          Thread support: posix (MPI_THREAD_MULTIPLE: yes, OPAL support: yes, OMPI progress: no, ORTE progress: yes, Event lib: yes)
           Sparse Groups: no
  Internal debug support: no
  MPI interface warnings: yes
     MPI parameter check: runtime
Memory profiling support: no
Memory debugging support: no
              dl support: yes
   Heterogeneous support: no
 mpirun default --prefix: no
       MPI_WTIME support: native
     Symbol vis. support: yes
   Host topology support: yes
            IPv6 support: no
      MPI1 compatibility: yes
          MPI extensions: affinity, cuda, pcollreq
   FT Checkpoint support: no (checkpoint thread: no)
   C/R Enabled Debugging: no
  MPI_MAX_PROCESSOR_NAME: 256
    MPI_MAX_ERROR_STRING: 256
     MPI_MAX_OBJECT_NAME: 64
        MPI_MAX_INFO_KEY: 36
        MPI_MAX_INFO_VAL: 256
       MPI_MAX_PORT_NAME: 1024
  MPI_MAX_DATAREP_STRING: 128
           MCA allocator: basic (MCA v2.1.0, API v2.0.0, Component v4.1.6)
           MCA allocator: bucket (MCA v2.1.0, API v2.0.0, Component v4.1.6)
           MCA backtrace: execinfo (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                 MCA btl: self (MCA v2.1.0, API v3.1.0, Component v4.1.6)
                 MCA btl: tcp (MCA v2.1.0, API v3.1.0, Component v4.1.6)
                 MCA btl: vader (MCA v2.1.0, API v3.1.0, Component v4.1.6)
            MCA compress: bzip (MCA v2.1.0, API v2.0.0, Component v4.1.6)
            MCA compress: gzip (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                 MCA crs: none (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                  MCA dl: dlopen (MCA v2.1.0, API v1.0.0, Component v4.1.6)
               MCA event: external (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA hwloc: external (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                  MCA if: linux_ipv6 (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                  MCA if: posix_ipv4 (MCA v2.1.0, API v2.0.0, Component v4.1.6)
         MCA installdirs: env (MCA v2.1.0, API v2.0.0, Component v4.1.6)
         MCA installdirs: config (MCA v2.1.0, API v2.0.0, Component v4.1.6)
              MCA memory: patcher (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA mpool: hugepage (MCA v2.1.0, API v3.0.0, Component v4.1.6)
             MCA patcher: overwrite (MCA v2.1.0, API v1.0.0, Component v4.1.6)
                MCA pmix: ext3x (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA pmix: flux (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA pmix: isolated (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA pstat: linux (MCA v2.1.0, API v2.0.0, Component v4.1.6)
              MCA rcache: grdma (MCA v2.1.0, API v3.3.0, Component v4.1.6)
           MCA reachable: weighted (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA shmem: mmap (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA shmem: posix (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA shmem: sysv (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA timer: linux (MCA v2.1.0, API v2.0.0, Component v4.1.6)
              MCA errmgr: default_app (MCA v2.1.0, API v3.0.0, Component v4.1.6)
              MCA errmgr: default_hnp (MCA v2.1.0, API v3.0.0, Component v4.1.6)
              MCA errmgr: default_orted (MCA v2.1.0, API v3.0.0, Component v4.1.6)
              MCA errmgr: default_tool (MCA v2.1.0, API v3.0.0, Component v4.1.6)
                 MCA ess: env (MCA v2.1.0, API v3.0.0, Component v4.1.6)
                 MCA ess: hnp (MCA v2.1.0, API v3.0.0, Component v4.1.6)
                 MCA ess: pmi (MCA v2.1.0, API v3.0.0, Component v4.1.6)
                 MCA ess: singleton (MCA v2.1.0, API v3.0.0, Component v4.1.6)
                 MCA ess: tool (MCA v2.1.0, API v3.0.0, Component v4.1.6)
               MCA filem: raw (MCA v2.1.0, API v2.0.0, Component v4.1.6)
             MCA grpcomm: direct (MCA v2.1.0, API v3.0.0, Component v4.1.6)
                 MCA iof: hnp (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                 MCA iof: orted (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                 MCA iof: tool (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA odls: default (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA odls: pspawn (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                 MCA oob: tcp (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                 MCA plm: isolated (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                 MCA plm: rsh (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                 MCA ras: simulator (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA regx: fwd (MCA v2.1.0, API v1.0.0, Component v4.1.6)
                MCA regx: naive (MCA v2.1.0, API v1.0.0, Component v4.1.6)
                MCA regx: reverse (MCA v2.1.0, API v1.0.0, Component v4.1.6)
               MCA rmaps: mindist (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA rmaps: ppr (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA rmaps: rank_file (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA rmaps: resilient (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA rmaps: round_robin (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA rmaps: seq (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                 MCA rml: oob (MCA v2.1.0, API v3.0.0, Component v4.1.6)
              MCA routed: binomial (MCA v2.1.0, API v3.0.0, Component v4.1.6)
              MCA routed: direct (MCA v2.1.0, API v3.0.0, Component v4.1.6)
              MCA routed: radix (MCA v2.1.0, API v3.0.0, Component v4.1.6)
                 MCA rtc: hwloc (MCA v2.1.0, API v1.0.0, Component v4.1.6)
              MCA schizo: flux (MCA v2.1.0, API v1.0.0, Component v4.1.6)
              MCA schizo: jsm (MCA v2.1.0, API v1.0.0, Component v4.1.6)
              MCA schizo: ompi (MCA v2.1.0, API v1.0.0, Component v4.1.6)
              MCA schizo: orte (MCA v2.1.0, API v1.0.0, Component v4.1.6)
               MCA state: app (MCA v2.1.0, API v1.0.0, Component v4.1.6)
               MCA state: hnp (MCA v2.1.0, API v1.0.0, Component v4.1.6)
               MCA state: novm (MCA v2.1.0, API v1.0.0, Component v4.1.6)
               MCA state: orted (MCA v2.1.0, API v1.0.0, Component v4.1.6)
               MCA state: tool (MCA v2.1.0, API v1.0.0, Component v4.1.6)
                 MCA bml: r2 (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA coll: adapt (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA coll: basic (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA coll: han (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA coll: inter (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA coll: libnbc (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA coll: monitoring (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA coll: self (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA coll: sm (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA coll: sync (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA coll: tuned (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA fbtl: posix (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA fcoll: dynamic (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA fcoll: dynamic_gen2 (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA fcoll: individual (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA fcoll: two_phase (MCA v2.1.0, API v2.0.0, Component v4.1.6)
               MCA fcoll: vulcan (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                  MCA fs: ufs (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                  MCA io: ompio (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                  MCA io: romio321 (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                  MCA op: avx (MCA v2.1.0, API v1.0.0, Component v4.1.6)
                 MCA osc: monitoring (MCA v2.1.0, API v3.0.0, Component v4.1.6)
                 MCA osc: pt2pt (MCA v2.1.0, API v3.0.0, Component v4.1.6)
                 MCA osc: rdma (MCA v2.1.0, API v3.0.0, Component v4.1.6)
                 MCA osc: sm (MCA v2.1.0, API v3.0.0, Component v4.1.6)
                 MCA pml: v (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                 MCA pml: cm (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                 MCA pml: monitoring (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                 MCA pml: ob1 (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                 MCA rte: orte (MCA v2.1.0, API v2.0.0, Component v4.1.6)
            MCA sharedfp: individual (MCA v2.1.0, API v2.0.0, Component v4.1.6)
            MCA sharedfp: lockedfile (MCA v2.1.0, API v2.0.0, Component v4.1.6)
            MCA sharedfp: sm (MCA v2.1.0, API v2.0.0, Component v4.1.6)
                MCA topo: basic (MCA v2.1.0, API v2.2.0, Component v4.1.6)
                MCA topo: treematch (MCA v2.1.0, API v2.2.0, Component v4.1.6)
           MCA vprotocol: pessimist (MCA v2.1.0, API v2.0.0, Component v4.1.6)

rocm-smi: NOT AVAILABLE
rocminfo: NOT AVAILABLE
```
</details>

A list of generally useful information is harvested by default. Additional enironment variables and commands to be called can be added via environment variables.