### PR TITLE
Teuchos:  POSIX code in Trilinos not compatible with Windows

### DIFF
--- a/packages/teuchos/core/src/Teuchos_SystemInformation.cpp
+++ b/packages/teuchos/core/src/Teuchos_SystemInformation.cpp
@@ -24,6 +24,14 @@
 // needs to be in the global namespace
 extern char **environ;
 #endif
+#if defined(_WIN32)
+#include <stdio.h>
+FILE *popen(const char *command, const char *mode)
+{ return _popen(command, mode); }
+
+int pclose(FILE *stream)
+{ return _pclose(stream);}
+#endif
 
 namespace Teuchos::SystemInformation {
 
@@ -213,7 +221,7 @@ void initializeCollection() {
 
 #if !defined(__GNUC__) || (__GNUC__ >= 10)
   try {
-    const std::string executable = std::filesystem::canonical("/proc/self/exe");
+    const std::string executable = std::filesystem::canonical("/proc/self/exe").string();
     if (!executable.empty()) {
       registerCommand("ldd", "ldd " + executable, "ldd");
     }


### PR DESCRIPTION


@trilinos/teuchos 

## Motivation
The WIN32 API includes a compatible counterpart to the POSIX functions introduced in the commit referenced in the issue description (popen and pclose). The Windows versions have the same parameters, return type, and behavior, but the function name is different (_popen and _pclose).  There is also a correction to the return value from the function std::filesystem::canonical, which is being assigned to a std::string when the function returns a std::filesystem::path.

## Related Issues

<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes #14717 

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback

## Testing
Windows development and test machine with this compiler stack:

Visual Studio 2022 version 17.9.2
Intel OneAPI Base Toolkit version 2024.2
Intel HPC ToolKit with Intel(R) MPI Library for Windows* OS, Version 2021.13 Build 20240701

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
