### PR TITLE
PR reproducer script

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 # actions: write needed by skip-duplicate-actions (handled below as per OpenSSF scorecard)
-permissions: 
+permissions:
   contents: read
 
 jobs:
@@ -35,6 +35,9 @@ jobs:
   gcc12-openmpi4:
     needs: pre-checks
     runs-on: [self-hosted, gcc-12.3.0-openmpi-4.1.6, 20251204]
+    env:
+      IMAGE: registry-ex.sandia.gov/trilinos-project/trilinos-containers/experimental/ubi8-gcc-12.3.0-openmpi-4.1.6:20251204
+      GENCONFIG_BUILD_NAME: rhel8_gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
     if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}
     steps:
       - name: env
@@ -89,10 +92,12 @@ jobs:
           export TRILINOS_DIR=${GITHUB_WORKSPACE:?}
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/GenConfig
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/pr_tools
-          export GENCONFIG_BUILD_NAME=rhel8_gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
           printf "\n\n\n"
 
           echo "image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}"
+          if [ "${IMAGE}" ~= "${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}" ] ; then
+              exit 1
+          fi
 
           python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
             --target-branch-name ${{ github.event.pull_request.base.ref }} \
@@ -134,6 +139,9 @@ jobs:
   clang19-openmpi4:
     needs: pre-checks
     runs-on: [self-hosted, clang-19.1.6-openmpi-4.1.6, 20251204]
+    env:
+      IMAGE: registry-ex.sandia.gov/trilinos-project/trilinos-containers/production/ubi9-clang-19.1.6-openmpi-4.1.6:20251204
+      GENCONFIG_BUILD_NAME: rhel_clang-openmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
     if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}
     steps:
       - name: env
@@ -188,10 +196,12 @@ jobs:
           export TRILINOS_DIR=${GITHUB_WORKSPACE:?}
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/GenConfig
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/pr_tools
-          export GENCONFIG_BUILD_NAME=rhel_clang-openmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
           printf "\n\n\n"
 
           echo "image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}"
+          if [ "${IMAGE}" ~= "${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}" ] ; then
+              exit 1
+          fi
 
           python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
             --target-branch-name ${{ github.event.pull_request.base.ref }} \
@@ -233,6 +243,9 @@ jobs:
   cuda12:
     needs: pre-checks
     runs-on: [self-hosted, cuda-12.4.1-gcc-12.3.0-openmpi-4.1.6, 20251204, gpu:A100]
+    env:
+      IMAGE: registry-ex.sandia.gov/trilinos-project/trilinos-containers/production/ubi8-cuda-12.4.1-gcc-12.3.0-openmpi-4.1.6:20251204
+      GENCONFIG_BUILD_NAME: rhel_cuda-12-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables
     if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}
     steps:
       - name: env
@@ -286,10 +299,13 @@ jobs:
           export TRILINOS_DIR=${GITHUB_WORKSPACE:?}
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/GenConfig
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/pr_tools
-          export GENCONFIG_BUILD_NAME=rhel_cuda-12-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables
           printf "\n\n\n"
 
           echo "image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}"
+          if [ "${IMAGE}" ~= "${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}" ] ; then
+              exit 1
+          fi
+
           type python
           python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
             --target-branch-name ${{ github.event.pull_request.base.ref }} \
@@ -332,6 +348,9 @@ jobs:
   gcc14:
     needs: pre-checks
     runs-on: [self-hosted, gcc-14, 20251204]
+    env:
+      IMAGE: registry-ex.sandia.gov/trilinos-project/trilinos-containers/production/ubi10-gcc-14:20251204
+      GENCONFIG_BUILD_NAME: rhel_gcc_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
     if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}
     steps:
       - name: env
@@ -386,11 +405,13 @@ jobs:
           export TRILINOS_DIR=${GITHUB_WORKSPACE:?}
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/GenConfig
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/pr_tools
-          export GENCONFIG_BUILD_NAME=rhel_gcc_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 
           printf "\n\n\n"
 
           echo "image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}"
