### PR TITLE
Tpetra: Fix MatrixMatrix_UnitTests.cpp

### DIFF
--- a/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
@@ -2524,7 +2524,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, cancellation_zero_entry_test, S
 
   // Confirm that re-use for RAP works correctly without cancellation
   auto unity = Teuchos::ScalarTraits<SC>::one();
-  set2x2BlockAlphaBeta(*A, 2.0 * unity, unity);
+  set2x2BlockAlphaBeta(*A, SC(2.0) * unity, unity);
 
   TEST_NOTHROW(Tpetra::MatrixMatrix::Multiply(*P, true, *A, false, *PTA, fillComplete, label, my_matrixmatrix_params));
   TEST_NOTHROW(Tpetra::MatrixMatrix::Multiply(*PTA, false, *P, false, *PTAP, fillComplete, label, my_matrixmatrix_params));


### PR DESCRIPTION
@trilinos/tpetra

## Motivation
Fixes
```
/tmp/trilinos/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp:2527:3: error: no matching function for call to 'set2x2BlockAlphaBeta'
 2527 |   set2x2BlockAlphaBeta(*A, 2.0 * unity, unity);
      |   ^~~~~~~~~~~~~~~~~~~~
/tmp/trilinos/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp:2946:43: note: in instantiation of member function '(anonymous
      namespace)::Tpetra_MatMat_cancellation_zero_entry_test_UnitTest<float, int, long long, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial>>::runUnitTestImpl' requested here
 2946 | TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR(UNIT_TEST_GROUP_SC_LO_GO_NO)
      |                                           ^
/tmp/trilinos/build/packages/tpetra/core/src/TpetraCore_ETIHelperMacros.h:118:2: note: expanded from macro 'TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR'
  118 |         INSTMACRO( float , int , longlong , Tpetra_KokkosCompat_KokkosSerialWrapperNode )\
      |         ^
/tmp/trilinos/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp:2941:3: note: expanded from macro 'UNIT_TEST_GROUP_SC_LO_GO_NO'
 2941 |   UNIT_TEST_GROUP_SC_LO_GO_NO_COMMON(SC, LO, GO, NT)
      |   ^
/tmp/trilinos/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp:2924:3: note: expanded from macro 'UNIT_TEST_GROUP_SC_LO_GO_NO_COMMON'
 2924 |   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(Tpetra_MatMat, cancellation_zero_entry_test, SC, LO, GO, NT) \
      |   ^
/tmp/trilinos/packages/teuchos/core/src/Teuchos_UnitTestHelpers.hpp:380:18: note: expanded from macro 'TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT'
  380 |   template class TEST_GROUP##_##TEST_NAME##_UnitTest<TYPE1, TYPE2, TYPE3, TYPE4 >; \
      |                  ^
<scratch space>:35:1: note: expanded from here
   35 | Tpetra_MatMat_cancellation_zero_entry_test_UnitTest
      | ^
/tmp/trilinos/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp:2418:6: note: candidate template ignored: deduced conflicting types for parameter 'SC' ('float' vs. 'double')
 2418 | void set2x2BlockAlphaBeta(
      |      ^
```