### PR TITLE
Remove Epetra from doxygen config files

### DIFF
--- a/doc/build_docs.pl
+++ b/doc/build_docs.pl
@@ -146,6 +146,7 @@ sub buildDocs {
         print "$shortDir...\n";
         
         my $output = `$absFile 2>&1`;
+        print "$output\n\n";
         my $failed = $?;
     }    
     

--- a/packages/anasazi/doc/Doxyfile
+++ b/packages/anasazi/doc/Doxyfile
@@ -44,14 +44,14 @@ QUIET                  = NO
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_FORMAT            = "$file:$line: $text"
-INPUT                  = index.doc groups.doc ../src ../thyra/src ../epetra/src ../tpetra/src
+INPUT                  = index.doc groups.doc ../src ../thyra/src ../tpetra/src
 RECURSIVE              = YES
 EXCLUDE                = ../src/ModalAnalysisSolvers ../src/AnasaziDenseMatTraits.hpp ../src/AnasaziDirectSolver.hpp
 EXCLUDE_PATTERNS       = *.x *.o *.out
 #
 # Set up paths and patterns for examples
 #
-EXAMPLE_PATH           = ../epetra/example ../tpetra/example
+EXAMPLE_PATH           = ../tpetra/example
 EXAMPLE_RECURSIVE      = YES
 EXAMPLE_PATTERNS       = *.cpp *.hpp
 #
@@ -75,13 +75,13 @@ MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
 SEARCH_INCLUDES        = YES
 INCLUDE_FILE_PATTERNS  = 
-PREDEFINED             = DOXYGEN_COMPILE DOXYGEN_SHOULD_SKIP_THIS EPETRA_MPI Anasazi::StatusTest
+PREDEFINED             = DOXYGEN_COMPILE DOXYGEN_SHOULD_SKIP_THIS Anasazi::StatusTest
 INCLUDE_PATH           = ../src
 EXPAND_AS_DEFINED      = STANDARD_MEMBER_COMPOSITION_MEMBERS
 #
 # Links to other packages
 #
-TAGFILES               = ../../common/tag_files/epetra.tag=../../../epetra/doc/html ../../common/tag_files/teuchos.tag=../../../teuchos/doc/html ../../common/tag_files/ThyraInterfacesOperatorVectorANAFundamental.tag=../../../thyra/src/interfaces/operator_vector/ana/fundamental/doc/html
+TAGFILES               = ../../common/tag_files/teuchos.tag=../../../teuchos/doc/html ../../common/tag_files/ThyraInterfacesOperatorVectorANAFundamental.tag=../../../thyra/src/interfaces/operator_vector/ana/fundamental/doc/html
 GENERATE_TAGFILE       = ../../common/tag_files/anasazi.tag
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = NO

--- a/packages/belos/browser/doc/Doxyfile
+++ b/packages/belos/browser/doc/Doxyfile
@@ -2,7 +2,6 @@
 # Note: all relative paths are relative to package/doc!
 #
 @INCLUDE = Doxyfile.options
-@INCLUDE = epetraext/doc/BrowserTagFiles # Requires @INCLUDE_PAH=$(TRILINOS_HOME)/packages
 #
 # Override some options from Doxyfile.options
 #

--- a/packages/belos/doc/DoxyfileWeb
+++ b/packages/belos/doc/DoxyfileWeb
@@ -101,25 +101,7 @@ FILE_PATTERNS          = *.h *.hpp *.cpp
 RECURSIVE              = YES
 EXCLUDE                = 
 EXCLUDE_PATTERNS       = *.x *.o *.out
