### PR TITLE
ROL: fix access to Kokkos DynRankView

### DIFF
--- a/packages/rol/example/PDE-OPT/TOOLS/assemblerK_def.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/assemblerK_def.hpp
@@ -3161,8 +3161,7 @@ void Assembler<Real,DeviceType>::assembleParamFieldMatrix(ROL::Ptr<Tpetra::Multi
     // assembly on the overlap map
     for (int i=0; i<numCells_; ++i) {
       for (int j=0; j<numLocalDofs; ++j) {
-        matOverlap->sumIntoGlobalValue(cellDofs(myCellIds_[i],j),
-                                        k,(val[k])[i*numLocalDofs+j]);
+        matOverlap->sumIntoGlobalValue(cellDofs(myCellIds_[i],j), k,(val[k])(i,j));
       }
     }
     // change map


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/rol 

## Motivation
Accessing a DynRankView using operator [] is only allowed for rank-1 views.
Addresses issue in PR #14666

<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

@dridzal This is a one-line fix needed for 17.0 release. No sure what's the best procedure now that ROL is snapshot into Trilinos. 



