### PR TITLE
stokhos,zoltan2: lambda capture by ref instead of value

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas2_gemv_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas2_gemv_MP_Vector.hpp
@@ -123,7 +123,7 @@ public:
         {
             Scalar tmp = 0.;
             Kokkos::parallel_reduce(
-                Kokkos::TeamThreadRange(team, nj), [=](int jj, Scalar &tmp_sum) {
+                Kokkos::TeamThreadRange(team, nj), [&](int jj, Scalar &tmp_sum) {
                     tmp_sum += A_(jj + j_min, i) * x_(jj + j_min);
                 },
                 tmp);
@@ -137,7 +137,7 @@ public:
         {
             Scalar tmp = 0.;
             Kokkos::parallel_reduce(
-                Kokkos::TeamThreadRange(team, nj), [=](int jj, Scalar &tmp_sum) {
+                Kokkos::TeamThreadRange(team, nj), [&](int jj, Scalar &tmp_sum) {
                     tmp_sum += A_(jj + j_min, i) * x_(jj + j_min);
                 },
                 tmp);

--- a/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -3725,7 +3725,7 @@ struct ReduceWeightsFunctor {
       sh_mem_size);
 
     // init the shared array to 0
-    Kokkos::single(Kokkos::PerTeam(teamMember), [=] () {
+    Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
       for(int n = 0; n < value_count_weights; ++n) {
         shared_ptr[n] = 0;
       }
@@ -3739,7 +3739,7 @@ struct ReduceWeightsFunctor {
 
     Kokkos::parallel_for(
       Kokkos::TeamThreadRange(teamMember, begin, end),
-      [=] (index_t ii) {
+      [&] (index_t ii) {
 #else // KOKKOS_ENABLE_CUDA || KOKKOS_ENABLE_HIP
     // create the team shared data - each thread gets one of the arrays
     size_t sh_mem_size = sizeof(array_t) * (value_count_weights +
@@ -4508,7 +4508,7 @@ struct ReduceArrayFunctor {
 
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     // init the shared array to 0
-    Kokkos::single(Kokkos::PerTeam(teamMember), [=] () {
+    Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
       for(int n = 0; n < value_count; ++n) {
         shared_ptr[n] = 0;
       }
@@ -4516,7 +4516,7 @@ struct ReduceArrayFunctor {
     teamMember.team_barrier();
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, begin, end),
-      [=] (index_t ii) {
+      [&] (index_t ii) {
 #else // KOKKOS_ENABLE_CUDA || KOKKOS_ENABLE_HIP
     // select the array for this thread
     Zoltan2_MJArrayType<array_t> array(&shared_ptr[teamMember.team_rank() *


### PR DESCRIPTION
avoid warnings in c++20 builds (cuda, hip) of the form: "warning: implicit capture of 'this' with a capture default of '=' is deprecated "

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/stokhos @trilinos/zoltan2 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Avoid warnings of deprecated code of type
`warning: implicit capture of 'this' with a capture default of '=' is deprecated ` in build with c++20, more detailed snippets:

**stokhos**
```
/root/Trilinos/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas2_gemv_MP_Vector.hpp:127:32: warning: implicit capture of 'this' with a capture default of '=' is deprecated [-Wdeprecated-this-capture]
  127 |                     tmp_sum += A_(jj + j_min, i) * x_(jj + j_min);
      |                                ^
/root/Trilinos/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas2_gemv_MP_Vector.hpp:126:53: note: add an explicit capture of 'this' to capture '*this' by reference
  126 |                 Kokkos::TeamThreadRange(team, nj), [=](int jj, Scalar &tmp_sum) {
      |                                                     ^
      |                                                      , this
/root/Trilinos/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas2_gemv_MP_Vector.hpp:141:32: warning: implicit capture of 'this' with a capture default of '=' is deprecated [-Wdeprecated-this-capture]
  141 |                     tmp_sum += A_(jj + j_min, i) * x_(jj + j_min);
      |                                ^
/root/Trilinos/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas2_gemv_MP_Vector.hpp:140:53: note: add an explicit capture of 'this' to capture '*this' by reference
  140 |                 Kokkos::TeamThreadRange(team, nj), [=](int jj, Scalar &tmp_sum) {
      |                                                     ^
      |                                                      , this
2 warnings generated when compiling for gfx90a.
```

**zoltan2**
```
/root/Trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:3729:26: warning: implicit capture of 'this' with a capture default of '=' is deprecated [-Wdeprecated-this-capture]
 3729 |       for(int n = 0; n < value_count_weights; ++n) {
      |                          ^
/root/Trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:3728:50: note: add an explicit capture of 'this' to capture '*this' by reference
 3728 |     Kokkos::single(Kokkos::PerTeam(teamMember), [=] () {
      |                                                  ^
      |                                                   , this
/root/Trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:3770:15: warning: implicit capture of 'this' with a capture default of '=' is deprecated [-Wdeprecated-this-capture]
 3770 |       int i = permutations(ii);
      |               ^
/root/Trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:3742:8: note: add an explicit capture of 'this' to capture '*this' by reference
 3742 |       [=] (index_t ii) {
      |        ^
      |         , this
/root/Trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:4512:26: warning: implicit capture of 'this' with a capture default of '=' is deprecated [-Wdeprecated-this-capture]
 4512 |       for(int n = 0; n < value_count; ++n) {
      |                          ^
/root/Trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:4511:50: note: add an explicit capture of 'this' to capture '*this' by reference
 4511 |     Kokkos::single(Kokkos::PerTeam(teamMember), [=] () {
      |                                                  ^
      |                                                   , this
/root/Trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:4537:34: warning: implicit capture of 'this' with a capture default of '=' is deprecated [-Wdeprecated-this-capture]
 4537 |       index_t coordinate_index = permutations(ii);
      |                                  ^
/root/Trilinos/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp:4519:8: note: add an explicit capture of 'this' to capture '*this' by reference
```

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
