### PR TITLE
MueLu: Improve cut-drop `CoalesceDropFactory_kokkos: Dropping decisions` performance

### DIFF
--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CutDrop.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CutDrop.hpp
@@ -325,11 +325,11 @@ class UnscaledDistanceLaplacianComparison {
 #endif
   using magnitudeType = typename ATS::magnitudeType;
   using values_view   = Kokkos::View<magnitudeType*, memory_space>;
-  mutable values_view values;
 
   Teuchos::RCP<diag_vec_type> diagVec;
   diag_view_type diag;
   DistanceFunctorType dist2;
+  mutable values_view values;
 
  public:
   UnscaledDistanceLaplacianComparison(matrix_type& A_, DistanceFunctorType& dist2_, results_view& results_)


### PR DESCRIPTION
@trilinos/muelu 

Pre-compute comparator `ScaledDistanceLaplacianComparison::Comparator::get_value` results to avoid recomputation in `Misc::serialHeapSort` and later when computing the dropping indices.

Here's an example for a thermal battery application with n=509427, nnz=4573399 on a single rank:

Prior to change:
```
|   Driver: 2 - MueLu Setup: 1.84832 - 11.0895% [1]
|   |   MueLu: ParameterListInterpreter (ParameterList): 0.0107363 - 0.58087% [1]
|   |   MueLu: Hierarchy: Setup (total, level=0): 0.0716607 - 3.87708% [1]
|   |   |   MueLu: Ifpack2Smoother: Setup Smoother (total): 0.0713749 - 99.6011% [1]
|   |   |   |   UtilitiesBase::GetLumpedMatrixDiagonal (Kokkos implementation): 0.0214983 - 30.1203% [1]
|   |   |   |   |   GetLumpedMatrixDiagonal: parallel_for (doReciprocal): 0.0189456 - 88.1261% [1]
|   |   |   |   |   ComputeLumpedDiagonalInverse: parallel_for (doReciprocal): 0.000609688 - 2.83598% [1]
|   |   |   |   |   Remainder: 0.00194301 - 9.03796%
|   |   |   |   MueLu: Ifpack2Smoother: SetPrecParameters: 0.00131391 - 1.84086% [1]
|   |   |   |   MueLu: Ifpack2Smoother: Preconditioner init (sub, total): 4.146e-06 - 0.00580877% [1]
|   |   |   |   MueLu: Ifpack2Smoother: Preconditioner compute (sub, total): 0.0470433 - 65.9102% [1]
|   |   |   |   |   Ifpack2::Chebyshev::compute: 0.0470392 - 99.9911% [1]
|   |   |   |   |   Remainder: 4.194e-06 - 0.00891518%
|   |   |   |   Remainder: 0.00151515 - 2.1228%
|   |   |   Remainder: 0.000285828 - 0.398863%
|   |   MueLu: Hierarchy: Setup (total, level=1): 1.60806 - 87.0014% [1]
|   |   |   MueLu: RebalanceTransferFactory: Build (total): 1.60339 - 99.7093% [1]
|   |   |   |   MueLu: SaPFactory: Prolongator smoothing (total): 1.46938 - 91.6425% [1]
|   |   |   |   |   MueLu: CoalesceDropFactory_kokkos: BuildScalar (total): 1.21392 - 82.6145% [1]
|   |   |   |   |   |   MueLu: CoalesceDropFactory_kokkos: Boundary detection (sub, total): 0.00237154 - 0.195361% [1]
|   |   |   |   |   |   MueLu: CoalesceDropFactory_kokkos: Dropping decisions (sub, total): 1.18333 - 97.4798% [1]
|   |   |   |   |   |   MueLu: CoalesceDropFactory_kokkos: Filtered matrix fill (sub, total): 0.0251752 - 2.07387% [1]
```

With change:
```
|   Driver: 2 - MueLu Setup: 0.880108 - 5.7311% [1]
|   |   MueLu: ParameterListInterpreter (ParameterList): 0.0105831 - 1.20247% [1]
|   |   MueLu: Hierarchy: Setup (total, level=0): 0.0606239 - 6.88824% [1]
|   |   |   MueLu: Ifpack2Smoother: Setup Smoother (total): 0.0602908 - 99.4504% [1]
|   |   |   |   UtilitiesBase::GetLumpedMatrixDiagonal (Kokkos implementation): 0.0107707 - 17.8646% [1]
|   |   |   |   |   GetLumpedMatrixDiagonal: parallel_for (doReciprocal): 0.00899731 - 83.5349% [1]
|   |   |   |   |   ComputeLumpedDiagonalInverse: parallel_for (doReciprocal): 0.000624167 - 5.79503% [1]
|   |   |   |   |   Remainder: 0.00114925 - 10.6701%
|   |   |   |   MueLu: Ifpack2Smoother: SetPrecParameters: 0.0012362 - 2.0504% [1]
|   |   |   |   MueLu: Ifpack2Smoother: Preconditioner init (sub, total): 4.789e-06 - 0.00794317% [1]
|   |   |   |   MueLu: Ifpack2Smoother: Preconditioner compute (sub, total): 0.0470653 - 78.0639% [1]
|   |   |   |   |   Ifpack2::Chebyshev::compute: 0.0470608 - 99.9903% [1]
|   |   |   |   |   Remainder: 4.57e-06 - 0.00970991%
|   |   |   |   Remainder: 0.0012137 - 2.01308%
|   |   |   Remainder: 0.000333176 - 0.549578%
|   |   MueLu: Hierarchy: Setup (total, level=1): 0.728505 - 82.7745% [1]
|   |   |   MueLu: RebalanceTransferFactory: Build (total): 0.72373 - 99.3445% [1]
|   |   |   |   MueLu: SaPFactory: Prolongator smoothing (total): 0.59814 - 82.6468% [1]
|   |   |   |   |   MueLu: CoalesceDropFactory_kokkos: BuildScalar (total): 0.345879 - 57.8258% [1]
|   |   |   |   |   |   MueLu: CoalesceDropFactory_kokkos: Boundary detection (sub, total): 0.00238474 - 0.689472% [1]
|   |   |   |   |   |   MueLu: CoalesceDropFactory_kokkos: Dropping decisions (sub, total): 0.322992 - 93.3829% [1]
|   |   |   |   |   |   MueLu: CoalesceDropFactory_kokkos: Filtered matrix fill (sub, total): 0.0183225 - 5.29737% [1]
```