### PR TITLE
Belos tpetra init

### DIFF
--- a/packages/belos/tpetra/example/SolverFactory/SolverFactoryTpetraGaleriEx.cpp
+++ b/packages/belos/tpetra/example/SolverFactory/SolverFactoryTpetraGaleriEx.cpp
@@ -72,7 +72,7 @@ int run(int argc, char *argv[]) {
   using Teuchos::rcp;
   using Teuchos::ParameterList;
 
-  Teuchos::GlobalMPISession mpiSession (&argc, &argv, &std::cout);
+  Tpetra::initialize(&argc, &argv);
   const auto comm = Tpetra::getDefaultComm();
   const int myPID = comm->getRank();
 
@@ -258,6 +258,8 @@ int run(int argc, char *argv[]) {
     }
   }
   TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  Tpetra::finalize();
 
   return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/packages/tpetra/core/src/Tpetra_Details_normImpl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_normImpl.hpp
@@ -25,6 +25,7 @@
 #include "Teuchos_CommHelpers.hpp"
 #include "KokkosBlas.hpp"
 #include "KokkosKernels_ArithTraits.hpp"
+#include "Tpetra_Details_Profiling.hpp"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace Teuchos {
@@ -83,6 +84,8 @@ void lclNormImpl(const RV& normsOut,
   using Kokkos::ALL;
   using Kokkos::subview;
   using mag_type = typename RV::non_const_value_type;
+
+  Details::ProfilingRegion region("Tpetra::Details::lclNormImpl");
 
   static_assert(static_cast<int>(RV::rank) == 1,
                 "Tpetra::MultiVector::lclNormImpl: "
@@ -176,6 +179,8 @@ void gblNormImpl(const RV& normsOut,
   using Teuchos::REDUCE_SUM;
   using Teuchos::reduceAll;
   typedef typename RV::non_const_value_type mag_type;
+
+  Details::ProfilingRegion region("Tpetra::Details::gblNormImpl");
 
   const size_t numVecs = normsOut.extent(0);
 

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -2099,6 +2099,8 @@ void gblDotImpl(const RV& dotsOut,
   using Teuchos::reduceAll;
   typedef typename RV::non_const_value_type dot_type;
 
+  Details::ProfilingRegion region("Tpetra::gblDotImpl");
+
   const size_t numVecs = dotsOut.extent(0);
 
   // If the MultiVector is distributed over multiple processes, do
@@ -2237,27 +2239,31 @@ multiVectorSingleColumnDot(const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal
   if (comm.is_null()) {
     return KokkosKernels::ArithTraits<dot_type>::zero();
   } else {
-    using LO = LocalOrdinal;
-    // The min just ensures that we don't overwrite memory that
-    // doesn't belong to us, in the erroneous input case where x
-    // and y have different numbers of rows.
-    const LO lclNumRows = static_cast<LO>(std::min(x.getLocalLength(),
-                                                   y.getLocalLength()));
-    const Kokkos::pair<LO, LO> rowRng(0, lclNumRows);
     dot_type lclDot = KokkosKernels::ArithTraits<dot_type>::zero();
     dot_type gblDot = KokkosKernels::ArithTraits<dot_type>::zero();
+    {
+      ProfilingRegion regionLclDot("Tpetra::multiVectorSingleColumnDot::lclDot");
+      using LO = LocalOrdinal;
+      // The min just ensures that we don't overwrite memory that
+      // doesn't belong to us, in the erroneous input case where x
+      // and y have different numbers of rows.
+      const LO lclNumRows = static_cast<LO>(std::min(x.getLocalLength(),
+                                                     y.getLocalLength()));
+      const Kokkos::pair<LO, LO> rowRng(0, lclNumRows);
 
-    // All non-unary kernels are executed on the device as per Tpetra policy.  Sync to device if needed.
-    // const_cast<MV&>(x).sync_device ();
-    // const_cast<MV&>(y).sync_device ();
+      // All non-unary kernels are executed on the device as per Tpetra policy.  Sync to device if needed.
+      // const_cast<MV&>(x).sync_device ();
+      // const_cast<MV&>(y).sync_device ();
 
-    auto x_2d = x.getLocalViewDevice(Access::ReadOnly);
-    auto x_1d = Kokkos::subview(x_2d, rowRng, 0);
-    auto y_2d = y.getLocalViewDevice(Access::ReadOnly);
-    auto y_1d = Kokkos::subview(y_2d, rowRng, 0);
-    lclDot    = KokkosBlas::dot(x_1d, y_1d);
+      auto x_2d = x.getLocalViewDevice(Access::ReadOnly);
+      auto x_1d = Kokkos::subview(x_2d, rowRng, 0);
+      auto y_2d = y.getLocalViewDevice(Access::ReadOnly);
+      auto y_1d = Kokkos::subview(y_2d, rowRng, 0);
+      lclDot    = KokkosBlas::dot(x_1d, y_1d);
+    }
 
     if (x.isDistributed()) {
+      ProfilingRegion regionReduce("Tpetra::multiVectorSingleColumnDot::reduce");
       using Teuchos::outArg;
       using Teuchos::REDUCE_SUM;
       using Teuchos::reduceAll;


### PR DESCRIPTION
@trilinos/tpetra @trilinos/belos 

## Motivation
- Tpetra: Add profiling regions for local and nonlocal parts of norm and dot.
- Belos Tpetra example: Initialize Tpetra instead of relying on on-the-fly initialization. The performance testing results got skewed by initialization cost appearing in sub-timers. We have only limited influence over initialization of TPLs like Cuda and it is not really helpful to time it.