### PR TITLE
Tpetra: Fence at the end of endTransfer

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -1156,7 +1156,6 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
           // Copy src_j into tgt_j
           // DEEP_COPY REVIEW - HOSTMIRROR-TO-HOSTMIRROR
           Kokkos::deep_copy(space, tgt_j, src_j);
-          space.fence("Tpetra::MultiVector::copyAndPermute-1");
         }
       }
     } else {  // copy on device
@@ -1183,7 +1182,6 @@ void MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
           // Copy src_j into tgt_j
           // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
           Kokkos::deep_copy(space, tgt_j, src_j);
-          space.fence("Tpetra::MultiVector::copyAndPermute-2");
         }
       }
     }


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
This PR moves the fence from `MultiVector::copyAndPermute` to the end of `DistObject::endTransfer`.

Questions:
- There was no fence for `CM == ADD_ASSIGN` in `MultiVector::copyAndPermute`. I think that we need the same fence, regardless of the combine mode?
- I looked for fences in `copyAndPermute` for other objects derived from `DistObject`, but didn't find them.