### PR TITLE
Avoid storing the local matrix device in CrsMatrixMultiplyOp.

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrixMultiplyOp.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrixMultiplyOp.hpp
@@ -140,6 +140,10 @@ class CrsMatrixMultiplyOp : public Operator<Scalar, LocalOrdinal, GlobalOrdinal,
  protected:
   typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
 
+  using local_matrix_op_t =
+      LocalCrsMatrixOperator<Scalar, MatScalar,
+                             typename crs_matrix_type::device_type>;
+
   //! The underlying CrsMatrix object.
   const Teuchos::RCP<const crs_matrix_type> matrix_;
 


### PR DESCRIPTION
@trilinos/tpetra 

This resolves issue https://github.com/trilinos/Trilinos/issues/13545.

