### PR TITLE
Conditioning some ETI directives to both trilinoscouplings and tpetra being ON during configuration

### DIFF
--- a/packages/trilinoscouplings/CMakeLists.txt
+++ b/packages/trilinoscouplings/CMakeLists.txt
@@ -10,33 +10,35 @@ TRIBITS_PACKAGE(TrilinosCouplings  DISABLE_CIRCULAR_REF_DETECTION_FAILURE)
 # B) Set up package-specific options
 #
 
-#
-# Do explicit template instantiation (ETI) and testing over the same
-# Scalar, LocalOrdinal, and GlobalOrdinal types as for Tpetra objects.
-# However, by default, exclude all of Tpetra's GlobalOrdinal (GO)
-# types from the ETI list.  This is because Tpetra adds all GO ETI
-# types to the list of Scalar ETI types.  (This lets it implement
-# certain communication patterns involving e.g., Vector<GO, LO, GO>.)
-#
+IF(HAVE_TRILINOSCOUPLINGS_TPETRA)
+  #
+  # Do explicit template instantiation (ETI) and testing over the same
+  # Scalar, LocalOrdinal, and GlobalOrdinal types as for Tpetra objects.
+  # However, by default, exclude all of Tpetra's GlobalOrdinal (GO)
+  # types from the ETI list.  This is because Tpetra adds all GO ETI
+  # types to the list of Scalar ETI types.  (This lets it implement
+  # certain communication patterns involving e.g., Vector<GO, LO, GO>.)
+  #
 
-# Make sure that Tpetra actually defined these variables, even if they
-# are empty.
-ASSERT_DEFINED(TpetraCore_ETI_SCALARS_NO_ORDS)
-ASSERT_DEFINED(TpetraCore_ETI_LORDS)
-ASSERT_DEFINED(TpetraCore_ETI_GORDS)
-ASSERT_DEFINED(TpetraCore_ETI_NODES)
+  # Make sure that Tpetra actually defined these variables, even if they
+  # are empty.
+  ASSERT_DEFINED(TpetraCore_ETI_SCALARS_NO_ORDS)
+  ASSERT_DEFINED(TpetraCore_ETI_LORDS)
+  ASSERT_DEFINED(TpetraCore_ETI_GORDS)
+  ASSERT_DEFINED(TpetraCore_ETI_NODES)
 
-# Promote these variables to be visible outside of the "scope" of this
-# directory -- e.g., to other packages.
-GLOBAL_SET(TrilinosCouplings_ETI_SCALARS ${TpetraCore_ETI_SCALARS_NO_ORDS})
-GLOBAL_SET(TrilinosCouplings_ETI_LORDS   ${TpetraCore_ETI_LORDS})
-GLOBAL_SET(TrilinosCouplings_ETI_GORDS   ${TpetraCore_ETI_GORDS})
-GLOBAL_SET(TrilinosCouplings_ETI_NODES   ${TpetraCore_ETI_NODES})
+  # Promote these variables to be visible outside of the "scope" of this
+  # directory -- e.g., to other packages.
+  GLOBAL_SET(TrilinosCouplings_ETI_SCALARS ${TpetraCore_ETI_SCALARS_NO_ORDS})
+  GLOBAL_SET(TrilinosCouplings_ETI_LORDS   ${TpetraCore_ETI_LORDS})
+  GLOBAL_SET(TrilinosCouplings_ETI_GORDS   ${TpetraCore_ETI_GORDS})
+  GLOBAL_SET(TrilinosCouplings_ETI_NODES   ${TpetraCore_ETI_NODES})
 
-TRIBITS_ADD_EXPLICIT_INSTANTIATION_OPTION()
+  TRIBITS_ADD_EXPLICIT_INSTANTIATION_OPTION()
 
-# we use this for testing as well as library eti, so do it regardless
-TRIBITS_ADD_ETI_SUPPORT()
+  # we use this for testing as well as library eti, so do it regardless
+  TRIBITS_ADD_ETI_SUPPORT()
+ENDIF()
 
 
 TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_ENABLE_Newp_swahili


### PR DESCRIPTION
<!---
  Note that anything between these delimiters is a comment that will not appear
  in the pull request description once created. Most areas in this message are
  commented out and can be easily added by removing the comment delimiters.

  CHOOSE APPROPRIATE BRANCH
  Be sure to select `develop` as the `base` branch against which to create this
  pull request.  Only pull requests against `develop` will undergo Trilinos'
  automated testing.  Pull requests against `master` will be ignored.

  TITLE
  Provide a general summary of your changes in the Title above.  If this pull
  request pertains to a particular package in Trilinos, it's worthwhile to start
  the title with "PackageName:  ".

  REVIEWERS
  Please make sure to mark:
  * Reviewers
  * Assignees
  * Labels

  SHOULD THIS PR BE IN THE RELEASE NOTES?
  If the changes in the PR should be considered for inclusion in the release notes,
  please apply the label "xx.y release note" where xx.y is the version of the
  upcoming release.

  NOTIFY THE RIGHT TEAMS
  Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/<teamName>

## Motivation
<!--- 
  Why is this change required?  What problem does it solve? Please link to a github 
  issue that describes the problem/issue/bug this PR solves.
-->

The XYCE team has situations where trilinoscouplings=ON but tpetra=OFF, in which cases the trilinos configuration fails.

## Related Issues
<!---
  If applicable, let us know how this merge request is related to any other open
  issues or pull requests:
-->

* Closes #14945

<!--
  Other options are
  * Blocks 
  * Is blocked by 
  * Follows 
  * Precedes 
  * Related to 
  * Part of 
  * Composed of 
-->


## Stakeholder Feedback
<!--- 
  If a github issue includes feedback from the relevant stakeholder(s), please link it.  
  If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
  Please confirm that any classes or functions in the Trilinos library that this PR touches are 
  exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
  changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

The reported error ceases to happen. Also, the case when trilinos is configured with both trilinoscouplings=ON and tpetra=ON continue to work.

<!--- 
  ## Additional Information
  Anything else we need to know in evaluating this merge request?
-->
