### PR TITLE
Panzer: Disable memUtils test

### DIFF
--- a/packages/panzer/core/test/memUtils.cpp
+++ b/packages/panzer/core/test/memUtils.cpp
@@ -57,19 +57,22 @@ namespace panzer
     delete[] newDouble;
   } // end of TEUCHOS_UNIT_TEST()
 
+  // CAG: Test disabled since it failed on some systems. In all these failures
+  //      the peak memory usage was below the current one.
+
   // Test that the peak memory usage is always greater than the current memory
   // usage.
-  TEUCHOS_UNIT_TEST(memUtils, currentVsPeak)
-  {
-    Teuchos::RCP<const Teuchos::Comm<int> > comm =
-      Teuchos::DefaultComm<int>::getComm();
+  // TEUCHOS_UNIT_TEST(memUtils, currentVsPeak)
+  // {
+  //   Teuchos::RCP<const Teuchos::Comm<int> > comm =
+  //     Teuchos::DefaultComm<int>::getComm();
 
-    // Get the current and peak memory usage.
-    MemUsage mem = getMemoryUsage(*comm);
+  //   // Get the current and peak memory usage.
+  //   MemUsage mem = getMemoryUsage(*comm);
 
-    // Test that the peak usage is greater than the current usage.
-    TEST_COMPARE(mem.peakMin, >=, mem.currMin);
-    TEST_COMPARE(mem.peakMax, >=, mem.currMax);
-    TEST_COMPARE(mem.peakTot, >=, mem.currTot);
-  } // end of TEUCHOS_UNIT_TEST()
+  //   // Test that the peak usage is greater than the current usage.
+  //   TEST_COMPARE(mem.peakMin, >=, mem.currMin);
+  //   TEST_COMPARE(mem.peakMax, >=, mem.currMax);
+  //   TEST_COMPARE(mem.peakTot, >=, mem.currTot);
+  // } // end of TEUCHOS_UNIT_TEST()
 } // end namespace panzer


### PR DESCRIPTION
@trilinos/panzer 

## Motivation
The `memUtils` test fails on some of the runners because nonsensical memory usage is reported.