### PR TITLE
KokkosKernels: Silence warnings

### DIFF
--- a/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_InnerTrsm_Serial_Impl.hpp
+++ b/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_InnerTrsm_Serial_Impl.hpp
@@ -39,7 +39,14 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<5>::serial_invoke(const Va
                   a_40 = A[4 * _as0 + 0 * _as1], a_41 = A[4 * _as0 + 1 * _as1], a_42 = A[4 * _as0 + 2 * _as1],
                   a_43 = A[4 * _as0 + 3 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p, ValueType &b_4p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[5];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+    auto &b_4p = b_p[4];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -76,8 +83,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<5>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[5];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3], b_p[4]);
+    trsv(p);
   }
   return 0;
 }
@@ -91,7 +97,13 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<4>::serial_invoke(const Va
   const ValueType a_10 = A[1 * _as0 + 0 * _as1], a_20 = A[2 * _as0 + 0 * _as1], a_21 = A[2 * _as0 + 1 * _as1],
                   a_30 = A[3 * _as0 + 0 * _as1], a_31 = A[3 * _as0 + 1 * _as1], a_32 = A[3 * _as0 + 2 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[4];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -120,8 +132,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<4>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[4];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3]);
+    trsv(p);
   }
   return 0;
 }
@@ -134,7 +145,12 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<3>::serial_invoke(const Va
 
   const ValueType a_10 = A[1 * _as0 + 0 * _as1], a_20 = A[2 * _as0 + 0 * _as1], a_21 = A[2 * _as0 + 1 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[3];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -156,8 +172,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<3>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[3];
-    trsv(p, b_p[0], b_p[1], b_p[2]);
+    trsv(p);
   }
   return 0;
 }
