### PR TITLE
Tpetra: Move Harwell-Boeing reader to its own namespace

### DIFF
--- a/packages/anasazi/test/BlockDavidson/cxx_main_complex.cpp
+++ b/packages/anasazi/test/BlockDavidson/cxx_main_complex.cpp
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
   double *dvals;
   int *colptr,*rowind;
   nnz = -1;
-  info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+  info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
                               &colptr,&rowind,&dvals);
   if (info == 0 || nnz < 0) {
     if (verbose && MyPID == 0) {

--- a/packages/anasazi/test/BlockKrylovSchur/cxx_main_complex.cpp
+++ b/packages/anasazi/test/BlockKrylovSchur/cxx_main_complex.cpp
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
   double *dvals;
   int *colptr,*rowind;
   nnz = -1;
-  info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+  info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
                               &colptr,&rowind,&dvals);
   if (info == 0 || nnz < 0) {
     if (MyPID == 0) {

--- a/packages/anasazi/test/IRTR/cxx_main_complex.cpp
+++ b/packages/anasazi/test/IRTR/cxx_main_complex.cpp
@@ -94,7 +94,7 @@ int main(int argc, char *argv[])
   double *dvals;
   int *colptr,*rowind;
   nnz = -1;
-  info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+  info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
                               &colptr,&rowind,&dvals);
   if (info == 0 || nnz < 0) {
     if (verbose && MyPID == 0) {

--- a/packages/anasazi/test/LOBPCG/cxx_main_complex.cpp
+++ b/packages/anasazi/test/LOBPCG/cxx_main_complex.cpp
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
   double *dvals;
   int *colptr,*rowind;
   nnz = -1;
-  info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+  info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
                               &colptr,&rowind,&dvals);
   if (info == 0 || nnz < 0) {
     if (verbose && MyPID == 0) {

--- a/packages/anasazi/test/MVOPTester/cxx_main_complex.cpp
+++ b/packages/anasazi/test/MVOPTester/cxx_main_complex.cpp
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
   double *dvals;
   int *colptr,*rowind;
   nnz = -1;
-  info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
+  info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
   if (info == 0 || nnz < 0) {
     MyOM->stream(Anasazi::Warnings)
       << "Warning reading '" << filename << "'" << endl

--- a/packages/anasazi/test/OrthoManager/cxx_gentest_complex.cpp
+++ b/packages/anasazi/test/OrthoManager/cxx_gentest_complex.cpp
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
       double *dvals;
       int *colptr,*rowind;
       nnz = -1;
-      int info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+      int info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
           &colptr,&rowind,&dvals);
       TEUCHOS_TEST_FOR_EXCEPTION(info == 0 || nnz < 0, 
           std::runtime_error,

--- a/packages/anasazi/test/OrthoManager/cxx_main_complex.cpp
+++ b/packages/anasazi/test/OrthoManager/cxx_main_complex.cpp
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
       double *dvals;
       int *colptr,*rowind;
       nnz = -1;
-      int info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+      int info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
           &colptr,&rowind,&dvals);
       TEUCHOS_TEST_FOR_EXCEPTION(info == 0 || nnz < 0, 
           std::runtime_error,

--- a/packages/anasazi/test/OrthoManager/cxx_mattest_complex.cpp
+++ b/packages/anasazi/test/OrthoManager/cxx_mattest_complex.cpp
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
       double *dvals;
       int *colptr,*rowind;
       nnz = -1;
-      int info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+      int info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
           &colptr,&rowind,&dvals);
       TEUCHOS_TEST_FOR_EXCEPTION(info == 0 || nnz < 0, 
           std::runtime_error,

--- a/packages/anasazi/tpetra/test/BlockDavidson/cxx_main_complex.cpp
+++ b/packages/anasazi/tpetra/test/BlockDavidson/cxx_main_complex.cpp
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
 
     if (MyPID == 0) {
 
-      info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
+      info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
       // find maximum NNZ over all rows
       vector<int> rnnz(dim,0);
       for (int *ri=rowind; ri<rowind+nnz; ++ri) {

--- a/packages/anasazi/tpetra/test/BlockKrylovSchur/cxx_main_complex.cpp
+++ b/packages/anasazi/tpetra/test/BlockKrylovSchur/cxx_main_complex.cpp
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
     int info = 0;
     if (MyPID == 0) {
 
-      info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
+      info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
       // find maximum NNZ over all rows
       vector<int> rnnz(dim,0);
       for (int *ri=rowind; ri<rowind+nnz; ++ri) {

--- a/packages/anasazi/tpetra/test/IRTR/cxx_main_complex.cpp
+++ b/packages/anasazi/tpetra/test/IRTR/cxx_main_complex.cpp
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
   int *colptr,*rowind;
   nnz = -1;
   if (MyPID == 0) {
-    info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
+    info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
     // find maximum NNZ over all rows
     vector<int> rnnz(dim,0);
     for (int *ri=rowind; ri<rowind+nnz; ++ri) {

--- a/packages/anasazi/tpetra/test/LOBPCG/cxx_main_complex.cpp
+++ b/packages/anasazi/tpetra/test/LOBPCG/cxx_main_complex.cpp
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
 
     if (MyPID == 0) {
 
-      info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
+      info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
       // find maximum NNZ over all rows
       vector<int> rnnz(dim,0);
       for (int *ri=rowind; ri<rowind+nnz; ++ri) {

--- a/packages/anasazi/tpetra/test/OrthoManager/cxx_main_complex.cpp
+++ b/packages/anasazi/tpetra/test/OrthoManager/cxx_main_complex.cpp
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
       int *colptr,*rowind;
       nnz = -1;
       if (MyPID == 0) {
-        info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
+        info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
         // find maximum NNZ over all rows
         vector<int> rnnz(dim,0);
         for (int *ri=rowind; ri<rowind+nnz; ++ri) {

--- a/packages/anasazi/tpetra/test/OrthoManager/cxx_main_tsqr.cpp
+++ b/packages/anasazi/tpetra/test/OrthoManager/cxx_main_tsqr.cpp
@@ -267,7 +267,7 @@ main (int argc, char *argv[])
             // format) from the file into the tuple (numRows, numCols, nnz,
             // colptr, rowind, dvals).  The routine allocates memory for
             // colptr, rowind, and dvals using malloc().
-            info = readHB_newmat_double (filename.c_str(), &numRows, &numCols,
+            info = Tpetra::HB::readHB_newmat_double (filename.c_str(), &numRows, &numCols,
                                          &nnz, &colptr, &rowind, &dvals);
             // The Harwell-Boeing routines use info == 0 to signal failure.
             if (info != 0)

--- a/packages/anasazi/tpetra/test/Randomized/cxx_main_complex.cpp
+++ b/packages/anasazi/tpetra/test/Randomized/cxx_main_complex.cpp
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
     int *colptr,*rowind;
     nnz = -1;
     if (MyPID == 0) {
-      info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
+      info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
       // find maximum NNZ over all rows
       vector<int> rnnz(dim,0);
       for (int *ri=rowind; ri<rowind+nnz; ++ri) {

--- a/packages/belos/test/BlockCG/test_bl_cg_complex_hb.cpp
+++ b/packages/belos/test/BlockCG/test_bl_cg_complex_hb.cpp
@@ -90,7 +90,7 @@ int main(int argc, char *argv[]) {
     int *colptr,*rowind;
     ST *cvals;
     nnz = -1;
-    info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+    info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
         &colptr,&rowind,&dvals);
     if (info == 0 || nnz < 0) {
       if (MyPID==0) {

--- a/packages/belos/test/BlockCG/test_bl_cg_real_hb.cpp
+++ b/packages/belos/test/BlockCG/test_bl_cg_real_hb.cpp
@@ -92,7 +92,7 @@ int main(int argc, char *argv[]) {
     int *colptr,*rowind;
     ST *cvals;
     nnz = -1;
-    info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+    info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
         &colptr,&rowind,&cvals);
     if (info == 0 || nnz < 0) {
       if (MyPID==0) {

--- a/packages/belos/test/BlockGmres/test_bl_gmres_complex_hb.cpp
+++ b/packages/belos/test/BlockGmres/test_bl_gmres_complex_hb.cpp
@@ -100,7 +100,7 @@ int main(int argc, char *argv[]) {
     int *colptr,*rowind;
     ST *cvals;
     nnz = -1;
-    info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+    info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
         &colptr,&rowind,&dvals);
     if (info == 0 || nnz < 0) {
       if (MyPID==0) {

--- a/packages/belos/test/BlockGmres/test_hybrid_gmres_complex_hb.cpp
+++ b/packages/belos/test/BlockGmres/test_hybrid_gmres_complex_hb.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *argv[]) {
     int *colptr,*rowind;
     ST *cvals;
     nnz = -1;
-    info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+    info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
         &colptr,&rowind,&dvals);
     if (info == 0 || nnz < 0) {
       if (MyPID==0) {

--- a/packages/belos/test/GCRODR/test_gcrodr_complex_hb.cpp
+++ b/packages/belos/test/GCRODR/test_gcrodr_complex_hb.cpp
@@ -86,7 +86,7 @@ int main(int argc, char *argv[]) {
     int *colptr,*rowind;
     ST *cvals;
     nnz = -1;
-    info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+    info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
         &colptr,&rowind,&dvals);
     if (info == 0 || nnz < 0) {
       if (MyPID==0) {

--- a/packages/belos/test/MINRES/test_minres_complex_hb.cpp
+++ b/packages/belos/test/MINRES/test_minres_complex_hb.cpp
@@ -86,7 +86,7 @@ bool proc_verbose = false;
   int *colptr,*rowind;
   ST *cvals;
   nnz = -1;
-  info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+  info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
                               &colptr,&rowind,&dvals);
   if (info == 0 || nnz < 0) {
     if (MyPID==0) {

--- a/packages/belos/test/MVOPTester/cxx_main_complex.cpp
+++ b/packages/belos/test/MVOPTester/cxx_main_complex.cpp
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
     double *dvals;
     int *colptr,*rowind;
     nnz = -1;
-    info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
+    info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
     if (info == 0 || nnz < 0) {
       MyOM->stream(Belos::Warnings)
         << "Warning reading '" << filename << "'" << std::endl

--- a/packages/belos/test/TFQMR/test_pseudo_tfqmr_complex_hb.cpp
+++ b/packages/belos/test/TFQMR/test_pseudo_tfqmr_complex_hb.cpp
@@ -88,7 +88,7 @@ int main(int argc, char *argv[]) {
     int *colptr,*rowind;
     ST *cvals;
     nnz = -1;
-    info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+    info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
         &colptr,&rowind,&dvals);
     if (info == 0 || nnz < 0) {
       if (MyPID==0) {

--- a/packages/belos/test/TFQMR/test_tfqmr_complex_hb.cpp
+++ b/packages/belos/test/TFQMR/test_tfqmr_complex_hb.cpp
@@ -87,7 +87,7 @@ int main(int argc, char *argv[]) {
     int *colptr,*rowind;
     ST *cvals;
     nnz = -1;
-    info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+    info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
         &colptr,&rowind,&dvals);
     if (info == 0 || nnz < 0) {
       if (MyPID==0) {

--- a/packages/belos/tpetra/src/BelosTpetraTestFramework.hpp
+++ b/packages/belos/tpetra/src/BelosTpetraTestFramework.hpp
@@ -112,7 +112,7 @@ namespace Belos {
         int *colptr,*rowind;
         nnz = -1;
         if (MyPID == 0) {
-          info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
+          info = ::Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
           // find maximum NNZ over all rows
           std::vector<int> rnnz(dim,0);
           for (int *ri=rowind; ri<rowind+nnz; ++ri) {

--- a/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb_multiprec.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb_multiprec.cpp
@@ -242,7 +242,7 @@ int main(int argc, char *argv[])
   if (mptestmypid == 0) {
     int dim2;
     double *dvals;
-    info = readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
+    info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,&colptr,&rowind,&dvals);
     // Truncate data into float
     fvals = new float[nnz];
     std::copy( dvals, dvals+nnz, fvals );

--- a/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb_df.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb_df.cpp
@@ -228,7 +228,7 @@ int main(int argc, char *argv[])
   nnz = -1;
   if (mptestmypid == 0) {
     int dim2;
-    info = readHB_newmat_double(filename.c_str(),&mptestdim,&dim2,&nnz,&colptr,&rowind,&dvals);
+    info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&mptestdim,&dim2,&nnz,&colptr,&rowind,&dvals);
     // find maximum NNZ over all rows
     vector<int> rnnz(mptestdim,0);
     for (int *ri=rowind; ri<rowind+nnz; ++ri) {

--- a/packages/belos/tpetra/test/OrthoManager/belos_orthomanager_tpetra_util.hpp
+++ b/packages/belos/tpetra/test/OrthoManager/belos_orthomanager_tpetra_util.hpp
@@ -123,9 +123,9 @@ namespace Belos {
               // format) from the file into the tuple (loadedNumRows, numCols, nnz,
               // colptr, rowind, dvals).  The routine allocates memory for
               // colptr, rowind, and dvals using malloc().
-              info = readHB_newmat_double (filename.c_str(), &loadedNumRows,
-                                           &numCols, &nnz, &colptr, &rowind,
-                                           &dvals);
+              info = Tpetra::HB::readHB_newmat_double (filename.c_str(), &loadedNumRows,
+                                                       &numCols, &nnz, &colptr, &rowind,
+                                                       &dvals);
               // Make sure that loadedNumRows has a sensible value,
               // since we'll need to allocate an std::vector with that
               // many elements.

--- a/packages/tpetra/core/inout/Tpetra_Util_iohb.cpp
+++ b/packages/tpetra/core/inout/Tpetra_Util_iohb.cpp
@@ -219,9 +219,13 @@ Fri Aug 15 16:29:47 EDT 1997
 #include <cstring>
 #include <cmath>
 #include <cstdlib>
-using std::free;
-using std::malloc;
-using std::size_t;
+#include <cctype>
+
+namespace Tpetra::HB {
+
+using ::std::free;
+using ::std::malloc;
+using ::std::size_t;
 
 char* substr(const char* S, const int pos, const int len);
 void upcase(char* S);
@@ -1642,16 +1646,17 @@ char* substr(const char* S, const int pos, const int len) {
   return SubS;
 }
 
-#include <cctype>
 void upcase(char* S) {
   /*  Convert S to uppercase     */
   int i, len;
-  len = std::strlen(S);
+  len = ::std::strlen(S);
   for (i = 0; i < len; i++)
-    S[i] = std::toupper(S[i]);
+    S[i] = ::std::toupper(S[i]);
 }
 
 void IOHBTerminate(const char* message) {
-  std::fprintf(stderr, "%s", message);
-  std::exit(1);
+  ::std::fprintf(stderr, "%s", message);
+  ::std::exit(1);
 }
+
+}  // namespace Tpetra::HB

--- a/packages/tpetra/core/inout/Tpetra_Util_iohb.h
+++ b/packages/tpetra/core/inout/Tpetra_Util_iohb.h
@@ -53,6 +53,8 @@
 #include<cstdio>
 #include<cstdlib>
 
+namespace Tpetra::HB {
+
 int readHB_info(const char* filename, int* M, int* N, int* nz, char** Type, 
                                                       int* Nrhs);
 
@@ -103,5 +105,7 @@ int ParseIfmt(char* fmt, int* perline, int* width);
 int ParseRfmt(char* fmt, int* perline, int* width, int* prec, int* flag);
 
 void IOHBTerminate(char* message);
+
+}
 
 #endif


### PR DESCRIPTION
@trilinos/tpetra @trilinos/belos @trilinos/anasazi 

## Motivation
I copied the HB reader over from TriUtils before it got removed. On some older builds this caused issues with duplicate symbols. We should be able to backport this fix.