### PR TITLE
RTOp: Move github.io Package Description

### DIFF
--- a/packages/rtop/README.md
+++ b/packages/rtop/README.md
@@ -2,14 +2,23 @@
 
 Interfaces and Support Software for Vector Reduction Transformation Operations
 
+RTOp (reduction/transformation operators) provides the basic mechanism for implementing vector operations in a flexible and efficient manner.
+
+## Documentation
+
+RTOp is part of the [Trilinos Project](https://trilinos.github.io).
+
+## Questions?
+
+Contact the lead developers:
+
+- **RTOp team**:          GitHub handle: @trilinos/rtop
+- **Roscoe A. Bartlett**: GitHub handle: [bartlettroscoe](https://github.com/bartlettroscoe) or rabartl@sandia.gov
 
 ## Copyright and License
-See rtop/COPYRIGHT, rtop/LICENSE, https://trilinos.github.io/license.html and individual file headers for additional information.
 
+For general copyright and license information, refer to the Trilinos [License and Copyright](https://trilinos.github.io/about.html#license-and-copyright) page.
 
-## Questions? 
-Contact lead developers:
+For RTOp-specific copyright and license details, refer to the [rtop/COPYRIGHT](COPYRIGHT) and [rtop/LICENSE](LICENSE) files located in the `rtop` directory. Additional copyright information may also be found in the headers of individual source files.
 
-* RTOp team          (GitHub handle: @trilinos/rtop)
-* Roscoe A. Bartlett (GitHub handle: [bartlettroscoe](https://github.com/bartlettroscoe) or rabartl@sandia.gov)
-
+For developers, general guidance on documenting copyrights and licenses can be found in the Trilinos [Guidance on Copyrights and Licenses](https://github.com/trilinos/Trilinos/wiki/Guidance-on-Copyrights-and-Licenses) document.


### PR DESCRIPTION
Merged the package description from github.io to the github README.md.

@trilinos/rtop