### PR TITLE
Panzer: Graph assembly

### DIFF
--- a/packages/panzer/disc-fe/src/lof/Panzer_BlockedTpetraLinearObjFactory.hpp
+++ b/packages/panzer/disc-fe/src/lof/Panzer_BlockedTpetraLinearObjFactory.hpp
@@ -333,7 +333,11 @@ protected:
 
    // get the graph of the crs matrix
    virtual Teuchos::RCP<const CrsGraphType> buildTpetraGraph(int i,int j) const;
+
+
+ public:
    virtual Teuchos::RCP<const CrsGraphType> buildTpetraGhostedGraph(int i,int j) const;
+ protected:
 
    // storage for Tpetra graphs and maps
    Teuchos::RCP<const Teuchos::MpiComm<int> > comm_;

--- a/packages/panzer/disc-fe/src/lof/Panzer_BlockedTpetraLinearObjFactory_impl.hpp
+++ b/packages/panzer/disc-fe/src/lof/Panzer_BlockedTpetraLinearObjFactory_impl.hpp
@@ -13,11 +13,14 @@
 
 // Panzer
 #include "Panzer_BlockedVector_ReadOnly_GlobalEvaluationData.hpp"
+#include <utility>
 #ifdef PANZER_HAVE_EPETRA_STACK
 #include "Panzer_EpetraVector_Write_GlobalEvaluationData.hpp"                    // JMG:  Remove this eventually.
 #endif
 #include "Panzer_TpetraVector_ReadOnly_GlobalEvaluationData.hpp"
 #include "Panzer_GlobalIndexer.hpp"
+
+#include "KokkosSparse_SortCrs.hpp"
 
 // Thyra
 #include "Thyra_DefaultBlockedLinearOp.hpp"
@@ -960,6 +963,12 @@ buildTpetraGraph(int i,int j) const
    return graph;
 }
 
+template <class LocalOrdinalT>
+struct entry_type {
+  LocalOrdinalT row;
+  LocalOrdinalT col;
+};
+
 template <typename Traits,typename ScalarT,typename LocalOrdinalT,typename GlobalOrdinalT,typename NodeT>
 Teuchos::RCP<const Tpetra::CrsGraph<LocalOrdinalT,GlobalOrdinalT,NodeT> >
 BlockedTpetraLinearObjFactory<Traits,ScalarT,LocalOrdinalT,GlobalOrdinalT,NodeT>::
@@ -969,6 +978,8 @@ buildTpetraGhostedGraph(int i,int j) const
 
    using Teuchos::RCP;
    using Teuchos::rcp;
+   using exec_space = typename CrsGraphType::execution_space;
+   using memory_space = typename NodeT::memory_space;
 
    // build the map and allocate the space for the graph and
    // grab the ghosted graph
@@ -985,60 +996,130 @@ buildTpetraGhostedGraph(int i,int j) const
    gidProviders_[0]->getElementBlockIds(elementBlockIds); // each sub provider "should" have the
                                                           // same element blocks
 
