### PR TITLE
Tpetra: Refactor lowCommunicationMakeColMapAndReindex

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
@@ -27,6 +27,7 @@
 #include "KokkosSparse_SortCrs.hpp"
 #include <Teuchos_Array.hpp>
 #include "Tpetra_Details_createMirrorView.hpp"
+#include "Tpetra_Details_Profiling.hpp"
 #include <Kokkos_Core.hpp>
 #include <Kokkos_UnorderedMap.hpp>
 #include <Kokkos_Sort.hpp>
@@ -40,19 +41,16 @@ namespace {
 struct LocalRemoteCount {
   size_t numLocalColGIDs;
   size_t numRemoteColGIDs;
-  int maxPID;
 
   KOKKOS_INLINE_FUNCTION
   LocalRemoteCount()
     : numLocalColGIDs(0)
-    , numRemoteColGIDs(0)
-    , maxPID(-1) {}
+    , numRemoteColGIDs(0) {}
 
   KOKKOS_INLINE_FUNCTION
   LocalRemoteCount& operator+=(const LocalRemoteCount& src) {
     numLocalColGIDs += src.numLocalColGIDs;
     numRemoteColGIDs += src.numRemoteColGIDs;
-    maxPID = Kokkos::max(maxPID, src.maxPID);
     return *this;
   }
 };
@@ -827,10 +825,6 @@ void lowCommunicationMakeColMapAndReindex(
   auto owningPIDs_view = Details::create_mirror_view_from_raw_host_array(device, owningPIDs.getRawPtr(), owningPIDs.size(), true, "owningPIDs");
 
   typename decltype(colind_LID_view)::host_mirror_type colind_LID_host(colind_LID.getRawPtr(), colind_LID.size());
-  // typename decltype(colind_GID_view)::host_mirror_type colind_GID_host(colind_GID.getRawPtr(), colind_GID.size());
-
-  // Kokkos::deep_copy(colind_LID_view, colind_LID_host);
-  // Kokkos::deep_copy(colind_GID_view, colind_GID_host);
 
   lowCommunicationMakeColMapAndReindex(rowptr_view, colind_LID_view, colind_GID_view, domainMapRCP, owningPIDs_view, remotePIDs, colMap);
 
@@ -854,9 +848,11 @@ void lowCommunicationMakeColMapAndReindex(
   typedef Tpetra::global_size_t GST;
   typedef Tpetra::Map<LO, GO, Node> map_type;
   const char prefix[] = "lowCommunicationMakeColMapAndReindex: ";
+  Tpetra::Details::ProfilingRegion regOuter("lowCommunicationMakeColMapAndReindex");
 
   typedef typename Node::device_type DT;
   using execution_space = typename DT::execution_space;
+  using memory_space    = typename DT::memory_space;
   execution_space exec;
   using team_policy = Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>;
   typedef typename map_type::local_map_type local_map_type;
@@ -871,13 +867,14 @@ void lowCommunicationMakeColMapAndReindex(
   const size_t numDomainElements = domainMap.getLocalNumElements();
   Kokkos::View<bool*, DT> LocalGIDs_view("LocalGIDs", numDomainElements);
 
-  auto map_capacity = 1.2 * (colind_LID_view.size() + 1);
-  Kokkos::UnorderedMap<GO, int, DT> GIDs_map;
+  auto map_capacity = std::max(std::min(uint32_t(1.2 * colind_LID_view.size()),
+                                        uint32_t(2 * numDomainElements)),
+                               uint32_t(5000));
+  Kokkos::UnorderedMap<GO, int, DT> GIDs_map(map_capacity);
   size_t NumLocalColGIDs;
   size_t NumRemoteColGIDs;
-  int PID_max = -1;
   while (true) {
-    GIDs_map          = Kokkos::UnorderedMap<GO, int, DT>(map_capacity);
+    Tpetra::Details::ProfilingRegion reg("lowCommunicationMakeColMapAndReindex::fill_map");
     const LO LINVALID = Teuchos::OrdinalTraits<LO>::invalid();
 
     // Scan all column indices and sort into two groups:
@@ -908,7 +905,6 @@ void lowCommunicationMakeColMapAndReindex(
                   auto outcome  = GIDs_map.insert(GID, PID);
                   if (outcome.success()) {
                     innerUpdate.numRemoteColGIDs++;
-                    innerUpdate.maxPID = Kokkos::max(innerUpdate.maxPID, PID);
                     if (PID == -1) {
                       Kokkos::abort("Cannot figure out if ID is owned.\n");
                     }
@@ -922,14 +918,12 @@ void lowCommunicationMakeColMapAndReindex(
     if (!GIDs_map.failed_insert()) {
       NumLocalColGIDs  = counts.numLocalColGIDs;
       NumRemoteColGIDs = counts.numRemoteColGIDs;
-      PID_max          = counts.maxPID;
       break;
-    } else
+    } else {
       map_capacity *= 1.5;
+      GIDs_map = Kokkos::UnorderedMap<GO, int, DT>(map_capacity);
+    }
   }
-
-  Kokkos::View<int*, DT> PIDList_view(Kokkos::ViewAllocateWithoutInitializing("PIDList_d"), NumRemoteColGIDs);
-  Kokkos::View<GO*, DT> RemoteGIDList_view(Kokkos::ViewAllocateWithoutInitializing("RemoteGIDList"), NumRemoteColGIDs);
 
   // Possible short-circuit: If all domain map GIDs are present as
   // column indices, then set ColMap=domainMap and quit.
@@ -951,72 +945,72 @@ void lowCommunicationMakeColMapAndReindex(
       auto localColMap = colMap->getLocalMap();
       Kokkos::parallel_for(
           Kokkos::RangePolicy<execution_space>(0, colind_GID_view.size()), KOKKOS_LAMBDA(const int i) {
-            colind_LID_view[i] = localColMap.getLocalElement(colind_GID_view[i]);
+            colind_LID_view(i) = localColMap.getLocalElement(colind_GID_view(i));
           });
       return;
     }
   }
 
+  Kokkos::View<GO*, DT> RemoteColMapIndices_unsorted(Kokkos::ViewAllocateWithoutInitializing("RemoteColMapIndices_unsorted"), NumRemoteColGIDs);
+  Kokkos::View<int*, DT> RemotePIDs_unsorted(Kokkos::ViewAllocateWithoutInitializing("RemotePIDs_unsorted"), NumRemoteColGIDs);
+
   // For each index in RemoteGIDs_map that contains a GID, use "update" to indicate the number of GIDs "before" this GID
   // This maps each element in the RemoteGIDs hash table to an index in RemoteGIDList / PIDList without any overwriting or empty spaces between indices
-  Kokkos::parallel_scan(
-      Kokkos::RangePolicy<execution_space>(0, GIDs_map.capacity()), KOKKOS_LAMBDA(const int i, size_t& update, const bool final) {
-        if (GIDs_map.valid_at(i) && GIDs_map.value_at(i) != -1) {
-          if (final) {
-            RemoteGIDList_view[update] = GIDs_map.key_at(i);
-            PIDList_view[update]       = GIDs_map.value_at(i);
-          }
-          update += 1;
-        }
-      });
 
+  {
+    Tpetra::Details::ProfilingRegion reg("lowCommunicationMakeColMapAndReindex::process_map");
+    size_t numEnteredRemotes;
+    Kokkos::parallel_scan(
+        Kokkos::RangePolicy<execution_space>(0, GIDs_map.capacity()), KOKKOS_LAMBDA(const int i, size_t& update, const bool final) {
+          if (GIDs_map.valid_at(i) && GIDs_map.value_at(i) != -1) {
+            if (final) {
+              RemoteColMapIndices_unsorted(update) = GIDs_map.key_at(i);
+              RemotePIDs_unsorted(update)          = GIDs_map.value_at(i);
+            }
+            ++update;
+          }
+        },
+        numEnteredRemotes);
+    TEUCHOS_ASSERT(numEnteredRemotes == NumRemoteColGIDs);
+  }
   // Now build the array containing column GIDs
   // Build back end, containing remote GIDs, first
   const size_t numMyCols = NumLocalColGIDs + NumRemoteColGIDs;
-  Kokkos::View<GO*, DT> ColIndices_view(Kokkos::ViewAllocateWithoutInitializing("ColIndices"), numMyCols);
+  Kokkos::View<GO*, DT> ColMapIndices(Kokkos::ViewAllocateWithoutInitializing("ColMapIndices"), numMyCols);
 
-  // We don't need to load the backend of ColIndices or sort if there are no remote GIDs
+  // We don't need to load the back end of ColMapIndices or sort if there are no remote GIDs
   if (NumRemoteColGIDs > 0) {
-    // Make a subview of ColIndices for remote GID sorting
-    auto ColIndices_subview = Kokkos::subview(ColIndices_view, Kokkos::make_pair(NumLocalColGIDs, ColIndices_view.size()));
+    Tpetra::Details::ProfilingRegion reg("lowCommunicationMakeColMapAndReindex::sort");
+    auto RemoteColMapIndices_sorted = Kokkos::subview(ColMapIndices, Kokkos::make_pair(NumLocalColGIDs, numMyCols));
 
-    if (NumLocalColGIDs != static_cast<size_t>(numMyCols)) {
-      Kokkos::deep_copy(ColIndices_subview, RemoteGIDList_view);
-    }
-
-    using KeyViewTypePID = decltype(PIDList_view);
-    using BinSortOpPID   = Kokkos::BinOp1D<KeyViewTypePID>;
-
-    // Make binOp with bins = PID_max + 1, min = 0, max = PID_max
-    BinSortOpPID binOp2(PID_max + 1, 0, PID_max);
-
-    // Sort External column indices so that all columns coming from a
-    // given remote processor are contiguous.  This is a sort with one
-    // auxilary array: RemoteColIndices
-    Kokkos::BinSort<KeyViewTypePID, BinSortOpPID> bin_sort2(PIDList_view, 0, PIDList_view.size(), binOp2, false);
-    bin_sort2.create_permute_vector(exec);
-    bin_sort2.sort(exec, PIDList_view);
-    bin_sort2.sort(exec, ColIndices_subview);
-    auto offsets = bin_sort2.get_bin_offsets();
-
-    // Sort external column indices so that columns from a given remote
-    // processor are not only contiguous but also in ascending
-    // order. NOTE: I don't know if the number of externals associated
-    // with a given remote processor is known at this point ... so I
-    // count them here.
+    // Create a permutation that sorts by first by PID and then by GID.
+    Kokkos::View<size_t*, memory_space> index(Kokkos::ViewAllocateWithoutInitializing("index"), NumRemoteColGIDs);
     Kokkos::parallel_for(
-        team_policy(offsets.extent(0) - 1, Kokkos::AUTO), KOKKOS_LAMBDA(const typename team_policy::member_type& member) {
-          const auto i      = member.league_rank();
-          auto StartCurrent = offsets(i);
-          auto StartNext    = offsets(i + 1);
-          Kokkos::Experimental::sort_team(member, Kokkos::subview(ColIndices_view, Kokkos::make_pair(NumLocalColGIDs + StartCurrent, NumLocalColGIDs + StartNext)));
+        Kokkos::RangePolicy<execution_space>(0, NumRemoteColGIDs), KOKKOS_LAMBDA(const size_t i) {
+          index(i) = i;
+        });
+    Kokkos::sort(
+        exec, index, KOKKOS_LAMBDA(const size_t i, const size_t j) {
+          auto pid_i = RemotePIDs_unsorted(i);
+          auto pid_j = RemotePIDs_unsorted(j);
+          if (pid_i == pid_j)
+            return RemoteColMapIndices_unsorted(i) < RemoteColMapIndices_unsorted(j);
+          else
+            return pid_i < pid_j;
+        });
+    // Apply the permutation to remote GIDs and PIDs.
+    Kokkos::View<int*, memory_space> RemotePIDs_sorted(Kokkos::ViewAllocateWithoutInitializing("RemotePIDs_new"), NumRemoteColGIDs);
+    Kokkos::parallel_for(
+        Kokkos::RangePolicy<execution_space>(0, NumRemoteColGIDs), KOKKOS_LAMBDA(const size_t i) {
+          RemoteColMapIndices_sorted(i) = RemoteColMapIndices_unsorted(index(i));
+          RemotePIDs_sorted(i)          = RemotePIDs_unsorted(index(i));
         });
 
     // Deep copy back from device to host
     // Stash the RemotePIDs. Once remotePIDs is changed to become a Kokkos view, we can remove this and copy directly.
     Teuchos::Array<int> PIDList(NumRemoteColGIDs);
-    Kokkos::View<int*, Kokkos::HostSpace> PIDList_host(PIDList.data(), PIDList.size());
-    Kokkos::deep_copy(exec, PIDList_host, PIDList_view);
+    Kokkos::View<int*, Kokkos::HostSpace> RemotePIDs_sorted_host(PIDList.data(), NumRemoteColGIDs);
+    Kokkos::deep_copy(exec, RemotePIDs_sorted_host, RemotePIDs_sorted);
     exec.fence();
 
     remotePIDs = PIDList;
@@ -1037,16 +1031,17 @@ void lowCommunicationMakeColMapAndReindex(
   if (static_cast<size_t>(NumLocalColGIDs) == numDomainElements) {
     if (NumLocalColGIDs > 0) {
       // Load Global Indices into first numMyCols elements column GID list
-      Kokkos::deep_copy(Kokkos::subview(ColIndices_view, Kokkos::make_pair((size_t)0, numDomainElements)), domainMap.getMyGlobalIndicesDevice());
+      auto LocalColMapIndices = Kokkos::subview(ColMapIndices, Kokkos::make_pair((size_t)0, numDomainElements));
+      Kokkos::deep_copy(LocalColMapIndices, domainMap.getMyGlobalIndicesDevice());
     }
   } else {
     // This part isn't actually tested in the unit tests
     LO NumLocalAgain = 0;
     Kokkos::parallel_scan(
         Kokkos::RangePolicy<execution_space>(0, numDomainElements), KOKKOS_LAMBDA(const int i, LO& update, const bool final) {
-          if (LocalGIDs_view[i]) {
+          if (LocalGIDs_view(i)) {
             if (final) {
-              ColIndices_view[update] = domainMap_local.getGlobalElement(i);
+              ColMapIndices(update) = domainMap_local.getGlobalElement(i);
             }
             update++;
           }
@@ -1061,14 +1056,14 @@ void lowCommunicationMakeColMapAndReindex(
   // Make column Map
   const GST minus_one = Teuchos::OrdinalTraits<GST>::invalid();
 
-  colMap = rcp(new map_type(minus_one, ColIndices_view, domainMap.getIndexBase(),
+  colMap = rcp(new map_type(minus_one, ColMapIndices, domainMap.getIndexBase(),
                             domainMap.getComm()));
 
   // Fill out colind_LID using local map
   auto localColMap = colMap->getLocalMap();
   Kokkos::parallel_for(
       Kokkos::RangePolicy<execution_space>(0, colind_GID_view.size()), KOKKOS_LAMBDA(const int i) {
-        colind_LID_view[i] = localColMap.getLocalElement(colind_GID_view[i]);
+        colind_LID_view(i) = localColMap.getLocalElement(colind_GID_view(i));
       });
 }
 

--- a/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
@@ -21,22 +21,53 @@
 #include "Tpetra_Map.hpp"
 #include "Tpetra_Util.hpp"
 #include "Tpetra_Distributor.hpp"
-#include "Tpetra_Details_reallocDualViewIfNeeded.hpp"
 #include "Tpetra_Details_MpiTypeTraits.hpp"
 #include "Tpetra_Vector.hpp"
 #include "Kokkos_DualView.hpp"
 #include "KokkosSparse_SortCrs.hpp"
 #include <Teuchos_Array.hpp>
 #include "Tpetra_Details_createMirrorView.hpp"
+#include <Kokkos_Core.hpp>
 #include <Kokkos_UnorderedMap.hpp>
-#include <unordered_map>
+#include <Kokkos_Sort.hpp>
 #include <utility>
 #include <set>
 
 #include "Tpetra_CrsMatrix_decl.hpp"
 
-#include <Kokkos_Core.hpp>
-#include <Kokkos_Sort.hpp>
+namespace {
+
+struct LocalRemoteCount {
+  size_t numLocalColGIDs;
+  size_t numRemoteColGIDs;
+  int maxPID;
+
+  KOKKOS_INLINE_FUNCTION
+  LocalRemoteCount()
+    : numLocalColGIDs(0)
+    , numRemoteColGIDs(0)
+    , maxPID(-1) {}
+
+  KOKKOS_INLINE_FUNCTION
+  LocalRemoteCount& operator+=(const LocalRemoteCount& src) {
+    numLocalColGIDs += src.numLocalColGIDs;
+    numRemoteColGIDs += src.numRemoteColGIDs;
+    maxPID = Kokkos::max(maxPID, src.maxPID);
+    return *this;
+  }
+};
+
+}  // namespace
+
+namespace Kokkos {
+
+template <>
+struct reduction_identity<LocalRemoteCount> {
+  KOKKOS_FORCEINLINE_FUNCTION static LocalRemoteCount sum() {
+    return LocalRemoteCount();
+  }
+};
+}  // namespace Kokkos
 
 namespace Tpetra {
 namespace Import_Util {
@@ -786,23 +817,24 @@ void lowCommunicationMakeColMapAndReindex(
   using DT              = typename Node::device_type;
   using execution_space = typename DT::execution_space;
   execution_space exec;
+  DT device;
 
   // Create device mirror and host mirror views from function parameters
   // When we pass in views instead of Teuchos::ArrayViews, we can avoid copying views
-  auto colind_LID_view = Details::create_mirror_view_from_raw_host_array(exec, colind_LID.getRawPtr(), colind_LID.size(), true, "colind_LID");
-  auto rowptr_view     = Details::create_mirror_view_from_raw_host_array(exec, rowptr.getRawPtr(), rowptr.size(), true, "rowptr");
-  auto colind_GID_view = Details::create_mirror_view_from_raw_host_array(exec, colind_GID.getRawPtr(), colind_GID.size(), true, "colind_GID");
-  auto owningPIDs_view = Details::create_mirror_view_from_raw_host_array(exec, owningPIDs.getRawPtr(), owningPIDs.size(), true, "owningPIDs");
+  auto colind_LID_view = Details::create_mirror_view_from_raw_host_array(device, colind_LID.getRawPtr(), colind_LID.size(), true, "colind_LID");
+  auto rowptr_view     = Details::create_mirror_view_from_raw_host_array(device, rowptr.getRawPtr(), rowptr.size(), true, "rowptr");
+  auto colind_GID_view = Details::create_mirror_view_from_raw_host_array(device, colind_GID.getRawPtr(), colind_GID.size(), true, "colind_GID");
+  auto owningPIDs_view = Details::create_mirror_view_from_raw_host_array(device, owningPIDs.getRawPtr(), owningPIDs.size(), true, "owningPIDs");
 
   typename decltype(colind_LID_view)::host_mirror_type colind_LID_host(colind_LID.getRawPtr(), colind_LID.size());
-  typename decltype(colind_GID_view)::host_mirror_type colind_GID_host(colind_GID.getRawPtr(), colind_GID.size());
+  // typename decltype(colind_GID_view)::host_mirror_type colind_GID_host(colind_GID.getRawPtr(), colind_GID.size());
 
-  Kokkos::deep_copy(colind_LID_view, colind_LID_host);
-  Kokkos::deep_copy(colind_GID_view, colind_GID_host);
+  // Kokkos::deep_copy(colind_LID_view, colind_LID_host);
+  // Kokkos::deep_copy(colind_GID_view, colind_GID_host);
 
   lowCommunicationMakeColMapAndReindex(rowptr_view, colind_LID_view, colind_GID_view, domainMapRCP, owningPIDs_view, remotePIDs, colMap);
 
-  // For now, we copy back into colind_LID_host (which also overwrites the colind_LID Tuechos array)
+  // For now, we copy back into colind_LID_host (which also overwrites the colind_LID Teuchos array)
   // When colind_LID becomes a Kokkos View we can delete this
   Kokkos::deep_copy(exec, colind_LID_host, colind_LID_view);
 }
@@ -833,72 +865,71 @@ void lowCommunicationMakeColMapAndReindex(
   // (common) special case to return the columnMap = domainMap.
   const map_type& domainMap = *domainMapRCP;
 
-  Kokkos::UnorderedMap<LO, bool, DT> LocalGIDs_view_map(colind_LID_view.size());
-  Kokkos::UnorderedMap<GO, LO, DT> RemoteGIDs_view_map(colind_LID_view.size());
-
   const size_t numMyRows         = rowptr_view.size() - 1;
   local_map_type domainMap_local = domainMap.getLocalMap();
 
   const size_t numDomainElements = domainMap.getLocalNumElements();
   Kokkos::View<bool*, DT> LocalGIDs_view("LocalGIDs", numDomainElements);
-  auto LocalGIDs_host = Kokkos::create_mirror_view(LocalGIDs_view);
 
-  size_t NumLocalColGIDs = 0;
+  auto map_capacity = 1.2 * (colind_LID_view.size() + 1);
+  Kokkos::UnorderedMap<GO, int, DT> GIDs_map;
+  size_t NumLocalColGIDs;
+  size_t NumRemoteColGIDs;
+  int PID_max = -1;
+  while (true) {
+    GIDs_map          = Kokkos::UnorderedMap<GO, int, DT>(map_capacity);
+    const LO LINVALID = Teuchos::OrdinalTraits<LO>::invalid();
 
-  // Scan all column indices and sort into two groups:
-  // Local:  those whose GID matches a GID of the domain map on this processor and
-  // Remote: All others.
-  // Kokkos::Parallel_reduce sums up NumLocalColGIDs, while we use the size of the Remote GIDs map to find NumRemoteColGIDs
-  Kokkos::parallel_reduce(
-      team_policy(numMyRows, Kokkos::AUTO), KOKKOS_LAMBDA(const typename team_policy::member_type& member, size_t& update) {
-        const int i                 = member.league_rank();
-        size_t NumLocalColGIDs_temp = 0;
-        size_t rowptr_start         = rowptr_view[i];
-        size_t rowptr_end           = rowptr_view[i + 1];
-        Kokkos::parallel_reduce(
-            Kokkos::TeamThreadRange(member, rowptr_start, rowptr_end), [&](const size_t j, size_t& innerUpdate) {
-              const GO GID = colind_GID_view[j];
-              // Check if GID matches a row GID in local domain map
-              const LO LID = domainMap_local.getLocalElement(GID);
-              if (LID != -1) {
-                auto outcome = LocalGIDs_view_map.insert(LID);
-                // Fresh insert
-                if (outcome.success()) {
-                  LocalGIDs_view[LID] = true;
-                  innerUpdate++;
+    // Scan all column indices and sort into two groups:
+    // Local:  those whose GID matches a GID of the domain map on this processor and
+    // Remote: All others.
+    // Kokkos::Parallel_reduce sums up NumLocalColGIDs, while we use the size of the Remote GIDs map to find NumRemoteColGIDs
+    LocalRemoteCount counts;
+    Kokkos::parallel_reduce(
+        team_policy(numMyRows, Kokkos::AUTO), KOKKOS_LAMBDA(const typename team_policy::member_type& member, LocalRemoteCount& update) {
+          const int i = member.league_rank();
+          LocalRemoteCount NumLocalColGIDs_temp;
+          size_t rowptr_start = rowptr_view[i];
+          size_t rowptr_end   = rowptr_view[i + 1];
+          Kokkos::parallel_reduce(
+              Kokkos::TeamThreadRange(member, rowptr_start, rowptr_end), [&](const size_t j, LocalRemoteCount& innerUpdate) {
+                const GO GID = colind_GID_view[j];
+                // Check if GID matches a row GID in local domain map
+                const LO LID = domainMap_local.getLocalElement(GID);
+                if (LID != LINVALID) {
+                  auto outcome = GIDs_map.insert(GID, -1);
+                  // Fresh insert
+                  if (outcome.success()) {
+                    LocalGIDs_view[LID] = true;
+                    innerUpdate.numLocalColGIDs++;
+                  }
+                } else {
+                  const int PID = owningPIDs_view[j];
+                  auto outcome  = GIDs_map.insert(GID, PID);
+                  if (outcome.success()) {
+                    innerUpdate.numRemoteColGIDs++;
+                    innerUpdate.maxPID = Kokkos::max(innerUpdate.maxPID, PID);
+                    if (PID == -1) {
+                      Kokkos::abort("Cannot figure out if ID is owned.\n");
+                    }
+                  }
                 }
-              } else {
-                const int PID = owningPIDs_view[j];
-                auto outcome  = RemoteGIDs_view_map.insert(GID, PID);
-                if (outcome.success() && PID == -1) {
-                  Kokkos::abort("Cannot figure out if ID is owned.\n");
-                }
-              }
-            },
-            NumLocalColGIDs_temp);
-        if (member.team_rank() == 0) update += NumLocalColGIDs_temp;
-      },
-      NumLocalColGIDs);
+              },
+              NumLocalColGIDs_temp);
+          if (member.team_rank() == 0) update += NumLocalColGIDs_temp;
+        },
+        counts);
+    if (!GIDs_map.failed_insert()) {
+      NumLocalColGIDs  = counts.numLocalColGIDs;
+      NumRemoteColGIDs = counts.numRemoteColGIDs;
+      PID_max          = counts.maxPID;
+      break;
+    } else
+      map_capacity *= 1.5;
+  }
 
-  LO NumRemoteColGIDs = RemoteGIDs_view_map.size();
-
-  Kokkos::View<int*, DT> PIDList_view("PIDList_d", NumRemoteColGIDs);
-
-  Kokkos::View<GO*, DT> RemoteGIDList_view("RemoteGIDList", NumRemoteColGIDs);
-  auto RemoteGIDList_host = Kokkos::create_mirror_view(RemoteGIDList_view);
-
-  // For each index in RemoteGIDs_map that contains a GID, use "update" to indicate the number of GIDs "before" this GID
-  // This maps each element in the RemoteGIDs hash table to an index in RemoteGIDList / PIDList without any overwriting or empty spaces between indices
-  Kokkos::parallel_scan(
-      Kokkos::RangePolicy<execution_space>(0, RemoteGIDs_view_map.capacity()), KOKKOS_LAMBDA(const int i, GO& update, const bool final) {
-        if (final && RemoteGIDs_view_map.valid_at(i)) {
-          RemoteGIDList_view[update] = RemoteGIDs_view_map.key_at(i);
-          PIDList_view[update]       = RemoteGIDs_view_map.value_at(i);
-        }
-        if (RemoteGIDs_view_map.valid_at(i)) {
-          update += 1;
-        }
-      });
+  Kokkos::View<int*, DT> PIDList_view(Kokkos::ViewAllocateWithoutInitializing("PIDList_d"), NumRemoteColGIDs);
+  Kokkos::View<GO*, DT> RemoteGIDList_view(Kokkos::ViewAllocateWithoutInitializing("RemoteGIDList"), NumRemoteColGIDs);
 
   // Possible short-circuit: If all domain map GIDs are present as
   // column indices, then set ColMap=domainMap and quit.
@@ -926,33 +957,35 @@ void lowCommunicationMakeColMapAndReindex(
     }
   }
 
+  // For each index in RemoteGIDs_map that contains a GID, use "update" to indicate the number of GIDs "before" this GID
+  // This maps each element in the RemoteGIDs hash table to an index in RemoteGIDList / PIDList without any overwriting or empty spaces between indices
+  Kokkos::parallel_scan(
+      Kokkos::RangePolicy<execution_space>(0, GIDs_map.capacity()), KOKKOS_LAMBDA(const int i, size_t& update, const bool final) {
+        if (GIDs_map.valid_at(i) && GIDs_map.value_at(i) != -1) {
+          if (final) {
+            RemoteGIDList_view[update] = GIDs_map.key_at(i);
+            PIDList_view[update]       = GIDs_map.value_at(i);
+          }
+          update += 1;
+        }
+      });
+
   // Now build the array containing column GIDs
   // Build back end, containing remote GIDs, first
-  const LO numMyCols = NumLocalColGIDs + NumRemoteColGIDs;
-  Kokkos::View<GO*, DT> ColIndices_view("ColIndices", numMyCols);
+  const size_t numMyCols = NumLocalColGIDs + NumRemoteColGIDs;
+  Kokkos::View<GO*, DT> ColIndices_view(Kokkos::ViewAllocateWithoutInitializing("ColIndices"), numMyCols);
 
   // We don't need to load the backend of ColIndices or sort if there are no remote GIDs
   if (NumRemoteColGIDs > 0) {
-    if (NumLocalColGIDs != static_cast<size_t>(numMyCols)) {
-      Kokkos::parallel_for(
-          Kokkos::RangePolicy<execution_space>(0, NumRemoteColGIDs), KOKKOS_LAMBDA(const int i) {
-            ColIndices_view[NumLocalColGIDs + i] = RemoteGIDList_view[i];
-          });
-    }
+    // Make a subview of ColIndices for remote GID sorting
+    auto ColIndices_subview = Kokkos::subview(ColIndices_view, Kokkos::make_pair(NumLocalColGIDs, ColIndices_view.size()));
 
-    // Find the largest PID for bin sorting purposes
-    int PID_max = 0;
-    Kokkos::parallel_reduce(
-        Kokkos::RangePolicy<execution_space>(0, PIDList_view.size()), KOKKOS_LAMBDA(const int i, int& max) {
-          if (max < PIDList_view[i]) max = PIDList_view[i];
-        },
-        Kokkos::Max<int>(PID_max));
+    if (NumLocalColGIDs != static_cast<size_t>(numMyCols)) {
+      Kokkos::deep_copy(ColIndices_subview, RemoteGIDList_view);
+    }
 
     using KeyViewTypePID = decltype(PIDList_view);
     using BinSortOpPID   = Kokkos::BinOp1D<KeyViewTypePID>;
-
-    // Make a subview of ColIndices for remote GID sorting
-    auto ColIndices_subview = Kokkos::subview(ColIndices_view, Kokkos::make_pair(NumLocalColGIDs, ColIndices_view.size()));
 
     // Make binOp with bins = PID_max + 1, min = 0, max = PID_max
     BinSortOpPID binOp2(PID_max + 1, 0, PID_max);
@@ -964,6 +997,20 @@ void lowCommunicationMakeColMapAndReindex(
     bin_sort2.create_permute_vector(exec);
     bin_sort2.sort(exec, PIDList_view);
     bin_sort2.sort(exec, ColIndices_subview);
+    auto offsets = bin_sort2.get_bin_offsets();
+
+    // Sort external column indices so that columns from a given remote
+    // processor are not only contiguous but also in ascending
+    // order. NOTE: I don't know if the number of externals associated
+    // with a given remote processor is known at this point ... so I
+    // count them here.
+    Kokkos::parallel_for(
+        team_policy(offsets.extent(0) - 1, Kokkos::AUTO), KOKKOS_LAMBDA(const typename team_policy::member_type& member) {
+          const auto i      = member.league_rank();
+          auto StartCurrent = offsets(i);
+          auto StartNext    = offsets(i + 1);
+          Kokkos::Experimental::sort_team(member, Kokkos::subview(ColIndices_view, Kokkos::make_pair(NumLocalColGIDs + StartCurrent, NumLocalColGIDs + StartNext)));
+        });
 
     // Deep copy back from device to host
     // Stash the RemotePIDs. Once remotePIDs is changed to become a Kokkos view, we can remove this and copy directly.
@@ -973,24 +1020,6 @@ void lowCommunicationMakeColMapAndReindex(
     exec.fence();
 
     remotePIDs = PIDList;
-
-    // Sort external column indices so that columns from a given remote
-    // processor are not only contiguous but also in ascending
-    // order. NOTE: I don't know if the number of externals associated
-    // with a given remote processor is known at this point ... so I
-    // count them here.
-    LO StartCurrent = 0, StartNext = 1;
-    while (StartNext < NumRemoteColGIDs) {
-      if (PIDList_host[StartNext] == PIDList_host[StartNext - 1]) {
-        StartNext++;
-      } else {
-        Kokkos::sort(ColIndices_view, NumLocalColGIDs + StartCurrent, NumLocalColGIDs + StartNext);
-        StartCurrent = StartNext;
-        StartNext++;
-      }
-    }
-
-    Kokkos::sort(ColIndices_view, NumLocalColGIDs + StartCurrent, NumLocalColGIDs + StartNext);
   }
 
   // Build permute array for *local* reindexing.
@@ -1008,20 +1037,17 @@ void lowCommunicationMakeColMapAndReindex(
   if (static_cast<size_t>(NumLocalColGIDs) == numDomainElements) {
     if (NumLocalColGIDs > 0) {
       // Load Global Indices into first numMyCols elements column GID list
-      Kokkos::parallel_for(
-          Kokkos::RangePolicy<execution_space>(0, numDomainElements), KOKKOS_LAMBDA(const int i) {
-            ColIndices_view[i] = domainMap_local.getGlobalElement(i);
-          });
+      Kokkos::deep_copy(Kokkos::subview(ColIndices_view, Kokkos::make_pair((size_t)0, numDomainElements)), domainMap.getMyGlobalIndicesDevice());
     }
   } else {
     // This part isn't actually tested in the unit tests
     LO NumLocalAgain = 0;
     Kokkos::parallel_scan(
         Kokkos::RangePolicy<execution_space>(0, numDomainElements), KOKKOS_LAMBDA(const int i, LO& update, const bool final) {
-          if (final && LocalGIDs_view[i]) {
-            ColIndices_view[update] = domainMap_local.getGlobalElement(i);
-          }
           if (LocalGIDs_view[i]) {
+            if (final) {
+              ColIndices_view[update] = domainMap_local.getGlobalElement(i);
+            }
             update++;
           }
         },

--- a/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
@@ -110,11 +110,11 @@ void lowCommunicationMakeColMapAndReindex(
 /// path in Tpetra::CrsMatrix, thus avoiding unnecessary deep_copy's.
 template <typename LocalOrdinal, typename GlobalOrdinal, typename Node>
 void lowCommunicationMakeColMapAndReindex(
-    const Kokkos::View<size_t*, typename Node::device_type> rowptr_view,
+    const Kokkos::View<const size_t*, typename Node::device_type> rowptr_view,
     const Kokkos::View<LocalOrdinal*, typename Node::device_type> colind_LID_view,
     const Kokkos::View<GlobalOrdinal*, typename Node::device_type> colind_GID_view,
     const Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& domainMapRCP,
-    const Teuchos::ArrayView<const int>& owningPIDs,
+    const Kokkos::View<const int*, typename Node::device_type> owningPIDs_view,
     Teuchos::Array<int>& remotePIDs,
     Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& colMap);
 
@@ -783,18 +783,9 @@ void lowCommunicationMakeColMapAndReindex(
     const Teuchos::ArrayView<const int>& owningPIDs,
     Teuchos::Array<int>& remotePIDs,
     Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& colMap) {
-  using Teuchos::rcp;
-  typedef LocalOrdinal LO;
-  typedef GlobalOrdinal GO;
-  typedef Tpetra::global_size_t GST;
-  typedef Tpetra::Map<LO, GO, Node> map_type;
-  const char prefix[] = "lowCommunicationMakeColMapAndReindex: ";
-
-  typedef typename Node::device_type DT;
+  using DT              = typename Node::device_type;
   using execution_space = typename DT::execution_space;
   execution_space exec;
-  using team_policy = Kokkos::TeamPolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>;
-  typedef typename map_type::local_map_type local_map_type;
 
   // Create device mirror and host mirror views from function parameters
   // When we pass in views instead of Teuchos::ArrayViews, we can avoid copying views
@@ -809,229 +800,7 @@ void lowCommunicationMakeColMapAndReindex(
   Kokkos::deep_copy(colind_LID_view, colind_LID_host);
   Kokkos::deep_copy(colind_GID_view, colind_GID_host);
 
-  // The domainMap is an RCP because there is a shortcut for a
-  // (common) special case to return the columnMap = domainMap.
-  const map_type& domainMap = *domainMapRCP;
-
-  Kokkos::UnorderedMap<LO, bool, DT> LocalGIDs_view_map(colind_LID.size());
-  Kokkos::UnorderedMap<GO, LO, DT> RemoteGIDs_view_map(colind_LID.size());
-
-  const size_t numMyRows         = rowptr.size() - 1;
-  local_map_type domainMap_local = domainMap.getLocalMap();
-
-  const size_t numDomainElements = domainMap.getLocalNumElements();
-  Kokkos::View<bool*, DT> LocalGIDs_view("LocalGIDs", numDomainElements);
-  auto LocalGIDs_host = Kokkos::create_mirror_view(LocalGIDs_view);
-
-  size_t NumLocalColGIDs = 0;
-
-  // Scan all column indices and sort into two groups:
-  // Local:  those whose GID matches a GID of the domain map on this processor and
-  // Remote: All others.
-  // Kokkos::Parallel_reduce sums up NumLocalColGIDs, while we use the size of the Remote GIDs map to find NumRemoteColGIDs
-  Kokkos::parallel_reduce(
-      team_policy(numMyRows, Kokkos::AUTO), KOKKOS_LAMBDA(const typename team_policy::member_type& member, size_t& update) {
-        const int i                 = member.league_rank();
-        size_t NumLocalColGIDs_temp = 0;
-        size_t rowptr_start         = rowptr_view[i];
-        size_t rowptr_end           = rowptr_view[i + 1];
-        Kokkos::parallel_reduce(
-            Kokkos::TeamThreadRange(member, rowptr_start, rowptr_end), [&](const size_t j, size_t& innerUpdate) {
-              const GO GID = colind_GID_view[j];
-              // Check if GID matches a row GID in local domain map
-              const LO LID = domainMap_local.getLocalElement(GID);
-              if (LID != -1) {
-                auto outcome = LocalGIDs_view_map.insert(LID);
-                // Fresh insert
-                if (outcome.success()) {
-                  LocalGIDs_view[LID] = true;
-                  innerUpdate++;
-                }
-              } else {
-                const int PID = owningPIDs_view[j];
-                auto outcome  = RemoteGIDs_view_map.insert(GID, PID);
-                if (outcome.success() && PID == -1) {
-                  Kokkos::abort("Cannot figure out if ID is owned.\n");
-                }
-              }
-            },
-            NumLocalColGIDs_temp);
-        if (member.team_rank() == 0) update += NumLocalColGIDs_temp;
-      },
-      NumLocalColGIDs);
-
-  LO NumRemoteColGIDs = RemoteGIDs_view_map.size();
-
-  Kokkos::View<int*, DT> PIDList_view("PIDList", NumRemoteColGIDs);
-  auto PIDList_host = Kokkos::create_mirror_view(PIDList_view);
-
-  Kokkos::View<GO*, DT> RemoteGIDList_view("RemoteGIDList", NumRemoteColGIDs);
-  auto RemoteGIDList_host = Kokkos::create_mirror_view(RemoteGIDList_view);
-
-  // For each index in RemoteGIDs_map that contains a GID, use "update" to indicate the number of GIDs "before" this GID
-  // This maps each element in the RemoteGIDs hash table to an index in RemoteGIDList / PIDList without any overwriting or empty spaces between indices
-  Kokkos::parallel_scan(
-      Kokkos::RangePolicy<execution_space>(0, RemoteGIDs_view_map.capacity()), KOKKOS_LAMBDA(const int i, GO& update, const bool final) {
-        if (final && RemoteGIDs_view_map.valid_at(i)) {
-          RemoteGIDList_view[update] = RemoteGIDs_view_map.key_at(i);
-          PIDList_view[update]       = RemoteGIDs_view_map.value_at(i);
-        }
-        if (RemoteGIDs_view_map.valid_at(i)) {
-          update += 1;
-        }
-      });
-
-  // Possible short-circuit: If all domain map GIDs are present as
-  // column indices, then set ColMap=domainMap and quit.
-  if (domainMap.getComm()->getSize() == 1) {
-    // Sanity check: When there is only one process, there can be no
-    // remoteGIDs.
-    TEUCHOS_TEST_FOR_EXCEPTION(
-        NumRemoteColGIDs != 0, std::runtime_error, prefix << "There is only one "
-                                                             "process in the domain Map's communicator, which means that there are no "
-                                                             "\"remote\" indices.  Nevertheless, some column indices are not in the "
-                                                             "domain Map.");
-    if (static_cast<size_t>(NumLocalColGIDs) == numDomainElements) {
-      // In this case, we just use the domainMap's indices, which is,
-      // not coincidently, what we clobbered colind with up above
-      // anyway.  No further reindexing is needed.
-      colMap = domainMapRCP;
-
-      // Fill out local colMap (which should only contain local GIDs)
-      auto localColMap = colMap->getLocalMap();
-      Kokkos::parallel_for(
-          Kokkos::RangePolicy<execution_space>(0, colind_GID.size()), KOKKOS_LAMBDA(const int i) {
-            colind_LID_view[i] = localColMap.getLocalElement(colind_GID_view[i]);
-          });
-      Kokkos::deep_copy(execution_space(), colind_LID_host, colind_LID_view);
-      return;
-    }
-  }
-
-  // Now build the array containing column GIDs
-  // Build back end, containing remote GIDs, first
-  const LO numMyCols = NumLocalColGIDs + NumRemoteColGIDs;
-  Kokkos::View<GO*, DT> ColIndices_view("ColIndices", numMyCols);
-
-  // We don't need to load the backend of ColIndices or sort if there are no remote GIDs
-  if (NumRemoteColGIDs > 0) {
-    if (NumLocalColGIDs != static_cast<size_t>(numMyCols)) {
-      Kokkos::parallel_for(
-          Kokkos::RangePolicy<execution_space>(0, NumRemoteColGIDs), KOKKOS_LAMBDA(const int i) {
-            ColIndices_view[NumLocalColGIDs + i] = RemoteGIDList_view[i];
-          });
-    }
-
-    // Find the largest PID for bin sorting purposes
-    int PID_max = 0;
-    Kokkos::parallel_reduce(
-        Kokkos::RangePolicy<execution_space>(0, PIDList_host.size()), KOKKOS_LAMBDA(const int i, int& max) {
-          if (max < PIDList_view[i]) max = PIDList_view[i];
-        },
-        Kokkos::Max<int>(PID_max));
-
-    using KeyViewTypePID = decltype(PIDList_view);
-    using BinSortOpPID   = Kokkos::BinOp1D<KeyViewTypePID>;
-
-    // Make a subview of ColIndices for remote GID sorting
-    auto ColIndices_subview = Kokkos::subview(ColIndices_view, Kokkos::make_pair(NumLocalColGIDs, ColIndices_view.size()));
-
-    // Make binOp with bins = PID_max + 1, min = 0, max = PID_max
-    BinSortOpPID binOp2(PID_max + 1, 0, PID_max);
-
-    // Sort External column indices so that all columns coming from a
-    // given remote processor are contiguous.  This is a sort with one
-    // auxilary array: RemoteColIndices
-    Kokkos::BinSort<KeyViewTypePID, BinSortOpPID> bin_sort2(PIDList_view, 0, PIDList_view.size(), binOp2, false);
-    bin_sort2.create_permute_vector(exec);
-    bin_sort2.sort(exec, PIDList_view);
-    bin_sort2.sort(exec, ColIndices_subview);
-
-    // Deep copy back from device to host
-    Kokkos::deep_copy(exec, PIDList_host, PIDList_view);
-
-    // Stash the RemotePIDs. Once remotePIDs is changed to become a Kokkos view, we can remove this and copy directly.
-    // Note: If Teuchos::Array had a shrink_to_fit like std::vector,
-    // we'd call it here.
-
-    exec.fence("fence before setting PIDList");
-    Teuchos::Array<int> PIDList(NumRemoteColGIDs);
-    for (LO i = 0; i < NumRemoteColGIDs; ++i) {
-      PIDList[i] = PIDList_host[i];
-    }
-
-    remotePIDs = PIDList;
-
-    // Sort external column indices so that columns from a given remote
-    // processor are not only contiguous but also in ascending
-    // order. NOTE: I don't know if the number of externals associated
-    // with a given remote processor is known at this point ... so I
-    // count them here.
-    LO StartCurrent = 0, StartNext = 1;
-    while (StartNext < NumRemoteColGIDs) {
-      if (PIDList_host[StartNext] == PIDList_host[StartNext - 1]) {
-        StartNext++;
-      } else {
-        Kokkos::sort(ColIndices_view, NumLocalColGIDs + StartCurrent, NumLocalColGIDs + StartNext);
-        StartCurrent = StartNext;
-        StartNext++;
-      }
-    }
-
-    Kokkos::sort(ColIndices_view, NumLocalColGIDs + StartCurrent, NumLocalColGIDs + StartNext);
-  }
-
-  // Build permute array for *local* reindexing.
-
-  // Now fill front end. Two cases:
-  //
-  // (1) If the number of Local column GIDs is the same as the number
-  //     of Local domain GIDs, we can simply read the domain GIDs into
-  //     the front part of ColIndices, otherwise
-  //
-  // (2) We step through the GIDs of the domainMap, checking to see if
-  //     each domain GID is a column GID.  we want to do this to
-  //     maintain a consistent ordering of GIDs between the columns
-  //     and the domain.
-  if (static_cast<size_t>(NumLocalColGIDs) == numDomainElements) {
-    if (NumLocalColGIDs > 0) {
-      // Load Global Indices into first numMyCols elements column GID list
-      Kokkos::parallel_for(
-          Kokkos::RangePolicy<execution_space>(0, numDomainElements), KOKKOS_LAMBDA(const int i) {
-            ColIndices_view[i] = domainMap_local.getGlobalElement(i);
-          });
-    }
-  } else {
-    // This part isn't actually tested in the unit tests
-    LO NumLocalAgain = 0;
-    Kokkos::parallel_scan(
-        Kokkos::RangePolicy<execution_space>(0, numDomainElements), KOKKOS_LAMBDA(const int i, LO& update, const bool final) {
-          if (final && LocalGIDs_view[i]) {
-            ColIndices_view[update] = domainMap_local.getGlobalElement(i);
-          }
-          if (LocalGIDs_view[i]) {
-            update++;
-          }
-        },
-        NumLocalAgain);
-
-    TEUCHOS_TEST_FOR_EXCEPTION(
-        static_cast<size_t>(NumLocalAgain) != NumLocalColGIDs,
-        std::runtime_error, prefix << "Local ID count test failed.");
-  }
-
-  // Make column Map
-  const GST minus_one = Teuchos::OrdinalTraits<GST>::invalid();
-
-  colMap = rcp(new map_type(minus_one, ColIndices_view, domainMap.getIndexBase(),
-                            domainMap.getComm()));
-
-  // Fill out colind_LID using local map
-  auto localColMap = colMap->getLocalMap();
-  Kokkos::parallel_for(
-      Kokkos::RangePolicy<execution_space>(0, colind_GID.size()), KOKKOS_LAMBDA(const int i) {
-        colind_LID_view[i] = localColMap.getLocalElement(colind_GID_view[i]);
-      });
+  lowCommunicationMakeColMapAndReindex(rowptr_view, colind_LID_view, colind_GID_view, domainMapRCP, owningPIDs_view, remotePIDs, colMap);
 
   // For now, we copy back into colind_LID_host (which also overwrites the colind_LID Tuechos array)
   // When colind_LID becomes a Kokkos View we can delete this
@@ -1040,11 +809,11 @@ void lowCommunicationMakeColMapAndReindex(
 
 template <typename LocalOrdinal, typename GlobalOrdinal, typename Node>
 void lowCommunicationMakeColMapAndReindex(
-    const Kokkos::View<size_t*, typename Node::device_type> rowptr_view,
+    const Kokkos::View<const size_t*, typename Node::device_type> rowptr_view,
     const Kokkos::View<LocalOrdinal*, typename Node::device_type> colind_LID_view,
     const Kokkos::View<GlobalOrdinal*, typename Node::device_type> colind_GID_view,
     const Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& domainMapRCP,
-    const Kokkos::View<int*, typename Node::device_type> owningPIDs_view,
+    const Kokkos::View<const int*, typename Node::device_type> owningPIDs_view,
     Teuchos::Array<int>& remotePIDs,
     Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& colMap) {
   using Teuchos::rcp;


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
- We have two variants of `lowCommunicationMakeColMapAndReindex`, one for `Teuchos::ArrayViews` and one for `Kokkos::Views`. It was not obvious to me why they both need to have their own implementation instead of re-wrapping the data and then calling the Kokkos version. We also have a purely serial variant of the method. We could re-evaluate how much faster that actually is.
- I reduced the number of kernel calls for the Kokkos variant.