### PR TITLE
AMD, Cholmod, UMFPACK, yamlcpp: Changes to detection on RedHat

### DIFF
--- a/cmake/TPLs/FindTPLAMD.cmake
+++ b/cmake/TPLs/FindTPLAMD.cmake
@@ -19,6 +19,11 @@ if (AMD_ALLOW_PREFIND)
 endif()
 
 if (NOT TARGET AMD::all_libs)
+
+  set(AMD_INCLUDE_DIRS_DEFAULT "/usr/include/suitesparse")
+  set(AMD_INCLUDE_DIRS "${AMD_INCLUDE_DIRS_DEFAULT}" CACHE PATH
+    "Default path to find AMD include files")
+
   tribits_tpl_find_include_dirs_and_libraries( AMD
     REQUIRED_HEADERS ${REQUIRED_HEADERS}
     REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} )

--- a/cmake/TPLs/FindTPLCholmod.cmake
+++ b/cmake/TPLs/FindTPLCholmod.cmake
@@ -1,5 +1,5 @@
 set(REQUIRED_HEADERS cholmod.h cholmod_core.h )
-set(REQUIRED_LIBS_NAMES libcholmod.a libamd.a libcolamd.a libccolamd.a libcamd.a libsuitesparseconfig.a )
+set(REQUIRED_LIBS_NAMES cholmod amd colamd ccolamd camd suitesparseconfig )
 set(IMPORTED_TARGETS_FOR_ALL_LIBS SuiteSparse::CHOLMOD )
 
 tribits_tpl_allow_pre_find_package(Cholmod  Cholmod_ALLOW_PREFIND)
@@ -17,6 +17,10 @@ if (Cholmod_ALLOW_PREFIND)
 endif()
 
 if (NOT TARGET Cholmod::all_libs)
+  set(Cholmod_INCLUDE_DIRS_DEFAULT "/usr/include/suitesparse")
+  set(Cholmod_INCLUDE_DIRS "${Cholmod_INCLUDE_DIRS_DEFAULT}" CACHE PATH
+    "Default path to find Cholmod include files")
+
   tribits_tpl_find_include_dirs_and_libraries( Cholmod
     REQUIRED_HEADERS ${REQUIRED_HEADERS}
     REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} )

--- a/cmake/TPLs/FindTPLUMFPACK.cmake
+++ b/cmake/TPLs/FindTPLUMFPACK.cmake
@@ -17,6 +17,11 @@ if (UMFPACK_ALLOW_PREFIND)
 endif()
 
 if (NOT TARGET UMFPACK::all_libs)
+
+  set(UMFPACK_INCLUDE_DIRS_DEFAULT "/usr/include/suitesparse")
+  set(UMFPACK_INCLUDE_DIRS "${UMFPACK_INCLUDE_DIRS_DEFAULT}" CACHE PATH
+    "Default path to find UMFPACK include files")
+
   tribits_tpl_find_include_dirs_and_libraries( UMFPACK
     REQUIRED_HEADERS ${REQUIRED_HEADERS}
     REQUIRED_LIBS_NAMES ${REQUIRED_LIBS_NAMES} )

--- a/cmake/TPLs/FindTPLyamlcpp.cmake
+++ b/cmake/TPLs/FindTPLyamlcpp.cmake
@@ -1,5 +1,5 @@
 
 TRIBITS_TPL_FIND_INCLUDE_DIRS_AND_LIBRARIES( yamlcpp
-  REQUIRED_HEADERS yaml-cpp/yaml.h
-  REQUIRED_LIBS_NAMES yaml-cpp
+  REQUIRED_HEADERS yaml-cpp/yaml.h yaml.h
+  REQUIRED_LIBS_NAMES "yaml-cpp yaml"
   )


### PR DESCRIPTION
@trilinos/framework @bartlettroscoe 

## Motivation
This is an attempt to improve the detection of TPLs AMD, Cholmod, UMFPACK and yamlcpp on RedHat type systems.
Unfortunately, the suitesparse package on Rocky* does not provide any information to CMake and installs its headers in a sub-directory of /usr/include. This means that by default CMake/TriBITS does not find the files.

@bartlettroscoe Is this the correct way of augmenting the search path? I am worried about what happens if the user did not specify `AMD_INCLUDE_DIRS` and the headers are installed in `/usr/include`. Would that path still be searched?