### PR TITLE
sacado: test updates for Kokkos_ENABLE_DEPRECATED_CODE_5=OFF

### DIFF
--- a/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
@@ -563,7 +563,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 #if KOKKOS_VERSION >= 40799 && !defined (SACADO_DISABLE_FAD_VIEW_SPEC) && !defined(KOKKOS_ENABLE_IMPL_VIEW_LEGACY)
   auto va = Sacado::as_scalar_view(v);
 #else
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   typename ViewType::array_type va = v;
+#else
+  typename ViewType::type va = v;
+#endif
 #endif
   Kokkos::deep_copy( va, 1.0 );
 
@@ -611,7 +615,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 #if KOKKOS_VERSION >= 40799 && !defined (SACADO_DISABLE_FAD_VIEW_SPEC) && !defined(KOKKOS_ENABLE_IMPL_VIEW_LEGACY)
   auto va = Sacado::as_scalar_view(v);
 #else
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   typename ViewType::array_type va = v;
+#else
+  typename ViewType::type va = v;
+#endif
 #endif
   Kokkos::deep_copy( va, 1.0 );
 
@@ -658,7 +666,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 #if KOKKOS_VERSION >= 40799 && !defined (SACADO_DISABLE_FAD_VIEW_SPEC) && !defined(KOKKOS_ENABLE_IMPL_VIEW_LEGACY)
   auto va = Sacado::as_scalar_view(v);
 #else
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   typename ViewType::array_type va = v;
+#else
+  typename ViewType::type va = v;
+#endif
 #endif
   Kokkos::deep_copy( va, 1.0 );
 
@@ -705,7 +717,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 #if KOKKOS_VERSION >= 40799 && !defined (SACADO_DISABLE_FAD_VIEW_SPEC) && !defined(KOKKOS_ENABLE_IMPL_VIEW_LEGACY)
   auto va = Sacado::as_scalar_view(v);
 #else
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   typename ViewType::array_type va = v;
+#else
+  typename ViewType::type va = v;
+#endif
 #endif
   Kokkos::deep_copy( va, 1.0 );
 
@@ -761,7 +777,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 #if KOKKOS_VERSION >= 40799 && !defined (SACADO_DISABLE_FAD_VIEW_SPEC) && !defined(KOKKOS_ENABLE_IMPL_VIEW_LEGACY)
   auto va = Sacado::as_scalar_view(v);
 #else
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   typename ViewType::array_type va = v;
+#else
+  typename ViewType::type va = v;
+#endif
 #endif
   Kokkos::deep_copy( va, 1.0 );
 
@@ -826,7 +846,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 #if KOKKOS_VERSION >= 40799 && !defined (SACADO_DISABLE_FAD_VIEW_SPEC) && !defined(KOKKOS_ENABLE_IMPL_VIEW_LEGACY)
   auto va = Sacado::as_scalar_view(v);
 #else
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   typename ViewType::array_type va = v;
+#else
+  typename ViewType::type va = v;
+#endif
 #endif
   Kokkos::deep_copy( va, 1.0 );
 
@@ -891,7 +915,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 #if KOKKOS_VERSION >= 40799 && !defined (SACADO_DISABLE_FAD_VIEW_SPEC) && !defined(KOKKOS_ENABLE_IMPL_VIEW_LEGACY)
   auto va = Sacado::as_scalar_view(v);
 #else
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   typename ViewType::array_type va = v;
+#else
+  typename ViewType::type va = v;
+#endif
 #endif
   Kokkos::deep_copy( va, 1.0 );
 
@@ -940,7 +968,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 #if KOKKOS_VERSION >= 40799 && !defined (SACADO_DISABLE_FAD_VIEW_SPEC) && !defined(KOKKOS_ENABLE_IMPL_VIEW_LEGACY)
   auto va = Sacado::as_scalar_view(v);
 #else
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   typename ViewType::array_type va = v;
+#else
+  typename ViewType::type va = v;
+#endif
 #endif
   Kokkos::deep_copy( va, 1.0 );
 
@@ -1288,7 +1320,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 #if KOKKOS_VERSION >= 40799 && !defined (SACADO_DISABLE_FAD_VIEW_SPEC) && !defined(KOKKOS_ENABLE_IMPL_VIEW_LEGACY)
   auto h_a = Sacado::as_scalar_view(h_v);
 #else
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   typename host_view_type::array_type h_a = h_v;
+#else
+  typename host_view_type::type h_a = h_v;
+#endif
 #endif
   Kokkos::deep_copy(h_a, 1.0);
 


### PR DESCRIPTION
Compatibility update follow up for https://github.com/kokkos/kokkos/pull/7360

Locally tested in a Serial build with `Kokkos_ENABLE_DEPRECATED_CODE_5=OFF`

@trilinos/sacado @etphipp 

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
