### PR TITLE
tpetra: remove fatal_error check on KOKKOS_ENABLE_CUDA_LAMBDA

### DIFF
--- a/packages/tpetra/CMakeCuda.txt
+++ b/packages/tpetra/CMakeCuda.txt
@@ -28,9 +28,6 @@ IF (Tpetra_ENABLE_CUDA)
   IF (DEFINED CUDA_VERSION)
     message(STATUS "CUDA_VERSION=${CUDA_VERSION}")
   ENDIF ()
-  IF (NOT DEFINED Kokkos_ENABLE_CUDA_LAMBDA OR NOT Kokkos_ENABLE_CUDA_LAMBDA)
-    MESSAGE (FATAL_ERROR "If building with CUDA, Tpetra and downstream packages require that you set the CMake option Kokkos_ENABLE_CUDA_LAMBDA:BOOL=ON (this is the default behavior).")
-  ENDIF ()
 ENDIF ()
 
 


### PR DESCRIPTION
Compatibility update with kokkos@develop -
Kokkos_ENABLE_CUDA_LAMBDA was deprecrated during the 4.x cycle, and removed as part of deprecated code cleanup in kokkos/kokkos#8957

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
Resolves configuration errors with kokkos@develop in Cuda builds, tested in local build to confirm configuration succeeds with these changes