### PR TITLE
Intrepid2: fix creation of views of fad types

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellGeometryDef.hpp
@@ -175,7 +175,7 @@ namespace Intrepid2
         
         int cellTypeModulus = uniformJacobianModulus();
         
-        data = createDynRankViewFromView(pointComponentView, "CellGeometryProvider: Jacobian data", cellTypeModulus, spaceDim, spaceDim);
+        data = Impl::createMatchingDynRankView(pointComponentView, "CellGeometryProvider: Jacobian data", cellTypeModulus, spaceDim, spaceDim);
       }
       else
       {
@@ -184,7 +184,7 @@ namespace Intrepid2
         variationType[D2_DIM] = BLOCK_PLUS_DIAGONAL;
         blockPlusDiagonalLastNonDiagonal = -1;
         
-        data = createDynRankViewFromView(pointComponentView, "CellGeometryProvider: Jacobian data", spaceDim);
+        data = Impl::createMatchingDynRankView(pointComponentView, "CellGeometryProvider: Jacobian data", spaceDim);
       }
     }
     else if (cellGeometryType_ == TENSOR_GRID)
@@ -201,7 +201,7 @@ namespace Intrepid2
         variationType[D1_DIM]    = GENERAL;
         variationType[D2_DIM]    = GENERAL;
         
-        data = createDynRankViewFromView(data, "CellGeometryProvider: Jacobian data", numCells_, spaceDim, spaceDim);
+        data = Impl::createMatchingDynRankView(data, "CellGeometryProvider: Jacobian data", numCells_, spaceDim, spaceDim);
       }
       else
       {
@@ -212,12 +212,12 @@ namespace Intrepid2
         {
           // no point variation
           variationType[POINT_DIM] = CONSTANT;
-          data = createDynRankViewFromView(data, "CellGeometryProvider: Jacobian data", numCellsWorkset, spaceDim, spaceDim);
+          data = Impl::createMatchingDynRankView(data, "CellGeometryProvider: Jacobian data", numCellsWorkset, spaceDim, spaceDim);
         }
         else
         {
           variationType[POINT_DIM] = GENERAL;
-          data = createDynRankViewFromView(data, "CellGeometryProvider: Jacobian data", numCellsWorkset, pointsPerCell, spaceDim, spaceDim);
+          data = Impl::createMatchingDynRankView(data, "CellGeometryProvider: Jacobian data", numCellsWorkset, pointsPerCell, spaceDim, spaceDim);
         }
       }
     }
@@ -228,7 +228,7 @@ namespace Intrepid2
       variationType[POINT_DIM] = GENERAL;
       variationType[D1_DIM]    = GENERAL;
       variationType[D2_DIM]    = GENERAL;
