### PR TITLE
Stokhos:  Enable the original PCE scalar types even when Stokhos_ENABLE_PCE_Scalar_Type=OFF

### DIFF
--- a/packages/stokhos/example/CMakeLists.txt
+++ b/packages/stokhos/example/CMakeLists.txt
@@ -395,49 +395,45 @@ IF (Stokhos_ENABLE_EpetraExt)
 
 ENDIF()
 
-IF(Stokhos_ENABLE_PCE_Scalar_Type)
+TRIBITS_ADD_EXECUTABLE(
+  uq_handbook_pce_example
+  SOURCES uq_handbook/pce_example.cpp
+  COMM serial mpi
+  )
 
-  TRIBITS_ADD_EXECUTABLE(
-    uq_handbook_pce_example
-    SOURCES uq_handbook/pce_example.cpp
-    COMM serial mpi
-    )
-
-  IF (Stokhos_ENABLE_EpetraExt AND
-      Stokhos_ENABLE_AztecOO AND
-      Stokhos_ENABLE_ML AND
-      Stokhos_ENABLE_Ifpack AND
-      Stokhos_ENABLE_NOX)
-
-    TRIBITS_ADD_EXECUTABLE_AND_TEST(
-      uq_handbook_nonlinear_sg_example
-      SOURCES uq_handbook/nonlinear_sg_example.cpp
-              uq_handbook/SimpleME.hpp
-              uq_handbook/SimpleME.cpp
-      ARGS
-      COMM serial mpi
-      NUM_MPI_PROCS 1
-      )
-
-  ENDIF()
+IF (Stokhos_ENABLE_EpetraExt AND
+    Stokhos_ENABLE_AztecOO AND
+    Stokhos_ENABLE_ML AND
+    Stokhos_ENABLE_Ifpack AND
+    Stokhos_ENABLE_NOX)
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    sacado_example
-    SOURCES sacado/sacado_example.cpp
+    uq_handbook_nonlinear_sg_example
+    SOURCES uq_handbook/nonlinear_sg_example.cpp
+            uq_handbook/SimpleME.hpp
+            uq_handbook/SimpleME.cpp
     ARGS
     COMM serial mpi
     NUM_MPI_PROCS 1
     )
 
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    division_example
-    SOURCES sacado/division_example.cpp
-    COMM serial mpi
-    PASS_REGULAR_EXPRESSION "Example Passed"
-    NUM_MPI_PROCS 1
-    )
-
 ENDIF()
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  sacado_example
+  SOURCES sacado/sacado_example.cpp
+  ARGS
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  division_example
+  SOURCES sacado/division_example.cpp
+  COMM serial mpi
+  PASS_REGULAR_EXPRESSION "Example Passed"
+  NUM_MPI_PROCS 1
+  )
 
 IF(Stokhos_ENABLE_Ensemble_Scalar_Type)
   TRIBITS_ADD_EXECUTABLE(

--- a/packages/stokhos/src/CMakeLists.txt
+++ b/packages/stokhos/src/CMakeLists.txt
@@ -632,25 +632,23 @@ IF (Stokhos_ENABLE_Sacado)
   SET(SACADO_HEADERS "")
   SET(SACADO_SOURCES "")
   SET(STOKHOS_DEPLIBS stokhos)
-  IF(Stokhos_ENABLE_PCE_Scalar_Type)
-    LIST(APPEND SACADO_HEADERS
-      sacado/Stokhos_Sacado.hpp
-      sacado/Stokhos_Sacado_MathFunctions.hpp
-      sacado/Sacado_PCE_OrthogPoly.hpp
-      sacado/Sacado_PCE_OrthogPolyImp.hpp
-      sacado/Sacado_PCE_OrthogPolyTraits.hpp
-      sacado/Sacado_PCE_ScalarTraitsImp.hpp
-      sacado/Sacado_ETPCE_OrthogPoly.hpp
-      sacado/Sacado_ETPCE_OrthogPolyImp.hpp
-      sacado/Sacado_ETPCE_OrthogPolyTraits.hpp
-      sacado/Sacado_ETPCE_OrthogPolyOps.hpp
-      sacado/Sacado_ETPCE_ExpressionTraits.hpp
-      )
-    LIST(APPEND SACADO_SOURCES
-      sacado/Sacado_PCE_OrthogPoly.cpp
-      sacado/Sacado_ETPCE_OrthogPoly.cpp
-      )
-  ENDIF()
+  LIST(APPEND SACADO_HEADERS
+    sacado/Stokhos_Sacado.hpp
+    sacado/Stokhos_Sacado_MathFunctions.hpp
+    sacado/Sacado_PCE_OrthogPoly.hpp
+    sacado/Sacado_PCE_OrthogPolyImp.hpp
+    sacado/Sacado_PCE_OrthogPolyTraits.hpp
+    sacado/Sacado_PCE_ScalarTraitsImp.hpp
+    sacado/Sacado_ETPCE_OrthogPoly.hpp
+    sacado/Sacado_ETPCE_OrthogPolyImp.hpp
+    sacado/Sacado_ETPCE_OrthogPolyTraits.hpp
+    sacado/Sacado_ETPCE_OrthogPolyOps.hpp
+    sacado/Sacado_ETPCE_ExpressionTraits.hpp
+    )
+  LIST(APPEND SACADO_SOURCES
+    sacado/Sacado_PCE_OrthogPoly.cpp
+    sacado/Sacado_ETPCE_OrthogPoly.cpp
+    )
   TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/sacado/kokkos)
   LIST(APPEND SACADO_HEADERS
     sacado/kokkos/Stokhos_Sacado_Kokkos.hpp

--- a/packages/stokhos/test/UnitTest/CMakeLists.txt
+++ b/packages/stokhos/test/UnitTest/CMakeLists.txt
@@ -354,40 +354,41 @@ IF(Stokhos_ENABLE_Sacado)
     STANDARD_PASS_OUTPUT
     )
 
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    SacadoPCEUnitTest
+    SOURCES Stokhos_SacadoPCEUnitTest.cpp Stokhos_SacadoPCEUnitTest.hpp
+    COMM serial mpi
+    STANDARD_PASS_OUTPUT
+    NUM_MPI_PROCS 1
+    )
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    SacadoETPCEUnitTest
+    SOURCES Stokhos_SacadoETPCEUnitTest.cpp Stokhos_SacadoPCEUnitTest.hpp
+    COMM serial mpi
+    STANDARD_PASS_OUTPUT
+    NUM_MPI_PROCS 1
+    )
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    SacadoPCESerializationTests
+    SOURCES Stokhos_SacadoPCESerializationTests.cpp ${UTILS_SOURCES}
+    ARGS
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+    )
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    SacadoPCECommTests
+    SOURCES Stokhos_SacadoPCECommTests.cpp ${UTILS_SOURCES}
+    ARGS
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+    )
+
   IF(Stokhos_ENABLE_PCE_Scalar_Type)
