### PR TITLE
Tpetra: Distributor & DistributorPlan parameter problems

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -29,8 +29,8 @@ const bool tpetraDistributorDebugDefault = false;
 Distributor::
     Distributor(const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
                 const Teuchos::RCP<Teuchos::FancyOStream>& /* out */,
-                const Teuchos::RCP<Teuchos::ParameterList>& plist)
-  : plan_(comm) {
+                const Teuchos::RCP<Teuchos::ParameterList>& plist) {
+  plan_ = Teuchos::rcp(new Details::DistributorPlan(comm));
   this->setParameterList(plist);
 }
 
@@ -100,7 +100,7 @@ std::unique_ptr<std::string>
 Distributor::
     createPrefix(const char methodName[]) const {
   return Details::createPrefix(
-      plan_.getComm().getRawPtr(), "Distributor", methodName);
+      plan_->getComm().getRawPtr(), "Distributor", methodName);
 }
 
 void Distributor::
@@ -125,7 +125,7 @@ void Distributor::
     RCP<ParameterList> planParams(plist);
     planParams->remove("Debug", false);
     planParams->remove("VerboseObject", false);
-    plan_.setParameterList(planParams);
+    plan_->setParameterList(planParams);
   }
 }
 
@@ -164,23 +164,23 @@ Distributor::getValidParameters() const {
   return Teuchos::rcp_const_cast<const ParameterList>(plist);
 }
 
-size_t Distributor::getTotalReceiveLength() const { return plan_.getTotalReceiveLength(); }
+size_t Distributor::getTotalReceiveLength() const { return plan_->getTotalReceiveLength(); }
 
-size_t Distributor::getNumReceives() const { return plan_.getNumReceives(); }
+size_t Distributor::getNumReceives() const { return plan_->getNumReceives(); }
 
-bool Distributor::hasSelfMessage() const { return plan_.hasSelfMessage(); }
+bool Distributor::hasSelfMessage() const { return plan_->hasSelfMessage(); }
 
-size_t Distributor::getNumSends() const { return plan_.getNumSends(); }
+size_t Distributor::getNumSends() const { return plan_->getNumSends(); }
 
-size_t Distributor::getMaxSendLength() const { return plan_.getMaxSendLength(); }
+size_t Distributor::getMaxSendLength() const { return plan_->getMaxSendLength(); }
 
-Teuchos::ArrayView<const int> Distributor::getProcsFrom() const { return plan_.getProcsFrom(); }
+Teuchos::ArrayView<const int> Distributor::getProcsFrom() const { return plan_->getProcsFrom(); }
 
-Teuchos::ArrayView<const size_t> Distributor::getLengthsFrom() const { return plan_.getLengthsFrom(); }
+Teuchos::ArrayView<const size_t> Distributor::getLengthsFrom() const { return plan_->getLengthsFrom(); }
 
-Teuchos::ArrayView<const int> Distributor::getProcsTo() const { return plan_.getProcsTo(); }
+Teuchos::ArrayView<const int> Distributor::getProcsTo() const { return plan_->getProcsTo(); }
 
