### PR TITLE
MueLu: Correctly set subblock nullspaces in MueLu::MultiPhys

### DIFF
--- a/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
@@ -118,6 +118,12 @@ void MultiPhys<Scalar, LocalOrdinal, GlobalOrdinal, Node>::compute(bool reuse) {
       }
     }
 
+    if (arrayOfNullspaces_ != Teuchos::null) {
+      if (arrayOfNullspaces_[iii] != Teuchos::null) {
+        arrayOfParamLists_[iii]->sublist("user data").set("Nullspace", arrayOfNullspaces_[iii]);
+      }
+    }
+
     bool wantToRepartition = false;
     if (paramListMultiphysics_->isParameter("repartition: enable"))
       wantToRepartition = paramListMultiphysics_->get<bool>("repartition: enable");


### PR DESCRIPTION
@trilinos/muelu