### PR TITLE
Stokhos: fix execution policy of kernels used with `ENSEMBLE_REDUCTION=OFF`

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas2_gemv_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas2_gemv_MP_Vector.hpp
@@ -222,12 +222,12 @@ void inner_products_MP(
 
     if (beta == Scalar(0.))
         Kokkos::parallel_for(
-            m, KOKKOS_LAMBDA(const int i) {
+            Kokkos::RangePolicy<execution_space>(0, m), KOKKOS_LAMBDA(const int i) {
                 y(i) = beta;
             });
     else
         Kokkos::parallel_for(
-            m, KOKKOS_LAMBDA(const int i) {
+            Kokkos::RangePolicy<execution_space>(0, m), KOKKOS_LAMBDA(const int i) {
                 y(i) *= beta;
             });
 


### PR DESCRIPTION
@trilinos/stokhos
@etphipp

This PR fixes the execution policy of two kernels used with `ENSEMBLE_REDUCTION=OFF`. 

Currently, these execution policies use the default execution space. And so the problem is that in a build with both a host and a device backend enabled, the work doesn't go to the right execution space in host tests. This leads to certain tests failing at run time, such as `Stokhos_TpetraCrsMatrixMPVectorUnitTest_Serial_MPI_4`.