### PR TITLE
Tpetra: Use sorting from Kokkos Kernels

### DIFF
--- a/packages/kokkos-kernels/sparse/src/KokkosSparse_SortCrs.hpp
+++ b/packages/kokkos-kernels/sparse/src/KokkosSparse_SortCrs.hpp
@@ -442,7 +442,7 @@ void sort_and_merge_graph(const exec_space& exec, const typename rowmap_t::const
   nc_rowmap_t nc_rowmap_out(Kokkos::view_alloc(exec, Kokkos::WithoutInitializing, "SortedMerged rowmap"), numRows + 1);
   Offset numCompressedEntries = 0;
   Kokkos::parallel_reduce("KokkosSparse::Impl::MergedRowmapFunctor", range_t(exec, 0, numRows),
-                          Impl::MergedRowmapFunctor<rowmap_t, entries_t>(nc_rowmap_out, rowmap_in, entries_in),
+                          Impl::MergedRowmapFunctor<nc_rowmap_t, entries_t>(nc_rowmap_out, rowmap_in, entries_in),
                           numCompressedEntries);
   if (entries_in.extent(0) == size_t(numCompressedEntries)) {
     // No merges to perform, so the output rowmap is unchanged and we can just

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1989,17 +1989,6 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   // mfh 08 May 2017: I only restore "protected" here for backwards
   // compatibility.
  protected:
-  /// \brief Sort and merge duplicate column indices in the given row.
-  ///
-  /// \pre The graph is locally indexed:
-  ///   <tt>isGloballyIndexed() == false</tt>.
-  /// \pre The graph is not already storage optimized:
-  ///   <tt>isStorageOptimized() == false</tt>
-  ///
-  /// \return The number of duplicate column indices eliminated from the row.
-  size_t sortAndMergeRowIndices(const RowInfo& rowInfo,
-                                const bool sorted,
-                                const bool merged);
   //@}
 
   /// Set the domain and range Maps, and invalidate the Import

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_CrsSortingUtils.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_CrsSortingUtils.cpp
@@ -134,7 +134,7 @@ void shuffle_crs_entries(std::vector<ordinal_type>& colind_rand,
 //
 
 // Unit Test the functionality in Tpetra_Import_Util
-TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Import_Util, SortCrsEntries, Scalar, LO, GO) {
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Import_Util, SortCrsEntries, Scalar, LO, GO, NT) {
   using Tpetra::Import_Util::sortAndMergeCrsEntries;
   using Tpetra::Import_Util::sortCrsEntries;
 
@@ -146,6 +146,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Import_Util, SortCrsEntries, Scalar, LO, GO) {
   typedef typename std::vector<ordinal_type> colind_type;
   typedef typename std::vector<scalar_type> vals_type;
   typedef typename colind_type::size_type size_type;
+
+  // Map is not actually used, but is needed to instantiate Kokkos
+  auto comm = Tpetra::getDefaultComm();
+  const Tpetra::global_size_t INVALID =
+      Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
+  auto dummy_map = Tpetra::Map<LO, GO, NT>(INVALID, 1, 0, comm);
 
   int max_num_entries_per_row = 7;   // should be odd
   int num_cols                = 15;  // should be odd
@@ -393,10 +399,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Import_Util, SortCrsEntriesKokkos, Scalar, LO,
 // INSTANTIATIONS
 //
 
-#define UNIT_TEST_GROUP_SC_LO_GO(SC, LO, GO) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(Import_Util, SortCrsEntries, SC, LO, GO)
-
-#define UNIT_TEST_GROUP_SC_LO_GO_NO(SC, LO, GO, NT) \
+#define UNIT_TEST_GROUP_SC_LO_GO_NO(SC, LO, GO, NT)                                 \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(Import_Util, SortCrsEntries, SC, LO, GO, NT) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(Import_Util, SortCrsEntriesKokkos, SC, LO, GO, NT)
 
 // Note: This test fails.  Should fix later.
@@ -406,8 +410,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
 
 // Test CrsMatrix for all Scalar, LO, GO template parameter
 // combinations, and the default Node type.
-TPETRA_INSTANTIATE_SLG_NO_ORDINAL_SCALAR(UNIT_TEST_GROUP_SC_LO_GO)
-
 TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR(UNIT_TEST_GROUP_SC_LO_GO_NO)
 
 }  // namespace


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Use sorting methods from Kokkos Kernels.
- `CrsGraph::sortAndMergeAllIndices` can now run on device.
- Hook up Kokkos Kernels in `Import_Util` except for `sortAndMergeEntries` with `ArrayView`s. That case is tricky since we'd wrap the inputs as unmanaged views which causes issues for view allocation in `sort_and_merge_graph`.
- This PR contains the fix from https://github.com/kokkos/kokkos-kernels/pull/2918.

Timings for "Tpetra FE Assembly 1 rank" on H100:

Before (f04cbe79cd1):
```
X) Global: 54.5396 [1]
|   Kokkos::deep_copy [Host=>Cuda]: 0.106784 - 0.195792% [2]
|   Kokkos::deep_copy [Cuda=>Cuda]: 3.9452e-05 - 7.23365e-05% [2]
|   Kokkos::deep_copy_scalar [Host=>Host]: 0.172129 - 0.315605% [1]
|   1) ElementLoop  (Graph): 27.5438 - 50.5024% [1]
|   |   Kokkos::deep_copy [Cuda=>Host]: 0.247232 - 0.897595% [1]
|   |   Remainder: 27.2966 - 99.1024%
|   2) FillComplete (Graph): 23.2765 - 42.6781% [1]
|   |   Kokkos::deep_copy [Cuda=>Host]: 2.04445 - 8.78333% [2]
|   |   Kokkos::deep_copy_small [Cuda=>Host]: 0.000360374 - 0.00154823% [2]
|   |   Kokkos::deep_copy [Host=>Cuda]: 2.20245 - 9.46213% [4]
|   |   Remainder: 19.0292 - 81.753%
|   3.1) ElementLoop  (Memory): 0.00900406 - 0.0165092% [1]
|   3.2) ElementLoop  (Matrix): 0.648121 - 1.18835% [1]
|   |   Kokkos::deep_copy [Host=>Cuda]: 0.644955 - 99.5114% [1]
|   |   Remainder: 0.0031664 - 0.488551%
|   4) FillComplete (Matrix): 0.00126471 - 0.00231889% [1]
|   5) GlobalAssemble (RHS): 4.574e-06 - 8.38657e-06% [1]
|   Remainder: 2.78198 - 5.10084%
```

After:
```
X) Global: 47.344 [1]
|   Kokkos::deep_copy [Host=>Cuda]: 0.106505 - 0.224959% [2]
|   Kokkos::deep_copy [Cuda=>Cuda]: 3.5859e-05 - 7.57413e-05% [2]
|   Kokkos::deep_copy_scalar [Host=>Host]: 0.183073 - 0.386687% [1]
|   1) ElementLoop  (Graph): 29.0491 - 61.3574% [1]
|   |   Kokkos::deep_copy [Cuda=>Host]: 0.257241 - 0.885539% [1]
|   |   Remainder: 28.7918 - 99.1145%
|   2) FillComplete (Graph): 14.4212 - 30.4605% [1]
|   |   Kokkos::deep_copy [Cuda=>Host]: 0.088724 - 0.615232% [2]
|   |   Kokkos::deep_copy_small [Cuda=>Host]: 0.000340641 - 0.00236208% [2]
|   |   Kokkos::deep_copy [Host=>Cuda]: 1.50744 - 10.4529% [4]
|   |   Remainder: 12.8247 - 88.9295%
|   3.1) ElementLoop  (Memory): 0.00933815 - 0.019724% [1]
|   3.2) ElementLoop  (Matrix): 0.65045 - 1.37388% [1]
|   |   Kokkos::deep_copy [Host=>Cuda]: 0.647764 - 99.5869% [1]
|   |   Remainder: 0.00268671 - 0.413053%
|   4) FillComplete (Matrix): 0.00121414 - 0.00256451% [1]
|   5) GlobalAssemble (RHS): 6.888e-06 - 1.45488e-05% [1]
|   Remainder: 2.92312 - 6.17421%
```

Neither run included https://github.com/kokkos/kokkos/pull/8822 which should fix a performance regression. Before that regression, we had 
```FillComplete (Graph): 18.5s```
Since that regression is unrelated, we can hope to end up at less than 10s.