### PR TITLE
Intrepid2 Integration test01: Attempt to speed things up

### DIFF
--- a/packages/intrepid2/unit-test/Discretization/Integration/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Integration/test_01.hpp
@@ -404,12 +404,16 @@ namespace Intrepid2 {
         }
         
         {
+          std::vector<CubatureLineType> lines;
+          for (ordinal_type deg=0;deg<=maxTotalCubatureDegree;++deg) {
+            lines.push_back(CubatureLineType(deg));
+          }
           for (ordinal_type z_deg=0;z_deg<=maxTotalCubatureDegree-2;++z_deg)
             for (ordinal_type y_deg=0;y_deg<=maxTotalCubatureDegree-z_deg;++y_deg)
               for (ordinal_type x_deg=0;x_deg<=maxTotalCubatureDegree-z_deg-y_deg;++x_deg) {
-                const auto x_line = CubatureLineType(x_deg);
-                const auto y_line = CubatureLineType(y_deg);
-                const auto z_line = CubatureLineType(z_deg);
+                const auto &x_line = lines[x_deg];
+                const auto &y_line = lines[y_deg];
+                const auto &z_line = lines[z_deg];
                 CubatureTensorType cub( x_line, y_line, z_line );
 
                 auto cubTensorPoints  = cub.allocateCubaturePoints();


### PR DESCRIPTION
@trilinos/intrepid2 

## Motivation
The test Intrepid2_unit-test_Discretization_Integration_test_01_CUDA_DOUBLE_MPI_1 has a tendency to time out. There is a lot of variation in run times:
https://sems-cdash-son.sandia.gov/cdash/queryTests.php?project=Trilinos&begin=2025-09-01&end=2025-10-11&filtercount=1&showfilters=1&field1=testname&compare1=63&value1=Intrepid2_unit-test_Discretization_Integration_test_01_CUDA

I tried to reproduce this, and sometimes I saw really slow runs. But I cannot confidently say that there is a problem with the test itself.

The change in this PR speeds things up, but it's not clear by how much.