### PR TITLE
Ifpack2: Revert #14337 (moving symbolic on device)

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Map_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_decl.hpp
@@ -1092,9 +1092,14 @@ class Map : public Teuchos::Describable {
       const global_ordinal_type indexBase,
       const Teuchos::RCP<const Teuchos::Comm<int>>& comm);
 
-  //! Copy the local map from device to host, if it's not on host already
+ public:
+  /// \brief Push the device data to host, if needed
+  ///
+  /// \warning lazyPushToHost is SUBJECT TO CHANGE and is for EXPERT USERS ONLY.
+  /// We STRONGLY advise against its use.
   void lazyPushToHost() const;
 
+ private:
   //! The communicator over which this Map is distributed.
   Teuchos::RCP<const Teuchos::Comm<int>> comm_;
 


### PR DESCRIPTION
@trilinos/ifpack2 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
A bisect showed that PR #14337 (moving BTD symbolic phase to device) caused issue #14529. That bug is not understood yet, so this reverts #14337 until it can be fixed.

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Issue report and bisect to the bad PR was by @vbrunini for SPARC. 
## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