-EXAMPLE_PATH           = ../epetra/example \
-                         ../epetra/example/BlockCG/BlockCGEpetraExFile.cpp \
-                         ../epetra/example/BlockCG/BlockPrecCGEpetraExFile.cpp \
-                         ../epetra/example/BlockCG/PseudoBlockCGEpetraExFile.cpp \
-                         ../epetra/example/BlockCG/PseudoBlockPrecCGEpetraExFile.cpp \
-                         ../epetra/example/BlockGmres/BlockGmresEpetraExFile.cpp \
-                         ../epetra/example/BlockGmres/BlockPrecGmresEpetraExFile.cpp \
-                         ../epetra/example/BlockGmres/BlockFlexGmresEpetraExFile.cpp \
-                         ../epetra/example/BlockGmres/BlockGmresPolyEpetraExFile.cpp \
-                         ../epetra/example/BlockGmres/PseudoBlockGmresEpetraExFile.cpp \
-                         ../epetra/example/BlockGmres/PseudoBlockPrecGmresEpetraExFile.cpp \
-                         ../epetra/example/GCRODR/GCRODREpetraExFile.cpp \
-                         ../epetra/example/GCRODR/PrecGCRODREpetraExFile.cpp \
-                         ../epetra/example/RCG/RCGEpetraExFile.cpp \
-                         ../epetra/example/PCPG/PCPGEpetraExFile.cpp \
-                         ../epetra/example/TFQMR/TFQMREpetraExFile.cpp \
-                         ../epetra/example/TFQMR/PseudoBlockTFQMREpetraExFile.cpp \
-                         ../epetra/example/SolverFactory/SolverFactoryEpetraGaleriEx.cpp \
-                         ../tpetra/example \
+EXAMPLE_PATH           = ../tpetra/example \
                          ../tpetra/example/BlockCG/BlockCGTpetraExFile.cpp \
                          ../tpetra/example/BlockCG/PseudoBlockCGTpetraExFile.cpp \
                          ../tpetra/example/BlockGmres/PseudoBlockGmresTpetraExFile.cpp \
@@ -153,14 +135,14 @@ MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
 SEARCH_INCLUDES        = YES
 INCLUDE_FILE_PATTERNS  = 
-PREDEFINED             = DOXYGEN_COMPILE DOXYGEN_SHOULD_SKIP_THIS EPETRA_MPI
+PREDEFINED             = DOXYGEN_COMPILE DOXYGEN_SHOULD_SKIP_THIS
 INCLUDE_PATH           = ../../teuchos/src
 EXPAND_AS_DEFINED      = STANDARD_COMPOSITION_MEMBERS STANDARD_NONCONST_COMPOSITION_MEMBERS \
                          STANDARD_CONST_COMPOSITION_MEMBERS STANDARD_MEMBER_COMPOSITION_MEMBERS
 #
 # Links to other packages
 #
-TAGFILES               = ../../common/tag_files/epetra.tag=../../../epetra/doc/html ../../common/tag_files/teuchos.tag=../../../teuchos/doc/html 
+TAGFILES               = ../../common/tag_files/teuchos.tag=../../../teuchos/doc/html 
 GENERATE_TAGFILE       = ../../common/tag_files/belos.tag
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = NO

--- a/packages/galeri/browser/doc/Doxyfile
+++ b/packages/galeri/browser/doc/Doxyfile
@@ -2,7 +2,6 @@
 # Note: all relative paths are relative to package/doc!
 #
 @INCLUDE = Doxyfile.options
-@INCLUDE = epetra/doc/BrowserTagFiles # Requires @INCLUDE_PAH=$(TRILINOS_HOME)/packages
 #
 # Override some options from Doxyfile.options
 #

--- a/packages/ifpack2/doc/Doxyfile
+++ b/packages/ifpack2/doc/Doxyfile
@@ -1198,7 +1198,7 @@ SKIP_FUNCTION_MACROS   = YES
 # If a tag file is not located in the directory in which doxygen 
 # is run, you must also specify the path to the tagfile here.
 
-TAGFILES               = ../../common/tag_files/teuchos.tag=../../../teuchos/doc/html ../../common/tag_files/epetra.tag=../../../epetra/doc/html \
+TAGFILES               = ../../common/tag_files/teuchos.tag=../../../teuchos/doc/html \
                          ../../common/tag_files/belos.tag=../../../belos/doc/html ../../common/tag_files/anasazi.tag=../../../anasazi/doc/html 
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create 

--- a/packages/muelu/doc/Doxyfile.options
+++ b/packages/muelu/doc/Doxyfile.options
@@ -264,22 +264,15 @@ INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = DOXYGEN_COMPILE \
                          DOXYGEN_SHOULD_SKIP_THIS \
                          HAVE_MPI \
-                         EPETRA_MPI \
-                         HAVE_MUELU_AMESOS \
                          HAVE_MUELU_AMESOS2 \
                          HAVE_MUELU_AMGX \
                          HAVE_MUELU_AZTECOO \
                          HAVE_MUELU_BELOS \
                          HAVE_MUELU_BOOST \
