### PR TITLE
stokhos: update array_type -> type

### DIFF
--- a/packages/stokhos/test/Performance/MPVectorKernels/TestSpMv.hpp
+++ b/packages/stokhos/test/Performance/MPVectorKernels/TestSpMv.hpp
@@ -118,9 +118,15 @@ test_mpvector_spmv(const int ensemble_length,
     // The VectorType may be dynamic (with allocated memory)
     // so cannot pass a VectorType value to the device.
     // Get an array-of-intrinsic View and fill that view.
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
     typename vector_type::array_type xx( x );
     typename vector_type::array_type yy( y );
     typename matrix_values_type::array_type mm( matrix_values );
+#else
+    typename vector_type::type xx( x );
+    typename vector_type::type yy( y );
+    typename matrix_values_type::type mm( matrix_values );
+#endif
 
     Kokkos::deep_copy( xx , value_type(1.0) );
     Kokkos::deep_copy( yy , value_type(1.0) );


### PR DESCRIPTION
Compatibility update for Kokkos_ENABLE_DEPRECATED_CODE_5=OFF

@trilinos/stokhos @etphipp 

This only showed up in a Cuda build for some reason, but not Serial or Hip builds

```
/root/Trilinos/packages/stokhos/test/Performance/MPVectorKernels/TestSpMv.hpp(121): error: class "Kokkos::View<Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::Cuda>> *, Kokkos::LayoutRight, Kokkos::Cuda>" has no member "array_type"
/root/Trilinos/packages/stokhos/test/Performance/MPVectorKernels/TestSpMv.hpp(122): error: class "Kokkos::View<Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::Cuda>> *, Kokkos::LayoutRight, Kokkos::Cuda>" has no member "array_type"
/root/Trilinos/packages/stokhos/test/Performance/MPVectorKernels/TestSpMv.hpp(123): error: class "Kokkos::View<Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::Cuda>> *, Kokkos::LayoutRight, Kokkos::Device<Kokkos::CudaSpace::execution_space, Kokkos::CudaSpace::memory_space>, void>" has no member "array_type"
```

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
