### PR TITLE
Tpetra makeColMap: Move to device

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -21,6 +21,7 @@
 #include "Tpetra_RowGraph.hpp"
 #include "Tpetra_Util.hpp"  // need this here for sort2
 #include "Tpetra_Details_WrappedDualView.hpp"
+#include "Tpetra_Details_makeColMap.hpp"
 
 #include "KokkosSparse_findRelOffset.hpp"
 #include "Kokkos_DualView.hpp"
@@ -1634,6 +1635,16 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
                                                              typename CrsGraphType::global_ordinal_type,
                                                              typename CrsGraphType::node_type>>& rangeMap,
                                 const Teuchos::RCP<Teuchos::ParameterList>& params);
+
+  // Friend declaration for nonmember function.
+  template <class LO, class GO, class NT>
+  friend int
+  Details::makeColMap(Teuchos::RCP<const Tpetra::Map<LO, GO, NT>>& colMap,
+                      Teuchos::Array<int>& remotePIDs,
+                      const Teuchos::RCP<const Tpetra::Map<LO, GO, NT>>& domMap,
+                      const CrsGraph<LO, GO, NT>& graph,
+                      const bool sortEachProcsGids,
+                      std::ostream* errStrm);
 
  public:
   /// \brief Import from <tt>this</tt> to the given destination

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -4213,8 +4213,8 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     std::cerr << os.str();
   }
   Details::ProfilingRegion region(
-      "Tpetra::CrsMatrix::fillCompete",
-      "fillCompete");
+      "Tpetra::CrsMatrix::fillComplete",
+      "fillComplete");
 
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(!this->isFillActive() || this->isFillComplete(), std::runtime_error,
                                         "Matrix fill state must be active (isFillActive() "
@@ -4225,7 +4225,7 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   // Read parameters from the input ParameterList.
   //
   {
-    Details::ProfilingRegion region_fc("Tpetra::CrsMatrix::fillCompete", "ParameterList");
+    Details::ProfilingRegion region_fc("Tpetra::CrsMatrix::fillComplete", "ParameterList");
 
     // If true, the caller promises that no process did nonlocal
     // changes since the last call to fillComplete.
@@ -4271,7 +4271,7 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     }
   }
   if (this->isStaticGraph()) {
-    Details::ProfilingRegion region_isg("Tpetra::CrsMatrix::fillCompete", "isStaticGraph");
+    Details::ProfilingRegion region_isg("Tpetra::CrsMatrix::fillComplete", "isStaticGraph");
     // FIXME (mfh 14 Nov 2016) In order to fix #843, I enable the
     // checks below only in debug mode.  It would be nicer to do a
     // local check, then propagate the error state in a deferred
@@ -4318,7 +4318,7 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     // structure is already fixed, so just fill the local matrix.
     this->fillLocalMatrix(params);
   } else {
-    Details::ProfilingRegion region_insg("Tpetra::CrsMatrix::fillCompete", "isNotStaticGraph");
+    Details::ProfilingRegion region_insg("Tpetra::CrsMatrix::fillComplete", "isNotStaticGraph");
     // Set the graph's domain and range Maps.  This will clear the
     // Import if the domain Map has changed (is a different
     // pointer), and the Export if the range Map has changed (is a
@@ -4372,7 +4372,7 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   this->fillComplete_ = true;  // Now we're fill complete!
   {
     Details::ProfilingRegion region_cis(
-        "Tpetra::CrsMatrix::fillCompete", "checkInternalState");
+        "Tpetra::CrsMatrix::fillComplete", "checkInternalState");
     this->checkInternalState();
   }
 }  // fillComplete(domainMap, rangeMap, params)

--- a/packages/tpetra/core/src/Tpetra_Details_makeColMap_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_makeColMap_decl.hpp
@@ -23,7 +23,7 @@
 
 #include "TpetraCore_config.h"
 #include "Tpetra_Map_fwd.hpp"
-#include "Tpetra_RowGraph_fwd.hpp"
+#include "Tpetra_CrsGraph_fwd.hpp"
 #include "Kokkos_Core.hpp"
 #include <ostream>
 
@@ -98,7 +98,7 @@ template <class LO, class GO, class NT>
 int makeColMap(Teuchos::RCP<const Tpetra::Map<LO, GO, NT>>& colMap,
                Teuchos::Array<int>& remotePIDs,
                const Teuchos::RCP<const Tpetra::Map<LO, GO, NT>>& domMap,
-               const RowGraph<LO, GO, NT>& graph,
+               const CrsGraph<LO, GO, NT>& graph,
                const bool sortEachProcsGids = true,
                std::ostream* errStrm        = NULL);
 

--- a/packages/zoltan2/core/src/input/Zoltan2_BasicVectorAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_BasicVectorAdapter.hpp
@@ -194,11 +194,11 @@ public:
   // The Adapter interface.
   ////////////////////////////////////////////////////////////////
 
-  size_t getLocalNumIDs() const { return numIds_; }
+  size_t getLocalNumIDs() const override { return numIds_; }
 
