### PR TITLE
Framework: Remove per-build CMAKE_CXX_FLAGS

### DIFF
--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -59,8 +59,8 @@ set(upcoming_warnings
     dangling-pointer=2  # -Wall
     # deprecated-copy  # -Wextra, lots of warnings
     implicit-fallthrough=3  # -Wextra
-    maybe-uninitialized
-    mismatched-new-delete
+    maybe-uninitialized  # -Wall
+    mismatched-new-delete  # -Wall
     pessimizing-move  # -Wall
     redundant-move  # -Wextra
     restrict

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1236,9 +1236,6 @@ opt-set-cmake-var Trilinos_EXTRA_LINK_FLAGS STRING FORCE : -lm
 [CUDA]
 use SPACK_CUDA_TPLS
 
-#CXX Settings
-opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -fPIC -Wall -Warray-bounds -Wchar-subscripts -Wcomment -Wenum-compare -Wformat -Wuninitialized -Wmaybe-uninitialized -Wmain -Wnarrowing -Wnonnull -Wreorder -Wreturn-type -Wsequence-point -Wtrigraphs -Wunused-function -Wunused-but-set-variable -Wwrite-strings
-
 #Package Options
 opt-set-cmake-var Kokkos_ENABLE_CUDA_LAMBDA BOOL FORCE : ON
 opt-set-cmake-var Kokkos_ENABLE_CXX11_DISPATCH_LAMBDA BOOL FORCE : ON
@@ -1627,7 +1624,6 @@ opt-set-cmake-var TPL_ENABLE_Scotch   BOOL FORCE : OFF
 opt-set-cmake-var TPL_Netcdf_LIBRARIES STRING FORCE : ${NETCDF_C_LIB|ENV}/libnetcdf.so
 
 opt-set-cmake-var Trilinos_ENABLE_Fortran OFF    BOOL         : OFF
-opt-set-cmake-var CMAKE_CXX_FLAGS STRING : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare
 
 [rhel8_sems-gnu-8.5.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel8_sems-gnu-8.5.0-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
@@ -1660,7 +1656,6 @@ use SPACK_NETLIB_BLAS_LAPACK
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                   STRING       : --bind-to;none --mca btl vader,self
 opt-set-cmake-var CMAKE_CXX_EXTENSIONS                          BOOL         : OFF
 opt-set-cmake-var Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                               STRING       : -fno-strict-aliasing -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare
 
 opt-set-cmake-var TPL_HDF5_LIBRARIES STRING : ${HDF5_LIB|ENV}/libhdf5_hl.so;${HDF5_LIB|ENV}/libhdf5.so;${ZLIB_LIB|ENV}/libz.so;-ldl
 
@@ -1695,8 +1690,6 @@ opt-set-cmake-var KokkosKernels_blas_serial_MPI_1_DISABLE                BOOL   
 opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE BOOL         : ON
 opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE                     BOOL         : ON
 opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE                     BOOL         : ON
-
-opt-set-cmake-var CMAKE_CXX_FLAGS                                        STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare
 
 # Test failures as of 11-28-22
 opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL : ON
@@ -1795,7 +1788,6 @@ opt-set-cmake-var ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE     BOO
 opt-set-cmake-var ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE BOOL         : ON
 opt-set-cmake-var Pliris_vector_random_MPI_3_DISABLE                         BOOL         : ON
 opt-set-cmake-var Pliris_vector_random_MPI_4_DISABLE                         BOOL         : ON
-opt-set-cmake-var CMAKE_CXX_FLAGS                                            STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare
 
 opt-set-cmake-var TPL_ENABLE_SuperLUDist BOOL FORCE: OFF
 
@@ -1821,7 +1813,6 @@ use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
 opt-set-cmake-var MPI_EXEC_PRE_NUMPROCS_FLAGS                                STRING       : --bind-to;none --mca btl vader,self
-opt-set-cmake-var CMAKE_CXX_FLAGS                                            STRING FORCE : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare
 
 opt-set-cmake-var TPL_ENABLE_SuperLUDist      BOOL FORCE : ON
 opt-set-cmake-var TPL_ENABLE_ParMETIS         BOOL FORCE : ON
@@ -1864,7 +1855,6 @@ use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
-opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-unused-but-set-variable
 
 opt-set-cmake-var TPL_Netcdf_LIBRARIES      STRING FORCE : ""
 
@@ -1891,7 +1881,6 @@ use USE-UVM|NO
 use USE-DEPRECATED|YES
 use PACKAGE-ENABLES|NO-PACKAGE-ENABLES
 
-opt-set-cmake-var CMAKE_CXX_FLAGS                STRING       : -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-nonnull-compare -Wno-unused-but-set-variable -Wno-missing-braces
 
 opt-set-cmake-var TPL_Netcdf_LIBRARIES      STRING FORCE : ""
 

--- a/packages/shylu/shylu_node/hts/src/shylu_hts_impl.hpp
+++ b/packages/shylu/shylu_node/hts/src/shylu_hts_impl.hpp
@@ -365,7 +365,6 @@ template<typename Int, typename Size, typename Sclr> struct Impl {
       ~Thread();
     };
     Array<Thread> t_;
-    mutable int done_ctr_;
     void inv_init_metadata(const InitInfo& in);
     void inv_init_memory();
     void inv_reinit_numeric();

--- a/packages/stokhos/test/Performance/MPVectorKernels/TestSpMv.cpp
+++ b/packages/stokhos/test/Performance/MPVectorKernels/TestSpMv.cpp
@@ -81,11 +81,10 @@ int main(int argc, char *argv[])
 #endif
     CLP.parse( argc, argv );
 
-    typedef int Ordinal;
-    typedef double Scalar;
-
 #ifdef KOKKOS_ENABLE_THREADS
     if (threads) {
+      typedef int Ordinal;
+      typedef double Scalar;
       typedef Kokkos::Threads Device;
       typedef Stokhos::StaticFixedStorage<Ordinal,Scalar,1,Device> Storage;
 
@@ -109,6 +108,8 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_OPENMP
     if (openmp) {
+      typedef int Ordinal;
+      typedef double Scalar;
       typedef Kokkos::OpenMP Device;
       typedef Stokhos::StaticFixedStorage<Ordinal,Scalar,1,Device> Storage;
 
@@ -132,6 +133,8 @@ int main(int argc, char *argv[])
 
 #ifdef KOKKOS_ENABLE_CUDA
     if (cuda) {
+      typedef int Ordinal;
+      typedef double Scalar;
       typedef Kokkos::Cuda Device;
       typedef Stokhos::StaticFixedStorage<Ordinal,Scalar,1,Device> Storage;
 


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Warnings flags are set in cmake/ProjectCompilerPostConfig.cmake.
Overwriting them creates confusion about what is actually tested.
Let's see how many warnings we get....