### PR TITLE
[NOX] Remove `checkStatus()` call from `NOX::Solver::InexactTrustRegionBased:: reset()`

### DIFF
--- a/packages/nox/src/NOX_Solver_InexactTrustRegionBased.C
+++ b/packages/nox/src/NOX_Solver_InexactTrustRegionBased.C
@@ -269,15 +269,6 @@ reset()
   status = StatusTest::Unconverged;
   if (useCounters)
     counters->reset();
-
-  // Test the initial guess
-  status = testPtr->checkStatus(*this, checkType);
-
-  if (utils->isPrintType(NOX::Utils::Parameters)) {
-    utils->out() << "\n-- Status Tests Passed to Nonlinear Solver --\n\n";
-    testPtr->print(utils->out(), 5);
-    utils->out() <<"\n" << NOX::Utils::fill(72) << "\n";
-  }
 }
 
 //*************************************************************************


### PR DESCRIPTION
@trilinos/nox @rppawlo

## Motivation
It looks like the original intention to call `testPtr->checkStatus()` was related only to the case when the initial guess is provided, i.e. the other 2 `reset()` methods. I do not think it is reasonable for empty `reset()`.
