### PR TITLE
Tpetra: fix overflow in BlockCrsMatrix

### DIFF
--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -705,7 +705,7 @@ LO BlockCrsMatrix<Scalar, LO, GO, Node>::
   auto val_out                      = const_cast<this_BCRS_type&>(*this).getValuesHostNonConst(localRowInd);
   impl_scalar_type* vOut            = val_out.data();
 
-  const size_t perBlockSize = static_cast<LO>(offsetPerBlock());
+  const size_t perBlockSize = offsetPerBlock();
   const ptrdiff_t STINV     = Teuchos::OrdinalTraits<ptrdiff_t>::invalid();
   size_t pointOffset        = 0;  // Current offset into input values
   LO validCount             = 0;  // number of valid offsets
@@ -739,7 +739,7 @@ LO BlockCrsMatrix<Scalar, LO, GO, Node>::
   auto val_out                      = getValuesHost(localRowInd);
   impl_scalar_type* vOut            = const_cast<impl_scalar_type*>(val_out.data());
 
-  const size_t perBlockSize = static_cast<LO>(offsetPerBlock());
+  const size_t perBlockSize = offsetPerBlock();
   const size_t STINV        = Teuchos::OrdinalTraits<size_t>::invalid();
   size_t pointOffset        = 0;  // Current offset into input values
   LO validCount             = 0;  // number of valid offsets
@@ -775,7 +775,7 @@ LO BlockCrsMatrix<Scalar, LO, GO, Node>::
   auto val_out           = const_cast<this_BCRS_type&>(*this).getValuesHostNonConst(localRowInd);
   impl_scalar_type* vOut = val_out.data();
 
-  const size_t perBlockSize = static_cast<LO>(offsetPerBlock());
+  const size_t perBlockSize = offsetPerBlock();
   const size_t STINV        = Teuchos::OrdinalTraits<size_t>::invalid();
   size_t pointOffset        = 0;  // Current offset into input values
   LO validCount             = 0;  // number of valid offsets
@@ -829,9 +829,9 @@ typename BlockCrsMatrix<Scalar, LO, GO, Node>::
     impl_scalar_type_dualview::t_host::const_type
     BlockCrsMatrix<Scalar, LO, GO, Node>::
         getValuesHost(const LO& lclRow) const {
-  const size_t perBlockSize = static_cast<LO>(offsetPerBlock());
+  const size_t perBlockSize = offsetPerBlock();
   auto val                  = val_.getHostView(Access::ReadOnly);
-  auto r_val                = Kokkos::subview(val, Kokkos::pair<LO, LO>(ptrHost_(lclRow) * perBlockSize, ptrHost_(lclRow + 1) * perBlockSize));
+  auto r_val                = Kokkos::subview(val, Kokkos::pair<size_t, size_t>(ptrHost_(lclRow) * perBlockSize, ptrHost_(lclRow + 1) * perBlockSize));
   return r_val;
 }
 
@@ -840,9 +840,9 @@ typename BlockCrsMatrix<Scalar, LO, GO, Node>::
     impl_scalar_type_dualview::t_dev::const_type
     BlockCrsMatrix<Scalar, LO, GO, Node>::
         getValuesDevice(const LO& lclRow) const {
-  const size_t perBlockSize = static_cast<LO>(offsetPerBlock());
+  const size_t perBlockSize = offsetPerBlock();
   auto val                  = val_.getDeviceView(Access::ReadOnly);
-  auto r_val                = Kokkos::subview(val, Kokkos::pair<LO, LO>(ptrHost_(lclRow) * perBlockSize, ptrHost_(lclRow + 1) * perBlockSize));
+  auto r_val                = Kokkos::subview(val, Kokkos::pair<size_t, size_t>(ptrHost_(lclRow) * perBlockSize, ptrHost_(lclRow + 1) * perBlockSize));
   return r_val;
 }
 
@@ -850,9 +850,9 @@ template <class Scalar, class LO, class GO, class Node>
 typename BlockCrsMatrix<Scalar, LO, GO, Node>::impl_scalar_type_dualview::t_host
 BlockCrsMatrix<Scalar, LO, GO, Node>::
     getValuesHostNonConst(const LO& lclRow) {
-  const size_t perBlockSize = static_cast<LO>(offsetPerBlock());
+  const size_t perBlockSize = offsetPerBlock();
   auto val                  = val_.getHostView(Access::ReadWrite);
-  auto r_val                = Kokkos::subview(val, Kokkos::pair<LO, LO>(ptrHost_(lclRow) * perBlockSize, ptrHost_(lclRow + 1) * perBlockSize));
+  auto r_val                = Kokkos::subview(val, Kokkos::pair<size_t, size_t>(ptrHost_(lclRow) * perBlockSize, ptrHost_(lclRow + 1) * perBlockSize));
   return r_val;
 }
 
@@ -860,9 +860,9 @@ template <class Scalar, class LO, class GO, class Node>
 typename BlockCrsMatrix<Scalar, LO, GO, Node>::impl_scalar_type_dualview::t_dev
 BlockCrsMatrix<Scalar, LO, GO, Node>::
     getValuesDeviceNonConst(const LO& lclRow) {
-  const size_t perBlockSize = static_cast<LO>(offsetPerBlock());
+  const size_t perBlockSize = offsetPerBlock();
   auto val                  = val_.getDeviceView(Access::ReadWrite);
-  auto r_val                = Kokkos::subview(val, Kokkos::pair<LO, LO>(ptrHost_(lclRow) * perBlockSize, ptrHost_(lclRow + 1) * perBlockSize));
+  auto r_val                = Kokkos::subview(val, Kokkos::pair<size_t, size_t>(ptrHost_(lclRow) * perBlockSize, ptrHost_(lclRow + 1) * perBlockSize));
   return r_val;
 }
 
@@ -872,9 +872,9 @@ BlockCrsMatrix<Scalar, LO, GO, Node>::
     getNumEntriesInLocalRow(const LO localRowInd) const {
   const size_t numEntInGraph = graph_.getNumEntriesInLocalRow(localRowInd);
   if (numEntInGraph == Teuchos::OrdinalTraits<size_t>::invalid()) {
-    return static_cast<LO>(0);  // the calling process doesn't have that row
+    return 0;  // the calling process doesn't have that row
   } else {
-    return static_cast<LO>(numEntInGraph);
+    return numEntInGraph;
   }
 }
 


### PR DESCRIPTION
- fix overflow in BlockCrsMatrix row-viewing functions: ``ptrHost_(lclRow) * perBlockSize`` has type ``size_type`` so we don't want to narrow this to LO. This number can easily be larger than 2^31 in practice since perBlockSize is blocksize^2.
- remove some unnecessary casts to LO. For example ``offsetPerBlock()`` is already LO.

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Fixes overflow in subviewing. Ifpack2's BTD matrix builder/Galeri uses these functions to fill the matrix values, and this was causing a real crash in a large run on ElDorado.

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
getLocalRowView is tested in BCrs unit tests (a matrix big enough to trigger the overflow would be impractical in unit tests though).