### PR TITLE
intrepid2: guard is_view_fad namespace based on new/old View impl

### DIFF
--- a/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
@@ -409,7 +409,11 @@ namespace Intrepid2 {
     createMatchingUnmanagedView(const InViewType &view, const CtorProp &data, const Dims... dims)
     {
   #ifdef HAVE_INTREPID2_SACADO
+  #ifdef SACADO_HAS_NEW_KOKKOS_VIEW_IMPL
       if constexpr (Sacado::is_view_fad<InViewType>::value)
+  #else
+      if constexpr (Kokkos::is_view_fad<InViewType>::value)
+  #endif
       {
         const int derivative_dimension = get_dimension_scalar(view);
         return OutViewType(data, dims..., derivative_dimension);


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/intrepid2 @mperego @CamelliaDPG 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->
Attempt to fix build issues in configurations using the legacy View implementation, errors of the type:
```
02:40:37 /home/jenkins/blake-new/workspace/KokkosEco_Trilinos_Blake_Gcc_1130_OpenMPI_415_SKX_OPENMP-4t_legacy_view/Trilinos/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp:412:29: error: 'is_view_fad' is not a member of 'Sacado'; did you mean 'Kokkos::is_view_fad'?
```

Note: support for the legacy View implementation is not planned beyond 5.0, but trying to keep support while the kokkos@5.0.1 release settles in

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes `put-issue-number-here`

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
I have not manually retested this yet with the legacy View enabled
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
