### PR TITLE
Tpetra RowMatrixTransposer: Process "compute global constants" in createTransposeLocal

### DIFF
--- a/packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp
@@ -154,6 +154,12 @@ RowMatrixTransposer<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     graphParams = rcp(new Teuchos::ParameterList);
     graphParams->set("sorted", false);
   }
+  const char computeGlobalConstantsParamName[] = "compute global constants";
+  if (!params.is_null() && params->isParameter(computeGlobalConstantsParamName)) {
+    if (graphParams.is_null())
+      graphParams = rcp(new Teuchos::ParameterList);
+    graphParams->set(computeGlobalConstantsParamName, params->get<bool>(computeGlobalConstantsParamName));
+  }
 
   return rcp(new crs_matrix_type(lclTransposeMatrix,
                                  origMatrix_->getColMap(),


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Skip the computation of global constants when they are requested to be skipped.