### PR TITLE
Tpetra: matrix sort and merge

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -4167,9 +4167,6 @@ void prepareSortMergeUnpackedGraph(rowptr_type rowptr, colinds_type colinds, num
 
 template <class execution_space, class LO, class rowptr_type, class colinds_type, class numRowEntries_type>
 void mergeUnpackedGraph(rowptr_type rowptr, colinds_type colinds, numRowEntries_type numRowEntries) {
-  // For this to work correctly, we require that the unsused column entries have been filled
-  // with indices that get ordered last.
-
   auto numRows = rowptr.extent(0) - 1;
 
   // merge
@@ -4198,7 +4195,6 @@ void CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
     sortAndMergeAllIndices(const bool sorted, const bool merged) {
   using std::endl;
   const char tfecfFuncName[] = "sortAndMergeAllIndices";
-  Details::ProfilingRegion regionSortAndMerge("Tpetra::CrsGraph::sortAndMergeAllIndices");
 
   std::unique_ptr<std::string> prefix;
   if (verbose_) {
@@ -4217,6 +4213,8 @@ void CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
                                         "Please report this bug to the Tpetra developers.");
 
   if (!sorted || !merged) {
+    Details::ProfilingRegion regionSortAndMerge("Tpetra::CrsGraph::sortAndMergeAllIndices");
+
     if (storageStatus_ == Details::STORAGE_1D_UNPACKED) {
       // We are sorting & merging the unpacked views.
       // This means that not all entries are actually in use. We need to take k_numRowEntries_ into account.
@@ -4230,6 +4228,8 @@ void CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
       prepareSortMergeUnpackedGraph<execution_space, LocalOrdinal>(rowptr, colinds, k_numRowEntries_d);
 
       if (!sorted) {
+        // For this to work correctly, we require that the unused column entries have been filled
+        // with indices that get ordered last.
         KokkosSparse::sort_crs_graph(rowptr, colinds);
         this->indicesAreSorted_ = true;  // we just sorted every row
       }

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -1756,10 +1756,13 @@ void CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 void CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
     checkInternalState() const {
+  using Details::ProfilingRegion;
   if (debug_) {
     using std::endl;
     const char tfecfFuncName[] = "checkInternalState: ";
     const char suffix[]        = "  Please report this bug to the Tpetra developers.";
+
+    ProfilingRegion("Tpetra::CrsGraph::checkInternalState");
 
     std::unique_ptr<std::string> prefix;
     if (verbose_) {
@@ -3208,8 +3211,6 @@ void CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
 
   fillComplete_ = true;
 
-  MM = Teuchos::null;
-  MM = Teuchos::rcp(new Tpetra::Details::ProfilingRegion("Tpetra ESFC-G-cIS"));
   checkInternalState();
 }
 

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -3724,19 +3724,6 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   void allocateValues(ELocalGlobal lg, GraphAllocationStatus gas,
                       const bool verbose);
 
-  /// \brief Merge duplicate row indices in the given row, along
-  ///   with their corresponding values.
-  ///
-  /// This method is only called by sortAndMergeIndicesAndValues(),
-  /// and only when the matrix owns the graph, not when the matrix
-  /// was constructed with a const graph.
-  ///
-  /// \pre The graph is not already storage optimized:
-  ///   <tt>isStorageOptimized() == false</tt>
-  /// \return The new row length, after merging.
-  static size_t
-  mergeRowIndicesAndValues(size_t rowLen, local_ordinal_type* cols, impl_scalar_type* vals);
-
   /// \brief Sort and merge duplicate local column indices in all
   ///   rows on the calling process, along with their corresponding
   ///   values.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -4370,11 +4370,8 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   // FIXME (mfh 28 Aug 2014) "Preserve Local Graph" bool parameter no longer used.
 
   this->fillComplete_ = true;  // Now we're fill complete!
-  {
-    Details::ProfilingRegion region_cis(
-        "Tpetra::CrsMatrix::fillComplete", "checkInternalState");
-    this->checkInternalState();
-  }
+
+  this->checkInternalState();
 }  // fillComplete(domainMap, rangeMap, params)
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -4419,11 +4416,8 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
                                         ": We're at the end of fillComplete(), but isFillActive() is true.  "
                                         "Please report this bug to the Tpetra developers.");
 #endif  // HAVE_TPETRA_DEBUG
-  {
-    Tpetra::Details::ProfilingRegion cIS("Tpetra ESFC-M-cIS");
 
-    checkInternalState();
-  }
+  checkInternalState();
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
- Skip creation of profiling regions for some no-ops (`checkInternalState` without debug and `sortAndMerge` on sorted and merged objects).
- Move `CrsMatrix::sortAndMergeIndicesAndValues` to device.