### PR TITLE
Tpetra CrsGraph: Remove very fine grained profiling regions

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -1460,8 +1460,6 @@ CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   typedef GlobalOrdinal GO;
   const char tfecfFuncName[] = "insertIndices: ";
 
-  Details::ProfilingRegion regionII("Tpetra::CrsGraph::insertIndices");
-
   size_t oldNumEnt = 0;
   if (debug_) {
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(lg != GlobalIndices && lg != LocalIndices, std::invalid_argument,
@@ -1572,8 +1570,6 @@ CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   using LO = LocalOrdinal;
   using GO = GlobalOrdinal;
 
-  Details::ProfilingRegion regionIGII("Tpetra::CrsGraph::insertGlobalIndicesImpl");
-
   const char tfecfFuncName[] = "insertGlobalIndicesImpl: ";
   const LO lclRow            = static_cast<LO>(rowInfo.localRow);
 
@@ -1638,8 +1634,6 @@ void CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   using Kokkos::View;
   using LO = LocalOrdinal;
 
-  Details::ProfilingRegion regionILII("Tpetra::CrsGraph::insertLocallIndicesImpl");
-
   const char tfecfFuncName[] = "insertLocallIndicesImpl: ";
 
   const RowInfo rowInfo = this->getRowInfo(myRow);
@@ -1699,8 +1693,6 @@ CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   using GO = GlobalOrdinal;
   using Kokkos::MemoryUnmanaged;
   using Kokkos::View;
-
-  Details::ProfilingRegion regionFGI("Tpetra::CrsGraph::findGlobalIndices");
 
   auto invalidCount = Teuchos::OrdinalTraits<size_t>::invalid();
 
@@ -2165,8 +2157,6 @@ void CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
                      size_t& numEntries) const {
   using Teuchos::ArrayView;
   const char tfecfFuncName[] = "getGlobalRowCopy: ";
-
-  Details::ProfilingRegion regionGGRC("Tpetra::CrsGraph::getGlobalRowCopy");
 
   // This does the right thing (reports an empty row) if the input
   // row is invalid.


### PR DESCRIPTION
@trilinos/tpetra

## Motivation
These regions might be the reason for recent slow-downs in the FEAssembly tests.

Testing in H100 with a single run of Tpetra's FE Assembly example on 1 rank with `TPETRA_USE_KOKKOS_PROFILING` set to `OFF` or `ON`.

| ref | profiling off | profiling on |
|--|--|--|
| develop | 51.8029s | 55.1983 s|
| #14545 reverted| 50.2623s | 50.9915s |
| this PR |48.9306s | 49.0529s |

We should discuss whether it's worthwhile enabling `TPETRA_USE_NEW_COPY_AND_PERMUTE=ON` by default. It looks like the profiling regions were already in the original PR #13714. So they could have caused the slowdown that lead to the revert in #13821.

Spot checking Tpetra FE Assembly, 4 ranks with `TPETRA_USE_NEW_COPY_AND_PERMUTE=ON`:

|ref | profiling off | profiling on |
|--|--|--|
| develop |  16.6965s| 16.5672s |
| this PR | 15.5084s | 15.2872s |