### PR TITLE
Sacado: Move github.io Package Description

### DIFF
--- a/packages/sacado/README.md
+++ b/packages/sacado/README.md
@@ -8,13 +8,21 @@ the Fad package by Nicolas Di Cesare (Nicolas.Dicesare@ann.jussieu.fr).  The
 Fad package is available at http://www.ann.jussieu.fr/~dicesare.  A portion
 of the original Fad package is also included here in the Fad directory.
 
+## Documentation
+
+Sacado is part of the [Trilinos Project](https://trilinos.github.io), and additional information (e.g., examples, tutorials, and source code documentation) is available through [Sacado's Doxygen webpages](https://trilinos.github.io/docs/sacado/index.html).
+
+## Questions?
+
+Contact the lead developers:
+
+- **Sacado team**:    GitHub handle: @trilinos/sacado
+- **Eric T. Phipps**: GitHub handle: [etphipp](https://github.com/etphipp) or etphipp@sandia.gov
 
 ## Copyright and License
-See sacado/COPYRIGHT, sacado/LICENSE, https://trilinos.github.io/license.html and individual file headers for additional information.
 
+For general copyright and license information, refer to the Trilinos [License and Copyright](https://trilinos.github.io/about.html#license-and-copyright) page.
 
-## Questions? 
-Contact lead developers:
+For Sacado-specific copyright and license details, refer to the [sacado/COPYRIGHT](COPYRIGHT) and [sacado/LICENSE](LICENSE) files located in the `sacado` directory. Additional copyright information may also be found in the headers of individual source files.
 
-* Sacado team     (GitHub handle: @trilinos/sacado)
-* Eric T. Phipps  (GitHub handle: [etphipp](https://github.com/etphipp) or etphipp@sandia.gov)
+For developers, general guidance on documenting copyrights and licenses can be found in the Trilinos [Guidance on Copyrights and Licenses](https://github.com/trilinos/Trilinos/wiki/Guidance-on-Copyrights-and-Licenses) document.


### PR DESCRIPTION
Merged the package description from github.io to the github README.md.

@trilinos/sacado 