-  void getIDsView(const gno_t *&ids) const { ids = idList_; }
+  void getIDsView(const gno_t *&ids) const override { ids = idList_; }
 
-  void getIDsKokkosView(typename Base::ConstIdsDeviceView &ids) const {
+  void getIDsKokkosView(typename Base::ConstIdsDeviceView &ids) const override {
     ids = this->kIds_;
   }
 
@@ -212,14 +212,14 @@ public:
     ids = this->kIds_;
   }
 
-  int getNumWeightsPerID() const { return numWeights_; }
+  int getNumWeightsPerID() const override { return numWeights_; }
 
   virtual void
   getWeightsKokkos2dView(typename Base::WeightsDeviceView &wgt) const {
     wgt = kWeights_;
   }
 
-  void getWeightsView(const scalar_t *&weights, int &stride, int idx) const {
+  void getWeightsView(const scalar_t *&weights, int &stride, int idx) const override {
     AssertCondition((idx >= 0) and (idx < numWeights_),
                     "Invalid weight index.");
 
@@ -272,10 +272,10 @@ public:
   // The VectorAdapter interface.
   ////////////////////////////////////////////////////
 
-  int getNumEntriesPerID() const { return numEntriesPerID_; }
+  int getNumEntriesPerID() const override { return numEntriesPerID_; }
 
   void getEntriesView(const scalar_t *&entries, int &stride,
-                      int idx = 0) const {
+                      int idx = 0) const override {
     if (idx < 0 || idx >= numEntriesPerID_) {
       std::ostringstream emsg;
       emsg << __FILE__ << ":" << __LINE__ << "  Invalid vector index " << idx
@@ -287,7 +287,7 @@ public:
   }
 
   void getEntriesKokkosView(
-      typename AdapterWithCoords<User>::CoordsDeviceView &entries) const {
+      typename AdapterWithCoords<User>::CoordsDeviceView &entries) const override {
     entries = kEntries_;
   }
 

--- a/packages/zoltan2/core/src/input/Zoltan2_TpetraRowMatrixAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_TpetraRowMatrixAdapter.hpp
@@ -168,13 +168,13 @@ public:
 // The MatrixAdapter Interface
 /////////////////////////////////////////////////////////////////
 
-  size_t getLocalNumRows() const;
+  size_t getLocalNumRows() const override;
 
-  size_t getLocalNumColumns() const;
+  size_t getLocalNumColumns() const override;
 
-  size_t getLocalNumEntries() const;
+  size_t getLocalNumEntries() const override;
 
-  bool CRSViewAvailable() const;
+  bool CRSViewAvailable() const override;
 
   void getRowIDsView(const gno_t *&rowIds) const override;
 
@@ -185,7 +185,7 @@ public:
       typename Base::ConstIdsDeviceView &rowIds) const override;
 
   void getCRSView(ArrayRCP<const offset_t> &offsets,
-                  ArrayRCP<const gno_t> &colIds) const;
+                  ArrayRCP<const gno_t> &colIds) const override;
 
   void getCRSHostView(
       typename Base::ConstOffsetsHostView &offsets,
@@ -197,7 +197,7 @@ public:
 
   void getCRSView(ArrayRCP<const offset_t> &offsets,
                   ArrayRCP<const gno_t> &colIds,
-                  ArrayRCP<const scalar_t> &values) const;
+                  ArrayRCP<const scalar_t> &values) const override;
 
   void getCRSHostView(
       typename Base::ConstOffsetsHostView &offsets,
@@ -209,24 +209,24 @@ public:
       typename Base::ConstIdsDeviceView &colIds,
       typename Base::ConstScalarsDeviceView &values) const override;
 
-  int getNumWeightsPerRow() const;
+  int getNumWeightsPerRow() const override;
 
   void getRowWeightsView(const scalar_t *&weights, int &stride,
-                         int idx = 0) const;
+                         int idx = 0) const override;
 
   void getRowWeightsDeviceView(typename Base::WeightsDeviceView1D &weights,
-                                  int idx = 0) const;
+                                  int idx = 0) const override;
 
   void getRowWeightsDeviceView(
       typename Base::WeightsDeviceView &weights) const override;
 
   void getRowWeightsHostView(typename Base::WeightsHostView1D &weights,
-                                int idx = 0) const;
+                                int idx = 0) const override;
 
   void getRowWeightsHostView(
       typename Base::WeightsHostView &weights) const override;
 
