### PR TITLE
Panzer MiniEM: Hook up Maxwell1 type solvers

### DIFF
--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -2121,6 +2121,13 @@ optimized neighbor discovery for Importer construction.</description>
     </parameter>
 
     <parameter>
+      <name>maxwell1: check and fix D0 scaling</name>
+      <type>bool</type>
+      <default>false</default>
+      <description>Check that D0 is scaled appropriately and rescale if necessary.</description>
+    </parameter>
+
+    <parameter>
       <name>maxwell1: nodal smoother fix zero diagonal threshold</name>
       <comment-ML>Hardwired to 1e-10 in ML</comment-ML>
       <type>double</type>

--- a/packages/muelu/doc/UsersGuide/paramlist.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist.tex
@@ -258,6 +258,8 @@
           
 \cbb{maxwell1: dump matrices}{bool}{false}{Dump matrices to disk.}
           
+\cbb{maxwell1: check and fix D0 scaling}{bool}{false}{Check that D0 is scaled appropriately and rescale if necessary.}
+          
 \cbb{maxwell1: nodal smoother fix zero diagonal threshold}{double}{1e-10}{Specifies the fix zero diagonals threshold to be used for the nodal smoothing matrices.}
           
 \cbb{refmaxwell: mode}{string}{"additive"}{Specifying the order of solve of the block system. Allowed values are: "additive" (default), "121", "212", "1", "2"}

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -476,6 +476,8 @@ optimized neighbor discovery for Importer construction.}
         
 \cbb{maxwell1: dump matrices}{bool}{false}{Dump matrices to disk.}
         