+          if [ "${IMAGE}" ~= "${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}" ] ; then
+              exit 1
+          fi
 
           python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
             --target-branch-name ${{ github.event.pull_request.base.ref }} \
@@ -432,6 +453,9 @@ jobs:
   cuda12-uvm:
     needs: pre-checks
     runs-on: [self-hosted, cuda-12.4.1-gcc-12.3.0-openmpi-4.1.6, 20251204]
+    env:
+      IMAGE: registry-ex.sandia.gov/trilinos-project/trilinos-containers/production/ubi8-cuda-12.4.1-gcc-12.3.0-openmpi-4.1.6:20251204
+      GENCONFIG_BUILD_NAME: rhel_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables
     if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}
     steps:
       - name: env
@@ -485,10 +509,13 @@ jobs:
           export TRILINOS_DIR=${GITHUB_WORKSPACE:?}
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/GenConfig
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/pr_tools
-          export GENCONFIG_BUILD_NAME=rhel_cuda-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_uvm_deprecated-on_no-package-enables
           printf "\n\n\n"
 
           echo "image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}"
+          if [ "${IMAGE}" ~= "${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}" ] ; then
+              exit 1
+          fi
+
           type python
           python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
             --target-branch-name ${{ github.event.pull_request.base.ref }} \
@@ -530,6 +557,9 @@ jobs:
   oneapi2024:
     needs: pre-checks
     runs-on: [self-hosted, oneapi-2024.2, 20251204]
+    env:
+      IMAGE: registry-ex.sandia.gov/trilinos-project/trilinos-containers/production/ubi9-oneapi-2024.2:20251204
+      GENCONFIG_BUILD_NAME: rhel_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
     if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}
     steps:
       - name: env
@@ -581,10 +611,12 @@ jobs:
           export TRILINOS_DIR=${GITHUB_WORKSPACE:?}
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/GenConfig
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/pr_tools
-          export GENCONFIG_BUILD_NAME=rhel_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
           printf "\n\n\n"
 
           echo "image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}"
+          if [ "${IMAGE}" ~= "${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}" ] ; then
+              exit 1
+          fi
 
           python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
             --target-branch-name ${{ github.event.pull_request.base.ref }} \
@@ -626,6 +658,9 @@ jobs:
   openmp:
     needs: pre-checks
     runs-on: [self-hosted, gcc-12.3.0-openmpi-4.1.6, 20251204]
+    env:
+      IMAGE: registry-ex.sandia.gov/trilinos-project/trilinos-containers/experimental/ubi8-gcc-12.3.0-openmpi-4.1.6:20251204
+      GENCONFIG_BUILD_NAME: rhel8_gcc-openmpi-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
     if: ${{ needs.pre-checks.outputs.should_skip != 'true' && (github.event.action == 'synchronize' || github.event.action == 'opened' || github.event.review.state == 'APPROVED') }}
     steps:
       - name: env
@@ -680,10 +715,12 @@ jobs:
           export TRILINOS_DIR=${GITHUB_WORKSPACE:?}
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/GenConfig
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/pr_tools
-          export GENCONFIG_BUILD_NAME=rhel8_gcc-openmpi-openmp_release-debug_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
           printf "\n\n\n"
 
           echo "image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}"
+          if [ "${IMAGE}" ~= "${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}" ] ; then
+              exit 1
+          fi
 
           python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
             --target-branch-name ${{ github.event.pull_request.base.ref }} \

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ rsync.*
 # clangd server stuff
 .cache/
 compile_commands.json
+
+# virtual environment used for PR reproducer script
+/commonTools/pr_reproducer/.pr_reproducer_venv/

