### PR TITLE
Framework: OneAPI toolchain update

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -661,7 +661,7 @@ jobs:
           export TRILINOS_DIR=${GITHUB_WORKSPACE:?}
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/GenConfig
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/pr_tools
-          export GENCONFIG_BUILD_NAME=rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+          export GENCONFIG_BUILD_NAME=rhel_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
           printf "\n\n\n"
 
           echo "image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}"

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2023,7 +2023,7 @@ use TEST_DISABLES|CLANG
 use rhel_clang-openmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
-[rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
+[rhel_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]
 use COMMON_SPACK_TPLS
 use COMPILER|INTEL
 use BUILD-TYPE|RELEASE-DEBUG
@@ -2055,8 +2055,8 @@ opt-set-cmake-var MueLu_Structured_Interp_Laplace2D_kokkos_MPI_4_DISABLE BOOL : 
 opt-set-cmake-var MueLu_Structured_Interp_SA_Laplace2D_kokkos_MPI_1_DISABLE BOOL : ON
 opt-set-cmake-var MueLu_Structured_Interp_SA_Laplace2D_kokkos_MPI_4_DISABLE BOOL : ON
 
-[rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
-use rhel8_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+[rhel_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+use rhel_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
 [rhel_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables]

--- a/packages/framework/ini-files/environment-specs.ini
+++ b/packages/framework/ini-files/environment-specs.ini
@@ -178,7 +178,7 @@ envvar-set OMP_NUM_THREADS : 2
 [rhel8_python]
 envvar-find-in-path PYTHON_EXECUTABLE : python3
 
-[rhel8_oneapi-intelmpi]
+[rhel_oneapi-intelmpi]
 use MPI-COMPILER-VARS
 envvar-find-in-path I_MPI_CXX : icpx
 envvar-find-in-path I_MPI_CC  : icx
@@ -186,3 +186,6 @@ envvar-find-in-path I_MPI_F90  : ifx
 envvar-set I_MPI_PIN : 0
 envvar-set MPIR_CVAR_CH4_OFI_TAG_BITS : 31
 envvar-set MPIR_CVAR_CH4_OFI_RANK_BITS : 8
+
+[rhel8_oneapi-intelmpi]
+use rhel_oneapi-intelmpi

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -143,6 +143,7 @@ gcc
 cuda-gcc-openmpi
 cuda-12-gcc-openmpi
 clang-openmpi
+oneapi-intelmpi
 
 [rhel7]
 sems-gnu-7.2.0-anaconda3-serial:


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Need OneAPI 2024.2 for Kokkos 5.0, but more importantly need a newer underlying GCC than the current 8.5.0.  Use newer container from https://github.com/trilinos/containers/pull/25 to get GCC11 as underlying compiler, which should allow for C++20 (it built for me when I tested).

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-726


## Testing
Everything built and all tests passed except for a single Stokhos/Sacado test.  Should show up in PR testing and be able to be discussed on this PR.