### PR TITLE
Remove use of deprecated Kokkos::Cuda ctor

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.hpp
@@ -180,7 +180,15 @@ Kokkos::Cuda make_instance() {
   }
   TPETRA_DETAILS_SPACES_CUDA_RUNTIME(
       cudaStreamCreateWithPriority(&stream, cudaStreamNonBlocking, prio));
-  return Kokkos::Cuda(stream, true /*Kokkos will manage this stream*/);
+
+  Kokkos::push_finalize_hook([=] {
+    if (stream != nullptr) {
+      TPETRA_DETAILS_SPACES_CUDA_RUNTIME(cudaStreamSynchronize(stream));
+      TPETRA_DETAILS_SPACES_CUDA_RUNTIME(cudaStreamDestroy(stream));
+    }
+  });
+
+  return Kokkos::Cuda(stream);
 }
 #endif  // KOKKOS_ENABLE_CUDA
 


### PR DESCRIPTION
Kokkos doesn't want to clean these up, so Tpetra has to do it. Register a Kokkos::finalize hook to drop all references to any execution spaces we created.

After https://github.com/kokkos/kokkos/pull/8957
