### PR TITLE
Tpetra: fix invalid Kokkos::View CTOR call

### DIFF
--- a/packages/tpetra/core/example/advanced/Benchmarks/blockCrsMatrixMatVec.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/blockCrsMatrixMatVec.cpp
@@ -78,7 +78,7 @@ void localApplyBlockNoTrans(Tpetra::BlockCrsMatrix<Scalar, LO, GO, Node>& A,
   auto ptrHost  = lclGraph.row_map;
   auto indHost  = lclGraph.entries;
   Teuchos::Array<IST> localMem(blockSize);
-  little_vec_type Y_lcl(localMem.getRawPtr(), blockSize, 1);
+  little_vec_type Y_lcl(localMem.getRawPtr(), blockSize);
 
   for (LO j = 0; j < numVecs; ++j) {
     for (LO lclRow = 0; lclRow < numLocalMeshRows; ++lclRow) {


### PR DESCRIPTION
As far as I can tell that type is always 1D. Defined in Tpetra_BlockMultiVector_decl.hpp:160

This failed to compile with the new View implementation. 