### PR TITLE
Epetra: Return unified error flag for matrix diagonal replace

### DIFF
--- a/packages/epetra/src/Epetra_CrsMatrix.cpp
+++ b/packages/epetra/src/Epetra_CrsMatrix.cpp
@@ -1537,7 +1537,9 @@ int Epetra_CrsMatrix::ReplaceDiagonalValues(const Epetra_Vector & Diagonal) {
   NormInf_ = -1.0; // Reset Norm so it will be recomputed.
   NormFrob_ = -1.0;
 
-  EPETRA_CHK_ERR(ierr);
+  int gerr;
+  Comm().MaxAll(&ierr, &gerr, 1);
+  EPETRA_CHK_ERR(gerr);
 
   return(0);
 }


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/epetra 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
We have weird behavior in our code, due to `ReplaceDiagonalValues` potentially returning different error flags on each proc. I think it makes sense to return a unified flag, either on all procs things work as intended, or we throw a warning flag.

Not sure if the current behavior is explicitly wanted.
