### PR TITLE
Ifpack2/Tpetra: fix #14529 and re-do of #14337

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -2194,11 +2194,12 @@ void performSymbolicPhase(const Teuchos::RCP<const typename BlockHelperDetails::
       // Also check that the final elements of R_rowptr (aka amd.rowptr)
       // and R_rowptr_remote (aka amd.rowptr_remote) match the total entry counts computed earlier.
       {
-        size_type R_rowptr_final, R_rowptr_remote_final;
+        size_type R_rowptr_final;
         KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr, R_rowptr_final);
-        KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr_remote, R_rowptr_remote_final);
         TEUCHOS_ASSERT(R_rowptr_final == R_nnz_owned);
         if (overlap_communication_and_computation) {
+          size_type R_rowptr_remote_final;
+          KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr_remote, R_rowptr_remote_final);
           TEUCHOS_ASSERT(R_rowptr_remote_final == R_nnz_remote);
         }
       }


### PR DESCRIPTION
- move BTD symbolic phase to device again
  - including workaround for #14529, by splitting the rowptr prefix sums out into separate kernels from the graph fill.
- Make ``Tpetra::Map::lazyPushToHost`` private again.

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 
@trilinos/tpetra 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Putting symbolic on device improves performance. This also resolves the failures SPARC saw from #14337 .

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Fixes #14529 
* Follows #14337 and #14551
* Issue's root cause: https://github.com/kokkos/kokkos/issues/8607