### PR TITLE
Looks like an invalid loop index in a Zoltan2 class

### DIFF
--- a/packages/zoltan2/core/src/input/Zoltan2_TpetraRowMatrixAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_TpetraRowMatrixAdapter.hpp
@@ -305,7 +305,7 @@ TpetraRowMatrixAdapter<User, UserCoord>::TpetraRowMatrixAdapter(
     for (offset_t e = offsHost_(r), i = 0; e < offsHost_(r + 1); e++) {
       colIdsHost_(e) = matrix_->getColMap()->getGlobalElement(localColInds(i++));
     }
-    for (size_t j = 0; j < nnz; j++) {
+    for (size_t j = 0; j < numEntries; j++) {
       valuesHost_(r) = localVals[j];
     }
   }


### PR DESCRIPTION
It looks like there is a plain wrong loop range used. This caused a failure in a debug build with Kokkos develop due to out-of-bounds access. 

`localVals` is initialized to a length of `getLocalMaxNumRowEntries()` while when interrated over a range of `nnz` which is `getLocalNumEntries()` of a Tpetra Matrix. 