### PR TITLE
Kokkos Kernels: Add and use shell sort on CPU

### DIFF
--- a/packages/kokkos-kernels/sparse/impl/KokkosSparse_sort_crs_impl.hpp
+++ b/packages/kokkos-kernels/sparse/impl/KokkosSparse_sort_crs_impl.hpp
@@ -10,6 +10,65 @@
 namespace KokkosSparse {
 namespace Impl {
 
+template <typename rowmap_t, typename entries_t, typename values_t, bool permute_values_array>
+struct MatrixShellSortFunctor {
+  typedef typename entries_t::non_const_value_type ordinal_type;
+  typedef typename values_t::non_const_value_type scalar_type;
+
+  MatrixShellSortFunctor (const rowmap_t& ptr,
+                          const entries_t& ind,
+                          const values_t& val) :
+    ptr_ (ptr),
+    ind_ (ind),
+    val_ (val)
+  {
+    static_assert (std::is_signed<ordinal_type>::value, "The type of each "
+                   "column index -- that is, the type of each entry of ind "
+                   "-- must be signed in order for this functor to work.");
+  }
+
+  KOKKOS_FUNCTION void operator() (const size_t i) const
+  {
+    const size_t nnz = ind_.extent (0);
+    const size_t start = ptr_(i);
+
+
+    if (start < nnz) {
+      const size_t NumEntries = ptr_(i+1) - start;
+
+      const ordinal_type n = static_cast<ordinal_type> (NumEntries);
+      ordinal_type m = 1;
+      while (m<n) m = m*3+1;
+      m /= 3;
+
+      while (m > 0) {
+        ordinal_type max = n - m;
+        for (ordinal_type j = 0; j < max; j++) {
+          for (ordinal_type k = j; k >= 0; k -= m) {
+            const size_t sk = start+k;
+            if (ind_(sk+m) >= ind_(sk)) {
+              break;
+            }
+            if constexpr (permute_values_array) {
+              const scalar_type dtemp = val_(sk+m);
+              val_(sk+m)   = val_(sk);
+              val_(sk)     = dtemp;
+            }
+            const ordinal_type itemp = ind_(sk+m);
+            ind_(sk+m) = ind_(sk);
+            ind_(sk)   = itemp;
+          }
+        }
+        m = m/3;
+      }
+    }
+  }
+
+  rowmap_t ptr_;
+  entries_t ind_;
+  values_t val_;
+};
+
 template <typename rowmap_t, typename entries_t, typename values_t>
 struct MatrixRadixSortFunctor {
   using Offset          = typename rowmap_t::non_const_value_type;

--- a/packages/kokkos-kernels/sparse/src/KokkosSparse_SortCrs.hpp
+++ b/packages/kokkos-kernels/sparse/src/KokkosSparse_SortCrs.hpp
@@ -23,7 +23,7 @@ namespace KokkosSparse {
 // duplicated entries in A, A is sorted and returned (instead of a newly
 // allocated matrix).
 
-enum class SortAlgorithm { DEFAULT, PARALLEL_THREAD_LEVEL, BULK_SORT };
+enum class SortAlgorithm { DEFAULT, PARALLEL_THREAD_LEVEL, BULK_SORT, RADIX, SHELL };
 
 // Sort a CRS matrix: within each row, sort entries ascending by column.
 // At the same time, permute the values.
@@ -54,10 +54,21 @@ void sort_crs_matrix(const execution_space& exec, const rowmap_t& rowmap, const 
   }
   Ordinal numRows = rowmap.extent(0) ? rowmap.extent(0) - 1 : 0;
   if constexpr (!KokkosKernels::Impl::is_gpu_exec_space_v<execution_space>) {
-    // On CPUs, use a sequential radix sort within each row.
-    Kokkos::parallel_for("sort_crs_matrix[CPU,radix]",
-                         Kokkos::RangePolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>(exec, 0, numRows),
-                         Impl::MatrixRadixSortFunctor<rowmap_t, entries_t, values_t>(rowmap, entries, values));
+    if (option == SortAlgorithm::DEFAULT) {
+      option = SortAlgorithm::SHELL;
+    } else if ((option != SortAlgorithm::RADIX) && (option != SortAlgorithm::SHELL)) {
+      throw std::invalid_argument(
+        "sort_csr_matrix: Only RADIX and SHELL sort are available on CPU.");
+    }
+
+    if (option == SortAlgorithm::RADIX)
+      Kokkos::parallel_for("sort_crs_matrix[CPU,radix]",
+                           Kokkos::RangePolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>(exec, 0, numRows),
+                           Impl::MatrixRadixSortFunctor<rowmap_t, entries_t, values_t>(rowmap, entries, values));
+    else
+      Kokkos::parallel_for("sort_crs_matrix[CPU,shell]",
+                           Kokkos::RangePolicy<execution_space, Kokkos::Schedule<Kokkos::Dynamic>>(exec, 0, numRows),
+                           Impl::MatrixShellSortFunctor<rowmap_t, entries_t, values_t, true>(rowmap, entries, values));
   } else {
     // On GPUs:
     //   If the matrix is highly imbalanced, or has long rows AND the dimensions


### PR DESCRIPTION
@trilinos/kokkos-kernels 

## Motivation
Tpetra recently switched to use KokkosKernels for matrix sorting. It's faster on GPU but slower on CPU. This PR adds the previously used sorting algorithm to KokkosKernels and uses it by default on CPU. If we can verify in our performance testing that this recovers performance everywhere we can backport this to KokkosKernels.