### PR TITLE
Ifpack2: fix a lot of "host called from host/device" warnings

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockComputeResidualVector_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockComputeResidualVector_def.hpp
@@ -413,7 +413,6 @@ struct ComputeResidualFunctor {
 
   struct SeqTag {};
 
-  KOKKOS_INLINE_FUNCTION
   void
   operator()(const SeqTag &, const local_ordinal_type &i) const {
     const local_ordinal_type blocksize        = blocksize_requested;
@@ -517,7 +516,7 @@ struct ComputeResidualFunctor {
 
   // CPU implementation for all cases
   template <int B, bool async, bool overlap, bool haveBlockMatrix>
-  KOKKOS_INLINE_FUNCTION void
+  void
   operator()(const GeneralTag<B, async, overlap, haveBlockMatrix> &, const local_ordinal_type &rowidx) const {
     const local_ordinal_type blocksize = (B == 0 ? blocksize_requested : B);
 


### PR DESCRIPTION
@trilinos/ifpack2

## Motivation
Fix a lot of warnings like
```
warning #20011-D: calling a __host__ function("Ifpack2::BlockHelperDetails::ComputeResidualFunctor...
```
by removing KOKKOS_INLINE_FUNCTION for kernels that are only intended to be run on host.
These existed before but I noticed them in the autotester logs for #14982.

Tested locally in 2 builds: one cuda and one serial.