### PR TITLE
Framework: MPI_COMM_WORLD checker UTF8 fix

### DIFF
--- a/commonTools/test/utilities/check-mpi-comm-world-usage.py
+++ b/commonTools/test/utilities/check-mpi-comm-world-usage.py
@@ -85,9 +85,15 @@ def get_changed_files(target_branch, feature_branch):
         start_commit,
         feature_branch
     ]
-    result = subprocess.check_output(cmd).decode("utf-8")
+    out = subprocess.check_output(cmd)
+    result = []
+    for line in out.splitlines():
+        try:
+            result.append(line.decode("utf-8"))
+        except UnicodeDecodeError:
+            print(f"WARNING: Line {line} contains non-UTF8 characters; ignoring it")
 
-    return parse_diff_output(result)
+    return parse_diff_output("\n".join(result))
 
 
 def print_occurences(changed_files, title):


### PR DESCRIPTION
@trilinos/framework 

## Motivation
If a non-UTF8 character is encountered while checking file content, just ignore that line instead of failing the check.

## Related Issues
I ran into this while working on removing the deprecated packages as part of #14300 and #14637

