### PR TITLE
TrilinosCouplings: Move github.io Package Description

### DIFF
--- a/packages/trilinoscouplings/README.md
+++ b/packages/trilinoscouplings/README.md
@@ -1,20 +1,21 @@
 # TrilinosCouplings Package
 
-TrilinosCouplings is a meta-package of other Trilinos packages, in
-the sense that its purpose is to resolve compile-time circular
-dependencies between Trilinos packages.  Thus is part of the
-infrastructure/coupling provided by Trilinos and falls under the
-Trilinos copyright and license.
+TrilinosCouplings is a meta-package of other Trilinos packages and provides a location for multiple Trilinos packages to be combined for testing integrated package capabilities.  Additionally, it can help resolve compile-time circular dependencies between Trilinos packages.  It is part of the Trilinos infrastructure and falls under the Trilinos copyright and license (versus the individual package's copyright and licenses).
 
+## Examples
+
+A number of [example drivers](https://trilinos.github.io/docs//trilinoscouplings/index.html#trilinoscouplings_scaling_ex) are included in TrilinosCouplings that use the finite element method to solve the Poisson equation, an advection-diffusion equation, and a system of div-curl equations. (See the “Scaling Examples” section.)
+
+## Questions?
+
+Contact the lead developers:
+
+- **TrilinosCouplings team**:   GitHub handle: @trilinos/trilinoscouplings
 
 ## Copyright and License
-The default copyright and license are Trilinos's, ../../COPYRIGHT,
-and ../../LICENSE.
 
-See also https://trilinos.github.io/license.html and individual file headers for additional information.
+For general copyright and license information, refer to the Trilinos [License and Copyright](https://trilinos.github.io/about.html#license-and-copyright) page.
 
+For the Trilinos infrastructure copyright and license details, refer to the [../../COPYRIGHT](COPYRIGHT) and [../../LICENSE](LICENSE) files located in the `Trilinos` directory. Additional copyright information may also be found in the headers of individual source files.
 
-## Questions? 
-Contact lead developers:
-
-* TrilinosCouplings team     (GitHub handle: @trilinos/trilinoscouplings)
+For developers, general guidance on documenting copyrights and licenses can be found in the Trilinos [Guidance on Copyrights and Licenses](https://github.com/trilinos/Trilinos/wiki/Guidance-on-Copyrights-and-Licenses) document.


### PR DESCRIPTION
Merged the package description from github.io to the github README.md.

@trilinos/trilinoscouplings 