### PR TITLE
Framework: Fix CDash URL generation in SimpleTesting cmake scripts

### DIFF
--- a/cmake/SimpleTesting/cmake/ctest-functions.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-functions.cmake
@@ -170,7 +170,6 @@ function(generate_build_url3 url_output cdash_site cdash_location project_name b
     banner("generate_build_url3() FINISH")
 endfunction()
 
-
 # generate_build_url4 generates a link to view all builds for a particular PR
 function(generate_build_url4 url_output cdash_site cdash_location project_name pr_num)
     banner("generate_build_url4() START")
@@ -179,7 +178,7 @@ function(generate_build_url4 url_output cdash_site cdash_location project_name p
     message(">>> project_name  : ${project_name}")
     message(">>> pr_num        : ${pr_num}")
     string(REPLACE " " "%20" url_output_tmp
-        "https://${cdash_site}${cdash_location}index.php?project=${project_name}&display=project&begin=2024-01-01&end=now&filtercount=1&showfilters=1&field1=buildname&compare1=65&value1=PR-${pr_num}"
+        "https://${cdash_site}${cdash_location}index.php?project=${project_name}&display=project&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=65&value1=PR-${pr_num}&field2=buildstarttime&compare2=84&value2=now"
     )
     set(${url_output} ${url_output_tmp} PARENT_SCOPE)
     banner("generate_build_url4() FINISH")


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
After a recent CDash upgrade, it appears that you can no longer use the 'now' keyword for in the begin/end fields for CDash queries. Instead switch to adding a filter to display builds with a start time before 'now'.

A similar change had to be made in #14372 a while back, but for the GitHub Actions cdash-url job.