+\cbb{maxwell1: check and fix D0 scaling}{bool}{false}{Check that D0 is scaled appropriately and rescale if necessary.}
+        
 \cbb{maxwell1: nodal smoother fix zero diagonal threshold}{double}{1e-10}{Specifies the fix zero diagonals threshold to be used for the nodal smoothing matrices.}
         
 \cbb{refmaxwell: mode}{string}{"additive"}{Specifying the order of solve of the block system. Allowed values are: "additive" (default), "121", "212", "1", "2"}

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -120,6 +120,7 @@ namespace MueLu {
     if (name == "repartition: put on single proc") { ss << "<Parameter name=\"repartition: put on single proc\" type=\"int\" value=" << value << "/>"; return ss.str(); }      
     if (name == "use external multigrid package") { ss << "<Parameter name=\"use external multigrid package\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
     if (name == "maxwell1: dump matrices") { ss << "<Parameter name=\"maxwell1: dump matrices\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
+    if (name == "maxwell1: check and fix D0 scaling") { ss << "<Parameter name=\"maxwell1: check and fix D0 scaling\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
     if (name == "refmaxwell: mode") { ss << "<Parameter name=\"refmaxwell: mode\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
     if (name == "refmaxwell: disable addon") { ss << "<Parameter name=\"refmaxwell: disable addon\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
     if (name == "refmaxwell: use as preconditioner") { ss << "<Parameter name=\"refmaxwell: use as preconditioner\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
@@ -355,6 +356,7 @@ namespace MueLu {
   "<ParameterList name=\"maxwell1: 11list\"/>"
   "<ParameterList name=\"maxwell1: 22list\"/>"
   "<Parameter name=\"maxwell1: dump matrices\" type=\"bool\" value=\"false\"/>"
+  "<Parameter name=\"maxwell1: check and fix D0 scaling\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"maxwell1: nodal smoother fix zero diagonal threshold\" type=\"double\" value=\"1e-10\"/>"
   "<Parameter name=\"refmaxwell: mode\" type=\"string\" value=\"additive\"/>"
   "<Parameter name=\"refmaxwell: disable addon\" type=\"bool\" value=\"true\"/>"
@@ -987,6 +989,8 @@ namespace MueLu {
          ("maxwell1: 22list","maxwell1: 22list")
       
          ("maxwell1: dump matrices","maxwell1: dump matrices")
+      
+         ("maxwell1: check and fix D0 scaling","maxwell1: check and fix D0 scaling")
       
          ("maxwell1: nodal smoother fix zero diagonal threshold","maxwell1: nodal smoother fix zero diagonal threshold")
       

--- a/packages/muelu/src/Operators/MueLu_Maxwell1_decl.hpp
+++ b/packages/muelu/src/Operators/MueLu_Maxwell1_decl.hpp
@@ -295,7 +295,7 @@ class Maxwell1 : public VerboseObject, public Xpetra::Operator<Scalar, LocalOrdi
   //! Material
   Teuchos::RCP<MultiVector> Material_;
   //! Some options
-  bool useKokkos_, allEdgesBoundary_, allNodesBoundary_, dump_matrices_, enable_reuse_, syncTimers_;
+  bool useKokkos_, allEdgesBoundary_, allNodesBoundary_, dump_matrices_, check_D0_scaling_, enable_reuse_, syncTimers_;
   bool applyBCsTo22_;
 
   //! Execution modes

--- a/packages/muelu/src/Operators/MueLu_Maxwell1_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_Maxwell1_def.hpp
@@ -117,6 +117,7 @@ void Maxwell1<Scalar, LocalOrdinal, GlobalOrdinal, Node>::setParameters(Teuchos:
   std::string mode_string = list.get("maxwell1: mode", MasterList::getDefault<std::string>("maxwell1: mode"));
   applyBCsTo22_           = list.get("maxwell1: apply BCs to 22", false);
   dump_matrices_          = list.get("maxwell1: dump matrices", MasterList::getDefault<bool>("maxwell1: dump matrices"));
+  check_D0_scaling_       = list.get("maxwell1: check and fix D0 scaling", MasterList::getDefault<bool>("maxwell1: check and fix D0 scaling"));
 
   // Default smoother.  We'll copy this around.
   Teuchos::ParameterList defaultSmootherList;
@@ -760,6 +761,41 @@ bool Maxwell1<Scalar, LocalOrdinal, GlobalOrdinal, Node>::hasTransposeApply() co
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void scaleD0(Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& D0) {
+  // We assume that D0 has entries +-1.
+  // Construction D0 via interpolation can instead give +-0.5
+  // Let's check and scale D0.
+
+  using range_type       = Kokkos::RangePolicy<LocalOrdinal, typename Node::execution_space>;
+  using Matrix           = Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+  using impl_scalar_type = typename Matrix::impl_scalar_type;
+  using impl_ATS         = KokkosKernels::ArithTraits<impl_scalar_type>;
+  using magnitude_type   = typename impl_ATS::magnitudeType;
+  using MinMax           = Kokkos::MinMax<magnitude_type>;
+
+  typename MinMax::value_type result;
+  {
+    auto lclD0 = D0.getLocalMatrixDevice();
+    Kokkos::parallel_reduce(
+        "MueLu::Maxwell1::D0_fixup",
+        range_type(0, lclD0.nnz()),
+        KOKKOS_LAMBDA(const LocalOrdinal k, typename MinMax::value_type& res) {
+          auto val    = impl_ATS::magnitude(lclD0.values(k));
+          res.min_val = Kokkos::min(res.min_val, val);
+          res.max_val = Kokkos::max(res.max_val, val);
+        },
+        MinMax(result));
+  }
+
+  TEUCHOS_ASSERT_EQUALITY(result.min_val, result.max_val);
+
+  if (impl_ATS::magnitude(result.max_val - impl_ATS::one()) > impl_ATS::eps()) {
+    Scalar scaling = impl_ATS::one() / result.max_val;
+    D0.scale(scaling);
+  }
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void Maxwell1<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     initialize(const Teuchos::RCP<Matrix>& D0_Matrix,
                const Teuchos::RCP<Matrix>& Kn_Matrix,
@@ -789,6 +825,7 @@ void Maxwell1<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   allEdgesBoundary_ = false;
   allNodesBoundary_ = false;
   dump_matrices_    = false;
+  check_D0_scaling_ = false;
   enable_reuse_     = false;
   syncTimers_       = false;
   applyBCsTo22_     = false;
@@ -824,6 +861,9 @@ void Maxwell1<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     D0_Matrix_ = D0copy;
   } else
     D0_Matrix_ = MatrixFactory::BuildCopy(D0_Matrix);
+
+  if (check_D0_scaling_)
+    scaleD0(*D0_Matrix_);
 
   Kn_Matrix_ = Kn_Matrix;
   Coords_    = Coords;

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeTetMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeTetMeshFactory.cpp
@@ -179,6 +179,8 @@ void CubeTetMeshFactory::setParameterList(const Teuchos::RCP<Teuchos::ParameterL
    createEdgeBlocks_ = paramList->get<bool>("Create Edge Blocks");
    createFaceBlocks_ = paramList->get<bool>("Create Face Blocks");
 
+   splitHexIntoTwelveTets_ = paramList->get<bool>("Split hex into 12 tets");
+
    // read in periodic boundary conditions
    parsePeriodicBCList(Teuchos::rcpFromRef(paramList->sublist("Periodic BCs")),periodicBCVec_,useBBoxSearch_);
 }
@@ -215,6 +217,8 @@ Teuchos::RCP<const Teuchos::ParameterList> CubeTetMeshFactory::getValidParameter
       // default to false for backward compatibility
       defaultParams->set<bool>("Create Edge Blocks",false,"Create edge blocks in the mesh");
       defaultParams->set<bool>("Create Face Blocks",false,"Create face blocks in the mesh");
+
+      defaultParams->set<bool>("Split hex into 12 tets",true,"Create a tet mesh by splitting hexes into 12 tets. If false, split into 6 tets.");
 
       Teuchos::ParameterList & bcs = defaultParams->sublist("Periodic BCs");
       bcs.set<int>("Count",0); // no default periodic boundary conditions
@@ -354,19 +358,24 @@ void CubeTetMeshFactory::buildBlock(stk::ParallelMachine /* parallelMach */,int 
             nodes[6] = nodes[2]+(totalYElems+1)*(totalXElems+1);
             nodes[7] = nodes[3]+(totalYElems+1)*(totalXElems+1);
 
-            buildTetsOnHex(Teuchos::tuple(totalXElems,totalYElems,totalZElems),
-                           Teuchos::tuple(nx,ny,nz),
-                           block,nodes,mesh);
+            if (splitHexIntoTwelveTets_)
+              buildTwelveTetsOnHex(Teuchos::tuple(totalXElems,totalYElems,totalZElems),
+                                   Teuchos::tuple(nx,ny,nz),
+                                   block,nodes,mesh);
+            else
+              buildSixTetsOnHex(Teuchos::tuple(totalXElems,totalYElems,totalZElems),
+                                Teuchos::tuple(nx,ny,nz),
+                                block,nodes,mesh);
          }
       }
    }
 }
 
-void CubeTetMeshFactory::buildTetsOnHex(const Teuchos::Tuple<int,3> & meshDesc,
-                                        const Teuchos::Tuple<int,3> & element,
-                                        stk::mesh::Part * block,
-                                        const std::vector<stk::mesh::EntityId> & h_nodes,
-                                        STK_Interface & mesh) const
+  void CubeTetMeshFactory::buildTwelveTetsOnHex(const Teuchos::Tuple<int,3> & meshDesc,
+                                                const Teuchos::Tuple<int,3> & element,
+                                                stk::mesh::Part * block,
+                                                const std::vector<stk::mesh::EntityId> & h_nodes,
+                                                STK_Interface & mesh) const
 {
    Teuchos::FancyOStream out(Teuchos::rcpFromRef(std::cout));
    out.setShowProcRank(true);
@@ -419,6 +428,78 @@ void CubeTetMeshFactory::buildTetsOnHex(const Teuchos::Tuple<int,3> & meshDesc,
       nodes[1] = h_nodes[idSet[i][1]];
       nodes[2] = h_nodes[idSet[i][2]];
       nodes[3] = centroid;
+
+      // add element to mesh
+      mesh.addElement(rcp(new ElementDescriptor(gid_0+i,nodes)),block);
+   }
+}
+
+void CubeTetMeshFactory::buildSixTetsOnHex(const Teuchos::Tuple<int,3> & meshDesc,
+                                           const Teuchos::Tuple<int,3> & element,
+                                           stk::mesh::Part * block,
+                                           const std::vector<stk::mesh::EntityId> & h_nodes,
+                                           STK_Interface & mesh) const
+{
+   Teuchos::FancyOStream out(Teuchos::rcpFromRef(std::cout));
+   out.setShowProcRank(true);
+   out.setOutputToRootOnly(-1);
+
+   int totalXElems = meshDesc[0]; int totalYElems = meshDesc[1]; int totalZElems = meshDesc[2];
+   int nx = element[0]; int ny = element[1]; int nz = element[2];
+
+   stk::mesh::EntityId hex_id = totalXElems*totalYElems*nz+totalXElems*ny+nx+1;
+   stk::mesh::EntityId gid_0 = 6*(hex_id-1)+1;
+   std::vector<stk::mesh::EntityId> nodes(4);
+
+   // add centroid node
+   stk::mesh::EntityId centroid = 0;
+   {
+      stk::mesh::EntityId largestNode = (totalXElems+1)*(totalYElems+1)*(totalZElems+1);
+      centroid = hex_id+largestNode;
+
+      // compute average of coordinates
+      std::vector<double> coord(3,0.0);
+      for(std::size_t i=0;i<h_nodes.size();i++) {
+         const double * node_coord = mesh.getNodeCoordinates(h_nodes[i]);
+         coord[0] += node_coord[0];
+         coord[1] += node_coord[1];
+         coord[2] += node_coord[2];
+      }
+      coord[0] /= 8.0;
+      coord[1] /= 8.0;
+      coord[2] /= 8.0;
+
+      mesh.addNode(centroid,coord);
+   }
+
+   //
+   // int idSet[][3] = { { 0, 1, 2}, // back
+   //                    { 0, 2, 3},
+   //                    { 0, 5, 1}, // bottom
+   //                    { 0, 4, 5},
+   //                    { 0, 7, 4}, // left
+   //                    { 0, 3, 7},
+   //                    { 6, 1, 5}, // right
+   //                    { 6, 2, 1},
+   //                    { 6, 3, 2}, // top
+   //                    { 6, 7, 3},
+   //                    { 6, 4, 7}, // front
+   //                    { 6, 5, 4} };
+
+   int idSet[][4] = {
+     {0, 3, 7, 6},
+     {0, 7, 4, 6},
+     {0, 5, 4, 6},
+     {0, 1, 5, 6},
+     {0, 1, 2, 6},
+     {0, 2, 3, 6}
+   };
+
+   for(int i=0;i<6;i++) {
+      nodes[0] = h_nodes[idSet[i][0]];
+      nodes[1] = h_nodes[idSet[i][1]];
+      nodes[2] = h_nodes[idSet[i][2]];
+      nodes[3] = h_nodes[idSet[i][3]];
 
       // add element to mesh
       mesh.addElement(rcp(new ElementDescriptor(gid_0+i,nodes)),block);

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeTetMeshFactory.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeTetMeshFactory.hpp
@@ -62,11 +62,17 @@ protected:
    void addEdgeBlocks(STK_Interface & mesh) const;
    void addFaceBlocks(STK_Interface & mesh) const;
 
-   void buildTetsOnHex(const Teuchos::Tuple<int,3> & meshDesc,
-                       const Teuchos::Tuple<int,3> & element,
-                       stk::mesh::Part * block,
-                       const std::vector<stk::mesh::EntityId> & h_nodes,
-                       STK_Interface & mesh) const;
+   void buildTwelveTetsOnHex(const Teuchos::Tuple<int,3> & meshDesc,
+                             const Teuchos::Tuple<int,3> & element,
+                             stk::mesh::Part * block,
+                             const std::vector<stk::mesh::EntityId> & h_nodes,
+                             STK_Interface & mesh) const;
+
+   void buildSixTetsOnHex(const Teuchos::Tuple<int,3> & meshDesc,
+                          const Teuchos::Tuple<int,3> & element,
+                          stk::mesh::Part * block,
+                          const std::vector<stk::mesh::EntityId> & h_nodes,
+                          STK_Interface & mesh) const;
 
    double x0_, y0_, z0_;
    double xf_, yf_, zf_;
@@ -83,6 +89,8 @@ protected:
 
    bool createEdgeBlocks_;
    bool createFaceBlocks_;
+
+   bool splitHexIntoTwelveTets_;
 
    std::string edgeBlockName_;
    std::string faceBlockName_;

--- a/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
+++ b/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
@@ -74,18 +74,19 @@ TRIBITS_ADD_TEST(
 TRIBITS_ADD_TEST(
    BlockPrec
    NAME "Maxwell_MueLu"
-   POSTFIX_AND_ARGS_0 "order1"              --solver=MueLu --numTimeSteps=1 --linAlgebra=Tpetra
-   POSTFIX_AND_ARGS_1 "order1_reuse"        --solver=MueLu --numTimeSteps=3 --linAlgebra=Tpetra --resetSolver
-   POSTFIX_AND_ARGS_2 "order2"              --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-pthOrder.xml --basis-order=2 --pCoarsenSchedule="1"
-   POSTFIX_AND_ARGS_3 "order3"              --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-pthOrder.xml --basis-order=3 --pCoarsenSchedule="1"
-   POSTFIX_AND_ARGS_4 "order3,2"            --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-pthOrder.xml --basis-order=3 --pCoarsenSchedule="2,1"
-   POSTFIX_AND_ARGS_5 "order2_matrixFree"   --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-pthOrder.xml --basis-order=2  --pCoarsenSchedule="1" --matrixFree
-   POSTFIX_AND_ARGS_6 "order3_matrixFree"   --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-pthOrder.xml --basis-order=3  --pCoarsenSchedule="1" --matrixFree
-   POSTFIX_AND_ARGS_7 "order3,2_matrixFree" --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-pthOrder.xml --basis-order=3 --pCoarsenSchedule="2,1" --matrixFree
-   POSTFIX_AND_ARGS_8 "2D"                  --solver=MueLu --numTimeSteps=1 --linAlgebra=Tpetra --inputFile=maxwell2D.xml
-   POSTFIX_AND_ARGS_9 "order1_analytic"     --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-analyticSolution.xml
-   POSTFIX_AND_ARGS_10 "order1_truncated"    --solver=MueLu --numTimeSteps=1 --linAlgebra=Tpetra --truncateMueLuHierarchy
-   POSTFIX_AND_ARGS_11 "order1_barriers"     --solver=MueLu --numTimeSteps=1 --linAlgebra=Tpetra --barriers
+   POSTFIX_AND_ARGS_0 "order1"                      --solver=MueLu --numTimeSteps=1 --linAlgebra=Tpetra
+   POSTFIX_AND_ARGS_1 "order1_reuse"                --solver=MueLu --numTimeSteps=3 --linAlgebra=Tpetra --resetSolver
+   POSTFIX_AND_ARGS_2 "order2"                      --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-pthOrder.xml --basis-order=2 --pCoarsenSchedule="1"
+   POSTFIX_AND_ARGS_3 "order3"                      --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-pthOrder.xml --basis-order=3 --pCoarsenSchedule="1"
+   POSTFIX_AND_ARGS_4 "order3,2"                    --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-pthOrder.xml --basis-order=3 --pCoarsenSchedule="2,1"
+   POSTFIX_AND_ARGS_5 "order2_matrixFree"           --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-pthOrder.xml --basis-order=2  --pCoarsenSchedule="1" --matrixFree
+   POSTFIX_AND_ARGS_6 "order3_matrixFree"           --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-pthOrder.xml --basis-order=3  --pCoarsenSchedule="1" --matrixFree
+   POSTFIX_AND_ARGS_7 "order3,2_matrixFree"         --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-pthOrder.xml --basis-order=3 --pCoarsenSchedule="2,1" --matrixFree
+   POSTFIX_AND_ARGS_8 "2D"                          --solver=MueLu --numTimeSteps=1 --linAlgebra=Tpetra --inputFile=maxwell2D.xml
+   POSTFIX_AND_ARGS_9 "order1_analytic"             --solver=MueLu --linAlgebra=Tpetra --inputFile=maxwell-analyticSolution.xml
+   POSTFIX_AND_ARGS_10 "order1_truncated"           --solver=MueLu --numTimeSteps=1 --linAlgebra=Tpetra --truncateMueLuHierarchy
+   POSTFIX_AND_ARGS_11 "order1_barriers"            --solver=MueLu --numTimeSteps=1 --linAlgebra=Tpetra --barriers
+   POSTFIX_AND_ARGS_12 "order1_maxwell1_unsmoothed" --solver=Maxwell1-RS --numTimeSteps=1 --linAlgebra=Tpetra
    NUM_MPI_PROCS 4
    )
 
@@ -131,6 +132,16 @@ TRIBITS_ADD_TEST(
    CATEGORIES PERFORMANCE
    RUN_SERIAL
    ENVIRONMENT "TPETRA_USE_NEW_COPY_AND_PERMUTE=ON"
+   )
+
+TRIBITS_ADD_TEST(
+   BlockPrec
+   NAME "MiniEM-BlockPrec_Maxwell1_unsmoothed_Performance_4"
+   ARGS "--stacked-timer --solver=Maxwell1-RS --numTimeSteps=3 --linAlgebra=Tpetra --inputFile=maxwell-large.xml --test-name=\"MiniEM 3D Maxwell1 unsmoothed\""
+   COMM mpi
+   NUM_MPI_PROCS 4
+   CATEGORIES PERFORMANCE
+   RUN_SERIAL
    )
 
 TRIBITS_ADD_TEST(

--- a/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
+++ b/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
@@ -19,6 +19,7 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyBlockPrecFiles
   maxwell-bdot-small.xml maxwell-bdot-medium.xml maxwell-bdot-large.xml
   maxwell-exterior-small.xml maxwell-exterior-medium.xml maxwell-exterior-large.xml
   maxwell-donut.xml maxwell-analyticSolution.xml
+  steadyState.xml steadyState2D.xml
   darcyTet.xml darcyHex.xml
   darcyTetAnalytic.xml darcyHexAnalytic.xml
   solverCG.xml solverGMRES.xml

--- a/packages/panzer/mini-em/example/BlockPrec/MiniEM_helpers.cpp
+++ b/packages/panzer/mini-em/example/BlockPrec/MiniEM_helpers.cpp
@@ -229,6 +229,8 @@ namespace mini_em {
 
     }
 
+    TEUCHOS_TEST_FOR_EXCEPTION(solver == MAXWELL1_EMIN, std::runtime_error, "Maxwelll1 Emin is not yet available.");
+
     return lin_solver_pl;
   }
 

--- a/packages/panzer/mini-em/example/BlockPrec/MiniEM_helpers.cpp
+++ b/packages/panzer/mini-em/example/BlockPrec/MiniEM_helpers.cpp
@@ -17,6 +17,7 @@ namespace mini_em {
                int &x_elements,
                int &y_elements,
                int &z_elements,
+               std::string meshType,
                int &basis_order,
                Teuchos::RCP<const Teuchos::MpiComm<int> > &comm,
                Teuchos::RCP<panzer_stk::STK_Interface> &mesh,
@@ -54,7 +55,26 @@ namespace mini_em {
       // set mesh factory parameters
       Teuchos::ParameterList & inline_gen_pl = mesh_pl.sublist("Inline Mesh");
       RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList(inline_gen_pl.sublist("Mesh Factory Parameter List")));
-      dim = inline_gen_pl.get<int>("Mesh Dimension");
+
+      if (meshType == "") {
+        meshType = inline_gen_pl.get<std::string>("Mesh Type");
+      }
+
+      // build mesh
+      if (meshType == "tet") {
+        dim = 3;
+        mesh_factory = rcp(new panzer_stk::CubeTetMeshFactory());
+      } else if (meshType == "hex") {
+        dim = 3;
+        mesh_factory = rcp(new panzer_stk::CubeHexMeshFactory());
+      } else if (meshType == "tri") {
+        dim = 2;
+        mesh_factory = rcp(new panzer_stk::SquareTriMeshFactory());
+      } else if (meshType == "quad") {
+        dim = 2;
+        mesh_factory = rcp(new panzer_stk::SquareQuadMeshFactory());
+      } else
+        throw;
 
       // overrides from command line
       if (x_elements > 0)
@@ -63,23 +83,13 @@ namespace mini_em {
         pl->set<int>("Y Elements",y_elements);
       if (dim == 3 && z_elements > 0)
         pl->set<int>("Z Elements",z_elements);
-
-      // build mesh
-      if (dim == 3) {
-        if (inline_gen_pl.get<std::string>("Mesh Type") == "tet")
-          mesh_factory = rcp(new panzer_stk::CubeTetMeshFactory());
-        else if (inline_gen_pl.get<std::string>("Mesh Type") == "quad")
-          mesh_factory = rcp(new panzer_stk::CubeHexMeshFactory());
-        else
-          throw;
-      } else if (dim == 2) {
-        if (inline_gen_pl.get<std::string>("Mesh Type") == "tet")
-          mesh_factory = rcp(new panzer_stk::SquareTriMeshFactory());
-        else if (inline_gen_pl.get<std::string>("Mesh Type") == "quad")
-          mesh_factory = rcp(new panzer_stk::SquareQuadMeshFactory());
-        else
-          throw;
+      if (dim == 2) {
+        if (pl->isParameter("Z Elements"))
+          pl->remove("Z Elements");
+        if (pl->isParameter("Z Blocks"))
+          pl->remove("Z Blocks");
       }
+
       mesh_factory->setParameterList(pl);
       mesh = mesh_factory->buildUncommitedMesh((*comm->getRawMpiComm())());
 

--- a/packages/panzer/mini-em/example/BlockPrec/MiniEM_helpers.cpp
+++ b/packages/panzer/mini-em/example/BlockPrec/MiniEM_helpers.cpp
@@ -146,7 +146,7 @@ namespace mini_em {
             throw;
         else if (solver == ML) {
           updateParams("solverML.xml", lin_solver_pl, comm, out);
-        } else if (solver == MUELU) {
+        } else if ((solver == MUELU) || (solver == MAXWELL1_RS) || (solver == MAXWELL1_SA_RS) || (solver == MAXWELL1_EMIN)) {
           if (linAlgebra == linAlgTpetra) {
             updateParams("solverMueLu.xml", lin_solver_pl, comm, out);
 
@@ -201,6 +201,22 @@ namespace mini_em {
         }
       } else
         updateParams(xml, lin_solver_pl, comm, out);
+
+      Teuchos::ParameterList& S_E_list = lin_solver_pl->sublist("Preconditioner Types").sublist("Teko").sublist("Inverse Factory Library").sublist("Maxwell").sublist("S_E Preconditioner");
+      if (solver == MAXWELL1_RS) {
+        S_E_list.set("Type", "MueLuMaxwell1");
+        S_E_list.sublist("Preconditioner Types").sublist("MueLuMaxwell1").sublist("maxwell1: 11list").set("multigrid algorithm", "unsmoothed reitzinger");
+        S_E_list.sublist("Preconditioner Types").sublist("MueLuMaxwell1").sublist("maxwell1: 22list").set("multigrid algorithm", "unsmoothed");
+      } else if (solver == MAXWELL1_SA_RS) {
+        S_E_list.set("Type", "MueLuMaxwell1");
+        S_E_list.sublist("Preconditioner Types").sublist("MueLuMaxwell1").sublist("maxwell1: 11list").set("multigrid algorithm", "smoothed reitzinger");
+        S_E_list.sublist("Preconditioner Types").sublist("MueLuMaxwell1").sublist("maxwell1: 22list").set("multigrid algorithm", "sa");
+      } else if (solver == MAXWELL1_EMIN) {
+        S_E_list.set("Type", "MueLuMaxwell1");
+        S_E_list.sublist("Preconditioner Types").sublist("MueLuMaxwell1").sublist("maxwell1: 11list").set("multigrid algorithm", "emin reitzinger");
+        S_E_list.sublist("Preconditioner Types").sublist("MueLuMaxwell1").sublist("maxwell1: 22list").set("multigrid algorithm", "sa");
+      }
+
     }
 
     return lin_solver_pl;
@@ -343,12 +359,12 @@ namespace mini_em {
           opPostfix = "";
         }
 
-        if (solver == MUELU || solver == ML)
+        if (solver == MUELU || solver == ML || solver == MAXWELL1_RS || solver == MAXWELL1_SA_RS || solver == MAXWELL1_EMIN)
           auxFieldOrder += " "+auxNodalField+" "+auxEdgeField;
         else
           auxFieldOrder += " "+auxEdgeField;
 
-        if (solver == MUELU || solver == ML) {
+        if (solver == MUELU || solver == ML || solver == MAXWELL1_RS || solver == MAXWELL1_SA_RS|| solver == MAXWELL1_EMIN) {
           // discrete gradient
           auto gradPL = Teuchos::ParameterList();
           gradPL.set("Source", auxNodalField);
@@ -372,7 +388,7 @@ namespace mini_em {
           schurComplementPL.set("Integration Order", 2*polynomialOrder);
           auxPhysicsBlocksPL.sublist("Auxiliary Edge SchurComplement Physics" + opPostfix) = schurComplementPL;
 
-          if (solver == MUELU || solver == ML) {
+          if (solver == MUELU || solver == ML || solver == MAXWELL1_RS || solver == MAXWELL1_SA_RS|| solver == MAXWELL1_EMIN) {
             // Projected Schur complement
             auto projectedSchurComplementPL = Teuchos::ParameterList();
             projectedSchurComplementPL.set("Type", "Auxiliary ProjectedSchurComplement");

--- a/packages/panzer/mini-em/example/BlockPrec/MiniEM_helpers.hpp
+++ b/packages/panzer/mini-em/example/BlockPrec/MiniEM_helpers.hpp
@@ -58,6 +58,7 @@ namespace mini_em {
                int &x_elements,
                int &y_elements,
                int &z_elements,
+               std::string meshType,
                int &basis_order,
                Teuchos::RCP<const Teuchos::MpiComm<int> > &comm,
                Teuchos::RCP<panzer_stk::STK_Interface> &mesh,

--- a/packages/panzer/mini-em/example/BlockPrec/MiniEM_helpers.hpp
+++ b/packages/panzer/mini-em/example/BlockPrec/MiniEM_helpers.hpp
@@ -47,7 +47,10 @@ namespace mini_em {
     MUELU,
     ML,
     CG,
-    GMRES
+    GMRES,
+    MAXWELL1_RS,
+    MAXWELL1_SA_RS,
+    MAXWELL1_EMIN
   };
 
   void getMesh(Teuchos::ParameterList &mesh_pl,

--- a/packages/panzer/mini-em/example/BlockPrec/darcyHex.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/darcyHex.xml
@@ -20,8 +20,7 @@
     </ParameterList>
 
     <ParameterList name="Inline Mesh">
-      <Parameter name="Mesh Dimension" type="int" value="3"/>
-      <Parameter name="Mesh Type" type="string" value="quad"/>
+      <Parameter name="Mesh Type" type="string" value="hex"/>
       <!-- <Parameter name="Mesh Type" type="string" value="tet"/> -->
       <Parameter name="CFL" type="double" value="4.0"/>
       <ParameterList name="Mesh Factory Parameter List">

--- a/packages/panzer/mini-em/example/BlockPrec/darcyHexAnalytic.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/darcyHexAnalytic.xml
@@ -20,8 +20,7 @@
     </ParameterList>
 
     <ParameterList name="Inline Mesh">
-      <Parameter name="Mesh Dimension" type="int" value="3"/>
-      <Parameter name="Mesh Type" type="string" value="quad"/>
+      <Parameter name="Mesh Type" type="string" value="hex"/>
       <!-- <Parameter name="Mesh Type" type="string" value="tet"/> -->
       <Parameter name="CFL" type="double" value="4.0"/>
       <ParameterList name="Mesh Factory Parameter List">

--- a/packages/panzer/mini-em/example/BlockPrec/darcyTet.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/darcyTet.xml
@@ -20,8 +20,7 @@
     </ParameterList>
 
     <ParameterList name="Inline Mesh">
-      <Parameter name="Mesh Dimension" type="int" value="3"/>
-      <!-- <Parameter name="Mesh Type" type="string" value="quad"/> -->
+      <!-- <Parameter name="Mesh Type" type="string" value="hex"/> -->
       <Parameter name="Mesh Type" type="string" value="tet"/>
       <Parameter name="CFL" type="double" value="4.0"/>
       <ParameterList name="Mesh Factory Parameter List">

--- a/packages/panzer/mini-em/example/BlockPrec/darcyTetAnalytic.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/darcyTetAnalytic.xml
@@ -20,8 +20,7 @@
     </ParameterList>
 
     <ParameterList name="Inline Mesh">
-      <Parameter name="Mesh Dimension" type="int" value="3"/>
-      <!-- <Parameter name="Mesh Type" type="string" value="quad"/> -->
+      <!-- <Parameter name="Mesh Type" type="string" value="hex"/> -->
       <Parameter name="Mesh Type" type="string" value="tet"/>
       <Parameter name="CFL" type="double" value="4.0"/>
       <ParameterList name="Mesh Factory Parameter List">

--- a/packages/panzer/mini-em/example/BlockPrec/main.cpp
+++ b/packages/panzer/mini-em/example/BlockPrec/main.cpp
@@ -128,8 +128,8 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
     bool matrix_output = false;
     std::string input_file = "maxwell.xml";
     std::string xml = "";
-    solverType solverValues[5] = {AUGMENTATION, MUELU, ML, CG, GMRES};
-    const char * solverNames[5] = {"Augmentation", "MueLu", "ML", "CG", "GMRES"};
+    solverType solverValues[8] = {AUGMENTATION, MUELU, ML, CG, GMRES, MAXWELL1_RS, MAXWELL1_SA_RS, MAXWELL1_EMIN};
+    const char * solverNames[8] = {"Augmentation", "MueLu", "ML", "CG", "GMRES", "Maxwell1-RS", "Maxwell1-SA-RS", "Maxwell1-Emin"};
     bool preferTPLs = false;
     bool useBarriers = false;
     bool truncateMueLuHierarchy = false;
@@ -158,7 +158,7 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
     clp.setOption("matrix-output","no-matrix-output",&matrix_output);
     clp.setOption("inputFile",&input_file,"XML file with the problem definitions");
     clp.setOption("solverFile",&xml,"XML file with the solver params");
-    clp.setOption<solverType>("solver",&solver,5,solverValues,solverNames,"Solver that is used");
+    clp.setOption<solverType>("solver",&solver,8,solverValues,solverNames,"Solver that is used");
     clp.setOption("tpl", "no-tpl", &preferTPLs, "Prefer TPL usage over fused kernels");
     clp.setOption("barriers", "no-barriers", &useBarriers, "Use barriers in the solver");
     clp.setOption("truncateMueLuHierarchy", "no-truncateMueLuHierarchy", &truncateMueLuHierarchy, "Truncate the MueLu hierarchy");
@@ -784,10 +784,10 @@ int main(int argc,char * argv[]){
   const char * linAlgebraNames[2] = {"Tpetra", "Epetra"};
   linearAlgebraType linAlgebra = linAlgTpetra;
   clp.setOption<linearAlgebraType>("linAlgebra",&linAlgebra,2,linAlgebraValues,linAlgebraNames);
-  solverType solverValues[5] = {AUGMENTATION, MUELU, ML, CG, GMRES};
-  const char * solverNames[5] = {"Augmentation", "MueLu", "ML", "CG", "GMRES"};
+  solverType solverValues[8] = {AUGMENTATION, MUELU, ML, CG, GMRES, MAXWELL1_RS, MAXWELL1_SA_RS, MAXWELL1_EMIN};
+  const char * solverNames[8] = {"Augmentation", "MueLu", "ML", "CG", "GMRES", "Maxwell1-RS", "Maxwell1-SA-RS", "Maxwell1-Emin"};
   solverType solver = MUELU;
-  clp.setOption<solverType>("solver",&solver,5,solverValues,solverNames,"Solver that is used");
+  clp.setOption<solverType>("solver",&solver,8,solverValues,solverNames,"Solver that is used");
   // bool useComplex = false;
   // clp.setOption("complex","real",&useComplex);
   clp.recogniseAllOptions(false);

--- a/packages/panzer/mini-em/example/BlockPrec/main.cpp
+++ b/packages/panzer/mini-em/example/BlockPrec/main.cpp
@@ -120,6 +120,7 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
   {
     // defaults for command-line options
     int x_elements=-1,y_elements=-1,z_elements=-1,basis_order=1;
+    std::string meshType = "";
     int workset_size=2000;
     std::string pCoarsenScheduleStr = "1";
     double dt=0.0;
@@ -149,6 +150,7 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
     clp.setOption("x-elements",&x_elements);
     clp.setOption("y-elements",&y_elements);
     clp.setOption("z-elements",&z_elements);
+    clp.setOption("meshType",&meshType);
     clp.setOption("basis-order",&basis_order);
     clp.setOption("workset-size",&workset_size);
     clp.setOption("pCoarsenSchedule",&pCoarsenScheduleStr);
@@ -258,7 +260,7 @@ int main_(Teuchos::CommandLineProcessor &clp, int argc,char * argv[])
     {
       Teuchos::TimeMonitor tMmesh(*Teuchos::TimeMonitor::getNewTimer(std::string("Mini-EM: build mesh")));
       double mesh_size = 0.;
-      mini_em::getMesh(mesh_pl, meshFile, x_elements, y_elements, z_elements, basis_order, comm, mesh, mesh_factory, mesh_size);
+      mini_em::getMesh(mesh_pl, meshFile, x_elements, y_elements, z_elements, meshType, basis_order, comm, mesh, mesh_factory, mesh_size);
       dim = Teuchos::as<int>(mesh->getDimension());
 
       // set dt

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell-analyticSolution.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell-analyticSolution.xml
@@ -4,8 +4,7 @@
     <Parameter name="Source" type="string" value="Inline Mesh" />
     <ParameterList name="Inline Mesh">
       <Parameter name="final time" type="double" value="5e-9"/>
-      <Parameter name="Mesh Dimension" type="int" value="3"/>
-      <Parameter name="Mesh Type" type="string" value="quad"/>
+      <Parameter name="Mesh Type" type="string" value="hex"/>
       <Parameter name="CFL" type="double" value="4.0"/>
       <ParameterList name="Mesh Factory Parameter List">
         <Parameter name="X Procs" type="int" value="-1" />

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell-large.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell-large.xml
@@ -20,8 +20,7 @@
     </ParameterList>
 
     <ParameterList name="Inline Mesh">
-      <Parameter name="Mesh Dimension" type="int" value="3"/>
-      <!-- Parameter name="Mesh Type" type="string" value="quad"/-->
+      <!-- Parameter name="Mesh Type" type="string" value="hex"/-->
       <Parameter name="Mesh Type" type="string" value="tet"/>
       <Parameter name="CFL" type="double" value="4.0"/>
       <ParameterList name="Mesh Factory Parameter List">

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell-pthOrder.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell-pthOrder.xml
@@ -20,8 +20,7 @@
     </ParameterList>
 
     <ParameterList name="Inline Mesh">
-      <Parameter name="Mesh Dimension" type="int" value="3"/>
-      <!-- <Parameter name="Mesh Type" type="string" value="quad"/> -->
+      <!-- <Parameter name="Mesh Type" type="string" value="hex"/> -->
       <Parameter name="Mesh Type" type="string" value="tet"/>
       <Parameter name="CFL" type="double" value="4.0"/>
       <ParameterList name="Mesh Factory Parameter List">

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell.xml
@@ -26,6 +26,7 @@
       <!-- <Parameter name="Mesh Type" type="string" value="tet"/> -->
       <Parameter name="CFL" type="double" value="4.0"/>
       <ParameterList name="Mesh Factory Parameter List">
+        <!-- <Parameter name="Split hex into 12 tets" type="bool" value="false"/> -->
         <!-- <Parameter name="X Procs" type="int" value="-1" /> -->
         <!-- <Parameter name="Y Procs" type="int" value="-1" /> -->
         <!-- <Parameter name="Z Procs" type="int" value="-1" /> -->

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell.xml
@@ -20,8 +20,9 @@
     </ParameterList>
 
     <ParameterList name="Inline Mesh">
-      <Parameter name="Mesh Dimension" type="int" value="3"/>
-      <Parameter name="Mesh Type" type="string" value="quad"/>
+      <!-- <Parameter name="Mesh Type" type="string" value="quad"/> -->
+      <!-- <Parameter name="Mesh Type" type="string" value="tri"/> -->
+      <Parameter name="Mesh Type" type="string" value="hex"/>
       <!-- <Parameter name="Mesh Type" type="string" value="tet"/> -->
       <Parameter name="CFL" type="double" value="4.0"/>
       <ParameterList name="Mesh Factory Parameter List">

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell2D.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell2D.xml
@@ -4,9 +4,8 @@
     <Parameter name="Source" type="string" value="Inline Mesh" />
 
     <ParameterList name="Inline Mesh">
-      <Parameter name="Mesh Dimension" type="int" value="2"/>
       <Parameter name="Mesh Type" type="string" value="quad"/>
-      <!-- <Parameter name="Mesh Type" type="string" value="tet"/> -->
+      <!-- <Parameter name="Mesh Type" type="string" value="tri"/> -->
       <Parameter name="CFL" type="double" value="4.0"/>
       <ParameterList name="Mesh Factory Parameter List">
         <Parameter name="X Blocks" type="int" value="1" />

--- a/packages/panzer/mini-em/example/BlockPrec/solverMueLu.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/solverMueLu.xml
@@ -318,6 +318,87 @@
                   </ParameterList>
                 </ParameterList>
               </ParameterList>
+
+              <ParameterList name="MueLuMaxwell1">
+                <Parameter name="maxwell1: mode" type="string" value="standard"/>
+                <Parameter name="parameterlist: syntax" type="string" value="muelu"/>
+                <Parameter name="use kokkos refactor" type="bool" value="false"/>
+                <Parameter name="verbosity" type="string" value="extreme"/>
+                <Parameter name="maxwell1: use as preconditioner" type="bool" value="true"/>
+                <Parameter name="maxwell1: enable reuse" type="bool" value="true"/>
+                <Parameter name="maxwell1: disable addon" type="bool" value="false"/>
+                <Parameter name="maxwell1: dump matrices" type="bool" value="false"/>
+                <Parameter name="maxwell1: check and fix D0 scaling" type="bool" value="true"/>
+                <Parameter name="maxwell1: subsolves on subcommunicators" type="bool" value="true"/>
+                <Parameter name="maxwell1: subsolves striding" type="int" value="1"/>
+
+                <Parameter name="fuse prolongation and update" type="bool" value="true"/>
+
+                <!-- <Parameter name="rap: triple product" type="bool" value="true"/> -->
+                <!-- <Parameter name="transpose: use implicit" type="bool" value="true"/> -->
+
+                <ParameterList name="maxwell1: 11list">
+                  <Parameter name="verbosity" type="string" value="extreme"/>
+                  <Parameter name="number of equations" type="int" value="3"/>
+                  
+                  <Parameter name="fuse prolongation and update" type="bool" value="true"/>
+
+                  <!-- "multigrid algorithm" gets set at runtime -->
+                  
+                  <ParameterList name="matvec params">
+                    <Parameter name="Send type" type="string" value="Isend"/>
+                  </ParameterList>
+
+                  <Parameter name="coarse: type" type="string" value="KLU"/>
+
+                  <Parameter name="smoother: type" type="string" value="HIPTMAIR"/>
+                  <ParameterList name="smoother: params">
+                    <Parameter name="hiptmair: smoother type 1" type="string" value="CHEBYSHEV"/>
+                    <Parameter name="hiptmair: smoother type 2" type="string" value="CHEBYSHEV"/>
+                    <ParameterList name="hiptmair: smoother list 1">
+                      <Parameter name="chebyshev: degree" type="int" value="2"/>
+                      <Parameter name="chebyshev: ratio eigenvalue" type="double" value="5.4"/>
+                      <Parameter name="chebyshev: eigenvalue max iterations" type="int" value="100"/>
+                      <Parameter name="chebyshev: algorithm" type="string" value="opt_fourth"/>
+                      <Parameter name="chebyshev: use native spmv" type="bool" value="false"/>
+                    </ParameterList>
+                    <ParameterList name="hiptmair: smoother list 2">
+                      <Parameter name="chebyshev: degree" type="int" value="2"/>
+                      <Parameter name="chebyshev: ratio eigenvalue" type="double" value="7.0"/>
+                      <Parameter name="chebyshev: eigenvalue max iterations" type="int" value="100"/>
+                      <Parameter name="chebyshev: algorithm" type="string" value="opt_fourth"/>
+                      <Parameter name="chebyshev: use native spmv" type="bool" value="false"/>
+                    </ParameterList>
+                  </ParameterList>
+                </ParameterList>
+
+                <ParameterList name="maxwell1: 22list">
+                  <Parameter name="verbosity" type="string" value="extreme"/>
+                  <Parameter name="coarse: max size" type="int" value="1000"/>
+
+                  <!-- "multigrid algorithm" gets set at runtime -->
+
+                  <Parameter name="aggregation: drop scheme" type="string" value="distance laplacian"/>
+                  <Parameter name="aggregation: distance laplacian algo" type="string" value="scaled cut"/>
+                  <Parameter name="aggregation: drop tol" type="double" value="0.35"/>
+
+                  <!-- Currently needed but we should fix this -->
+                  <Parameter name="tentative: constant column sums" type="bool" value="false"/>
+                  <Parameter name="tentative: calculate qr" type="bool" value="false"/>
+
+                  <Parameter name="repartition: enable" type="bool" value="true"/>
+                  <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
+                  <Parameter name="repartition: start level" type="int" value="2"/>
+                  <Parameter name="repartition: target rows per thread" type="int" value="400"/>
+                  <Parameter name="repartition: min rows per thread" type="int" value="1000"/>
+                  <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
+                  <Parameter name="repartition: remap parts" type="bool" value="true"/>
+                  <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
+                  <ParameterList name="repartition: params">
+                    <Parameter name="algorithm" type="string" value="multijagged"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
             </ParameterList>
             <ParameterList name="Required Parameters">
               <Parameter name="Coordinates" type="string" value="AUXILIARY_NODE"/>

--- a/packages/panzer/mini-em/example/BlockPrec/steadyState.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/steadyState.xml
@@ -1,3 +1,9 @@
+<!--
+    Instead of setting up a time dependent Maxwell problem, set up a steady state problem
+
+    epsilon E + curl 1/mu curl E
+-->
+
 <ParameterList>
 
   <ParameterList name="Mesh">
@@ -6,23 +12,26 @@
     <!-- <Parameter name="Source" type="string" value="Exodus File" /> -->
 
     <ParameterList name="Exodus File">
-      <Parameter name="dt" type="double" value="6.0e-12"/>
+      <Parameter name="dt" type="double" value="1.0"/>
+      <Parameter name="final time" type="double" value="1.0"/>
       <ParameterList name="Exodus Parameters">
         <Parameter name="File Name" type="string" value="blob/blob.g" />
       </ParameterList>
     </ParameterList>
 
     <ParameterList name="Pamgen Mesh">
-      <Parameter name="dt" type="double" value="6.0e-12"/>
+      <Parameter name="dt" type="double" value="1.0"/>
+      <Parameter name="final time" type="double" value="1.0"/>
       <ParameterList name="Pamgen Parameters">
         <Parameter name="File Name" type="string" value="pamgen.gen"/>
       </ParameterList>
     </ParameterList>
 
     <ParameterList name="Inline Mesh">
-      <!-- <Parameter name="Mesh Type" type="string" value="hex"/> -->
-      <Parameter name="Mesh Type" type="string" value="tet"/>
-      <Parameter name="CFL" type="double" value="4.0"/>
+      <Parameter name="dt" type="double" value="1.0"/>
+      <Parameter name="final time" type="double" value="1.0"/>
+      <Parameter name="Mesh Type" type="string" value="hex"/>
+      <!-- <Parameter name="Mesh Type" type="string" value="tet"/> -->
       <ParameterList name="Mesh Factory Parameter List">
         <!-- <Parameter name="X Procs" type="int" value="-1" /> -->
         <!-- <Parameter name="Y Procs" type="int" value="-1" /> -->
@@ -30,9 +39,9 @@
         <Parameter name="X Blocks" type="int" value="1" />
         <Parameter name="Y Blocks" type="int" value="1" />
         <Parameter name="Z Blocks" type="int" value="1" />
-        <Parameter name="X Elements" type="int" value="5" />
-        <Parameter name="Y Elements" type="int" value="5" />
-        <Parameter name="Z Elements" type="int" value="5" />
+        <Parameter name="X Elements" type="int" value="15" />
+        <Parameter name="Y Elements" type="int" value="15" />
+        <Parameter name="Z Elements" type="int" value="15" />
         <!-- <ParameterList name="Periodic BCs"> -->
         <!--   <Parameter name="Count" type="int" value="3"/> -->
         <!--   <Parameter name="Periodic Condition 1" type="string" value="xz-all 1e-8: top;bottom"/> -->
@@ -54,17 +63,15 @@
   </ParameterList>
 
    <ParameterList name="Assembly">
-     <Parameter name="Field Order"           type="string" value="blocked: B_face E_edge"/>
+     <Parameter name="Field Order"  type="string" value="blocked: B_face E_edge"/>
    </ParameterList>
 
   <ParameterList name="Physics Blocks">
     <!-- The 2x2 Maxwell system -->
-    <!-- Gets epsilon, sigma and 1/mu from closure model 'electromagnetics' -->
+    <!-- Gets epsilon, sigma and mu from closure model 'electromagnetics' -->
     <ParameterList name="Maxwell Physics">
       <ParameterList name="Maxwell Physics">
         <Parameter name="Type"                 type="string" value="Maxwell"/>
-        <Parameter name="Basis Order"          type="int"    value="1"/>
-        <Parameter name="Integration Order"    type="int"    value="2"/>
         <Parameter name="Model ID"             type="string" value="electromagnetics"/>
         <Parameter name="Permittivity"         type="string" value="epsilon"/>
         <Parameter name="Conductivity"         type="string" value="sigma"/>
@@ -87,7 +94,7 @@
       </ParameterList>
       <!-- Permittivity -->
       <ParameterList name="epsilon">
-        <Parameter name="Value" type="double" value="8.854187817e-12"/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <!-- Conductivity -->
       <ParameterList name="sigma">
@@ -100,31 +107,9 @@
       </ParameterList>
       <!-- Permeability -->
       <ParameterList name="mu">
-        <Parameter name="Value" type="double" value="1.2566370614e-6"/>
-      </ParameterList>
-      <!-- Add 1/2 * ((E, epsilon * E) + (B, 1/mu * B)) and  -->
-      <!--     1/2/dt^2 * ((E, epsilon * E) + (B, 1/mu * B)) -->
-      <ParameterList name="EM_ENERGY">
-        <Parameter name="Type" type="string" value="ELECTROMAGNETIC ENERGY"/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList>
-
-  <ParameterList name="Responses">
-    <!-- <ParameterList name="Electromagnetic Energy"> -->
-    <!--   <Parameter name="Type" type="string" value="Functional"/> -->
-    <!--   <Parameter name="Field Name" type="string" value="EM_ENERGY"/> -->
-    <!--   <Parameter name="Element Blocks" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Evaluation Types" type="string" value="Residual"/> -->
-    <!--   <Parameter name="Requires Cell Integral" type="bool" value="true"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList name="Electromagnetic Energy/dt^2"> -->
-    <!--   <Parameter name="Type" type="string" value="Functional"/> -->
-    <!--   <Parameter name="Field Name" type="string" value="EM_ENERGY/dt^2"/> -->
-    <!--   <Parameter name="Element Blocks" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Evaluation Types" type="string" value="Residual"/> -->
-    <!--   <Parameter name="Requires Cell Integral" type="bool" value="true"/> -->
-    <!-- </ParameterList> -->
   </ParameterList>
 
   <ParameterList name="Boundary Conditions">

--- a/packages/panzer/mini-em/example/BlockPrec/steadyState2D.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/steadyState2D.xml
@@ -1,3 +1,9 @@
+<!--
+    Instead of setting up a time dependent Maxwell problem, set up a steady state problem
+
+    epsilon E + curl 1/mu curl E
+-->
+
 <ParameterList>
 
   <ParameterList name="Mesh">
@@ -6,38 +12,37 @@
     <!-- <Parameter name="Source" type="string" value="Exodus File" /> -->
 
     <ParameterList name="Exodus File">
-      <Parameter name="dt" type="double" value="6.0e-12"/>
+      <Parameter name="dt" type="double" value="1.0"/>
+      <Parameter name="final time" type="double" value="1.0"/>
       <ParameterList name="Exodus Parameters">
         <Parameter name="File Name" type="string" value="blob/blob.g" />
       </ParameterList>
     </ParameterList>
 
     <ParameterList name="Pamgen Mesh">
-      <Parameter name="dt" type="double" value="6.0e-12"/>
+      <Parameter name="dt" type="double" value="1.0"/>
+      <Parameter name="final time" type="double" value="1.0"/>
       <ParameterList name="Pamgen Parameters">
         <Parameter name="File Name" type="string" value="pamgen.gen"/>
       </ParameterList>
     </ParameterList>
 
     <ParameterList name="Inline Mesh">
-      <!-- <Parameter name="Mesh Type" type="string" value="hex"/> -->
-      <Parameter name="Mesh Type" type="string" value="tet"/>
-      <Parameter name="CFL" type="double" value="4.0"/>
+      <Parameter name="dt" type="double" value="1.0"/>
+      <Parameter name="final time" type="double" value="1.0"/>
+      <Parameter name="Mesh Type" type="string" value="quad"/>
+      <!-- <Parameter name="Mesh Type" type="string" value="tri"/> -->
       <ParameterList name="Mesh Factory Parameter List">
         <!-- <Parameter name="X Procs" type="int" value="-1" /> -->
         <!-- <Parameter name="Y Procs" type="int" value="-1" /> -->
-        <!-- <Parameter name="Z Procs" type="int" value="-1" /> -->
         <Parameter name="X Blocks" type="int" value="1" />
         <Parameter name="Y Blocks" type="int" value="1" />
-        <Parameter name="Z Blocks" type="int" value="1" />
-        <Parameter name="X Elements" type="int" value="5" />
-        <Parameter name="Y Elements" type="int" value="5" />
-        <Parameter name="Z Elements" type="int" value="5" />
+        <Parameter name="X Elements" type="int" value="15" />
+        <Parameter name="Y Elements" type="int" value="15" />
         <!-- <ParameterList name="Periodic BCs"> -->
         <!--   <Parameter name="Count" type="int" value="3"/> -->
         <!--   <Parameter name="Periodic Condition 1" type="string" value="xz-all 1e-8: top;bottom"/> -->
         <!--   <Parameter name="Periodic Condition 2" type="string" value="yz-all 1e-8: left;right"/> -->
-        <!--   <Parameter name="Periodic Condition 3" type="string" value="xy-all 1e-8: front;back"/> -->
         <!-- </ParameterList> -->
       </ParameterList>
     </ParameterList>
@@ -46,25 +51,23 @@
 
 
   <ParameterList name="Block ID to Physics ID Mapping">
-    <Parameter name="eblock-0_0_0" type="string" value="Maxwell Physics"/>
+    <Parameter name="eblock-0_0" type="string" value="Maxwell Physics"/>
   </ParameterList>
 
   <ParameterList name="Block ID to Auxiliary Physics ID Mapping">
-    <Parameter name="eblock-0_0_0" type="string" value="Auxiliary Physics Block"/>
+    <Parameter name="eblock-0_0" type="string" value="Auxiliary Physics Block"/>
   </ParameterList>
 
    <ParameterList name="Assembly">
-     <Parameter name="Field Order"           type="string" value="blocked: B_face E_edge"/>
+     <Parameter name="Field Order"  type="string" value="blocked: B_face E_edge"/>
    </ParameterList>
 
   <ParameterList name="Physics Blocks">
     <!-- The 2x2 Maxwell system -->
-    <!-- Gets epsilon, sigma and 1/mu from closure model 'electromagnetics' -->
+    <!-- Gets epsilon, sigma and mu from closure model 'electromagnetics' -->
     <ParameterList name="Maxwell Physics">
       <ParameterList name="Maxwell Physics">
         <Parameter name="Type"                 type="string" value="Maxwell"/>
-        <Parameter name="Basis Order"          type="int"    value="1"/>
-        <Parameter name="Integration Order"    type="int"    value="2"/>
         <Parameter name="Model ID"             type="string" value="electromagnetics"/>
         <Parameter name="Permittivity"         type="string" value="epsilon"/>
         <Parameter name="Conductivity"         type="string" value="sigma"/>
@@ -87,7 +90,7 @@
       </ParameterList>
       <!-- Permittivity -->
       <ParameterList name="epsilon">
-        <Parameter name="Value" type="double" value="8.854187817e-12"/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <!-- Conductivity -->
       <ParameterList name="sigma">
@@ -100,31 +103,9 @@
       </ParameterList>
       <!-- Permeability -->
       <ParameterList name="mu">
-        <Parameter name="Value" type="double" value="1.2566370614e-6"/>
-      </ParameterList>
-      <!-- Add 1/2 * ((E, epsilon * E) + (B, 1/mu * B)) and  -->
-      <!--     1/2/dt^2 * ((E, epsilon * E) + (B, 1/mu * B)) -->
-      <ParameterList name="EM_ENERGY">
-        <Parameter name="Type" type="string" value="ELECTROMAGNETIC ENERGY"/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList>
-
-  <ParameterList name="Responses">
-    <!-- <ParameterList name="Electromagnetic Energy"> -->
-    <!--   <Parameter name="Type" type="string" value="Functional"/> -->
-    <!--   <Parameter name="Field Name" type="string" value="EM_ENERGY"/> -->
-    <!--   <Parameter name="Element Blocks" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Evaluation Types" type="string" value="Residual"/> -->
-    <!--   <Parameter name="Requires Cell Integral" type="bool" value="true"/> -->
-    <!-- </ParameterList> -->
-    <!-- <ParameterList name="Electromagnetic Energy/dt^2"> -->
-    <!--   <Parameter name="Type" type="string" value="Functional"/> -->
-    <!--   <Parameter name="Field Name" type="string" value="EM_ENERGY/dt^2"/> -->
-    <!--   <Parameter name="Element Blocks" type="string" value="eblock-0_0_0"/> -->
-    <!--   <Parameter name="Evaluation Types" type="string" value="Residual"/> -->
-    <!--   <Parameter name="Requires Cell Integral" type="bool" value="true"/> -->
-    <!-- </ParameterList> -->
   </ParameterList>
 
   <ParameterList name="Boundary Conditions">
@@ -132,42 +113,42 @@
     <!-- <ParameterList> -->
     <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
     <!--   <Parameter name="Sideset ID" type="string" value="top"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
+    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> -->
     <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
     <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
     <!-- </ParameterList> -->
     <!-- <ParameterList> -->
     <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
     <!--   <Parameter name="Sideset ID" type="string" value="bottom"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
+    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> -->
     <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
     <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
     <!-- </ParameterList> -->
     <!-- <ParameterList> -->
     <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
     <!--   <Parameter name="Sideset ID" type="string" value="left"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
+    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> -->
     <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
     <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
     <!-- </ParameterList> -->
     <!-- <ParameterList> -->
     <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
     <!--   <Parameter name="Sideset ID" type="string" value="right"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
+    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> -->
     <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
     <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
     <!-- </ParameterList> -->
     <!-- <ParameterList> -->
     <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
     <!--   <Parameter name="Sideset ID" type="string" value="front"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
+    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> -->
     <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
     <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
     <!-- </ParameterList> -->
     <!-- <ParameterList> -->
     <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
     <!--   <Parameter name="Sideset ID" type="string" value="back"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
+    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> -->
     <!--   <Parameter name="Equation Set Name" type="string" value="E_edge"/> -->
     <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
     <!-- </ParameterList> -->
@@ -176,42 +157,42 @@
     <!-- <ParameterList> -->
     <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
     <!--   <Parameter name="Sideset ID" type="string" value="top"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
+    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> -->
     <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
     <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
     <!-- </ParameterList> -->
     <!-- <ParameterList> -->
     <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
     <!--   <Parameter name="Sideset ID" type="string" value="bottom"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
+    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> -->
     <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
     <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
     <!-- </ParameterList> -->
     <!-- <ParameterList> -->
     <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
     <!--   <Parameter name="Sideset ID" type="string" value="left"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
+    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> -->
     <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
     <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
     <!-- </ParameterList> -->
     <!-- <ParameterList> -->
     <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
     <!--   <Parameter name="Sideset ID" type="string" value="right"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
+    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> -->
     <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
     <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
     <!-- </ParameterList> -->
     <!-- <ParameterList> -->
     <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
     <!--   <Parameter name="Sideset ID" type="string" value="front"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
+    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> -->
     <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
     <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
     <!-- </ParameterList> -->
     <!-- <ParameterList> -->
     <!--   <Parameter name="Type" type="string" value="Dirichlet"/> -->
     <!--   <Parameter name="Sideset ID" type="string" value="back"/> -->
-    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0_0"/> -->
+    <!--   <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> -->
     <!--   <Parameter name="Equation Set Name" type="string" value="B_face"/> -->
     <!--   <Parameter name="Strategy" type="string" value="Constant"/> -->
     <!-- </ParameterList> -->

--- a/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
+++ b/packages/panzer/mini-em/src/solvers/MiniEM_FullMaxwellPreconditionerFactory.cpp
@@ -259,6 +259,47 @@ Teko::LinearOp FullMaxwellPreconditionerFactory::buildPreconditionerOperator(Tek
            invS_E = Teko::buildInverse(*invLib.getInverseFactory("S_E Solve"),S_E,S_E_prec_);
          }
        } 
+     } else if (S_E_prec_type_ == "MueLuMaxwell1") {// Maxwell1
+
+       RCP<Teko::InverseFactory> S_E_prec_factory;
+       Teuchos::ParameterList S_E_prec_pl;
+       S_E_prec_factory = invLib.getInverseFactory("S_E Preconditioner");
+       S_E_prec_pl = *S_E_prec_factory->getParameterList();
+
+       // Get coordinates
+       {
+         TEUCHOS_ASSERT(useTpetra)
+         RCP<Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Coordinates = S_E_prec_pl.get<RCP<Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >("Coordinates");
+         S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).set("Coordinates",Coordinates);
+       }
+
+       // Form the curl-curl matrix
+       if (S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).sublist("maxwell1: 11list").get<std::string>("multigrid algorithm") == "smoothed reitzinger") {
+         auto curl_curl = Teko::explicitAdd(S_E, Teko::scale(-1.0, Q_E), Teuchos::null);
+         S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).set("CurlCurl",curl_curl);
+       }
+
+       {
+         Teko::InverseLibrary myInvLib = invLib;
+         S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).set("Type",S_E_prec_type_);
+         myInvLib.addInverse("S_E Preconditioner",S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_));
+         S_E_prec_factory = myInvLib.getInverseFactory("S_E Preconditioner");
+       }
+
+       // Are we building a solver or a preconditioner?
+       {
+         Teuchos::TimeMonitor tm(*Teuchos::TimeMonitor::getNewTimer("MaxwellPreconditioner: Build S_E preconditioner"));
+
+         if (useAsPreconditioner)
+           invS_E = Teko::buildInverse(*S_E_prec_factory,S_E);
+         else {
+           if (S_E_prec_.is_null())
+             S_E_prec_ = Teko::buildInverse(*S_E_prec_factory,S_E);
+           else
+             Teko::rebuildInverse(*S_E_prec_factory,S_E, S_E_prec_);
+           invS_E = Teko::buildInverse(*invLib.getInverseFactory("S_E Solve"),S_E,S_E_prec_);
+         }
+       }
      } else {
        if (useAsPreconditioner)
          invS_E = Teko::buildInverse(*invLib.getInverseFactory("S_E Preconditioner"),S_E);
@@ -439,6 +480,27 @@ void FullMaxwellPreconditionerFactory::initializeFromParameterList(const Teuchos
      describeMatrix("DiscreteGradient",*T,debug);
 
      invLib.addInverse("S_E Preconditioner",S_E_prec_pl);
+
+   } else if (S_E_prec_type_ == "MueLuMaxwell1") { // RefMaxwell based solve
+
+     // S_E solve
+     Teuchos::ParameterList ml_pl = pl.sublist("S_E Solve");
+     invLib.addInverse("S_E Solve",ml_pl);
+
+     // S_E preconditioner
+     Teuchos::ParameterList S_E_prec_pl = pl.sublist("S_E Preconditioner");
+
+     // add discrete gradient
+     auto T = getRequestHandler()->request<Teko::LinearOp>(Teko::RequestMesg("Discrete Gradient"));
+     S_E_prec_pl.sublist("Preconditioner Types").sublist(S_E_prec_type_).set("D0",T);
+
+     if (dump) {
+       writeOut("DiscreteGradient.mm",*T);
+     }
+     describeMatrix("DiscreteGradient",*T,debug);
+
+     invLib.addInverse("S_E Preconditioner",S_E_prec_pl);
+
    } else {
      // S_E solve
      if (pl.isParameter("S_E Solve")) {


### PR DESCRIPTION
@trilinos/panzer @trilinos/muelu 

## Motivation
In addition to RefMaxwell, also hook up unsmoothed Maxwell1 solvers. Add a regular and a performance tests. We will use the performance tests to evaluate the impact of #14990, a fix for smoothed Maxwell1 and subsequently for an energy minimization variant of Maxwell1.

I also added a second type of tet mesh generation that splits hexes into six instead of 12 tets. The default has not changed.