### PR TITLE
Tpetra: Don't use anonymous namespace in Tpetra_Map_def.hpp

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -39,10 +39,10 @@
 namespace Tpetra {
 namespace Impl {
 
-void checkMapInputArray(const char ctorName[],
-                        const void* indexList,
-                        const size_t indexListSize,
-                        const Teuchos::Comm<int>* const comm) {
+inline void checkMapInputArray(const char ctorName[],
+                               const void* indexList,
+                               const size_t indexListSize,
+                               const Teuchos::Comm<int>* const comm) {
   using Tpetra::Details::Behavior;
 
   const bool debug = Behavior::debug("Map");


### PR DESCRIPTION
@trilinos/tpetra

## Motivation
Similar to https://github.com/trilinos/Trilinos/pull/14822, using anonymous namespaces in header files is potentially problematic whem using C++20 modules even when the related symbols aren't explicitly exported.
```
In module 'dealii.external.trilinos' imported from /home/daniel/dealii/build/module/implementation_module_partitions/base/index_set.cc:39:
/usr/include/trilinos/Tpetra_Map_def.hpp:920:5: error: no matching function for call to 'checkMapInputArray'
  920 |     checkMapInputArray ("(GST, ArrayView, GO, comm)",
      |     ^~~~~~~~~~~~~~~~~~
/usr/include/trilinos/Teuchos_RCPDecl.hpp:1181:13: note: in instantiation of member function 'Tpetra::Map<>::Map' requested here
 1181 |         new T(std::forward<Args>(args)...)
      |             ^
1 error generated.
```
Using namespace `Impl` (or any other named namespace) instead fixes the issue.

## Related Issues
https://github.com/dealii/dealii/pull/19127#issuecomment-3687410637 is related.