### PR TITLE
Downgrade minimum CMake version from 3.28 to 3.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 # To be safe, define your minimum CMake version.  This may be newer than the
 # min required by TriBITS.
-CMAKE_MINIMUM_REQUIRED(VERSION 3.28.0 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.27.0 FATAL_ERROR)
 
 # Must set the project name as a variable at very beginning before including anything else
 # We set the project name in a separate file so CTest scripts can use it.


### PR DESCRIPTION
@trilinos/framework 

## Motivation
It appears that several systems (in particular rhel8) only have 3.27.