### PR TITLE
Tpetra: add is_unified_memory_space to Node

### DIFF
--- a/packages/tpetra/core/compat/Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp
+++ b/packages/tpetra/core/compat/Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp
@@ -65,6 +65,10 @@ class KokkosDeviceWrapperNode {
   //! Whether the ExecutionSpace is GPU-like (its default memory space is not HostSpace)
   static constexpr bool is_gpu = !is_cpu;
 
+  //! Whether the device is an APU with a single memory space shared between device and host (but which is not HostSpace).
+  static constexpr bool is_unified_memory_space = is_gpu &&
+                                                  Kokkos::SpaceAccessibility<Kokkos::DefaultHostExecutionSpace, typename execution_space::memory_space>::accessible;
+
   KokkosDeviceWrapperNode(Teuchos::ParameterList& /* params */) = delete;
   KokkosDeviceWrapperNode()                                     = delete;
 


### PR DESCRIPTION
True for architectures like AMD_GFX942_APU where the device space is not HostSpace, but it's still accessible on host.
Might help for cases where special logic is required for APUs, like #14681.

@trilinos/tpetra 