-Teuchos::ArrayView<const size_t> Distributor::getLengthsTo() const { return plan_.getLengthsTo(); }
+Teuchos::ArrayView<const size_t> Distributor::getLengthsTo() const { return plan_->getLengthsTo(); }
 
 Teuchos::RCP<Distributor>
 Distributor::getReverse(bool create) const {
@@ -195,8 +195,9 @@ Distributor::getReverse(bool create) const {
 }
 
 void Distributor::createReverseDistributor() const {
-  reverseDistributor_           = Teuchos::rcp(new Distributor(plan_.getComm()));
-  reverseDistributor_->plan_    = *plan_.getReversePlan();
+  reverseDistributor_           = Teuchos::rcp(new Distributor(plan_->getComm()));
+  auto revPlan                  = plan_->getReversePlan();
+  reverseDistributor_->plan_    = revPlan;
   reverseDistributor_->verbose_ = verbose_;
 
   // requests_: Allocated on demand.
@@ -217,7 +218,7 @@ void Distributor::createReverseDistributor() const {
 }
 
 void Distributor::doWaits() {
-  actor_.doWaits(plan_);
+  actor_.doWaits(*plan_);
 }
 
 void Distributor::doReverseWaits() {
@@ -236,10 +237,10 @@ std::string Distributor::description() const {
     out << "Label: " << label << ", ";
   }
   out << "How initialized: "
-      << Details::DistributorHowInitializedEnumToString(plan_.howInitialized())
+      << Details::DistributorHowInitializedEnumToString(plan_->howInitialized())
       << ", Parameters: {"
       << "Send type: "
-      << DistributorSendTypeEnumToString(plan_.getSendType())
+      << DistributorSendTypeEnumToString(plan_->getSendType())
       << ", Debug: " << (verbose_ ? "true" : "false")
       << "}}";
   return out.str();
@@ -254,7 +255,7 @@ Distributor::
   using Teuchos::VERB_HIGH;
 
   // This preserves current behavior of Distributor.
-  if (vl <= Teuchos::VERB_LOW || plan_.getComm().is_null()) {
+  if (vl <= Teuchos::VERB_LOW || plan_->getComm().is_null()) {
     return std::string();
   }
 
@@ -262,27 +263,27 @@ Distributor::
   auto outp                  = Teuchos::getFancyOStream(outStringP);  // returns RCP
   Teuchos::FancyOStream& out = *outp;
 
-  const int myRank   = plan_.getComm()->getRank();
-  const int numProcs = plan_.getComm()->getSize();
+  const int myRank   = plan_->getComm()->getRank();
+  const int numProcs = plan_->getComm()->getSize();
   out << "Process " << myRank << " of " << numProcs << ":" << endl;
   Teuchos::OSTab tab1(out);
 
   out << "selfMessage: " << hasSelfMessage() << endl;
   out << "numSends: " << getNumSends() << endl;
   if (vl == VERB_HIGH || vl == VERB_EXTREME) {
-    out << "procsTo: " << toString(plan_.getProcsTo()) << endl;
-    out << "lengthsTo: " << toString(plan_.getLengthsTo()) << endl;
+    out << "procsTo: " << toString(plan_->getProcsTo()) << endl;
+    out << "lengthsTo: " << toString(plan_->getLengthsTo()) << endl;
     out << "maxSendLength: " << getMaxSendLength() << endl;
   }
   if (vl == VERB_EXTREME) {
-    out << "startsTo: " << toString(plan_.getStartsTo()) << endl;
-    out << "indicesTo: " << toString(plan_.getIndicesTo()) << endl;
+    out << "startsTo: " << toString(plan_->getStartsTo()) << endl;
+    out << "indicesTo: " << toString(plan_->getIndicesTo()) << endl;
   }
   if (vl == VERB_HIGH || vl == VERB_EXTREME) {
     out << "numReceives: " << getNumReceives() << endl;
     out << "totalReceiveLength: " << getTotalReceiveLength() << endl;
-    out << "lengthsFrom: " << toString(plan_.getLengthsFrom()) << endl;
-    out << "procsFrom: " << toString(plan_.getProcsFrom()) << endl;
+    out << "lengthsFrom: " << toString(plan_->getLengthsFrom()) << endl;
+    out << "procsFrom: " << toString(plan_->getProcsFrom()) << endl;
   }
 
   out.flush();  // make sure the ostringstream got everything
@@ -310,11 +311,11 @@ void Distributor::
   // operations with the other processes.  In that case, it is not
   // even legal to call this method.  The reasonable thing to do in
   // that case is nothing.
-  if (plan_.getComm().is_null()) {
+  if (plan_->getComm().is_null()) {
     return;
   }
-  const int myRank   = plan_.getComm()->getRank();
-  const int numProcs = plan_.getComm()->getSize();
+  const int myRank   = plan_->getComm()->getRank();
+  const int numProcs = plan_->getComm()->getSize();
 
   // Only Process 0 should touch the output stream, but this method
   // in general may need to do communication.  Thus, we may need to
@@ -341,13 +342,13 @@ void Distributor::
     }
     out << "Number of processes: " << numProcs << endl
         << "How initialized: "
-        << Details::DistributorHowInitializedEnumToString(plan_.howInitialized())
+        << Details::DistributorHowInitializedEnumToString(plan_->howInitialized())
         << endl;
     {
       out << "Parameters: " << endl;
       Teuchos::OSTab tab2(out);
       out << "\"Send type\": "
-          << DistributorSendTypeEnumToString(plan_.getSendType()) << endl
+          << DistributorSendTypeEnumToString(plan_->getSendType()) << endl
           << "\"Debug\": " << (verbose_ ? "true" : "false") << endl;
     }
   }  // if myRank == 0
@@ -355,7 +356,7 @@ void Distributor::
   // This is collective over the Map's communicator.
   if (vl > VERB_LOW) {
     const std::string lclStr = this->localDescribeToString(vl);
-    Tpetra::Details::gathervPrint(out, lclStr, *plan_.getComm());
+    Tpetra::Details::gathervPrint(out, lclStr, *plan_->getComm());
   }
 
   out << "Reverse Distributor:";
@@ -370,13 +371,13 @@ void Distributor::
 size_t
 Distributor::
     createFromSends(const Teuchos::ArrayView<const int>& exportProcIDs) {
-  return plan_.createFromSends(exportProcIDs);
+  return plan_->createFromSends(exportProcIDs);
 }
 
 void Distributor::
     createFromSendsAndRecvs(const Teuchos::ArrayView<const int>& exportProcIDs,
                             const Teuchos::ArrayView<const int>& remoteProcIDs) {
-  plan_.createFromSendsAndRecvs(exportProcIDs, remoteProcIDs);
+  plan_->createFromSendsAndRecvs(exportProcIDs, remoteProcIDs);
 }
 
 }  // namespace Tpetra

--- a/packages/tpetra/core/src/Tpetra_Distributor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.hpp
@@ -323,7 +323,7 @@ class Distributor : public Teuchos::Describable,
   /// This is an implementation detail of Tpetra.  Please do not
   /// call this method or rely on it existing in your code.
   Details::EDistributorHowInitialized howInitialized() const {
-    return plan_.howInitialized();
+    return plan_->howInitialized();
   }
 
   //@}
@@ -552,10 +552,10 @@ class Distributor : public Teuchos::Describable,
   ///
   /// FIXME: Delete this method when it's no longer needed for non-blocking
   ///        communication in the DistObject
-  const Details::DistributorPlan& getPlan() const { return plan_; }
+  const Details::DistributorPlan& getPlan() const { return *plan_; }
 
  private:
-  Details::DistributorPlan plan_;
+  Teuchos::RCP<Details::DistributorPlan> plan_;
   Details::DistributorActor actor_;
 
   //! @name Parameters read in from the Teuchos::ParameterList
@@ -616,7 +616,7 @@ Distributor::
     doPostsAndWaits(const ExpView& exports,
                     size_t numPackets,
                     const ImpView& imports) {
-  actor_.doPostsAndWaits(plan_, exports, numPackets, imports);
+  actor_.doPostsAndWaits(*plan_, exports, numPackets, imports);
 }
 
 template <class ExpView, class ImpView>
@@ -626,7 +626,7 @@ Distributor::
                     const Teuchos::ArrayView<const size_t>& numExportPacketsPerLID,
                     const ImpView& imports,
                     const Teuchos::ArrayView<const size_t>& numImportPacketsPerLID) {
-  actor_.doPostsAndWaits(plan_, exports, numExportPacketsPerLID, imports, numImportPacketsPerLID);
+  actor_.doPostsAndWaits(*plan_, exports, numExportPacketsPerLID, imports, numImportPacketsPerLID);
 }
 
 template <class ExpView, class ImpView>
@@ -635,7 +635,7 @@ Distributor::
     doPosts(const ExpView& exports,
             size_t numPackets,
             const ImpView& imports) {
-  actor_.doPosts(plan_, exports, numPackets, imports);
+  actor_.doPosts(*plan_, exports, numPackets, imports);
 }
 
 template <class ExpView, class ImpView>
@@ -645,7 +645,7 @@ Distributor::
             const Teuchos::ArrayView<const size_t>& numExportPacketsPerLID,
             const ImpView& imports,
             const Teuchos::ArrayView<const size_t>& numImportPacketsPerLID) {
-  actor_.doPosts(plan_, exports, numExportPacketsPerLID, imports, numImportPacketsPerLID);
+  actor_.doPosts(*plan_, exports, numExportPacketsPerLID, imports, numImportPacketsPerLID);
 }
 
 template <class ExpView, class ImpView>
