### PR TITLE
Panzer: add missing 'template' for get_field (Clang) Fixes #12345

### DIFF
--- a/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherExodusCellDataToIP_impl.hpp
+++ b/packages/panzer/adapters-stk/src/evaluators/Panzer_STK_GatherExodusCellDataToIP_impl.hpp
@@ -63,7 +63,7 @@ postRegistrationSetup(typename Traits::SetupData /* d */,
   for (std::size_t fd = 0; fd < gatherFields_.size(); ++fd) {
     std::string fieldName = gatherFields_[fd].fieldTag().name();
 
-    stkFields_[fd] = mesh_->getMetaData()->get_field<double>(stk::topology::ELEMENT_RANK, exodusNames_[fd]);
+    stkFields_[fd] = mesh_->getMetaData()->template get_field<double>(stk::topology::ELEMENT_RANK, exodusNames_[fd]);
 
     if(stkFields_[fd]==0) {
       std::stringstream ss;


### PR DESCRIPTION
@trilinos/panzer

## Motivation
Clang (Apple/LLVM) enforces `template` on dependent names. `Panzer_STK_GatherExodusCellDataToIP_impl.hpp` failed to build; adding the keyword resolves the error. See compiler diagnostic in the linked issue.

## Related Issues
Closes #14509

## Stakeholder Feedback
N/A

## Testing
"N/A"