-      data = createDynRankViewFromView(data, "CellGeometryProvider: Jacobian data", numCellsWorkset, pointsPerCell, spaceDim, spaceDim);
+      data = Impl::createMatchingDynRankView(data, "CellGeometryProvider: Jacobian data", numCellsWorkset, pointsPerCell, spaceDim, spaceDim);
     }
     else
     {
@@ -335,8 +335,8 @@ namespace Intrepid2
 
           // TODO: find an allocation-free way to do this… (consider modifying CellTools::setJacobian() to support affine case.)
           const int onePoint = 1;
-          auto testPointView = createDynRankViewFromView(dataView3, "CellGeometryProvider: test point", onePoint, spaceDim);
-          auto tempData      = createDynRankViewFromView(dataView3, "CellGeometryProvider: temporary Jacobian data", numCellsWorkset, onePoint, spaceDim, spaceDim);
+          auto testPointView = Impl::createMatchingDynRankView(dataView3, "CellGeometryProvider: test point", onePoint, spaceDim);
+          auto tempData      = Impl::createMatchingDynRankView(dataView3, "CellGeometryProvider: temporary Jacobian data", numCellsWorkset, onePoint, spaceDim, spaceDim);
           
           Kokkos::deep_copy(testPointView, 0.0);
           
@@ -840,8 +840,8 @@ namespace Intrepid2
             const int numPoints = points.extent_int(1);
             const int numFields = basisForNodes->getCardinality();
             
-            auto cellBasisGradientsView = createDynRankViewFromView(points, "CellGeometryProvider: cellBasisGradients", numCells, numFields, numPoints, spaceDim);
-            auto basisGradientsView     = createDynRankViewFromView(points, "CellGeometryProvider: basisGradients", numFields, numPoints, spaceDim);
+            auto cellBasisGradientsView = Impl::createMatchingDynRankView(points, "CellGeometryProvider: cellBasisGradients", numCells, numFields, numPoints, spaceDim);
+            auto basisGradientsView     = Impl::createMatchingDynRankView(points, "CellGeometryProvider: basisGradients", numFields, numPoints, spaceDim);
             
             for (int cellOrdinal=0; cellOrdinal<numCells; cellOrdinal++)
             {
@@ -923,7 +923,7 @@ namespace Intrepid2
           // and/or very high polynomial order.)
           
           auto firstPointComponentView = points.getTensorComponent(0); // (P,D0)
-          auto basisGradientsView = createDynRankViewFromView(firstPointComponentView, "CellGeometryProvider: temporary basisGradients", numFields, numPoints, spaceDim);
+          auto basisGradientsView = Impl::createMatchingDynRankView(firstPointComponentView, "CellGeometryProvider: temporary basisGradients", numFields, numPoints, spaceDim);
           
           using ExecutionSpace = typename DeviceType::execution_space;
           auto policy = Kokkos::MDRangePolicy<ExecutionSpace,Kokkos::Rank<3>>({0,0,0},{numFields,numPoints,spaceDim});

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefInclusion.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefInclusion.hpp
@@ -245,13 +245,13 @@ namespace Intrepid2 {
       numPoints = points.extent(points.rank()-2), 
       spaceDim = cellTopo.getDimension();
 
-    auto refPoints = createDynRankViewFromView(points, "CellTools::checkPointwiseInclusion::refPoints", numCells, numPoints, spaceDim);
+    auto refPoints = Impl::createMatchingDynRankView(points, "CellTools::checkPointwiseInclusion::refPoints", numCells, numPoints, spaceDim);
     
     // expect refPoints(CPD), points (CPD or PD), cellWorkset(CND) 
     if(points.rank() == 3)  
       mapToReferenceFrame(refPoints, points, cellWorkset, cellTopo);
     else { //points.rank() == 2
-      auto cellPoints = createDynRankViewFromView(points, "CellTools::checkPointwiseInclusion::physCellPoints", numCells, numPoints, spaceDim);
+      auto cellPoints = Impl::createMatchingDynRankView(points, "CellTools::checkPointwiseInclusion::physCellPoints", numCells, numPoints, spaceDim);
       RealSpaceTools<DeviceType>::clone(cellPoints,points);
       mapToReferenceFrame(refPoints, cellPoints, cellWorkset, cellTopo);
     }    

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
@@ -104,19 +104,19 @@ namespace Intrepid2 {
     if ( cellVaries && pointVaries )
     {
       auto data = jacobian.getUnderlyingView4();
-      auto detData = createDynRankViewFromView(data, "Jacobian det data", data.extent_int(0), data.extent_int(1));
+      auto detData = Impl::createMatchingDynRankView(data, "Jacobian det data", data.extent_int(0), data.extent_int(1));
       return Data<PointScalar,DeviceType>(detData,2,extents,variationTypes);
     }
     else if (cellVaries || pointVaries)
     {
       auto data = jacobian.getUnderlyingView3();
-      auto detData = createDynRankViewFromView(data, "Jacobian det data", data.extent_int(0));
+      auto detData = Impl::createMatchingDynRankView(data, "Jacobian det data", data.extent_int(0));
       return Data<PointScalar,DeviceType>(detData,2,extents,variationTypes);
     }
     else
     {
       auto data = jacobian.getUnderlyingView1();
-      auto detData = createDynRankViewFromView(data, "Jacobian det data", 1);
+      auto detData = Impl::createMatchingDynRankView(data, "Jacobian det data", 1);
       return Data<PointScalar,DeviceType>(detData,2,extents,variationTypes);
     }
   }
@@ -132,25 +132,25 @@ namespace Intrepid2 {
     if ( jacDataRank == 4 )
     {
       auto jacData = jacobian.getUnderlyingView4();
-      auto invData = createDynRankViewFromView(jacData, "Jacobian inv data",jacData.extent(0),jacData.extent(1),jacData.extent(2),jacData.extent(3));
+      auto invData = Impl::createMatchingDynRankView(jacData, "Jacobian inv data",jacData.extent(0),jacData.extent(1),jacData.extent(2),jacData.extent(3));
       return Data<PointScalar,DeviceType>(invData,4,extents,variationTypes);
     }
     else if (jacDataRank == 3)
     {
       auto jacData = jacobian.getUnderlyingView3();
-      auto invData = createDynRankViewFromView(jacData, "Jacobian inv data",jacData.extent(0),jacData.extent(1),jacData.extent(2));
+      auto invData = Impl::createMatchingDynRankView(jacData, "Jacobian inv data",jacData.extent(0),jacData.extent(1),jacData.extent(2));
       return Data<PointScalar,DeviceType>(invData,4,extents,variationTypes);
     }
     else if (jacDataRank == 2)
     {
       auto jacData = jacobian.getUnderlyingView2();
-      auto invData = createDynRankViewFromView(jacData, "Jacobian inv data",jacData.extent(0),jacData.extent(1));
+      auto invData = Impl::createMatchingDynRankView(jacData, "Jacobian inv data",jacData.extent(0),jacData.extent(1));
       return Data<PointScalar,DeviceType>(invData,4,extents,variationTypes);
     }
     else if (jacDataRank == 1)
     {
       auto jacData = jacobian.getUnderlyingView1();
-      auto invData = createDynRankViewFromView(jacData, "Jacobian inv data",jacData.extent(0));
+      auto invData = Impl::createMatchingDynRankView(jacData, "Jacobian inv data",jacData.extent(0));
       return Data<PointScalar,DeviceType>(invData,4,extents,variationTypes);
     }
     else
@@ -828,7 +828,7 @@ namespace Intrepid2 {
     switch (pointRank) {
     case 2: {
       // For most FEMs
-      grads = createViewFromViewWithType<GradViewType>(points, "CellTools::setJacobian::grads", basisCardinality, numPoints, spaceDim);
+      grads = Impl::createMatchingView<GradViewType>(points, "CellTools::setJacobian::grads", basisCardinality, numPoints, spaceDim);
       basis->getValues(grads, 
                        points, 
                        OPERATOR_GRAD);
@@ -836,7 +836,7 @@ namespace Intrepid2 {
     }
     case 3: { 
       // For CVFEM
-      grads = createViewFromViewWithType<GradViewType>(points, "CellTools::setJacobian::grads", numCells, basisCardinality, numPoints, spaceDim);
+      grads = Impl::createMatchingView<GradViewType>(points, "CellTools::setJacobian::grads", numCells, basisCardinality, numPoints, spaceDim);
       for (ordinal_type cell=0;cell<numCells;++cell) 
         basis->getValues(Kokkos::subview( grads,  cell, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL() ),  
                          Kokkos::subview( points, cell, Kokkos::ALL(), Kokkos::ALL() ),  

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefNodeInfo.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefNodeInfo.hpp
@@ -356,8 +356,8 @@ namespace Intrepid2 {
     // Reference face normal = vector product of reference face tangents. Allocate temp FC storage:
     const auto dim = parentCell.getDimension();
     using ViewType = Kokkos::DynRankView< typename decltype(refFaceNormal)::value_type, DeviceType >; 
-    ViewType refFaceTanU = createViewFromViewWithType<ViewType>(refFaceNormal,"CellTools::getReferenceFaceNormal::refFaceTanU", dim);
-    ViewType refFaceTanV = createViewFromViewWithType<ViewType>(refFaceNormal,"CellTools::getReferenceFaceNormal::refFaceTanV", dim);
+    ViewType refFaceTanU = Impl::createMatchingView<ViewType>(refFaceNormal,"CellTools::getReferenceFaceNormal::refFaceTanU", dim);
+    ViewType refFaceTanV = Impl::createMatchingView<ViewType>(refFaceNormal,"CellTools::getReferenceFaceNormal::refFaceTanV", dim);
     getReferenceFaceTangents(refFaceTanU, refFaceTanV, faceOrd, parentCell);
   
     RealSpaceTools<DeviceType>::vecprod(refFaceNormal, refFaceTanU, refFaceTanV);
@@ -410,7 +410,7 @@ namespace Intrepid2 {
     // Storage for constant reference edge tangent: rank-1 (D) arrays
     const auto dim = parentCell.getDimension();
     using ViewType = Kokkos::DynRankView< typename decltype(edgeTangents)::value_type, DeviceType >; 
-    ViewType refEdgeTan = createViewFromViewWithType<ViewType>(edgeTangents,"CellTools::getPhysicalEdgeTangents::refEdgeTan", dim);
+    ViewType refEdgeTan = Impl::createMatchingView<ViewType>(edgeTangents,"CellTools::getPhysicalEdgeTangents::refEdgeTan", dim);
     getReferenceEdgeTangent(refEdgeTan, worksetEdgeOrd, parentCell);
     
     RealSpaceTools<DeviceType>::matvec(edgeTangents, worksetJacobians, refEdgeTan);
@@ -497,7 +497,7 @@ namespace Intrepid2 {
     const ordinal_type dim = parentCell.getDimension();
     
     using ViewType = Kokkos::DynRankView< typename decltype(edgeTangents)::value_type, DeviceType >; 
-    ViewType refEdgeTan = createViewFromViewWithType<ViewType>(edgeTangents,"CellTools::getPhysicalEdgeTangents::refEdgeTan", edgeTangents.extent(0), dim);
+    ViewType refEdgeTan = Impl::createMatchingView<ViewType>(edgeTangents,"CellTools::getPhysicalEdgeTangents::refEdgeTan", edgeTangents.extent(0), dim);
 
     const auto edgeMap = RefSubcellParametrization<DeviceType>::get(1, parentCell.getKey());
 
@@ -563,8 +563,8 @@ namespace Intrepid2 {
     const auto dim = parentCell.getDimension();
 
     using ViewType = Kokkos::DynRankView< typename decltype(faceTanU)::value_type, DeviceType >; 
-    ViewType refFaceTanU = createViewFromViewWithType<ViewType>(faceTanU,"CellTools::getPhysicalFaceTangents::refFaceTanU", dim);
-    ViewType refFaceTanV = createViewFromViewWithType<ViewType>(faceTanV,"CellTools::getPhysicalFaceTangents::refFaceTanV", dim);
+    ViewType refFaceTanU = Impl::createMatchingView<ViewType>(faceTanU,"CellTools::getPhysicalFaceTangents::refFaceTanU", dim);
+    ViewType refFaceTanV = Impl::createMatchingView<ViewType>(faceTanV,"CellTools::getPhysicalFaceTangents::refFaceTanV", dim);
 
     getReferenceFaceTangents(refFaceTanU, refFaceTanV, worksetFaceOrd, parentCell);
 
@@ -664,8 +664,8 @@ namespace Intrepid2 {
     const ordinal_type dim  = parentCell.getDimension();
 
     using ViewType = Kokkos::DynRankView< typename decltype(faceTanU)::value_type, DeviceType >; 
-    ViewType refFaceTanU = createViewFromViewWithType<ViewType>(faceTanU,"CellTools::getPhysicalFaceTangents::refFaceTanU", faceTanU.extent(0), dim);
-    ViewType refFaceTanV = createViewFromViewWithType<ViewType>(faceTanV,"CellTools::getPhysicalFaceTangents::refFaceTanV", faceTanV.extent(0), dim);
+    ViewType refFaceTanU = Impl::createMatchingView<ViewType>(faceTanU,"CellTools::getPhysicalFaceTangents::refFaceTanU", faceTanU.extent(0), dim);
+    ViewType refFaceTanV = Impl::createMatchingView<ViewType>(faceTanV,"CellTools::getPhysicalFaceTangents::refFaceTanV", faceTanV.extent(0), dim);
     
 
     const auto faceMap = RefSubcellParametrization<DeviceType>::get(2, parentCell.getKey());
@@ -735,7 +735,7 @@ namespace Intrepid2 {
     if (dim == 2) {
       // compute edge tangents and rotate it
       using ViewType = Kokkos::DynRankView< typename decltype(sideNormals)::value_type, DeviceType >; 
-      ViewType edgeTangents = createViewFromViewWithType<ViewType>(sideNormals,"CellTools::getPhysicalSideNormals::edgeTan", sideNormals.extent(0), sideNormals.extent(1), sideNormals.extent(2));
+      ViewType edgeTangents = Impl::createMatchingView<ViewType>(sideNormals,"CellTools::getPhysicalSideNormals::edgeTan", sideNormals.extent(0), sideNormals.extent(1), sideNormals.extent(2));
       getPhysicalEdgeTangents(edgeTangents, worksetJacobians, worksetSideOrd, parentCell);
 
       //Note: this function has several template parameters and the compiler gets confused if using a lambda function
@@ -778,7 +778,7 @@ namespace Intrepid2 {
 
     if (dim == 2) {
       using ViewType = Kokkos::DynRankView< typename decltype(sideNormals)::value_type, DeviceType >; 
-      ViewType edgeTangents = createViewFromViewWithType<ViewType>(sideNormals,"CellTools::getPhysicalSideNormals::edgeTan", sideNormals.extent(0), sideNormals.extent(1), sideNormals.extent(2));
+      ViewType edgeTangents = Impl::createMatchingView<ViewType>(sideNormals,"CellTools::getPhysicalSideNormals::edgeTan", sideNormals.extent(0), sideNormals.extent(1), sideNormals.extent(2));
       getPhysicalEdgeTangents(edgeTangents, worksetJacobians, worksetSideOrds, parentCell);
 
       //Note: this function has several template parameters and the compiler gets confused if using a lambda function
@@ -841,8 +841,8 @@ namespace Intrepid2 {
     const auto dim = parentCell.getDimension();
 
     using ViewType = Kokkos::DynRankView< typename decltype(faceNormals)::value_type, DeviceType >; 
-    ViewType faceTanU = createViewFromViewWithType<ViewType>(faceNormals, "CellTools::getPhysicalFaceNormals::faceTanU", worksetSize, facePtCount, dim);
-    ViewType faceTanV = createViewFromViewWithType<ViewType>(faceNormals, "CellTools::getPhysicalFaceNormals::faceTanV", worksetSize, facePtCount, dim);
+    ViewType faceTanU = Impl::createMatchingView<ViewType>(faceNormals, "CellTools::getPhysicalFaceNormals::faceTanU", worksetSize, facePtCount, dim);
+    ViewType faceTanV = Impl::createMatchingView<ViewType>(faceNormals, "CellTools::getPhysicalFaceNormals::faceTanV", worksetSize, facePtCount, dim);
 
     getPhysicalFaceTangents(faceTanU, faceTanV, 
                             worksetJacobians, 
@@ -906,8 +906,8 @@ namespace Intrepid2 {
     const auto dim = parentCell.getDimension();
 
     using ViewType = Kokkos::DynRankView< typename decltype(faceNormals)::value_type, DeviceType >; 
-    ViewType faceTanU = createViewFromViewWithType<ViewType>(faceNormals,"CellTools::getPhysicalFaceNormals::faceTanU", worksetSize, facePtCount, dim);
-    ViewType faceTanV = createViewFromViewWithType<ViewType>(faceNormals,"CellTools::getPhysicalFaceNormals::faceTanV", worksetSize, facePtCount, dim);
+    ViewType faceTanU = Impl::createMatchingView<ViewType>(faceNormals,"CellTools::getPhysicalFaceNormals::faceTanU", worksetSize, facePtCount, dim);
+    ViewType faceTanV = Impl::createMatchingView<ViewType>(faceNormals,"CellTools::getPhysicalFaceNormals::faceTanV", worksetSize, facePtCount, dim);
 
     getPhysicalFaceTangents(faceTanU, faceTanV,
                             worksetJacobians,

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefPhysToRef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefPhysToRef.hpp
@@ -68,7 +68,7 @@ namespace Intrepid2 {
     const auto numPoints = physPoints.extent(1);
     
     // init guess is created locally and non fad whatever refpoints type is 
-    auto initGuess = createDynRankViewFromView(refPoints, "CellTools::mapToReferenceFrame::initGuess", numCells, numPoints, spaceDim );
+    auto initGuess = Impl::createMatchingDynRankView(refPoints, "CellTools::mapToReferenceFrame::initGuess", numCells, numPoints, spaceDim );
     rst::clone(initGuess, cellCenter);
     
     mapToReferenceFrameInitGuess(refPoints, initGuess, physPoints, worksetCell, cellTopo);  
@@ -120,8 +120,8 @@ namespace Intrepid2 {
 
     using result_layout = typename DeduceLayout< decltype(refPoints) >::result_layout;
     // Temp arrays for Newton iterates and Jacobians. Resize according to rank of ref. point array
-    auto xOld = createDynRankViewFromView(refPoints, "CellTools::mapToReferenceFrameInitGuess::xOld", numCells, numPoints, spaceDim);
-    auto xTmp = createDynRankViewFromView(refPoints, "CellTools::mapToReferenceFrameInitGuess::xTmp", numCells, numPoints, spaceDim);
+    auto xOld = Impl::createMatchingDynRankView(refPoints, "CellTools::mapToReferenceFrameInitGuess::xOld", numCells, numPoints, spaceDim);
+    auto xTmp = Impl::createMatchingDynRankView(refPoints, "CellTools::mapToReferenceFrameInitGuess::xTmp", numCells, numPoints, spaceDim);
 
     // deep copy may not work with FAD but this is right thing to do as it can move data between devices
     Kokkos::deep_copy(xOld, initGuess);
@@ -129,7 +129,7 @@ namespace Intrepid2 {
     // jacobian should select fad dimension between xOld and worksetCell as they are input; no front interface yet
     using valueTypeJ = std::common_type_t<typename decltype(refPoints)::value_type, typename decltype(worksetCell)::value_type>;    
     using viewTypeJ = Kokkos::DynRankView<valueTypeJ, result_layout, DeviceType >;
-    using view_factory = CreateViewFactory<decltype(refPoints), decltype(worksetCell)>;
+    using view_factory = Impl::CreateViewFactory<decltype(refPoints), decltype(worksetCell)>;
     viewTypeJ jacobian = view_factory::template create_view<viewTypeJ>(refPoints, worksetCell, "CellTools::mapToReferenceFrameInitGuess::jacobian", numCells, numPoints, spaceDim, spaceDim);
     viewTypeJ jacobianInv = view_factory::template create_view<viewTypeJ>(refPoints, worksetCell, "CellTools::mapToReferenceFrameInitGuess::jacobianInv", numCells, numPoints, spaceDim, spaceDim);
     

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefRefToPhys.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefRefToPhys.hpp
@@ -165,7 +165,7 @@ namespace Intrepid2 {
     switch (refPointRank) {
     case 2: {
       // refPoints is (P,D): single set of ref. points is mapped to one or multiple physical cells
-      vals = createViewFromViewWithType<valViewType>(physPoints, "CellTools::mapToPhysicalFrame::vals", basisCardinality, numPoints);
+      vals = Impl::createMatchingView<valViewType>(physPoints, "CellTools::mapToPhysicalFrame::vals", basisCardinality, numPoints);
       basis->getValues(vals,
                        refPoints,
                        OPERATOR_VALUE);
@@ -173,7 +173,7 @@ namespace Intrepid2 {
     }
     case 3: {
       // refPoints is (C,P,D): multiple sets of ref. points are mapped to matching number of physical cells.
-      vals = createViewFromViewWithType<valViewType>(physPoints, "CellTools::mapToPhysicalFrame::vals", numCells, basisCardinality, numPoints);
+      vals = Impl::createMatchingView<valViewType>(physPoints, "CellTools::mapToPhysicalFrame::vals", numCells, basisCardinality, numPoints);
       for (size_type cell=0;cell<numCells;++cell)
         basis->getValues(Kokkos::subdynrankview( vals,      cell, Kokkos::ALL(), Kokkos::ALL() ),
                          Kokkos::subdynrankview( refPoints, cell, Kokkos::ALL(), Kokkos::ALL() ),

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -71,7 +71,7 @@ using HostBasisPtr = BasisPtr<typename Kokkos::HostSpace::device_type, OutputTyp
               some conversion mechanisms defined elsewhere, a LayoutLeft view (the default for Cuda views in
               Kokkos) or a LayoutRight view (the default on most other platforms).  This does introduce some
               additional complexity when Views need to be allocated for temporary storage; see the method
-              \ref createDynRankViewFromView() provided in \ref Intrepid_Utils.hpp.
+              \ref createMatchingDynRankView() provided in \ref Intrepid_Utils.hpp.
    
       \remark To limit memory use by factory-type objects (basis factories will be included in future
               releases of Intrepid2), tag data is not initialized by basis ctors,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEM.hpp
@@ -110,7 +110,7 @@ namespace Intrepid2 {
 
           typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-          workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+          workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
           switch (opType) {
           case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEMDef.hpp
@@ -55,10 +55,10 @@ namespace Intrepid2 {
       switch (OpType) {
       case OPERATOR_VALUE: {
 
-        ViewType workLine = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
-        ViewType outputLine_A = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts);
-        ViewType outputLine_B = createUnmanagedViewWithType<ViewType>(input, ptr2, cardLine, npts);
-        ViewType outputBubble = createUnmanagedViewWithType<ViewType>(input, ptr3, cardBubble, npts);
+        ViewType workLine = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
+        ViewType outputLine_A = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts);
+        ViewType outputLine_B = createMatchingUnmanagedView<ViewType>(input, ptr2, cardLine, npts);
+        ViewType outputBubble = createMatchingUnmanagedView<ViewType>(input, ptr3, cardBubble, npts);
         
         // tensor product
         ordinal_type idx = 0;
@@ -141,12 +141,12 @@ namespace Intrepid2 {
          auto ptr4 = work.data() + 4*cardLine*npts*dim_s;
          auto ptr5 = work.data() + 5*cardLine*npts*dim_s;
          
-        ViewType workLine = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
-        ViewType outputLine_A = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts);
-        ViewType outputLine_B = createUnmanagedViewWithType<ViewType>(input, ptr2, cardLine, npts);
-        ViewType outputLine_DA = createUnmanagedViewWithType<ViewType>(input, ptr3, cardLine, npts, 1);
-        ViewType outputLine_DB = createUnmanagedViewWithType<ViewType>(input, ptr4, cardLine, npts, 1);
-        ViewType outputBubble = createUnmanagedViewWithType<ViewType>(input, ptr5, cardBubble, npts);
+        ViewType workLine = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
+        ViewType outputLine_A = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts);
+        ViewType outputLine_B = createMatchingUnmanagedView<ViewType>(input, ptr2, cardLine, npts);
+        ViewType outputLine_DA = createMatchingUnmanagedView<ViewType>(input, ptr3, cardLine, npts, 1);
+        ViewType outputLine_DB = createMatchingUnmanagedView<ViewType>(input, ptr4, cardLine, npts, 1);
+        ViewType outputBubble = createMatchingUnmanagedView<ViewType>(input, ptr5, cardBubble, npts);
 
         // tensor product
         ordinal_type idx = 0;
@@ -292,7 +292,7 @@ namespace Intrepid2 {
       switch (operatorType) {
       case OPERATOR_VALUE: {
         auto workSize = Serial<OPERATOR_VALUE>::getWorkSizePerPoint(order);
-        auto work = createDynRankViewFromView(inputPoints, "Basis_CURL_HEX_In_FEM::getValues::work", workSize, inputPoints.extent(0));
+        auto work = createMatchingDynRankView(inputPoints, "Basis_CURL_HEX_In_FEM::getValues::work", workSize, inputPoints.extent(0));
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
             OPERATOR_VALUE,numPtsPerEval> FunctorType;
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinvLine, vinvBubble, work) );
@@ -300,7 +300,7 @@ namespace Intrepid2 {
       }
       case OPERATOR_CURL: {
         auto workSize = Serial<OPERATOR_CURL>::getWorkSizePerPoint(order);
-        auto work = createDynRankViewFromView(inputPoints, "Basis_CURL_HEX_In_FEM::getValues::work", workSize, inputPoints.extent(0));
+        auto work = createMatchingDynRankView(inputPoints, "Basis_CURL_HEX_In_FEM::getValues::work", workSize, inputPoints.extent(0));
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
             OPERATOR_CURL,numPtsPerEval> FunctorType;
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinvLine, vinvBubble, work) );

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEM.hpp
@@ -101,7 +101,7 @@ namespace Intrepid2 {
 
           typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-          workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+          workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
           switch (opType) {
           case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEMDef.hpp
@@ -52,9 +52,9 @@ namespace Intrepid2 {
 
       switch (OpType) {
       case OPERATOR_VALUE: {
-        ViewType workLine = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
-        ViewType outputLine = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts);
-        ViewType outputBubble = createUnmanagedViewWithType<ViewType>(input, ptr2, cardBubble, npts);
+        ViewType workLine = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
+        ViewType outputLine = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts);
+        ViewType outputBubble = createMatchingUnmanagedView<ViewType>(input, ptr2, cardBubble, npts);
 
         // tensor product
         ordinal_type idx = 0;
@@ -100,11 +100,11 @@ namespace Intrepid2 {
       case OPERATOR_CURL: {
         ordinal_type idx = 0;
         { // x - component
-          ViewType workLine = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
+          ViewType workLine = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
           // x bubble value
-          ViewType output_x = createUnmanagedViewWithType<ViewType>(input, ptr2, cardBubble, npts);
+          ViewType output_x = createMatchingUnmanagedView<ViewType>(input, ptr2, cardBubble, npts);
           // y line grad
-          ViewType output_y = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts,1);
+          ViewType output_y = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts,1);
 
           Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
             getValues(output_x, input_x, workLine, vinvBubble);
@@ -119,11 +119,11 @@ namespace Intrepid2 {
                 output.access(idx,k) = -output_x.access(i,k)*output_y.access(j,k,0);
         }
         { // y - component
-          ViewType workLine = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
+          ViewType workLine = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
           // x line grad
-          ViewType output_x = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts,1);
+          ViewType output_x = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts,1);
           // y bubble value
-          ViewType output_y = createUnmanagedViewWithType<ViewType>(input, ptr2, cardBubble, npts);
+          ViewType output_y = createMatchingUnmanagedView<ViewType>(input, ptr2, cardBubble, npts);
 
           Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
             getValues(output_y, input_y, workLine, vinvBubble);
@@ -181,7 +181,7 @@ namespace Intrepid2 {
       switch (operatorType) {
       case OPERATOR_VALUE: {
         auto workSize = Serial<OPERATOR_VALUE>::getWorkSizePerPoint(order);
-        auto work = createDynRankViewFromView(inputPoints, "Basis_HCURL_QUAD_In_FEM::getValues::work", workSize, inputPoints.extent(0));
+        auto work = createMatchingDynRankView(inputPoints, "Basis_HCURL_QUAD_In_FEM::getValues::work", workSize, inputPoints.extent(0));
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
             OPERATOR_VALUE,numPtsPerEval> FunctorType;
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinvLine, vinvBubble, work) );
@@ -189,7 +189,7 @@ namespace Intrepid2 {
       }
       case OPERATOR_CURL: {
         auto workSize = Serial<OPERATOR_CURL>::getWorkSizePerPoint(order);
-        auto work = createDynRankViewFromView(inputPoints, "Basis_HCURL_QUAD_In_FEM::getValues::work", workSize, inputPoints.extent(0));
+        auto work = createMatchingDynRankView(inputPoints, "Basis_HCURL_QUAD_In_FEM::getValues::work", workSize, inputPoints.extent(0));
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
             OPERATOR_CURL,numPtsPerEval> FunctorType;
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinvLine, vinvBubble, work) );

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEM.hpp
@@ -143,7 +143,7 @@ public:
 
       typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-      workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+      workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
       switch (opType) {
       case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEMDef.hpp
@@ -59,7 +59,7 @@ getValues(       OutputViewType output,
 
   switch (OpType) {
   case OPERATOR_VALUE: {
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts);
     ViewType dummyView;
 
     Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::
@@ -75,9 +75,9 @@ getValues(       OutputViewType output,
     break;
   }
   case OPERATOR_CURL: {
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim);
     ptr += card*npts*spaceDim*get_dimension_scalar(input);
-    const ViewType workView = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim+1);
+    const ViewType workView = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim+1);
 
     Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::
     Serial<OPERATOR_GRAD>::getValues(phis, input, workView, order);
@@ -132,14 +132,14 @@ getValues(
 
   switch (operatorType) {
   case OPERATOR_VALUE: {
-    auto work = createDynRankViewFromView(inputPoints, "Basis_HCURL_TET_In_FEM::getValues::work", cardinality, inputPoints.extent(0));
+    auto work = createMatchingDynRankView(inputPoints, "Basis_HCURL_TET_In_FEM::getValues::work", cardinality, inputPoints.extent(0));
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
         OPERATOR_VALUE,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, coeffs, work) );
     break;
   }
   case OPERATOR_CURL: {
-    auto work = createDynRankViewFromView(inputPoints, "Basis_HCURL_TET_In_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
+    auto work = createMatchingDynRankView(inputPoints, "Basis_HCURL_TET_In_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
         OPERATOR_CURL,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, coeffs, work) );

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEM.hpp
@@ -133,7 +133,7 @@ public:
 
       typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-      workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+      workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
       switch (opType) {
       case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
@@ -58,7 +58,7 @@ namespace Intrepid2 {
 
       switch (OpType) {
       case OPERATOR_VALUE: {
-        const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts), dummyView;
+        const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts), dummyView;
 
         Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::
           Serial<OpType>::getValues(phis, input, dummyView, order);
@@ -73,9 +73,9 @@ namespace Intrepid2 {
         break;
       }
       case OPERATOR_CURL: {
-        const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim);
+        const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim);
         ptr += card*npts*spaceDim*get_dimension_scalar(input);
-        const ViewType workView = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim+1);
+        const ViewType workView = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim+1);
 
         Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::
           Serial<OPERATOR_GRAD>::getValues(phis, input, workView, order);
@@ -125,14 +125,14 @@ namespace Intrepid2 {
 
       switch (operatorType) {
       case OPERATOR_VALUE: {
-        auto work = createDynRankViewFromView(inputPoints, "Basis_HCURL_TRI_In_FEM::getValues::work", cardinality, inputPoints.extent(0));
+        auto work = createMatchingDynRankView(inputPoints, "Basis_HCURL_TRI_In_FEM::getValues::work", cardinality, inputPoints.extent(0));
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
           OPERATOR_VALUE,numPtsPerEval> FunctorType;
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, coeffs, work) );
         break;
       }
       case OPERATOR_CURL: {
-        auto work = createDynRankViewFromView(inputPoints, "Basis_HCURL_TRI_In_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
+        auto work = createMatchingDynRankView(inputPoints, "Basis_HCURL_TRI_In_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
           OPERATOR_CURL,numPtsPerEval> FunctorType;
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, coeffs, work) );

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEM.hpp
@@ -100,7 +100,7 @@ namespace Intrepid2 {
 
           typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-          workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+          workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
           switch (opType) {
           case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEMDef.hpp
@@ -54,10 +54,10 @@ namespace Intrepid2 {
 
       switch (OpType) {
       case OPERATOR_VALUE: {
-        ViewType workLine = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
-        ViewType outputLine = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts);
-        ViewType outputBubble_A = createUnmanagedViewWithType<ViewType>(input, ptr2, cardBubble, npts);
-        ViewType outputBubble_B = createUnmanagedViewWithType<ViewType>(input, ptr3, cardBubble, npts);
+        ViewType workLine = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
+        ViewType outputLine = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts);
+        ViewType outputBubble_A = createMatchingUnmanagedView<ViewType>(input, ptr2, cardBubble, npts);
+        ViewType outputBubble_B = createMatchingUnmanagedView<ViewType>(input, ptr3, cardBubble, npts);
         
         // tensor product
         ordinal_type idx = 0;
@@ -137,13 +137,13 @@ namespace Intrepid2 {
         break;
       }
       case OPERATOR_DIV: {      
-        ViewType workLine = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
+        ViewType workLine = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
         // A line value
-        ViewType outputBubble_A = createUnmanagedViewWithType<ViewType>(input, ptr2, cardBubble, npts);
+        ViewType outputBubble_A = createMatchingUnmanagedView<ViewType>(input, ptr2, cardBubble, npts);
         // B line value
-        ViewType outputBubble_B = createUnmanagedViewWithType<ViewType>(input, ptr3, cardBubble, npts);
+        ViewType outputBubble_B = createMatchingUnmanagedView<ViewType>(input, ptr3, cardBubble, npts);
         // Line grad
-        ViewType outputLine = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts, 1);
+        ViewType outputLine = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts, 1);
         
         // tensor product
         ordinal_type idx = 0;
@@ -255,7 +255,7 @@ namespace Intrepid2 {
       switch (operatorType) {
       case OPERATOR_VALUE: {
         auto workSize = Serial<OPERATOR_VALUE>::getWorkSizePerPoint(order);
-        auto work = createDynRankViewFromView(inputPoints, "Basis_HDIV_HEX_In_FEM::getValues::work", workSize, inputPoints.extent(0));
+        auto work = createMatchingDynRankView(inputPoints, "Basis_HDIV_HEX_In_FEM::getValues::work", workSize, inputPoints.extent(0));
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
             OPERATOR_VALUE,numPtsPerEval> FunctorType;
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinvLine, vinvBubble, work) );
@@ -263,7 +263,7 @@ namespace Intrepid2 {
       }
       case OPERATOR_DIV: {
         auto workSize = Serial<OPERATOR_DIV>::getWorkSizePerPoint(order);
-        auto work = createDynRankViewFromView(inputPoints, "Basis_HDIV_HEX_In_FEM::getValues::work", workSize, inputPoints.extent(0));
+        auto work = createMatchingDynRankView(inputPoints, "Basis_HDIV_HEX_In_FEM::getValues::work", workSize, inputPoints.extent(0));
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
             OPERATOR_DIV,numPtsPerEval> FunctorType;
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinvLine, vinvBubble, work) );

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEM.hpp
@@ -100,7 +100,7 @@ namespace Intrepid2 {
 
           typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-          workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+          workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
           switch (opType) {
           case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEMDef.hpp
@@ -52,9 +52,9 @@ namespace Intrepid2 {
 
       switch (OpType) {
       case OPERATOR_VALUE: {
-        ViewType workLine = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
-        ViewType outputLine = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts);
-        ViewType outputBubble = createUnmanagedViewWithType<ViewType>(input, ptr2, cardBubble, npts);
+        ViewType workLine = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
+        ViewType outputLine = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts);
+        ViewType outputBubble = createMatchingUnmanagedView<ViewType>(input, ptr2, cardBubble, npts);
 
         // tensor product
         ordinal_type idx = 0;
@@ -98,11 +98,11 @@ namespace Intrepid2 {
       case OPERATOR_DIV: {
         ordinal_type idx = 0;
         { // x - component
-          ViewType workLine = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
+          ViewType workLine = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
           // x bubble value
-          ViewType output_x = createUnmanagedViewWithType<ViewType>(input, ptr2, cardBubble, npts);
+          ViewType output_x = createMatchingUnmanagedView<ViewType>(input, ptr2, cardBubble, npts);
           // y line grad
-          ViewType output_y = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts,1);
+          ViewType output_y = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts,1);
 
           Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
             getValues(output_x, input_x, workLine, vinvBubble);
@@ -117,11 +117,11 @@ namespace Intrepid2 {
                 output.access(idx,k) = output_x.access(i,k)*output_y.access(j,k,0);
         }
         { // y - component
-          ViewType workLine = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
+          ViewType workLine = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
           // x line grad
-          ViewType output_x = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts,1);
+          ViewType output_x = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts,1);
           // y bubble value
-          ViewType output_y = createUnmanagedViewWithType<ViewType>(input, ptr2, cardBubble, npts);
+          ViewType output_y = createMatchingUnmanagedView<ViewType>(input, ptr2, cardBubble, npts);
 
           Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
             getValues(output_y, input_y, workLine, vinvBubble);
@@ -181,7 +181,7 @@ namespace Intrepid2 {
       switch (operatorType) {
       case OPERATOR_VALUE: {
         auto workSize = Serial<OPERATOR_VALUE>::getWorkSizePerPoint(order);
-        auto work = createDynRankViewFromView(inputPoints, "Basis_HDIV_QUAD_In_FEM::getValues::work", workSize, inputPoints.extent(0));
+        auto work = createMatchingDynRankView(inputPoints, "Basis_HDIV_QUAD_In_FEM::getValues::work", workSize, inputPoints.extent(0));
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
             OPERATOR_VALUE,numPtsPerEval> FunctorType;
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinvLine, vinvBubble, work) );
@@ -189,7 +189,7 @@ namespace Intrepid2 {
       }
       case OPERATOR_DIV: {
         auto workSize = Serial<OPERATOR_DIV>::getWorkSizePerPoint(order);
-        auto work = createDynRankViewFromView(inputPoints, "Basis_HDIV_QUAD_In_FEM::getValues::work", workSize, inputPoints.extent(0));
+        auto work = createMatchingDynRankView(inputPoints, "Basis_HDIV_QUAD_In_FEM::getValues::work", workSize, inputPoints.extent(0));
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
             OPERATOR_DIV,numPtsPerEval> FunctorType;
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinvLine, vinvBubble, work) );

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEM.hpp
@@ -135,7 +135,7 @@ public:
 
       typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-      workViewType  work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+      workViewType  work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
       switch (opType) {
       case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
@@ -58,7 +58,7 @@ getValues(       OutputViewType output,
 
   switch (OpType) {
   case OPERATOR_VALUE: {
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts);
     ViewType dummyView;
 
     Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::
@@ -74,9 +74,9 @@ getValues(       OutputViewType output,
     break;
   }
   case OPERATOR_DIV: {
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim);
     ptr += card*npts*spaceDim*get_dimension_scalar(input);
-    const ViewType workView = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim+1);
+    const ViewType workView = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim+1);
 
     Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::
     Serial<OPERATOR_GRAD>::getValues(phis, input, workView, order);
@@ -123,14 +123,14 @@ getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties.
 
   switch (operatorType) {
   case OPERATOR_VALUE: {
-    auto work = createDynRankViewFromView(inputPoints, "Basis_HDIV_TET_In_FEM::getValues::work", cardinality, inputPoints.extent(0));
+    auto work = createMatchingDynRankView(inputPoints, "Basis_HDIV_TET_In_FEM::getValues::work", cardinality, inputPoints.extent(0));
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
         OPERATOR_VALUE,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, coeffs, work) );
     break;
   }
   case OPERATOR_DIV: {
-    auto work = createDynRankViewFromView(inputPoints, "Basis_HDIV_TET_In_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
+    auto work = createMatchingDynRankView(inputPoints, "Basis_HDIV_TET_In_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
         OPERATOR_DIV,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, coeffs, work) );

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEM.hpp
@@ -138,7 +138,7 @@ public:
 
       typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-      workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+      workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
 
       switch (opType) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
@@ -57,7 +57,7 @@ getValues(      OutputViewType  output,
 
   switch (OpType) {
   case OPERATOR_VALUE: {
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts);
     ViewType dummyView;
 
     Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::
@@ -73,9 +73,9 @@ getValues(      OutputViewType  output,
     break;
   }
   case OPERATOR_DIV: {
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim);
     ptr += card*npts*spaceDim*get_dimension_scalar(work);
-    const ViewType workView = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim+1);
+    const ViewType workView = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim+1);
 
     Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::
     Serial<OPERATOR_GRAD>::getValues(phis, input, workView, order);
@@ -122,14 +122,14 @@ getValues( /* */ Kokkos::DynRankView<outputValueValueType,outputValueProperties.
 
   switch (operatorType) {
   case OPERATOR_VALUE: {
-    auto work = createDynRankViewFromView(inputPoints, "Basis_HDIV_TRI_In_FEM::getValues::work", cardinality, inputPoints.extent(0));
+    auto work = createMatchingDynRankView(inputPoints, "Basis_HDIV_TRI_In_FEM::getValues::work", cardinality, inputPoints.extent(0));
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
         OPERATOR_VALUE,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, coeffs, work) );
     break;
   }
   case OPERATOR_DIV: {
-    auto work = createDynRankViewFromView(inputPoints, "Basis_HDIV_TRI_In_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
+    auto work = createMatchingDynRankView(inputPoints, "Basis_HDIV_TRI_In_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, decltype(work),
         OPERATOR_DIV,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, coeffs, work) );

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEM.hpp
@@ -92,7 +92,7 @@ namespace Intrepid2 {
 
           typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-          workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+          workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
           switch (opType) {
           case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEMDef.hpp
@@ -54,10 +54,10 @@ namespace Intrepid2 {
 
       switch (opType) {
       case OPERATOR_VALUE: {
-        viewType work_line = createUnmanagedViewWithType<viewType>(input, ptr0, cardLine, npts);
-        viewType output_x = createUnmanagedViewWithType<viewType>(input, ptr1, cardLine, npts);
-        viewType output_y = createUnmanagedViewWithType<viewType>(input, ptr2, cardLine, npts);
-        viewType output_z = createUnmanagedViewWithType<viewType>(input, ptr3, cardLine, npts);
+        viewType work_line = createMatchingUnmanagedView<viewType>(input, ptr0, cardLine, npts);
+        viewType output_x = createMatchingUnmanagedView<viewType>(input, ptr1, cardLine, npts);
+        viewType output_y = createMatchingUnmanagedView<viewType>(input, ptr2, cardLine, npts);
+        viewType output_z = createMatchingUnmanagedView<viewType>(input, ptr3, cardLine, npts);
         
         Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
           getValues(output_x, input_x, work_line, vinv);
@@ -105,35 +105,35 @@ namespace Intrepid2 {
             if (mult_x < 0) {
               // pass
             } else {              
-              viewType work_line = createUnmanagedViewWithType<viewType>(input, ptr0, cardLine, npts);
+              viewType work_line = createMatchingUnmanagedView<viewType>(input, ptr0, cardLine, npts);
               decltype(work_line)  output_x, output_y, output_z;
                   
               if (mult_x) {
-                output_x = createUnmanagedViewWithType<viewType>(input, ptr1, cardLine, npts, 1);
+                output_x = createMatchingUnmanagedView<viewType>(input, ptr1, cardLine, npts, 1);
                 Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_Dn>::
                   getValues(output_x, input_x, work_line, vinv, mult_x);
               } else {
-                output_x = createUnmanagedViewWithType<viewType>(input, ptr1, cardLine, npts);
+                output_x = createMatchingUnmanagedView<viewType>(input, ptr1, cardLine, npts);
                 Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
                   getValues(output_x, input_x, work_line, vinv);
               }
               
               if (mult_y) {
-                output_y = createUnmanagedViewWithType<viewType>(input, ptr2, cardLine, npts, 1);
+                output_y = createMatchingUnmanagedView<viewType>(input, ptr2, cardLine, npts, 1);
                 Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_Dn>::
                   getValues(output_y, input_y, work_line, vinv, mult_y);
               } else {
-                output_y = createUnmanagedViewWithType<viewType>(input, ptr2, cardLine, npts);
+                output_y = createMatchingUnmanagedView<viewType>(input, ptr2, cardLine, npts);
                 Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
                   getValues(output_y, input_y, work_line, vinv);
               }
 
               if (mult_z) {
-                output_z = createUnmanagedViewWithType<viewType>(input, ptr3, cardLine, npts, 1);
+                output_z = createMatchingUnmanagedView<viewType>(input, ptr3, cardLine, npts, 1);
                 Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_Dn>::
                   getValues(output_z, input_z, work_line, vinv, mult_z);
               } else {
-                output_z = createUnmanagedViewWithType<viewType>(input, ptr3, cardLine, npts);
+                output_z = createMatchingUnmanagedView<viewType>(input, ptr3, cardLine, npts);
                 Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
                   getValues(output_z, input_z, work_line, vinv);
               }
@@ -184,7 +184,7 @@ namespace Intrepid2 {
       const ordinal_type cardLine = std::cbrt(cardinality);
       const ordinal_type workSize = 4*cardLine;
 
-      auto work = createDynRankViewFromView(inputPoints, "Basis_HGRAD_HEX_Cn_FEM::getValues::work", workSize, inputPoints.extent(0));
+      auto work = createMatchingDynRankView(inputPoints, "Basis_HGRAD_HEX_Cn_FEM::getValues::work", workSize, inputPoints.extent(0));
 
       switch (operatorType) {
       case OPERATOR_VALUE: {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM.hpp
@@ -112,7 +112,7 @@ namespace Intrepid2 {
 
           typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-          workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+          workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
           switch (opType) {
           case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
@@ -46,7 +46,7 @@ namespace Intrepid2 {
       
       switch (opType) {
       case OPERATOR_VALUE: {
-        ViewType phis = createUnmanagedViewWithType<ViewType>(input, work.data(), card, npts);     
+        ViewType phis = createMatchingUnmanagedView<ViewType>(input, work.data(), card, npts);     
 
         Impl::Basis_HGRAD_LINE_Cn_FEM_JACOBI::
           Serial<opType>::getValues(phis, input, order, alpha, beta);
@@ -74,7 +74,7 @@ namespace Intrepid2 {
       case OPERATOR_Dn: {
         // dkcard is always 1 for 1D element
         const ordinal_type dkcard = 1;
-        ViewType phis = createUnmanagedViewWithType<ViewType>(input, work.data(), card, npts, dkcard);     
+        ViewType phis = createMatchingUnmanagedView<ViewType>(input, work.data(), card, npts, dkcard);     
         Impl::Basis_HGRAD_LINE_Cn_FEM_JACOBI::
           Serial<opType>::getValues(phis, input, order, alpha, beta, opDn);
 
@@ -119,7 +119,7 @@ namespace Intrepid2 {
 
       const ordinal_type cardinality = outputValues.extent(0);
 
-      auto work = createDynRankViewFromView(inputPoints, "Basis_HGRAD_LINE_Cn_FEM::getValues::work", cardinality, inputPoints.extent(0));
+      auto work = createMatchingDynRankView(inputPoints, "Basis_HGRAD_LINE_Cn_FEM::getValues::work", cardinality, inputPoints.extent(0));
 
       switch (operatorType) {
       case OPERATOR_VALUE: {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEM.hpp
@@ -97,7 +97,7 @@ namespace Intrepid2 {
 
           typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-          workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+          workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
           switch (opType) {
           case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEMDef.hpp
@@ -52,9 +52,9 @@ namespace Intrepid2 {
       
       switch (OpType) {
       case OPERATOR_VALUE: {
-        ViewType work_line = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
-        ViewType output_x = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts);
-        ViewType output_y = createUnmanagedViewWithType<ViewType>(input, ptr2, cardLine, npts);
+        ViewType work_line = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
+        ViewType output_x = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts);
+        ViewType output_y = createMatchingUnmanagedView<ViewType>(input, ptr2, cardLine, npts);
         
         Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
           getValues(output_x, input_x, work_line, vinv);
@@ -72,29 +72,29 @@ namespace Intrepid2 {
       }
       case OPERATOR_CURL: {
         for (auto l=0;l<2;++l) {
-          ViewType work_line = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
+          ViewType work_line = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
           
           ViewType output_x, output_y;
           
           typename WorkViewType::value_type s = 0.0;
           if (l) {
             // l = 1
-            output_x = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts, 1);
+            output_x = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts, 1);
             Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_Dn>::
               getValues(output_x, input_x, work_line, vinv, 1);                           
 
-            output_y = createUnmanagedViewWithType<ViewType>(input, ptr2, cardLine, npts);
+            output_y = createMatchingUnmanagedView<ViewType>(input, ptr2, cardLine, npts);
             Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
               getValues(output_y, input_y, work_line, vinv);                           
 
             s = -1.0;
           } else {
             // l = 0
-            output_x = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts);
+            output_x = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts);
             Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
               getValues(output_x, input_x, work_line, vinv);                           
 
-            output_y = createUnmanagedViewWithType<ViewType>(input, ptr2, cardLine, npts, 1);
+            output_y = createMatchingUnmanagedView<ViewType>(input, ptr2, cardLine, npts, 1);
             Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_Dn>::
               getValues(output_y, input_y, work_line, vinv, 1);                           
 
@@ -125,7 +125,7 @@ namespace Intrepid2 {
       case OPERATOR_Dn: {
         const auto dkcard = opDn + 1;
         for (auto l=0;l<dkcard;++l) {
-          ViewType work_line = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
+          ViewType work_line = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
           
           ViewType output_x, output_y;
           
@@ -133,21 +133,21 @@ namespace Intrepid2 {
           const auto mult_y = l;
           
           if (mult_x) {
-            output_x = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts, 1);
+            output_x = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts, 1);
             Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_Dn>::
               getValues(output_x, input_x, work_line, vinv, mult_x);                           
           } else {
-            output_x = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts);
+            output_x = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts);
             Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
               getValues(output_x, input_x, work_line, vinv);                           
           }
 
           if (mult_y) {
-            output_y = createUnmanagedViewWithType<ViewType>(input, ptr2, cardLine, npts, 1);
+            output_y = createMatchingUnmanagedView<ViewType>(input, ptr2, cardLine, npts, 1);
             Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_Dn>::
               getValues(output_y, input_y, work_line, vinv, mult_y);                           
           } else {
-            output_y = createUnmanagedViewWithType<ViewType>(input, ptr2, cardLine, npts);
+            output_y = createMatchingUnmanagedView<ViewType>(input, ptr2, cardLine, npts);
             Impl::Basis_HGRAD_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
               getValues(output_y, input_y, work_line, vinv);                           
           }
@@ -196,7 +196,7 @@ namespace Intrepid2 {
       const ordinal_type cardLine = std::sqrt(cardinality);
       const ordinal_type workSize = 3*cardLine;
       
-      auto work = createDynRankViewFromView(inputPoints, "Basis_HGRAD_QUAD_Cn_FEM::getValues::work", workSize, inputPoints.extent(0));
+      auto work = createMatchingDynRankView(inputPoints, "Basis_HGRAD_QUAD_Cn_FEM::getValues::work", workSize, inputPoints.extent(0));
 
       switch (operatorType) {
       case OPERATOR_VALUE: {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM.hpp
@@ -124,7 +124,7 @@ namespace Intrepid2 {
 
           typename WorkViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-          WorkViewType work = createUnmanagedViewWithType<WorkViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+          WorkViewType work = createMatchingUnmanagedView<WorkViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
           switch (OpType) {
           case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEMDef.hpp
@@ -48,7 +48,7 @@ getValues(       OutputViewType output,
 
   switch (OpType) {
   case OPERATOR_VALUE: {
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts);
     ViewType dummyView;
 
     Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::
@@ -64,9 +64,9 @@ getValues(       OutputViewType output,
   }
   case OPERATOR_GRAD:
   case OPERATOR_D1: {
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr,card, npts, spaceDim);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr,card, npts, spaceDim);
     ptr += card*npts*spaceDim*get_dimension_scalar(input);
-    const ViewType workView = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim+1);
+    const ViewType workView = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim+1);
     Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::
     Serial<OpType>::getValues(phis, input, workView, order);
 
@@ -92,7 +92,7 @@ getValues(       OutputViewType output,
   case OPERATOR_D9:
   case OPERATOR_D10: {
     const ordinal_type dkcard = getDkCardinality<OpType,spaceDim>(); //(orDn + 1);
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, dkcard);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, dkcard);
     ViewType dummyView;
 
     Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::
@@ -145,7 +145,7 @@ getValues(
 
   switch (operatorType) {
   case OPERATOR_VALUE: {
-    workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HGRAD_TET_Cn_FEM::getValues::work", cardinality, inputPoints.extent(0));
+    workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HGRAD_TET_Cn_FEM::getValues::work", cardinality, inputPoints.extent(0));
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, workViewType,
         OPERATOR_VALUE,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work, order) );
@@ -153,7 +153,7 @@ getValues(
   }
   case OPERATOR_GRAD:
   case OPERATOR_D1: {
-    workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HGRAD_TET_Cn_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
+    workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HGRAD_TET_Cn_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, workViewType,
         OPERATOR_D1,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work, order) );
@@ -162,7 +162,7 @@ getValues(
   case OPERATOR_D2: {
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, workViewType,
         OPERATOR_D2,numPtsPerEval> FunctorType;
-    workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HGRAD_TET_Cn_FEM::getValues::work", cardinality*outputValues.extent(2), inputPoints.extent(0));
+    workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HGRAD_TET_Cn_FEM::getValues::work", cardinality*outputValues.extent(2), inputPoints.extent(0));
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work, order) );
     break;
   }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTHDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTHDef.hpp
@@ -290,8 +290,8 @@ typedef typename inputViewType::memory_space memory_space;
 typedef typename Kokkos::View<fad_type***, memory_space> outViewType;
 typedef typename Kokkos::View<fad_type**, memory_space> inViewType;
 
-inViewType in = createUnmanagedViewWithType<inViewType>(input, (value_type*)&inBuf[0][0], npts, spaceDim);
-outViewType out = createUnmanagedViewWithType<outViewType>(input, (value_type*)&outBuf[0][0][0], card, npts, n*(n+1)/2);
+inViewType in = createMatchingUnmanagedView<inViewType>(input, (value_type*)&inBuf[0][0], npts, spaceDim);
+outViewType out = createMatchingUnmanagedView<outViewType>(input, (value_type*)&outBuf[0][0][0], card, npts, n*(n+1)/2);
 
 for (ordinal_type i=0;i<npts;++i)
   for (ordinal_type j=0;j<spaceDim;++j) {
@@ -304,7 +304,7 @@ outViewType_ workView;
 if (n==2) {
   //char outBuf[bufSize*sizeof(typename inViewType::value_type)];
   fad_type outBuf[maxCard][Parameters::MaxNumPtsPerBasisEval][spaceDim+1];
-  workView = createUnmanagedViewWithType<outViewType_>(in, (value_type*)&outBuf[0][0][0], card, npts, spaceDim+1);
+  workView = createMatchingUnmanagedView<outViewType_>(in, (value_type*)&outBuf[0][0][0], card, npts, spaceDim+1);
 }
 OrthPolynomialTet<outViewType,inViewType,outViewType_,hasDeriv,n-1>::generate(out, in, workView, order);
 
@@ -410,7 +410,7 @@ getValues(
   }
   case OPERATOR_GRAD:
   case OPERATOR_D1: {
-    workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HGRAD_TET_In_FEM_ORTH::getValues::work", cardinality, inputPoints.extent(0), spaceDim+1);
+    workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HGRAD_TET_In_FEM_ORTH::getValues::work", cardinality, inputPoints.extent(0), spaceDim+1);
     typedef Functor<outputValueViewType,inputPointViewType,workViewType,OPERATOR_D1,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, work, order) );
     break;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM.hpp
@@ -122,7 +122,7 @@ namespace Intrepid2 {
 
           typename WorkViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-          WorkViewType work = createUnmanagedViewWithType<WorkViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+          WorkViewType work = createMatchingUnmanagedView<WorkViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
           switch (OpType) {
           case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
@@ -47,7 +47,7 @@ getValues(       OutputViewType output,
 
   switch (OpType) {
   case OPERATOR_VALUE: {
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts);
     ViewType dummyView;
 
     Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::
@@ -63,9 +63,9 @@ getValues(       OutputViewType output,
   }
   case OPERATOR_GRAD:
   case OPERATOR_D1: {
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim);
     ptr += card*npts*spaceDim*get_dimension_scalar(input);
-    const ViewType workView = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim+1);
+    const ViewType workView = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim+1);
     Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::
     Serial<OpType>::getValues(phis, input, workView, order);
 
@@ -88,7 +88,7 @@ getValues(       OutputViewType output,
   case OPERATOR_D9:
   case OPERATOR_D10: {
     const ordinal_type dkcard = getDkCardinality<OpType,spaceDim>(); //(orDn + 1);
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, dkcard);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, dkcard);
     ViewType dummyView;
 
     Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::
@@ -104,9 +104,9 @@ getValues(       OutputViewType output,
     break;
   }
   case OPERATOR_CURL: { // only works in 2d. first component is -d/dy, second is d/dx
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim);
     ptr += card*npts*spaceDim*get_dimension_scalar(input);
-    const ViewType workView = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim+1);
+    const ViewType workView = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim+1);
 
 
     Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::
@@ -161,7 +161,7 @@ getValues(
 
   switch (operatorType) {
   case OPERATOR_VALUE: {
-    workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HGRAD_TRI_Cn_FEM::getValues::work", cardinality, inputPoints.extent(0));
+    workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HGRAD_TRI_Cn_FEM::getValues::work", cardinality, inputPoints.extent(0));
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, workViewType,
         OPERATOR_VALUE,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work, order) );
@@ -169,14 +169,14 @@ getValues(
   }
   case OPERATOR_GRAD:
   case OPERATOR_D1: {
-    workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HGRAD_TRI_Cn_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
+    workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HGRAD_TRI_Cn_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, workViewType,
         OPERATOR_D1,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work, order) );
     break;
   }
   case OPERATOR_CURL: {
-    workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HGRAD_TRI_Cn_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
+    workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HGRAD_TRI_Cn_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, workViewType,
         OPERATOR_CURL,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work, order) );
@@ -185,7 +185,7 @@ getValues(
   case OPERATOR_D2: {
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, workViewType,
         OPERATOR_D2,numPtsPerEval> FunctorType;
-    workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HGRAD_TRI_Cn_FEM::getValues::work", cardinality*outputValues.extent(2), inputPoints.extent(0));
+    workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HGRAD_TRI_Cn_FEM::getValues::work", cardinality*outputValues.extent(2), inputPoints.extent(0));
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work, order) );
     break;
   }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTHDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTHDef.hpp
@@ -271,7 +271,7 @@ getValues(
   }
   case OPERATOR_GRAD:
   case OPERATOR_D1: {
-    workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HGRAD_TRI_In_FEM_ORTH::getValues::work", cardinality, inputPoints.extent(0), spaceDim+1);
+    workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HGRAD_TRI_In_FEM_ORTH::getValues::work", cardinality, inputPoints.extent(0), spaceDim+1);
     typedef Functor<outputValueViewType,inputPointViewType,workViewType,OPERATOR_D1,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, work, order) );
     break;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEM.hpp
@@ -94,7 +94,7 @@ namespace Intrepid2 {
 
           typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-          workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+          workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
           switch (opType) {
           case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEMDef.hpp
@@ -53,10 +53,10 @@ namespace Intrepid2 {
 
       switch (OpType) {
       case OPERATOR_VALUE: {
-        ViewType work_line = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
-        ViewType output_x = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts);
-        ViewType output_y = createUnmanagedViewWithType<ViewType>(input, ptr2, cardLine, npts);
-        ViewType output_z = createUnmanagedViewWithType<ViewType>(input, ptr3, cardLine, npts);
+        ViewType work_line = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
+        ViewType output_x = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts);
+        ViewType output_y = createMatchingUnmanagedView<ViewType>(input, ptr2, cardLine, npts);
+        ViewType output_z = createMatchingUnmanagedView<ViewType>(input, ptr3, cardLine, npts);
         
         Impl::Basis_HVOL_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
           getValues(output_x, input_x, work_line, vinv);
@@ -104,35 +104,35 @@ namespace Intrepid2 {
             if (mult_x < 0) {
               // pass
             } else {              
-              ViewType work_line = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
+              ViewType work_line = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
               decltype(work_line)  output_x, output_y, output_z;
                   
               if (mult_x) {
-                output_x = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts, 1);
+                output_x = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts, 1);
                 Impl::Basis_HVOL_LINE_Cn_FEM::Serial<OPERATOR_Dn>::
                   getValues(output_x, input_x, work_line, vinv, mult_x);
               } else {
-                output_x = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts);
+                output_x = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts);
                 Impl::Basis_HVOL_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
                   getValues(output_x, input_x, work_line, vinv);
               }
               
               if (mult_y) {
-                output_y = createUnmanagedViewWithType<ViewType>(input, ptr2, cardLine, npts, 1);
+                output_y = createMatchingUnmanagedView<ViewType>(input, ptr2, cardLine, npts, 1);
                 Impl::Basis_HVOL_LINE_Cn_FEM::Serial<OPERATOR_Dn>::
                   getValues(output_y, input_y, work_line, vinv, mult_y);
               } else {
-                output_y = createUnmanagedViewWithType<ViewType>(input, ptr2, cardLine, npts);
+                output_y = createMatchingUnmanagedView<ViewType>(input, ptr2, cardLine, npts);
                 Impl::Basis_HVOL_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
                   getValues(output_y, input_y, work_line, vinv);
               }
 
               if (mult_z) {
-                output_z = createUnmanagedViewWithType<ViewType>(input, ptr3, cardLine, npts, 1);
+                output_z = createMatchingUnmanagedView<ViewType>(input, ptr3, cardLine, npts, 1);
                 Impl::Basis_HVOL_LINE_Cn_FEM::Serial<OPERATOR_Dn>::
                   getValues(output_z, input_z, work_line, vinv, mult_z);
               } else {
-                output_z = createUnmanagedViewWithType<ViewType>(input, ptr3, cardLine, npts);
+                output_z = createMatchingUnmanagedView<ViewType>(input, ptr3, cardLine, npts);
                 Impl::Basis_HVOL_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
                   getValues(output_z, input_z, work_line, vinv);
               }
@@ -182,7 +182,7 @@ namespace Intrepid2 {
       const ordinal_type cardLine = std::cbrt(cardinality);
       const ordinal_type workSize = 4*cardLine;
 
-      auto work = createDynRankViewFromView(inputPoints, "Basis_HVOL_HEX_Cn_FEM::getValues::work", workSize, inputPoints.extent(0));
+      auto work = createMatchingDynRankView(inputPoints, "Basis_HVOL_HEX_Cn_FEM::getValues::work", workSize, inputPoints.extent(0));
 
       switch (operatorType) {
       case OPERATOR_VALUE: {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEM.hpp
@@ -113,7 +113,7 @@ namespace Intrepid2 {
 
           typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-          workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+          workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
           switch (opType) {
           case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEMDef.hpp
@@ -45,7 +45,7 @@ namespace Intrepid2 {
       
       switch (opType) {
       case OPERATOR_VALUE: {
-        ViewType phis = createUnmanagedViewWithType<ViewType>(input, work.data(), card, npts);     
+        ViewType phis = createMatchingUnmanagedView<ViewType>(input, work.data(), card, npts);     
 
         Impl::Basis_HGRAD_LINE_Cn_FEM_JACOBI::
           Serial<opType>::getValues(phis, input, order, alpha, beta);
@@ -73,7 +73,7 @@ namespace Intrepid2 {
       case OPERATOR_Dn: {
         // dkcard is always 1 for 1D element
         const ordinal_type dkcard = 1;
-        ViewType phis = createUnmanagedViewWithType<ViewType>(input, work.data(), card, npts, dkcard);     
+        ViewType phis = createMatchingUnmanagedView<ViewType>(input, work.data(), card, npts, dkcard);     
         Impl::Basis_HGRAD_LINE_Cn_FEM_JACOBI::
           Serial<opType>::getValues(phis, input, order, alpha, beta, opDn);
 
@@ -117,7 +117,7 @@ namespace Intrepid2 {
 
       const ordinal_type cardinality = outputValues.extent(0);
 
-      auto work = createDynRankViewFromView(inputPoints, "Basis_HVOL_LINE_Cn_FEM::getValues::work", cardinality, inputPoints.extent(0));
+      auto work = createMatchingDynRankView(inputPoints, "Basis_HVOL_LINE_Cn_FEM::getValues::work", cardinality, inputPoints.extent(0));
 
       switch (operatorType) {
       case OPERATOR_VALUE: {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEM.hpp
@@ -95,7 +95,7 @@ namespace Intrepid2 {
 
           typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-          workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+          workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
           switch (opType) {
           case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEMDef.hpp
@@ -51,9 +51,9 @@ namespace Intrepid2 {
 
       switch (OpType) {
       case OPERATOR_VALUE: {
-        ViewType work_line = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
-        ViewType output_x = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts);
-        ViewType output_y = createUnmanagedViewWithType<ViewType>(input, ptr2, cardLine, npts);
+        ViewType work_line = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
+        ViewType output_x = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts);
+        ViewType output_y = createMatchingUnmanagedView<ViewType>(input, ptr2, cardLine, npts);
         
         Impl::Basis_HVOL_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
           getValues(output_x, input_x, work_line, vinv);
@@ -84,7 +84,7 @@ namespace Intrepid2 {
       case OPERATOR_Dn: {
         const auto dkcard = opDn + 1;
         for (auto l=0;l<dkcard;++l) {
-          ViewType work_line = createUnmanagedViewWithType<ViewType>(input, ptr0, cardLine, npts);
+          ViewType work_line = createMatchingUnmanagedView<ViewType>(input, ptr0, cardLine, npts);
           
           ViewType output_x, output_y;
           
@@ -92,21 +92,21 @@ namespace Intrepid2 {
           const auto mult_y = l;
           
           if (mult_x) {
-            output_x = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts, 1);
+            output_x = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts, 1);
             Impl::Basis_HVOL_LINE_Cn_FEM::Serial<OPERATOR_Dn>::
               getValues(output_x, input_x, work_line, vinv, mult_x);                           
           } else {
-            output_x = createUnmanagedViewWithType<ViewType>(input, ptr1, cardLine, npts);
+            output_x = createMatchingUnmanagedView<ViewType>(input, ptr1, cardLine, npts);
             Impl::Basis_HVOL_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
               getValues(output_x, input_x, work_line, vinv);                           
           }
 
           if (mult_y) {
-            output_y = createUnmanagedViewWithType<ViewType>(input, ptr2, cardLine, npts, 1);
+            output_y = createMatchingUnmanagedView<ViewType>(input, ptr2, cardLine, npts, 1);
             Impl::Basis_HVOL_LINE_Cn_FEM::Serial<OPERATOR_Dn>::
               getValues(output_y, input_y, work_line, vinv, mult_y);                           
           } else {
-            output_y = createUnmanagedViewWithType<ViewType>(input, ptr2, cardLine, npts);
+            output_y = createMatchingUnmanagedView<ViewType>(input, ptr2, cardLine, npts);
             Impl::Basis_HVOL_LINE_Cn_FEM::Serial<OPERATOR_VALUE>::
               getValues(output_y, input_y, work_line, vinv);                           
           }
@@ -154,7 +154,7 @@ namespace Intrepid2 {
       const ordinal_type cardLine = std::sqrt(cardinality);
       const ordinal_type workSize = 3*cardLine;
       
-      auto work = createDynRankViewFromView(inputPoints, "Basis_HVOL_QUAD_Cn_FEM::getValues::work", workSize, inputPoints.extent(0));
+      auto work = createMatchingDynRankView(inputPoints, "Basis_HVOL_QUAD_Cn_FEM::getValues::work", workSize, inputPoints.extent(0));
 
       switch (operatorType) {
       case OPERATOR_VALUE: {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEM.hpp
@@ -121,7 +121,7 @@ namespace Intrepid2 {
 
           typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-          workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+          workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
           switch (opType) {
           case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEMDef.hpp
@@ -55,7 +55,7 @@ namespace Intrepid2 {
 
       switch (OpType) {
       case OPERATOR_VALUE: {
-        const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts);
+        const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts);
         ViewType dummyView;
 
         Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::
@@ -71,9 +71,9 @@ namespace Intrepid2 {
       }
       case OPERATOR_GRAD:
       case OPERATOR_D1: {
-        const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim);
+        const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim);
         ptr += card*npts*spaceDim*get_dimension_scalar(input);
-        const ViewType workView = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim+1);
+        const ViewType workView = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim+1);
         Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::
           Serial<OpType>::getValues(phis, input, workView, order);
 
@@ -97,7 +97,7 @@ namespace Intrepid2 {
       case OPERATOR_D10: {
         const ordinal_type dkcard = getDkCardinality<OpType,spaceDim>(); //(orDn + 1);
         const 
-        ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, dkcard);
+        ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, dkcard);
         ViewType dummyView;
 
         Impl::Basis_HGRAD_TET_Cn_FEM_ORTH::
@@ -151,7 +151,7 @@ namespace Intrepid2 {
       switch (operatorType) {
       case OPERATOR_VALUE: {
         auto bufferSize = Basis_HVOL_TET_Cn_FEM::Serial<OPERATOR_VALUE>::getWorkSizePerPoint(order);
-        workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HVOL_TET_Cn_FEM::getValues::work", bufferSize, inputPoints.extent(0));
+        workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HVOL_TET_Cn_FEM::getValues::work", bufferSize, inputPoints.extent(0));
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, workViewType,
             OPERATOR_VALUE,numPtsPerEval> FunctorType;
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work) );
@@ -160,7 +160,7 @@ namespace Intrepid2 {
       case OPERATOR_GRAD:
       case OPERATOR_D1: {
         auto bufferSize = Basis_HVOL_TET_Cn_FEM::Serial<OPERATOR_D1>::getWorkSizePerPoint(order);
-        workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HVOL_TET_Cn_FEM::getValues::work", bufferSize, inputPoints.extent(0));
+        workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HVOL_TET_Cn_FEM::getValues::work", bufferSize, inputPoints.extent(0));
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, workViewType,
             OPERATOR_D1,numPtsPerEval> FunctorType;
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work) );
@@ -170,14 +170,14 @@ namespace Intrepid2 {
         auto bufferSize = Basis_HVOL_TET_Cn_FEM::Serial<OPERATOR_D2>::getWorkSizePerPoint(order);
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, workViewType,
             OPERATOR_D2,numPtsPerEval> FunctorType;
-        workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HVOL_TET_Cn_FEM::getValues::work", bufferSize, inputPoints.extent(0));
+        workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HVOL_TET_Cn_FEM::getValues::work", bufferSize, inputPoints.extent(0));
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work) );
         break;
       }
     /*  case OPERATOR_D3: {
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, workViewType
             OPERATOR_D3,numPtsPerEval> FunctorType;
-        workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HVOL_TET_Cn_FEM::getValues::work", cardinality, inputPoints.extent(0), outputValues.extent(2));
+        workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HVOL_TET_Cn_FEM::getValues::work", cardinality, inputPoints.extent(0), outputValues.extent(2));
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work) );
         break;
       }*/

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEM.hpp
@@ -119,7 +119,7 @@ namespace Intrepid2 {
 
           typename workViewType::pointer_type ptr = _work.data() + _work.extent(0)*ptBegin*get_dimension_scalar(_work);
 
-          workViewType work = createUnmanagedViewWithType<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
+          workViewType work = createMatchingUnmanagedView<workViewType>(_work, ptr, (ptEnd-ptBegin)*_work.extent(0));
 
           switch (opType) {
           case OPERATOR_VALUE : {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEMDef.hpp
@@ -54,7 +54,7 @@ namespace Impl {
 
   switch (OpType) {
   case OPERATOR_VALUE: {
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts);
       ViewType dummyView;
 
     Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::
@@ -70,9 +70,9 @@ namespace Impl {
   }
   case OPERATOR_GRAD:
   case OPERATOR_D1: {
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim);
     ptr += card*npts*spaceDim*get_dimension_scalar(input);
-    const ViewType workView = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, spaceDim+1);
+    const ViewType workView = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, spaceDim+1);
     Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::
     Serial<OpType>::getValues(phis, input, workView, order);
 
@@ -95,7 +95,7 @@ namespace Impl {
   case OPERATOR_D9:
   case OPERATOR_D10: {
     const ordinal_type dkcard = getDkCardinality<OpType,spaceDim>(); //(orDn + 1);
-    const ViewType phis = createUnmanagedViewWithType<ViewType>(input, ptr, card, npts, dkcard);
+    const ViewType phis = createMatchingUnmanagedView<ViewType>(input, ptr, card, npts, dkcard);
     ViewType dummyView;
 
     Impl::Basis_HGRAD_TRI_Cn_FEM_ORTH::
@@ -145,7 +145,7 @@ getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties.
 
   switch (operatorType) {
   case OPERATOR_VALUE: {
-    workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HVOL_TRI_Cn_FEM::getValues::work", cardinality, inputPoints.extent(0));
+    workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HVOL_TRI_Cn_FEM::getValues::work", cardinality, inputPoints.extent(0));
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, workViewType,
         OPERATOR_VALUE,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work) );
@@ -153,7 +153,7 @@ getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties.
   }
   case OPERATOR_GRAD:
   case OPERATOR_D1: {
-    workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HVOL_TRI_Cn_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
+    workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HVOL_TRI_Cn_FEM::getValues::work", cardinality*(2*spaceDim+1), inputPoints.extent(0));
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, workViewType,
         OPERATOR_D1,numPtsPerEval> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work) );
@@ -162,14 +162,14 @@ getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties.
   case OPERATOR_D2: {
     typedef Functor<outputValueViewType,inputPointViewType,vinvViewType, workViewType,
         OPERATOR_D2,numPtsPerEval> FunctorType;
-    workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HVOL_TRI_Cn_FEM::getValues::work", cardinality*outputValues.extent(2), inputPoints.extent(0));
+    workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HVOL_TRI_Cn_FEM::getValues::work", cardinality*outputValues.extent(2), inputPoints.extent(0));
     Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work) );
     break;
   }
   /*  case OPERATOR_D3: {
         typedef Functor<outputValueViewType,inputPointViewType,vinvViewType,
             OPERATOR_D3,numPtsPerEval> FunctorType;
-        workViewType work = createViewFromViewWithType<workViewType>(inputPoints, "Basis_HVOL_TRI_Cn_FEM::getValues::work", cardinality, inputPoints.extent(0), outputValues.extent(2));
+        workViewType work = createMatchingView<workViewType>(inputPoints, "Basis_HVOL_TRI_Cn_FEM::getValues::work", cardinality, inputPoints.extent(0), outputValues.extent(2));
         Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, vinv, work) );
         break;
       }*/

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
@@ -1651,14 +1651,14 @@ struct OperatorTensorDecomposition
               
               OutputViewType outputValues1, outputValues2;
               if (op1 == OPERATOR_VALUE)
-                outputValues1 = createDynRankViewFromView(outputValues, "output values - basis 1",basisCardinality1,pointCount1);
+                outputValues1 = Impl::createMatchingDynRankView(outputValues, "output values - basis 1",basisCardinality1,pointCount1);
               else
-                outputValues1 = createDynRankViewFromView(outputValues, "output values - basis 1",basisCardinality1,pointCount1,dkCardinality1);
+                outputValues1 = Impl::createMatchingDynRankView(outputValues, "output values - basis 1",basisCardinality1,pointCount1,dkCardinality1);
               
               if (op2 == OPERATOR_VALUE)
-                outputValues2 = createDynRankViewFromView(outputValues, "output values - basis 2",basisCardinality2,pointCount2);
+                outputValues2 = Impl::createMatchingDynRankView(outputValues, "output values - basis 2",basisCardinality2,pointCount2);
               else
-                outputValues2 = createDynRankViewFromView(outputValues, "output values - basis 2",basisCardinality2,pointCount2,dkCardinality2);
+                outputValues2 = Impl::createMatchingDynRankView(outputValues, "output values - basis 2",basisCardinality2,pointCount2,dkCardinality2);
                 
               basis1_->getValues(outputValues1,inputPoints1,op1);
               basis2_->getValues(outputValues2,inputPoints2,op2);
@@ -1798,11 +1798,11 @@ struct OperatorTensorDecomposition
       OutputViewType outputValues1, outputValues2;
       if (outputRank1 == 0)
       {
-        outputValues1 = createDynRankViewFromView(outputValues,"output values - basis 1",basisCardinality1,pointCount1);
+        outputValues1 = Impl::createMatchingDynRankView(outputValues,"output values - basis 1",basisCardinality1,pointCount1);
       }
       else if (outputRank1 == 1)
       {
-        outputValues1 = createDynRankViewFromView(outputValues,"output values - basis 1",basisCardinality1,pointCount1,spaceDim1);
+        outputValues1 = Impl::createMatchingDynRankView(outputValues,"output values - basis 1",basisCardinality1,pointCount1,spaceDim1);
       }
       else
       {
@@ -1811,11 +1811,11 @@ struct OperatorTensorDecomposition
       
       if (outputRank2 == 0)
       {
-        outputValues2 = createDynRankViewFromView(outputValues,"output values - basis 2",basisCardinality2,pointCount2);
+        outputValues2 = Impl::createMatchingDynRankView(outputValues,"output values - basis 2",basisCardinality2,pointCount2);
       }
       else if (outputRank2 == 1)
       {
-        outputValues2 = createDynRankViewFromView(outputValues,"output values - basis 2",basisCardinality2,pointCount2,spaceDim2);
+        outputValues2 = Impl::createMatchingDynRankView(outputValues,"output values - basis 2",basisCardinality2,pointCount2,spaceDim2);
       }
       else
       {
@@ -2314,29 +2314,29 @@ struct OperatorTensorDecomposition
       if ((spaceDim1 == 1) && (operatorType1 == OPERATOR_VALUE))
       {
         // use a rank 2 container for basis1
-        outputValues1 = createDynRankViewFromView(outputValues,"output values - basis 1",basisCardinality1,pointCount1);
+        outputValues1 = Impl::createMatchingDynRankView(outputValues,"output values - basis 1",basisCardinality1,pointCount1);
       }
       else
       {
-        outputValues1 = createDynRankViewFromView(outputValues,"output values - basis 1",basisCardinality1,pointCount1,spaceDim1);
+        outputValues1 = Impl::createMatchingDynRankView(outputValues,"output values - basis 1",basisCardinality1,pointCount1,spaceDim1);
       }
       if ((spaceDim2 == 1) && (operatorType2 == OPERATOR_VALUE))
       {
         // use a rank 2 container for basis2
-        outputValues2 = createDynRankViewFromView(outputValues,"output values - basis 2",basisCardinality2,pointCount2);
+        outputValues2 = Impl::createMatchingDynRankView(outputValues,"output values - basis 2",basisCardinality2,pointCount2);
       }
       else
       {
-        outputValues2 = createDynRankViewFromView(outputValues,"output values - basis 2",basisCardinality2,pointCount2,spaceDim2);
+        outputValues2 = Impl::createMatchingDynRankView(outputValues,"output values - basis 2",basisCardinality2,pointCount2,spaceDim2);
       }
       if ((spaceDim3 == 1) && (operatorType3 == OPERATOR_VALUE))
       {
         // use a rank 2 container for basis2
-        outputValues3 = createDynRankViewFromView(outputValues,"output values - basis 3",basisCardinality3,pointCount3);
+        outputValues3 = Impl::createMatchingDynRankView(outputValues,"output values - basis 3",basisCardinality3,pointCount3);
       }
       else
       {
-        outputValues3 = createDynRankViewFromView(outputValues,"output values - basis 3",basisCardinality3,pointCount3,spaceDim3);
+        outputValues3 = Impl::createMatchingDynRankView(outputValues,"output values - basis 3",basisCardinality3,pointCount3,spaceDim3);
       }
 
       basis1_->getValues(outputValues1,inputPoints1,operatorType1);

--- a/packages/intrepid2/src/Discretization/FunctionSpaceTools/Intrepid2_FunctionSpaceToolsDef.hpp
+++ b/packages/intrepid2/src/Discretization/FunctionSpaceTools/Intrepid2_FunctionSpaceToolsDef.hpp
@@ -596,7 +596,7 @@ namespace Intrepid2 {
 #endif
 
     // face normals (reshape scratch)
-    auto faceNormals = createUnmanagedDynRankView(inputJac, scratch.data(), inputJac.extent(0), inputJac.extent(1), inputJac.extent(2));
+    auto faceNormals = Impl::createMatchingUnmanagedDynRankView(inputJac, scratch.data(), inputJac.extent(0), inputJac.extent(1), inputJac.extent(2));
 
     // compute normals
     CellTools<DeviceType>::getPhysicalFaceNormals(faceNormals, inputJac, whichFace, parentCell);
@@ -633,7 +633,7 @@ namespace Intrepid2 {
 #endif
 
     // edge tangents (reshape scratch)
-    auto edgeTangents = createUnmanagedDynRankView(inputJac, scratch.data(), inputJac.extent(0), inputJac.extent(1), inputJac.extent(2));
+    auto edgeTangents = Impl::createMatchingUnmanagedDynRankView(inputJac, scratch.data(), inputJac.extent(0), inputJac.extent(1), inputJac.extent(2));
 
     // compute normals
     CellTools<DeviceType>::getPhysicalEdgeTangents(edgeTangents, inputJac, whichEdge, parentCell);

--- a/packages/intrepid2/src/Shared/Intrepid2_Data.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Data.hpp
@@ -1068,13 +1068,13 @@ public:
     {
       switch (dataRank_)
       {
-        case 1: return createDynRankViewFromView(get_fixed_view<View1>(underlyingView_), "Intrepid2 Data", get_fixed_view<View1>(underlyingView_).extent_int(0));
-        case 2: return createDynRankViewFromView(get_fixed_view<View2>(underlyingView_), "Intrepid2 Data", get_fixed_view<View2>(underlyingView_).extent_int(0), get_fixed_view<View2>(underlyingView_).extent_int(1));
-        case 3: return createDynRankViewFromView(get_fixed_view<View3>(underlyingView_), "Intrepid2 Data", get_fixed_view<View3>(underlyingView_).extent_int(0), get_fixed_view<View3>(underlyingView_).extent_int(1), get_fixed_view<View3>(underlyingView_).extent_int(2));
-        case 4: return createDynRankViewFromView(get_fixed_view<View4>(underlyingView_), "Intrepid2 Data", get_fixed_view<View4>(underlyingView_).extent_int(0), get_fixed_view<View4>(underlyingView_).extent_int(1), get_fixed_view<View4>(underlyingView_).extent_int(2), get_fixed_view<View4>(underlyingView_).extent_int(3));
-        case 5: return createDynRankViewFromView(get_fixed_view<View5>(underlyingView_), "Intrepid2 Data", get_fixed_view<View5>(underlyingView_).extent_int(0), get_fixed_view<View5>(underlyingView_).extent_int(1), get_fixed_view<View5>(underlyingView_).extent_int(2), get_fixed_view<View5>(underlyingView_).extent_int(3), get_fixed_view<View5>(underlyingView_).extent_int(4));
-        case 6: return createDynRankViewFromView(get_fixed_view<View6>(underlyingView_), "Intrepid2 Data", get_fixed_view<View6>(underlyingView_).extent_int(0), get_fixed_view<View6>(underlyingView_).extent_int(1), get_fixed_view<View6>(underlyingView_).extent_int(2), get_fixed_view<View6>(underlyingView_).extent_int(3), get_fixed_view<View6>(underlyingView_).extent_int(4), get_fixed_view<View6>(underlyingView_).extent_int(5));
-        case 7: return createDynRankViewFromView(get_fixed_view<View7>(underlyingView_), "Intrepid2 Data", get_fixed_view<View7>(underlyingView_).extent_int(0), get_fixed_view<View7>(underlyingView_).extent_int(1), get_fixed_view<View7>(underlyingView_).extent_int(2), get_fixed_view<View7>(underlyingView_).extent_int(3), get_fixed_view<View7>(underlyingView_).extent_int(4), get_fixed_view<View7>(underlyingView_).extent_int(5), get_fixed_view<View7>(underlyingView_).extent_int(6));
+        case 1: return Impl::createMatchingDynRankView(get_fixed_view<View1>(underlyingView_), "Intrepid2 Data", get_fixed_view<View1>(underlyingView_).extent_int(0));
+        case 2: return Impl::createMatchingDynRankView(get_fixed_view<View2>(underlyingView_), "Intrepid2 Data", get_fixed_view<View2>(underlyingView_).extent_int(0), get_fixed_view<View2>(underlyingView_).extent_int(1));
+        case 3: return Impl::createMatchingDynRankView(get_fixed_view<View3>(underlyingView_), "Intrepid2 Data", get_fixed_view<View3>(underlyingView_).extent_int(0), get_fixed_view<View3>(underlyingView_).extent_int(1), get_fixed_view<View3>(underlyingView_).extent_int(2));
+        case 4: return Impl::createMatchingDynRankView(get_fixed_view<View4>(underlyingView_), "Intrepid2 Data", get_fixed_view<View4>(underlyingView_).extent_int(0), get_fixed_view<View4>(underlyingView_).extent_int(1), get_fixed_view<View4>(underlyingView_).extent_int(2), get_fixed_view<View4>(underlyingView_).extent_int(3));
+        case 5: return Impl::createMatchingDynRankView(get_fixed_view<View5>(underlyingView_), "Intrepid2 Data", get_fixed_view<View5>(underlyingView_).extent_int(0), get_fixed_view<View5>(underlyingView_).extent_int(1), get_fixed_view<View5>(underlyingView_).extent_int(2), get_fixed_view<View5>(underlyingView_).extent_int(3), get_fixed_view<View5>(underlyingView_).extent_int(4));
+        case 6: return Impl::createMatchingDynRankView(get_fixed_view<View6>(underlyingView_), "Intrepid2 Data", get_fixed_view<View6>(underlyingView_).extent_int(0), get_fixed_view<View6>(underlyingView_).extent_int(1), get_fixed_view<View6>(underlyingView_).extent_int(2), get_fixed_view<View6>(underlyingView_).extent_int(3), get_fixed_view<View6>(underlyingView_).extent_int(4), get_fixed_view<View6>(underlyingView_).extent_int(5));
+        case 7: return Impl::createMatchingDynRankView(get_fixed_view<View7>(underlyingView_), "Intrepid2 Data", get_fixed_view<View7>(underlyingView_).extent_int(0), get_fixed_view<View7>(underlyingView_).extent_int(1), get_fixed_view<View7>(underlyingView_).extent_int(2), get_fixed_view<View7>(underlyingView_).extent_int(3), get_fixed_view<View7>(underlyingView_).extent_int(4), get_fixed_view<View7>(underlyingView_).extent_int(5), get_fixed_view<View7>(underlyingView_).extent_int(6));
         default: INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Invalid data rank");
       }
     }
@@ -1085,13 +1085,13 @@ public:
     {
       switch (dataRank_)
       {
-        case 1: return createDynRankViewFromView(get_fixed_view<View1>(underlyingView_), "Intrepid2 Data", dims...);
-        case 2: return createDynRankViewFromView(get_fixed_view<View2>(underlyingView_), "Intrepid2 Data", dims...);
-        case 3: return createDynRankViewFromView(get_fixed_view<View3>(underlyingView_), "Intrepid2 Data", dims...);
-        case 4: return createDynRankViewFromView(get_fixed_view<View4>(underlyingView_), "Intrepid2 Data", dims...);
-        case 5: return createDynRankViewFromView(get_fixed_view<View5>(underlyingView_), "Intrepid2 Data", dims...);
-        case 6: return createDynRankViewFromView(get_fixed_view<View6>(underlyingView_), "Intrepid2 Data", dims...);
-        case 7: return createDynRankViewFromView(get_fixed_view<View7>(underlyingView_), "Intrepid2 Data", dims...);
+        case 1: return Impl::createMatchingDynRankView(get_fixed_view<View1>(underlyingView_), "Intrepid2 Data", dims...);
+        case 2: return Impl::createMatchingDynRankView(get_fixed_view<View2>(underlyingView_), "Intrepid2 Data", dims...);
+        case 3: return Impl::createMatchingDynRankView(get_fixed_view<View3>(underlyingView_), "Intrepid2 Data", dims...);
+        case 4: return Impl::createMatchingDynRankView(get_fixed_view<View4>(underlyingView_), "Intrepid2 Data", dims...);
+        case 5: return Impl::createMatchingDynRankView(get_fixed_view<View5>(underlyingView_), "Intrepid2 Data", dims...);
+        case 6: return Impl::createMatchingDynRankView(get_fixed_view<View6>(underlyingView_), "Intrepid2 Data", dims...);
+        case 7: return Impl::createMatchingDynRankView(get_fixed_view<View7>(underlyingView_), "Intrepid2 Data", dims...);
         default: INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Invalid data rank");
       }
     }
@@ -1415,34 +1415,34 @@ public:
       auto viewToMatch = A_MatData.getUnderlyingView();
       if (resultNumActiveDims == 1)
       {
-        data = createDynRankViewFromView(viewToMatch, "Data mat-mat result", resultDataDims[0]);
+        data = Impl::createMatchingDynRankView(viewToMatch, "Data mat-mat result", resultDataDims[0]);
       }
       else if (resultNumActiveDims == 2)
       {
-        data = createDynRankViewFromView(viewToMatch, "Data mat-mat result", resultDataDims[0], resultDataDims[1]);
+        data = Impl::createMatchingDynRankView(viewToMatch, "Data mat-mat result", resultDataDims[0], resultDataDims[1]);
       }
       else if (resultNumActiveDims == 3)
       {
-        data = createDynRankViewFromView(viewToMatch, "Data mat-mat result", resultDataDims[0], resultDataDims[1], resultDataDims[2]);
+        data = Impl::createMatchingDynRankView(viewToMatch, "Data mat-mat result", resultDataDims[0], resultDataDims[1], resultDataDims[2]);
       }
       else if (resultNumActiveDims == 4)
       {
-        data = createDynRankViewFromView(viewToMatch, "Data mat-mat result", resultDataDims[0], resultDataDims[1], resultDataDims[2],
+        data = Impl::createMatchingDynRankView(viewToMatch, "Data mat-mat result", resultDataDims[0], resultDataDims[1], resultDataDims[2],
                                         resultDataDims[3]);
       }
       else if (resultNumActiveDims == 5)
       {
-        data = createDynRankViewFromView(viewToMatch, "Data mat-mat result", resultDataDims[0], resultDataDims[1], resultDataDims[2],
+        data = Impl::createMatchingDynRankView(viewToMatch, "Data mat-mat result", resultDataDims[0], resultDataDims[1], resultDataDims[2],
                                         resultDataDims[3], resultDataDims[4]);
       }
       else if (resultNumActiveDims == 6)
       {
-        data = createDynRankViewFromView(viewToMatch, "Data mat-mat result", resultDataDims[0], resultDataDims[1], resultDataDims[2],
+        data = Impl::createMatchingDynRankView(viewToMatch, "Data mat-mat result", resultDataDims[0], resultDataDims[1], resultDataDims[2],
                                         resultDataDims[3], resultDataDims[4], resultDataDims[5]);
       }
       else // resultNumActiveDims == 7
       {
-        data = createDynRankViewFromView(viewToMatch, "Data mat-mat result", resultDataDims[0], resultDataDims[1], resultDataDims[2],
+        data = Impl::createMatchingDynRankView(viewToMatch, "Data mat-mat result", resultDataDims[0], resultDataDims[1], resultDataDims[2],
                                         resultDataDims[3], resultDataDims[4], resultDataDims[5], resultDataDims[6]);
       }
       

--- a/packages/intrepid2/src/Shared/Intrepid2_PointToolsDef.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_PointToolsDef.hpp
@@ -114,7 +114,7 @@ getLattice(       Kokkos::DynRankView<pointValueType,pointProperties...> points,
     auto hostPoints = Kokkos::create_mirror_view(points);
     shards::CellTopology line(shards::getCellTopologyData<shards::Line<2> >());
     const ordinal_type numPoints = getLatticeSize( line, order, offset );
-    auto linePoints = createDynRankViewFromView(hostPoints, "linePoints", numPoints, 1);
+    auto linePoints = Impl::createMatchingDynRankView(hostPoints, "linePoints", numPoints, 1);
     getLatticeLine( linePoints, order, offset, pointType );
     ordinal_type idx=0;
     for (ordinal_type j=0; j<numPoints; ++j) {
@@ -130,7 +130,7 @@ getLattice(       Kokkos::DynRankView<pointValueType,pointProperties...> points,
     auto hostPoints = Kokkos::create_mirror_view(points);
     shards::CellTopology line(shards::getCellTopologyData<shards::Line<2> >());
     const ordinal_type numPoints = getLatticeSize( line, order, offset );
-    auto linePoints = createDynRankViewFromView(hostPoints, "linePoints", numPoints, 1);
+    auto linePoints = Impl::createMatchingDynRankView(hostPoints, "linePoints", numPoints, 1);
     getLatticeLine( linePoints, order, offset, pointType );
     ordinal_type idx=0;
     for (ordinal_type k=0; k<numPoints; ++k) {

--- a/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
@@ -335,105 +335,112 @@ namespace Intrepid2 {
   };
 
 
-
-  //! @brief Factory to create a view based on the properties of input views
-  /// The class is useful when the view can be of Fad type
-  /// It works with both DynRankViews and Views
-  template <class... ViewPack>
-  struct CreateViewFactory
+  namespace Impl
   {
-    //! \brief Creates and returns a view that matches the value_type of the provided view 
-    ///        When Sacado is enabled we use Sacado implementation
-    /// \param [in] views  - the view(s) to match
+    //! @brief Factory to create a view based on the properties of input views
+    /// The class is useful when the view can be of Fad type
+    /// It works with both DynRankViews and Views
+    template <class... ViewPack>
+    struct CreateViewFactory
+    {
+      //! \brief Creates and returns a view that matches the value_type of the provided view 
+      ///        When Sacado is enabled we use Sacado implementation
+      /// \param [in] views  - the view(s) to match
+      /// \param [in] prop - the properties (e.g., label)
+      /// \param [in] dims  - dimensions to use for the view (the logical dimensions; this method handles adding the derivative dimension required for Fad types).
+      template <class OutViewType, class CtorProp, class... Dims>
+      static OutViewType
+      create_view(const ViewPack &...views,
+                  const CtorProp &prop,
+                  const Dims... dims)
+      {
+  #ifdef HAVE_INTREPID2_SACADO
+        using view_factory = Kokkos::ViewFactory<ViewPack...>;
+        return view_factory::template create_view<OutViewType>(views..., prop, dims...);
+  #else
+        (void)views, ...;
+        return OutViewType(prop, dims...);
+  #endif
+      }
+    };
+
+    //! \brief Creates and returns a view that matches the value_type of the provided view
+    ///        The type of the output view needs to be provided
+    ///        It works both with DynRankViews and Views
+    /// \param [in] view  - the view(s) to match
     /// \param [in] prop - the properties (e.g., label)
     /// \param [in] dims  - dimensions to use for the view (the logical dimensions; this method handles adding the derivative dimension required for Fad types).
-    template <class OutViewType, class CtorProp, class... Dims>
-    static OutViewType
-    create_view(const ViewPack &...views,
-                const CtorProp &prop,
-                const Dims... dims)
+    template <typename OutViewType, typename InViewType, typename CtorProp, typename... Dims>
+    OutViewType
+    createMatchingView(const InViewType &view,
+                              const CtorProp &prop,
+                              const Dims... dims)
     {
-#ifdef HAVE_INTREPID2_SACADO
-      using view_factory = Kokkos::ViewFactory<ViewPack...>;
-      return view_factory::template create_view<OutViewType>(views..., prop, dims...);
-#else
-      (void)views, ...;
-      return OutViewType(prop, dims...);
-#endif
+      using cvf = CreateViewFactory<InViewType>;
+      return cvf::template create_view<OutViewType>(view, prop, dims...);
     }
-  };
 
-  //! \brief Creates and returns a view that matches the value_type of the provided view
-  ///        The type of the output view needs to be provided
-  ///        It works both with DynRankViews and Views
-  /// \param [in] view  - the view(s) to match
-  /// \param [in] prop - the properties (e.g., label)
-  /// \param [in] dims  - dimensions to use for the view (the logical dimensions; this method handles adding the derivative dimension required for Fad types).
-  template <typename OutViewType, typename InViewType, typename CtorProp, typename... Dims>
-  OutViewType
-  createViewFromViewWithType(const InViewType &view,
-                             const CtorProp &prop,
-                             const Dims... dims)
-  {
-    using cvf = CreateViewFactory<InViewType>;
-    return cvf::template create_view<OutViewType>(view, prop, dims...);
-  }
-
-  //! \brief Creates and returns a view that matches the value_type of the provided view
-  ///        The output view type is deduced from the input view, choosing the default layout when the input view has a stride layout
-  /// \param [in] view  - the view(s) to match
-  /// \param [in] prop - the properties (e.g., label)
-  /// \param [in] dims  - dimensions to use for the view (the logical dimensions; this method handles adding the derivative dimension required for Fad types).
-  template <typename InViewType, typename CtorProp, typename... Dims>
-  typename DeduceDynRankView<InViewType>::type
-  createDynRankViewFromView(const InViewType &view,
-                            const CtorProp &prop,
-                            const Dims... dims)
-  {
-    using OutViewType = typename DeduceDynRankView<InViewType>::type;
-    return createViewFromViewWithType<OutViewType>(view, prop, dims...);
-  }
-
-  //! \brief Creates an unmanaged view that matches the value_type of the provided view
-  ///        The type of the output view needs to be provided
-  /// \param [in] view  - the view(s) to match
-  /// \param [in] view  - the view(s) to match
-  /// \param [in] data  - pointer to array
-  /// \param [in] dims  - dimensions to use for the view (the logical dimensions; this method handles adding the derivative dimension required for Fad types).
-  template <typename OutViewType, typename InViewType, typename CtorProp, typename... Dims>
-  KOKKOS_INLINE_FUNCTION
-  OutViewType
-  createUnmanagedViewWithType(const InViewType &view, const CtorProp &data, const Dims... dims)
-  {
-#ifdef HAVE_INTREPID2_SACADO
-    if constexpr (Sacado::is_view_fad<InViewType>::value)
+    //! \brief Creates and returns a view that matches the value_type of the provided view
+    ///        The output view type is deduced from the input view, choosing the default layout when the input view has a stride layout
+    /// \param [in] view  - the view(s) to match
+    /// \param [in] prop - the properties (e.g., label)
+    /// \param [in] dims  - dimensions to use for the view (the logical dimensions; this method handles adding the derivative dimension required for Fad types).
+    template <typename InViewType, typename CtorProp, typename... Dims>
+    typename DeduceDynRankView<InViewType>::type
+    createMatchingDynRankView(const InViewType &view,
+                              const CtorProp &prop,
+                              const Dims... dims)
     {
-      const int derivative_dimension = get_dimension_scalar(view);
-      return OutViewType(data, dims..., derivative_dimension);
-    }
-    else
-      return OutViewType(data, dims...);
-#else
-    (void)view;
-    return OutViewType(data, dims...);
-#endif
-  }
-
-  //! \brief Creates an unmanaged view that matches the value_type of the provided view
-  ///        The output view type is deduced from the input view, choosing the default layout when the input view has a stride layout
-  /// \param [in] view  - the view(s) to match
-  /// \param [in] data  - pointer to array
-  /// \param [in] dims  - dimensions to use for the view (the logical dimensions; this method handles adding the derivative dimension required for Fad types).
-  template <typename InViewType, typename CtorProp, typename ... Dims>
-  KOKKOS_INLINE_FUNCTION
-  typename DeduceDynRankView<InViewType>::type
-  createUnmanagedDynRankView(const InViewType& view, const CtorProp&  data, const Dims... dims){
       using OutViewType = typename DeduceDynRankView<InViewType>::type;
-      return createUnmanagedViewWithType<OutViewType>(view, data, dims...);
-  }
+      return createMatchingView<OutViewType>(view, prop, dims...);
+    }
+
+    //! \brief Creates an unmanaged view that matches the value_type of the provided view
+    ///        The type of the output view needs to be provided
+    /// \param [in] view  - the view(s) to match
+    /// \param [in] view  - the view(s) to match
+    /// \param [in] data  - pointer to array
+    /// \param [in] dims  - dimensions to use for the view (the logical dimensions; this method handles adding the derivative dimension required for Fad types).
+    template <typename OutViewType, typename InViewType, typename CtorProp, typename... Dims>
+    KOKKOS_INLINE_FUNCTION
+    typename std::enable_if<
+    std::is_pointer_v<CtorProp> && !std::is_convertible_v<CtorProp, const char*>,
+    OutViewType>::type
+    createMatchingUnmanagedView(const InViewType &view, const CtorProp &data, const Dims... dims)
+    {
+  #ifdef HAVE_INTREPID2_SACADO
+      if constexpr (Sacado::is_view_fad<InViewType>::value)
+      {
+        const int derivative_dimension = get_dimension_scalar(view);
+        return OutViewType(data, dims..., derivative_dimension);
+      }
+      else
+        return OutViewType(data, dims...);
+  #else
+      (void)view;
+      return OutViewType(data, dims...);
+  #endif
+    }
+
+    //! \brief Creates an unmanaged view that matches the value_type of the provided view
+    ///        The output view type is deduced from the input view, choosing the default layout when the input view has a stride layout
+    /// \param [in] view  - the view(s) to match
+    /// \param [in] data  - pointer to array
+    /// \param [in] dims  - dimensions to use for the view (the logical dimensions; this method handles adding the derivative dimension required for Fad types).
+    template <typename InViewType, typename CtorProp, typename ... Dims>
+    KOKKOS_INLINE_FUNCTION
+    typename std::enable_if<
+    std::is_pointer_v<CtorProp> && !std::is_convertible_v<CtorProp, const char*>,
+    typename DeduceDynRankView<InViewType>::type>::type
+    createMatchingUnmanagedDynRankView(const InViewType& view, const CtorProp&  data, const Dims... dims){
+        using OutViewType = typename DeduceDynRankView<InViewType>::type;
+        return createMatchingUnmanagedView<OutViewType>(view, data, dims...);
+    }
+
+  } //Impl namespace
 
   
-  //! \brief Creates and returns a view that matches the provided view in Kokkos Layout. DEPRECATED, use createDynRankViewFromView instead
+  //! \brief Creates and returns a view that matches the provided view in Kokkos Layout. DEPRECATED, use Impl::createMatchingDynRankView instead
   //! \param [in] view  - the view to match
   //! \param [in] label - a string label for the view to be created
   //! \param [in] dims  - dimensions to use for the view (the logical dimensions; this method handles adding the derivative dimension required for Fad types).
@@ -446,7 +453,7 @@ namespace Intrepid2 {
   Kokkos::DynRankView<typename ViewType::value_type, typename DeduceLayout< ViewType >::result_layout, typename ViewType::device_type >
   getMatchingViewWithLabel(const ViewType &view, const std::string &label, DimArgs... dims)
   {
-    return createDynRankViewFromView(view, label, dims...);
+    return Impl::createMatchingDynRankView(view, label, dims...);
   }
 
   using std::enable_if_t;


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/intrepid2 

## Motivation
With the Kokkos 5 view refactoring, `common_alloc_view_prop` is no longer reliable.
This PR implements methods to create views based on `Kokkos::view_factory` in `Sacado` and replace the current implementation.



## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes [`14853`](https://github.com/trilinos/Trilinos/issues/14853)

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->