### PR TITLE
Percept: use underlying view when calling Intrepid2 functions

### DIFF
--- a/packages/percept/src/percept/norm/IntrepidManager.cpp
+++ b/packages/percept/src/percept/norm/IntrepidManager.cpp
@@ -138,7 +138,7 @@
     {
       //Intrepid2::CellTools<Kokkos::HostSpace>::mapToPhysicalFrame(images, preImages, triNodes, triangle_3);
       auto basis = BasisTable::getInstance()->getBasis(*m_im.m_topo);
-      Intrepid2::CellTools<Kokkos::HostSpace>::mapToPhysicalFrame(*this, xi, c, basis);
+      Intrepid2::CellTools<Kokkos::HostSpace>::mapToPhysicalFrame(this->getArray(), xi.getArray(), c.getArray(), basis);
     }
 
     //------------------------------------------------------------------------------------------------------------------------
@@ -155,7 +155,7 @@
 
     operator()(CubaturePoints& xi, CellWorkSet& c, CellTopology& topo)
     {
-      CellTools<Kokkos::HostSpace>::setJacobian(*this, xi, c, topo);           // compute cell Jacobians
+      CellTools<Kokkos::HostSpace>::setJacobian(this->getArray(), xi.getArray(), c.getArray(), topo);           // compute cell Jacobians
     }
 
     //------------------------------------------------------------------------------------------------------------------------
@@ -171,7 +171,7 @@
     IntrepidManager::FaceNormal::
     operator()(Jacobian& jac, int i_face, CellTopology& topo)
     {
-      Intrepid2::CellTools<Kokkos::HostSpace>::getPhysicalFaceNormals(*this, jac, i_face, topo);
+      Intrepid2::CellTools<Kokkos::HostSpace>::getPhysicalFaceNormals(this->getArray(), jac.getArray(), i_face, topo);
     }
 
 
@@ -187,7 +187,7 @@
     void    IntrepidManager::JacobianInverse::
     operator()(Jacobian& jac)
     {
-      CellTools<Kokkos::HostSpace>::setJacobianInv(*this, jac);
+      CellTools<Kokkos::HostSpace>::setJacobianInv(this->getArray(), jac.getArray());
     }
 
 
@@ -204,7 +204,7 @@
     IntrepidManager::JacobianDet::
     operator()(Jacobian& jac)
     {
-      Intrepid2::CellTools<Kokkos::HostSpace>::setJacobianDet(*this, jac);
+      Intrepid2::CellTools<Kokkos::HostSpace>::setJacobianDet(this->getArray(), jac.getArray());
     }
 
     //------------------------------------------------------------------------------------------------------------------------
@@ -220,7 +220,7 @@
     IntrepidManager::WeightedMeasure::
     operator()(CubatureWeights& w, JacobianDet& dJ)
     {
-      FunctionSpaceTools<Kokkos::HostSpace>::computeCellMeasure(*this, dJ, w);
+      FunctionSpaceTools<Kokkos::HostSpace>::computeCellMeasure(this->getArray(), dJ.getArray(), w.getArray());
     }
 
     //------------------------------------------------------------------------------------------------------------------------

--- a/packages/percept/src/percept/norm/IntrepidManager.hpp
+++ b/packages/percept/src/percept/norm/IntrepidManager.hpp
@@ -164,6 +164,10 @@ using namespace Intrepid2;
 
         CubaturePoints(const IM& im) ;
 
+        BaseType& getArray() {
+          return *this; 
+        }
+
         void copyTo(MDArray& mda)
         {
           Kokkos::resize(mda, m_im.m_Cub_Points_Tag.num, m_im.m_Spatial_Dim_Tag.num);
@@ -180,6 +184,10 @@ using namespace Intrepid2;
       public:
         typedef MDArray BaseType;
 
+        BaseType& getArray() {
+          return *this; 
+        }
+
         CubatureWeights(const IM& im);
         using BaseType::operator();
 
@@ -190,6 +198,10 @@ using namespace Intrepid2;
       {
       public:
         typedef MDArray BaseType;
+
+        BaseType& getArray() {
+          return *this; 
+        }
 
         CellWorkSet(const IM& im);
         using BaseType::operator();
@@ -204,6 +216,10 @@ using namespace Intrepid2;
         typedef MDArray BaseType;
 
         PhysicalCoords(const IM& im);
+
+        BaseType& getArray() {
+          return *this; 
+        }
 
         void operator()(CellWorkSet& c, CubaturePoints& xi);
         
@@ -227,6 +243,10 @@ using namespace Intrepid2;
         Jacobian(const IM& im);
         void operator()(CubaturePoints& xi, CellWorkSet& c, CellTopology& topo);
 
+        BaseType& getArray() {
+          return *this; 
+        }
+
         void copyTo(MDArray& mda)
         {
           Kokkos::resize(mda, m_im.m_Elements_Tag.num, m_im.m_Cub_Points_Tag.num, m_im.m_Spatial_Dim_Tag.num, m_im.m_Spatial_Dim_Tag.num);
@@ -243,6 +263,12 @@ using namespace Intrepid2;
         typedef MDArray BaseType;
 
         FaceNormal(const IM& im);
+
+
+        BaseType& getArray() {
+          return *this; 
+        }
+
         void operator()(Jacobian& jac, int i_face, CellTopology& topo);
 
         using BaseType::operator();
@@ -256,6 +282,12 @@ using namespace Intrepid2;
         typedef MDArray BaseType;
 
         JacobianInverse(const IM& im);
+
+
+        BaseType& getArray() {
+          return *this; 
+        }
+
         void operator()(Jacobian& jac);
         using BaseType::operator();
       };
@@ -268,6 +300,11 @@ using namespace Intrepid2;
         typedef MDArray BaseType;
 
         JacobianDet(const IM& im);
+
+
+        BaseType& getArray() {
+          return *this; 
+        }
 
         void operator()(Jacobian& jac);
         using BaseType::operator();
@@ -283,6 +320,10 @@ using namespace Intrepid2;
         typedef MDArray BaseType;
 
         WeightedMeasure(const IM& im);
+
+        BaseType& getArray() {
+          return *this; 
+        }
 
         void operator()(CubatureWeights& w, JacobianDet& dJ);
         using BaseType::operator();


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/percept 

## Motivation
Some Intrepid2 functions such as `mapToPhysicalFrame` will require a `Kokkos::View` or a `Kokkos::DynRankView`. At the moment Percept calls those function passing a type derived from Kokkos::DynRankViews. Fixing these calls by passing the underlying view.
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

@bricar @alanw0 can you please check and snaphot these changes into Sierra?