@@ -678,7 +678,7 @@ Distributor::
                    const ImpView& imports) {
   // FIXME (mfh 29 Mar 2012) WHY?
   TEUCHOS_TEST_FOR_EXCEPTION(
-      !plan_.getIndicesTo().is_null(), std::runtime_error,
+      !plan_->getIndicesTo().is_null(), std::runtime_error,
       "Tpetra::Distributor::doReversePosts(3 args): Can only do "
       "reverse communication when original data are blocked by process.");
   if (reverseDistributor_.is_null()) {
@@ -696,7 +696,7 @@ Distributor::
                    const Teuchos::ArrayView<const size_t>& numImportPacketsPerLID) {
   // FIXME (mfh 29 Mar 2012) WHY?
   TEUCHOS_TEST_FOR_EXCEPTION(
-      !plan_.getIndicesTo().is_null(), std::runtime_error,
+      !plan_->getIndicesTo().is_null(), std::runtime_error,
       "Tpetra::Distributor::doReversePosts(3 args): Can only do "
       "reverse communication when original data are blocked by process.");
   if (reverseDistributor_.is_null()) {
@@ -726,7 +726,7 @@ void Distributor::
   const char suffix[] =
       "  Please report this bug to the Tpetra developers.";
 
-  const int myRank = plan_.getComm()->getRank();
+  const int myRank = plan_->getComm()->getRank();
 
   TEUCHOS_TEST_FOR_EXCEPTION(importGIDs.size() != importProcIDs.size(),
                              std::invalid_argument, errPrefix << "On Process " << myRank << ": importProcIDs.size()=" << importProcIDs.size() << " != importGIDs.size()=" << importGIDs.size() << ".");
@@ -742,7 +742,7 @@ void Distributor::
   // Use a temporary Distributor to send the (importGIDs[i], myRank)
   // pairs to importProcIDs[i].
   //
-  Distributor tempPlan(plan_.getComm());
+  Distributor tempPlan(plan_->getComm());
   // mfh 20 Mar 2014: An extra-cautious cast from unsigned to
   // signed, in order to forestall any possible causes for Bug 6069.
   const size_t numExportsAsSizeT =
@@ -797,7 +797,7 @@ void Distributor::
                     Teuchos::Array<int>& exportProcIDs) {
   using std::endl;
   const char errPrefix[] = "Tpetra::Distributor::createFromRecvs: ";
-  const int myRank       = plan_.getComm()->getRank();
+  const int myRank       = plan_->getComm()->getRank();
 
   std::unique_ptr<std::string> prefix;
   if (verbose_) {
@@ -817,7 +817,7 @@ void Distributor::
     const int errProc =
         (remoteGIDs.size() != remoteProcIDs.size()) ? myRank : -1;
     int maxErrProc = -1;
-    reduceAll(*plan_.getComm(), REDUCE_MAX, errProc, outArg(maxErrProc));
+    reduceAll(*plan_->getComm(), REDUCE_MAX, errProc, outArg(maxErrProc));
     TEUCHOS_TEST_FOR_EXCEPTION(maxErrProc != -1, std::runtime_error, errPrefix << "Lists "
                                                                                   "of remote IDs and remote process IDs must have the same "
                                                                                   "size on all participating processes.  Maximum process ID "
@@ -834,7 +834,7 @@ void Distributor::
 
   computeSends(remoteGIDs, remoteProcIDs, exportGIDs, exportProcIDs);
 
-  plan_.createFromRecvs(remoteProcIDs);
+  plan_->createFromRecvs(remoteProcIDs);
 
   if (verbose_) {
     std::ostringstream os;

--- a/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
+++ b/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
@@ -926,6 +926,47 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL(Distributor, createFromRecvs, Ordinal) {
   TEST_EQUALITY_CONST(globalSuccess_int, 0);
 }
 
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL(Distributor, reverseAndParams, Ordinal) {
+  // Test that parameters get correctly propagated from Distributor to DistributorPlan.
+
+  RCP<const Comm<int> > comm = getDefaultComm();
+  const int numImages        = comm->getSize();
+  const int myImageID        = comm->getRank();
+  const int length           = numImages;
+  // Set up a distributor.
+  Array<int> importImageIDs;
+  Array<Ordinal> importGIDs;
+  importImageIDs.reserve(length);
+  importGIDs.reserve(length);
+  for (int i = 0; i < length; ++i) {
+    importImageIDs.push_back(i);
+    importGIDs.push_back(as<Ordinal>(generateValue(i, myImageID)));
+  }
+  Distributor distributor(comm);
+  Array<int> exportImageIDs;
+  Array<Ordinal> exportGIDs;
+  distributor.createFromRecvs<Ordinal>(importGIDs, importImageIDs, exportGIDs, exportImageIDs);
+
+  // Trigger construction of reverse distributor and its plan
+  auto revDistributor = distributor.getReverse();
+
+  auto pl = Teuchos::rcp(new Teuchos::ParameterList());
+  pl->set("Send type", Tpetra::Details::DISTRIBUTOR_ISEND);
+
+  // Change send type on distributor and its reverse
+  distributor.setParameterList(pl);
+  distributor.getReverse()->setParameterList(pl);
+
+  // Send type got propagated correctly to distributor's plan
+  TEUCHOS_ASSERT_EQUALITY(distributor.getPlan().getSendType(), Tpetra::Details::DISTRIBUTOR_ISEND);
+
+  // Send type got propagated correctly to reverse distributor's plan
+  TEUCHOS_ASSERT_EQUALITY(distributor.getReverse()->getPlan().getSendType(), Tpetra::Details::DISTRIBUTOR_ISEND);
+
+  // Send type propagated to distributor's plan's reverse which is the same as the reverse distributor's plan
+  TEUCHOS_ASSERT_EQUALITY(distributor.getPlan().getReversePlan()->getSendType(), Tpetra::Details::DISTRIBUTOR_ISEND);
+}
+
 //
 // INSTANTIATIONS
 //
@@ -935,12 +976,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL(Distributor, createFromRecvs, Ordinal) {
 // #define FAST_DEVELOPMENT_UNIT_TEST_BUILD
 
 #ifdef HAVE_TPETRA_DEBUG
+#define UNIT_TEST_GROUP_ORDINAL(ORDINAL)                                       \
+  TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT(Distributor, createFromRecvs, ORDINAL)  \
+  TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT(Distributor, badArgsFromRecvs, ORDINAL) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT(Distributor, reverseAndParams, ORDINAL)
+#else
 #define UNIT_TEST_GROUP_ORDINAL(ORDINAL)                                      \
   TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT(Distributor, createFromRecvs, ORDINAL) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT(Distributor, badArgsFromRecvs, ORDINAL)
-#else
-#define UNIT_TEST_GROUP_ORDINAL(ORDINAL) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT(Distributor, createFromRecvs, ORDINAL)
+  TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT(Distributor, reverseAndParams, ORDINAL)
 #endif  // HAVE_TPETRA_DEBUG
 
 #ifdef FAST_DEVELOPMENT_UNIT_TEST_BUILD


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
I ran into the issue that parameters set on a reverse distributor (e.g. MPI send type) were not actually used during communication. The issue is this line:
https://github.com/trilinos/Trilinos/blob/a323658d9cecef1f21209af56681e21f58ca12f3/packages/tpetra/core/src/Tpetra_Distributor.cpp#L199
The plan of the reverse distributor and `plan_.getReversePlan()` are not the same object.
Depending on whether one does
```
distributor.getReverse().getPlan()
```
or 
```
distributor.getPlan().getReversePlan()
```
one ends up with different objects, but this should really commute.
Subsequently
```
distributor.getReverse().setParameterList()
```
will only change values of `distributor.getReverse().getPlan()`. Unfortunately, there are spots where `distributor.getPlan().getReversePlan()` is used in Tpetra.

I changed `Distributor::plan_` to an RCP to fix this.