### PR TITLE
MueLu: ReitzingerPFactory

### DIFF
--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_decl.hpp
@@ -10,10 +10,6 @@
 #ifndef MUELU_REITZINGERPFACTORY_DECL_HPP
 #define MUELU_REITZINGERPFACTORY_DECL_HPP
 
-#include <Teuchos_ScalarTraits.hpp>
-#include <Teuchos_SerialDenseMatrix.hpp>
-#include <Teuchos_SerialQRDenseSolver.hpp>
-
 #include <Xpetra_CrsMatrix_fwd.hpp>
 #include <Xpetra_Matrix_fwd.hpp>
 #include <Xpetra_MapFactory_fwd.hpp>
@@ -43,7 +39,6 @@ namespace MueLu {
   ### User parameters of ReitzingerPFactory ###
   Parameter | type | default | master.xml | validated | requested | description
   ----------|------|---------|:----------:|:---------:|:---------:|------------
-   A        | Factory | null |   | * | * | Generating factory of the matrix A
    P        | Factory | null |   | * | * | Generating factory of the nodal Prolongator
    D0       | Factory | null |   | * | * | Generating factory of the discrete gradient operator
    NodeMatrix  | Factory | null |   | * | * | Generating factory of the nodal A matrix

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_def.hpp
@@ -16,16 +16,15 @@
 #include <Xpetra_Matrix.hpp>
 #include <Xpetra_MatrixMatrix.hpp>
 #include <Xpetra_MultiVector.hpp>
-#include <Xpetra_MultiVectorFactory.hpp>
 #include <Xpetra_VectorFactory.hpp>
 #include <Xpetra_Import.hpp>
 #include <Xpetra_ImportFactory.hpp>
 #include <Xpetra_CrsMatrixWrap.hpp>
-#include <Xpetra_StridedMap.hpp>
-#include <Xpetra_StridedMapFactory.hpp>
-#include <Xpetra_IO.hpp>
+// #include <Xpetra_IO.hpp>
 
 #include "MueLu_ReitzingerPFactory_decl.hpp"
+
+#include <Teuchos_ScalarTraits.hpp>
 
 #include "MueLu_MasterList.hpp"
 #include "MueLu_Monitor.hpp"
@@ -45,11 +44,9 @@ RCP<const ParameterList> ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal,
   SET_VALID_ENTRY("tentative: constant column sums");
 #undef SET_VALID_ENTRY
 
-  validParamList->set<RCP<const FactoryBase> >("A", Teuchos::null, "Generating factory of the matrix A");
   validParamList->set<RCP<const FactoryBase> >("D0", Teuchos::null, "Generating factory of the matrix D0");
   validParamList->set<RCP<const FactoryBase> >("NodeAggMatrix", Teuchos::null, "Generating factory of the matrix NodeAggMatrix");
   validParamList->set<RCP<const FactoryBase> >("Pnodal", Teuchos::null, "Generating factory of the matrix P");
-  validParamList->set<RCP<const FactoryBase> >("NodeImporter", Teuchos::null, "Generating factory of the matrix NodeImporter");
 
   // Make sure we don't recursively validate options for the matrixmatrix kernels
   ParameterList norecurse;
@@ -61,12 +58,9 @@ RCP<const ParameterList> ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal,
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel, Level& coarseLevel) const {
-  Input(fineLevel, "A");
   Input(fineLevel, "D0");
-  Input(fineLevel, "NodeAggMatrix");
   Input(coarseLevel, "NodeAggMatrix");
   Input(coarseLevel, "Pnodal");
-  //    Input(coarseLevel, "NodeImporter");
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -77,346 +71,338 @@ void ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level&
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& fineLevel, Level& coarseLevel) const {
   FactoryMonitor m(*this, "Build", coarseLevel);
-  using Teuchos::arcp_const_cast;
-  using MT                    = typename Teuchos::ScalarTraits<SC>::magnitudeType;
-  using XMM                   = Xpetra::MatrixMatrix<SC, LO, GO, NO>;
+
+  using XMM               = Xpetra::MatrixMatrix<SC, LO, GO, NO>;
+  using local_matrix_type = typename Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::local_matrix_type;
+  using rowptr_type       = typename local_matrix_type::row_map_type::non_const_type;
+  using colidx_type       = typename local_matrix_type::index_type::non_const_type;
+  using values_type       = typename local_matrix_type::values_type::non_const_type;
+
+  using impl_scalar_type = typename Matrix::impl_scalar_type;
+  using ATS              = KokkosKernels::ArithTraits<impl_scalar_type>;
+  using mag_type         = typename KokkosKernels::ArithTraits<impl_scalar_type>::magnitudeType;
+  using magATS           = KokkosKernels::ArithTraits<mag_type>;
+
+  using execution_space = typename Node::execution_space;
+  using memory_space    = typename Node::memory_space;
+
+  const auto one_Scalar      = Teuchos::ScalarTraits<Scalar>::one();
+  const auto one_impl_scalar = ATS::one();
+  const auto zero_LO         = KokkosKernels::ArithTraits<LocalOrdinal>::zero();
+  const auto one_LO          = KokkosKernels::ArithTraits<LocalOrdinal>::one();
+  const auto one_mag         = magATS::one();
+  const auto eps_mag         = magATS::epsilon();
+  const auto INVALID_GO      = Teuchos::OrdinalTraits<GlobalOrdinal>::invalid();
+
+  // Using a nodal prolongator Pn and the discrete gradient matrix D0, this factory constructs
+  // a coarse discrete gradient matrix D0H and an edge prolongator Pe such that the commuting
+  // relationship
+  //
+  //  D0 * Pn = Pe * D0H
+  //
+  // holds.
+
+  // The construction of the coarse discrete gradient works as follows.
+  // We create edges between aggregates that contain at least one pair of connected nodes.
+  // This boils down to computing the matrix
+  //
+  //  Z := (D0*Pn)^T * (D0 * Pn).
+  //
+  // If Z_ij != 0 we create an edge e between the nodal aggregates i and j.
+  // Z is clearly symmetric. We only create a single edge between i and j.
+  // In the distributed case, we also need to decide which rank owns the coarse edge e.
+  // If both endpoints i and j live on process proc0 then proc0 should obiously own the edge e.
+  // If i lives on proc0 and j lives on proc1, we tie-break based on the rule
+  //
+  //  min{proc0, proc1} if proc0+proc1 is odd,
+  //  max{proc0, proc1} if proc0+proc1 is even.
+  //
+  // The orientation of the edge (encoded in the values 1 and -1) is determined by the GIDs of the endpoints.
+  // All edges point from smaller GID to larger GID, i.e. i < j.
+
+  // We also perform detection of boundary condtions and add additional edges to the coarse discrete gradient.
+  // We detect all edges in D0 that only connect to a single node.
+
   Teuchos::FancyOStream& out0 = GetBlackHole();
   const ParameterList& pL     = GetParameterList();
 
   bool update_communicators = pL.get<bool>("repartition: enable") && pL.get<bool>("repartition: use subcommunicators");
 
-  // If these are set correctly we assume that the nodal P contains only ones
-  bool nodal_p_is_all_ones = !pL.get<bool>("tentative: constant column sums") && !pL.get<bool>("tentative: calculate qr");
-
-  RCP<Matrix> EdgeMatrix = Get<RCP<Matrix> >(fineLevel, "A");
-  RCP<Matrix> D0         = Get<RCP<Matrix> >(fineLevel, "D0");
-  RCP<Matrix> NodeMatrix = Get<RCP<Matrix> >(fineLevel, "NodeAggMatrix");
-  RCP<Matrix> Pn         = Get<RCP<Matrix> >(coarseLevel, "Pnodal");
-
-  const GO GO_INVALID = Teuchos::OrdinalTraits<GO>::invalid();
-  const LO LO_INVALID = Teuchos::OrdinalTraits<LO>::invalid();
+  RCP<Matrix> D0 = Get<RCP<Matrix> >(fineLevel, "D0");
+  RCP<Matrix> Pn = Get<RCP<Matrix> >(coarseLevel, "Pnodal");
 
   // This needs to be an Operator because if NodeMatrix gets repartitioned away, we get an Operator on the level
   RCP<Operator> CoarseNodeMatrix = Get<RCP<Operator> >(coarseLevel, "NodeAggMatrix");
-  int MyPID                      = EdgeMatrix.is_null() ? -1 : EdgeMatrix->getRowMap()->getComm()->getRank();
 
   // Matrix matrix params
   RCP<ParameterList> mm_params = rcp(new ParameterList);
-  ;
   if (pL.isSublist("matrixmatrix: kernel params"))
     mm_params->sublist("matrixmatrix: kernel params") = pL.sublist("matrixmatrix: kernel params");
 
-  // Normalize P
-  if (!nodal_p_is_all_ones) {
-    // The parameters told us the nodal P isn't all ones, so we make a copy that is.
-    GetOStream(Runtime0) << "ReitzingerPFactory::BuildP(): Assuming Pn is not normalized" << std::endl;
-    RCP<Matrix> Pn_old = Pn;
+  {  // Check that Pn is piecewise constant
+    // TODO: Should this be a debug-only check?
 
-    Pn = Xpetra::MatrixFactory<SC, LO, GO, NO>::Build(Pn->getCrsGraph());
-    Pn->setAllToScalar(Teuchos::ScalarTraits<SC>::one());
-    Pn->fillComplete(Pn->getDomainMap(), Pn->getRangeMap());
-  } else {
-    // The parameters claim P is all ones.
-    GetOStream(Runtime0) << "ReitzingerPFactory::BuildP(): Assuming Pn is normalized" << std::endl;
+    auto vec_ones = VectorFactory::Build(Pn->getDomainMap(), false);
+    vec_ones->putScalar(one_Scalar);
+    auto vec_rowsums = VectorFactory::Build(Pn->getRangeMap(), false);
+    Pn->apply(*vec_ones, *vec_rowsums, Teuchos::NO_TRANS);
+
+    auto lclPn      = Pn->getLocalMatrixDevice();
+    auto lclRowSums = vec_rowsums->getLocalViewDevice(Tpetra::Access::ReadOnly);
+
+    bool all_entries_ok = true;
+    Kokkos::parallel_reduce(
+        Kokkos::RangePolicy<execution_space>(0, lclPn.numRows()), KOKKOS_LAMBDA(const LocalOrdinal rlid, bool& entries_ok) {
+      // rowsums are 1
+      entries_ok = entries_ok && (ATS::magnitude(lclRowSums(rlid, 0) - one_impl_scalar) < eps_mag);
+
+      // all nonzero entries are 1
+      auto row = lclPn.rowConst(rlid);
+      for (LocalOrdinal k = 0; k < row.length; ++k) {
+        entries_ok = entries_ok && (ATS::magnitude(row.value(k)-one_impl_scalar) < eps_mag);
+
+      } }, Kokkos::LAnd<bool>(all_entries_ok));
+
+    TEUCHOS_TEST_FOR_EXCEPTION(!all_entries_ok, std::runtime_error, "The prolongator needs to be piecewise constant and all entries need to be 1.");
   }
 
-  // TODO: We need to make sure Pn isn't normalized.  Right now this has to be done explicitly by the user
-
-  // TODO: We need to look through and see which of these really need importers and which ones don't
-
-  /* Generate the D0 * Pn matrix and its transpose */
-  RCP<Matrix> D0_Pn, PnT_D0T, D0_Pn_nonghosted;
-  Teuchos::Array<int> D0_Pn_col_pids;
+  RCP<Matrix> D0_Pn;
+  RCP<Matrix> D0H;
+  LocalOrdinal numCoarseEdges          = 0;
+  LocalOrdinal numCoarseRegularEdges   = 0;
+  LocalOrdinal numCoarseDirichletEdges = 0;
+  auto isDirichletFineEdge             = Xpetra::VectorFactory<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node>::Build(D0->getRowMap(), false);
+  auto numFineEdges                    = isDirichletFineEdge->getMap()->getLocalNumElements();
   {
+    // Construct D0*Pn and Z := (D0*Pn)^T * (D0*Pn)
     RCP<Matrix> dummy;
-    SubFactoryMonitor m2(*this, "Generate D0*Pn", coarseLevel);
-    D0_Pn = XMM::Multiply(*D0, false, *Pn, false, dummy, out0, true, true, "D0*Pn", mm_params);
+    D0_Pn         = XMM::Multiply(*D0, false, *Pn, false, dummy, GetOStream(Runtime0), true, true);
+    RCP<Matrix> Z = XMM::Multiply(*D0_Pn, true, *D0_Pn, false, dummy, GetOStream(Runtime0), true, true);
 
-    // We don't want this guy getting accidently used later
-    if (!mm_params.is_null()) mm_params->remove("importer", false);
+    auto rowMap       = Z->getRowMap();
+    auto colMap       = Z->getColMap();
+    auto lclRowMap    = rowMap->getLocalMap();
+    auto lclColMap    = colMap->getLocalMap();
+    auto lclZ         = Z->getLocalMatrixDevice();
+    auto numLocalRows = lclZ.numRows();
 
-    // Save this so we don't need to do the multiplication again later
-    D0_Pn_nonghosted = D0_Pn;
+#ifdef HAVE_MUELU_DEBUG
+    TEUCHOS_ASSERT(Utilities::MapsAreNested(*rowMap, *colMap));
+#endif
 
-    // Get owning PID information on columns for tie-breaking
-    if (!D0_Pn->getCrsGraph()->getImporter().is_null()) {
+    auto importer = Z->getCrsGraph()->getImporter();
+    // TODO: replace with Kokkos once PID data lives on device
+    Teuchos::Array<int> Z_col_pids;
+    Kokkos::View<int*, memory_space> Z_col_pids_d;
+    if (!importer.is_null()) {
       MueLu::ImportUtils<LO, GO, NO> utils;
-      utils.getPids(*D0_Pn->getCrsGraph()->getImporter(), D0_Pn_col_pids, false);
-    } else {
-      D0_Pn_col_pids.resize(D0_Pn->getCrsGraph()->getColMap()->getLocalNumElements(), MyPID);
+      utils.getPids(*importer, Z_col_pids, false);
+      Kokkos::View<int*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > Z_col_pids_h(Z_col_pids.data(), Z_col_pids.size());
+      Z_col_pids_d = Kokkos::View<int*, memory_space>("Z_col_pids_d", Z_col_pids.size());
+      Kokkos::deep_copy(Z_col_pids_d, Z_col_pids_h);
     }
-  }
 
-  {
-    // Get the transpose
-    SubFactoryMonitor m2(*this, "Transpose D0*Pn", coarseLevel);
-    PnT_D0T = Utilities::Transpose(*D0_Pn, true);
-  }
+    int myProcId = rowMap->getComm()->getRank();
 
-  // We really need a ghosted version of D0_Pn here.
-  // The reason is that if there's only one fine edge between two coarse nodes, somebody is going
-  // to own the associated coarse edge.  The sum/sign rule doesn't guarantee the fine owner is the coarse owner.
-  // So you can wind up with a situation that only guy who *can* register the coarse edge isn't the sum/sign
-  // owner.  Adding more ghosting fixes that.
-  if (!PnT_D0T->getCrsGraph()->getImporter().is_null()) {
-    RCP<const Import> Importer     = PnT_D0T->getCrsGraph()->getImporter();
-    RCP<const CrsMatrix> D0_Pn_crs = rcp_dynamic_cast<const CrsMatrixWrap>(D0_Pn)->getCrsMatrix();
-    RCP<Matrix> D0_Pn_new          = rcp(new CrsMatrixWrap(CrsMatrixFactory::Build(D0_Pn_crs, *Importer, D0_Pn->getDomainMap(), Importer->getTargetMap())));
-    D0_Pn                          = D0_Pn_new;
-    // Get owning PID information on columns for tie-breaking
-    if (!D0_Pn->getCrsGraph()->getImporter().is_null()) {
-      MueLu::ImportUtils<LO, GO, NO> utils;
-      utils.getPids(*D0_Pn->getCrsGraph()->getImporter(), D0_Pn_col_pids, false);
-    } else {
-      D0_Pn_col_pids.resize(D0_Pn->getCrsGraph()->getColMap()->getLocalNumElements(), MyPID);
-    }
-  }
-
-  // FIXME: This is using deprecated interfaces
-  ArrayView<const LO> colind_E, colind_N;
-  ArrayView<const SC> values_E, values_N;
-
-  size_t Ne = EdgeMatrix->getLocalNumRows();
-
-  // Notinal upper bound on local number of coarse edges
-  size_t max_edges = PnT_D0T->getLocalNumEntries();
-  ArrayRCP<size_t> D0_rowptr(Ne + 1);
-  ArrayRCP<LO> D0_colind(max_edges);
-  ArrayRCP<SC> D0_values(max_edges);
-  D0_rowptr[0] = 0;
-
-  LO current = 0;
-  LO Nnc     = PnT_D0T->getRowMap()->getLocalNumElements();
-
-  // Get the node maps for D0_coarse
-  RCP<const Map> ownedCoarseNodeMap           = Pn->getDomainMap();
-  RCP<const Map> ownedPlusSharedCoarseNodeMap = D0_Pn->getCrsGraph()->getColMap();
-
-
-  for (LO i = 0; i < (LO)Nnc; i++) {
-    LO local_column_i = ownedPlusSharedCoarseNodeMap->getLocalElement(PnT_D0T->getRowMap()->getGlobalElement(i));
-
-    // FIXME: We don't really want an std::map here.  This is just a first cut implementation
-    using value_type = bool;
-    std::map<LO, value_type> ce_map;
-
-    // FIXME: This is using deprecated interfaces
-    PnT_D0T->getLocalRowView(i, colind_E, values_E);
-
-    for (LO j = 0; j < (LO)colind_E.size(); j++) {
-      // NOTE: Edges between procs will be via handled via the a version
-      // of ML's odd/even rule
-      // For this to function correctly, we make two assumptions:
-      //  (a) The processor that owns a fine edge owns at least one of the attached nodes.
-      //  (b) Aggregation is uncoupled.
-
-      // TODO: Add some debug code to check the assumptions
-
-      // Check to see if we own this edge and continue if we don't
-      GO edge_gid = PnT_D0T->getColMap()->getGlobalElement(colind_E[j]);
-      LO j_row    = D0_Pn->getRowMap()->getLocalElement(edge_gid);
-      int pid0, pid1;
-      D0_Pn->getLocalRowView(j_row, colind_N, values_N);
-
-      // Skip incomplete rows
-      if (colind_N.size() != 2) continue;
-
-      pid0 = D0_Pn_col_pids[colind_N[0]];
-      pid1 = D0_Pn_col_pids[colind_N[1]];
-      //        printf("[%d] Row %d considering edge (%d)%d -> (%d)%d\n",MyPID,global_i,colind_N[0],D0_Pn->getColMap()->getGlobalElement(colind_N[0]),colind_N[1],D0_Pn->getColMap()->getGlobalElement(colind_N[1]));
-
-      // Check to see who owns these nodes
-      // If the sum of owning procs is odd, the lower ranked proc gets it
-
-      bool zero_matches     = pid0 == MyPID;
-      bool one_matches      = pid1 == MyPID;
-      bool keep_shared_edge = false, own_both_nodes = false;
-      if (zero_matches && one_matches) {
-        own_both_nodes = true;
+    // Tie-break criterion for owner of coarse edges
+    auto tie_break = KOKKOS_LAMBDA(int proc0, int proc1) {
+      if ((proc0 + proc1) % 2 == 1) {
+        return Kokkos::min(proc0, proc1);
       } else {
-        bool sum_is_even  = (pid0 + pid1) % 2 == 0;
-        bool i_am_smaller = MyPID == std::min(pid0, pid1);
-        if (sum_is_even && i_am_smaller) keep_shared_edge = true;
-        if (!sum_is_even && !i_am_smaller) keep_shared_edge = true;
+        return Kokkos::max(proc0, proc1);
       }
-      //        printf("[%d] - matches %d/%d keep_shared = %d own_both = %d\n",MyPID,(int)zero_matches,(int)one_matches,(int)keep_shared_edge,(int)own_both_nodes);
-      if (!keep_shared_edge && !own_both_nodes) continue;
+    };
 
-      // We're doing this in GID space, but only because it allows us to explain
-      // the edge orientation as "always goes from lower GID to higher GID".  This could
-      // be done entirely in LIDs, but then the ordering is a little more confusing.
-      // This could be done in local indices later if we need the extra performance.
-      for (LO k = 0; k < (LO)colind_N.size(); k++) {
-        LO my_colind = colind_N[k];
-        if (my_colind != LO_INVALID && ((keep_shared_edge && my_colind != local_column_i) || (own_both_nodes && my_colind > local_column_i))) {
-          ce_map.emplace(std::make_pair(my_colind, true));
-        }
-      }  // end for k < colind_N.size()
-    }    // end for j < colind_E.size()
-
-    // std::map is sorted, so we'll just iterate through this
-    for (auto iter = ce_map.begin(); iter != ce_map.end(); iter++) {
-      LO col = iter->first;
-      if (col == local_column_i) {
-        continue;
+    // Utility function to determine whether we need to add a coarse edge for entry
+    // (rlid, clid) of Z.
+    auto add_edge = KOKKOS_LAMBDA(LocalOrdinal rlid, LocalOrdinal clid) {
+      if (clid < numLocalRows) {
+        // Both row and column index are local, this process owns the new edge.
+        // Only create one edge between rlid and clid and ignore the transposed entry.
+        return (rlid < clid);
+      } else {
+        // Column index is nonlocal. Need to decide if this process owns the new edge.
+        int otherProcId = Z_col_pids_d(clid);
+        int owner       = tie_break(myProcId, otherProcId);
+        return (owner == myProcId);
       }
+    };
 
-      // Exponential memory reallocation, if needed
-      if (current + 1 >= Teuchos::as<LocalOrdinal>(max_edges)) {
-        max_edges *= 2;
-        D0_colind.resize(max_edges);
-        D0_values.resize(max_edges);
-      }
-      if (current / 2 + 1 >= D0_rowptr.size()) {
-        D0_rowptr.resize(2 * D0_rowptr.size() + 1);
-      }
+    // Count up how many coarse regular edges we are creating.
+    Kokkos::parallel_reduce(
+        Kokkos::RangePolicy<execution_space>(0, numLocalRows), KOKKOS_LAMBDA(const LocalOrdinal rlid, LocalOrdinal& ne) {
+          auto row = lclZ.rowConst(rlid);
+          // Loop over entries in row of Z
+          for (LocalOrdinal k = 0; k < row.length; ++k) {
+            auto clid = row.colidx(k);
+            if (add_edge(rlid, clid))
+              ++ne;
+          }
+        },
+        numCoarseRegularEdges);
 
-      // NOTE: "i" here might not be a valid local column id, so we read it from the map
-      D0_colind[current] = local_column_i;
-      D0_values[current] = -1;
-      current++;
-      D0_colind[current] = col;
-      D0_values[current] = 1;
-      current++;
-      D0_rowptr[current / 2] = current;
-    }
+    // Mark as singleParents any D0 edges with only one node (so these are
+    // edges that connect an interior node with a Dirichlet node).
+    // isDirichletFineEdge is 1 for edges with a single endpoint and 0 otherwise.
+    using LOMatrix = Tpetra::CrsMatrix<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node>;
+    RCP<LOMatrix> D0_LocalOrdinal;
+    {
+      // We want to do a apply using D0 on vectors with Scalar=LocalOrdinal.
+      // Something like this could work and would not require any memory allocations, but it requires
+      // "convert" to be ETI'd for all possible scalar types.
 
-  }  // end for i < Nn
+      // toTpetra(D0)->template convert<LocalOrdinal>()->apply(*toTpetra(oneVec), *toTpetra(isDirichletFineEdge), Teuchos::NO_TRANS);
 
-  LO num_coarse_edges = current / 2;
+      using lo_local_matrix_type = typename LOMatrix::local_matrix_device_type;
 
-#define DirFixForEminHcurl 
-#ifdef DirFixForEminHcurl 
-
-  // Mark as singleParents any D0 edges with only one node (so these are
-  // edges that connect an interior node with a Dirichlet node).
-  // We also define a vector that records the global Id of the 
-  // interior node associated with each singleParent edge
-
-  SC myzero  = Teuchos::ScalarTraits<SC>::zero();
-  SC myone   = Teuchos::ScalarTraits<SC>::one();
-  RCP<MultiVector> ntheSingleParent = MultiVectorFactory::Build(D0->getRowMap(),1);
-  RCP<MultiVector> singleParentAggGid   = MultiVectorFactory::Build(D0->getRowMap(),1);
-  RCP<MultiVector> oneVec = MultiVectorFactory::Build(D0->getDomainMap(),1);
-  RCP<MultiVector> v1= MultiVectorFactory::Build(PnT_D0T->getRowMap(),1);
-  RCP<MultiVector> v2= MultiVectorFactory::Build(PnT_D0T->getRowMap(),1);
-  oneVec->putScalar(myone );
-  ntheSingleParent->putScalar(myzero);
-  singleParentAggGid->putScalar(myzero);
-  D0->apply(*oneVec,*ntheSingleParent,Teuchos::NO_TRANS);
-  Teuchos::ArrayRCP<SC> ntheSingleParentData = ntheSingleParent->getDataNonConst(0);
-  Teuchos::ArrayRCP<SC> singleParentAggGidData = singleParentAggGid->getDataNonConst(0);
-  ArrayView<const LO> cols;
-  ArrayView<const SC> vals;
-  for (size_t i = 0; i < ntheSingleParent->getMap()->getLocalNumElements(); i++ ) {
-    if (ntheSingleParentData[i] != 1) ntheSingleParentData[i] = 0.0;
-    else {
-      D0_Pn->getLocalRowView(i, cols, vals);
-      TEUCHOS_TEST_FOR_EXCEPTION(cols.size() != 1, Exceptions::RuntimeError, "MueLu::ReitzingerPFactory: single parent Edges should have just 1 nnz.");
-      singleParentAggGidData[i] = ownedCoarseNodeMap->getGlobalElement(cols[0]);
-    }
-  }
-
-  // For Orphan edge i, D0_Pn(i,:) has just one nonzero (when Pn is a tentative prolongator
-  // as it should be for ReitzingerPFactory). This means that the transpose has just one
-  // nonzero equal to 1 or -1 in the associated column. We can set all nonzeros equal to 
-  // 1 in PnT_D0T and do matvecs with v. These matvecs should sum all entries of v associated
-  // with the same coarse node (which should all be equal to each other for v1 and for v2). 
-  // Thus, the desired gid is obtained via v2/v1 where v2[i] = gid*k and v1[i]=k where k
-  // is the number of fine singleParent edges incident to the same gid^th coarse node (or aggregate)
-
-  PnT_D0T->setAllToScalar(Teuchos::ScalarTraits<Scalar>::one());
-  PnT_D0T->apply(*ntheSingleParent,*v1,Teuchos::NO_TRANS);
-  PnT_D0T->apply(*singleParentAggGid,*v2,Teuchos::NO_TRANS);
-  Teuchos::ArrayRCP<SC> v1Data = v1->getDataNonConst(0);
-  Teuchos::ArrayRCP<SC> v2Data = v2->getDataNonConst(0);
-  for (size_t i = 0; i < v1->getMap()->getLocalNumElements(); i++ ) {
-    if (v1Data[i] != 0.0)  {
-      // Exponential memory reallocation, if needed
-      if (current     >= Teuchos::as<LocalOrdinal>(max_edges)) {
-        max_edges *= 2;
-        D0_colind.resize(max_edges);
-        D0_values.resize(max_edges);
-      }
-      if (current / 2 + 1 >= D0_rowptr.size()) {
-        D0_rowptr.resize(2 * D0_rowptr.size() + 1);
-      }
-
-      D0_colind[current] = ownedCoarseNodeMap->getLocalElement( (LO) (Teuchos::ScalarTraits<SC>::magnitude(v2Data[i])/v1Data[i]) );
-      D0_values[current] = 1;
-      current++;
-      num_coarse_edges++;
-      D0_rowptr[num_coarse_edges] = current;
-    }
-  }
-#endif
-  D0_rowptr.resize(num_coarse_edges + 1);
-  D0_colind.resize(current);
-  D0_values.resize(current);
-
-  // Handle empty ranks gracefully
-  if (num_coarse_edges == 0) {
-    D0_rowptr[0] = 0;
-  }
-
-  // Count the total number of edges
-  // NOTE: Since we solve the ownership issue above, this should do what we want
-  RCP<const Map> ownedCoarseEdgeMap = Xpetra::MapFactory<LO, GO, NO>::Build(EdgeMatrix->getRowMap()->lib(), GO_INVALID, num_coarse_edges, EdgeMatrix->getRowMap()->getIndexBase(), EdgeMatrix->getRowMap()->getComm());
-
-  // Create the coarse D0
-  RCP<CrsMatrix> D0_coarse;
-  {
-    SubFactoryMonitor m2(*this, "Build D0", coarseLevel);
-    // FIXME: We can be smarter with memory here
-    // TODO: Is there a smarter way to get this importer?
-    D0_coarse = CrsMatrixFactory::Build(ownedCoarseEdgeMap, ownedPlusSharedCoarseNodeMap, 0);
-    TEUCHOS_TEST_FOR_EXCEPTION(D0_coarse.is_null(), Exceptions::RuntimeError, "MueLu::ReitzingerPFactory: CrsMatrixFatory failed.");
-
-    // FIXME: Deprecated code
-    ArrayRCP<size_t> ia;
-    ArrayRCP<LO> ja;
-    ArrayRCP<SC> val;
-    D0_coarse->allocateAllValues(current, ia, ja, val);
-    std::copy(D0_rowptr.begin(), D0_rowptr.end(), ia.begin());
-    std::copy(D0_colind.begin(), D0_colind.end(), ja.begin());
-    std::copy(D0_values.begin(), D0_values.end(), val.begin());
-    D0_coarse->setAllValues(ia, ja, val);
-
-#if 0
+      auto lclGraph = D0->getCrsGraph()->getLocalGraphDevice();
+      Kokkos::View<LocalOrdinal*, memory_space> values(Kokkos::ViewAllocateWithoutInitializing("values_LocalOrdinal"), D0->getLocalNumEntries());
       {
-        char fname[80];
-        int fine_level_id = fineLevel.GetLevelID();
-        printf("[%d] Level %d D0: ia.size() = %d ja.size() = %d\n",MyPID,fine_level_id,(int)ia.size(),(int)ja.size());
-        printf("[%d] Level %d D0: ia  :",MyPID,fine_level_id);
-        for(int i=0; i<(int)ia.size(); i++)
-          printf("%d ",(int)ia[i]);
-        printf("\n[%d] Level %d D0: global ja  :",MyPID,fine_level_id);
-        for(int i=0; i<(int)ja.size(); i++)
-          printf("%d ",(int)ownedPlusSharedCoarseNodeMap->getGlobalElement(ja[i]));
-        printf("\n[%d] Level %d D0: local ja  :",MyPID,fine_level_id);
-        for(int i=0; i<(int)ja.size(); i++)
-          printf("%d ",(int)ja[i]);
-        printf("\n");
-
-        sprintf(fname,"D0_global_ja_%d_%d.dat",MyPID,fine_level_id);
-        FILE * f = fopen(fname,"w");
-        for(int i=0; i<(int)ja.size(); i++)
-          fprintf(f,"%d ",(int)ownedPlusSharedCoarseNodeMap->getGlobalElement(ja[i]));
-        fclose(f);
-
-        sprintf(fname,"D0_local_ja_%d_%d.dat",MyPID,fine_level_id);
-        f = fopen(fname,"w");
-        for(int i=0; i<(int)ja.size(); i++)
-          fprintf(f,"%d ",(int)ja[i]);
-        fclose(f);
-
+        auto values_scalar = D0->getLocalMatrixDevice().values;
+        Kokkos::parallel_for(
+            "MueLu::ReitzingerPFactory::convert", Kokkos::RangePolicy<execution_space>(0, values.extent(0)), KOKKOS_LAMBDA(const size_t i) {
+              if (values_scalar(i) == one_impl_scalar)
+                values(i) = one_LO;
+              else if (values_scalar(i) == -one_impl_scalar)
+                values(i) = -one_LO;
+              else
+                Kokkos::abort("D0 contains bad values");
+            });
       }
-#endif
-    D0_coarse->expertStaticFillComplete(ownedCoarseNodeMap, ownedCoarseEdgeMap);
+      lo_local_matrix_type lclMatrix("D0_LocalOrdinal", D0->getLocalMatrixDevice().numCols(), values, lclGraph);
+
+      D0_LocalOrdinal = rcp(new LOMatrix(lclMatrix, toTpetra(D0->getRowMap()), toTpetra(D0->getColMap()), toTpetra(D0->getDomainMap()), toTpetra(D0->getRangeMap())));
+    }
+    {
+      auto oneVec = Xpetra::VectorFactory<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node>::Build(D0->getDomainMap(), false);
+      oneVec->putScalar(KokkosKernels::ArithTraits<LocalOrdinal>::one());
+      D0_LocalOrdinal->apply(*toTpetra(oneVec), *toTpetra(isDirichletFineEdge), Teuchos::NO_TRANS);
+
+      auto lcl_isDirichletFineEdge = isDirichletFineEdge->getLocalViewDevice(Tpetra::Access::ReadWrite);
+      auto lcl_D0_Pn               = D0_Pn->getLocalMatrixDevice();
+      Kokkos::parallel_for(
+          Kokkos::RangePolicy<execution_space>(0, lcl_isDirichletFineEdge.extent(0)), KOKKOS_LAMBDA(const LocalOrdinal i) {
+            if (ATS::magnitude(ATS::magnitude(lcl_isDirichletFineEdge(i, 0)) - one_mag) > eps_mag) {
+              // This is a regular edge with two end points.
+              lcl_isDirichletFineEdge(i, 0) = zero_LO;
+            } else {
+              // This is an edge with one endpoint.
+              lcl_isDirichletFineEdge(i, 0) = one_LO;
+            }
+          });
+    }
+
+    // Count the number of fine Dirichlet edges that are connected to every coarse nodal aggregate via
+    // the graph of D0*Pn.
+    auto numberConnectedFineDirichletEdgesToCoarseNode = Xpetra::VectorFactory<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node>::Build(D0_Pn->getDomainMap(), false);
+    {
+      auto abs_D0_Pn = LOMatrix(toTpetra(D0_Pn->getCrsGraph()));
+      abs_D0_Pn.fillComplete(toTpetra(D0_Pn->getDomainMap()), toTpetra(D0_Pn->getRangeMap()));
+      abs_D0_Pn.setAllToScalar(KokkosKernels::ArithTraits<LocalOrdinal>::one());
+      abs_D0_Pn.apply(*toTpetra(isDirichletFineEdge), *toTpetra(numberConnectedFineDirichletEdgesToCoarseNode), Teuchos::TRANS);
+    }
+
+    // Count local Dirichlet coarse edges
+    {
+      auto lcl_numberConnectedFineDirichletEdgesToCoarseNode = numberConnectedFineDirichletEdgesToCoarseNode->getLocalViewDevice(Tpetra::Access::ReadOnly);
+
+      Kokkos::parallel_reduce(
+          Kokkos::RangePolicy<execution_space>(0, lcl_numberConnectedFineDirichletEdgesToCoarseNode.extent(0)),
+          KOKKOS_LAMBDA(const LocalOrdinal i, LocalOrdinal& ne) {
+            if (ATS::magnitude(lcl_numberConnectedFineDirichletEdgesToCoarseNode(i, 0)) > eps_mag) {
+              ++ne;
+            }
+          },
+          numCoarseDirichletEdges);
+    }
+
+    if (IsPrint(Statistics0)) {
+      LocalOrdinal numGlobalRegularEdges;
+      LocalOrdinal numGlobalDirichletEdges;
+      MueLu_sumAll(rowMap->getComm(), numCoarseRegularEdges, numGlobalRegularEdges);
+      MueLu_sumAll(rowMap->getComm(), numCoarseDirichletEdges, numGlobalDirichletEdges);
+      GetOStream(Statistics0) << "regular edges: " << numGlobalRegularEdges << ", Dirichlet edges: " << numGlobalDirichletEdges << std::endl;
+    }
+
+    numCoarseEdges = numCoarseRegularEdges + numCoarseDirichletEdges;
+    rowptr_type rowptr(Kokkos::ViewAllocateWithoutInitializing("rowptr D0H"), numCoarseEdges + 1);
+    // 2 entries per regular edge, 1 entry per Dirichlet edge
+    LocalOrdinal nnz = 2 * numCoarseRegularEdges + numCoarseDirichletEdges;
+    colidx_type colidx(Kokkos::ViewAllocateWithoutInitializing("colidx D0H"), nnz);
+    values_type values(Kokkos::ViewAllocateWithoutInitializing("values D0H"), nnz);
+
+    // Fill regular edges
+    Kokkos::parallel_scan(
+        Kokkos::RangePolicy<execution_space>(0, numLocalRows),
+        KOKKOS_LAMBDA(const LocalOrdinal rlid, LocalOrdinal& ne, const bool update) {
+          auto row = lclZ.rowConst(rlid);
+          if (!update) {
+            // First pass: figure out offsets for entries.
+            for (LocalOrdinal k = 0; k < row.length; ++k) {
+              auto clid = row.colidx(k);
+              if (add_edge(rlid, clid))
+                ++ne;
+            }
+          } else {
+            // Second pass: enter entries
+
+            // initialize
+            if (rlid == 0)
+              rowptr(rlid) = 0;
+
+            auto rgid  = lclRowMap.getGlobalElement(rlid);
+            auto rclid = lclColMap.getLocalElement(rgid);
+
+            // loop over entries in row of Z
+            for (LocalOrdinal k = 0; k < row.length; ++k) {
+              auto clid = row.colidx(k);
+              if (add_edge(rlid, clid)) {
+                auto cgid = lclColMap.getGlobalElement(clid);
+                // enter the two end-points of the edge, orient edge based on GIDs of nodal endpoints
+                colidx(2 * ne)     = rclid;
+                colidx(2 * ne + 1) = clid;
+                if (rgid < cgid) {
+                  values(2 * ne)     = -one_impl_scalar;
+                  values(2 * ne + 1) = one_impl_scalar;
+                } else {
+                  values(2 * ne)     = one_impl_scalar;
+                  values(2 * ne + 1) = -one_impl_scalar;
+                }
+                ++ne;
+                rowptr(ne) = 2 * ne;
+              }
+            }
+          }
+        });
+
+    // Fill Dirichlet edges
+    // Create one coarse Dirichlet edge for every nodal aggregate that is connected to at least one fine Dirichlet edge.
+    {
+      auto lcl_numberConnectedFineDirichletEdgesToCoarseNode = numberConnectedFineDirichletEdgesToCoarseNode->getLocalViewDevice(Tpetra::Access::ReadOnly);
+      Kokkos::parallel_scan(
+          Kokkos::RangePolicy<execution_space>(0, lcl_numberConnectedFineDirichletEdgesToCoarseNode.extent(0)),
+          KOKKOS_LAMBDA(const LocalOrdinal agg_lid, LocalOrdinal& ne, const bool update) {
+            if (ATS::magnitude(lcl_numberConnectedFineDirichletEdgesToCoarseNode(agg_lid, 0)) > eps_mag) {
+              if (!update) {
+                // First pass: figure out offsets
+                ++ne;
+              } else {
+                // Second pass: fill
+                colidx(2 * numCoarseRegularEdges + ne) = agg_lid;
+                values(2 * numCoarseRegularEdges + ne) = one_impl_scalar;
+                ++ne;
+                rowptr(numCoarseRegularEdges + ne) = 2 * numCoarseRegularEdges + ne;
+              }
+            }
+          });
+    }
+
+    auto D0H_rowmap = MapFactory::Build(rowMap->lib(), INVALID_GO, numCoarseEdges, 0, rowMap->getComm());
+    auto lclD0H     = local_matrix_type("D0H", numCoarseEdges, colMap->getLocalNumElements(), nnz, values, rowptr, colidx);
+
+    // Construct distributed matrix
+    D0H = MatrixFactory::Build(lclD0H, D0H_rowmap, colMap, Z->getDomainMap(), D0H_rowmap);
   }
-  RCP<Matrix> D0_coarse_m         = rcp(new CrsMatrixWrap(D0_coarse));
-  Xpetra::IO<SC,LO,GO,NO>::Write("newD0Coarse",*D0_coarse_m);
-  RCP<Teuchos::FancyOStream> fout = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
 
   // Create the Pe matrix, but with the extra entries.  From ML's notes:
   /* The general idea is that the matrix                              */
@@ -424,7 +410,8 @@ void ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level
   /* is almost Pe. If we make sure that P_n contains 1's and -1's, the*/
   /* matrix triple product will yield a matrix with +/- 1 and +/- 2's.*/
   /* If we remove all the 1's and divide the 2's by 2. we arrive at Pe*/
-  RCP<Matrix> Pe;
+
+  RCP<Matrix> D0_Pn_D0HT;
   {
     SubFactoryMonitor m2(*this, "Generate Pe (pre-fix)", coarseLevel);
 #if 0
@@ -437,10 +424,10 @@ void ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level
              Pn->getRowMap()->getComm()->getSize(),
              Pn->getColMap()->getComm()->getSize(),
              Pn->getDomainMap()->getComm()->getSize(),
-             D0_coarse_m->getRangeMap()->getComm()->getSize(),
-             D0_coarse_m->getRowMap()->getComm()->getSize(),
-             D0_coarse_m->getColMap()->getComm()->getSize(),
-             D0_coarse_m->getDomainMap()->getComm()->getSize(),
+             D0H->getRangeMap()->getComm()->getSize(),
+             D0H->getRowMap()->getComm()->getSize(),
+             D0H->getColMap()->getComm()->getSize(),
+             D0H->getDomainMap()->getComm()->getSize(),
              D0->getRangeMap()->getComm()->getSize(),
              D0->getRowMap()->getComm()->getSize(),
              D0->getColMap()->getComm()->getSize(),
@@ -450,60 +437,160 @@ void ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level
     }
 #endif
     RCP<Matrix> dummy;
-    RCP<Matrix> Pn_D0cT = XMM::Multiply(*Pn, false, *D0_coarse_m, true, dummy, out0, true, true, "Pn*D0c'", mm_params);
+    RCP<Matrix> Pn_D0cT = XMM::Multiply(*Pn, false, *D0H, true, dummy, out0, true, true, "Pn*D0c'", mm_params);
 
     // We don't want this guy getting accidently used later
     if (!mm_params.is_null()) mm_params->remove("importer", false);
 
-    Pe = XMM::Multiply(*D0, false, *Pn_D0cT, false, dummy, out0, true, true, "D0*(Pn*D0c')", mm_params);
+    D0_Pn_D0HT = XMM::Multiply(*D0, false, *Pn_D0cT, false, dummy, out0, true, true, "D0*(Pn*D0c')", mm_params);
 
     // TODO: Something like this *might* work.  But this specifically, doesn't
-    // Pe = XMM::Multiply(*D0_Pn_nonghosted,false,*D0_coarse_m,true,dummy,out0,true,true,"(D0*Pn)*D0c'",mm_params);
+    // Pe = XMM::Multiply(*D0_Pn_nonghosted,false,*D0H,true,dummy,out0,true,true,"(D0*Pn)*D0c'",mm_params);
   }
 
-  /* Weed out the +/- entries, shrinking the matrix as we go */
+  RCP<Matrix> Pe;
   {
-    SubFactoryMonitor m2(*this, "Generate Pe (post-fix)", coarseLevel);
-    Pe->resumeFill();
-    SC one     = Teuchos::ScalarTraits<SC>::one();
-    MT two     = 2 * Teuchos::ScalarTraits<MT>::one();
-    SC zero    = Teuchos::ScalarTraits<SC>::zero();
-    SC neg_one = -one;
+    auto lcl_D0_Pn               = D0_Pn->getLocalMatrixDevice();
+    auto lcl_D0_Pn_D0HT          = D0_Pn_D0HT->getLocalMatrixDevice();
+    auto lcl_isDirichletFineEdge = isDirichletFineEdge->getLocalViewDevice(Tpetra::Access::ReadOnly);
 
-    RCP<const CrsMatrix> Pe_crs = rcp_dynamic_cast<const CrsMatrixWrap>(Pe)->getCrsMatrix();
-    TEUCHOS_TEST_FOR_EXCEPTION(Pe_crs.is_null(), Exceptions::RuntimeError, "MueLu::ReitzingerPFactory: Pe is not a crs matrix.");
-    ArrayRCP<const size_t> rowptr_const;
-    ArrayRCP<const LO> colind_const;
-    ArrayRCP<const SC> values_const;
-    Pe_crs->getAllValues(rowptr_const, colind_const, values_const);
-    ArrayRCP<size_t> rowptr = arcp_const_cast<size_t>(rowptr_const);
-    ArrayRCP<LO> colind     = arcp_const_cast<LO>(colind_const);
-    ArrayRCP<SC> values     = arcp_const_cast<SC>(values_const);
-    LO ct                   = 0;
-    LO lower                = rowptr[0];
-    for (LO i = 0; i < (LO)Ne; i++) {
-      for (size_t j = lower; j < rowptr[i + 1]; j++) {
-        if (values[j] == one || values[j] == neg_one || values[j] == zero) {
-          // drop this guy
-        } else {
-          colind[ct] = colind[j];
-          values[ct] = values[j] / two;
-          ct++;
-        }
+    auto lcl_colmap_D0_Pn_D0HT = D0_Pn_D0HT->getColMap()->getLocalMap();
+
+    const auto half = one_impl_scalar / (one_impl_scalar + one_impl_scalar);
+
+    // overallocate by 1 to allow for easier counting
+    rowptr_type Pe_rowptr("Pe_rowptr", numFineEdges + 2);
+
+    // count entries per row
+    Kokkos::parallel_for(
+        "Pe_count_entries", Kokkos::RangePolicy<execution_space>(0, numFineEdges), KOKKOS_LAMBDA(const LocalOrdinal fineEdge) {
+          if (lcl_isDirichletFineEdge(fineEdge, 0) != one_LO) {
+            // regular fine edge
+            auto row = lcl_D0_Pn_D0HT.rowConst(fineEdge);
+            for (int k = 0; k < row.length; ++k) {
+              auto val = row.value(k);
+              // filter out entries +-1 and 0
+              if (!((ATS::magnitude(val - one_impl_scalar) < eps_mag) || (ATS::magnitude(val + one_impl_scalar) < eps_mag) || (ATS::magnitude(val) < eps_mag))) {
+                // add entry (fineEdge, clid) -> val/2.
+                ++Pe_rowptr(fineEdge + 2);
+              }
+            }
+          } else {
+            // Dirichlet interior fine edge
+            ++Pe_rowptr(fineEdge + 2);
+          }
+        });
+
+    // prefix sum
+    LocalOrdinal Pe_nnz;
+    Kokkos::parallel_scan(
+        "Pe_prefix_sum", Kokkos::RangePolicy<execution_space>(0, numFineEdges + 2), KOKKOS_LAMBDA(const LocalOrdinal rlid, LocalOrdinal& nnz, const bool update) {
+          nnz += Pe_rowptr(rlid);
+          if (update) {
+            Pe_rowptr(rlid) = nnz;
+          }
+        },
+        Pe_nnz);
+
+    // allocate view for indices and values
+    colidx_type Pe_colidx("Pe_colidx", Pe_nnz);
+    values_type Pe_values("Pe_values", Pe_nnz);
+
+    // We build the mapping from coarse nodes lids wrt column map of D0_Pn to coarse edge gids.
+    RCP<GOVector> map_coarseNodes_colMap_D0_Pn_to_coarseEdges;
+    {
+      auto map_coarseEdges_rowMap_D0H_to_coarseEdges = Xpetra::VectorFactory<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node>::Build(D0H->getRowMap());
+      {
+        auto lcl_map_coarseEdges_rowMap_D0H_to_coarseEdges = map_coarseEdges_rowMap_D0H_to_coarseEdges->getLocalViewDevice(Tpetra::Access::OverwriteAll);
+        auto lclMap                                        = D0H->getRowMap()->getLocalMap();
+        Kokkos::parallel_for(
+            Kokkos::RangePolicy<execution_space>(numCoarseRegularEdges, numCoarseEdges), KOKKOS_LAMBDA(const LocalOrdinal coarseEdge) {
+              lcl_map_coarseEdges_rowMap_D0H_to_coarseEdges(coarseEdge, 0) = lclMap.getGlobalElement(coarseEdge);
+            });
       }
-      lower         = rowptr[i + 1];
-      rowptr[i + 1] = ct;
-    }
-    rowptr[Ne] = ct;
-    colind.resize(ct);
-    values.resize(ct);
-    rcp_const_cast<CrsMatrix>(Pe_crs)->setAllValues(rowptr, colind, values);
+      auto map_coarseNodes_domainMap_D0_Pn_to_coarseEdges = Xpetra::VectorFactory<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node>::Build(D0H->getDomainMap());
+      {
+        // We want to do a transpose apply using D0H on vectors with Scalar=GlobalOrdinal.
+        // Something like this could work and would not require any memory allocations, but it requires
+        // "convert" to be ETI'd for all possible scalar types.
 
-    Pe->fillComplete(Pe->getDomainMap(), Pe->getRangeMap());
+        // toTpetra(D0H)->template convert<GlobalOrdinal>()->apply(*toTpetra(map_coarseEdges_rowMap_D0H_to_coarseEdges), *toTpetra(map_coarseNodes_domainMap_D0_Pn_to_coarseEdges), Teuchos::TRANS);
+
+        using GOMatrix             = Tpetra::CrsMatrix<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node>;
+        using go_local_matrix_type = typename GOMatrix::local_matrix_device_type;
+
+        auto lclGraph = D0H->getCrsGraph()->getLocalGraphDevice();
+        typename go_local_matrix_type::values_type::non_const_type ones("ones_GlobalOrdinal", D0H->getLocalNumEntries());
+        const auto one_GO = KokkosKernels::ArithTraits<typename go_local_matrix_type::values_type::value_type>::one();
+        Kokkos::deep_copy(ones, one_GO);
+
+        go_local_matrix_type lclMatrix("D0H_GlobalOrdinal", D0H->getLocalMatrixDevice().numCols(), ones, lclGraph);
+
+        auto D0H_GlobalOrdinal = GOMatrix(lclMatrix, toTpetra(D0H->getRowMap()), toTpetra(D0H->getColMap()), toTpetra(D0H->getDomainMap()), toTpetra(D0H->getRangeMap()));
+        D0H_GlobalOrdinal.apply(*toTpetra(map_coarseEdges_rowMap_D0H_to_coarseEdges), *toTpetra(map_coarseNodes_domainMap_D0_Pn_to_coarseEdges), Teuchos::TRANS);
+      }
+
+      auto importer = D0_Pn->getCrsGraph()->getImporter();
+      if (!importer.is_null()) {
+        map_coarseNodes_colMap_D0_Pn_to_coarseEdges = Xpetra::VectorFactory<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node>::Build(D0_Pn->getColMap());
+        map_coarseNodes_colMap_D0_Pn_to_coarseEdges->doImport(*map_coarseNodes_domainMap_D0_Pn_to_coarseEdges, *importer, Xpetra::INSERT);
+      } else {
+        map_coarseNodes_colMap_D0_Pn_to_coarseEdges = map_coarseNodes_domainMap_D0_Pn_to_coarseEdges;
+      }
+    }
+    {
+      auto lcl_map_coarseNodes_colMap_D0_Pn_to_coarseEdges = map_coarseNodes_colMap_D0_Pn_to_coarseEdges->getLocalViewDevice(Tpetra::Access::ReadOnly);
+
+      // fill
+      Kokkos::parallel_for(
+          "Pe_fill", Kokkos::RangePolicy<execution_space>(0, numFineEdges), KOKKOS_LAMBDA(const LocalOrdinal fineEdge_lid) {
+            if (lcl_isDirichletFineEdge(fineEdge_lid, 0) != one_LO) {
+              // regular fine edge
+              auto row = lcl_D0_Pn_D0HT.rowConst(fineEdge_lid);
+              for (int k = 0; k < row.length; ++k) {
+                auto val = row.value(k);
+                if (!((ATS::magnitude(val - one_impl_scalar) < eps_mag) || (ATS::magnitude(val + one_impl_scalar) < eps_mag) || (ATS::magnitude(val) < eps_mag))) {
+                  auto clid = row.colidx(k);
+                  // add entry (fineEdge_lid, clid) -> val/2.
+                  auto offset       = Pe_rowptr(fineEdge_lid + 1);
+                  Pe_colidx(offset) = clid;
+                  Pe_values(offset) = val * half;
+                  ++Pe_rowptr(fineEdge_lid + 1);
+                }
+              }
+            } else {
+              // Dirichlet interior fine edge
+              // Only one nonzero entry in row of D0_Pn: (fineEdge_lid, coarseNode_lid_D0_Pn) -> val_D0_Pn
+              for (auto offset_D0_Pn = lcl_D0_Pn.graph.row_map(fineEdge_lid); offset_D0_Pn < lcl_D0_Pn.graph.row_map(fineEdge_lid + 1); ++offset_D0_Pn) {
+                LocalOrdinal coarseNode_lid_D0_Pn = lcl_D0_Pn.graph.entries(offset_D0_Pn);
+                impl_scalar_type val_D0_Pn        = lcl_D0_Pn.values(offset_D0_Pn);
+                if (ATS::magnitude(val_D0_Pn) > eps_mag) {
+                  GlobalOrdinal coarseEdge_gid = lcl_map_coarseNodes_colMap_D0_Pn_to_coarseEdges(coarseNode_lid_D0_Pn, 0);
+
+                  auto coarseEdge_lid_D0_Pn_D0HT = lcl_colmap_D0_Pn_D0HT.getLocalElement(coarseEdge_gid);
+
+                  // We rely on the fact that all coarse interior edges have been created with value 1.
+                  const auto val_D0H = one_impl_scalar;
+
+                  // add entry (fineEdge_lid, coarseEdge) -> val_D0_Pn/val_D0H to edge prolongator
+                  auto offset_Pe       = Pe_rowptr(fineEdge_lid + 1);
+                  Pe_colidx(offset_Pe) = coarseEdge_lid_D0_Pn_D0HT;
+                  Pe_values(offset_Pe) = val_D0_Pn / val_D0H;
+                  ++Pe_rowptr(fineEdge_lid + 1);
+                  break;
+                }
+              }
+            }
+          });
+    }
+    auto lclPe = local_matrix_type("Pe", numFineEdges, D0_Pn_D0HT->getColMap()->getLocalNumElements(), Pe_nnz, Pe_values, Kokkos::subview(Pe_rowptr, Kokkos::make_pair((decltype(numFineEdges))0, numFineEdges + 1)), Pe_colidx);
+
+    // Construct distributed matrix
+    Pe = MatrixFactory::Build(lclPe, D0->getRowMap(), D0_Pn_D0HT->getColMap(), D0H->getRangeMap(), D0->getRangeMap());
   }
 
   /* Check commuting property */
-  CheckCommutingProperty(*Pe, *D0_coarse_m, *D0, *Pn);
+  CheckCommutingProperty(*Pe, *D0H, *D0, *Pn);
 
   /*  If we're repartitioning here, we need to cut down the communicators */
   // NOTE: We need to do this *after* checking the commuting property, since
@@ -512,23 +599,22 @@ void ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level
     // NOTE: We can only do D0 here.  We have to do Ke_coarse=(Re Ke_fine Pe) in RebalanceAcFactory
     RCP<const Teuchos::Comm<int> > newComm;
     if (!CoarseNodeMatrix.is_null()) newComm = CoarseNodeMatrix->getDomainMap()->getComm();
-    RCP<const Map> newMap = Xpetra::MapFactory<LO, GO, NO>::copyMapWithNewComm(D0_coarse_m->getRowMap(), newComm);
-    D0_coarse_m->removeEmptyProcessesInPlace(newMap);
+    RCP<const Map> newMap = MapFactory::copyMapWithNewComm(D0H->getRowMap(), newComm);
+    D0H->removeEmptyProcessesInPlace(newMap);
 
     // The "in place" still leaves a dummy matrix here.  That needs to go
-    if (newMap.is_null()) D0_coarse_m = Teuchos::null;
+    if (newMap.is_null()) D0H = Teuchos::null;
 
     Set(coarseLevel, "InPlaceMap", newMap);
   }
-
   /* Set output on the level */
   Set(coarseLevel, "P", Pe);
   Set(coarseLevel, "Ptent", Pe);
 
-  Set(coarseLevel, "D0", D0_coarse_m);
+  Set(coarseLevel, "D0", D0H);
 
   /* This needs to be kept for the smoothers */
-  coarseLevel.Set("D0", D0_coarse_m, NoFactory::get());
+  coarseLevel.Set("D0", D0H, NoFactory::get());
   coarseLevel.AddKeepFlag("D0", NoFactory::get(), MueLu::Final);
   coarseLevel.RemoveKeepFlag("D0", NoFactory::get(), MueLu::UserData);
 
@@ -537,10 +623,16 @@ void ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level
     int numProcs = Pe->getRowMap()->getComm()->getSize();
     char fname[80];
 
-    sprintf(fname,"Pe_%d_%d.mat",numProcs,fineLevel.GetLevelID());  Xpetra::IO<SC,LO,GO,NO>::Write(fname,*Pe);
-    sprintf(fname,"Pn_%d_%d.mat",numProcs,fineLevel.GetLevelID());  Xpetra::IO<SC,LO,GO,NO>::Write(fname,*Pn);
-    sprintf(fname,"D0c_%d_%d.mat",numProcs,fineLevel.GetLevelID());  Xpetra::IO<SC,LO,GO,NO>::Write(fname,*D0_coarse_m);
-    sprintf(fname,"D0f_%d_%d.mat",numProcs,fineLevel.GetLevelID());  Xpetra::IO<SC,LO,GO,NO>::Write(fname,*D0);
+    sprintf(fname, "Pe_%d_%d.mat", numProcs, fineLevel.GetLevelID());
+    Xpetra::IO<SC, LO, GO, NO>::Write(fname, *Pe);
+    sprintf(fname, "Pn_%d_%d.mat", numProcs, fineLevel.GetLevelID());
+    Xpetra::IO<SC, LO, GO, NO>::Write(fname, *Pn);
+    if (!D0H.is_null()) {
+      sprintf(fname, "D0c_%d_%d.mat", numProcs, fineLevel.GetLevelID());
+      Xpetra::IO<SC, LO, GO, NO>::Write(fname, *D0H);
+    }
+    sprintf(fname, "D0f_%d_%d.mat", numProcs, fineLevel.GetLevelID());
+    Xpetra::IO<SC, LO, GO, NO>::Write(fname, *D0);
   }
 #endif
 
@@ -550,24 +642,19 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     CheckCommutingProperty(const Matrix& Pe, const Matrix& D0_c, const Matrix& D0_f, const Matrix& Pn) const {
   if (IsPrint(Statistics0)) {
-    using XMM = Xpetra::MatrixMatrix<SC, LO, GO, NO>;
-    using MT  = typename Teuchos::ScalarTraits<SC>::magnitudeType;
-    SC one    = Teuchos::ScalarTraits<SC>::one();
-    SC zero   = Teuchos::ScalarTraits<SC>::zero();
+    using XMM = MatrixMatrix;
+    auto one  = Teuchos::ScalarTraits<SC>::one();
 
     RCP<Matrix> dummy;
-    Teuchos::FancyOStream& out0 = GetBlackHole();
-    RCP<Matrix> left            = XMM::Multiply(Pe, false, D0_c, false, dummy, out0);
-    RCP<Matrix> right           = XMM::Multiply(D0_f, false, Pn, false, dummy, out0);
+    RCP<Matrix> left  = XMM::Multiply(Pe, false, D0_c, false, dummy, GetOStream(Runtime0));
+    RCP<Matrix> right = XMM::Multiply(D0_f, false, Pn, false, dummy, GetOStream(Runtime0));
 
-    // We need a non-FC matrix for the add, sadly
-    RCP<CrsMatrix> sum_c  = CrsMatrixFactory::Build(left->getRowMap(), left->getLocalMaxNumRowEntries() + right->getLocalMaxNumRowEntries());
-    RCP<Matrix> summation = rcp(new CrsMatrixWrap(sum_c));
-    XMM::TwoMatrixAdd(*left, false, one, *summation, zero);
-    XMM::TwoMatrixAdd(*right, false, -one, *summation, one);
+    RCP<Matrix> summation;
+    XMM::TwoMatrixAdd(*left, false, one, *right, false, -one, summation, GetOStream(Runtime0));
+    summation->fillComplete(left->getDomainMap(), left->getRangeMap());
 
-    MT norm = summation->getFrobeniusNorm();
-    GetOStream(Statistics0) << "CheckCommutingProperty: ||Pe D0_c - D0_f Pn || = " << norm << std::endl;
+    auto norm = summation->getFrobeniusNorm();
+    GetOStream(Statistics0) << "CheckCommutingProperty: || Pe D0_c - D0_f Pn || = " << norm << std::endl;
   }
 
 }  // end CheckCommutingProperty


### PR DESCRIPTION
@trilinos/muelu 

## Motivation

- Kokkosify `MueLu::ReitzingerPFactory`.
- Adds new code for handling edges with only one endpoint. This can arise when edges in the interior of the domain with one endpoint on the Dirichlet boundary.

Developed together with @rstumin 