-   // Count number of entries in each row of graph; needed for graph constructor
-   std::vector<size_t> nEntriesPerRow(map_i->getLocalNumElements(), 0);
-   std::vector<std::string>::const_iterator blockItr;
-   for(blockItr=elementBlockIds.begin();blockItr!=elementBlockIds.end();++blockItr) {
-      std::string blockId = *blockItr;
-      // grab elements for this block
-      const std::vector<LocalOrdinalT> & elements = gidProviders_[0]->getElementBlock(blockId); // each sub provider "should" have the
-                                                                                                // same elements in each element block
+   // Gather elements from mesh blocks.
+   size_t numElements;
+   Kokkos::View<LocalOrdinalT*, memory_space> elementsFromBlocks;
+   {
+     auto numElementBlocks = elementBlockIds.size();
 
-      // get information about number of indicies
-      std::vector<GlobalOrdinalT> row_gids;
-      std::vector<GlobalOrdinalT> col_gids;
+     std::vector<size_t> elementBlockOffsets(numElementBlocks+1);
+     elementBlockOffsets[0] = 0;
 
-      // loop over the elemnts
-      for(std::size_t elmt=0;elmt<elements.size();elmt++) {
+     numElements = 0;
+     size_t blockNo = 0;
+     std::vector<std::string>::const_iterator blockItr;
+     for(blockItr=elementBlockIds.begin();blockItr!=elementBlockIds.end();++blockItr) {
+       std::string blockId = *blockItr;
+       const std::vector<LocalOrdinalT> & elements = gidProviders_[0]->getElementBlock(blockId); // each sub provider "should" have the
+                                                                                                 // same elements in each element block
+       numElements += elements.size();
+       ++blockNo;
+       elementBlockOffsets[blockNo] = numElements;
+     }
+     elementsFromBlocks = Kokkos::View<LocalOrdinalT*, memory_space>("elementsFromBlocks", numElements);
+     blockNo = 0;
+     for(blockItr=elementBlockIds.begin();blockItr!=elementBlockIds.end();++blockItr) {
+       std::string blockId = *blockItr;
+       const std::vector<LocalOrdinalT> & elements = gidProviders_[0]->getElementBlock(blockId); // each sub provider "should" have the
+                                                                                                 // same elements in each element block
+       Kokkos::View<const LocalOrdinalT*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> elements_h(elements.data(), elements.size());
+       Kokkos::deep_copy(Kokkos::subview(elementsFromBlocks, Kokkos::make_pair(elementBlockOffsets[blockNo],
+                                                                               elementBlockOffsets[blockNo+1])),
+                         elements_h);
+       ++blockNo;
+     }
+   }
 
-         rowProvider->getElementGIDs(elements[elmt],row_gids);
-         colProvider->getElementGIDs(elements[elmt],col_gids);
-         for(std::size_t row=0;row<row_gids.size();row++) {
-            LocalOrdinalT lid = map_i->getLocalElement(row_gids[row]);
-            nEntriesPerRow[lid] += col_gids.size();
+   RCP<CrsGraphType> graph;
+   {
+
+     using local_graph_type = typename CrsGraphType::local_graph_device_type;
+     using rowptr_type       = typename local_graph_type::row_map_type::non_const_type;
+     using colidx_type       = typename local_graph_type::entries_type::non_const_type;
+
+     using entries_map_type = Kokkos::UnorderedMap<entry_type<LocalOrdinalT>, void, exec_space>;
+
+     auto numRows = map_i->getLocalNumElements();
+
+     // We are overallocating by 1 here. This simplifies the logic below. But we have to remember to take a subview in the end.
+     rowptr_type rowptr("ghostedGraph_rowptr", numRows+2);
+
+     auto rowLIDs = rowProvider->getLIDs();
+     auto colLIDs = colProvider->getLIDs();
+
+     auto numDoFsPerElementRow = rowLIDs.extent(1);
+     auto numDoFsPerElementCol = colLIDs.extent(1);
+
+     auto capacity = numElements*numDoFsPerElementRow*numDoFsPerElementCol;
+     entries_map_type entries(capacity);
+
+     while (true) {
+
+       // Loop over all elements and record the entries that we need in the graph.
+       // Also start building the rowptr.
+       Kokkos::parallel_for("collect_entries", Kokkos::RangePolicy<exec_space>(0, numElements), KOKKOS_LAMBDA(const LocalOrdinalT k) {
+         auto elementId = elementsFromBlocks(k);
+         entry_type<LocalOrdinalT> entry;
+         for (size_t dofNoRow = 0; dofNoRow<numDoFsPerElementRow; ++dofNoRow) {
+           entry.row = rowLIDs(elementId, dofNoRow);
+           for (size_t dofNoCol = 0; dofNoCol<numDoFsPerElementCol; ++dofNoCol) {
+             entry.col = colLIDs(elementId, dofNoCol);
+             auto result = entries.insert(entry);
+             if (result.success()) {
+               // New entry. We offset by 2 here.
+               Kokkos::atomic_inc(&rowptr(entry.row+2));
+             }
+           }
          }
-      }
+       });
+
+       if (!entries.failed_insert()) {
+         auto numEntries = entries.size();
+
+         // Prefix sum to get offsets.
+         // This is not the correct rowptr yet.
+         // We have essentially shifted everything by one position.
+         // This is useful for when we fill.
+         typename rowptr_type::value_type numEntries2;
+         Kokkos::parallel_scan("prefix_sum", Kokkos::RangePolicy<exec_space>(0, numRows+2), KOKKOS_LAMBDA(const size_t rlid, typename rowptr_type::value_type &nnz, const bool is_final) {
+           nnz += rowptr(rlid);
+           if (is_final)
+             rowptr(rlid) = nnz;
+         }, numEntries2);
+         TEUCHOS_ASSERT_EQUALITY(numEntries, numEntries2);
+
+         // The column indices.
+         colidx_type colidx(Kokkos::ViewAllocateWithoutInitializing("ghostedGraph_colidx"), numEntries);
+
+         // Fill the column indices.
+         // We are using the rowptr to figure out offsets.
+         // After this step the rowptr is correct.
+         Kokkos::parallel_for("fill", Kokkos::RangePolicy<exec_space>(0, entries.capacity()), KOKKOS_LAMBDA(const uint32_t c) {
+           if (entries.valid_at(c)) {
+             auto entry = entries.key_at(c);
+             auto offset = Kokkos::atomic_fetch_inc(&rowptr(entry.row+1));
+             colidx(offset) = entry.col;
+           }
+         });
+
+         // Sort the rows.
+         KokkosSparse::sort_crs_graph(rowptr, colidx);
+
+         // Create the graph
+         graph = rcp(new CrsGraphType(map_i, map_j, Kokkos::subview(rowptr, Kokkos::make_pair((decltype(numRows))0, numRows+1)), colidx));
+         graph->fillComplete(getMap(j),getMap(i));
+
+         break;
+       } else {
+         // We ended up not having enough capacity in the UnorderedMap.
+         // Bump it up and try again.
+         std::cout << "Insufficient capacity: " << capacity << std::endl;
+         capacity *= 2;
+         Kokkos::deep_copy(rowptr, 0);
+         entries = entries_map_type(capacity);
+       }
+     }
    }
-   Teuchos::ArrayView<const size_t> nEntriesPerRowView(nEntriesPerRow);
-   RCP<CrsGraphType> graph  = rcp(new CrsGraphType(map_i,map_j, nEntriesPerRowView));
-
-
-
-   // graph information about the mesh
-   for(blockItr=elementBlockIds.begin();blockItr!=elementBlockIds.end();++blockItr) {
-      std::string blockId = *blockItr;
-
-      // grab elements for this block
-      const std::vector<LocalOrdinalT> & elements = gidProviders_[0]->getElementBlock(blockId); // each sub provider "should" have the
-                                                                                                // same elements in each element block
-
-      // get information about number of indicies
-      std::vector<GlobalOrdinalT> row_gids;
-      std::vector<GlobalOrdinalT> col_gids;
-
-      // loop over the elemnts
-      for(std::size_t elmt=0;elmt<elements.size();elmt++) {
-
-         rowProvider->getElementGIDs(elements[elmt],row_gids);
-         colProvider->getElementGIDs(elements[elmt],col_gids);
-         for(std::size_t row=0;row<row_gids.size();row++)
-            graph->insertGlobalIndices(row_gids[row],col_gids);
-      }
-   }
-
-   // finish filling the graph: Make sure the colmap and row maps coincide to
-   //                           minimize calls to LID lookups
-   graph->fillComplete(getMap(j),getMap(i));
 
    return graph;
 }


### PR DESCRIPTION
@trilinos/panzer @rppawlo 

## Motivation
Move the assembly of a `Tpetra::CrsGraph` in `panzer:: BlockedTpetraLinearObjFactory::buildTpetraGhostedGraph` to device.

## Questions
- ~~I am not looping over the element blocks, but directly over the elements. Is this problematic? I.e. could we have elements that are not actually part of any blocks?~~ Fixed to use element blocks.
- I am using a `Kokkos::UnorderedMap`. If the allocated capacity is insufficent, we bump it up and try again. For now, I added a print statement to alert if that happens. I could be useful to tune the initial capacity. Is this ok for now? We obviously don't want to flood users with these warnings, but we also don't want to get slow performance because we don't realize that we are under-allocating.

## Testing
I ran MiniEM with `maxwell-large.xml` input deck (768k elements) on one node of blake (H100) on 4 MPI ranks.

Observed timings for `panzer::BlockedTpetraLinearObjFactory::buildTpetraGhostedGraph`:
- before: 0.57 s for Maxwell system, 0.58 s for auxiliary blocks
- after: 0.08 s for Maxwell system, 0.07 s for auxiliary blocks