-  bool useNumNonzerosAsRowWeight(int idx) const;
+  bool useNumNonzerosAsRowWeight(int idx) const override;
 
   template <typename Adapter>
   void applyPartitioningSolution(

--- a/packages/zoltan2/core/src/input/Zoltan2_XpetraCrsMatrixAdapter.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_XpetraCrsMatrixAdapter.hpp
@@ -126,31 +126,31 @@ public:
   // The MatrixAdapter interface.
   ////////////////////////////////////////////////////
 
-  size_t getLocalNumRows() const {
+  size_t getLocalNumRows() const override {
     return matrix_->getLocalNumRows();
   }
 
-  size_t getLocalNumColumns() const {
+  size_t getLocalNumColumns() const override {
     return matrix_->getLocalNumCols();
   }
 
-  size_t getLocalNumEntries() const {
+  size_t getLocalNumEntries() const override {
     return matrix_->getLocalNumEntries();
   }
 
-  void getRowIDsView(const gno_t *&rowIds) const
+  void getRowIDsView(const gno_t *&rowIds) const override
   {
     ArrayView<const gno_t> rowView = rowMap_->getLocalElementList();
     rowIds = rowView.getRawPtr();
   }
 
-  void getColumnIDsView(const gno_t *&colIds) const
+  void getColumnIDsView(const gno_t *&colIds) const override
   {
     ArrayView<const gno_t> colView = colMap_->getLocalElementList();
     colIds = colView.getRawPtr();
   }
 
-  void getCRSView(ArrayRCP<const offset_t> &offsets, ArrayRCP<const gno_t> &colIds) const
+  void getCRSView(ArrayRCP<const offset_t> &offsets, ArrayRCP<const gno_t> &colIds) const override
   {
     ArrayRCP< const lno_t > localColumnIds;
     ArrayRCP<const scalar_t> values;
@@ -158,11 +158,11 @@ public:
     colIds = columnIds_;
   }
 
-  bool CRSViewAvailable() const { return true; }
+  bool CRSViewAvailable() const override { return true; }
 
   void getCRSView(ArrayRCP<const offset_t> &offsets,
                   ArrayRCP<const gno_t> &colIds,
-                  ArrayRCP<const scalar_t> &values) const {
+                  ArrayRCP<const scalar_t> &values) const override {
     ArrayRCP< const lno_t > localColumnIds;
     matrix_->getAllValues(offsets,localColumnIds,values);
     colIds = columnIds_;
@@ -228,10 +228,10 @@ public:
     offsets = ccsOffsets;
   }
 
-  int getNumWeightsPerRow() const { return nWeightsPerRow_; }
+  int getNumWeightsPerRow() const override { return nWeightsPerRow_; }
 
   void getRowWeightsView(const scalar_t *&weights, int &stride,
-                           int idx = 0) const
+                           int idx = 0) const override
   {
     if(idx<0 || idx >= nWeightsPerRow_)
     {
@@ -245,7 +245,7 @@ public:
     rowWeights_[idx].getStridedList(length, weights, stride);
   }
 
-  bool useNumNonzerosAsRowWeight(int idx) const { return numNzWeight_[idx];}
+  bool useNumNonzerosAsRowWeight(int idx) const override { return numNzWeight_[idx];}
 
   template <typename Adapter>
     void applyPartitioningSolution(const User &in, User *&out,

--- a/packages/zoltan2/test/core/partition/mj_backwardcompat.cpp
+++ b/packages/zoltan2/test/core/partition/mj_backwardcompat.cpp
@@ -179,18 +179,18 @@ public:
     }
   }
 
-  size_t getLocalNumIDs() const { return nids; }
+  size_t getLocalNumIDs() const override { return nids; }
 
   void getIDsView(const gno_t *&ids) const override {
     auto kokkosIds = kokkos_gids.view_host();
     ids = kokkosIds.data();
   }
 
-  virtual void getIDsKokkosView(Kokkos::View<const gno_t *, device_t> &ids) const {
+  virtual void getIDsKokkosView(Kokkos::View<const gno_t *, device_t> &ids) const override {
     ids = kokkos_gids.template view<device_t>();
   }
 
-  int getNumWeightsPerID() const { return (kokkos_weights.view_host().size() != 0); }
+  int getNumWeightsPerID() const override { return (kokkos_weights.view_host().size() != 0); }
 
   void getWeightsView(const scalar_t *&wgt, int &stride,
                       int idx = 0) const override
@@ -201,11 +201,11 @@ public:
     stride = 1;
   }
 
-  virtual void getWeightsKokkosView(Kokkos::View<scalar_t **, device_t> & wgt) const {
+  virtual void getWeightsKokkosView(Kokkos::View<scalar_t **, device_t> & wgt) const override {
     wgt = kokkos_weights.template view<device_t>();
   }
 
-  int getNumEntriesPerID() const { return dim; }
+  int getNumEntriesPerID() const override { return dim; }
 
   void getEntriesView(const scalar_t *&elements,
     int &stride, int idx = 0) const override {
@@ -214,7 +214,7 @@ public:
   }
 
   virtual void getEntriesKokkosView(Kokkos::View<scalar_t **,
-    Kokkos::LayoutLeft, device_t> & coo) const {
+    Kokkos::LayoutLeft, device_t> & coo) const override {
     coo = kokkos_coords.template view<device_t>();
   }
 


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Refactor `makeColMap` and so that most of it now runs on device. I did use the `CrsGraph` interface instead of `RowGraph`. In local testing I saw no issues with that.

Using the finite element assembly example on H100 I see for the `makeColMap` timer (using `export TPETRA_USE_TEUCHOS_TIMERS=1`):

| | 1 rank | 4 ranks |
| -- |--|--|
| develop | 12.1s | 4.44s |
| this PR | 2.65s | 0.78s |