### PR TITLE
Zoltan2: Silence warning

### DIFF
--- a/packages/zoltan2/test/core/correctness/zoltanCompare.cpp
+++ b/packages/zoltan2/test/core/correctness/zoltanCompare.cpp
@@ -110,9 +110,9 @@ static void zobjlist(void *data, int ngid, int nlid,
   *ierr = ZOLTAN_OK;
   tMVector_t *vec = (tMVector_t *) data;
   size_t n = vec->getLocalLength();
-
+  zgno_t vgid = 0;
   for (size_t i = 0; i < n; i++) {
-    zgno_t vgid = vec->getMap()->getGlobalElement(i);
+    vgid = vec->getMap()->getGlobalElement(i);
     ZOLTAN_ID_PTR vgidptr = (ZOLTAN_ID_PTR) &vgid;
     SET_ZID(znGidEnt, &(gids[i*znGidEnt]), vgidptr);
     lids[i] = i;


### PR DESCRIPTION
@trilinos/zoltan2 

## Motivation
Silence warning:
```
/workspace/trilinos/source/packages/zoltan2/test/core/correctness/zoltanCompare.cpp: In function 'void zobjlist(void*, int, int, ZOLTAN_ID_PTR, ZOLTAN_ID_PTR, int, float*, int*)':
/workspace/trilinos/source/packages/zoltan2/test/core/correctness/zoltanCompare.cpp:92:47: error: 'vgid' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   92 |       (a)[ZOLTAN_ID_LOOP] = (b)[ZOLTAN_ID_LOOP];                        \
      |                                               ^
/workspace/trilinos/source/packages/zoltan2/test/core/correctness/zoltanCompare.cpp:115:12: note: 'vgid' was declared here
  115 |     zgno_t vgid = vec->getMap()->getGlobalElement(i);
```