### PR TITLE
Teuchos: MueLu: Tpetra: fix stack timer usage

### DIFF
--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -277,7 +277,7 @@ bool Hierarchy<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Setup(int coarseLevel
 
   Level& level = *Levels_[coarseLevelID];
 
-  bool useStackedTimer = !Teuchos::TimeMonitor::stackedTimerNameIsDefault();
+  bool useStackedTimer = !Teuchos::TimeMonitor::stackedTimerHasDefaultState();
 
   std::string label = FormattingHelper::getColonLabel(level.getObjectLabel());
   RCP<TimeMonitor> m1;
@@ -898,7 +898,7 @@ ConvergenceStatus Hierarchy<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Iterate(
   std::string levelSuffix  = " (level=" + toString(startLevel) + ")";
   std::string levelSuffix1 = " (level=" + toString(startLevel + 1) + ")";
 
-  bool useStackedTimer = !Teuchos::TimeMonitor::stackedTimerNameIsDefault();
+  bool useStackedTimer = !Teuchos::TimeMonitor::stackedTimerHasDefaultState();
 
   RCP<Monitor> iterateTime;
   RCP<TimeMonitor> iterateTime1;

--- a/packages/muelu/src/Utils/MueLu_Monitor.cpp
+++ b/packages/muelu/src/Utils/MueLu_Monitor.cpp
@@ -49,7 +49,7 @@ SubMonitor::~SubMonitor() = default;
 FactoryMonitor::FactoryMonitor(const BaseClass& object, const std::string& msg, int levelID, MsgType msgLevel, MsgType timerLevel)
   : Monitor(object, msg, msgLevel, timerLevel) {
   if (object.IsPrint(TimingsByLevel)) {
-    if (Teuchos::TimeMonitor::stackedTimerNameIsDefault())
+    if (Teuchos::TimeMonitor::stackedTimerHasDefaultState())
       levelTimeMonitor_ = rcp(new TimeMonitor(object, object.ShortClassName() + ": " + msg + " (total, level=" + Teuchos::Utils::toString(levelID) + ")", timerLevel));
   }
 }
@@ -58,7 +58,7 @@ FactoryMonitor::FactoryMonitor(const BaseClass& object, const std::string& msg, 
   : Monitor(object, msg, FormattingHelper::getColonLabel(level.getObjectLabel()), msgLevel, timerLevel) {
   if (object.IsPrint(TimingsByLevel)) {
     std::string label = FormattingHelper::getColonLabel(level.getObjectLabel());
-    if (Teuchos::TimeMonitor::stackedTimerNameIsDefault())
+    if (Teuchos::TimeMonitor::stackedTimerHasDefaultState())
       levelTimeMonitor_ = rcp(new TimeMonitor(object, label + object.ShortClassName() + ": " + msg + " (total, level=" + Teuchos::Utils::toString(level.GetLevelID()) + ")", timerLevel));
   }
 }
@@ -67,13 +67,13 @@ FactoryMonitor::~FactoryMonitor() = default;
 
 SubFactoryMonitor::SubFactoryMonitor(const BaseClass& object, const std::string& msg, int levelID, MsgType msgLevel, MsgType timerLevel)
   : SubMonitor(object, msg, msgLevel, timerLevel) {
-  if (object.IsPrint(TimingsByLevel) && Teuchos::TimeMonitor::stackedTimerNameIsDefault())
+  if (object.IsPrint(TimingsByLevel) && Teuchos::TimeMonitor::stackedTimerHasDefaultState())
     levelTimeMonitor_ = rcp(new TimeMonitor(object, object.ShortClassName() + ": " + msg + " (sub, total, level=" + Teuchos::Utils::toString(levelID) + ")", timerLevel));
 }
 
 SubFactoryMonitor::SubFactoryMonitor(const BaseClass& object, const std::string& msg, const Level& level, MsgType msgLevel, MsgType timerLevel)
   : SubMonitor(object, msg, FormattingHelper::getColonLabel(level.getObjectLabel()), msgLevel, timerLevel) {
-  if (object.IsPrint(TimingsByLevel) && Teuchos::TimeMonitor::stackedTimerNameIsDefault()) {
+  if (object.IsPrint(TimingsByLevel) && Teuchos::TimeMonitor::stackedTimerHasDefaultState()) {
     std::string label = FormattingHelper::getColonLabel(level.getObjectLabel());
     levelTimeMonitor_ = rcp(new TimeMonitor(object, label + object.ShortClassName() + ": " + msg + " (sub, total, level=" + Teuchos::Utils::toString(level.GetLevelID()) + ")", timerLevel));
   }

--- a/packages/muelu/src/Utils/MueLu_TimeMonitor.cpp
+++ b/packages/muelu/src/Utils/MueLu_TimeMonitor.cpp
@@ -41,7 +41,7 @@ TimeMonitor::TimeMonitor(const BaseClass& object, const std::string& msg, MsgTyp
   SetProcRankVerbose(object.GetProcRankVerbose());
 
 #ifdef HAVE_TEUCHOS_ADD_TIME_MONITOR_TO_STACKED_TIMER
-  useStackedTimer_ = !Teuchos::TimeMonitor::stackedTimerNameIsDefault();
+  useStackedTimer_ = !Teuchos::TimeMonitor::stackedTimerHasDefaultState();
 #else
   useStackedTimer_ = false;
 #endif

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -319,6 +319,15 @@ protected:
       return my_name;
     }
 
+    std::string get_parent_name() const {
+      std::string my_parent_name;
+      if (parent_ != nullptr)
+        my_parent_name = parent_->get_name();
+      else
+        my_parent_name = "NULL STACKED TIMER PARENT";
+      return my_parent_name;
+    }
+
     /**
      * Return the number of timers on this level
      * @return the number of timers and sub timers
@@ -490,6 +499,10 @@ public:
 
   std::string name() {
     return timer_.get_full_name();
+  }
+
+  std::string parent_name() {
+    return timer_.get_parent_name();
   }
 
   /**

--- a/packages/teuchos/comm/src/Teuchos_TimeMonitor.cpp
+++ b/packages/teuchos/comm/src/Teuchos_TimeMonitor.cpp
@@ -1473,8 +1473,8 @@ namespace Teuchos {
   }
 
   bool
-  TimeMonitor::stackedTimerNameIsDefault() {
-    return stackedTimer_.is_null() || (stackedTimer_->name() == defaultStackedTimerName);
+  TimeMonitor::stackedTimerHasDefaultState() {
+    return stackedTimer_.is_null() || (stackedTimer_->name() == defaultStackedTimerName && stackedTimer_->parent_name() == defaultStackedTimerName);
   }
 
   RCP<const ParameterList>

--- a/packages/teuchos/comm/src/Teuchos_TimeMonitor.hpp
+++ b/packages/teuchos/comm/src/Teuchos_TimeMonitor.hpp
@@ -607,7 +607,8 @@ public:
   //! The StackedTimer used by the TimeMonitor.
   static Teuchos::RCP<Teuchos::StackedTimer> getStackedTimer();
 
-  static bool stackedTimerNameIsDefault();
+  //! StackedTimer is either null, or it exists but has the default name and no child timers.
+  static bool stackedTimerHasDefaultState();
 
  private:
   /// \brief Valid output formats for report().

--- a/packages/tpetra/core/src/Tpetra_Details_KokkosTeuchosTimerInjection.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_KokkosTeuchosTimerInjection.cpp
@@ -107,7 +107,7 @@ void kokkosp_begin_deep_copy(Kokkos::Tools::SpaceHandle dst_handle, const char* 
     label_ = std::string("Kokkos::deep_copy [") + src_handle.name + "=>" + dst_handle.name + "]" + extra_label;
 
 #ifdef HAVE_TEUCHOS_ADD_TIME_MONITOR_TO_STACKED_TIMER
-  if (!Teuchos::TimeMonitor::stackedTimerNameIsDefault()) {
+  if (!Teuchos::TimeMonitor::stackedTimerHasDefaultState()) {
     const auto stackedTimer = Teuchos::TimeMonitor::getStackedTimer();
     stackedTimer->start(label_);
   } else
@@ -121,7 +121,7 @@ void kokkosp_begin_deep_copy(Kokkos::Tools::SpaceHandle dst_handle, const char* 
 
 void kokkosp_end_deep_copy() {
 #ifdef HAVE_TEUCHOS_ADD_TIME_MONITOR_TO_STACKED_TIMER
-  if (!Teuchos::TimeMonitor::stackedTimerNameIsDefault()) {
+  if (!Teuchos::TimeMonitor::stackedTimerHasDefaultState()) {
     try {
       const auto stackedTimer = Teuchos::TimeMonitor::getStackedTimer();
       stackedTimer->stop(label_);
@@ -172,7 +172,7 @@ void kokkosp_begin_fence(const char* name, const uint32_t deviceId,
   label_ = std::string("Kokkos::fence ") + name + " " + device_label;
 
 #ifdef HAVE_TEUCHOS_ADD_TIME_MONITOR_TO_STACKED_TIMER
-  if (!Teuchos::TimeMonitor::stackedTimerNameIsDefault()) {
+  if (!Teuchos::TimeMonitor::stackedTimerHasDefaultState()) {
     const auto stackedTimer = Teuchos::TimeMonitor::getStackedTimer();
     stackedTimer->start(label_);
   } else
@@ -187,7 +187,7 @@ void kokkosp_begin_fence(const char* name, const uint32_t deviceId,
 void kokkosp_end_fence(const uint64_t handle) {
   if (handle == active_handle) {
 #ifdef HAVE_TEUCHOS_ADD_TIME_MONITOR_TO_STACKED_TIMER
-    if (!Teuchos::TimeMonitor::stackedTimerNameIsDefault()) {
+    if (!Teuchos::TimeMonitor::stackedTimerHasDefaultState()) {
       try {
         const auto stackedTimer = Teuchos::TimeMonitor::getStackedTimer();
         stackedTimer->stop(label_);
@@ -236,7 +236,7 @@ void kokkosp_begin_kernel(const char* kernelName, const char* kernelPrefix, cons
   label_ = std::string("Kokkos::") + kernelName + " " + kernelPrefix + " " + device_label;
 
 #ifdef HAVE_TEUCHOS_ADD_TIME_MONITOR_TO_STACKED_TIMER
-  if (!Teuchos::TimeMonitor::stackedTimerNameIsDefault()) {
+  if (!Teuchos::TimeMonitor::stackedTimerHasDefaultState()) {
     const auto stackedTimer = Teuchos::TimeMonitor::getStackedTimer();
     stackedTimer->start(label_);
   } else
@@ -262,7 +262,7 @@ void kokkosp_begin_reduce(const char* kernelPrefix, const uint32_t devID, uint64
 
 void kokkosp_end_kernel(const uint64_t handle) {
 #ifdef HAVE_TEUCHOS_ADD_TIME_MONITOR_TO_STACKED_TIMER
-  if (!Teuchos::TimeMonitor::stackedTimerNameIsDefault()) {
+  if (!Teuchos::TimeMonitor::stackedTimerHasDefaultState()) {
     try {
       const auto stackedTimer = Teuchos::TimeMonitor::getStackedTimer();
       stackedTimer->stop(label_);


### PR DESCRIPTION
Modify the check that is used to determine whether to use StackedTimer within Teuchos::TimeMonitor.

<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu @trilinos/teuchos @trilinos/tpetra 

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

MueLu timer usage within the Empire application was not being reported.
Follows up #14253.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->



<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Confirmed locally that this fixes timer reporting in sample Empire run.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
