### PR TITLE
Teuchos: Add missing explicit instantiation for getEnvironmentVariable()

### DIFF
--- a/packages/teuchos/core/src/Teuchos_EnvVariables.cpp
+++ b/packages/teuchos/core/src/Teuchos_EnvVariables.cpp
@@ -189,6 +189,8 @@ T idempotentlyGetEnvironmentVariable(
   return value;
 }
 
+template std::string getEnvironmentVariable(const std::string_view environmentVariableName,
+  const std::string defaultValue);
 
 template std::string idempotentlyGetEnvironmentVariable<std::string>(std::string&, bool&, const std::string_view, const std::string);
 template int idempotentlyGetEnvironmentVariable<int>(int&, bool&, const std::string_view, const int);


### PR DESCRIPTION
Without this explicit instaniation, I get the following link errors on my build of Trilinos:

```text
<path>/bin/ld: packages/teuchos/core/src/libteuchoscore.a(Teuchos_SystemInformation.cpp.o): in function `Teuchos::SystemInformation::collectSystemInformation[abi:cxx11]()':
<bash>/Trilinos/packages/teuchos/core/src/Teuchos_SystemInformation.cpp:263:(.text+0x153a): undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > Teuchos::getEnvironmentVariable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(std::basic_string_view<char, std::char_traits<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'
```

I produced this with the configuration based on the Trilinos clang-19 genconfig configuration in the files
[clang-genconfig-mull.tar.gz](https://github.com/user-attachments/files/23197745/clang-genconfig-mull.tar.gz) using the container:

* https://hub.docker.com/repository/docker/bartlettroscoe/mull-trilinos-clang-19.1.6-openmpi-4.1.6/tags/latest/sha256-63e54d14e20b3b4b4773e18500af67a243ffc54239bd260ad231ee2bf1506350