--- a/commonTools/pr_reproducer/container_commands.sh
+++ b/commonTools/pr_reproducer/container_commands.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+clean_trilinos() {
+    cmake --build $TRILINOS_BUILD_DIR --target clean
+}
+
+get_dependencies() {
+    ${TRILINOS_DIR}/packages/framework/get_dependencies.sh
+}
+
+configure_trilinos() {
+    source ${TRILINOS_DIR}/packages/framework/GenConfig/gen-config.sh --force --yes --ci-mode --cmake-fragment /workspace/pr.cmake ${GENCONFIG_BUILD_ID} ${TRILINOS_DIR}
+    rm -rf $TRILINOS_BUILD_DIR/CMakeCache.txt $TRILINOS_BUILD_DIR/CMakeFiles/
+    cmake -S $TRILINOS_DIR -B $TRILINOS_BUILD_DIR -C /workspace/pr.cmake -C /workspace/packageEnables.cmake -G Ninja |& tee $TRILINOS_BUILD_DIR/configure.log
+}
+
+build_trilinos() {
+    cmake --build $TRILINOS_BUILD_DIR $* -- -j 30
+}
+
+test_trilinos() {
+    ctest --test-dir $TRILINOS_BUILD_DIR $*
+}
+
+install_trilinos() {
+    rm -rf ${TRILINOS_INSTALL_DIR}/*
+    cmake --build $TRILINOS_BUILD_DIR --target install $* -- -j 30
+}
+
+reproduce_build() {
+    get_dependencies
+    configure_trilinos
+    build_trilinos
+    test_trilinos
+}
+
+export -f clean_trilinos
+export -f get_dependencies
+export -f configure_trilinos
+export -f build_trilinos
+export -f test_trilinos
+export -f install_trilinos
+
+mkdir -p ${TRILINOS_BUILD_DIR}
+mkdir -p ${TRILINOS_INSTALL_DIR}
+
+echo ""
+echo "The Trilinos source repository is ${TRILINOS_DIR}"
+echo "The build directory is            ${TRILINOS_BUILD_DIR}"
+echo "The install directory is          ${TRILINOS_INSTALL_DIR}"
+echo ""
+echo "Available commands:"
+echo " clean_trilinos     -- cleans up CMake files and allows to configure from scratch"
+echo " get_dependencies   -- installs GenConfig dependencies"
+echo " configure_trilinos -- configures Trilinos using CMake"
+echo " build_trilinos     -- build Trilinos"
+echo " test_trilinos      -- runs tests"
+echo " install_trilinos   -- installs Trilinos"
+echo " reproduce_build    -- installs dependencies, configures, builds and tests"
+echo ""
+echo "Normally, this is what you want to do:"
+echo " reproduce_build"
+echo ""

--- a/commonTools/pr_reproducer/pr_reproducer.py
+++ b/commonTools/pr_reproducer/pr_reproducer.py
@@ -1,0 +1,210 @@
+"""
+Helper script for reproducing PR builds
+
+This script uses the Github API to retrieve information about PRs and parses
+.github/workflows/AT2.yml for build information.
+"""
+from pathlib import Path
+import questionary
+import argparse
+from shutil import which
+import os
+from pprint import pformat
+import subprocess
+from github import Github
+from tools import (is_valid_pr_number,
+                   convert_to_pr_number,
+                   is_valid_source_dir,
+                   convert_to_valid_source_dir,
+                   get_github_upstream_of_local_branch,
+                   get_pr_number,
+                   parse_AT2_workflows,
+                   generate_package_enables,
+                   image_available,
+                   pull_image,
+                   launch_container)
+import logging
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+remote = "origin"
+repo = "trilinos/Trilinos"
+
+##################################################
+
+parser = argparse.ArgumentParser(description="""This script helps with reproducining PR builds for the Trilinos project.
+Run the script without any arguments in interactive mode or specify required information using the command line flags.""")
+parser.add_argument("--pr", type=convert_to_pr_number, help="Number of the PR that should be reproduced. Allows to skip the interactive prompt.")
+parser.add_argument("--source", type=convert_to_valid_source_dir, help="Trilinos source directory. Allows to skip the interactive prompt.")
+parser.add_argument("--build", help="PR build that should be reproduced. Allows to skip the interactive prompt.")
+parser.add_argument("--debug", action="store_true", help="debug mode")
+args = parser.parse_args()
+
+if args.debug:
+    logger.parent.setLevel(logging.DEBUG)
+
+logo = """
+
+         %%%%%%%%%%
+     %%%      %%% %%%%
+   %%%      %%% %%%%  %%%
+  %%      %%% %%%%      %%
+ %%  %%%%%%%%%%%%%%%%%%%%%%%       %%%%%%%%%%%%  %%%%%%%%      %%%  %%%%         %%%%  %%       %%%      %%%%%%         %%%%%%%%%%%
+%% %%%%%%%%%%%%%%%%%%%%%%%       %%%%%%%%%%%%  %%%%%%%%%%%%%%  %%%  %%%%         %%%% %%%%%%    %%%  %%%%%%%%%%%%%%  %%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%  %%         %%%%                %%%%  %%%  %%%%         %%%% %%%%%%%%  %%%  %%%        %%%% %%%%%%%%%%%
+%%%%%  %%% %%%%%          %%         %%%%      %%%%%%%%%%%%%   %%%  %%%%         %%%% %%%% %%%%%%%% %%%%        %%%%   %%%%%%%%%%%%
+%%%  %%%   %%%%%          %          %%%%      %%%     %%%%%   %%%  %%%%%%%%%%%  %%%% %%%%   %%%%%%  %%%%%%%%%%%%%%   %%%%%%%%%%%%%
+ %%%%%     %%%%%         %%          %%%%      %%%      %%%%%  %%%  %%%%%%%%%%   %%%% %%%%      %%      %%%%%%%%%    %%%%%%%%%%%%
+  %%       %%%%%        %%
+   %%%     %%%%%      %%
+     %%%%  %%%%%   %%%
+         %%%%%%%%%%
+
+"""
+
+questionary.print(logo)
+
+##################################################
+# Check that podman is available
+podman_cmd = which("podman")
+logger.debug(f"podman_cmd = {podman_cmd}")
+assert podman_cmd is not None, "No command \"podman\" in path"
+
+##################################################
+# Check that cmake is available
+cmake_cmd = which("cmake")
+logger.debug(f"cmake_cmd = {cmake_cmd}")
+assert cmake_cmd is not None, "No command \"cmake\" in path"
+
+##################################################
+# Trilinos source directory
+
+if args.source is not None:
+    trilinos_source = args.source
+else:
+    # relies on this file being in commonTools/or_reproducer/
+    trilinos_default_source = Path(os.path.abspath(__file__)).parent.parent.parent
+    logger.debug(f"trilinos_default_source = {trilinos_default_source}")
+    trilinos_source = questionary.path("Where is the Trilinos source code checked out?",
+                                       default=str(trilinos_default_source) if trilinos_default_source.exists() else "",
+                                       validate=is_valid_source_dir).ask()
+    trilinos_source = Path(trilinos_source)
+logger.debug(f"trilinos_source = {trilinos_source}")
+
+local_git_sha = subprocess.run(["git", "rev-parse", "HEAD"],
+                               capture_output=True, cwd=trilinos_source, universal_newlines=True).stdout[:-1]
+logger.debug(f"local_git_sha = {local_git_sha}")
+
+##################################################
+# Available builds
+
+pr_builds = parse_AT2_workflows(trilinos_source)
+logger.debug("pr_builds = \n" + pformat(pr_builds))
+assert pr_builds is not None and len(pr_builds) > 0
+
+##################################################
+# Get PR number
+
+if args.pr is not None:
+    pr_number = args.pr
+else:
+    upstream = get_github_upstream_of_local_branch(trilinos_source)
+    logger.debug(f"upstream = {upstream}")
+    if upstream is not None:
+        pr_number_default = get_pr_number(repo, upstream)
+    else:
+        pr_number_default = None
+    logger.debug(f"pr_number_default = {pr_number_default}")
+
+    pr_number = questionary.text("What is the number of the PR that should be reproduced?",
+                                 default=str(pr_number_default) if pr_number_default is not None else "",
+                                 validate=is_valid_pr_number).ask()
+    pr_number = convert_to_pr_number(pr_number)
+logger.debug(f"pr_number = {pr_number}")
+
+##################################################
+# Choose build
+
+if args.build is not None:
+    pr_build = args.build
+    assert pr_build in pr_builds, f"Specified build \"{pr_build}\" is not a known build. Known builds: {list(pr_builds.keys())}"
+else:
+    pr_build = questionary.select("Which PR build do you want to reproduce?", choices=pr_builds.keys()).ask()
+logger.debug(f"pr_build = {pr_build}")
+
+image = pr_builds[pr_build]["image"]
+tag = pr_builds[pr_build]["tag"]
+genconfig_build_id = pr_builds[pr_build]["genconfig_build_id"]
+logger.debug(f"image = {image}")
+logger.debug(f"tag = {tag}")
+logger.debug(f"genconfig_build_id = {genconfig_build_id}")
+
+##################################################
+# Retrieve PR information from Github
+
+g = Github()
+repo = g.get_repo(repo)
+pr = repo.get_pull(pr_number)
+pr_head_ref = pr.head.ref
+logger.debug(f"pr.head.sha = {pr.head.sha}")
+logger.debug(f"pr.merge_commit_sha = {pr.merge_commit_sha}")
+pr_base_ref = pr.base.ref
+logger.debug(f"pr_base_ref = {pr_base_ref}")
+
+if pr.head.sha != local_git_sha:
+    do_continue = questionary.confirm(f"The current commit SHA {local_git_sha} of the local repo does not match the SHA {pr.head.sha} of the PR. This might not be a problem if you made additional local changes. Continue?", default=True).ask()
+    if not do_continue:
+        exit()
+else:
+    logger.debug("Local commit SHA matches PR.")
+g.close()
+
+##################################################
+# Generate packageEnables.cmake
+
+packageEnablesFile = Path(".")/f'packageEnables-PR-{pr_number}.cmake'
+if packageEnablesFile.exists():
+    overwrite = questionary.confirm(f"File {packageEnablesFile} already exists. Overwrite?", default=True).ask()
+    if not overwrite:
+        questionary.print("Not overwriting file. Aborting.")
+        exit()
+
+logger.debug("Fetching target branch")
+subprocess.run(["git", "fetch", remote, f"{pr_base_ref}:{pr_number}-target"],
+               capture_output=True, cwd=trilinos_source, universal_newlines=True)
+logger.debug("Fetching merge branch")
+subprocess.run(["git", "fetch", remote, f"refs/pull/{pr_number}/merge:{pr_number}-merge"],
+               capture_output=True, cwd=trilinos_source, universal_newlines=True)
+
+output = generate_package_enables(trilinos_source, packageEnablesFile, f"{pr_number}-target", f"{pr_number}-merge")
+if not packageEnablesFile.exists():
+    logger.info("Output from script that generates CMake fragment with package enables:\n"+output)
+    assert False, "No package enables generated. Does the PR change any packages?"
+
+with open(packageEnablesFile, 'r') as f:
+    packageEnables = f.readlines()
+logger.debug(f"{packageEnablesFile}:" + ''.join(packageEnables))
+
+##################################################
+# Summary
+
+questionary.print(f"PR number:          {pr_number}")
+questionary.print(f"Title:              {pr.title}")
+questionary.print(f"Head ref:           {pr_head_ref}")
+questionary.print(f"Base ref:           {pr_base_ref}")
+questionary.print(f"Build:              {pr_build}")
+questionary.print(f"Container image:    {image}:{tag}")
+questionary.print(f"Genconfig build ID: {genconfig_build_id}")
+
+##################################################
+# Pull image
+
+image_avail = image_available(image, tag)
+logger.debug(f"image_avail = {image_avail}")
+if not image_avail:
+    pull_image(image, tag)
+
+##################################################
+# Launch container
+
+launch_container(trilinos_source, packageEnablesFile, image, tag, genconfig_build_id)

--- a/commonTools/pr_reproducer/reproducer.sh
+++ b/commonTools/pr_reproducer/reproducer.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# This script tries to install the Python dependencies before running pr_reproducer.py
+# This avoids having to provide instructions for installing dependencies.
+
+SCRIPT_DIR=`echo $BASH_SOURCE | sed "s/\(.*\)\/.*\.sh/\1/g"`
+TRILINOS_SOURCE_DIR=${SCRIPT_DIR}/../..
+
+if [[ ! -d ${SCRIPT_DIR}/.pr_reproducer_venv || ! -f ${SCRIPT_DIR}/.pr_reproducer_venv/succesful_install ]] ; then
+    rm -rf ${SCRIPT_DIR}/.pr_reproducer_venv
+    echo "Setting up a virtual environment in ${SCRIPT_DIR}/.pr_reproducer_venv"
+    echo ""
+    python3 -m venv ${SCRIPT_DIR}/.pr_reproducer_venv
+    source ${SCRIPT_DIR}/.pr_reproducer_venv/bin/activate
+    python3 -m pip install -r ${SCRIPT_DIR}/requirements.txt && touch ${SCRIPT_DIR}/.pr_reproducer_venv/succesful_install
+else
+    source ${SCRIPT_DIR}/.pr_reproducer_venv/bin/activate
+fi
+
+if [[ -f ${SCRIPT_DIR}/.pr_reproducer_venv/succesful_install ]] ; then
+    python3 ${SCRIPT_DIR}/pr_reproducer.py $*
+
+    deactivate
+else
+    deactivate
+
+    echo ""
+    echo "The installation of Python dependencies failed."
+    echo "One possible reason is that the used Python is too old. This script needs Python 3.9 or newer. This system has"
+    python3 --version
+
+    echo ""
+    echo "Another potential problem could be misconfigured certificates."
+    echo "You could try to set PIP_CERT to the location of your certificate bundle"
+    if [ -f /etc/ssl/certs/ca-bundle.crt ] ; then
+        echo "Try"
+        echo " export PIP_CERT=/etc/ssl/certs/ca-bundle.crt"
+    fi
+fi

--- a/commonTools/pr_reproducer/requirements.txt
+++ b/commonTools/pr_reproducer/requirements.txt
@@ -1,0 +1,3 @@
+PyYAML==6.0.2
+questionary==2.1.1
+PyGithub==2.6.1

--- a/commonTools/pr_reproducer/tools.py
+++ b/commonTools/pr_reproducer/tools.py
@@ -1,0 +1,199 @@
+import argparse
+from pathlib import Path
+import yaml
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+import os
+from shutil import which
+import subprocess
+from github import Github
+import logging
+logger = logging.getLogger(__name__)
+
+
+def is_valid_pr_number(s):
+    try:
+        pr_number = int(s)
+        return pr_number >= 1
+    except:
+        return False
+
+
+def convert_to_pr_number(v):
+    try:
+        pr_number = int(v)
+    except:
+        raise argparse.ArgumentTypeError(f"Cannot convert \"{v}\" to a valid PR number.")
+    if pr_number >= 1:
+        return pr_number
+    else:
+        raise argparse.ArgumentTypeError(f"Cannot convert \"{v}\" to a valid PR number.")
+
+
+def is_valid_source_dir(p):
+    return Path(p).exists() and (Path(p)/'.github'/'workflows'/'AT2.yml').exists()
+
+
+def convert_to_valid_source_dir(p):
+    if is_valid_source_dir(p):
+        return Path(p)
+    else:
+        raise argparse.ArgumentTypeError(f"Cannot convert \"{p}\" to a valid source directory.")
+
+
+def get_github_upstream_of_local_branch(source_dir):
+    try:
+        git_upstream = subprocess.run(["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+                                      capture_output=True, cwd=source_dir, universal_newlines=True).stdout[:-1]
+        git_upstream, git_upstream_branch = git_upstream.split('/')
+        git_push_url = subprocess.run(["git", "remote", "get-url", "--push", git_upstream],
+                                      capture_output=True, cwd=source_dir, universal_newlines=True).stdout[:-1]
+        git_repo = git_push_url.split(":")[-1]
+        git_owner = git_repo.split('/')[0]
+        head = f"{git_owner}:{git_upstream_branch}"
+        return head
+    except:
+        return None
+
+
+def get_pr_number(repo, upstream):
+    try:
+        g = Github()
+        repo = g.get_repo(repo)
+        pulls = repo.get_pulls(state='open', sort='created', base='develop', head=upstream)
+        pr_number = pulls[0].number
+        g.close()
+        return pr_number
+    except:
+        return None
+
+
+def parse_AT2_workflows(source_dir):
+    AT2_workflow = source_dir/'.github'/'workflows'/'AT2.yml'
+    assert AT2_workflow.exists()
+
+    with open(AT2_workflow, 'r') as f:
+        data = yaml.load(f, Loader=Loader)
+    pr_builds = {}
+
+    # loop over jobs
+    for jobname in data['jobs']:
+        logger.debug(f"Checking if \"{jobname}\" is a PR build job that can be reproduced")
+
+        job = data['jobs'][jobname]
+
+        if 'env' not in job:
+            logger.debug("no \"env\" attribute")
+            continue
+        env = job['env']
+
+        if 'IMAGE' not in env:
+            logger.debug("no \"IMAGE\" attribute")
+            continue
+        image, tag = env["IMAGE"].split(":")
+
+        if 'GENCONFIG_BUILD_NAME' not in env:
+            logger.debug("no \"GENCONFIG_BUILD_NAME\" attribute")
+            continue
+        genconfig_build_id = env["GENCONFIG_BUILD_NAME"]
+
+        pr_builds[jobname] = {"image": image,
+                              "tag": tag,
+                              "genconfig_build_id": genconfig_build_id}
+        logger.debug(f"\"{jobname}\" added")
+
+    return pr_builds
+
+
+def generate_package_enables(source_dir, packageEnablesFile, pr_base, pr_target, package_list_file=None):
+    cmd = [str(source_dir/"commonTools"/"framework"/"get-changed-trilinos-packages.sh"),
+           pr_base,
+           pr_target,
+           str(packageEnablesFile)]
+    if package_list_file is not None:
+        cmd += [str(package_list_file)]
+    out = subprocess.run(cmd,
+                         capture_output=True, cwd=packageEnablesFile.parent, universal_newlines=True).stdout[:-1]
+    return out
+
+
+def image_available(image, tag):
+    cmd = ["podman", "image", "exists", f"{image}:{tag}"]
+    ret = subprocess.run(cmd,
+                         capture_output=False, universal_newlines=True)
+    return ret.returncode == 0
+
+
+def pull_image(image, tag):
+    cmd = ["podman", "pull", f"{image}:{tag}"]
+    subprocess.run(cmd,
+                   capture_output=False, universal_newlines=True)
+
+
+def launch_container(source_dir, packageEnablesFile, image, tag, genconfig_build_id):
+    script_location = Path(os.path.abspath(__file__)).parent
+
+    # command
+    cmd = ["podman", "run"]
+    # delete container after exit
+    cmd += ["--rm"]
+    # interactive
+    cmd += ["-it"]
+    # mount source directory from host
+    cmd += ["-v", f"{source_dir}:/workspace/trilinos/source"]
+    # set environment variables for source, build and install directories
+    cmd += ["-e" "TRILINOS_DIR=/workspace/trilinos/source",
+            "-e" "TRILINOS_BUILD_DIR=/workspace/trilinos/build",
+            "-e" "TRILINOS_INSTALL_DIR=/workspace/trilinos/install"]
+    # mount package enables file
+    cmd += ["-v", f"{packageEnablesFile.absolute()}:/workspace/packageEnables.cmake"]
+    # set environment variable for GenConfig
+    cmd += ["-e" f"GENCONFIG_BUILD_ID={genconfig_build_id}"]
+    # mount script with environment
+    cmd += ["-v" f"{script_location}/container_commands.sh:/scripts/container_commands.sh:ro"]
+    # workdir
+    cmd += ["--workdir", "/workspace/trilinos"]
+    # map GPU
+    if which("nvidia-smi") is not None and image.find("cuda") >= 0:
+        cmd += ["--device", "nvidia.com/gpu=all"]
+
+    # deal with certificates
+    if Path("/etc/ssl/certs/ca-bundle.crt").exists():
+        cmd += ["-v", "/etc/ssl/certs/ca-bundle.crt:/certs/ca-bundle.crt:ro",
+                "-e", "SSL_CERT_FILE=/certs/ca-bundle.crt",
+                "-e", "PIP_CERT=/certs/ca-bundle.crt",
+                "-e", "CURL_CA_BUNDLE=/certs/ca-bundle.crt",
+                "-e", "REQUESTS_CA_BUNDLE=/certs/ca-bundle.crt"]
+    elif Path("/etc/ssl/certs/ca-certificates.crt").exists():
+        cmd += ["-v", "/etc/ssl/certs/ca-certificates.crt:/certs/ca-certificates.crt:ro",
+                "-e", "SSL_CERT_FILE=/certs/ca-certificates.crt",
+                "-e", "PIP_CERT=/certs/ca-certificates.crt",
+                "-e", "CURL_CA_BUNDLE=/certs/ca-certificates.crt",
+                "-e", "REQUESTS_CA_BUNDLE=/certs/ca-certificates.crt"]
+    else:
+        if "SSL_CERT_FILE" in os.environ:
+            ssl_cert_file = os.environ["SSL_CERT_FILE"]
+            cmd += ["-v", f"{ssl_cert_file}:/certs/ssl-cert.crt:ro",
+                    "-e", "SSL_CERT_FILE=/certs/ssl-cert.crt"]
+        if "PIP_CERT" in os.environ:
+            pip_cert = os.environ["PIP_CERT"]
+            cmd += ["-v", f"{pip_cert}:/certs/pip-cert.crt:ro",
+                    "-e", "PIP_CERT=/certs/pip-cert.crt"]
+        if "CURL_CA_BUNDLE" in os.environ:
+            curl_ca_bundle = os.environ["CURL_CA_BUNDLE"]
+            cmd += ["-v", f"{curl_ca_bundle}:/certs/curl-cert.crt:ro",
+                    "-e", "CURL_CA_BUNDLE=/certs/curl-cert.crt"]
+        if "REQUESTS_CA_BUNDLE" in os.environ:
+            requests_ca_bundle = os.environ["REQUESTS_CA_BUNDLE"]
+            cmd += ["-v", f"{requests_ca_bundle}:/certs/requests-cert.crt:ro",
+                    "-e", "REQUESTS_CA_BUNDLE=/certs/requests-cert.crt"]
+
+    # image to run
+    cmd += [f"{image}:{tag}"]
+    # command to be executed
+    cmd += ["bash", "-c", "echo \". /scripts/container_commands.sh\" >> $HOME/.bashrc; bash"]
+    logger.debug(f"podman command = {cmd}")
+    subprocess.run(cmd,
+                   capture_output=False, universal_newlines=True)


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Simplify reproducing PR builds. With this script it should be as easy as checking out the code and running 
```commonTools/pr_reproducer/reproducer.sh```
Sample output:
```
? Where is the Trilinos source code checked out? /home/caglusa/Trilinos
? What is the number of the PR that should be reproduced? 14742
? Which PR build do you want to reproduce? gcc14
PR number:          14742
Title:              nox,stokhos: namespace fixes for kokkos@5.0
Head ref:           arithtraits-ns-fixes
Base ref:           develop
Build:              gcc14
Container image:    registry-ex.sandia.gov/trilinos-project/trilinos-containers/production/ubi10-gcc-14:20250724
Genconfig build ID: rhel_gcc_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables

The Trilinos source repository is /workspace/trilinos/source
The build directory is            /workspace/trilinos/build
The install directory is          /workspace/trilinos/install

Available commands:
 clean_trilinos     -- cleans up CMake files and allows to configure from scratch
 get_dependencies   -- installs GenConfig dependencies
 configure_trilinos -- configures Trilinos using CMake
 build_trilinos     -- build Trilinos
 test_trilinos      -- runs tests
 install_trilinos   -- installs Trilinos
 reproduce_build    -- installs dependencies, configures, builds and tests

Normally, this is what you want to do:
 reproduce_build
```

For this to work I had to mess with the AT2 workflow and provide the image as an additional environment variable. The reason for this is that Github does not allow to download artifacts from workflows without logging in. The workflow summary is also not available.