### PR TITLE
Tpetra: Ensure global variables don't have interal linkage

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Access.hpp
+++ b/packages/tpetra/core/src/Tpetra_Access.hpp
@@ -18,11 +18,11 @@ struct OverwriteAllStruct {};
 struct ReadWriteStruct {};
 
 // Tag indicating intent to read up-to-date data, but not modify.
-constexpr struct ReadOnlyStruct ReadOnly = ReadOnlyStruct();
+inline constexpr struct ReadOnlyStruct ReadOnly = ReadOnlyStruct();
 // Tag indicating intent to completely overwrite existing data.
-constexpr struct OverwriteAllStruct OverwriteAll = OverwriteAllStruct();
+inline constexpr struct OverwriteAllStruct OverwriteAll = OverwriteAllStruct();
 // Tag indicating intent to both read up-to-date data and modify it.
-constexpr struct ReadWriteStruct ReadWrite = ReadWriteStruct();
+inline constexpr struct ReadWriteStruct ReadWrite = ReadWriteStruct();
 }  // namespace Access
 }  // namespace Tpetra
 


### PR DESCRIPTION
@trilinos/tpetra

## Motivation

Defining `Tpetra::Access::ReadOnly/OverwriteAll/ReadWrite` as global variables with internal linkage doesn't play well with using these symbolds with C++20 modules. Making them `inline` fixes that issue.


## Testing

N/A