### PR TITLE
tpetra: fixes with disable of kokkos deprecated code

### DIFF
--- a/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_decl.hpp
@@ -14,6 +14,7 @@
 /// \brief Declaration of Tpetra::computeRowAndColumnOneNorms
 
 #include "TpetraCore_config.h"
+#include "Kokkos_Core.hpp"
 #if KOKKOS_VERSION >= 40799
 #include "KokkosKernels_ArithTraits.hpp"
 #else

--- a/packages/tpetra/core/src/Tpetra_leftAndOrRightScaleCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_leftAndOrRightScaleCrsMatrix_decl.hpp
@@ -14,12 +14,12 @@
 /// \brief Declaration of Tpetra::leftAndOrRightScaleCrsMatrix
 
 #include "TpetraCore_config.h"
+#include "Kokkos_Core.hpp"
 #if KOKKOS_VERSION >= 40799
 #include "KokkosKernels_ArithTraits.hpp"
 #else
 #include "Kokkos_ArithTraits.hpp"
 #endif
-#include "Kokkos_Core.hpp"
 #include "Tpetra_CrsMatrix_fwd.hpp"
 #include "Tpetra_Vector_fwd.hpp"
 


### PR DESCRIPTION
* Compatibility fixes with KOKKOS_ENABLE_DEPRECATED_CODE_5=OFF
* The Kokkos_Core.hpp header needs to be included before the KOKKOS_VERSION macro check to include the correct (non-deprecated) ArithTraits header

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Resolve compilation errors with kokkos@develop and KOKKOS_ENABLE_DEPRECATED_CODE_5=OFF of the form:
```
In file included from /home/ndellin/trilinos/Trilinos-1/packages/tpetra/core/src/Tpetra_leftAndOrRightScaleCrsMatrix_decl.hpp:20,
                 from /home/ndellin/trilinos/Trilinos-1/Build/Blake-serial-gcc-1130-ompi-415/build/packages/tpetra/core/src/Tpetra_leftAndOrRightScaleCrsMatrix_DOUBLE_INT_LONG_LONG_SERIAL.cpp:34:
/home/ndellin/trilinos/Trilinos-1/kokkos-kernels/common/src/Kokkos_ArithTraits.hpp:13:15: error: static assertion failed: Header `Kokkos_ArithTraits.hpp` is deprecated, include `KokkosKernels_ArithTraits.hpp` instead
   13 | static_assert(false, "Header `Kokkos_ArithTraits.hpp` is deprecated, include `KokkosKernels_ArithTraits.hpp` instead");
```

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
Tested in local build
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
