### PR TITLE
Master merge again

### DIFF
--- a/.github/workflows/flag_prs_to_master.yml
+++ b/.github/workflows/flag_prs_to_master.yml
@@ -18,14 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Add label
-      uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3     
-      if: "!contains(github.event.sender.login,'trilinos-autotester')"
-      with:
-        labels: "AT: WIP"     
     - name: Add comment
       uses: mshick/add-pr-comment@ffd016c7e151d97d69d21a843022fd4cd5b96fe5 # v3.9.0.8.3.9.0
-      if: "!contains(github.event.sender.login,'trilinos-autotester')"
+      if: "!contains(github.event.sender.login,'snapshot-app[bot]')"
       with:
          message: |
             You seem to have created a PR on master.  This is not allowed behavior, so we've blocked your PR.  Please switch your PR to target the develop branch and remove the AT: WIP label.

--- a/.github/workflows/master_merge.yml
+++ b/.github/workflows/master_merge.yml
@@ -46,7 +46,7 @@ jobs:
           --body "Automatic PR from develop to master."
 
           # delete previously merged branches
-          merged_branches=`git branch --remote --merged master | grep "master_merge_"`
+          merged_branches=`git branch --remote --merged ${REMOTE}/master | grep "master_merge_"`
           for merged_branch in ${merged_branches} ; do
               # extract branch name
               merged_branch_name=`echo ${merged_branch} | cut -d "/" -f 2`


### PR DESCRIPTION
## Motivation
The master merge workflow is correctly using a dedicated branch (see #15029) but not listing the old merged branches (see https://github.com/trilinos/Trilinos/actions/runs/22782723142/job/66092296606).
This PR should fix that. Also modifies the workflow that tags PRs against master.