-                         HAVE_MUELU_EPETRA \
-                         HAVE_MUELU_EPETRAEXT \
                          HAVE_MUELU_EXPERIMENTAL \
                          HAVE_MUELU_GALERI \
-                         HAVE_MUELU_IFPACK \
                          HAVE_MUELU_IFPACK2 \
-                         HAVE_MUELU_ISORROPIA \
                          HAVE_MUELU_MATLAB \
-                         HAVE_MUELU_ML \
                          HAVE_MUELU_STRATIMIKOS \
                          HAVE_MUELU_TEKO \
                          HAVE_MUELU_TPETRA \
@@ -294,8 +287,6 @@ TAGFILES               = $(TRILINOS_HOME)/packages/common/tag_files/ifpack.tag=$
                          $(TRILINOS_HOME)/packages/common/tag_files/ifpack2.tag=$(TRILINOS_HOME)/packages/ifpack2/doc/html \
                          $(TRILINOS_HOME)/packages/common/tag_files/amesos.tag=$(TRILINOS_HOME)/packages/amesos/doc/html \
                          $(TRILINOS_HOME)/packages/common/tag_files/teuchos.tag=$(TRILINOS_HOME)/packages/teuchos/doc/html \
-                         $(TRILINOS_HOME)/packages/common/tag_files/epetraext.tag=$(TRILINOS_HOME)/packages/epetraext/doc/html \
-                         $(TRILINOS_HOME)/packages/common/tag_files/epetra.tag=$(TRILINOS_HOME)/packages/epetra/doc/html \
                          $(TRILINOS_HOME)/packages/common/tag_files/tpetra.tag=$(TRILINOS_HOME)/packages/tpetra/doc/html \
                          $(TRILINOS_HOME)/packages/common/tag_files/xpetra.tag=$(TRILINOS_HOME)/packages/xpetra/doc/html
 GENERATE_TAGFILE       = $(TRILINOS_HOME)/packages/common/tag_files/muelu.tag

--- a/packages/nox/doc/Doxyfile.default
+++ b/packages/nox/doc/Doxyfile.default
@@ -461,14 +461,12 @@ WARN_LOGFILE           =
 
 INPUT                  = ../src \
                          ../src-lapack \
-                         ../src-epetra \
                          ../src-thyra \
                          ../src-petsc \
                          ../src-belos \
                          ../src-loca/src \
                          ../src-loca/src-lapack \
-                         ../src-loca/src-thyra \
-                         ../src-loca/src-epetra
+                         ../src-loca/src-thyra
 
 # If the value of the INPUT tag contains directories, you can use the
 # FILE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp

--- a/packages/nox/doc/Doxyfile.in
+++ b/packages/nox/doc/Doxyfile.in
@@ -461,14 +461,12 @@ WARN_LOGFILE           =
 
 INPUT                  = ../src \
                          ../src-lapack \
-                         ../src-epetra \
                          ../src-thyra \
                          ../src-petsc \
                          ../src-belos \
                          ../src-loca/src \
                          ../src-loca/src-lapack \
-                         ../src-loca/src-thyra \
-                         ../src-loca/src-epetra
+                         ../src-loca/src-thyra
 
 # If the value of the INPUT tag contains directories, you can use the
 # FILE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp
@@ -1018,7 +1016,6 @@ INCLUDE_FILE_PATTERNS  =
 # instead of the = operator.
 
 PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS \
-             HAVE_NOX_EPETRAEXT \
              HAVE_NOX_STRATIMIKOS \
                          @WITH_PRERELEASE_SUBST@
 

--- a/packages/nox/doc/DoxyfileWeb
+++ b/packages/nox/doc/DoxyfileWeb
@@ -44,18 +44,15 @@ PROJECT_NAME           = NOX
 
 INPUT                  = ../src
 INPUT                 += ../src-loca
-INPUT                 += ../src-epetra
 INPUT                 += ../src-thyra
 INPUT                 += ../src-petsc
 INPUT                 += ../src-lapack
 INPUT                 += ../src-loca/src
 INPUT                 += ../src-loca/src-lapack