-    TRIBITS_ADD_EXECUTABLE_AND_TEST(
-      SacadoPCEUnitTest
-      SOURCES Stokhos_SacadoPCEUnitTest.cpp Stokhos_SacadoPCEUnitTest.hpp
-      COMM serial mpi
-      STANDARD_PASS_OUTPUT
-      NUM_MPI_PROCS 1
-      )
-
-    TRIBITS_ADD_EXECUTABLE_AND_TEST(
-      SacadoETPCEUnitTest
-      SOURCES Stokhos_SacadoETPCEUnitTest.cpp Stokhos_SacadoPCEUnitTest.hpp
-      COMM serial mpi
-      STANDARD_PASS_OUTPUT
-      NUM_MPI_PROCS 1
-      )
-
-    TRIBITS_ADD_EXECUTABLE_AND_TEST(
-      SacadoPCESerializationTests
-      SOURCES Stokhos_SacadoPCESerializationTests.cpp ${UTILS_SOURCES}
-      ARGS
-      COMM serial mpi
-      NUM_MPI_PROCS 1
-      STANDARD_PASS_OUTPUT
-      )
-
-    TRIBITS_ADD_EXECUTABLE_AND_TEST(
-      SacadoPCECommTests
-      SOURCES Stokhos_SacadoPCECommTests.cpp ${UTILS_SOURCES}
-      ARGS
-      COMM serial mpi
-      NUM_MPI_PROCS 1
-      STANDARD_PASS_OUTPUT
-      )
 
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
       SacadoUQPCEUnitTest


### PR DESCRIPTION
The original PCE scalar type does not use Kokkos, nor is the Tpetra stack instantiated on it, so it is not as problematic as the Sacado::UQ::PCE scalar type.  So we'll re-enable it even when the Kokkos PCE scalar type is disabled.

@hkthorn 