### PR TITLE
Doc: Remove timestamp from Doxygen runs

### DIFF
--- a/packages/common/footer.html
+++ b/packages/common/footer.html
@@ -25,6 +25,6 @@ iFrameResize({
 </script>
 
 <hr size="1"><address style="align: right;"><small>
-Generated on $datetime for $projectname by&nbsp;<a href="http://www.doxygen.org/index.html"><img src="doxygen.png" alt="doxygen" align="middle" border="0"></a> $doxygenversion</small></address>
+Generated for $projectname by&nbsp;<a href="http://www.doxygen.org/index.html"><img src="doxygen.png" alt="doxygen" align="middle" border="0"></a> $doxygenversion</small></address>
 </body>
 </html>


### PR DESCRIPTION
@trilinos/framework 

## Motivation
We are now hosting the Doxygen documentation out of GitHub pages. To reduce the diff between subsequent runs, remove the timestamp from the footer.