-INPUT                 += ../src-loca/src-epetra
 INPUT                 += ../src-loca/src-thyra
 
 FILE_PATTERNS          = *.H *.C *.hpp *.cpp
 
-TAGFILES               = ../../common/tag_files/epetra.tag=../../../epetra/doc/html
 TAGFILES              += ../../common/tag_files/teuchos.tag=../../../teuchos/doc/html
 
 GENERATE_TAGFILE       = ../../common/tag_files/nox.tag

--- a/packages/panzer/doc/Doxyfile
+++ b/packages/panzer/doc/Doxyfile
@@ -3,13 +3,7 @@
 @INCLUDE = Doxyfile.options
 TAGFILES += \
   $(TRILINOS_HOME)/packages/common/tag_files/teuchos.tag=$(TRILINOS_HOME)/packages/teuchos/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/epetra.tag=$(TRILINOS_HOME)/packages/epetra/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/epetraext.tag=$(TRILINOS_HOME)/packages/epetraext/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/amesos.tag=$(TRILINOS_HOME)/packages/amesos/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/aztecoo.tag=$(TRILINOS_HOME)/packages/aztecoo/doc/html \
   $(TRILINOS_HOME)/packages/common/tag_files/belos.tag=$(TRILINOS_HOME)/packages/belos/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/ifpack.tag=$(TRILINOS_HOME)/packages/ifpack/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/ml.tag=$(TRILINOS_HOME)/packages/ml/doc/html \
   $(TRILINOS_HOME)/packages/common/tag_files/nox.tag=$(TRILINOS_HOME)/packages/nox/doc/html \
   $(TRILINOS_HOME)/packages/common/tag_files/phalanx.tag=$(TRILINOS_HOME)/packages/phalanx/doc/html
 #

--- a/packages/sacado/browser/doc/Doxyfile
+++ b/packages/sacado/browser/doc/Doxyfile
@@ -2,7 +2,6 @@
 # Note: all relative paths are relative to package/doc!
 #
 @INCLUDE = Doxyfile.options
-@INCLUDE = epetra/doc/BrowserTagFiles # Requires @INCLUDE_PAH=$(TRILINOS_HOME)/packages
 #
 # Override some options from Doxyfile.options
 #

--- a/packages/sacado/doc/Doxyfile
+++ b/packages/sacado/doc/Doxyfile
@@ -551,7 +551,7 @@ INCLUDE_FILE_PATTERNS  =
 # or name=definition (no spaces). If the definition and the = are 
 # omitted =1 is assumed. 
 
-PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS EPETRA_MPI
+PREDEFINED             = DOXYGEN_SHOULD_SKIP_THIS
 
 # If the MACRO_EXPANSION and EXPAND_PREDEF_ONLY tags are set to YES then 
 # this tag can be used to specify a list of macro names that should be expanded. 

--- a/packages/sacado/doc/TagFiles
+++ b/packages/sacado/doc/TagFiles
@@ -1,3 +1,2 @@
-@INCLUDE = epetra/doc/TagFiles   # Requires @INCLUDE_PATH=$(TRILINOS_HOME)/packages
 TAGFILES += \
   $(TRILINOS_HOME)/packages/common/tag_files/sacado.tag=$(TRILINOS_HOME)/packages/sacado/doc/html

--- a/packages/shylu/doc/Doxyfile
+++ b/packages/shylu/doc/Doxyfile
@@ -46,7 +46,7 @@ WARNINGS             = YES
 WARN_IF_UNDOCUMENTED = YES
 WARN_FORMAT          = "$file:$line: $text"
 
-INPUT                = . ../core/src/epetra  ../core/src/interfaces ../ichol/src
+INPUT                = . ../core/src/interfaces ../ichol/src
 FILE_PATTERNS        = *.hpp *.h *.cpp *.c *.dox
 RECURSIVE            = YES
 EXCLUDE              = .git build
@@ -105,7 +105,6 @@ EXPAND_AS_DEFINED      =
 
 TAGFILES = \
   $(TRILINOS_HOME)/packages/common/tag_files/teuchos.tag=../$(TRILINOS_HOME)/packages/teuchos/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/epetra.tag=../$(TRILINOS_HOME)/packages/epetra/doc/html \
   $(TRILINOS_HOME)/packages/common/tag_files/tpetra.tag=../$(TRILINOS_HOME)/packages/tpetra/doc/html \
   $(TRILINOS_HOME)/packages/common/tag_files/kokkos.tag=../$(TRILINOS_HOME)/packages/kokkos/doc/html 
 

