### PR TITLE
Framework: Shorten the PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
  * Choose `base:develop` and NOT `base:master`!
  * Title should start with "PackageName:  ".
  * Select Reviewers, Assignees, and Labels.
-   - Should this PR be in the Release Notes?  Apply "xx.y release note" label.
+   - Should this PR be in the Release Notes?  Apply "Release Note" label.
  * Notify the appropriate teams.
 
 @trilinos/<teamName>


### PR DESCRIPTION
The PR template was too lengthy.  This shortens it while trying to remind developers of important
information to include.

@trilinos/framework 