### PR TITLE
MueLu: Fix cycle option

### DIFF
--- a/packages/muelu/doc/UsersGuide/update_params.sh
+++ b/packages/muelu/doc/UsersGuide/update_params.sh
@@ -79,7 +79,7 @@ namespace MueLu {
 
     if (name == "cycle type") {
       std::stringstream temp1; temp1 << "\"" << "MGV" << "\"";
-      std::stringstream temp2; temp2 << "\"" << "MGV" << "\"";
+      std::stringstream temp2; temp2 << "\"" << "MGW" << "\"";
       if (value == temp1.str() ) { ss << "<Parameter name=\"cycle type\" type=\"string\" value=\"V\"/>"; }
       else if (value == temp2.str()) { ss << "<Parameter name=\"cycle type\" type=\"string\" value=\"W\"/>"; }
       else TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "MasterList::interpretParameterName, Line " << __LINE__ << ". "

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -1077,7 +1077,7 @@ ConvergenceStatus Hierarchy<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Iterate(
 
           Iterate(*coarseRhs, *coarseX, 1, true, startLevel + 1);
           // ^^ zero initial guess
-          if (Cycle_ == WCYCLE && WCycleStartLevel_ >= startLevel)
+          if (Cycle_ == WCYCLE && WCycleStartLevel_ <= startLevel)
             Iterate(*coarseRhs, *coarseX, 1, false, startLevel + 1);
           // ^^ nonzero initial guess
 

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -59,7 +59,7 @@ namespace MueLu {
 
     if (name == "cycle type") {
       std::stringstream temp1; temp1 << "\"" << "MGV" << "\"";
-      std::stringstream temp2; temp2 << "\"" << "MGV" << "\"";
+      std::stringstream temp2; temp2 << "\"" << "MGW" << "\"";
       if (value == temp1.str() ) { ss << "<Parameter name=\"cycle type\" type=\"string\" value=\"V\"/>"; }
       else if (value == temp2.str()) { ss << "<Parameter name=\"cycle type\" type=\"string\" value=\"W\"/>"; }
       else TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::RuntimeError, "MasterList::interpretParameterName, Line " << __LINE__ << ". "


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
- There was a typo in `update_params.sh` that resulted in ML's W-cycle option being mapped to MueLu's V-cycle.
- I think the W-cycle logic in MueLu is not correct. `WCycleSTartLevel_` is 0 by default. My understanding is that every level should do a W-cycle then.