--- a/packages/stokhos/browser/doc/Doxyfile
+++ b/packages/stokhos/browser/doc/Doxyfile
@@ -2,7 +2,6 @@
 # Note: all relative paths are relative to package/doc!
 #
 @INCLUDE = Doxyfile.options
-@INCLUDE = epetra/doc/BrowserTagFiles # Requires @INCLUDE_PAH=$(TRILINOS_HOME)/packages
 #
 # Override some options from Doxyfile.options
 #

--- a/packages/stokhos/doc/TagFiles
+++ b/packages/stokhos/doc/TagFiles
@@ -1,3 +1,2 @@
-@INCLUDE = epetra/doc/TagFiles   # Requires @INCLUDE_PATH=$(TRILINOS_HOME)/packages
 TAGFILES += \
   $(TRILINOS_HOME)/packages/common/tag_files/stokhos.tag=$(TRILINOS_HOME)/packages/stokhos/doc/html

--- a/packages/stratimikos/adapters/amesos/doc/Doxyfile
+++ b/packages/stratimikos/adapters/amesos/doc/Doxyfile
@@ -2,7 +2,6 @@
 # Note: all relative paths are relative to package/doc!
 #
 @INCLUDE = Doxyfile.options
-@INCLUDE = epetra/doc/TagFiles # Requires @INCLUDE_PATH=$(TRILINOS_HOME)/packages
 #
 # Package options
 #

--- a/packages/stratimikos/adapters/aztecoo/doc/Doxyfile
+++ b/packages/stratimikos/adapters/aztecoo/doc/Doxyfile
@@ -2,7 +2,6 @@
 # Note: all relative paths are relative to package/doc!
 #
 @INCLUDE = Doxyfile.options
-@INCLUDE = epetra/doc/TagFiles # Requires @INCLUDE_PATH=$(TRILINOS_HOME)/packages
 #
 # Package options
 #

--- a/packages/stratimikos/adapters/belos/doc/Doxyfile
+++ b/packages/stratimikos/adapters/belos/doc/Doxyfile
@@ -2,7 +2,6 @@
 # Note: all relative paths are relative to package/doc!
 #
 @INCLUDE = Doxyfile.options
-#@INCLUDE = epetra/doc/TagFiles # Requires @INCLUDE_PATH=$(TRILINOS_HOME)/packages
 #
 # Package options
 #
@@ -27,7 +26,7 @@ IGNORE_PREFIX          =
 #
 # Links to other packages
 #
-TAGFILES               += ../../common/tag_files/amesos.tag=../../../doc/html ../../common/tag_files/teuchos.tag=../../../teuchos/doc/html ../../common/tag_files/amesos.tag=../../../epetra/doc/html 
+TAGFILES               += ../../common/tag_files/teuchos.tag=../../../teuchos/doc/html 
 # TAGFILES               = 
 GENERATE_TAGFILE       = ../../common/tag_files/BelosThyra.tag
 ALLEXTERNALS           = NO

--- a/packages/stratimikos/doc/Doxyfile
+++ b/packages/stratimikos/doc/Doxyfile
@@ -6,17 +6,8 @@
 # Note: I have to manually include these tag files because if I used the TagFile from
 # each package then doxygen hangs.
 TAGFILES += \
-  $(TRILINOS_HOME)/packages/common/tag_files/epetra.tag=$(TRILINOS_HOME)/packages/epetra/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/EpetraThyra.tag=$(TRILINOS_HOME)/packages/epetra/thyra/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/epetraext.tag=$(TRILINOS_HOME)/packages/epetraext/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/EpetraExtThyra.tag=$(TRILINOS_HOME)/packages/epetraext/thyra/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/amesos.tag=$(TRILINOS_HOME)/packages/amesos/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/AmesosThyra.tag=$(TRILINOS_HOME)/packages/amesos/thyra/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/aztecoo.tag=$(TRILINOS_HOME)/packages/aztecoo/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/AztecOOThyra.tag=$(TRILINOS_HOME)/packages/aztecoo/thyra/doc/html \
   $(TRILINOS_HOME)/packages/common/tag_files/belos.tag=$(TRILINOS_HOME)/packages/belos/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/BelosThyra.tag=$(TRILINOS_HOME)/packages/belos/thyra/doc/html \
