### PR TITLE
Record git SHA at configure time and record it in performance run logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,4 +56,6 @@ IF(${PROJECT_NAME}_ENABLE_YouCompleteMe)
   INCLUDE(CodeCompletion)
 ENDIF()
 
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/CollectGitInfo.cmake)
+
 message(STATUS "If publishing results using Trilinos, please cite us: https://trilinos.github.io/about.html#citing-trilinos")

--- a/cmake/CollectGitInfo.cmake
+++ b/cmake/CollectGitInfo.cmake
@@ -1,0 +1,23 @@
+find_package(Git)
+
+if (Git_FOUND)
+
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --dirty --always --match=""
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE TRILINOS_GIT_SHA
+    RESULT_VARIABLE RESULT
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(RESULT EQUAL 0)
+    message(STATUS "Current Git SHA: ${TRILINOS_GIT_SHA}")
+  else()
+    message(STATUS "Git returned code \"${RESULT}\", message \"${TRILINOS_GIT_SHA}\"")
+    set(TRILINOS_GIT_SHA "UNDEFINED")
+  endif()
+else()
+  message(STATUS "Git not found. Could not collect SHA.")
+  set(TRILINOS_GIT_SHA "UNDEFINED")
+endif()
+configure_file(${Trilinos_SOURCE_DIR}/cmake/Trilinos_git_sha.h.in Trilinos_git_sha.h)

--- a/cmake/Trilinos_git_sha.h.in
+++ b/cmake/Trilinos_git_sha.h.in
@@ -1,0 +1,9 @@
+#ifndef TRILINOS_GIT_SHA_H
+#define TRILINOS_GIT_SHA_H
+
+
+namespace Trilinos {
+ constexpr std::string_view TRILINOS_GIT_SHA = "@TRILINOS_GIT_SHA@";
+} // namespace Trilinos
+
+#endif

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -17,6 +17,9 @@
 #include <fstream>
 #include <sstream>
 
+#include "Trilinos_git_sha.h"
+
+
 namespace Teuchos {
 
 
@@ -750,7 +753,7 @@ std::string
 StackedTimer::reportWatchrXML(const std::string& name, Teuchos::RCP<const Teuchos::Comm<int> > comm) {
   const char* rawWatchrDir = getenv("WATCHR_PERF_DIR");
   const char* rawBuildName = getenv("WATCHR_BUILD_NAME");
-  const char* rawGitSHA = getenv("TRILINOS_GIT_SHA");
+  std::string gitSHA(Trilinos::TRILINOS_GIT_SHA);
   const char* rawBuildDateOverride = getenv("WATCHR_BUILD_DATE");
   //WATCHR_PERF_DIR is required (will also check nonempty below)
   if(!rawWatchrDir)
@@ -826,12 +829,8 @@ StackedTimer::reportWatchrXML(const std::string& name, Teuchos::RCP<const Teucho
     std::vector<bool> printed(flat_names_.size(), false);
     os << "<?xml version=\"1.0\"?>\n";
     os << "<performance-report date=\"" << timestamp << "\" name=\"nightly_run_" << datestamp << "\" time-units=\"seconds\">\n";
-    if(rawGitSHA)
+    if(gitSHA != "UNDEFINED")
     {
-      std::string gitSHA(rawGitSHA);
-      //Output the first 10 (hex) characters
-      if(gitSHA.length() > 10)
-        gitSHA = gitSHA.substr(0, 10);
       os << "  <metadata key=\"Trilinos Version\" value=\"" << gitSHA << "\"/>\n";
     }
     auto systemInfo = SystemInformation::collectSystemInformation();


### PR DESCRIPTION
@trilinos/tpetra @trilinos/teuchos 

## Motivation
Record the Git SHA during CMake configure. Add it to WATCHR performance run logs.