### PR TITLE
Ifpack2: in BTD perf test, do full untimed warmup

### DIFF
--- a/packages/ifpack2/example/BlockTriDi.cpp
+++ b/packages/ifpack2/example/BlockTriDi.cpp
@@ -297,6 +297,8 @@ Teuchos::RCP<Tpetra::BlockCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> 
   return bcrsmatrix;
 }  // BuildBlockMatrix()
 
+#endif  // HAVE_IFPACK2_XPETRA
+
 template <class SC, class LO, class GO, class NO>
 void solverWarmup(Teuchos::RCP<const Teuchos::Comm<int>>& comm, Teuchos::RCP<Tpetra::RowMatrix<>> Ablock, const Teuchos::Array<Teuchos::Array<LO>>& parts, int sublinesPerLineSchur, bool overlapCommAndComp, int nvecs) {
   using row_matrix_type = Tpetra::RowMatrix<>;
@@ -327,8 +329,6 @@ void solverWarmup(Teuchos::RCP<const Teuchos::Comm<int>>& comm, Teuchos::RCP<Tpe
   precond->compute();
   (void)precond->applyInverseJacobi(*B, *X, ap);
 }
-
-#endif  // HAVE_IFPACK2_XPETRA
 
 int main(int argc, char* argv[]) {
   using std::cerr;


### PR DESCRIPTION
BTD driver: do a full warmup setup+solve with the real matrix, to make sure necessary kernels and matrix data is copied to device memory before the real timed runs.

Use minimal repeats/iterations/numVecs to minimize the time needed for warmup. In my testing, this doesn't add a lot of wall time relative to launching the program and reading/generating the matrix.

Should fix noisy/slow solve timings on eldorado SPARC 1 GPU block Jacobi since #14982.

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/ifpack2 