-  $(TRILINOS_HOME)/packages/common/tag_files/ifpack.tag=$(TRILINOS_HOME)/packages/ifpack/doc/html
+  $(TRILINOS_HOME)/packages/common/tag_files/BelosThyra.tag=$(TRILINOS_HOME)/packages/belos/thyra/doc/html
 #
 # Package options
 #

--- a/packages/stratimikos/doc/TagFiles
+++ b/packages/stratimikos/doc/TagFiles
@@ -1,7 +1,4 @@
 @INCLUDE=thyra/doc/TagFiles # Requires @INCLUDE_PAH=$(TRILINOS_HOME)/packages
-@INCLUDE=amesos/doc/TagFiles # Requires @INCLUDE_PAH=$(TRILINOS_HOME)/packages
-@INCLUDE=aztecoo/doc/TagFiles # Requires @INCLUDE_PAH=$(TRILINOS_HOME)/packages
 @INCLUDE=belos/doc/TagFiles # Requires @INCLUDE_PAH=$(TRILINOS_HOME)/packages
-@INCLUDE=ifpack/doc/TagFiles # Requires @INCLUDE_PAH=$(TRILINOS_HOME)/packages
 TAGFILES += \
   $(TRILINOS_HOME)/packages/common/tag_files/stratimikos.tag=$(TRILINOS_HOME)/packages/stratimikos/doc/html

--- a/packages/thyra/doc/Doxyfile
+++ b/packages/thyra/doc/Doxyfile
@@ -3,7 +3,6 @@
 #
 @INCLUDE = Doxyfile.options
 @INCLUDE = rtop/doc/TagFiles # Requires @INCLUDE_PAH=$(TRILINOS_HOME)/packages
-@INCLUDE = epetra/doc/TagFiles
 @INCLUDE = tpetra/core/doc/TagFiles
 #
 # Package options
@@ -15,7 +14,6 @@ OUTPUT_DIRECTORY       = .
 #
 
 #INPUT                  = ./index.doc ./faq.doc ./groups.doc ./dirs.doc \
-#                         ../adapters/epetraext/src \
 
 INPUT                  = ./index.doc \
                          ./faq.doc \
@@ -32,9 +30,6 @@ INPUT                  = ./index.doc \
                          ../core/src/support/operator_solve/client_support \
                          ../core/src/support/nonlinear/model_evaluator/client_support \
                          ../core/src/support/nonlinear/solvers/client_support \
-                         ../adapters/epetra/src \
-                         ../adapters/epetraext/src/model_evaluator \
-                         ../adapters/epetraext/src/transformer \
                          ../adapters/tpetra/src \
                          ../core/example/operator_vector/exampleImplicitlyComposedLinearOperators.cpp \
                          ../core/example/operator_vector/ExampleTridiagSerialLinearOp.hpp \

--- a/packages/thyra/doc/TagFiles
+++ b/packages/thyra/doc/TagFiles
@@ -1,4 +1,3 @@
 @INCLUDE = rtop/doc/TagFiles   # Requires @INCLUDE_PATH=$(TRILINOS_HOME)/packages
-@INCLUDE = epetra/doc/TagFiles
 @INCLUDE = tpetra/core/doc/TagFiles
 TAGFILES += $(TRILINOS_HOME)/packages/common/tag_files/Thyra.tag=$(TRILINOS_HOME)/packages/thyra/doc/html

--- a/packages/trilinoscouplings/doc/TagFiles
+++ b/packages/trilinoscouplings/doc/TagFiles
@@ -1,3 +1,2 @@
-@INCLUDE = epetra/doc/TagFiles   # Requires @INCLUDE_PATH=$(TRILINOS_HOME)/packages
 TAGFILES += \
   $(TRILINOS_HOME)/packages/common/tag_files/trilinoscouplings.tag=$(TRILINOS_HOME)/packages/trilinoscouplings/doc/html


### PR DESCRIPTION
## Motivation
References to no longer existing Epetra package includes in Doxygen configurations silently crashed the generation of documentation. This PR removes references to Epetra stack packages from Doxyfiles.