@@ -170,7 +185,11 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<2>::serial_invoke(const Va
 
   const ValueType a_10 = A[1 * _as0 + 0 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p) {
+  auto trsv = [&](const int p) {
+    ValueType b_p[2];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -186,8 +205,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerUnitDiag<2>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[2];
-    trsv(p, b_p[0], b_p[1]);
+    trsv(p);
   }
 
   return 0;
@@ -367,7 +385,15 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<5>::serial_invoke(const
                   inv_a_33 = static_cast<ValueType>(1.0) / A[3 * _as0 + 3 * _as1],
                   inv_a_44 = static_cast<ValueType>(1.0) / A[4 * _as0 + 4 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p, ValueType &b_4p) {
+  auto trsv = [&](const int p) {
+
+    ValueType b_p[5];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+    auto &b_4p = b_p[4];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -412,8 +438,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<5>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[5];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3], b_p[4]);
+    trsv(p);
   }
 
   return 0;
@@ -440,7 +465,14 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<4>::serial_invoke(const
                   inv_a_22 = static_cast<ValueType>(1.0) / A[2 * _as0 + 2 * _as1],
                   inv_a_33 = static_cast<ValueType>(1.0) / A[3 * _as0 + 3 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p) {
+  auto trsv = [&](const int p) {
+
+    ValueType b_p[4];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -476,8 +508,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<4>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[4];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3]);
+    trsv(p);
   }
 
   return 0;
@@ -501,7 +532,13 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<3>::serial_invoke(const
                   inv_a_11 = static_cast<ValueType>(1.0) / A[1 * _as0 + 1 * _as1],
                   inv_a_22 = static_cast<ValueType>(1.0) / A[2 * _as0 + 2 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p) {
+  auto trsv = [&](const int p) {
+
+    ValueType b_p[3];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -529,8 +566,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<3>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[3];
-    trsv(p, b_p[0], b_p[1], b_p[2]);
+
+    trsv(p);
   }
 
   return 0;
@@ -552,7 +589,12 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<2>::serial_invoke(const
   const ValueType inv_a_00 = static_cast<ValueType>(1.0) / A[0 * _as0 + 0 * _as1],
                   inv_a_11 = static_cast<ValueType>(1.0) / A[1 * _as0 + 1 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p) {
+  auto trsv = [&](const int p) {
+
+    ValueType b_p[2];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -573,8 +615,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<2>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[2];
-    trsv(p, b_p[0], b_p[1]);
+
+    trsv(p);
   }
 
   return 0;
@@ -592,7 +634,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<1>::serial_invoke(const
 
   const ValueType inv_a_00 = static_cast<ValueType>(1.0) / A[0 * _as0 + 0 * _as1];
 
-  auto trsv = [&](const int p, ValueType & /* b_0p */) {
+  auto trsv = [&](const int p) {
     B[0 * _bs0 + p * _bs1] *= inv_a_00; /* b_0p /= a_00;*/
   };
 
@@ -600,8 +642,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftLowerNonUnitDiag<1>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p;
-    trsv(p, b_p);
+    trsv(p);
   }
 
   return 0;
@@ -775,7 +816,15 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<5>::serial_invoke(const Va
                   /**/ a_23 = A[2 * _as0 + 3 * _as1], a_24 = A[2 * _as0 + 4 * _as1],
                   /**/ a_34 = A[3 * _as0 + 4 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p, ValueType &b_4p) {
+  auto trsv = [&](const int p) {
+
+    ValueType b_p[5];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+    auto &b_4p = b_p[4];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -812,8 +861,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<5>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[5];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3], b_p[4]);
+    trsv(p);
   }
 
   return 0;
@@ -829,7 +877,14 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<4>::serial_invoke(const Va
                   /**/ a_12 = A[1 * _as0 + 2 * _as1], a_13 = A[1 * _as0 + 3 * _as1],
                   /**/ a_23 = A[2 * _as0 + 3 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p) {
+  auto trsv = [&](const int p) {
+
+    ValueType b_p[4];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -858,8 +913,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<4>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[4];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3]);
+    trsv(p);
   }
 
   return 0;
@@ -874,7 +928,13 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<3>::serial_invoke(const Va
   const ValueType a_01 = A[0 * _as0 + 1 * _as1], a_02 = A[0 * _as0 + 2 * _as1],
                   /**/ a_12 = A[1 * _as0 + 2 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p) {
+  auto trsv = [&](const int p) {
+
+    ValueType b_p[3];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -896,8 +956,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<3>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[3];
-    trsv(p, b_p[0], b_p[1], b_p[2]);
+    trsv(p);
   }
 
   return 0;
@@ -911,7 +970,12 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<2>::serial_invoke(const Va
 
   const ValueType a_01 = A[0 * _as0 + 1 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p) {
+  auto trsv = [&](const int p) {
+
+    ValueType b_p[2];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -927,8 +991,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperUnitDiag<2>::serial_invoke(const Va
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[2];
-    trsv(p, b_p[0], b_p[1]);
+    trsv(p);
   }
 
   return 0;
@@ -1109,7 +1172,15 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<5>::serial_invoke(const
                   inv_a_33 = static_cast<ValueType>(1.0) / A[3 * _as0 + 3 * _as1],
                   inv_a_44 = static_cast<ValueType>(1.0) / A[4 * _as0 + 4 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p, ValueType &b_4p) {
+  auto trsv = [&](const int p) {
+
+    ValueType b_p[5];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+    auto &b_4p = b_p[4];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -1154,8 +1225,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<5>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[5];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3], b_p[4]);
+    trsv(p);
   }
 
   return 0;
@@ -1183,7 +1253,14 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<4>::serial_invoke(const
                   inv_a_22 = static_cast<ValueType>(1.0) / A[2 * _as0 + 2 * _as1],
                   inv_a_33 = static_cast<ValueType>(1.0) / A[3 * _as0 + 3 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p, ValueType &b_3p) {
+  auto trsv = [&](const int p) {
+
+    ValueType b_p[4];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+    auto &b_3p = b_p[3];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -1219,8 +1296,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<4>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[4];
-    trsv(p, b_p[0], b_p[1], b_p[2], b_p[3]);
+    trsv(p);
   }
 
   return 0;
@@ -1245,7 +1321,13 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<3>::serial_invoke(const
                   inv_a_11 = static_cast<ValueType>(1.0) / A[1 * _as0 + 1 * _as1],
                   inv_a_22 = static_cast<ValueType>(1.0) / A[2 * _as0 + 2 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p, ValueType &b_2p) {
+  auto trsv = [&](const int p) {
+
+    ValueType b_p[3];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+    auto &b_2p = b_p[2];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -1273,8 +1355,8 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<3>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[3];
-    trsv(p, b_p[0], b_p[1], b_p[2]);
+
+    trsv(p);
   }
 
   return 0;
@@ -1296,7 +1378,12 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<2>::serial_invoke(const
   const ValueType inv_a_00 = static_cast<ValueType>(1.0) / A[0 * _as0 + 0 * _as1],
                   inv_a_11 = static_cast<ValueType>(1.0) / A[1 * _as0 + 1 * _as1];
 
-  auto trsv = [&](const int p, ValueType &b_0p, ValueType &b_1p) {
+  auto trsv = [&](const int p) {
+
+    ValueType b_p[2];
+    auto &b_0p = b_p[0];
+    auto &b_1p = b_p[1];
+
     // load
     b_0p = B[0 * _bs0 + p * _bs1];
     b_1p = B[1 * _bs0 + p * _bs1];
@@ -1317,8 +1404,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<2>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p[2];
-    trsv(p, b_p[0], b_p[1]);
+    trsv(p);
   }
 
   return 0;
@@ -1336,7 +1422,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<1>::serial_invoke(const
 
   const ValueType inv_a_00 = static_cast<ValueType>(1.0) / A[0 * _as0 + 0 * _as1];
 
-  auto trsv = [&](const int p, ValueType & /* b_0p */) {
+  auto trsv = [&](const int p) {
     // 0 iteration
     B[0 * _bs0 + p * _bs1] *= inv_a_00; /* b_0p /= a_00; */
   };
@@ -1345,8 +1431,7 @@ KOKKOS_INLINE_FUNCTION int InnerTrsmLeftUpperNonUnitDiag<1>::serial_invoke(const
 #pragma unroll
 #endif
   for (int p = 0; p < n; ++p) {
-    ValueType b_p;
-    trsv(p, b_p);
+    trsv(p);
   }
 
   return 0;


### PR DESCRIPTION
@trilinos/kokkos-kernels @trilinos/stokhos 

## Motivation
I was getting warnings like this:
```
In member function 'Sacado::MP::Vector<S>& Sacado::MP::Vector<S>::operator-=(const Sacado::MP::Expr<S>&) [with S = Sacado::MP::MultiplicationOp<Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >, Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> > >; Storage = Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP>]',
    inlined from 'KokkosBatched::InnerTrsmLeftLowerUnitDiag<4>::serial_invoke<Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> > >(const Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >*, int, Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >*)::<lambda(int, Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >&, Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >&, Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >&, Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >&)>' at /workspace/trilinos/source/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_InnerTrsm_Serial_Impl.hpp:104:10,
    inlined from 'int KokkosBatched::InnerTrsmLeftLowerUnitDiag<bmn>::serial_invoke(const ValueType*, int, ValueType*) [with ValueType = Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >; int bmn = 4]' at /workspace/trilinos/source/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_InnerTrsm_Serial_Impl.hpp:124:9:
/workspace/trilinos/source/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector.hpp:1295:18: warning: 'b_p' may be used uninitialized [-Wmaybe-uninitialized]
 1295 |             s[i] -= x.fastAccessCoeff(i);
      |             ~~~~~^~~~~~~~~~~~~~~~~~~~~~~
/workspace/trilinos/source/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_InnerTrsm_Serial_Impl.hpp: In function 'int KokkosBatched::InnerTrsmLeftLowerUnitDiag<bmn>::serial_invoke(const ValueType*, int, ValueType*) [with ValueType = Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::OpenMP> >; int bmn = 4]':
/workspace/trilinos/source/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_InnerTrsm_Serial_Impl.hpp:123:15: note: 'b_p' declared here
  123 |     ValueType b_p[4];
```
Is there a good reason for allocating memory outside of the lambda functions?
