### PR TITLE
Disable PanzerMiniEM_Maxwell_MueLu_order1_tpl_MPI_4 in Cuda12 PR build

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -2092,6 +2092,7 @@ opt-set-cmake-var PanzerMiniEM_Maxwell_MueLu_order1_tpl_MPI_4_DISABLE BOOL : ON
 use rhel_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 opt-set-cmake-var Intrepid2_unit-test_Discretization_Basis_HGRAD_TRI_Cn_FEM_test_02_CUDA_DOUBLE_DOUBLE_MPI_1_DISABLE BOOL : ON
 opt-set-cmake-var ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE BOOL : ON
+opt-set-cmake-var PanzerMiniEM_Maxwell_MueLu_order1_tpl_MPI_4_DISABLE BOOL : ON
 
 [rhel_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables]
 use COMMON_SPACK_TPLS


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Disable failing Panzer test in Cuda12 build:
https://sems-cdash-son.sandia.gov/cdash/queryTests.php?project=Trilinos&begin=2025-10-01&end=2025-10-13&filtercount=2&showfilters=1&filtercombine=and&field1=status&compare1=61&value1=failed&field2=testname&compare2=63&value2=PanzerMiniEM_Maxwell_MueLu_order1_tpl_MPI_4

The same test was previously disabled in Cuda11
4ccd739294dfb88f8142f680923fddd66462f788