### PR TITLE
MueLu ParameterListInterpreter: Replace macros with functions

### DIFF
--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -96,7 +96,7 @@
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::ParameterListInterpreter(ParameterList& paramList, Teuchos::RCP<const Teuchos::Comm<int> > comm, Teuchos::RCP<FactoryFactory> factFact, Teuchos::RCP<FacadeClassFactory> facadeFact)
+ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::ParameterListInterpreter(ParameterList& paramList, Teuchos::RCP<const Teuchos::Comm<int>> comm, Teuchos::RCP<FactoryFactory> factFact, Teuchos::RCP<FacadeClassFactory> facadeFact)
   : factFact_(factFact) {
   RCP<Teuchos::TimeMonitor> tM = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer(std::string("MueLu: ParameterListInterpreter (ParameterList)"))));
   if (facadeFact == Teuchos::null)
@@ -175,33 +175,49 @@ static inline bool areSame(const ParameterList& list1, const ParameterList& list
 // Get value from one of the lists, or set it to default
 // Use case: check for a parameter value in a level-specific sublist, then in a root level list;
 // if it is absent from both, set it to default
-#define MUELU_SET_VAR_2LIST(paramList, defaultList, paramName, paramType, varName) \
-  paramType varName;                                                               \
-  if (paramList.isParameter(paramName))                                            \
-    varName = paramList.get<paramType>(paramName);                                 \
-  else if (defaultList.isParameter(paramName))                                     \
-    varName = defaultList.get<paramType>(paramName);                               \
-  else                                                                             \
-    varName = MasterList::getDefault<paramType>(paramName);
+template <class paramType>
+static inline paramType set_var_2list(const Teuchos::ParameterList& paramList, const Teuchos::ParameterList& defaultList, const std::string& paramName) {
+  if (paramList.isParameter(paramName))
+    return paramList.get<paramType>(paramName);
+  else if (defaultList.isParameter(paramName))
+    return defaultList.get<paramType>(paramName);
+  else
+    return MasterList::getDefault<paramType>(paramName);
+}
 
-#define MUELU_TEST_AND_SET_VAR(paramList, paramName, paramType, varName) \
-  (paramList.isParameter(paramName) ? varName = paramList.get<paramType>(paramName), true : false)
+template <class paramType>
+static inline bool test_and_set_var(const Teuchos::ParameterList& paramList, const std::string& paramName, paramType& varName) {
+  if (paramList.isParameter(paramName)) {
+    varName = paramList.get<paramType>(paramName);
+    return true;
+  } else
+    return false;
+}
 
-// Set parameter in a list if it is present in any of two lists
-// User case: set factory specific parameter, first checking for a level-specific value, then cheking root level value
-#define MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, paramName, paramType, listWrite)                                                     \
-  try {                                                                                                                                             \
-    if (paramList.isParameter(paramName))                                                                                                           \
-      listWrite.set(paramName, paramList.get<paramType>(paramName));                                                                                \
-    else if (defaultList.isParameter(paramName))                                                                                                    \
-      listWrite.set(paramName, defaultList.get<paramType>(paramName));                                                                              \
-  } catch (Teuchos::Exceptions::InvalidParameterType&) {                                                                                            \
-    TEUCHOS_TEST_FOR_EXCEPTION_PURE_MSG(true, Teuchos::Exceptions::InvalidParameterType,                                                            \
-                                        "Error: parameter \"" << paramName << "\" must be of type " << Teuchos::TypeNameTraits<paramType>::name()); \
+template <class paramType>
+static inline void test_and_set_param_2list(const Teuchos::ParameterList& paramList, const Teuchos::ParameterList& defaultList, const std::string& paramName, Teuchos::ParameterList& listWrite) {
+  try {
+    if (paramList.isParameter(paramName))
+      listWrite.set(paramName, paramList.get<paramType>(paramName));
+    else if (defaultList.isParameter(paramName))
+      listWrite.set(paramName, defaultList.get<paramType>(paramName));
+  } catch (Teuchos::Exceptions::InvalidParameterType&) {
+    TEUCHOS_TEST_FOR_EXCEPTION_PURE_MSG(true, Teuchos::Exceptions::InvalidParameterType,
+                                        "Error: parameter \"" << paramName << "\" must be of type " << Teuchos::TypeNameTraits<paramType>::name());
   }
+}
 
-#define MUELU_TEST_PARAM_2LIST(paramList, defaultList, paramName, paramType, cmpValue) \
-  (cmpValue == (paramList.isParameter(paramName) ? paramList.get<paramType>(paramName) : (defaultList.isParameter(paramName) ? defaultList.get<paramType>(paramName) : MasterList::getDefault<paramType>(paramName))))
+template <class paramType>
+static inline void test_and_set_var_from_masterlist(Teuchos::ParameterList& paramList, const std::string& paramName) {
+  if (!paramList.isParameter(paramName)) {
+    paramList.set(paramName, MasterList::getDefault<paramType>(paramName));
+  }
+}
+
+template <class paramType>
+static inline bool test_param_2list(const Teuchos::ParameterList& paramList, const Teuchos::ParameterList& defaultList, const std::string& paramName, const paramType& cmpValue) {
+  return (cmpValue == set_var_2list<paramType>(paramList, defaultList, paramName));
+}
 
 #define MUELU_KOKKOS_FACTORY(varName, oldFactory, newFactory) \
   RCP<Factory> varName;                                       \
@@ -220,7 +236,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     SetEasyParameterList(const ParameterList& constParamList) {
   ParameterList paramList;
 
-  MUELU_SET_VAR_2LIST(constParamList, constParamList, "problem: type", std::string, problemType);
+  auto problemType = set_var_2list<std::string>(constParamList, constParamList, "problem: type");
   if (problemType != "unknown") {
     paramList = *MasterList::GetProblemSpecificList(problemType);
     paramList.setParameters(constParamList);
@@ -232,10 +248,10 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
   // Check for Kokkos
   useKokkos_ = !Node::is_serial;
-  (void)MUELU_TEST_AND_SET_VAR(paramList, "use kokkos refactor", bool, useKokkos_);
+  (void)test_and_set_var<bool>(paramList, "use kokkos refactor", useKokkos_);
 
   // Check for timer synchronization
-  MUELU_SET_VAR_2LIST(paramList, paramList, "synchronize factory timers", bool, syncTimers);
+  auto syncTimers = set_var_2list<bool>(paramList, paramList, "synchronize factory timers");
   if (syncTimers)
     Factory::EnableTimerSync();
 
@@ -266,7 +282,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   this->numDesiredLevel_ = paramList.get<int>("max levels", MasterList::getDefault<int>("max levels"));
   blockSize_             = paramList.get<int>("number of equations", MasterList::getDefault<int>("number of equations"));
 
-  (void)MUELU_TEST_AND_SET_VAR(paramList, "debug: graph level", int, this->graphOutputLevel_);
+  (void)test_and_set_var<int>(paramList, "debug: graph level", this->graphOutputLevel_);
 
   // Generic data keeping (this keeps the data on all levels)
   if (paramList.isParameter("keep data"))
@@ -302,12 +318,12 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   // Set verbosity parameter
   VerbLevel oldVerbLevel = VerboseObject::GetDefaultVerbLevel();
   {
-    MUELU_SET_VAR_2LIST(paramList, paramList, "verbosity", std::string, verbosityLevel);
-    this->verbosity_ = toVerbLevel(verbosityLevel);
+    auto verbosityLevel = set_var_2list<std::string>(paramList, paramList, "verbosity");
+    this->verbosity_    = toVerbLevel(verbosityLevel);
     VerboseObject::SetDefaultVerbLevel(this->verbosity_);
   }
 
-  MUELU_SET_VAR_2LIST(paramList, paramList, "output filename", std::string, outputFilename);
+  auto outputFilename = set_var_2list<std::string>(paramList, paramList, "output filename");
   if (outputFilename != "")
     VerboseObject::SetMueLuOFileStream(outputFilename);
 
@@ -320,22 +336,22 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   // and not present in the list, but it is better than nothing.
   useCoordinates_ = false;
   useBlockNumber_ = false;
-  if (MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: strength-of-connection: matrix", std::string, "distance laplacian"))
+  if (test_param_2list<std::string>(paramList, paramList, "aggregation: strength-of-connection: matrix", "distance laplacian"))
     useCoordinates_ = true;
-  if (MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: use blocking", bool, true))
+  if (test_param_2list<bool>(paramList, paramList, "aggregation: use blocking", true))
     useBlockNumber_ = true;
-  if (MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: drop scheme", std::string, "distance laplacian") ||
-      MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: type", std::string, "brick") ||
-      MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: export visualization data", bool, true)) {
+  if (test_param_2list<std::string>(paramList, paramList, "aggregation: drop scheme", "distance laplacian") ||
+      test_param_2list<std::string>(paramList, paramList, "aggregation: type", "brick") ||
+      test_param_2list<bool>(paramList, paramList, "aggregation: export visualization data", true)) {
     useCoordinates_ = true;
-  } else if (MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: drop scheme", std::string, "block diagonal distance laplacian")) {
+  } else if (test_param_2list<std::string>(paramList, paramList, "aggregation: drop scheme", "block diagonal distance laplacian")) {
     useCoordinates_ = true;
     useBlockNumber_ = true;
-  } else if (MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: drop scheme", std::string, "block diagonal") ||
-             MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: drop scheme", std::string, "block diagonal classical") ||
-             MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: drop scheme", std::string, "block diagonal signed classical") ||
-             MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: drop scheme", std::string, "block diagonal colored signed classical") ||
-             MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: drop scheme", std::string, "signed classical")) {
+  } else if (test_param_2list<std::string>(paramList, paramList, "aggregation: drop scheme", "block diagonal") ||
+             test_param_2list<std::string>(paramList, paramList, "aggregation: drop scheme", "block diagonal classical") ||
+             test_param_2list<std::string>(paramList, paramList, "aggregation: drop scheme", "block diagonal signed classical") ||
+             test_param_2list<std::string>(paramList, paramList, "aggregation: drop scheme", "block diagonal colored signed classical") ||
+             test_param_2list<std::string>(paramList, paramList, "aggregation: drop scheme", "signed classical")) {
     useBlockNumber_ = true;
   } else if (paramList.isSublist("smoother: params")) {
     const auto smooParamList = paramList.sublist("smoother: params");
@@ -350,18 +366,18 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       if (paramList.isSublist(levelStr)) {
         const ParameterList& levelList = paramList.sublist(levelStr);
 
-        if (MUELU_TEST_PARAM_2LIST(levelList, paramList, "aggregation: drop scheme", std::string, "distance laplacian") ||
-            MUELU_TEST_PARAM_2LIST(levelList, paramList, "aggregation: type", std::string, "brick") ||
-            MUELU_TEST_PARAM_2LIST(levelList, paramList, "aggregation: export visualization data", bool, true)) {
+        if (test_param_2list<std::string>(levelList, paramList, "aggregation: drop scheme", "distance laplacian") ||
+            test_param_2list<std::string>(levelList, paramList, "aggregation: type", "brick") ||
+            test_param_2list<bool>(levelList, paramList, "aggregation: export visualization data", true)) {
           useCoordinates_ = true;
-        } else if (MUELU_TEST_PARAM_2LIST(levelList, paramList, "aggregation: drop scheme", std::string, "block diagonal distance laplacian")) {
+        } else if (test_param_2list<std::string>(levelList, paramList, "aggregation: drop scheme", "block diagonal distance laplacian")) {
           useCoordinates_ = true;
           useBlockNumber_ = true;
-        } else if (MUELU_TEST_PARAM_2LIST(levelList, paramList, "aggregation: drop scheme", std::string, "block diagonal") ||
-                   MUELU_TEST_PARAM_2LIST(levelList, paramList, "aggregation: drop scheme", std::string, "block diagonal classical") ||
-                   MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: drop scheme", std::string, "block diagonal signed classical") ||
-                   MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: drop scheme", std::string, "block diagonal colored signed classical") ||
-                   MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: drop scheme", std::string, "signed classical")) {
+        } else if (test_param_2list<std::string>(levelList, paramList, "aggregation: drop scheme", "block diagonal") ||
+                   test_param_2list<std::string>(levelList, paramList, "aggregation: drop scheme", "block diagonal classical") ||
+                   test_param_2list<std::string>(levelList, paramList, "aggregation: drop scheme", "block diagonal signed classical") ||
+                   test_param_2list<std::string>(levelList, paramList, "aggregation: drop scheme", "block diagonal colored signed classical") ||
+                   test_param_2list<std::string>(levelList, paramList, "aggregation: drop scheme", "signed classical")) {
           useBlockNumber_ = true;
         }
       }
@@ -369,14 +385,14 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   }
 
   useMaterial_ = false;
-  if (MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: distance laplacian metric", std::string, "material")) {
+  if (test_param_2list<std::string>(paramList, paramList, "aggregation: distance laplacian metric", "material")) {
     useMaterial_ = true;
   }
 
-  if (MUELU_TEST_PARAM_2LIST(paramList, paramList, "repartition: enable", bool, true)) {
+  if (test_param_2list<bool>(paramList, paramList, "repartition: enable", true)) {
     // We don't need coordinates if we're doing the in-place restriction
-    if (MUELU_TEST_PARAM_2LIST(paramList, paramList, "repartition: use subcommunicators", bool, true) &&
-        MUELU_TEST_PARAM_2LIST(paramList, paramList, "repartition: use subcommunicators in place", bool, true)) {
+    if (test_param_2list<bool>(paramList, paramList, "repartition: use subcommunicators", true) &&
+        test_param_2list<bool>(paramList, paramList, "repartition: use subcommunicators in place", true)) {
       // do nothing --- these don't need coordinates
     } else if (!paramList.isSublist("repartition: params")) {
       useCoordinates_ = true;
@@ -398,7 +414,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     if (paramList.isSublist(levelStr)) {
       const ParameterList& levelList = paramList.sublist(levelStr);
 
-      if (MUELU_TEST_PARAM_2LIST(levelList, paramList, "repartition: enable", bool, true)) {
+      if (test_param_2list<bool>(levelList, paramList, "repartition: enable", true)) {
         if (!levelList.isSublist("repartition: params")) {
           useCoordinates_ = true;
           break;
@@ -422,19 +438,19 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   // Detect if we do implicit P and R rebalance
   changedPRrebalance_        = false;
   changedPRViaCopyrebalance_ = false;
-  if (MUELU_TEST_PARAM_2LIST(paramList, paramList, "repartition: enable", bool, true)) {
-    changedPRrebalance_        = MUELU_TEST_AND_SET_VAR(paramList, "repartition: rebalance P and R", bool, this->doPRrebalance_);
-    changedPRViaCopyrebalance_ = MUELU_TEST_AND_SET_VAR(paramList, "repartition: explicit via new copy rebalance P and R", bool, this->doPRViaCopyrebalance_);
+  if (test_param_2list<bool>(paramList, paramList, "repartition: enable", true)) {
+    changedPRrebalance_        = test_and_set_var<bool>(paramList, "repartition: rebalance P and R", this->doPRrebalance_);
+    changedPRViaCopyrebalance_ = test_and_set_var<bool>(paramList, "repartition: explicit via new copy rebalance P and R", this->doPRViaCopyrebalance_);
   }
 
   // Detect if we use implicit transpose
-  changedImplicitTranspose_ = MUELU_TEST_AND_SET_VAR(paramList, "transpose: use implicit", bool, this->implicitTranspose_);
+  changedImplicitTranspose_ = test_and_set_var<bool>(paramList, "transpose: use implicit", this->implicitTranspose_);
 
   // Detect if we use fuse prolongation and update
-  (void)MUELU_TEST_AND_SET_VAR(paramList, "fuse prolongation and update", bool, this->fuseProlongationAndUpdate_);
+  (void)test_and_set_var<bool>(paramList, "fuse prolongation and update", this->fuseProlongationAndUpdate_);
 
   // Detect if we suppress the dimension check of the user-given nullspace
-  (void)MUELU_TEST_AND_SET_VAR(paramList, "nullspace: suppress dimension check", bool, this->suppressNullspaceDimensionCheck_);
+  (void)test_and_set_var<bool>(paramList, "nullspace: suppress dimension check", this->suppressNullspaceDimensionCheck_);
 
   if (paramList.isSublist("matvec params"))
     this->matvecParams_ = Teuchos::parameterList(paramList.sublist("matvec params"));
@@ -483,10 +499,10 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   // FIXME: parameters passed to packages, like Ifpack2, are not touched by us, resulting in "[unused]" flag
   // being displayed. On the other hand, we don't want to simply iterate through them touching. I don't know
   // what a good solution looks like
-  if (MUELU_TEST_PARAM_2LIST(paramList, paramList, "print initial parameters", bool, true))
+  if (test_param_2list<bool>(paramList, paramList, "print initial parameters", true))
     this->GetOStream(static_cast<MsgType>(Runtime1), 0) << paramList << std::endl;
 
-  if (MUELU_TEST_PARAM_2LIST(paramList, paramList, "print unused parameters", bool, true)) {
+  if (test_param_2list<bool>(paramList, paramList, "print unused parameters", true)) {
     // Check unused parameters
     ParameterList unusedParamList;
 
@@ -543,11 +559,11 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   if (paramList.numParams() == 0 && defaultList.numParams() > 0)
     paramList = ParameterList(defaultList);
 
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "reuse: type", std::string, reuseType);
+  auto reuseType = set_var_2list<std::string>(paramList, defaultList, "reuse: type");
   TEUCHOS_TEST_FOR_EXCEPTION(strings({"none", "tP", "RP", "emin", "RAP", "full", "S"}).count(reuseType) == 0,
                              Exceptions::RuntimeError, "Unknown \"reuse: type\" value: \"" << reuseType << "\". Please consult User's Guide.");
 
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "multigrid algorithm", std::string, multigridAlgo);
+  auto multigridAlgo = set_var_2list<std::string>(paramList, defaultList, "multigrid algorithm");
   TEUCHOS_TEST_FOR_EXCEPTION(strings({"unsmoothed", "sa", "pg", "emin", "matlab", "pcoarsen", "classical", "smoothed reitzinger", "unsmoothed reitzinger", "replicate", "combine"}).count(multigridAlgo) == 0,
                              Exceptions::RuntimeError, "Unknown \"multigrid algorithm\" value: \"" << multigridAlgo << "\". Please consult User's Guide.");
 #ifndef HAVE_MUELU_MATLAB
@@ -580,7 +596,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   // == Non-serializable data ===
   // Check both the parameter and the type
   bool have_userP = false;
-  if (paramList.isParameter("P") && !paramList.get<RCP<Matrix> >("P").is_null())
+  if (paramList.isParameter("P") && !paramList.get<RCP<Matrix>>("P").is_null())
     have_userP = true;
 
   // === Coarse solver ===
@@ -703,9 +719,9 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     UpdateFactoryManager_Smoothers(ParameterList& paramList, const ParameterList& defaultList,
                                    FactoryManager& manager, int levelID, std::vector<keep_pair>& keeps) const {
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "multigrid algorithm", std::string, multigridAlgo);
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "reuse: type", std::string, reuseType);
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "sa: use rowsumabs diagonal scaling", bool, useMaxAbsDiagonalScaling);
+  auto multigridAlgo            = set_var_2list<std::string>(paramList, defaultList, "multigrid algorithm");
+  auto reuseType                = set_var_2list<std::string>(paramList, defaultList, "reuse: type");
+  auto useMaxAbsDiagonalScaling = set_var_2list<bool>(paramList, defaultList, "sa: use rowsumabs diagonal scaling");
 
   // === Smoothing ===
   // FIXME: should custom smoother check default list too?
@@ -716,7 +732,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       paramList.isParameter("smoother: sweeps") || paramList.isParameter("smoother: pre sweeps") || paramList.isParameter("smoother: post sweeps") ||
       paramList.isParameter("smoother: overlap") || paramList.isParameter("smoother: pre overlap") || paramList.isParameter("smoother: post overlap");
 
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "smoother: pre or post", std::string, PreOrPost);
+  auto PreOrPost = set_var_2list<std::string>(paramList, defaultList, "smoother: pre or post");
   if (PreOrPost == "none") {
     manager.SetFactory("Smoother", Teuchos::null);
 
@@ -775,8 +791,8 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       if (paramList.isParameter("smoother: pre type")) {
         preSmootherType = paramList.get<std::string>("smoother: pre type");
       } else {
-        MUELU_SET_VAR_2LIST(paramList, defaultList, "smoother: type", std::string, preSmootherTypeTmp);
-        preSmootherType = preSmootherTypeTmp;
+        auto preSmootherTypeTmp = set_var_2list<std::string>(paramList, defaultList, "smoother: type");
+        preSmootherType         = preSmootherTypeTmp;
       }
       if (paramList.isParameter("smoother: pre overlap"))
         overlap = paramList.get<int>("smoother: pre overlap");
@@ -821,8 +837,8 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       if (paramList.isParameter("smoother: post type"))
         postSmootherType = paramList.get<std::string>("smoother: post type");
       else {
-        MUELU_SET_VAR_2LIST(paramList, defaultList, "smoother: type", std::string, postSmootherTypeTmp);
-        postSmootherType = postSmootherTypeTmp;
+        auto postSmootherTypeTmp = set_var_2list<std::string>(paramList, defaultList, "smoother: type");
+        postSmootherType         = postSmootherTypeTmp;
       }
 
       if (paramList.isSublist("smoother: post params"))
@@ -936,14 +952,14 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   bool isCustomCoarseSolver =
       paramList.isParameter("coarse: type") ||
       paramList.isParameter("coarse: params");
-  if (MUELU_TEST_PARAM_2LIST(paramList, defaultList, "coarse: type", std::string, "none")) {
+  if (test_param_2list<std::string>(paramList, defaultList, "coarse: type", "none")) {
     manager.SetFactory("CoarseSolver", Teuchos::null);
 
   } else if (isCustomCoarseSolver) {
     // FIXME: get default values from the factory
     // NOTE: none of the smoothers at the moment use parameter validation framework, so we
     // cannot get the default values from it.
-    MUELU_SET_VAR_2LIST(paramList, defaultList, "coarse: type", std::string, coarseType);
+    auto coarseType = set_var_2list<std::string>(paramList, defaultList, "coarse: type");
 
     int overlap = 0;
     if (paramList.isParameter("coarse: overlap"))
@@ -991,10 +1007,10 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     UpdateFactoryManager_Reitzinger(ParameterList& paramList, const ParameterList& defaultList,
                                     FactoryManager& manager, int levelID, std::vector<keep_pair>& keeps) const {
   ParameterList rParams;
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: enable", bool, rParams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: use subcommunicators", bool, rParams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "tentative: constant column sums", bool, rParams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "tentative: calculate qr", bool, rParams);
+  test_and_set_param_2list<bool>(paramList, defaultList, "repartition: enable", rParams);
+  test_and_set_param_2list<bool>(paramList, defaultList, "repartition: use subcommunicators", rParams);
+  test_and_set_param_2list<bool>(paramList, defaultList, "tentative: constant column sums", rParams);
+  test_and_set_param_2list<bool>(paramList, defaultList, "tentative: calculate qr", rParams);
 
   RCP<Factory> rFactory = rcp(new ReitzingerPFactory());
   rFactory->SetParameterList(rParams);
@@ -1023,9 +1039,9 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
                                                 FactoryManager& manager, int levelID, std::vector<keep_pair>& keeps) const {
   using strings = std::unordered_set<std::string>;
 
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "reuse: type", std::string, reuseType);
+  auto reuseType = set_var_2list<std::string>(paramList, defaultList, "reuse: type");
 
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "aggregation: type", std::string, aggType);
+  auto aggType = set_var_2list<std::string>(paramList, defaultList, "aggregation: type");
   TEUCHOS_TEST_FOR_EXCEPTION(!strings({"uncoupled", "coupled", "brick", "matlab", "notay", "classical"}).count(aggType),
                              Exceptions::RuntimeError, "Unknown aggregation algorithm: \"" << aggType << "\". Please consult User's Guide.");
 
@@ -1039,7 +1055,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   // Aggregation graph
   RCP<Factory> dropFactory;
 
-  if (MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: drop scheme", std::string, "matlab")) {
+  if (test_param_2list<std::string>(paramList, paramList, "aggregation: drop scheme", "matlab")) {
 #ifdef HAVE_MUELU_MATLAB
     dropFactory             = rcp(new SingleLevelMatlabFactory());
     ParameterList socParams = paramList.sublist("strength-of-connection: params");
@@ -1047,52 +1063,52 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 #else
     throw std::runtime_error("Cannot use MATLAB evolutionary strength-of-connection - MueLu was not configured with MATLAB support.");
 #endif
-  } else if (MUELU_TEST_PARAM_2LIST(paramList, paramList, "aggregation: drop scheme", std::string, "unsupported vector smoothing")) {
+  } else if (test_param_2list<std::string>(paramList, paramList, "aggregation: drop scheme", "unsupported vector smoothing")) {
     dropFactory = rcp(new MueLu::SmooVecCoalesceDropFactory<SC, LO, GO, NO>());
     ParameterList dropParams;
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: drop scheme", std::string, dropParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: block diagonal: interleaved blocksize", int, dropParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: number of random vectors", int, dropParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: number of times to pre or post smooth", int, dropParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: penalty parameters", Teuchos::Array<double>, dropParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: drop scheme", dropParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "aggregation: block diagonal: interleaved blocksize", dropParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "aggregation: number of random vectors", dropParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "aggregation: number of times to pre or post smooth", dropParams);
+    test_and_set_param_2list<Teuchos::Array<double>>(paramList, defaultList, "aggregation: penalty parameters", dropParams);
     dropFactory->SetParameterList(dropParams);
   } else {
     MUELU_KOKKOS_FACTORY_NO_DECL(dropFactory, CoalesceDropFactory, CoalesceDropFactory_kokkos);
     ParameterList dropParams;
     if (!rcp_dynamic_cast<CoalesceDropFactory>(dropFactory).is_null())
       dropParams.set("lightweight wrap", true);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: drop scheme", std::string, dropParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: row sum drop tol", double, dropParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: block diagonal: interleaved blocksize", int, dropParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: drop tol", double, dropParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: use ml scaling of drop tol", bool, dropParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: drop scheme", dropParams);
+    test_and_set_param_2list<double>(paramList, defaultList, "aggregation: row sum drop tol", dropParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "aggregation: block diagonal: interleaved blocksize", dropParams);
+    test_and_set_param_2list<double>(paramList, defaultList, "aggregation: drop tol", dropParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: use ml scaling of drop tol", dropParams);
 
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: Dirichlet threshold", double, dropParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: greedy Dirichlet", bool, dropParams);
+    test_and_set_param_2list<double>(paramList, defaultList, "aggregation: Dirichlet threshold", dropParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: greedy Dirichlet", dropParams);
     if (useKokkos_)
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: distance laplacian metric", std::string, dropParams);
+      test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: distance laplacian metric", dropParams);
 #ifdef HAVE_MUELU_COALESCEDROP_ALLOW_OLD_PARAMETERS
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: distance laplacian algo", std::string, dropParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: classical algo", std::string, dropParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: distance laplacian algo", dropParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: classical algo", dropParams);
 #endif
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: distance laplacian directional weights", Teuchos::Array<double>, dropParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: coloring: localize color graph", bool, dropParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: dropping may create Dirichlet", bool, dropParams);
+    test_and_set_param_2list<Teuchos::Array<double>>(paramList, defaultList, "aggregation: distance laplacian directional weights", dropParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: coloring: localize color graph", dropParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: dropping may create Dirichlet", dropParams);
     if (useKokkos_) {
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: use blocking", bool, dropParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: symmetrize graph after dropping", bool, dropParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: strength-of-connection: matrix", std::string, dropParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: strength-of-connection: measure", std::string, dropParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: use lumping", bool, dropParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: reuse graph", bool, dropParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: reuse eigenvalue", bool, dropParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: use root stencil", bool, dropParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: Dirichlet threshold", double, dropParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: use spread lumping", bool, dropParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: lumping choice", std::string, dropParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: spread lumping diag dom growth factor", double, dropParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: spread lumping diag dom cap", double, dropParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: count negative diagonals", bool, dropParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: use blocking", dropParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: symmetrize graph after dropping", dropParams);
+      test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: strength-of-connection: matrix", dropParams);
+      test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: strength-of-connection: measure", dropParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: use lumping", dropParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: reuse graph", dropParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: reuse eigenvalue", dropParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: use root stencil", dropParams);
+      test_and_set_param_2list<double>(paramList, defaultList, "filtered matrix: Dirichlet threshold", dropParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: use spread lumping", dropParams);
+      test_and_set_param_2list<std::string>(paramList, defaultList, "filtered matrix: lumping choice", dropParams);
+      test_and_set_param_2list<double>(paramList, defaultList, "filtered matrix: spread lumping diag dom growth factor", dropParams);
+      test_and_set_param_2list<double>(paramList, defaultList, "filtered matrix: spread lumping diag dom cap", dropParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: count negative diagonals", dropParams);
     }
 
 #ifdef HAVE_MUELU_COALESCEDROP_ALLOW_OLD_PARAMETERS
@@ -1101,17 +1117,10 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
          ((dropParams.get<std::string>("aggregation: drop scheme") != "point-wise") && (dropParams.get<std::string>("aggregation: drop scheme") != "cut-drop")))) {
       Teuchos::ParameterList dropParamsWithDefaults(dropParams);
 
-#define MUELU_TEST_AND_SET_VAR_FROM_MASTERLIST(paramList, paramName, paramType) \
-  if (!paramList.isParameter(paramName)) {                                      \
-    paramList.set(paramName, MasterList::getDefault<paramType>(paramName));     \
-  }
-
-      MUELU_TEST_AND_SET_VAR_FROM_MASTERLIST(dropParamsWithDefaults, "aggregation: drop scheme", std::string);
-      MUELU_TEST_AND_SET_VAR_FROM_MASTERLIST(dropParamsWithDefaults, "aggregation: strength-of-connection: matrix", std::string);
-      MUELU_TEST_AND_SET_VAR_FROM_MASTERLIST(dropParamsWithDefaults, "aggregation: strength-of-connection: measure", std::string);
-      MUELU_TEST_AND_SET_VAR_FROM_MASTERLIST(dropParamsWithDefaults, "aggregation: use blocking", bool);
-
-#undef MUELU_TEST_AND_SET_VAR_FROM_MASTERLIST
+      test_and_set_var_from_masterlist<std::string>(dropParamsWithDefaults, "aggregation: drop scheme");
+      test_and_set_var_from_masterlist<std::string>(dropParamsWithDefaults, "aggregation: strength-of-connection: matrix");
+      test_and_set_var_from_masterlist<std::string>(dropParamsWithDefaults, "aggregation: strength-of-connection: measure");
+      test_and_set_var_from_masterlist<bool>(dropParamsWithDefaults, "aggregation: use blocking");
 
       // We are using the old style of dropping params
       TEUCHOS_TEST_FOR_EXCEPTION(dropParams.isParameter("aggregation: strength-of-connection: matrix") ||
@@ -1131,7 +1140,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       std::string drop_scheme = dropParams.get<std::string>("aggregation: drop scheme");
       if (drop_scheme == "block diagonal colored signed classical")
         manager.SetFactory("Coloring Graph", dropFactory);
-      if ((MUELU_TEST_PARAM_2LIST(dropParams, defaultList, "aggregation: use blocking", bool, true)) ||
+      if ((test_param_2list<bool>(dropParams, defaultList, "aggregation: use blocking", true)) ||
           (drop_scheme.find("block diagonal") != std::string::npos || drop_scheme == "signed classical")) {
         if (levelID > 0)
           dropFactory->SetFactory("BlockNumber", this->GetFactoryManager(levelID - 1)->GetFactory("BlockNumber"));
@@ -1153,34 +1162,34 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   if (aggType == "uncoupled") {
     aggFactory = rcp(new UncoupledAggregationFactory());
     ParameterList aggParams;
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: ordering", std::string, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: min agg size", int, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: max agg size", int, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: max selected neighbors", int, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: backend", std::string, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: phase 1 algorithm", std::string, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: deterministic", bool, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: coloring algorithm", std::string, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 1", bool, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 2a", bool, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 2b", bool, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: enable phase 3", bool, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: match ML phase1", bool, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: match ML phase2a", bool, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: match ML phase2b", bool, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: phase2a agg factor", double, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: preserve Dirichlet points", bool, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: error on nodes with no on-rank neighbors", bool, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: phase3 avoid singletons", bool, aggParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: ordering", aggParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "aggregation: min agg size", aggParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "aggregation: max agg size", aggParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "aggregation: max selected neighbors", aggParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: backend", aggParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: phase 1 algorithm", aggParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: deterministic", aggParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: coloring algorithm", aggParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: enable phase 1", aggParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: enable phase 2a", aggParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: enable phase 2b", aggParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: enable phase 3", aggParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: match ML phase1", aggParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: match ML phase2a", aggParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: match ML phase2b", aggParams);
+    test_and_set_param_2list<double>(paramList, defaultList, "aggregation: phase2a agg factor", aggParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: preserve Dirichlet points", aggParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: error on nodes with no on-rank neighbors", aggParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: phase3 avoid singletons", aggParams);
     aggFactory->SetParameterList(aggParams);
     // make sure that the aggregation factory has all necessary data
     aggFactory->SetFactory("DofsPerNode", manager.GetFactory("Graph"));
     aggFactory->SetFactory("Graph", manager.GetFactory("Graph"));
     //      aggFactory->SetFactory("UnAmalgamationInfo", manager.GetFactory("UnAmalgamationInfo"));
 
-    if (MUELU_TEST_PARAM_2LIST(paramList, defaultList, "aggregation: coloring algorithm", std::string, "mis2 aggregation") ||
-        MUELU_TEST_PARAM_2LIST(paramList, defaultList, "aggregation: coloring algorithm", std::string, "mis2 coarsening")) {
-      if (MUELU_TEST_PARAM_2LIST(paramList, defaultList, "aggregation: symmetrize graph after dropping", bool, false))
+    if (test_param_2list<std::string>(paramList, defaultList, "aggregation: coloring algorithm", "mis2 aggregation") ||
+        test_param_2list<std::string>(paramList, defaultList, "aggregation: coloring algorithm", "mis2 coarsening")) {
+      if (test_param_2list<bool>(paramList, defaultList, "aggregation: symmetrize graph after dropping", false))
         TEUCHOS_TEST_FOR_EXCEPTION(true,
                                    Exceptions::RuntimeError,
                                    "MIS2 algorithms require the use of a symmetrized graph. Please set \"aggregation: symmetrize graph after dropping\" to \"true\".");
@@ -1188,12 +1197,12 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   } else if (aggType == "brick") {
     aggFactory = rcp(new BrickAggregationFactory());
     ParameterList aggParams;
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: brick x size", int, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: brick y size", int, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: brick z size", int, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: brick x Dirichlet", bool, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: brick y Dirichlet", bool, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: brick z Dirichlet", bool, aggParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "aggregation: brick x size", aggParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "aggregation: brick y size", aggParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "aggregation: brick z size", aggParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: brick x Dirichlet", aggParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: brick y Dirichlet", aggParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: brick z Dirichlet", aggParams);
     aggFactory->SetParameterList(aggParams);
 
     // Unlike other factories, BrickAggregationFactory makes the Graph/DofsPerNode itself
@@ -1210,11 +1219,11 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     // Map and coloring
     RCP<Factory> mapFact = rcp(new ClassicalMapFactory());
     ParameterList mapParams;
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: deterministic", bool, mapParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: coloring algorithm", std::string, mapParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: deterministic", mapParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: coloring algorithm", mapParams);
 
     ParameterList tempParams;
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: drop scheme", std::string, tempParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: drop scheme", tempParams);
     std::string drop_algo = tempParams.get<std::string>("aggregation: drop scheme");
     if (drop_algo == "block diagonal colored signed classical") {
       mapParams.set("aggregation: coloring: use color graph", true);
@@ -1229,8 +1238,8 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
     aggFactory = rcp(new ClassicalPFactory());
     ParameterList aggParams;
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: classical scheme", std::string, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: drop scheme", std::string, aggParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: classical scheme", aggParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: drop scheme", aggParams);
     aggFactory->SetParameterList(aggParams);
     aggFactory->SetFactory("FC Splitting", manager.GetFactory("FC Splitting"));
     aggFactory->SetFactory("CoarseMap", manager.GetFactory("CoarseMap"));
@@ -1256,10 +1265,10 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   } else if (aggType == "notay") {
     aggFactory = rcp(new NotayAggregationFactory());
     ParameterList aggParams;
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: pairwise: size", int, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: pairwise: tie threshold", double, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: Dirichlet threshold", double, aggParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: ordering", std::string, aggParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "aggregation: pairwise: size", aggParams);
+    test_and_set_param_2list<double>(paramList, defaultList, "aggregation: pairwise: tie threshold", aggParams);
+    test_and_set_param_2list<double>(paramList, defaultList, "aggregation: Dirichlet threshold", aggParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: ordering", aggParams);
     aggFactory->SetParameterList(aggParams);
     aggFactory->SetFactory("DofsPerNode", manager.GetFactory("Graph"));
     aggFactory->SetFactory("Graph", manager.GetFactory("Graph"));
@@ -1286,8 +1295,8 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     ptentParams.sublist("matrixmatrix: kernel params", false) = paramList.sublist("matrixmatrix: kernel params");
   if (defaultList.isSublist("matrixmatrix: kernel params"))
     ptentParams.sublist("matrixmatrix: kernel params", false) = defaultList.sublist("matrixmatrix: kernel params");
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "tentative: calculate qr", bool, ptentParams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "tentative: build coarse coordinates", bool, ptentParams);
+  test_and_set_param_2list<bool>(paramList, defaultList, "tentative: calculate qr", ptentParams);
+  test_and_set_param_2list<bool>(paramList, defaultList, "tentative: build coarse coordinates", ptentParams);
   Ptent->SetParameterList(ptentParams);
   Ptent->SetFactory("Aggregates", manager.GetFactory("Aggregates"));
   Ptent->SetFactory("CoarseMap", manager.GetFactory("CoarseMap"));
@@ -1306,7 +1315,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     UpdateFactoryManager_RAP(ParameterList& paramList, const ParameterList& defaultList, FactoryManager& manager,
                              int levelID, std::vector<keep_pair>& keeps) const {
-  if (paramList.isParameter("A") && !paramList.get<RCP<Matrix> >("A").is_null()) {
+  if (paramList.isParameter("A") && !paramList.get<RCP<Matrix>>("A").is_null()) {
     // We have user matrix A
     manager.SetFactory("A", NoFactory::getRCP());
     return;
@@ -1317,30 +1326,30 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   RCP<RAPFactory> RAP;
   RCP<RAPShiftFactory> RAPs;
   // Allow for Galerkin or shifted RAP
-  // FIXME: Should this not be some form of MUELU_SET_VAR_2LIST?
+  // FIXME: Should this not be some form of set_var_2list?
   std::string alg = paramList.get("rap: algorithm", "galerkin");
   if (alg == "shift" || alg == "non-galerkin") {
     RAPs = rcp(new RAPShiftFactory());
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "rap: shift", double, RAPparams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "rap: shift diagonal M", bool, RAPparams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "rap: shift low storage", bool, RAPparams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "rap: shift array", Teuchos::Array<double>, RAPparams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "rap: cfl array", Teuchos::Array<double>, RAPparams);
+    test_and_set_param_2list<double>(paramList, defaultList, "rap: shift", RAPparams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "rap: shift diagonal M", RAPparams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "rap: shift low storage", RAPparams);
+    test_and_set_param_2list<Teuchos::Array<double>>(paramList, defaultList, "rap: shift array", RAPparams);
+    test_and_set_param_2list<Teuchos::Array<double>>(paramList, defaultList, "rap: cfl array", RAPparams);
 
   } else {
     RAP = rcp(new RAPFactory());
   }
 
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "rap: relative diagonal floor", Teuchos::Array<double>, RAPparams);
+  test_and_set_param_2list<Teuchos::Array<double>>(paramList, defaultList, "rap: relative diagonal floor", RAPparams);
 
   if (paramList.isSublist("matrixmatrix: kernel params"))
     RAPparams.sublist("matrixmatrix: kernel params", false) = paramList.sublist("matrixmatrix: kernel params");
   if (defaultList.isSublist("matrixmatrix: kernel params"))
     RAPparams.sublist("matrixmatrix: kernel params", false) = defaultList.sublist("matrixmatrix: kernel params");
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "transpose: use implicit", bool, RAPparams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "rap: fix zero diagonals", bool, RAPparams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "rap: fix zero diagonals threshold", double, RAPparams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "rap: fix zero diagonals replacement", Scalar, RAPparams);
+  test_and_set_param_2list<bool>(paramList, defaultList, "transpose: use implicit", RAPparams);
+  test_and_set_param_2list<bool>(paramList, defaultList, "rap: fix zero diagonals", RAPparams);
+  test_and_set_param_2list<double>(paramList, defaultList, "rap: fix zero diagonals threshold", RAPparams);
+  test_and_set_param_2list<Scalar>(paramList, defaultList, "rap: fix zero diagonals replacement", RAPparams);
 
   // if "rap: triple product" has not been set and algorithm is "unsmoothed" switch triple product on
   if (!paramList.isParameter("rap: triple product") &&
@@ -1348,7 +1357,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       paramList.get<std::string>("multigrid algorithm") == "unsmoothed")
     paramList.set("rap: triple product", true);
   else
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "rap: triple product", bool, RAPparams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "rap: triple product", RAPparams);
 
   try {
     if (paramList.isParameter("aggregation: allow empty prolongator columns")) {
@@ -1380,7 +1389,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   }
 
   // Matrix analysis
-  if (MUELU_TEST_PARAM_2LIST(paramList, defaultList, "matrix: compute analysis", bool, true)) {
+  if (test_param_2list<bool>(paramList, defaultList, "matrix: compute analysis", true)) {
     RCP<Factory> matrixAnalysisFact = rcp(new MatrixAnalysisFactory());
 
     if (!RAP.is_null())
@@ -1390,17 +1399,17 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   }
 
   // Aggregate qualities
-  if (MUELU_TEST_PARAM_2LIST(paramList, defaultList, "aggregation: compute aggregate qualities", bool, true)) {
+  if (test_param_2list<bool>(paramList, defaultList, "aggregation: compute aggregate qualities", true)) {
     RCP<Factory> aggQualityFact = rcp(new AggregateQualityEstimateFactory());
     ParameterList aggQualityParams;
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: good aggregate threshold", double, aggQualityParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: file output", bool, aggQualityParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: file base", std::string, aggQualityParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: check symmetry", bool, aggQualityParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: algorithm", std::string, aggQualityParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: zero threshold", double, aggQualityParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: percentiles", Teuchos::Array<double>, aggQualityParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregate qualities: mode", std::string, aggQualityParams);
+    test_and_set_param_2list<double>(paramList, defaultList, "aggregate qualities: good aggregate threshold", aggQualityParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregate qualities: file output", aggQualityParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregate qualities: file base", aggQualityParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregate qualities: check symmetry", aggQualityParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregate qualities: algorithm", aggQualityParams);
+    test_and_set_param_2list<double>(paramList, defaultList, "aggregate qualities: zero threshold", aggQualityParams);
+    test_and_set_param_2list<Teuchos::Array<double>>(paramList, defaultList, "aggregate qualities: percentiles", aggQualityParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregate qualities: mode", aggQualityParams);
     aggQualityFact->SetParameterList(aggQualityParams);
     aggQualityFact->SetFactory("Aggregates", manager.GetFactory("Aggregates"));
     aggQualityFact->SetFactory("CoarseMap", manager.GetFactory("CoarseMap"));
@@ -1412,18 +1421,18 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       RAPs->AddTransferFactory(aggQualityFact);
   }
 
-  if (MUELU_TEST_PARAM_2LIST(paramList, defaultList, "aggregation: export visualization data", bool, true)) {
+  if (test_param_2list<bool>(paramList, defaultList, "aggregation: export visualization data", true)) {
     RCP<AggregationExportFactory> aggExport = rcp(new AggregationExportFactory());
     ParameterList aggExportParams;
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: output filename", std::string, aggExportParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: output file: agg style", std::string, aggExportParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: output file: iter", int, aggExportParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: output file: time step", int, aggExportParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: output file: fine graph edges", bool, aggExportParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: output file: coarse graph edges", bool, aggExportParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: output file: build colormap", bool, aggExportParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: output file: aggregate qualities", bool, aggExportParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: output file: material", bool, aggExportParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: output filename", aggExportParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: output file: agg style", aggExportParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "aggregation: output file: iter", aggExportParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "aggregation: output file: time step", aggExportParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: output file: fine graph edges", aggExportParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: output file: coarse graph edges", aggExportParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: output file: build colormap", aggExportParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: output file: aggregate qualities", aggExportParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: output file: material", aggExportParams);
     aggExport->SetParameterList(aggExportParams);
     aggExport->SetFactory("AggregateQualities", manager.GetFactory("AggregateQualities"));
     aggExport->SetFactory("DofsPerNode", manager.GetFactory("DofsPerNode"));
@@ -1440,9 +1449,9 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   else
     manager.SetFactory("A", RAPs);
 
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "reuse: type", std::string, reuseType);
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "sa: use filtered matrix", bool, useFiltering);
-  bool filteringChangesMatrix = useFiltering && !MUELU_TEST_PARAM_2LIST(paramList, defaultList, "aggregation: drop tol", double, 0);
+  auto reuseType              = set_var_2list<std::string>(paramList, defaultList, "reuse: type");
+  auto useFiltering           = set_var_2list<bool>(paramList, defaultList, "sa: use filtered matrix");
+  bool filteringChangesMatrix = useFiltering && !test_param_2list<double>(paramList, defaultList, "aggregation: drop tol", 0);
 
   if (reuseType == "RP" || (reuseType == "tP" && !filteringChangesMatrix)) {
     if (!RAP.is_null()) {
@@ -1464,7 +1473,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     UpdateFactoryManager_Coordinates(ParameterList& paramList, const ParameterList& /* defaultList */,
                                      FactoryManager& manager, int /* levelID */, std::vector<keep_pair>& /* keeps */) const {
   bool have_userCO = false;
-  if (paramList.isParameter("Coordinates") && !paramList.get<RCP<MultiVector> >("Coordinates").is_null())
+  if (paramList.isParameter("Coordinates") && !paramList.get<RCP<MultiVector>>("Coordinates").is_null())
     have_userCO = true;
 
   if (useCoordinates_) {
@@ -1496,7 +1505,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     UpdateFactoryManager_Material(ParameterList& paramList, const ParameterList& /* defaultList */,
                                   FactoryManager& manager, int /* levelID */, std::vector<keep_pair>& /* keeps */) const {
   bool have_userMaterial = false;
-  if (paramList.isParameter("Material") && !paramList.get<RCP<MultiVector> >("Material").is_null())
+  if (paramList.isParameter("Material") && !paramList.get<RCP<MultiVector>>("Material").is_null())
     have_userMaterial = true;
 
   if (useMaterial_) {
@@ -1566,7 +1575,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   if (useBlockNumber_) {
     ParameterList myParams;
     RCP<Factory> fact = rcp(new InitialBlockNumberFactory());
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "aggregation: block diagonal: interleaved blocksize", int, myParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "aggregation: block diagonal: interleaved blocksize", myParams);
     fact->SetParameterList(myParams);
     manager.SetFactory("BlockNumber", fact);
   }
@@ -1579,15 +1588,15 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     UpdateFactoryManager_Restriction(ParameterList& paramList, const ParameterList& defaultList, FactoryManager& manager,
                                      int levelID, std::vector<keep_pair>& /* keeps */) const {
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "multigrid algorithm", std::string, multigridAlgo);
-  bool have_userR = false;
-  if (paramList.isParameter("R") && !paramList.get<RCP<Matrix> >("R").is_null())
+  auto multigridAlgo = set_var_2list<std::string>(paramList, defaultList, "multigrid algorithm");
+  bool have_userR    = false;
+  if (paramList.isParameter("R") && !paramList.get<RCP<Matrix>>("R").is_null())
     have_userR = true;
 
   // === Restriction ===
   RCP<Factory> R;
   if (!this->implicitTranspose_) {
-    MUELU_SET_VAR_2LIST(paramList, defaultList, "problem: symmetric", bool, isSymmetric);
+    auto isSymmetric = set_var_2list<bool>(paramList, defaultList, "problem: symmetric");
 
     if (isSymmetric == false && (multigridAlgo == "unsmoothed" || multigridAlgo == "emin")) {
       this->GetOStream(Warnings0) << "Switching \"problem: symmetric\" parameter to symmetric as multigrid algorithm. " << multigridAlgo << " is primarily supposed to be used for symmetric problems.\n\n"
@@ -1640,11 +1649,11 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     UpdateFactoryManager_Repartition(ParameterList& paramList, const ParameterList& defaultList, FactoryManager& manager,
                                      int levelID, std::vector<keep_pair>& keeps, RCP<Factory>& nullSpaceFactory) const {
   // === Repartitioning ===
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "reuse: type", std::string, reuseType);
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "repartition: enable", bool, enableRepart);
+  auto reuseType    = set_var_2list<std::string>(paramList, defaultList, "reuse: type");
+  auto enableRepart = set_var_2list<bool>(paramList, defaultList, "repartition: enable");
   if (enableRepart) {
 #if defined(HAVE_MPI) && (defined(HAVE_MUELU_ZOLTAN) || defined(HAVE_MUELU_ZOLTAN2))  // skip to the end, print warning, and turn off repartitioning if we don't have MPI and Zoltan/Zoltan2
-    MUELU_SET_VAR_2LIST(paramList, defaultList, "repartition: use subcommunicators in place", bool, enableInPlace);
+    auto enableInPlace = set_var_2list<bool>(paramList, defaultList, "repartition: use subcommunicators in place");
     // Short summary of the issue: RebalanceTransferFactory shares ownership
     // of "P" with SaPFactory, and therefore, changes the stored version.
     // That means that if SaPFactory generated P, and stored it on the level,
@@ -1686,7 +1695,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     // TEUCHOS_TEST_FOR_EXCEPTION(aggType == "brick", Exceptions::InvalidArgument,
     //                            "Aggregation type \"brick\" requires \"repartition: enable\" set to \"false\"");
 
-    MUELU_SET_VAR_2LIST(paramList, defaultList, "repartition: partitioner", std::string, partName);
+    auto partName = set_var_2list<std::string>(paramList, defaultList, "repartition: partitioner");
     TEUCHOS_TEST_FOR_EXCEPTION(partName != "zoltan" && partName != "zoltan2", Exceptions::InvalidArgument,
                                "Invalid partitioner name: \"" << partName << "\". Valid options: \"zoltan\", \"zoltan2\"");
 
@@ -1710,19 +1719,19 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     }
 #endif  // HAVE_MUELU_ZOLTAN2
 
-    MUELU_SET_VAR_2LIST(paramList, defaultList, "repartition: node repartition level", int, nodeRepartitionLevel);
+    auto nodeRepartitionLevel = set_var_2list<int>(paramList, defaultList, "repartition: node repartition level");
 
     // RepartitionHeuristic
     auto repartheurFactory = rcp(new RepartitionHeuristicFactory());
     ParameterList repartheurParams;
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: node repartition level", int, repartheurParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: start level", int, repartheurParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: min rows per proc", int, repartheurParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: target rows per proc", int, repartheurParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: min rows per thread", int, repartheurParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: target rows per thread", int, repartheurParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: max imbalance", double, repartheurParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: put on single proc", int, repartheurParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "repartition: node repartition level", repartheurParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "repartition: start level", repartheurParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "repartition: min rows per proc", repartheurParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "repartition: target rows per proc", repartheurParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "repartition: min rows per thread", repartheurParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "repartition: target rows per thread", repartheurParams);
+    test_and_set_param_2list<double>(paramList, defaultList, "repartition: max imbalance", repartheurParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "repartition: put on single proc", repartheurParams);
     repartheurFactory->SetParameterList(repartheurParams);
     repartheurFactory->SetFactory("A", manager.GetFactory("A"));
     manager.SetFactory("number of partitions", repartheurFactory);
@@ -1734,7 +1743,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       //        partitioner = rcp(new NodePartitionInterface());
       partitioner = rcp(new MueLu::NodePartitionInterface<SC, LO, GO, NO>());
       ParameterList partParams;
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: node id", int, repartheurParams);
+      test_and_set_param_2list<int>(paramList, defaultList, "repartition: node id", partParams);
       partitioner->SetParameterList(partParams);
       partitioner->SetFactory("Node Comm", manager.GetFactory("Node Comm"));
     } else if (partName == "zoltan") {
@@ -1767,10 +1776,10 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     // Repartitioner
     auto repartFactory = rcp(new RepartitionFactory());
     ParameterList repartParams;
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: print partition distribution", bool, repartParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: remap parts", bool, repartParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: remap num values", int, repartParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: save importer", bool, repartParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "repartition: print partition distribution", repartParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "repartition: remap parts", repartParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "repartition: remap num values", repartParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "repartition: save importer", repartParams);
     repartFactory->SetParameterList(repartParams);
     repartFactory->SetFactory("A", manager.GetFactory("A"));
     repartFactory->SetFactory("number of partitions", manager.GetFactory("number of partitions"));
@@ -1785,8 +1794,8 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       // The major application is the (1,1) hierarchy in the Maxwell1 preconditioner.
       auto newA = rcp(new RebalanceAcFactory());
       ParameterList rebAcParams;
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: use subcommunicators", bool, rebAcParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: use subcommunicators in place", bool, rebAcParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "repartition: use subcommunicators", rebAcParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "repartition: use subcommunicators in place", rebAcParams);
       newA->SetParameterList(rebAcParams);
       newA->SetFactory("A", manager.GetFactory("A"));
       newA->SetFactory("InPlaceMap", manager.GetFactory("InPlaceMap"));
@@ -1795,7 +1804,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       // Rebalanced A
       auto newA = rcp(new RebalanceAcFactory());
       ParameterList rebAcParams;
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: use subcommunicators", bool, rebAcParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "repartition: use subcommunicators", rebAcParams);
       newA->SetParameterList(rebAcParams);
       newA->SetFactory("A", manager.GetFactory("A"));
       newA->SetFactory("Importer", manager.GetFactory("Importer"));
@@ -1809,8 +1818,8 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
         newPparams.set("repartition: rebalance P and R", this->doPRrebalance_);
       if (changedPRViaCopyrebalance_)
         newPparams.set("repartition: explicit via new copy rebalance P and R", true);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: use subcommunicators", bool, newPparams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: send type", std::string, newPparams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "repartition: use subcommunicators", newPparams);
+      test_and_set_param_2list<std::string>(paramList, defaultList, "repartition: send type", newPparams);
       newP->SetParameterList(newPparams);
       newP->SetFactory("Importer", manager.GetFactory("Importer"));
       newP->SetFactory("P", manager.GetFactory("P"));
@@ -1836,8 +1845,8 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       auto newR = rcp(new RebalanceTransferFactory());
       ParameterList newRparams;
       newRparams.set("type", "Restriction");
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: use subcommunicators", bool, newRparams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "repartition: send type", std::string, newRparams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "repartition: use subcommunicators", newRparams);
+      test_and_set_param_2list<std::string>(paramList, defaultList, "repartition: send type", newRparams);
       if (changedPRrebalance_)
         newRparams.set("repartition: rebalance P and R", this->doPRrebalance_);
       if (changedPRViaCopyrebalance_)
@@ -1859,7 +1868,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       // the "Nullspace" of the manager
       // NOTE: This really needs to be set on the *NullSpaceFactory*, not manager.get("Nullspace").
       ParameterList newNullparams;
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "nullspace: calculate rotations", bool, newNullparams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "nullspace: calculate rotations", newNullparams);
       nullSpaceFactory->SetFactory("Nullspace", newP);
       nullSpaceFactory->SetParameterList(newNullparams);
     }
@@ -1881,7 +1890,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     UpdateFactoryManager_LowPrecision(ParameterList& paramList, const ParameterList& defaultList, FactoryManager& manager,
                                       int levelID, std::vector<keep_pair>& keeps) const {
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "transfers: half precision", bool, enableLowPrecision);
+  auto enableLowPrecision = set_var_2list<bool>(paramList, defaultList, "transfers: half precision");
 
   if (enableLowPrecision) {
     // Low precision P
@@ -1915,12 +1924,12 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   RCP<Factory> nullSpace = rcp(new NullspaceFactory());
 
   bool have_userNS = false;
-  if (paramList.isParameter("Nullspace") && !paramList.get<RCP<MultiVector> >("Nullspace").is_null())
+  if (paramList.isParameter("Nullspace") && !paramList.get<RCP<MultiVector>>("Nullspace").is_null())
     have_userNS = true;
 
   if (!have_userNS) {
     ParameterList newNullparams;
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "nullspace: calculate rotations", bool, newNullparams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "nullspace: calculate rotations", newNullparams);
     nullSpace->SetParameterList(newNullparams);
     nullSpace->SetFactory("Nullspace", manager.GetFactory("Ptent"));
     manager.SetFactory("Nullspace", nullSpace);
@@ -1948,13 +1957,13 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     ParameterList togglePParams;
     ParameterList semicoarsenPParams;
     ParameterList linedetectionParams;
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "semicoarsen: number of levels", int, togglePParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "semicoarsen: coarsen rate", int, semicoarsenPParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "semicoarsen: piecewise constant", bool, semicoarsenPParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "semicoarsen: piecewise linear", bool, semicoarsenPParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "semicoarsen: calculate nonsym restriction", bool, semicoarsenPParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "linedetection: orientation", std::string, linedetectionParams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "linedetection: num layers", int, linedetectionParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "semicoarsen: number of levels", togglePParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "semicoarsen: coarsen rate", semicoarsenPParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "semicoarsen: piecewise constant", semicoarsenPParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "semicoarsen: piecewise linear", semicoarsenPParams);
+    test_and_set_param_2list<bool>(paramList, defaultList, "semicoarsen: calculate nonsym restriction", semicoarsenPParams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "linedetection: orientation", linedetectionParams);
+    test_and_set_param_2list<int>(paramList, defaultList, "linedetection: num layers", linedetectionParams);
 
     MUELU_KOKKOS_FACTORY_NO_DECL(semicoarsenFactory, SemiCoarsenPFactory, SemiCoarsenPFactory_kokkos);
     RCP<LineDetectionFactory> linedetectionFactory = rcp(new LineDetectionFactory());
@@ -2033,8 +2042,8 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     // P-Coarsening by manual specification (old interface)
     ParameterList Pparams;
     auto P = rcp(new IntrepidPCoarsenFactory());
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "pcoarsen: hi basis", std::string, Pparams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "pcoarsen: lo basis", std::string, Pparams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "pcoarsen: hi basis", Pparams);
+    test_and_set_param_2list<std::string>(paramList, defaultList, "pcoarsen: lo basis", Pparams);
     P->SetParameterList(Pparams);
     manager.SetFactory("P", P);
 
@@ -2058,22 +2067,22 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     Pparams.sublist("matrixmatrix: kernel params", false) = paramList.sublist("matrixmatrix: kernel params");
   if (defaultList.isSublist("matrixmatrix: kernel params"))
     Pparams.sublist("matrixmatrix: kernel params", false) = defaultList.sublist("matrixmatrix: kernel params");
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "sa: damping factor", double, Pparams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "sa: calculate eigenvalue estimate", bool, Pparams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "sa: max eigenvalue", double, Pparams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "sa: eigenvalue estimate num iterations", int, Pparams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "sa: use rowsumabs diagonal scaling", bool, Pparams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "sa: rowsumabs diagonal replacement tolerance", double, Pparams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "sa: rowsumabs diagonal replacement value", double, Pparams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "sa: rowsumabs use automatic diagonal tolerance", bool, Pparams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "sa: enforce constraints", bool, Pparams);
-  // MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "sa: eigen-analysis type", std::string, Pparams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "tentative: calculate qr", bool, Pparams);
+  test_and_set_param_2list<double>(paramList, defaultList, "sa: damping factor", Pparams);
+  test_and_set_param_2list<bool>(paramList, defaultList, "sa: calculate eigenvalue estimate", Pparams);
+  test_and_set_param_2list<double>(paramList, defaultList, "sa: max eigenvalue", Pparams);
+  test_and_set_param_2list<int>(paramList, defaultList, "sa: eigenvalue estimate num iterations", Pparams);
+  test_and_set_param_2list<bool>(paramList, defaultList, "sa: use rowsumabs diagonal scaling", Pparams);
+  test_and_set_param_2list<double>(paramList, defaultList, "sa: rowsumabs diagonal replacement tolerance", Pparams);
+  test_and_set_param_2list<double>(paramList, defaultList, "sa: rowsumabs diagonal replacement value", Pparams);
+  test_and_set_param_2list<bool>(paramList, defaultList, "sa: rowsumabs use automatic diagonal tolerance", Pparams);
+  test_and_set_param_2list<bool>(paramList, defaultList, "sa: enforce constraints", Pparams);
+  // test_and_set_param_2list<std::string>(paramList, defaultList, "sa: eigen-analysis type", Pparams);
+  test_and_set_param_2list<bool>(paramList, defaultList, "tentative: calculate qr", Pparams);
 
   P->SetParameterList(Pparams);
 
   // Filtering
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "sa: use filtered matrix", bool, useFiltering);
+  auto useFiltering = set_var_2list<bool>(paramList, defaultList, "sa: use filtered matrix");
   if (useFiltering) {
     // NOTE: Here, non-Kokkos and Kokkos versions diverge in the way the
     // dependency tree is setup. The Kokkos version has merged the the
@@ -2082,16 +2091,16 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       RCP<Factory> filterFactory = rcp(new FilteredAFactory());
 
       ParameterList fParams;
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: use lumping", bool, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: reuse graph", bool, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: reuse eigenvalue", bool, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: use root stencil", bool, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: Dirichlet threshold", double, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: use spread lumping", bool, fParams);
-      // MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: lumping choice", std::string, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: spread lumping diag dom growth factor", double, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: spread lumping diag dom cap", double, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: count negative diagonals", bool, fParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: use lumping", fParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: reuse graph", fParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: reuse eigenvalue", fParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: use root stencil", fParams);
+      test_and_set_param_2list<double>(paramList, defaultList, "filtered matrix: Dirichlet threshold", fParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: use spread lumping", fParams);
+      // test_and_set_param_2list<std::string>(paramList, defaultList, "filtered matrix: lumping choice", fParams);
+      test_and_set_param_2list<double>(paramList, defaultList, "filtered matrix: spread lumping diag dom growth factor", fParams);
+      test_and_set_param_2list<double>(paramList, defaultList, "filtered matrix: spread lumping diag dom cap", fParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: count negative diagonals", fParams);
       filterFactory->SetParameterList(fParams);
       filterFactory->SetFactory("Graph", manager.GetFactory("Graph"));
       filterFactory->SetFactory("Aggregates", manager.GetFactory("Aggregates"));
@@ -2109,8 +2118,8 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   P->SetFactory("P", manager.GetFactory("Ptent"));
   manager.SetFactory("P", P);
 
-  bool filteringChangesMatrix = useFiltering && !MUELU_TEST_PARAM_2LIST(paramList, defaultList, "aggregation: drop tol", double, 0);
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "reuse: type", std::string, reuseType);
+  bool filteringChangesMatrix = useFiltering && !test_param_2list<double>(paramList, defaultList, "aggregation: drop tol", 0);
+  auto reuseType              = set_var_2list<std::string>(paramList, defaultList, "reuse: type");
   if (reuseType == "tP" && !filteringChangesMatrix)
     keeps.push_back(keep_pair("AP reuse data", P.get()));
 }
@@ -2122,19 +2131,19 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     UpdateFactoryManager_Emin(ParameterList& paramList, const ParameterList& defaultList, FactoryManager& manager,
                               int /* levelID */, std::vector<keep_pair>& /* keeps */) const {
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "emin: pattern", std::string, patternType);
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "reuse: type", std::string, reuseType);
+  auto patternType = set_var_2list<std::string>(paramList, defaultList, "emin: pattern");
+  auto reuseType   = set_var_2list<std::string>(paramList, defaultList, "reuse: type");
   TEUCHOS_TEST_FOR_EXCEPTION(patternType != "AkPtent", Exceptions::InvalidArgument,
                              "Invalid pattern name: \"" << patternType << "\". Valid options: \"AkPtent\"");
   // Pattern
   auto patternFactory = rcp(new PatternFactory());
   ParameterList patternParams;
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "emin: pattern order", int, patternParams);
+  test_and_set_param_2list<int>(paramList, defaultList, "emin: pattern order", patternParams);
   patternFactory->SetParameterList(patternParams);
   patternFactory->SetFactory("P", manager.GetFactory("Ptent"));
 
   // Filtering
-  MUELU_SET_VAR_2LIST(paramList, defaultList, "emin: use filtered matrix", bool, useFiltering);
+  auto useFiltering = set_var_2list<bool>(paramList, defaultList, "emin: use filtered matrix");
   if (useFiltering) {
     // NOTE: Here, non-Kokkos and Kokkos versions diverge in the way the
     // dependency tree is setup. The Kokkos version has merged the the
@@ -2143,15 +2152,15 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       RCP<Factory> filterFactory = rcp(new FilteredAFactory());
 
       ParameterList fParams;
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: use lumping", bool, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: reuse graph", bool, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: reuse eigenvalue", bool, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: use root stencil", bool, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: Dirichlet threshold", double, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: use spread lumping", bool, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: lumping choice", std::string, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: spread lumping diag dom growth factor", double, fParams);
-      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "filtered matrix: spread lumping diag dom cap", double, fParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: use lumping", fParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: reuse graph", fParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: reuse eigenvalue", fParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: use root stencil", fParams);
+      test_and_set_param_2list<double>(paramList, defaultList, "filtered matrix: Dirichlet threshold", fParams);
+      test_and_set_param_2list<bool>(paramList, defaultList, "filtered matrix: use spread lumping", fParams);
+      test_and_set_param_2list<std::string>(paramList, defaultList, "filtered matrix: lumping choice", fParams);
+      test_and_set_param_2list<double>(paramList, defaultList, "filtered matrix: spread lumping diag dom growth factor", fParams);
+      test_and_set_param_2list<double>(paramList, defaultList, "filtered matrix: spread lumping diag dom cap", fParams);
       filterFactory->SetParameterList(fParams);
       filterFactory->SetFactory("Graph", manager.GetFactory("Graph"));
       filterFactory->SetFactory("Aggregates", manager.GetFactory("Aggregates"));
@@ -2176,10 +2185,10 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
   // Energy minimization
   ParameterList Pparams;
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "emin: num iterations", int, Pparams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "emin: iterative method", std::string, Pparams);
+  test_and_set_param_2list<int>(paramList, defaultList, "emin: num iterations", Pparams);
+  test_and_set_param_2list<std::string>(paramList, defaultList, "emin: iterative method", Pparams);
   if (reuseType == "emin") {
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "emin: num reuse iterations", int, Pparams);
+    test_and_set_param_2list<int>(paramList, defaultList, "emin: num reuse iterations", Pparams);
     Pparams.set("Keep P0", true);
     Pparams.set("Keep Constraint0", true);
   }
@@ -2219,7 +2228,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   auto P = rcp(new MueLu::ReplicatePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>());
 
   ParameterList Pparams;
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "replicate: npdes", int, Pparams);
+  test_and_set_param_2list<int>(paramList, defaultList, "replicate: npdes", Pparams);
 
   P->SetParameterList(Pparams);
   manager.SetFactory("P", P);
@@ -2234,8 +2243,8 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   auto P = rcp(new MueLu::CombinePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>());
 
   ParameterList Pparams;
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "combine: numBlks", int, Pparams);
-  MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "combine: useMaxLevels", bool, Pparams);
+  test_and_set_param_2list<int>(paramList, defaultList, "combine: numBlks", Pparams);
+  test_and_set_param_2list<bool>(paramList, defaultList, "combine: useMaxLevels", Pparams);
 
   P->SetParameterList(Pparams);
   manager.SetFactory("P", P);
@@ -2260,10 +2269,6 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 #endif
 }
 
-#undef MUELU_SET_VAR_2LIST
-#undef MUELU_TEST_AND_SET_VAR
-#undef MUELU_TEST_AND_SET_PARAM_2LIST
-#undef MUELU_TEST_PARAM_2LIST
 #undef MUELU_KOKKOS_FACTORY
 
 size_t LevenshteinDistance(const char* s, size_t len_s, const char* t, size_t len_t);
@@ -2699,12 +2704,12 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
             continue;
           }
 
-          if (validParamList->isType<RCP<const FactoryBase> >(pName)) {
+          if (validParamList->isType<RCP<const FactoryBase>>(pName)) {
             // Generate or get factory described by pName and set dependency
             RCP<const FactoryBase> generatingFact = factFact_->BuildFactory(paramList1.getEntry(pName), factoryMapIn, factoryManagers);
             factory->SetFactory(pName, generatingFact.create_weak());
 
-          } else if (validParamList->isType<RCP<const ParameterList> >(pName)) {
+          } else if (validParamList->isType<RCP<const ParameterList>>(pName)) {
             if (pName == "ParameterList") {
               // NOTE: we cannot use
               //     subList = sublist(rcpFromRef(paramList), pName)


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
`MueLu::ParameterListInterpreter` relied heavily on preprocessor macros. Replacing them with inline functions reduced the size on disk of `ETI_MueLu_ParameterListInterpreter.cpp.o` by 30%. I did not observe any changes in runtime behavior or performance.