### PR TITLE
Amesos2: Removed namespace scoping from std namespace variable declarations

### DIFF
--- a/packages/amesos2/src/KLU2/Include/klu2_scalartraits.h
+++ b/packages/amesos2/src/KLU2/Include/klu2_scalartraits.h
@@ -68,10 +68,10 @@ struct KLU_ScalarTraits<float>
 
 template <typename T>
 struct KLU_ScalarTraits<
-std::complex<T>
+::std::complex<T>
 >
 {
-    typedef std::complex<T> ComplexT ;
+    typedef ::std::complex<T> ComplexT ;
     typedef typename KLU_ScalarTraits<T>::magnitudeType magnitudeType ;
 
     static inline ComplexT reciprocal (ComplexT c)
@@ -84,13 +84,13 @@ std::complex<T>
         {
             r = ci / cr ;
             den = cr + r * ci ;
-            ret = std::complex<T>(1.0 / den, -r / den) ;
+            ret = ::std::complex<T>(1.0 / den, -r / den) ;
         }
         else
         {
             r = cr / ci ;
             den = r * cr + ci ;
-            ret = std::complex<T>(r / den, -1.0 / den) ;
+            ret = ::std::complex<T>(r / den, -1.0 / den) ;
         }
         return ret;
     }
@@ -108,13 +108,13 @@ std::complex<T>
         {
             r = bi / br ;
             den = br + r * bi ;
-            ret = std::complex<T>((ar + ai * r) / den, (ai - ar * r) / den) ;
+            ret = ::std::complex<T>((ar + ai * r) / den, (ai - ar * r) / den) ;
         }
         else
         {
             r = br / bi ;
             den = r * br + bi ;
-            ret = std::complex<T>((ar * r + ai) / den, (ai * r - ar) / den) ;
+            ret = ::std::complex<T>((ar * r + ai) / den, (ai * r - ar) / den) ;
         }
         return ret;
     }
@@ -132,13 +132,13 @@ std::complex<T>
         {
             r = (-bi) / br ;
             den = br - r * bi ;
-            ret = std::complex<T>((ar + ai * r) / den, (ai - ar * r) / den) ;
+            ret = ::std::complex<T>((ar + ai * r) / den, (ai - ar * r) / den) ;
         }
         else
         {
             r = br / (-bi) ;
             den =  r * br - bi;
-            ret = std::complex<T>((ar * r + ai) / den, (ai * r - ar) / den) ;
+            ret = ::std::complex<T>((ar * r + ai) / den, (ai * r - ar) / den) ;
         }
         return ret;
     }

--- a/packages/amesos2/src/KLU2/Source/klu2.hpp
+++ b/packages/amesos2/src/KLU2/Source/klu2.hpp
@@ -304,7 +304,7 @@ void KLU_lsolve
             break ;
 
         default:
-            throw std::domain_error("More than 4 right-hand sides is not supported.");
+            throw ::std::domain_error("More than 4 right-hand sides is not supported.");
 
     }
 }


### PR DESCRIPTION

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/amesos2

## Motivation
There is a problem coming from how the KLU2 namespace is defined in the Amesos2_KLU2_FunctionMap.hpp file.  The function map header file injects the KLU2 solver templates, including std headers into the KLU2 namespace.  This confuses the Windows compilers, causing a build error.

This commit fixes that issue by changing the scope on the declarations that were giving ‘definition not found’ errors; instead of std::type, ::std::type seems to fix the build errors.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes #14602 

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
Windows development and test machine with this compiler stack:

Visual Studio 2022 version 17.9.2
Intel OneAPI Base Toolkit version 2024.2
Intel HPC ToolKit with Intel(R) MPI Library for Windows* OS, Version 2021.13 Build 20240701

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
