### PR TITLE
MueLu MatrixMatrixMultiply test: Add option to use Galeri matrices

### DIFF
--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -210,6 +210,50 @@ IF(${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK OR ${PACKAGE_NAME}_HAVE_EPETRA_SOLVE
   )
 
   TRIBITS_ADD_TEST(
+    MatrixMatrixMultiply
+    NAME MatrixMultiply_Performance_Laplace3D
+    COMM mpi
+    ARGS "--timings --nmults=5 --useGaleri --matrixType=Laplace3D --nx=22 --ny=22 --nz=22"
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+    RUN_SERIAL
+    CATEGORIES PERFORMANCE
+  )
+
+  TRIBITS_ADD_TEST(
+    MatrixMatrixMultiply
+    NAME MatrixMultiply_Performance_Laplace3D
+    COMM mpi
+    ARGS "--timings --nmults=5 --useGaleri --matrixType=Laplace3D --nx=44 --ny=44 --nz=22"
+    NUM_MPI_PROCS 4
+    STANDARD_PASS_OUTPUT
+    RUN_SERIAL
+    CATEGORIES PERFORMANCE
+  )
+
+  TRIBITS_ADD_TEST(
+    MatrixMatrixMultiply
+    NAME MatrixMultiply_Performance_Brick3D
+    COMM mpi
+    ARGS "--timings --nmults=5 --useGaleri --matrixType=Brick3D --nx=22 --ny=22 --nz=22"
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+    RUN_SERIAL
+    CATEGORIES PERFORMANCE
+  )
+
+  TRIBITS_ADD_TEST(
+    MatrixMatrixMultiply
+    NAME MatrixMultiply_Performance_Brick3D
+    COMM mpi
+    ARGS "--timings --nmults=5 --useGaleri --matrixType=Brick3D --nx=44 --ny=44 --nz=22"
+    NUM_MPI_PROCS 4
+    STANDARD_PASS_OUTPUT
+    RUN_SERIAL
+    CATEGORIES PERFORMANCE
+  )
+
+  TRIBITS_ADD_TEST(
     Driver
     NAME Driver_anisotropic
     #ARGS "--xml=anisotropic.xml --tol=1e-6 --its=66"


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
This PR adds testing of matrix-matrix multiplication using Galeri matrices, in addition to the random matrices that are already tested. The motivation is the choice of sorting algorithm on CPU which prompted #14935 and #14936.

Timings obtained for "TpetraExt: MMM: Newmatrix Final Sort" on blake:

| matrices | ranks | shell | radix |
|-----|----|----|--|
| random | 1 | 3.52222 | 0.63396 |
| random | 4 | 3.84335 |0.593538 | 
| Laplace3D | 1 | 0.00298161 | 0.0294905 |
| Laplace3D | 4 | 0.00330124 | 0.0306498 |
| Brick3D | 1 | 0.0270663 | 0.0496056 |
| Brick3D | 4 | 0.0415195 | 0.053548 |

The random input matrices have 25-50 entries per row. Their product could have up to 50^2 entries per row. This could explain why radix sort works better in this case. I am not sure if matrices with this density are particularly representative of typical use.