### PR TITLE
Teuchos: stacked timer and kokkos fence ordering

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -496,12 +496,13 @@ public:
    * Start the base level timer only
    */
   void startBaseTimer(const bool push_kokkos_profiling_region = true) {
-    timer_.BaseTimer::start();
 #ifdef HAVE_TEUCHOSCORE_KOKKOS
+    // Fence before starting timer to ignore async kernels started before this timer starts
     if (Behavior::fenceTimers()) {
       Kokkos::fence("timer_fence_begin_"+timer_.get_name());
     }
 #endif
+    timer_.BaseTimer::start();
 #if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOS)
     if (push_kokkos_profiling_region) {
       ::Kokkos::Tools::pushRegion(timer_.get_name());
@@ -513,8 +514,8 @@ public:
    * Stop the base level timer only
    */
   void stopBaseTimer(const bool pop_kokkos_profiling_region = true) {
-    timer_.BaseTimer::stop();
 #ifdef HAVE_TEUCHOSCORE_KOKKOS
+    // Fence before stopping the timer to include async kokkos kernels launched within this timer
     if (Behavior::fenceTimers()) {
       Kokkos::fence("timer_fence_end_"+timer_.get_name());
     }
@@ -524,6 +525,7 @@ public:
       ::Kokkos::Tools::popRegion();
     }
 #endif
+    timer_.BaseTimer::stop();
   }
 
   /**
@@ -537,12 +539,13 @@ public:
       if (top_ == nullptr) {
         top_ = timer_.start(name.c_str());
       } else {
-        top_ = top_->start(name.c_str());
 #ifdef HAVE_TEUCHOSCORE_KOKKOS
+        // Fence before starting timer to ignore async kernels started before this timer starts
         if (Behavior::fenceTimers()) {
           Kokkos::fence("timer_fence_begin_"+name);
         }
 #endif
+        top_ = top_->start(name.c_str());
 #if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOS)
         if (push_kokkos_profiling_region) {
           ::Kokkos::Tools::pushRegion(name);
@@ -580,8 +583,8 @@ public:
             const bool pop_kokkos_profiling_region = true) {
     if (enable_timers_) {
       if (top_) {
-        top_ = top_->stop(name);
 #ifdef HAVE_TEUCHOSCORE_KOKKOS
+        // Fence before stopping the timer to include async kokkos kernels launched within this timer
         if (Behavior::fenceTimers()) {
           Kokkos::fence("timer_fence_end_"+name);
         }
@@ -591,6 +594,7 @@ public:
           ::Kokkos::Tools::popRegion();
         }
 #endif
+        top_ = top_->stop(name);
       } else {
         timer_.BaseTimer::stop();
       }


### PR DESCRIPTION
Fence in start() should happen before starting the timer to exclude any async kernels launched before the timer started that have not yet finished.

Fence in stop() should happen before stopping the timer to include async kernels started inside the timed region.

Also fixed start and stop calls wrt to kokkos push/pop regions. The StackedTimer start() and stop() now enclose the kokkos push/pop.


@trilinos/teuchos 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
More accurate timings in presence of kokkos kernels

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Current tests cover this change.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
