### PR TITLE
[WIP] MueLu: Extend functionality of block-based AMG

### DIFF
--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_decl.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_decl.hpp
@@ -63,6 +63,10 @@
 #include "MueLu_SingleLevelMatlabFactory_fwd.hpp"
 #endif
 
+#ifdef HAVE_MUELU_TEKO
+#include "MueLu_TekoSmoother_fwd.hpp"
+#endif
+
 #include "MueLu_CoalesceDropFactory_kokkos_fwd.hpp"
 #include "MueLu_SemiCoarsenPFactory_kokkos_fwd.hpp"
 #include "MueLu_TentativePFactory_kokkos_fwd.hpp"

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -87,6 +87,11 @@
 #include "../matlab/src/MueLu_SingleLevelMatlabFactory_def.hpp"
 #endif
 
+#ifdef HAVE_MUELU_TEKO
+#include "MueLu_TekoSmoother_decl.hpp"
+#include "MueLu_TekoSmoother_def.hpp"
+#endif
+
 #ifdef HAVE_MUELU_INTREPID2
 #include "MueLu_IntrepidPCoarsenFactory.hpp"
 #endif
@@ -814,6 +819,11 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
         preSmoother = rcp(new SmootherFactory(rcp(new MatlabSmoother(preSmootherParams))));
       else
 #endif
+#ifdef HAVE_MUELU_TEKO
+          if (preSmootherType == "teko")
+        preSmoother = rcp(new SmootherFactory(rcp(new TekoSmoother(preSmootherParams))));
+      else
+#endif
         preSmoother = rcp(new SmootherFactory(rcp(new TrilinosSmoother(preSmootherType, preSmootherParams, overlap))));
     }
 
@@ -861,6 +871,11 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 #ifdef HAVE_MUELU_MATLAB
         if (postSmootherType == "matlab")
           postSmoother = rcp(new SmootherFactory(rcp(new MatlabSmoother(postSmootherParams))));
+        else
+#endif
+#ifdef HAVE_MUELU_TEKO
+            if (preSmootherType == "teko")
+          postSmoother = rcp(new SmootherFactory(rcp(new TekoSmoother(postSmootherParams))));
         else
 #endif
           postSmoother = rcp(new SmootherFactory(rcp(new TrilinosSmoother(postSmootherType, postSmootherParams, overlap))));
@@ -974,6 +989,11 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 #ifdef HAVE_MUELU_MATLAB
       if (coarseType == "matlab")
         coarseSmoother = rcp(new MatlabSmoother(coarseParams));
+      else
+#endif
+#ifdef HAVE_MUELU_TEKO
+          if (coarseType == "teko")
+        coarseSmoother = rcp(new TekoSmoother(coarseParams));
       else
 #endif
         coarseSmoother = rcp(new DirectSolver(coarseType, coarseParams));

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -874,7 +874,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
         else
 #endif
 #ifdef HAVE_MUELU_TEKO
-            if (preSmootherType == "teko")
+            if (postSmootherType == "teko")
           postSmoother = rcp(new SmootherFactory(rcp(new TekoSmoother(postSmootherParams))));
         else
 #endif

--- a/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
@@ -133,7 +133,7 @@ void MultiPhys<Scalar, LocalOrdinal, GlobalOrdinal, Node>::compute(bool reuse) {
     arrayOfParamLists_[iii]->set("repartition: explicit via new copy rebalance P and R", true);
 
     if (paramListMultiphysics_->isParameter("repartition: use subcommunicators"))
-      arrayOfParamLists_[iii]->set("repartition: use subcommunicators", paramListMultiphysics_->isParameter("repartition: use subcommunicators"));
+      arrayOfParamLists_[iii]->set("repartition: use subcommunicators", paramListMultiphysics_->get<bool>("repartition: use subcommunicators"));
     else
       arrayOfParamLists_[iii]->set("repartition: use subcommunicators", true);
   }

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_TekoSmoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_TekoSmoother_decl.hpp
@@ -60,6 +60,11 @@ class TekoSmoother : public SmootherPrototype<Scalar, LocalOrdinal, GlobalOrdina
     TEUCHOS_TEST_FOR_EXCEPTION(true, Exceptions::RuntimeError, "MueLu::TekoSmoother: Teko can only be used with SC=double. For more information refer to the doxygen documentation of TekoSmoother.");
   };
 
+  TekoSmoother(const Teuchos::ParameterList &paramList)
+    : type_("Teko smoother") {
+    TEUCHOS_TEST_FOR_EXCEPTION(true, Exceptions::RuntimeError, "MueLu::TekoSmoother: Teko can only be used with SC=double. For more information refer to the doxygen documentation of TekoSmoother.");
+  };
+
   //! Destructor
   virtual ~TekoSmoother() {}
   //@}
@@ -165,20 +170,31 @@ class TekoSmoother<double, int, GlobalOrdinal, Node> : public SmootherPrototype<
     , tekoParams_(Teuchos::null)
     , inverseOp_(Teuchos::null){};
 
+  TekoSmoother(const Teuchos::ParameterList &paramList)
+    : type_("Teko smoother")
+    , A_(Teuchos::null)
+    , bA_(Teuchos::null)
+    , bThyOp_(Teuchos::null)
+    , tekoParams_(Teuchos::null)
+    , inverseOp_(Teuchos::null) {
+    this->SetParameterList(paramList);
+    auto tekoParams = paramList.sublist("Inverse Factory Library");
+    tekoParams_     = rcpFromRef(tekoParams);
+
+    strat_ =
+        Teuchos::rcp(new Stratimikos::DefaultLinearSolverBuilder("",
+                                                                 "",
+                                                                 "",
+                                                                 "linear-solver-params-file",
+                                                                 "extra-linear-solver-params",
+                                                                 "linear-solver-params-used-file"));
+
+    Teko::addToStratimikosBuilder(strat_);
+  };
+
   //! Destructor
   virtual ~TekoSmoother() {}
   //@}
-
-  //! Input
-  //@{
-  RCP<const ParameterList> GetValidParameterList() const {
-    RCP<ParameterList> validParamList = rcp(new ParameterList());
-
-    validParamList->set<RCP<const FactoryBase> >("A", null, "Generating factory of the matrix A");
-    validParamList->set<std::string>("Inverse Type", "", "Name of parameter list within 'Teko parameters' containing the Teko smoother parameters.");
-
-    return validParamList;
-  }
 
   void DeclareInput(Level &currentLevel) const {
     this->Input(currentLevel, "A");
@@ -220,10 +236,8 @@ class TekoSmoother<double, int, GlobalOrdinal, Node> : public SmootherPrototype<
                                "MueLu::TekoSmoother::Build: You must provide a 'Smoother Type' name that is defined in the 'Teko parameters' sublist.");
     type_ = smootherType;
 
-    TEUCHOS_TEST_FOR_EXCEPTION(tekoParams_.is_null(), Exceptions::BadCast,
-                               "MueLu::TekoSmoother::Build: No Teko parameters have been set.");
-
-    Teuchos::RCP<Teko::InverseLibrary> invLib  = Teko::InverseLibrary::buildFromParameterList(*tekoParams_);
+    const auto &teko_params                    = pL.sublist("Inverse Factory Library");
+    Teuchos::RCP<Teko::InverseLibrary> invLib  = Teko::InverseLibrary::buildFromParameterList(teko_params, strat_);
     Teuchos::RCP<Teko::InverseFactory> inverse = invLib->getInverseFactory(smootherType);
 
     inverseOp_ = Teko::buildInverse(*inverse, thyOp);
@@ -239,36 +253,62 @@ class TekoSmoother<double, int, GlobalOrdinal, Node> : public SmootherPrototype<
   @param B right-hand side
   @param InitialGuessIsZero This option has no effect.
   */
-  void Apply(MultiVector &X, const MultiVector &B, bool /* InitialGuessIsZero */ = false) const {
+  void Apply(MultiVector &X, const MultiVector &B, bool InitialGuessIsZero = false) const {
     TEUCHOS_TEST_FOR_EXCEPTION(this->IsSetup() == false, Exceptions::RuntimeError,
                                "MueLu::TekoSmoother::Apply(): Setup() has not been called");
 
-    Teuchos::RCP<const Teuchos::Comm<int> > comm = X.getMap()->getComm();
+    auto comm           = X.getMap()->getComm();
+    auto rgMapExtractor = bA_->getRangeMapExtractor();
 
-    Teuchos::RCP<const MapExtractor> rgMapExtractor = bA_->getRangeMapExtractor();
-    TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(rgMapExtractor));
+    if (InitialGuessIsZero) {
+      TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(rgMapExtractor));
 
-    // copy initial solution vector X to Ptr<Thyra::MultiVectorBase> YY
+      // create a Thyra RHS vector
+      auto thyB     = Thyra::createMembers(Teuchos::rcp_dynamic_cast<const Thyra::VectorSpaceBase<Scalar> >(bThyOp_->productRange()), Teuchos::as<int>(B.getNumVectors()));
+      auto thyProdB = Teuchos::rcp_dynamic_cast<Thyra::ProductMultiVectorBase<Scalar> >(thyB);
+      TEUCHOS_TEST_FOR_EXCEPTION(thyProdB.is_null(), Exceptions::BadCast,
+                                 "MueLu::TekoSmoother::Apply: Failed to cast range space to product range space.");
 
-    // create a Thyra RHS vector
-    Teuchos::RCP<Thyra::MultiVectorBase<Scalar> > thyB = Thyra::createMembers(Teuchos::rcp_dynamic_cast<const Thyra::VectorSpaceBase<Scalar> >(bThyOp_->productRange()), Teuchos::as<int>(B.getNumVectors()));
-    Teuchos::RCP<Thyra::ProductMultiVectorBase<Scalar> > thyProdB =
-        Teuchos::rcp_dynamic_cast<Thyra::ProductMultiVectorBase<Scalar> >(thyB);
+      // copy RHS vector B to Thyra::MultiVectorBase thyProdB
+      Xpetra::ThyraUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::updateThyra(Teuchos::rcpFromRef(B), rgMapExtractor, thyProdB);
+
+      // create a Thyra SOL vector
+      auto thyX     = Thyra::createMembers(Teuchos::rcp_dynamic_cast<const Thyra::VectorSpaceBase<Scalar> >(bThyOp_->productDomain()), Teuchos::as<int>(X.getNumVectors()));
+      auto thyProdX = Teuchos::rcp_dynamic_cast<Thyra::ProductMultiVectorBase<Scalar> >(thyX);
+      TEUCHOS_TEST_FOR_EXCEPTION(thyProdX.is_null(), Exceptions::BadCast,
+                                 "MueLu::TekoSmoother::Apply: Failed to cast domain space to product domain space.");
+
+      // copy RHS vector X to Thyra::MultiVectorBase thyProdX
+      Xpetra::ThyraUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::updateThyra(Teuchos::rcpFromRef(X), rgMapExtractor, thyProdX);
+
+      inverseOp_->apply(
+          Thyra::NOTRANS,
+          *thyB,       // const MultiVectorBase<Scalar> &X,
+          thyX.ptr(),  // const Ptr<MultiVectorBase<Scalar> > &Y,
+          1.0,
+          0.0);
+
+      // copy back content of Ptr<Thyra::MultiVectorBase> thyX into X
+      Teuchos::RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > XX =
+          Xpetra::ThyraUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::toXpetra(thyX, comm);
+
+      X.update(Teuchos::ScalarTraits<Scalar>::one(), *XX, Teuchos::ScalarTraits<Scalar>::zero());
+      return;
+    }
+
+    auto residual = Utilities::Residual(*A_, X, B);
+
+    auto thyB     = Thyra::createMembers(Teuchos::rcp_dynamic_cast<const Thyra::VectorSpaceBase<Scalar> >(bThyOp_->productRange()), Teuchos::as<int>(residual->getNumVectors()));
+    auto thyProdB = Teuchos::rcp_dynamic_cast<Thyra::ProductMultiVectorBase<Scalar> >(thyB);
     TEUCHOS_TEST_FOR_EXCEPTION(thyProdB.is_null(), Exceptions::BadCast,
                                "MueLu::TekoSmoother::Apply: Failed to cast range space to product range space.");
+    // copy residual vector to Thyra::MultiVectorBase thyProdB
+    Xpetra::ThyraUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::updateThyra(residual, rgMapExtractor, thyProdB);
 
-    // copy RHS vector B to Thyra::MultiVectorBase thyProdB
-    Xpetra::ThyraUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::updateThyra(Teuchos::rcpFromRef(B), rgMapExtractor, thyProdB);
-
-    // create a Thyra SOL vector
-    Teuchos::RCP<Thyra::MultiVectorBase<Scalar> > thyX = Thyra::createMembers(Teuchos::rcp_dynamic_cast<const Thyra::VectorSpaceBase<Scalar> >(bThyOp_->productDomain()), Teuchos::as<int>(X.getNumVectors()));
-    Teuchos::RCP<Thyra::ProductMultiVectorBase<Scalar> > thyProdX =
-        Teuchos::rcp_dynamic_cast<Thyra::ProductMultiVectorBase<Scalar> >(thyX);
+    auto thyX     = Thyra::createMembers(Teuchos::rcp_dynamic_cast<const Thyra::VectorSpaceBase<Scalar> >(bThyOp_->productDomain()), Teuchos::as<int>(X.getNumVectors()));
+    auto thyProdX = Teuchos::rcp_dynamic_cast<Thyra::ProductMultiVectorBase<Scalar> >(thyX);
     TEUCHOS_TEST_FOR_EXCEPTION(thyProdX.is_null(), Exceptions::BadCast,
                                "MueLu::TekoSmoother::Apply: Failed to cast domain space to product domain space.");
-
-    // copy RHS vector X to Thyra::MultiVectorBase thyProdX
-    Xpetra::ThyraUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::updateThyra(Teuchos::rcpFromRef(X), rgMapExtractor, thyProdX);
 
     inverseOp_->apply(
         Thyra::NOTRANS,
@@ -281,7 +321,7 @@ class TekoSmoother<double, int, GlobalOrdinal, Node> : public SmootherPrototype<
     Teuchos::RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > XX =
         Xpetra::ThyraUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::toXpetra(thyX, comm);
 
-    X.update(Teuchos::ScalarTraits<Scalar>::one(), *XX, Teuchos::ScalarTraits<Scalar>::zero());
+    X.update(Teuchos::ScalarTraits<Scalar>::one(), *XX, Teuchos::ScalarTraits<Scalar>::one());
   }
   //@}
 
@@ -331,7 +371,9 @@ class TekoSmoother<double, int, GlobalOrdinal, Node> : public SmootherPrototype<
   RCP<ParameterList> tekoParams_;  // < ! parameter list containing Teko parameters. These parameters are not administrated by the factory and not validated.
 
   Teko::LinearOp inverseOp_;  // < ! Teko inverse operator
-};                            // class TekoSmoother (specialization on SC=double)
+
+  Teuchos::RCP<Stratimikos::DefaultLinearSolverBuilder> strat_;
+};  // class TekoSmoother (specialization on SC=double)
 }  // namespace MueLu
 
 #define MUELU_TEKOSMOOTHER_SHORT

--- a/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_decl.hpp
@@ -122,6 +122,8 @@ class Amesos2Smoother : public SmootherPrototype<Scalar, LocalOrdinal, GlobalOrd
   typedef Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> Tpetra_CrsMatrix;
   typedef Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> Tpetra_MultiVector;
 
+  void ApplyBlocked(MultiVector& X, const MultiVector& B) const;
+
   //! amesos2-specific key phrase that denote smoother type
   std::string type_;
 

--- a/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
@@ -166,6 +166,10 @@ void Amesos2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Setup(Level& cu
     this->GetOStream(Warnings0) << "MueLu::Amesos2Smoother::Setup(): Setup() has already been called" << std::endl;
 
   RCP<Matrix> A = Factory::Get<RCP<Matrix> >(currentLevel, "A");
+  auto A_block  = rcp_dynamic_cast<BlockedCrsMatrix>(A);
+  if (A_block) {
+    A = A_block->Merge();
+  }
 
   // Do a quick check if we need to modify the matrix
   RCP<const Map> rowMap = A->getRowMap();
@@ -308,6 +312,13 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void Amesos2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Apply(MultiVector& X, const MultiVector& B, bool /* InitialGuessIsZero */) const {
   TEUCHOS_TEST_FOR_EXCEPTION(SmootherPrototype::IsSetup() == false, Exceptions::RuntimeError, "MueLu::Amesos2Smoother::Apply(): Setup() has not been called");
 
+  RCP<BlockedMultiVector> blockedX = rcp_dynamic_cast<BlockedMultiVector>(rcpFromRef(X));
+  bool blocked                     = blockedX != Teuchos::null;
+  if (blocked) {
+    this->ApplyBlocked(X, B);
+    return;
+  }
+
   RCP<Tpetra_MultiVector> tX, tB;
   if (!useTransformation_) {
     tX = toTpetra(Teuchos::rcpFromRef(X));
@@ -356,6 +367,43 @@ void Amesos2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Apply(MultiVect
       projection_->projectOut(X);
     }
   }
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void Amesos2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::ApplyBlocked(MultiVector& X, const MultiVector& B) const {
+  TEUCHOS_TEST_FOR_EXCEPTION(useTransformation_, Exceptions::RuntimeError,
+                             "MueLu::Amesos2Smoother::ApplyBlocked: useTransformation_ == true is not supported");
+
+  Teuchos::ParameterList pL = this->GetParameterList();
+  const auto fixNullspace   = pL.get<bool>("fix nullspace");
+  TEUCHOS_TEST_FOR_EXCEPTION(fixNullspace, Exceptions::RuntimeError,
+                             "MueLu::Amesos2Smoother::ApplyBlocked: \"fix nullspace\" == true is not supported");
+
+  RCP<BlockedMultiVector> blockedX       = rcp_dynamic_cast<BlockedMultiVector>(rcpFromRef(X));
+  RCP<const BlockedMultiVector> blockedB = rcp_dynamic_cast<const BlockedMultiVector>(rcpFromRef(B));
+  TEUCHOS_TEST_FOR_EXCEPTION(blockedX == Teuchos::null || blockedB == Teuchos::null, Exceptions::RuntimeError,
+                             "MueLu::Amesos2Smoother::ApplyBlocked: Input and/or output vector are not BlockedMultiVector!");
+
+  bool blocked = blockedX != Teuchos::null;
+
+  RCP<MultiVector> mergedX = blockedX->Merge();
+  RCP<MultiVector> mergedB = blockedB->Merge();
+
+  RCP<Tpetra_MultiVector> tX, tB;
+  tX = toTpetra(mergedX);
+  tB = toTpetra(mergedB);
+
+  prec_->setX(tX);
+  prec_->setB(tB);
+
+  prec_->solve();
+
+  prec_->setX(Teuchos::null);
+  prec_->setB(Teuchos::null);
+
+  RCP<MultiVector> xx = Teuchos::rcp(new BlockedMultiVector(blockedX->getBlockedMap(), mergedX));
+  SC zero = Teuchos::ScalarTraits<SC>::zero(), one = Teuchos::ScalarTraits<SC>::one();
+  X.update(one, *xx, zero);
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/muelu/src/Transfers/Generic/MueLu_CombinePFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_CombinePFactory_decl.hpp
@@ -126,6 +126,7 @@ class CombinePFactory : public PFactory {
   //@}
 
  private:
+  void BuildPBlocked(Level& fineLevel, Level& coarseLevel) const;
   int numPDEs_;
 
 };  // class CombinePFactory

--- a/packages/muelu/src/Transfers/Generic/MueLu_CombinePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_CombinePFactory_def.hpp
@@ -97,11 +97,17 @@ void CombinePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& f
                                                                         Level& coarseLevel) const {
   FactoryMonitor m(*this, "Build", coarseLevel);
 
+  RCP<Matrix> A = Get<RCP<Matrix>>(fineLevel, "A");
+  using helpers = Xpetra::Helpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+  auto A_blk    = Teuchos::rcp_dynamic_cast<BlockedCrsMatrix>(A);
+  if (A->getRowMap()->lib() == Xpetra::UseTpetra && A_blk != Teuchos::null) {
+    this->BuildPBlocked(fineLevel, coarseLevel);
+    return;
+  }
+
   const ParameterList& pL = GetParameterList();
   const LO nBlks          = as<LO>(pL.get<int>("combine: numBlks"));
   const bool useMaxLevels = pL.get<bool>("combine: useMaxLevels");
-
-  RCP<Matrix> A = Get<RCP<Matrix>>(fineLevel, "A");
 
   // Record all matrices that each define a block in block diagonal comboP
   // matrix used for PDE/multiblock interpolation.  Additionally, count
@@ -294,7 +300,123 @@ void CombinePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& f
 
   Teuchos::RCP<Matrix> comboP = Teuchos::rcp(new CrsMatrixWrap(comboPCrs));
 
-  Set(coarseLevel, "P", comboP);
+  if (!restrictionMode_) {
+    Set(coarseLevel, "P", comboP);
+  } else {
+    RCP<Matrix> R = Utilities::Transpose(*comboP, true);
+    Set(coarseLevel, "R", R);
+  }
+}
+
+namespace impl {
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+class WrapProlongatorOperator : public Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node> {
+ public:
+  WrapProlongatorOperator(RCP<const Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> maybeOperator, RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> rangeMap, GlobalOrdinal indexBase)
+    : maybeOperator_(maybeOperator)
+    , rangeMap_(rangeMap)
+    , indexBase_(indexBase) {
+    using device_type = typename Node::device_type;
+    Kokkos::View<const GlobalOrdinal*, device_type> indexList;
+    if (maybeOperator_) {
+      const auto baseDomainMap = maybeOperator_->getDomainMap();
+      indexList                = baseDomainMap->getMyGlobalIndicesDevice();
+    }
+
+    GlobalOrdinal numGlobalElements = Teuchos::OrdinalTraits<GlobalOrdinal>::invalid();
+    auto comm                       = rangeMap_->getComm();
+    domainMap_                      = Teuchos::make_rcp<Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>(numGlobalElements, indexList, indexBase_, comm);
+  }
+
+  RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> getDomainMap() const override { return domainMap_; }
+  RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> getRangeMap() const override { return rangeMap_; }
+
+  void
+  apply(const Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& X,
+        Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Y,
+        Teuchos::ETransp mode = Teuchos::NO_TRANS,
+        Scalar alpha          = Teuchos::ScalarTraits<Scalar>::one(),
+        Scalar beta           = Teuchos::ScalarTraits<Scalar>::zero()) const override {
+    if (!maybeOperator_) return;
+    maybeOperator_->apply(X, Y, mode, alpha, beta);
+  }
+
+ private:
+  RCP<const Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> maybeOperator_;
+  RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> domainMap_;
+  RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> rangeMap_;
+  GlobalOrdinal indexBase_;
+};
+
+template <class LocalOrdinal, class GlobalOrdinal, class Node>
+RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>
+appendEmptyProcsToMap(RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>> inputMap, GlobalOrdinal indexBase, RCP<const Teuchos::Comm<int>> comm) {
+  using device_type = typename Node::device_type;
+  Kokkos::View<const GlobalOrdinal*, device_type> indexList;
+  if (inputMap) {
+    indexList = inputMap->getMyGlobalIndicesDevice();
+  }
+
+  GlobalOrdinal numGlobalElements = Teuchos::OrdinalTraits<GlobalOrdinal>::invalid();
+  return Teuchos::make_rcp<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>(numGlobalElements, indexList, indexBase, comm);
+}
+
+}  // namespace impl
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void CombinePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildPBlocked(Level& fineLevel,
+                                                                               Level& coarseLevel) const {
+#ifdef HAVE_XPETRA_THYRA
+  const ParameterList& pL = GetParameterList();
+  const LO nBlks          = as<LO>(pL.get<int>("combine: numBlks"));
+  const bool useMaxLevels = pL.get<bool>("combine: useMaxLevels");
+
+  RCP<Matrix> A = Get<RCP<Matrix>>(fineLevel, "A");
+
+  bool anyCoarseGridsRemaining = false;
+
+  if (useMaxLevels) {
+    for (int j = 0; j < nBlks; j++) {
+      std::string blockName = "Psubblock" + Teuchos::toString(j);
+      anyCoarseGridsRemaining |= coarseLevel.IsAvailable(blockName, NoFactory::get());
+    };
+
+    int localAnyCoarseGridsRemaining  = anyCoarseGridsRemaining;
+    int globalAnyCoarseGridsRemaining = localAnyCoarseGridsRemaining;
+    Teuchos::reduceAll(*A->getDomainMap()->getComm(), Teuchos::REDUCE_MAX, localAnyCoarseGridsRemaining, Teuchos::ptr(&globalAnyCoarseGridsRemaining));
+
+    anyCoarseGridsRemaining |= globalAnyCoarseGridsRemaining > 0;
+  }
+
+  auto blockProlongator = Teuchos::make_rcp<Thyra::DefaultBlockedLinearOp<Scalar>>();
+  blockProlongator->beginBlockFill(nBlks, nBlks);
+
+  for (int j = 0; j < nBlks; j++) {
+    RCP<Matrix> P_jj;
+
+    std::string blockName = "Psubblock" + Teuchos::toString(j);
+    if (coarseLevel.IsAvailable(blockName, NoFactory::get())) {
+      P_jj = coarseLevel.Get<RCP<Matrix>>(blockName, NoFactory::get());
+    } else if (useMaxLevels && anyCoarseGridsRemaining) {
+      std::string subblockOpName = "Operatorsubblock" + Teuchos::toString(j);
+      P_jj                       = constructIdentityProlongator<Scalar, LocalOrdinal, GlobalOrdinal, Node>(fineLevel.Get<RCP<Operator>>(subblockOpName)->getDomainMap());
+    }
+
+    RCP<const Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> tpetra_P_jj = Xpetra::toTpetra(P_jj);
+    auto thyra_P_jj                                                                    = Thyra::createConstLinearOp(tpetra_P_jj);
+    blockProlongator->setBlock(j, j, thyra_P_jj);
+  }
+
+  blockProlongator->endBlockFill();
+
+  Teuchos::RCP<Matrix> blockedProlongatorXpetra = Teuchos::make_rcp<Xpetra::BlockedCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(blockProlongator, Teuchos::null);
+
+  blockedProlongatorXpetra->fillComplete();
+
+  Set(coarseLevel, "P", blockedProlongatorXpetra);  // TODO: implement restriction mode here
+#else
+  throw Exceptions::RuntimeError("CombinePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildPBlocked requires HAVE_XPETRA_THYRA!");
+#endif
 }
 
 }  // namespace MueLu

--- a/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
@@ -48,6 +48,28 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
 Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     Transpose(Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Op, bool /* optimizeTranspose */, const std::string& label, const Teuchos::RCP<Teuchos::ParameterList>& params) {
+  auto blockOp = rcp_dynamic_cast<BlockedCrsMatrix>(rcpFromRef(Op));
+  if (blockOp != Teuchos::null) {
+    auto numEntPerRow = blockOp->getLocalMaxNumRowEntries();
+
+    // swap domain/range for transpose
+    auto rangeMaps  = blockOp->getBlockedDomainMap();
+    auto domainMaps = blockOp->getBlockedRangeMap();
+
+    auto blockOpT = make_rcp<BlockedCrsMatrix>(rangeMaps, domainMaps, numEntPerRow);
+    for (size_t row = 0; row < blockOp->Rows(); ++row) {
+      for (size_t col = 0; col < blockOp->Cols(); ++col) {
+        auto A_ij   = blockOp->getMatrix(row, col);
+        auto A_ij_T = Utilities::Transpose(*A_ij);
+        blockOpT->setMatrix(col, row, A_ij_T);
+      }
+    }
+
+    blockOpT->fillComplete();
+
+    return blockOpT;
+  }
+
   std::string TorE = "tpetra";
 
   if (TorE == "tpetra") {

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultBlockedLinearOp_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultBlockedLinearOp_def.hpp
@@ -10,113 +10,82 @@
 #ifndef THYRA_DEFAULT_BLOCKED_LINEAR_OP_DEF_HPP
 #define THYRA_DEFAULT_BLOCKED_LINEAR_OP_DEF_HPP
 
-
-#include "Thyra_DefaultBlockedLinearOp_decl.hpp"
-#include "Thyra_DefaultProductVectorSpace.hpp"
-#include "Thyra_DefaultProductVector.hpp"
-#include "Thyra_DefaultProductMultiVector.hpp"
-#include "Thyra_MultiVectorStdOps.hpp"
-#include "Thyra_VectorStdOps.hpp"
 #include "Thyra_AssertOp.hpp"
+#include "Thyra_DefaultBlockedLinearOp_decl.hpp"
+#include "Thyra_DefaultProductMultiVector.hpp"
+#include "Thyra_DefaultProductVector.hpp"
+#include "Thyra_DefaultProductVectorSpace.hpp"
+#include "Thyra_MultiVectorStdOps.hpp"
 #include "Thyra_ScaledAdjointLinearOpBase.hpp"
-
+#include "Thyra_VectorStdOps.hpp"
 
 namespace Thyra {
 
-
 // Constructors
 
-
-template<class Scalar>
+template <class Scalar>
 DefaultBlockedLinearOp<Scalar>::DefaultBlockedLinearOp()
-  :numRowBlocks_(0), numColBlocks_(0), blockFillIsActive_(false)
-{}
-
+    : numRowBlocks_(0), numColBlocks_(0), blockFillIsActive_(false) {}
 
 // Overridden from PhysicallyBlockedLinearOpBase
 
-
-template<class Scalar>
-void DefaultBlockedLinearOp<Scalar>::beginBlockFill()
-{
+template <class Scalar> void DefaultBlockedLinearOp<Scalar>::beginBlockFill() {
   assertBlockFillIsActive(false);
   uninitialize();
-  resetStorage(0,0);
+  resetStorage(0, 0);
 }
 
-
-template<class Scalar>
-void DefaultBlockedLinearOp<Scalar>::beginBlockFill(
-  const int numRowBlocks, const int numColBlocks
-  )
-{
+template <class Scalar>
+void DefaultBlockedLinearOp<Scalar>::beginBlockFill(const int numRowBlocks,
+                                                    const int numColBlocks) {
   assertBlockFillIsActive(false);
   uninitialize();
-  resetStorage(numRowBlocks,numColBlocks);
+  resetStorage(numRowBlocks, numColBlocks);
 }
 
-
-template<class Scalar>
+template <class Scalar>
 void DefaultBlockedLinearOp<Scalar>::beginBlockFill(
-  const RCP<const ProductVectorSpaceBase<Scalar> > &new_productRange
-  ,const RCP<const ProductVectorSpaceBase<Scalar> > &new_productDomain
-  )
-{
+    const RCP<const ProductVectorSpaceBase<Scalar>> &new_productRange,
+    const RCP<const ProductVectorSpaceBase<Scalar>> &new_productDomain) {
   using Teuchos::rcp_dynamic_cast;
   assertBlockFillIsActive(false);
   uninitialize();
   productRange_ = new_productRange.assert_not_null();
   productDomain_ = new_productDomain.assert_not_null();
   defaultProductRange_ =
-    rcp_dynamic_cast<const DefaultProductVectorSpace<Scalar> >(productRange_);
+      rcp_dynamic_cast<const DefaultProductVectorSpace<Scalar>>(productRange_);
   defaultProductDomain_ =
-    rcp_dynamic_cast<const DefaultProductVectorSpace<Scalar> >(productDomain_);
+      rcp_dynamic_cast<const DefaultProductVectorSpace<Scalar>>(productDomain_);
   // Note: the above spaces must be set before calling the next function!
   resetStorage(productRange_->numBlocks(), productDomain_->numBlocks());
 }
 
-
-template<class Scalar>
-bool DefaultBlockedLinearOp<Scalar>::blockFillIsActive() const
-{
+template <class Scalar>
+bool DefaultBlockedLinearOp<Scalar>::blockFillIsActive() const {
   return blockFillIsActive_;
 }
 
-
-template<class Scalar>
-bool DefaultBlockedLinearOp<Scalar>::acceptsBlock(
-  const int i, const int j
-  ) const
-{
+template <class Scalar>
+bool DefaultBlockedLinearOp<Scalar>::acceptsBlock(const int i,
+                                                  const int j) const {
   assertBlockFillIsActive(true);
-  assertBlockRowCol(i,j);
+  assertBlockRowCol(i, j);
   return true;
 }
 
-
-template<class Scalar>
+template <class Scalar>
 void DefaultBlockedLinearOp<Scalar>::setNonconstBlock(
-  const int i, const int j
-  ,const RCP<LinearOpBase<Scalar> > &block
-  )
-{
+    const int i, const int j, const RCP<LinearOpBase<Scalar>> &block) {
   setBlockImpl(i, j, block);
 }
 
-
-template<class Scalar>
+template <class Scalar>
 void DefaultBlockedLinearOp<Scalar>::setBlock(
-  const int i, const int j
-  ,const RCP<const LinearOpBase<Scalar> > &block
-  )
-{
+    const int i, const int j, const RCP<const LinearOpBase<Scalar>> &block) {
   setBlockImpl(i, j, block);
 }
 
-
-template<class Scalar>
-void DefaultBlockedLinearOp<Scalar>::endBlockFill()
-{
+template <class Scalar> void DefaultBlockedLinearOp<Scalar>::endBlockFill() {
 
   using Teuchos::as;
 
@@ -130,8 +99,7 @@ void DefaultBlockedLinearOp<Scalar>::endBlockFill()
   if (nonnull(productRange_)) {
     numRowBlocks_ = productRange_->numBlocks();
     numColBlocks_ = productDomain_->numBlocks();
-  }
-  else {
+  } else {
     numRowBlocks_ = rangeBlocks_.size();
     numColBlocks_ = domainBlocks_.size();
     // NOTE: Above, whether doing a flexible fill or not, all of the blocks
@@ -145,30 +113,31 @@ void DefaultBlockedLinearOp<Scalar>::endBlockFill()
   if (is_null(productRange_)) {
     for (int i = 0; i < numRowBlocks_; ++i) {
       TEUCHOS_TEST_FOR_EXCEPTION(
-        !rangeBlocks_[i].get(), std::logic_error
-        ,"DefaultBlockedLinearOp<Scalar>::endBlockFill():"
-        " Error, no linear operator block for the i="<<i<<" block row was added"
-        " and we can not complete the block fill!"
-        );
+          !rangeBlocks_[i].get(), std::logic_error,
+          "DefaultBlockedLinearOp<Scalar>::endBlockFill():"
+          " Error, no linear operator block for the i="
+              << i
+              << " block row was added"
+                 " and we can not complete the block fill!");
     }
-    for(int j = 0; j < numColBlocks_; ++j) {
+    for (int j = 0; j < numColBlocks_; ++j) {
       TEUCHOS_TEST_FOR_EXCEPTION(
-        !domainBlocks_[j].get(), std::logic_error
-        ,"DefaultBlockedLinearOp<Scalar>::endBlockFill():"
-        " Error, no linear operator block for the j="
-        <<j<<" block column was added"
-        " and we can not complete the block fill!"
-        );
+          !domainBlocks_[j].get(), std::logic_error,
+          "DefaultBlockedLinearOp<Scalar>::endBlockFill():"
+          " Error, no linear operator block for the j="
+              << j
+              << " block column was added"
+                 " and we can not complete the block fill!");
     }
   }
 #endif
 
   // Insert the block LOB objects if doing a flexible fill.
   if (Ops_stack_.size()) {
-    Ops_.resize(numRowBlocks_*numColBlocks_);
-    for ( int k = 0; k < as<int>(Ops_stack_.size()); ++k ) {
+    Ops_.resize(numRowBlocks_ * numColBlocks_);
+    for (int k = 0; k < as<int>(Ops_stack_.size()); ++k) {
       const BlockEntry<Scalar> &block_i_j = Ops_stack_[k];
-      Ops_[numRowBlocks_*block_i_j.j + block_i_j.i] = block_i_j.block;
+      Ops_[numRowBlocks_ * block_i_j.j + block_i_j.i] = block_i_j.block;
     }
     Ops_stack_.resize(0);
   }
@@ -186,13 +155,9 @@ void DefaultBlockedLinearOp<Scalar>::endBlockFill()
   domainBlocks_.resize(0);
 
   blockFillIsActive_ = false;
-
 }
 
-
-template<class Scalar>
-void DefaultBlockedLinearOp<Scalar>::uninitialize()
-{
+template <class Scalar> void DefaultBlockedLinearOp<Scalar>::uninitialize() {
   productRange_ = Teuchos::null;
   productDomain_ = Teuchos::null;
   numRowBlocks_ = 0;
@@ -204,222 +169,175 @@ void DefaultBlockedLinearOp<Scalar>::uninitialize()
   blockFillIsActive_ = false;
 }
 
-
 // Overridden from BlockedLinearOpBase
 
-
-template<class Scalar>
-RCP<const ProductVectorSpaceBase<Scalar> >
-DefaultBlockedLinearOp<Scalar>::productRange() const
-{
+template <class Scalar>
+RCP<const ProductVectorSpaceBase<Scalar>>
+DefaultBlockedLinearOp<Scalar>::productRange() const {
   return productRange_;
 }
 
-
-template<class Scalar>
-RCP<const ProductVectorSpaceBase<Scalar> >
-DefaultBlockedLinearOp<Scalar>::productDomain() const
-{
+template <class Scalar>
+RCP<const ProductVectorSpaceBase<Scalar>>
+DefaultBlockedLinearOp<Scalar>::productDomain() const {
   return productDomain_;
 }
 
-
-template<class Scalar>
-bool DefaultBlockedLinearOp<Scalar>::blockExists(
-  const int i, const int j
-  ) const
-{
+template <class Scalar>
+bool DefaultBlockedLinearOp<Scalar>::blockExists(const int i,
+                                                 const int j) const {
   assertBlockFillIsActive(false);
-  assertBlockRowCol(i,j);
-  return true;
+  assertBlockRowCol(i, j);
+  return !is_null(Ops_[numRowBlocks_ * j + i]);
 }
 
-
-template<class Scalar>
-bool DefaultBlockedLinearOp<Scalar>::blockIsConst(
-  const int i, const int j
-  ) const
-{
+template <class Scalar>
+bool DefaultBlockedLinearOp<Scalar>::blockIsConst(const int i,
+                                                  const int j) const {
 #ifdef TEUCHOS_DEBUG
-  TEUCHOS_TEST_FOR_EXCEPT(!blockExists(i,j));
+  TEUCHOS_TEST_FOR_EXCEPT(!blockExists(i, j));
 #endif
   assertBlockFillIsActive(false);
-  assertBlockRowCol(i,j);
-  return Ops_[numRowBlocks_*j+i].isConst();
+  assertBlockRowCol(i, j);
+  return Ops_[numRowBlocks_ * j + i].isConst();
 }
 
-
-template<class Scalar>
-RCP<LinearOpBase<Scalar> >
-DefaultBlockedLinearOp<Scalar>::getNonconstBlock(const int i, const int j)
-{
+template <class Scalar>
+RCP<LinearOpBase<Scalar>>
+DefaultBlockedLinearOp<Scalar>::getNonconstBlock(const int i, const int j) {
 #ifdef TEUCHOS_DEBUG
-  TEUCHOS_TEST_FOR_EXCEPT(!blockExists(i,j));
+  TEUCHOS_TEST_FOR_EXCEPT(!blockExists(i, j));
 #endif
   assertBlockFillIsActive(false);
-  assertBlockRowCol(i,j);
-  return Ops_[numRowBlocks_*j+i].getNonconstObj();
+  assertBlockRowCol(i, j);
+  return Ops_[numRowBlocks_ * j + i].getNonconstObj();
 }
 
-
-template<class Scalar>
-RCP<const LinearOpBase<Scalar> >
-DefaultBlockedLinearOp<Scalar>::getBlock(const int i, const int j) const
-{
+template <class Scalar>
+RCP<const LinearOpBase<Scalar>>
+DefaultBlockedLinearOp<Scalar>::getBlock(const int i, const int j) const {
 #ifdef TEUCHOS_DEBUG
-  TEUCHOS_TEST_FOR_EXCEPT(!blockExists(i,j));
+  TEUCHOS_TEST_FOR_EXCEPT(!blockExists(i, j));
 #endif
   assertBlockFillIsActive(false);
-  assertBlockRowCol(i,j);
-  return Ops_[numRowBlocks_*j+i];
+  assertBlockRowCol(i, j);
+  return Ops_[numRowBlocks_ * j + i];
 }
-
 
 // Overridden from LinearOpBase
 
-
-template<class Scalar>
-RCP< const VectorSpaceBase<Scalar> >
-DefaultBlockedLinearOp<Scalar>::range() const
-{
+template <class Scalar>
+RCP<const VectorSpaceBase<Scalar>>
+DefaultBlockedLinearOp<Scalar>::range() const {
   return productRange_;
 }
 
-
-template<class Scalar>
-RCP< const VectorSpaceBase<Scalar> >
-DefaultBlockedLinearOp<Scalar>::domain() const
-{
+template <class Scalar>
+RCP<const VectorSpaceBase<Scalar>>
+DefaultBlockedLinearOp<Scalar>::domain() const {
   return productDomain_;
 }
 
-
-template<class Scalar>
-RCP<const LinearOpBase<Scalar> >
-DefaultBlockedLinearOp<Scalar>::clone() const
-{
+template <class Scalar>
+RCP<const LinearOpBase<Scalar>> DefaultBlockedLinearOp<Scalar>::clone() const {
   return Teuchos::null; // ToDo: Implement this when needed!
 }
 
-
 // Overridden from Teuchos::Describable
 
-
-template<class Scalar>
-std::string DefaultBlockedLinearOp<Scalar>::description() const
-{
+template <class Scalar>
+std::string DefaultBlockedLinearOp<Scalar>::description() const {
   assertBlockFillIsActive(false);
   std::ostringstream oss;
-  oss
-    << Teuchos::Describable::description() << "{"
-    << "numRowBlocks="<<numRowBlocks_
-    << ",numColBlocks="<<numColBlocks_
-    << "}";
+  oss << Teuchos::Describable::description() << "{"
+      << "numRowBlocks=" << numRowBlocks_ << ",numColBlocks=" << numColBlocks_
+      << "}";
   return oss.str();
 }
 
-
-template<class Scalar>
+template <class Scalar>
 void DefaultBlockedLinearOp<Scalar>::describe(
-  Teuchos::FancyOStream &out_arg
-  ,const Teuchos::EVerbosityLevel verbLevel
-  ) const
-{
-  using Teuchos::rcpFromRef;
+    Teuchos::FancyOStream &out_arg,
+    const Teuchos::EVerbosityLevel verbLevel) const {
   using Teuchos::FancyOStream;
   using Teuchos::OSTab;
+  using Teuchos::rcpFromRef;
   assertBlockFillIsActive(false);
   RCP<FancyOStream> out = rcpFromRef(out_arg);
   OSTab tab1(out);
-  switch(verbLevel) {
-    case Teuchos::VERB_DEFAULT:
-    case Teuchos::VERB_LOW:
-      *out << this->description() << std::endl;
-      break;
-    case Teuchos::VERB_MEDIUM:
-    case Teuchos::VERB_HIGH:
-    case Teuchos::VERB_EXTREME:
-    {
-      *out
-        << Teuchos::Describable::description() << "{"
-        << "rangeDim=" << this->range()->dim()
-        << ",domainDim=" << this->domain()->dim()
-        << ",numRowBlocks=" << numRowBlocks_
-        << ",numColBlocks=" << numColBlocks_
-        << "}\n";
-      OSTab tab2(out);
-      *out
-        << "Constituent LinearOpBase objects for M = [ Op[0,0] ..."
-        << " ; ... ; ... Op[numRowBlocks-1,numColBlocks-1] ]:\n";
-      tab2.incrTab();
-      for( int i = 0; i < numRowBlocks_; ++i ) {
-        for( int j = 0; j < numColBlocks_; ++j ) {
-          *out << "Op["<<i<<","<<j<<"] = ";
-          RCP<const LinearOpBase<Scalar> >
-            block_i_j = getBlock(i,j);
-          if(block_i_j.get())
-            *out << Teuchos::describe(*getBlock(i,j),verbLevel);
-          else
-            *out << "NULL\n";
-        }
+  switch (verbLevel) {
+  case Teuchos::VERB_DEFAULT:
+  case Teuchos::VERB_LOW:
+    *out << this->description() << std::endl;
+    break;
+  case Teuchos::VERB_MEDIUM:
+  case Teuchos::VERB_HIGH:
+  case Teuchos::VERB_EXTREME: {
+    *out << Teuchos::Describable::description() << "{"
+         << "rangeDim=" << this->range()->dim()
+         << ",domainDim=" << this->domain()->dim()
+         << ",numRowBlocks=" << numRowBlocks_
+         << ",numColBlocks=" << numColBlocks_ << "}\n";
+    OSTab tab2(out);
+    *out << "Constituent LinearOpBase objects for M = [ Op[0,0] ..."
+         << " ; ... ; ... Op[numRowBlocks-1,numColBlocks-1] ]:\n";
+    tab2.incrTab();
+    for (int i = 0; i < numRowBlocks_; ++i) {
+      for (int j = 0; j < numColBlocks_; ++j) {
+        *out << "Op[" << i << "," << j << "] = ";
+        RCP<const LinearOpBase<Scalar>> block_i_j = getBlock(i, j);
+        if (block_i_j.get())
+          *out << Teuchos::describe(*getBlock(i, j), verbLevel);
+        else
+          *out << "NULL\n";
       }
-      break;
     }
-    default:
-      TEUCHOS_TEST_FOR_EXCEPT(true); // Should never get here!
+    break;
+  }
+  default:
+    TEUCHOS_TEST_FOR_EXCEPT(true); // Should never get here!
   }
 }
 
-
 // protected
-
 
 // Overridden from LinearOpBase
 
-
-template<class Scalar>
-bool DefaultBlockedLinearOp<Scalar>::opSupportedImpl(EOpTransp M_trans) const
-{
+template <class Scalar>
+bool DefaultBlockedLinearOp<Scalar>::opSupportedImpl(EOpTransp M_trans) const {
   bool supported = true;
-  for( int i = 0; i < numRowBlocks_; ++i ) {
-    for( int j = 0; j < numColBlocks_; ++j ) {
-      RCP<const LinearOpBase<Scalar> >
-        block_i_j = getBlock(i,j);
-      if( block_i_j.get() && !Thyra::opSupported(*block_i_j,M_trans) )
+  for (int i = 0; i < numRowBlocks_; ++i) {
+    for (int j = 0; j < numColBlocks_; ++j) {
+      RCP<const LinearOpBase<Scalar>> block_i_j = getBlock(i, j);
+      if (block_i_j.get() && !Thyra::opSupported(*block_i_j, M_trans))
         supported = false;
     }
   }
   return supported;
 }
 
-
-template<class Scalar>
+template <class Scalar>
 void DefaultBlockedLinearOp<Scalar>::applyImpl(
-  const EOpTransp M_trans,
-  const MultiVectorBase<Scalar> &X_in,
-  const Ptr<MultiVectorBase<Scalar> > &Y_inout,
-  const Scalar alpha,
-  const Scalar beta
-  ) const
-{
+    const EOpTransp M_trans, const MultiVectorBase<Scalar> &X_in,
+    const Ptr<MultiVectorBase<Scalar>> &Y_inout, const Scalar alpha,
+    const Scalar beta) const {
 
   using Teuchos::rcpFromRef;
   typedef Teuchos::ScalarTraits<Scalar> ST;
-  typedef RCP<MultiVectorBase<Scalar> > MultiVectorPtr;
-  typedef RCP<const MultiVectorBase<Scalar> > ConstMultiVectorPtr;
-  typedef RCP<const LinearOpBase<Scalar> > ConstLinearOpPtr;
+  typedef RCP<MultiVectorBase<Scalar>> MultiVectorPtr;
+  typedef RCP<const MultiVectorBase<Scalar>> ConstMultiVectorPtr;
+  typedef RCP<const LinearOpBase<Scalar>> ConstLinearOpPtr;
 
 #ifdef TEUCHOS_DEBUG
   THYRA_ASSERT_LINEAR_OP_MULTIVEC_APPLY_SPACES(
-    "DefaultBlockedLinearOp<Scalar>::apply(...)", *this, M_trans, X_in, &*Y_inout
-    );
+      "DefaultBlockedLinearOp<Scalar>::apply(...)", *this, M_trans, X_in,
+      &*Y_inout);
 #endif // TEUCHOS_DEBUG
 
-  const bool
-    struct_transp = (real_trans(M_trans)!=NOTRANS); // Structural transpose?
-  const int
-    opNumRowBlocks = ( !struct_transp ? numRowBlocks_ : numColBlocks_ ),
-    opNumColBlocks = ( !struct_transp ? numColBlocks_ : numRowBlocks_ );
+  const bool struct_transp =
+      (real_trans(M_trans) != NOTRANS); // Structural transpose?
+  const int opNumRowBlocks = (!struct_transp ? numRowBlocks_ : numColBlocks_),
+            opNumColBlocks = (!struct_transp ? numColBlocks_ : numRowBlocks_);
 
   //
   // Y = alpha * op(M) * X + beta*Y
@@ -431,33 +349,33 @@ void DefaultBlockedLinearOp<Scalar>::applyImpl(
   // , for i=0...opNumRowBlocks-1
   //
 
-  const RCP<const DefaultProductVectorSpace<Scalar> >
-    defaultProductRange_op = ( real_trans(M_trans)==NOTRANS
-      ? defaultProductRange_ : defaultProductDomain_ ),
-    defaultProductDomain_op = ( real_trans(M_trans)==NOTRANS
-      ? defaultProductDomain_ : defaultProductRange_ );
+  const RCP<const DefaultProductVectorSpace<Scalar>>
+      defaultProductRange_op =
+          (real_trans(M_trans) == NOTRANS ? defaultProductRange_
+                                          : defaultProductDomain_),
+      defaultProductDomain_op =
+          (real_trans(M_trans) == NOTRANS ? defaultProductDomain_
+                                          : defaultProductRange_);
 
-  const RCP<const ProductMultiVectorBase<Scalar> >
-    X = castOrCreateSingleBlockProductMultiVector<Scalar>(
-      defaultProductDomain_op, rcpFromRef(X_in));
-  const RCP<ProductMultiVectorBase<Scalar> >
-    Y = nonconstCastOrCreateSingleBlockProductMultiVector<Scalar>(
-      defaultProductRange_op, rcpFromPtr(Y_inout));
+  const RCP<const ProductMultiVectorBase<Scalar>> X =
+      castOrCreateSingleBlockProductMultiVector<Scalar>(defaultProductDomain_op,
+                                                        rcpFromRef(X_in));
+  const RCP<ProductMultiVectorBase<Scalar>> Y =
+      nonconstCastOrCreateSingleBlockProductMultiVector<Scalar>(
+          defaultProductRange_op, rcpFromPtr(Y_inout));
 
-  for( int i = 0; i < opNumRowBlocks; ++i ) {
+  for (int i = 0; i < opNumRowBlocks; ++i) {
     MultiVectorPtr Y_i = Y->getNonconstMultiVectorBlock(i);
-    for( int j = 0; j < opNumColBlocks; ++j ) {
-      ConstLinearOpPtr
-        Op_i_j = ( !struct_transp ? getBlock(i,j) : getBlock(j,i) );
-      ConstMultiVectorPtr
-        X_j = X->getMultiVectorBlock(j);
-      if(j==0) {
+    for (int j = 0; j < opNumColBlocks; ++j) {
+      ConstLinearOpPtr Op_i_j =
+          (!struct_transp ? getBlock(i, j) : getBlock(j, i));
+      ConstMultiVectorPtr X_j = X->getMultiVectorBlock(j);
+      if (j == 0) {
         if (nonnull(Op_i_j))
-          Thyra::apply(*Op_i_j, M_trans,* X_j, Y_i.ptr(), alpha, beta);
+          Thyra::apply(*Op_i_j, M_trans, *X_j, Y_i.ptr(), alpha, beta);
         else
           scale(beta, Y_i.ptr());
-      }
-      else {
+      } else {
         if (nonnull(Op_i_j))
           Thyra::apply(*Op_i_j, M_trans, *X_j, Y_i.ptr(), alpha, ST::one());
       }
@@ -467,62 +385,61 @@ void DefaultBlockedLinearOp<Scalar>::applyImpl(
 
 // Overridden from RowStatLinearOpBase
 
-template<class Scalar>
-bool
-DefaultBlockedLinearOp<Scalar>::rowStatIsSupportedImpl(
-    const RowStatLinearOpBaseUtils::ERowStat row_stat) const
-{
-  using Teuchos::rcpFromRef;
-  using Teuchos::rcp_dynamic_cast;
+template <class Scalar>
+bool DefaultBlockedLinearOp<Scalar>::rowStatIsSupportedImpl(
+    const RowStatLinearOpBaseUtils::ERowStat row_stat) const {
   using Teuchos::dyn_cast;
-  //typedef Teuchos::ScalarTraits<Scalar> ST; // unused
+  using Teuchos::rcp_dynamic_cast;
+  using Teuchos::rcpFromRef;
+  // typedef Teuchos::ScalarTraits<Scalar> ST; // unused
   typedef RowStatLinearOpBase<Scalar> RowStatOp;
-  typedef RCP<const LinearOpBase<Scalar> > ConstLinearOpPtr;
+  typedef RCP<const LinearOpBase<Scalar>> ConstLinearOpPtr;
   typedef const LinearOpBase<Scalar> ConstLinearOp;
 
   // Figure out what needs to be check for each sub block to compute
   // the require row stat
   RowStatLinearOpBaseUtils::ERowStat
-    subblk_stat = RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM,
-    subblk_trans_stat = RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM;
-  switch (row_stat) {
-    case RowStatLinearOpBaseUtils::ROW_STAT_INV_ROW_SUM:
-    case RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM:
-      subblk_stat = RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM;
+      subblk_stat = RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM,
       subblk_trans_stat = RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM;
-      break;
-    case RowStatLinearOpBaseUtils::ROW_STAT_INV_COL_SUM:
-    case RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM:
-      subblk_stat = RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM;
-      subblk_trans_stat = RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM;
-      break;
-    default:
-      TEUCHOS_TEST_FOR_EXCEPT(true);
+  switch (row_stat) {
+  case RowStatLinearOpBaseUtils::ROW_STAT_INV_ROW_SUM:
+  case RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM:
+    subblk_stat = RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM;
+    subblk_trans_stat = RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM;
+    break;
+  case RowStatLinearOpBaseUtils::ROW_STAT_INV_COL_SUM:
+  case RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM:
+    subblk_stat = RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM;
+    subblk_trans_stat = RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM;
+    break;
+  default:
+    TEUCHOS_TEST_FOR_EXCEPT(true);
   }
 
   // check each sub block for compatibility (null means zero,
   // automatically compatible)
-  for( int i = 0; i < numRowBlocks_; ++i ) {
-    for( int j = 0; j < numColBlocks_; ++j ) {
-      ConstLinearOpPtr Op_i_j = getBlock(i,j);
+  for (int i = 0; i < numRowBlocks_; ++i) {
+    for (int j = 0; j < numColBlocks_; ++j) {
+      ConstLinearOpPtr Op_i_j = getBlock(i, j);
 
       if (nonnull(Op_i_j)) {
         // pull out adjoint, and scaling
-        ConstLinearOp * Orig_i_j = 0;
+        ConstLinearOp *Orig_i_j = 0;
         Scalar scalar = 1.0;
         EOpTransp transp = NOTRANS;
-        Thyra::unwrap(*Op_i_j,&scalar,&transp,&Orig_i_j);
+        Thyra::unwrap(*Op_i_j, &scalar, &transp, &Orig_i_j);
 
-        const RowStatOp & row_stat_op = Teuchos::dyn_cast<const RowStatOp>(*Orig_i_j);
+        const RowStatOp &row_stat_op =
+            Teuchos::dyn_cast<const RowStatOp>(*Orig_i_j);
 
         // sub block must also support the required row stat operation
         RowStatLinearOpBaseUtils::ERowStat stat = subblk_stat;
-        if(transp==NOTRANS || transp==CONJ)
+        if (transp == NOTRANS || transp == CONJ)
           stat = subblk_stat;
-        else if(transp==TRANS || transp==CONJTRANS)
+        else if (transp == TRANS || transp == CONJTRANS)
           stat = subblk_trans_stat;
 
-        if(!row_stat_op.rowStatIsSupported(stat))
+        if (!row_stat_op.rowStatIsSupported(stat))
           return false;
       }
       // else: sub block is null, "0" is good enough
@@ -532,124 +449,122 @@ DefaultBlockedLinearOp<Scalar>::rowStatIsSupportedImpl(
   return true;
 }
 
-template<class Scalar>
-void
-DefaultBlockedLinearOp<Scalar>::getRowStatImpl(
+template <class Scalar>
+void DefaultBlockedLinearOp<Scalar>::getRowStatImpl(
     const RowStatLinearOpBaseUtils::ERowStat row_stat,
-    const Teuchos::Ptr<VectorBase< Scalar> > &rowStatVec) const
-{
-  using Teuchos::rcpFromRef;
-  using Teuchos::rcpFromPtr;
-  using Teuchos::rcp_dynamic_cast;
+    const Teuchos::Ptr<VectorBase<Scalar>> &rowStatVec) const {
   using Teuchos::dyn_cast;
+  using Teuchos::rcp_dynamic_cast;
+  using Teuchos::rcpFromPtr;
+  using Teuchos::rcpFromRef;
   typedef Teuchos::ScalarTraits<Scalar> ST;
   typedef RowStatLinearOpBase<Scalar> RowStatOp;
-  typedef RCP<const LinearOpBase<Scalar> > ConstLinearOpPtr;
+  typedef RCP<const LinearOpBase<Scalar>> ConstLinearOpPtr;
   typedef const LinearOpBase<Scalar> ConstLinearOp;
-  typedef RCP<VectorBase<Scalar> > VectorPtr;
+  typedef RCP<VectorBase<Scalar>> VectorPtr;
 
   // Figure out what needs to be check for each sub block to compute
   // the require row stat
   RowStatLinearOpBaseUtils::ERowStat
-    subblk_stat = RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM,
-    subblk_trans_stat = RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM;
-  switch (row_stat) {
-    case RowStatLinearOpBaseUtils::ROW_STAT_INV_ROW_SUM:
-    case RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM:
-      subblk_stat = RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM;
+      subblk_stat = RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM,
       subblk_trans_stat = RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM;
-      break;
-    case RowStatLinearOpBaseUtils::ROW_STAT_INV_COL_SUM:
-    case RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM:
-      subblk_stat = RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM;
-      subblk_trans_stat = RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM;
-      break;
-    default:
-      TEUCHOS_TEST_FOR_EXCEPT(true);
+  switch (row_stat) {
+  case RowStatLinearOpBaseUtils::ROW_STAT_INV_ROW_SUM:
+  case RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM:
+    subblk_stat = RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM;
+    subblk_trans_stat = RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM;
+    break;
+  case RowStatLinearOpBaseUtils::ROW_STAT_INV_COL_SUM:
+  case RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM:
+    subblk_stat = RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM;
+    subblk_trans_stat = RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM;
+    break;
+  default:
+    TEUCHOS_TEST_FOR_EXCEPT(true);
   }
 
-  const RCP<ProductVectorBase<Scalar> >
-    Y = rcp_dynamic_cast<ProductVectorBase<Scalar> >(rcpFromPtr(rowStatVec));
+  const RCP<ProductVectorBase<Scalar>> Y =
+      rcp_dynamic_cast<ProductVectorBase<Scalar>>(rcpFromPtr(rowStatVec));
 
   // using sub block row stat capability interrogate each for
   // its constribution
-  for( int i = 0; i < numRowBlocks_; ++i ) {
+  for (int i = 0; i < numRowBlocks_; ++i) {
     VectorPtr blk_vec = Y->getNonconstVectorBlock(i);
-    put_scalar (ST::zero (), blk_vec.ptr ()); // clear vector just in case
+    put_scalar(ST::zero(), blk_vec.ptr()); // clear vector just in case
 
-    for( int j = 0; j < numColBlocks_; ++j ) {
-      ConstLinearOpPtr Op_i_j = getBlock(i,j);
+    for (int j = 0; j < numColBlocks_; ++j) {
+      ConstLinearOpPtr Op_i_j = getBlock(i, j);
 
       VectorPtr tmp_vec = createMember(Op_i_j->range());
 
-      put_scalar (ST::zero (), tmp_vec.ptr ()); // clear vector just in case
+      put_scalar(ST::zero(), tmp_vec.ptr()); // clear vector just in case
 
       if (nonnull(Op_i_j)) {
         // pull out adjoint, and scaling
-        ConstLinearOp * Orig_i_j = 0;
+        ConstLinearOp *Orig_i_j = 0;
         Scalar scalar = 1.0;
         EOpTransp transp = NOTRANS;
-        Thyra::unwrap(*Op_i_j,&scalar,&transp,&Orig_i_j);
+        Thyra::unwrap(*Op_i_j, &scalar, &transp, &Orig_i_j);
 
-        const RowStatOp & row_stat_op = Teuchos::dyn_cast<const RowStatOp>(*Orig_i_j);
+        const RowStatOp &row_stat_op =
+            Teuchos::dyn_cast<const RowStatOp>(*Orig_i_j);
 
         // sub block must also support the required row stat operation
-        if(transp==NOTRANS || transp==CONJ)
-          row_stat_op.getRowStat(subblk_stat,tmp_vec.ptr());
-        else if(transp==TRANS || transp==CONJTRANS)
-          row_stat_op.getRowStat(subblk_trans_stat,tmp_vec.ptr());
-        else
-        { TEUCHOS_ASSERT(false); }
+        if (transp == NOTRANS || transp == CONJ)
+          row_stat_op.getRowStat(subblk_stat, tmp_vec.ptr());
+        else if (transp == TRANS || transp == CONJTRANS)
+          row_stat_op.getRowStat(subblk_trans_stat, tmp_vec.ptr());
+        else {
+          TEUCHOS_ASSERT(false);
+        }
 
         // some the temporary into the block vector
-        Vp_V(blk_vec.ptr(),*tmp_vec);
+        Vp_V(blk_vec.ptr(), *tmp_vec);
       }
     }
   }
 
   // do post processing as needed (take the inverse currently
   switch (row_stat) {
-    case RowStatLinearOpBaseUtils::ROW_STAT_INV_ROW_SUM:
-    case RowStatLinearOpBaseUtils::ROW_STAT_INV_COL_SUM:
-      reciprocal(*rowStatVec,rowStatVec.ptr());
-    case RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM:
-    case RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM:
-      break;
-    default:
-      TEUCHOS_TEST_FOR_EXCEPT(true);
+  case RowStatLinearOpBaseUtils::ROW_STAT_INV_ROW_SUM:
+  case RowStatLinearOpBaseUtils::ROW_STAT_INV_COL_SUM:
+    reciprocal(*rowStatVec, rowStatVec.ptr());
+  case RowStatLinearOpBaseUtils::ROW_STAT_ROW_SUM:
+  case RowStatLinearOpBaseUtils::ROW_STAT_COL_SUM:
+    break;
+  default:
+    TEUCHOS_TEST_FOR_EXCEPT(true);
   }
 }
 
 // Overridden from ScaledLinearOpBase
 
-template<class Scalar>
-bool
-DefaultBlockedLinearOp<Scalar>::supportsScaleLeftImpl() const
-{
-  using Teuchos::rcp_dynamic_cast;
+template <class Scalar>
+bool DefaultBlockedLinearOp<Scalar>::supportsScaleLeftImpl() const {
   using Teuchos::dyn_cast;
-  typedef RCP<const LinearOpBase<Scalar> > LinearOpPtr;
+  using Teuchos::rcp_dynamic_cast;
+  typedef RCP<const LinearOpBase<Scalar>> LinearOpPtr;
   typedef const LinearOpBase<Scalar> LinearOp;
   typedef const ScaledLinearOpBase<Scalar> ScaledOp;
 
   bool supported = true;
-  for( int i = 0; i < numRowBlocks_; ++i ) {
-    for( int j = 0; j < numColBlocks_; ++j ) {
-      LinearOpPtr Op_i_j = getBlock(i,j);
+  for (int i = 0; i < numRowBlocks_; ++i) {
+    for (int j = 0; j < numColBlocks_; ++j) {
+      LinearOpPtr Op_i_j = getBlock(i, j);
 
       EOpTransp transp = NOTRANS;
 
       if (nonnull(Op_i_j)) {
         // pull out adjoint, and scaling
-        LinearOp * Orig_i_j = 0;
+        LinearOp *Orig_i_j = 0;
         Scalar scalar = 1.0;
-        Thyra::unwrap(*Op_i_j,&scalar,&transp,&Orig_i_j);
+        Thyra::unwrap(*Op_i_j, &scalar, &transp, &Orig_i_j);
 
-        ScaledOp & scaled_op = Teuchos::dyn_cast<ScaledOp>(*Orig_i_j);
+        ScaledOp &scaled_op = Teuchos::dyn_cast<ScaledOp>(*Orig_i_j);
 
-        if(transp==NOTRANS || transp==CONJ)
+        if (transp == NOTRANS || transp == CONJ)
           supported &= scaled_op.supportsScaleLeft();
-        else if(transp==TRANS || transp==CONJTRANS)
+        else if (transp == TRANS || transp == CONJTRANS)
           supported &= scaled_op.supportsScaleRight();
       }
     }
@@ -658,33 +573,31 @@ DefaultBlockedLinearOp<Scalar>::supportsScaleLeftImpl() const
   return supported;
 }
 
-template<class Scalar>
-bool
-DefaultBlockedLinearOp<Scalar>::supportsScaleRightImpl() const
-{
-  using Teuchos::rcp_dynamic_cast;
+template <class Scalar>
+bool DefaultBlockedLinearOp<Scalar>::supportsScaleRightImpl() const {
   using Teuchos::dyn_cast;
-  typedef RCP<const LinearOpBase<Scalar> > LinearOpPtr;
+  using Teuchos::rcp_dynamic_cast;
+  typedef RCP<const LinearOpBase<Scalar>> LinearOpPtr;
   typedef const LinearOpBase<Scalar> LinearOp;
   typedef const ScaledLinearOpBase<Scalar> ScaledOp;
 
   bool supported = true;
-  for( int i = 0; i < numRowBlocks_; ++i ) {
-    for( int j = 0; j < numColBlocks_; ++j ) {
-      LinearOpPtr Op_i_j = getBlock(i,j);
+  for (int i = 0; i < numRowBlocks_; ++i) {
+    for (int j = 0; j < numColBlocks_; ++j) {
+      LinearOpPtr Op_i_j = getBlock(i, j);
 
       if (nonnull(Op_i_j)) {
         // pull out adjoint, and scaling
-        LinearOp * Orig_i_j = 0;
+        LinearOp *Orig_i_j = 0;
         Scalar scalar = 1.0;
         EOpTransp transp = NOTRANS;
-        Thyra::unwrap(*Op_i_j,&scalar,&transp,&Orig_i_j);
+        Thyra::unwrap(*Op_i_j, &scalar, &transp, &Orig_i_j);
 
-        ScaledOp & scaled_op = Teuchos::dyn_cast<ScaledOp>(*Orig_i_j);
+        ScaledOp &scaled_op = Teuchos::dyn_cast<ScaledOp>(*Orig_i_j);
 
-        if(transp==NOTRANS || transp==CONJ)
+        if (transp == NOTRANS || transp == CONJ)
           supported &= scaled_op.supportsScaleRight();
-        else if(transp==TRANS || transp==CONJTRANS)
+        else if (transp == TRANS || transp == CONJTRANS)
           supported &= scaled_op.supportsScaleLeft();
       }
     }
@@ -693,27 +606,25 @@ DefaultBlockedLinearOp<Scalar>::supportsScaleRightImpl() const
   return supported;
 }
 
-template<class Scalar>
-void
-DefaultBlockedLinearOp<Scalar>::scaleLeftImpl(
-  const VectorBase< Scalar > &row_scaling)
-{
+template <class Scalar>
+void DefaultBlockedLinearOp<Scalar>::scaleLeftImpl(
+    const VectorBase<Scalar> &row_scaling) {
   using Teuchos::dyn_cast;
   using Teuchos::rcp_dynamic_cast;
   typedef ScaledLinearOpBase<Scalar> ScaledOp;
-  typedef RCP<LinearOpBase<Scalar> > LinearOpPtr;
-  typedef RCP<const VectorBase<Scalar> > VectorPtr;
+  typedef RCP<LinearOpBase<Scalar>> LinearOpPtr;
+  typedef RCP<const VectorBase<Scalar>> VectorPtr;
 
-  const ProductVectorBase<Scalar> &
-    Y = dyn_cast<const ProductVectorBase<Scalar> >(row_scaling);
+  const ProductVectorBase<Scalar> &Y =
+      dyn_cast<const ProductVectorBase<Scalar>>(row_scaling);
 
   // using sub block row stat capability interrogate each for
   // its constribution
-  for( int i = 0; i < numRowBlocks_; ++i ) {
+  for (int i = 0; i < numRowBlocks_; ++i) {
     VectorPtr blk_vec = Y.getVectorBlock(i);
 
-    for( int j = 0; j < numColBlocks_; ++j ) {
-      LinearOpPtr Op_i_j = getNonconstBlock(i,j);
+    for (int j = 0; j < numColBlocks_; ++j) {
+      LinearOpPtr Op_i_j = getNonconstBlock(i, j);
 
       if (nonnull(Op_i_j)) {
         // pull out adjoint, and scaling
@@ -721,52 +632,50 @@ DefaultBlockedLinearOp<Scalar>::scaleLeftImpl(
         EOpTransp transp = NOTRANS;
 
         {
-          RCP<ScaledAdjointLinearOpBase<Scalar> > saOp
-              = rcp_dynamic_cast<ScaledAdjointLinearOpBase<Scalar> >(Op_i_j);
-          if(nonnull(saOp)) {
+          RCP<ScaledAdjointLinearOpBase<Scalar>> saOp =
+              rcp_dynamic_cast<ScaledAdjointLinearOpBase<Scalar>>(Op_i_j);
+          if (nonnull(saOp)) {
             transp = saOp->overallTransp();
             Orig_i_j = saOp->getNonconstOrigOp();
-          }
-          else
+          } else
             Orig_i_j = Op_i_j; // stick with the original
         }
 
         RCP<ScaledOp> scaled_op = rcp_dynamic_cast<ScaledOp>(Orig_i_j);
 
         // sub block must support a row stat operation
-        TEUCHOS_ASSERT(scaled_op!=Teuchos::null); // guranteed by compatibility check
+        TEUCHOS_ASSERT(scaled_op !=
+                       Teuchos::null); // guranteed by compatibility check
 
         // sub block must also support the required row stat operation
-        if(transp==NOTRANS || transp==CONJ)
+        if (transp == NOTRANS || transp == CONJ)
           scaled_op->scaleLeft(*blk_vec);
-        else if(transp==TRANS || transp==CONJTRANS)
+        else if (transp == TRANS || transp == CONJTRANS)
           scaled_op->scaleRight(*blk_vec);
       }
     }
   }
 }
 
-template<class Scalar>
-void
-DefaultBlockedLinearOp<Scalar>::scaleRightImpl(
-  const VectorBase< Scalar > &col_scaling)
-{
+template <class Scalar>
+void DefaultBlockedLinearOp<Scalar>::scaleRightImpl(
+    const VectorBase<Scalar> &col_scaling) {
   using Teuchos::dyn_cast;
   using Teuchos::rcp_dynamic_cast;
   typedef ScaledLinearOpBase<Scalar> ScaledOp;
-  typedef RCP<LinearOpBase<Scalar> > LinearOpPtr;
-  typedef RCP<const VectorBase<Scalar> > VectorPtr;
+  typedef RCP<LinearOpBase<Scalar>> LinearOpPtr;
+  typedef RCP<const VectorBase<Scalar>> VectorPtr;
 
-  const ProductVectorBase<Scalar> &
-    Y = dyn_cast<const ProductVectorBase<Scalar> >(col_scaling);
+  const ProductVectorBase<Scalar> &Y =
+      dyn_cast<const ProductVectorBase<Scalar>>(col_scaling);
 
   // using sub block row stat capability interrogate each for
   // its constribution
-  for( int j = 0; j < numColBlocks_; ++j ) {
+  for (int j = 0; j < numColBlocks_; ++j) {
     VectorPtr blk_vec = Y.getVectorBlock(j);
 
-    for( int i = 0; i < numRowBlocks_; ++i ) {
-      LinearOpPtr Op_i_j = getNonconstBlock(i,j);
+    for (int i = 0; i < numRowBlocks_; ++i) {
+      LinearOpPtr Op_i_j = getNonconstBlock(i, j);
 
       if (nonnull(Op_i_j)) {
         // pull out adjoint, and scaling
@@ -774,25 +683,25 @@ DefaultBlockedLinearOp<Scalar>::scaleRightImpl(
         EOpTransp transp = NOTRANS;
 
         {
-          RCP<ScaledAdjointLinearOpBase<Scalar> > saOp
-              = rcp_dynamic_cast<ScaledAdjointLinearOpBase<Scalar> >(Op_i_j);
-          if(nonnull(saOp)) {
+          RCP<ScaledAdjointLinearOpBase<Scalar>> saOp =
+              rcp_dynamic_cast<ScaledAdjointLinearOpBase<Scalar>>(Op_i_j);
+          if (nonnull(saOp)) {
             transp = saOp->overallTransp();
             Orig_i_j = saOp->getNonconstOrigOp();
-          }
-          else
+          } else
             Orig_i_j = Op_i_j; // stick with the original
         }
 
         RCP<ScaledOp> scaled_op = rcp_dynamic_cast<ScaledOp>(Orig_i_j);
 
         // sub block must support a row stat operation
-        TEUCHOS_ASSERT(scaled_op!=Teuchos::null); // guranteed by compatibility check
+        TEUCHOS_ASSERT(scaled_op !=
+                       Teuchos::null); // guranteed by compatibility check
 
         // sub block must also support the required row stat operation
-        if(transp==NOTRANS || transp==CONJ)
+        if (transp == NOTRANS || transp == CONJ)
           scaled_op->scaleRight(*blk_vec);
-        else if(transp==TRANS || transp==CONJTRANS)
+        else if (transp == TRANS || transp == CONJTRANS)
           scaled_op->scaleLeft(*blk_vec);
       }
     }
@@ -801,15 +710,12 @@ DefaultBlockedLinearOp<Scalar>::scaleRightImpl(
 
 // private
 
-
-template<class Scalar>
-void DefaultBlockedLinearOp<Scalar>::resetStorage(
-  const int numRowBlocks, const int numColBlocks
-  )
-{
+template <class Scalar>
+void DefaultBlockedLinearOp<Scalar>::resetStorage(const int numRowBlocks,
+                                                  const int numColBlocks) {
   numRowBlocks_ = numRowBlocks;
   numColBlocks_ = numColBlocks;
-  Ops_.resize(numRowBlocks_*numColBlocks_);
+  Ops_.resize(numRowBlocks_ * numColBlocks_);
   if (is_null(productRange_)) {
     rangeBlocks_.resize(numRowBlocks);
     domainBlocks_.resize(numColBlocks);
@@ -817,45 +723,35 @@ void DefaultBlockedLinearOp<Scalar>::resetStorage(
   blockFillIsActive_ = true;
 }
 
-
-template<class Scalar>
+template <class Scalar>
 void DefaultBlockedLinearOp<Scalar>::assertBlockFillIsActive(
-  bool wantedValue
-  ) const
-{
+    bool wantedValue) const {
 #ifdef TEUCHOS_DEBUG
-  TEUCHOS_TEST_FOR_EXCEPT(!(blockFillIsActive_==wantedValue));
+  TEUCHOS_TEST_FOR_EXCEPT(!(blockFillIsActive_ == wantedValue));
 #else
   (void)wantedValue;
 #endif
 }
 
-
-template<class Scalar>
-void DefaultBlockedLinearOp<Scalar>::assertBlockRowCol(
-  const int i, const int j
-  ) const
-{
+template <class Scalar>
+void DefaultBlockedLinearOp<Scalar>::assertBlockRowCol(const int i,
+                                                       const int j) const {
 #ifdef TEUCHOS_DEBUG
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    !( 0 <= i ), std::logic_error
-    ,"Error, i="<<i<<" is invalid!"
-    );
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    !( 0 <= j ), std::logic_error
-    ,"Error, j="<<j<<" is invalid!"
-    );
+  TEUCHOS_TEST_FOR_EXCEPTION(!(0 <= i), std::logic_error,
+                             "Error, i=" << i << " is invalid!");
+  TEUCHOS_TEST_FOR_EXCEPTION(!(0 <= j), std::logic_error,
+                             "Error, j=" << j << " is invalid!");
   // Only validate upper range if the number of row and column blocks is
   // fixed!
-  if(Ops_.size()) {
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      !( 0 <= i && i < numRowBlocks_ ), std::logic_error
-      ,"Error, i="<<i<<" does not fall in the range [0,"<<numRowBlocks_-1<<"]!"
-      );
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      !( 0 <= j && j < numColBlocks_ ), std::logic_error
-      ,"Error, j="<<j<<" does not fall in the range [0,"<<numColBlocks_-1<<"]!"
-      );
+  if (Ops_.size()) {
+    TEUCHOS_TEST_FOR_EXCEPTION(!(0 <= i && i < numRowBlocks_), std::logic_error,
+                               "Error, i=" << i
+                                           << " does not fall in the range [0,"
+                                           << numRowBlocks_ - 1 << "]!");
+    TEUCHOS_TEST_FOR_EXCEPTION(!(0 <= j && j < numColBlocks_), std::logic_error,
+                               "Error, j=" << j
+                                           << " does not fall in the range [0,"
+                                           << numColBlocks_ - 1 << "]!");
   }
 #else
   (void)i;
@@ -863,110 +759,98 @@ void DefaultBlockedLinearOp<Scalar>::assertBlockRowCol(
 #endif
 }
 
-
-template<class Scalar>
+template <class Scalar>
 void DefaultBlockedLinearOp<Scalar>::setBlockSpaces(
-  const int i, const int j, const LinearOpBase<Scalar> &block
-  )
-{
+    const int i, const int j, const LinearOpBase<Scalar> &block) {
   using Teuchos::toString;
   assertBlockFillIsActive(true);
-  assertBlockRowCol(i,j);
+  assertBlockRowCol(i, j);
 
   // Validate that if the vector space block is already set that it is
   // compatible with the block that is being set.
-  if( i < numRowBlocks_ && j < numColBlocks_ ) {
+  if (i < numRowBlocks_ && j < numColBlocks_) {
 #ifdef TEUCHOS_DEBUG
-    RCP<const VectorSpaceBase<Scalar> >
-      rangeBlock = (
-        productRange_.get()
-        ? productRange_->getBlock(i)
-        : rangeBlocks_[i]
-        ),
-      domainBlock = (
-        productDomain_.get()
-        ? productDomain_->getBlock(j)
-        : domainBlocks_[j]
-        );
-    if(rangeBlock.get()) {
+    RCP<const VectorSpaceBase<Scalar>> rangeBlock =
+                                           (productRange_.get()
+                                                ? productRange_->getBlock(i)
+                                                : rangeBlocks_[i]),
+                                       domainBlock =
+                                           (productDomain_.get()
+                                                ? productDomain_->getBlock(j)
+                                                : domainBlocks_[j]);
+    if (rangeBlock.get()) {
       THYRA_ASSERT_VEC_SPACES_NAMES(
-        "DefaultBlockedLinearOp<Scalar>::setBlockSpaces(i,j,block):\n\n"
-        "Adding block: " + block.description(),
-        *rangeBlock,("(*productRange->getBlock("+toString(i)+"))"),
-        *block.range(),("(*block["+toString(i)+","+toString(j)+"].range())")
-        );
+          "DefaultBlockedLinearOp<Scalar>::setBlockSpaces(i,j,block):\n\n"
+          "Adding block: " +
+              block.description(),
+          *rangeBlock, ("(*productRange->getBlock(" + toString(i) + "))"),
+          *block.range(),
+          ("(*block[" + toString(i) + "," + toString(j) + "].range())"));
     }
-    if(domainBlock.get()) {
+    if (domainBlock.get()) {
       THYRA_ASSERT_VEC_SPACES_NAMES(
-        "DefaultBlockedLinearOp<Scalar>::setBlockSpaces(i,j,block):\n\n"
-        "Adding block: " + block.description(),
-        *domainBlock,("(*productDomain->getBlock("+toString(j)+"))"),
-        *block.domain(),("(*block["+toString(i)+","+toString(j)+"].domain())")
-        );
+          "DefaultBlockedLinearOp<Scalar>::setBlockSpaces(i,j,block):\n\n"
+          "Adding block: " +
+              block.description(),
+          *domainBlock, ("(*productDomain->getBlock(" + toString(j) + "))"),
+          *block.domain(),
+          ("(*block[" + toString(i) + "," + toString(j) + "].domain())"));
     }
 #endif // TEUCHOS_DEBUG
   }
 
   // Add spaces missing range and domain space blocks if we are doing a
   // flexible fill (otherwise these loops will not be executed)
-  for( int k = numRowBlocks_; k <= i; ++k )
+  for (int k = numRowBlocks_; k <= i; ++k)
     rangeBlocks_.push_back(Teuchos::null);
-  for( int k = numColBlocks_; k <= j; ++k )
+  for (int k = numColBlocks_; k <= j; ++k)
     domainBlocks_.push_back(Teuchos::null);
 
   // Set the incoming range and domain blocks if not already set
-  if(!productRange_.get()) {
-    if(!rangeBlocks_[i].get())
+  if (!productRange_.get()) {
+    if (!rangeBlocks_[i].get())
       rangeBlocks_[i] = block.range().assert_not_null();
-    if(!domainBlocks_[j].get()) {
+    if (!domainBlocks_[j].get()) {
       domainBlocks_[j] = block.domain().assert_not_null();
     }
   }
 
   // Update the current number of row and columns blocks if doing a flexible
   // fill.
-  if(!Ops_.size()) {
+  if (!Ops_.size()) {
     numRowBlocks_ = rangeBlocks_.size();
     numColBlocks_ = domainBlocks_.size();
   }
-
 }
 
-
-template<class Scalar>
-template<class LinearOpType>
+template <class Scalar>
+template <class LinearOpType>
 void DefaultBlockedLinearOp<Scalar>::setBlockImpl(
-  const int i, const int j,
-  const RCP<LinearOpType> &block
-  )
-{
+    const int i, const int j, const RCP<LinearOpType> &block) {
   setBlockSpaces(i, j, *block);
   if (Ops_.size()) {
     // We are doing a fill with a fixed number of row and column blocks so we
     // can just set this.
-    Ops_[numRowBlocks_*j+i] = block;
-  }
-  else {
+    Ops_[numRowBlocks_ * j + i] = block;
+  } else {
     // We are doing a flexible fill so add the block to the stack of blocks or
     // replace a block that already exists.
     bool foundBlock = false;
-    for( unsigned int k = 0; k < Ops_stack_.size(); ++k ) {
+    for (unsigned int k = 0; k < Ops_stack_.size(); ++k) {
       BlockEntry<Scalar> &block_i_j = Ops_stack_[k];
-      if( block_i_j.i == i && block_i_j.j == j ) {
+      if (block_i_j.i == i && block_i_j.j == j) {
         block_i_j.block = block;
         foundBlock = true;
         break;
       }
     }
-    if(!foundBlock)
-      Ops_stack_.push_back(BlockEntry<Scalar>(i,j,block));
+    if (!foundBlock)
+      Ops_stack_.push_back(BlockEntry<Scalar>(i, j, block));
   }
 }
 
-
-template<class Scalar>
-void DefaultBlockedLinearOp<Scalar>::adjustBlockSpaces()
-{
+template <class Scalar>
+void DefaultBlockedLinearOp<Scalar>::adjustBlockSpaces() {
 
 #ifdef TEUCHOS_DEBUG
   TEUCHOS_ASSERT_INEQUALITY(Ops_.size(), !=, 0);
@@ -986,11 +870,11 @@ void DefaultBlockedLinearOp<Scalar>::adjustBlockSpaces()
   // Adjust blocks in the range space
   for (int i = 0; i < numRowBlocks_; ++i) {
     for (int j = 0; j < numColBlocks_; ++j) {
-      const RCP<const LinearOpBase<Scalar> >
-        op_i_j = Ops_[numRowBlocks_*j+i];
+      const RCP<const LinearOpBase<Scalar>> op_i_j =
+          Ops_[numRowBlocks_ * j + i];
       if (is_null(op_i_j))
         continue;
-      const RCP<const VectorSpaceBase<Scalar> > range_i_j = op_i_j->range();
+      const RCP<const VectorSpaceBase<Scalar>> range_i_j = op_i_j->range();
       if (is_null(productVectorSpaceBase<Scalar>(range_i_j, false))) {
         rangeBlocks_[i] = range_i_j;
         break;
@@ -1001,43 +885,34 @@ void DefaultBlockedLinearOp<Scalar>::adjustBlockSpaces()
   // Adjust blocks in the domain space
   for (int j = 0; j < numColBlocks_; ++j) {
     for (int i = 0; i < numRowBlocks_; ++i) {
-      const RCP<const LinearOpBase<Scalar> >
-        op_i_j = Ops_[numRowBlocks_*j+i];
+      const RCP<const LinearOpBase<Scalar>> op_i_j =
+          Ops_[numRowBlocks_ * j + i];
       if (is_null(op_i_j))
         continue;
-      const RCP<const VectorSpaceBase<Scalar> >
-        domain_i_j = op_i_j->domain();
+      const RCP<const VectorSpaceBase<Scalar>> domain_i_j = op_i_j->domain();
       if (is_null(productVectorSpaceBase<Scalar>(domain_i_j, false))) {
         domainBlocks_[j] = domain_i_j;
         break;
       }
     }
   }
-
 }
-
 
 } // namespace Thyra
 
-
-template<class Scalar>
-Teuchos::RCP<Thyra::DefaultBlockedLinearOp<Scalar> >
-Thyra::defaultBlockedLinearOp()
-{
+template <class Scalar>
+Teuchos::RCP<Thyra::DefaultBlockedLinearOp<Scalar>>
+Thyra::defaultBlockedLinearOp() {
   return Teuchos::rcp(new DefaultBlockedLinearOp<Scalar>());
 }
 
-
-template<class Scalar>
-Teuchos::RCP<const Thyra::LinearOpBase<Scalar> >
-Thyra::block1x1(
-  const RCP<const LinearOpBase<Scalar> > &A00,
-  const std::string &label
-  )
-{
-  RCP<PhysicallyBlockedLinearOpBase<Scalar> >
-    M = defaultBlockedLinearOp<Scalar>();
-  M->beginBlockFill(1,1);
+template <class Scalar>
+Teuchos::RCP<const Thyra::LinearOpBase<Scalar>>
+Thyra::block1x1(const RCP<const LinearOpBase<Scalar>> &A00,
+                const std::string &label) {
+  RCP<PhysicallyBlockedLinearOpBase<Scalar>> M =
+      defaultBlockedLinearOp<Scalar>();
+  M->beginBlockFill(1, 1);
   M->setBlock(0, 0, A00);
   M->endBlockFill();
   if (label.length())
@@ -1045,80 +920,72 @@ Thyra::block1x1(
   return M;
 }
 
-
-template<class Scalar>
-Teuchos::RCP<const Thyra::LinearOpBase<Scalar> >
-Thyra::block1x2(
-  const RCP<const LinearOpBase<Scalar> > &A00,
-  const RCP<const LinearOpBase<Scalar> > &A01,
-  const std::string &label
-  )
-{
-  RCP<PhysicallyBlockedLinearOpBase<Scalar> >
-    M = defaultBlockedLinearOp<Scalar>();
-  M->beginBlockFill(1,2);
-  if(A00.get()) M->setBlock(0,0,A00);
-  if(A01.get()) M->setBlock(0,1,A01);
+template <class Scalar>
+Teuchos::RCP<const Thyra::LinearOpBase<Scalar>>
+Thyra::block1x2(const RCP<const LinearOpBase<Scalar>> &A00,
+                const RCP<const LinearOpBase<Scalar>> &A01,
+                const std::string &label) {
+  RCP<PhysicallyBlockedLinearOpBase<Scalar>> M =
+      defaultBlockedLinearOp<Scalar>();
+  M->beginBlockFill(1, 2);
+  if (A00.get())
+    M->setBlock(0, 0, A00);
+  if (A01.get())
+    M->setBlock(0, 1, A01);
   M->endBlockFill();
   if (label.length())
     M->setObjectLabel(label);
   return M;
 }
 
-
-template<class Scalar>
-Teuchos::RCP<const Thyra::LinearOpBase<Scalar> >
-Thyra::block2x1(
-  const RCP<const LinearOpBase<Scalar> > &A00,
-  const RCP<const LinearOpBase<Scalar> > &A10,
-  const std::string &label
-  )
-{
-  RCP<PhysicallyBlockedLinearOpBase<Scalar> >
-    M = defaultBlockedLinearOp<Scalar>();
-  M->beginBlockFill(2,1);
-  if(A00.get()) M->setBlock(0,0,A00);
-  if(A10.get()) M->setBlock(1,0,A10);
+template <class Scalar>
+Teuchos::RCP<const Thyra::LinearOpBase<Scalar>>
+Thyra::block2x1(const RCP<const LinearOpBase<Scalar>> &A00,
+                const RCP<const LinearOpBase<Scalar>> &A10,
+                const std::string &label) {
+  RCP<PhysicallyBlockedLinearOpBase<Scalar>> M =
+      defaultBlockedLinearOp<Scalar>();
+  M->beginBlockFill(2, 1);
+  if (A00.get())
+    M->setBlock(0, 0, A00);
+  if (A10.get())
+    M->setBlock(1, 0, A10);
   M->endBlockFill();
   if (label.length())
     M->setObjectLabel(label);
   return M;
 }
 
-
-template<class Scalar>
-Teuchos::RCP<const Thyra::LinearOpBase<Scalar> >
-Thyra::block2x2(
-  const RCP<const LinearOpBase<Scalar> > &A00,
-  const RCP<const LinearOpBase<Scalar> > &A01,
-  const RCP<const LinearOpBase<Scalar> > &A10,
-  const RCP<const LinearOpBase<Scalar> > &A11,
-  const std::string &label
-  )
-{
-  RCP<PhysicallyBlockedLinearOpBase<Scalar> >
-    M = defaultBlockedLinearOp<Scalar>();
-  M->beginBlockFill(2,2);
-  if(A00.get()) M->setBlock(0,0,A00);
-  if(A01.get()) M->setBlock(0,1,A01);
-  if(A10.get()) M->setBlock(1,0,A10);
-  if(A11.get()) M->setBlock(1,1,A11);
+template <class Scalar>
+Teuchos::RCP<const Thyra::LinearOpBase<Scalar>>
+Thyra::block2x2(const RCP<const LinearOpBase<Scalar>> &A00,
+                const RCP<const LinearOpBase<Scalar>> &A01,
+                const RCP<const LinearOpBase<Scalar>> &A10,
+                const RCP<const LinearOpBase<Scalar>> &A11,
+                const std::string &label) {
+  RCP<PhysicallyBlockedLinearOpBase<Scalar>> M =
+      defaultBlockedLinearOp<Scalar>();
+  M->beginBlockFill(2, 2);
+  if (A00.get())
+    M->setBlock(0, 0, A00);
+  if (A01.get())
+    M->setBlock(0, 1, A01);
+  if (A10.get())
+    M->setBlock(1, 0, A10);
+  if (A11.get())
+    M->setBlock(1, 1, A11);
   M->endBlockFill();
   if (label.length())
     M->setObjectLabel(label);
   return M;
 }
 
-
-template<class Scalar>
-Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
-Thyra::nonconstBlock1x1(
-  const RCP<LinearOpBase<Scalar> > &A00,
-  const std::string &label
-  )
-{
-  RCP<PhysicallyBlockedLinearOpBase<Scalar> >
-    M = defaultBlockedLinearOp<Scalar>();
+template <class Scalar>
+Teuchos::RCP<Thyra::LinearOpBase<Scalar>>
+Thyra::nonconstBlock1x1(const RCP<LinearOpBase<Scalar>> &A00,
+                        const std::string &label) {
+  RCP<PhysicallyBlockedLinearOpBase<Scalar>> M =
+      defaultBlockedLinearOp<Scalar>();
   M->beginBlockFill(1, 1);
   M->setNonconstBlock(0, 0, A00);
   M->endBlockFill();
@@ -1127,70 +994,63 @@ Thyra::nonconstBlock1x1(
   return M;
 }
 
-
-template<class Scalar>
-Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
-Thyra::nonconstBlock1x2(
-  const RCP<LinearOpBase<Scalar> > &A00,
-  const RCP<LinearOpBase<Scalar> > &A01,
-  const std::string &label
-  )
-{
-  RCP<PhysicallyBlockedLinearOpBase<Scalar> >
-    M = defaultBlockedLinearOp<Scalar>();
-  M->beginBlockFill(1,2);
-  if(A00.get()) M->setNonconstBlock(0,0,A00);
-  if(A01.get()) M->setNonconstBlock(0,1,A01);
+template <class Scalar>
+Teuchos::RCP<Thyra::LinearOpBase<Scalar>>
+Thyra::nonconstBlock1x2(const RCP<LinearOpBase<Scalar>> &A00,
+                        const RCP<LinearOpBase<Scalar>> &A01,
+                        const std::string &label) {
+  RCP<PhysicallyBlockedLinearOpBase<Scalar>> M =
+      defaultBlockedLinearOp<Scalar>();
+  M->beginBlockFill(1, 2);
+  if (A00.get())
+    M->setNonconstBlock(0, 0, A00);
+  if (A01.get())
+    M->setNonconstBlock(0, 1, A01);
   M->endBlockFill();
   if (label.length())
     M->setObjectLabel(label);
   return M;
 }
 
-
-template<class Scalar>
-Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
-Thyra::nonconstBlock2x1(
-  const RCP<LinearOpBase<Scalar> > &A00,
-  const RCP<LinearOpBase<Scalar> > &A10,
-  const std::string &label
-  )
-{
-  RCP<PhysicallyBlockedLinearOpBase<Scalar> >
-    M = defaultBlockedLinearOp<Scalar>();
-  M->beginBlockFill(2,1);
-  if(A00.get()) M->setNonconstBlock(0,0,A00);
-  if(A10.get()) M->setNonconstBlock(1,0,A10);
+template <class Scalar>
+Teuchos::RCP<Thyra::LinearOpBase<Scalar>>
+Thyra::nonconstBlock2x1(const RCP<LinearOpBase<Scalar>> &A00,
+                        const RCP<LinearOpBase<Scalar>> &A10,
+                        const std::string &label) {
+  RCP<PhysicallyBlockedLinearOpBase<Scalar>> M =
+      defaultBlockedLinearOp<Scalar>();
+  M->beginBlockFill(2, 1);
+  if (A00.get())
+    M->setNonconstBlock(0, 0, A00);
+  if (A10.get())
+    M->setNonconstBlock(1, 0, A10);
   M->endBlockFill();
   if (label.length())
     M->setObjectLabel(label);
   return M;
 }
 
-
-template<class Scalar>
-Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
-Thyra::nonconstBlock2x2(
-  const RCP<LinearOpBase<Scalar> > &A00,
-  const RCP<LinearOpBase<Scalar> > &A01,
-  const RCP<LinearOpBase<Scalar> > &A10,
-  const RCP<LinearOpBase<Scalar> > &A11,
-  const std::string &label
-  )
-{
-  RCP<PhysicallyBlockedLinearOpBase<Scalar> >
-    M = defaultBlockedLinearOp<Scalar>();
-  M->beginBlockFill(2,2);
-  if(A00.get()) M->setNonconstBlock(0,0,A00);
-  if(A01.get()) M->setNonconstBlock(0,1,A01);
-  if(A10.get()) M->setNonconstBlock(1,0,A10);
-  if(A11.get()) M->setNonconstBlock(1,1,A11);
+template <class Scalar>
+Teuchos::RCP<Thyra::LinearOpBase<Scalar>> Thyra::nonconstBlock2x2(
+    const RCP<LinearOpBase<Scalar>> &A00, const RCP<LinearOpBase<Scalar>> &A01,
+    const RCP<LinearOpBase<Scalar>> &A10, const RCP<LinearOpBase<Scalar>> &A11,
+    const std::string &label) {
+  RCP<PhysicallyBlockedLinearOpBase<Scalar>> M =
+      defaultBlockedLinearOp<Scalar>();
+  M->beginBlockFill(2, 2);
+  if (A00.get())
+    M->setNonconstBlock(0, 0, A00);
+  if (A01.get())
+    M->setNonconstBlock(0, 1, A01);
+  if (A10.get())
+    M->setNonconstBlock(1, 0, A10);
+  if (A11.get())
+    M->setNonconstBlock(1, 1, A11);
   M->endBlockFill();
   if (label.length())
     M->setObjectLabel(label);
   return M;
 }
-
 
 //
 // Explicit instantiation macro
@@ -1198,71 +1058,45 @@ Thyra::nonconstBlock2x2(
 // Must be expanded from within the Thyra namespace!
 //
 
+#define THYRA_DEFAULT_BLOCKED_LINEAR_OP_INSTANT(SCALAR)                        \
+                                                                               \
+  template class DefaultBlockedLinearOp<SCALAR>;                               \
+                                                                               \
+  template RCP<DefaultBlockedLinearOp<SCALAR>>                                 \
+  defaultBlockedLinearOp<SCALAR>();                                            \
+                                                                               \
+  template RCP<const LinearOpBase<SCALAR>> block1x1(                           \
+      const RCP<const LinearOpBase<SCALAR>> &A00, const std::string &label);   \
+                                                                               \
+  template RCP<const LinearOpBase<SCALAR>> block1x2(                           \
+      const RCP<const LinearOpBase<SCALAR>> &A00,                              \
+      const RCP<const LinearOpBase<SCALAR>> &A01, const std::string &label);   \
+                                                                               \
+  template RCP<const LinearOpBase<SCALAR>> block2x1(                           \
+      const RCP<const LinearOpBase<SCALAR>> &A00,                              \
+      const RCP<const LinearOpBase<SCALAR>> &A10, const std::string &label);   \
+                                                                               \
+  template RCP<const LinearOpBase<SCALAR>> block2x2(                           \
+      const RCP<const LinearOpBase<SCALAR>> &A00,                              \
+      const RCP<const LinearOpBase<SCALAR>> &A01,                              \
+      const RCP<const LinearOpBase<SCALAR>> &A10,                              \
+      const RCP<const LinearOpBase<SCALAR>> &A11, const std::string &label);   \
+                                                                               \
+  template RCP<LinearOpBase<SCALAR>> nonconstBlock1x1(                         \
+      const RCP<LinearOpBase<SCALAR>> &A00, const std::string &label);         \
+                                                                               \
+  template RCP<LinearOpBase<SCALAR>> nonconstBlock1x2(                         \
+      const RCP<LinearOpBase<SCALAR>> &A00,                                    \
+      const RCP<LinearOpBase<SCALAR>> &A01, const std::string &label);         \
+                                                                               \
+  template RCP<LinearOpBase<SCALAR>> nonconstBlock2x1(                         \
+      const RCP<LinearOpBase<SCALAR>> &A00,                                    \
+      const RCP<LinearOpBase<SCALAR>> &A10, const std::string &label);         \
+                                                                               \
+  template RCP<LinearOpBase<SCALAR>> nonconstBlock2x2(                         \
+      const RCP<LinearOpBase<SCALAR>> &A00,                                    \
+      const RCP<LinearOpBase<SCALAR>> &A01,                                    \
+      const RCP<LinearOpBase<SCALAR>> &A10,                                    \
+      const RCP<LinearOpBase<SCALAR>> &A11, const std::string &label);
 
-#define THYRA_DEFAULT_BLOCKED_LINEAR_OP_INSTANT(SCALAR) \
-  \
-  template class DefaultBlockedLinearOp<SCALAR >; \
-   \
-  template RCP<DefaultBlockedLinearOp<SCALAR > > \
-  defaultBlockedLinearOp<SCALAR >(); \
-   \
-  template RCP<const LinearOpBase<SCALAR > > \
-  block1x1( \
-    const RCP<const LinearOpBase<SCALAR > > &A00, \
-    const std::string &label \
-    ); \
-   \
-  template RCP<const LinearOpBase<SCALAR > > \
-  block1x2( \
-    const RCP<const LinearOpBase<SCALAR > > &A00, \
-    const RCP<const LinearOpBase<SCALAR > > &A01, \
-    const std::string &label \
-    ); \
-   \
-  template RCP<const LinearOpBase<SCALAR > > \
-  block2x1( \
-    const RCP<const LinearOpBase<SCALAR > > &A00, \
-    const RCP<const LinearOpBase<SCALAR > > &A10, \
-    const std::string &label \
-    ); \
-   \
-  template RCP<const LinearOpBase<SCALAR > > \
-  block2x2( \
-    const RCP<const LinearOpBase<SCALAR > > &A00, \
-    const RCP<const LinearOpBase<SCALAR > > &A01, \
-    const RCP<const LinearOpBase<SCALAR > > &A10, \
-    const RCP<const LinearOpBase<SCALAR > > &A11, \
-    const std::string &label \
-    ); \
-   \
-  template RCP<LinearOpBase<SCALAR > > \
-  nonconstBlock1x1( \
-    const RCP<LinearOpBase<SCALAR > > &A00, \
-    const std::string &label \
-    ); \
-   \
-  template RCP<LinearOpBase<SCALAR > > \
-  nonconstBlock1x2( \
-    const RCP<LinearOpBase<SCALAR > > &A00, \
-    const RCP<LinearOpBase<SCALAR > > &A01, \
-    const std::string &label \
-    ); \
-   \
-  template RCP<LinearOpBase<SCALAR > > \
-  nonconstBlock2x1( \
-    const RCP<LinearOpBase<SCALAR > > &A00, \
-    const RCP<LinearOpBase<SCALAR > > &A10, \
-    const std::string &label \
-    ); \
-   \
-  template RCP<LinearOpBase<SCALAR > > \
-  nonconstBlock2x2( \
-    const RCP<LinearOpBase<SCALAR > > &A00, \
-    const RCP<LinearOpBase<SCALAR > > &A01, \
-    const RCP<LinearOpBase<SCALAR > > &A10, \
-    const RCP<LinearOpBase<SCALAR > > &A11, \
-    const std::string &label \
-    );
-
-
-#endif  // THYRA_DEFAULT_BLOCKED_LINEAR_OP_DEF_HPP
+#endif // THYRA_DEFAULT_BLOCKED_LINEAR_OP_DEF_HPP

--- a/packages/xpetra/src/Utils/Xpetra_MatrixMatrix_def.hpp
+++ b/packages/xpetra/src/Utils/Xpetra_MatrixMatrix_def.hpp
@@ -122,6 +122,12 @@ RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> MatrixMatrix<Scal
                                                                                                                                  bool doOptimizeStorage,
                                                                                                                                  const std::string& label,
                                                                                                                                  const RCP<ParameterList>& params) {
+  auto A_blk = rcp_dynamic_cast<const BlockedCrsMatrix>(rcpFromRef(A));
+  auto B_blk = rcp_dynamic_cast<const BlockedCrsMatrix>(rcpFromRef(B));
+  if (A_blk != Teuchos::null && B_blk != Teuchos::null) {
+    return TwoMatrixMultiplyBlock(*A_blk, transposeA, *B_blk, transposeB, fos);
+  }
+
   TEUCHOS_TEST_FOR_EXCEPTION(!A.isFillComplete(), Exceptions::RuntimeError, "A is not fill-completed");
   TEUCHOS_TEST_FOR_EXCEPTION(!B.isFillComplete(), Exceptions::RuntimeError, "B is not fill-completed");
 
@@ -176,15 +182,12 @@ RCP<Xpetra::BlockedCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> MatrixM
                                                                                                                                                          Teuchos::FancyOStream& fos,
                                                                                                                                                          bool doFillComplete,
                                                                                                                                                          bool doOptimizeStorage) {
-  TEUCHOS_TEST_FOR_EXCEPTION(transposeA || transposeB, Exceptions::RuntimeError,
-                             "TwoMatrixMultiply for BlockedCrsMatrix not implemented for transposeA==true or transposeB==true");
-
   // Preconditions
   TEUCHOS_TEST_FOR_EXCEPTION(!A.isFillComplete(), Exceptions::RuntimeError, "A is not fill-completed");
   TEUCHOS_TEST_FOR_EXCEPTION(!B.isFillComplete(), Exceptions::RuntimeError, "B is not fill-completed");
 
-  RCP<const MapExtractor> rgmapextractor = A.getRangeMapExtractor();
-  RCP<const MapExtractor> domapextractor = B.getDomainMapExtractor();
+  RCP<const MapExtractor> rgmapextractor = transposeA ? A.getDomainMapExtractor() : A.getRangeMapExtractor();
+  RCP<const MapExtractor> domapextractor = transposeB ? B.getRangeMapExtractor() : B.getDomainMapExtractor();
 
   RCP<BlockedCrsMatrix> C = rcp(new BlockedCrsMatrix(rgmapextractor, domapextractor, 33 /* TODO fix me */));
 
@@ -193,8 +196,8 @@ RCP<Xpetra::BlockedCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> MatrixM
       RCP<Matrix> Cij;
 
       for (size_t l = 0; l < B.Rows(); ++l) {  // loop for calculating entry C_{ij}
-        RCP<Matrix> crmat1 = A.getMatrix(i, l);
-        RCP<Matrix> crmat2 = B.getMatrix(l, j);
+        RCP<Matrix> crmat1 = transposeA ? A.getMatrix(l, i) : A.getMatrix(i, l);
+        RCP<Matrix> crmat2 = transposeB ? B.getMatrix(j, l) : B.getMatrix(l, j);
 
         if (crmat1.is_null() || crmat2.is_null())
           continue;
@@ -235,25 +238,37 @@ RCP<Xpetra::BlockedCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> MatrixM
         RCP<Matrix> temp = Teuchos::null;
 
         if (crop1 != Teuchos::null && crop2 != Teuchos::null)
-          temp = Multiply(*crop1, false, *crop2, false, fos);
+          temp = Multiply(*crop1, transposeA, *crop2, transposeB, fos);
         else {
           RCP<BlockedCrsMatrix> bop1 = Teuchos::rcp_dynamic_cast<BlockedCrsMatrix>(crmat1);
           RCP<BlockedCrsMatrix> bop2 = Teuchos::rcp_dynamic_cast<BlockedCrsMatrix>(crmat2);
           TEUCHOS_TEST_FOR_EXCEPTION(bop1.is_null() == true, Xpetra::Exceptions::BadCast, "A is not a BlockedCrsMatrix. (TwoMatrixMultiplyBlock)");
           TEUCHOS_TEST_FOR_EXCEPTION(bop2.is_null() == true, Xpetra::Exceptions::BadCast, "B is not a BlockedCrsMatrix. (TwoMatrixMultiplyBlock)");
-          TEUCHOS_TEST_FOR_EXCEPTION(bop1->Cols() != bop2->Rows(), Xpetra::Exceptions::RuntimeError, "A has " << bop1->Cols() << " columns and B has " << bop2->Rows() << " rows. Matrices are not compatible! (TwoMatrixMultiplyBlock)");
-          TEUCHOS_TEST_FOR_EXCEPTION(bop1->getDomainMap()->isSameAs(*(bop2->getRangeMap())) == false, Xpetra::Exceptions::RuntimeError, "Domain map of A is not the same as range map of B. Matrices are not compatible! (TwoMatrixMultiplyBlock)");
+
+          const auto op1Cols = transposeA ? bop1->Rows() : bop1->Cols();
+          const auto op2Rows = transposeB ? bop2->Cols() : bop2->Rows();
+          TEUCHOS_TEST_FOR_EXCEPTION(op1Cols != op2Rows, Xpetra::Exceptions::RuntimeError, "A has " << op1Cols << " columns and B has " << op2Rows << " rows. Matrices are not compatible! (TwoMatrixMultiplyBlock)");
+
+          const auto op1DomainMap = transposeA ? bop1->getRangeMap() : bop1->getDomainMap();
+          const auto op2RangeMap  = transposeB ? bop2->getDomainMap() : bop2->getRangeMap();
+          TEUCHOS_TEST_FOR_EXCEPTION(op1DomainMap->isSameAs(*(op2RangeMap)) == false, Xpetra::Exceptions::RuntimeError, "Domain map of A is not the same as range map of B. Matrices are not compatible! (TwoMatrixMultiplyBlock)");
 
           // recursive multiplication call
           temp = TwoMatrixMultiplyBlock(*bop1, transposeA, *bop2, transposeB, fos, doFillComplete, doOptimizeStorage);
 
+          const auto op1Rows = transposeA ? bop1->Cols() : bop1->Rows();
+          const auto op2Cols = transposeB ? bop2->Rows() : bop2->Cols();
+
+          const auto bop1RangeMap  = transposeA ? bop1->getDomainMapExtractor() : bop1->getRangeMapExtractor();
+          const auto bop2DomainMap = transposeB ? bop2->getRangeMapExtractor() : bop2->getDomainMapExtractor();
+
           RCP<BlockedCrsMatrix> btemp = Teuchos::rcp_dynamic_cast<BlockedCrsMatrix>(temp);
-          TEUCHOS_TEST_FOR_EXCEPTION(btemp->Rows() != bop1->Rows(), Xpetra::Exceptions::RuntimeError, "Number of block rows of local blocked operator is " << btemp->Rows() << " but should be " << bop1->Rows() << ". (TwoMatrixMultiplyBlock)");
-          TEUCHOS_TEST_FOR_EXCEPTION(btemp->Cols() != bop2->Cols(), Xpetra::Exceptions::RuntimeError, "Number of block cols of local blocked operator is " << btemp->Cols() << " but should be " << bop2->Cols() << ". (TwoMatrixMultiplyBlock)");
-          TEUCHOS_TEST_FOR_EXCEPTION(btemp->getRangeMapExtractor()->getFullMap()->isSameAs(*(bop1->getRangeMapExtractor()->getFullMap())) == false, Xpetra::Exceptions::RuntimeError, "Range map of local blocked operator should be same as first operator. (TwoMatrixMultiplyBlock)");
-          TEUCHOS_TEST_FOR_EXCEPTION(btemp->getDomainMapExtractor()->getFullMap()->isSameAs(*(bop2->getDomainMapExtractor()->getFullMap())) == false, Xpetra::Exceptions::RuntimeError, "Domain map of local blocked operator should be same as second operator. (TwoMatrixMultiplyBlock)");
-          TEUCHOS_TEST_FOR_EXCEPTION(btemp->getRangeMapExtractor()->getThyraMode() != bop1->getRangeMapExtractor()->getThyraMode(), Xpetra::Exceptions::RuntimeError, "Thyra mode of local range map extractor incompatible with range map extractor of A (TwoMatrixMultiplyBlock)");
-          TEUCHOS_TEST_FOR_EXCEPTION(btemp->getDomainMapExtractor()->getThyraMode() != bop2->getDomainMapExtractor()->getThyraMode(), Xpetra::Exceptions::RuntimeError, "Thyra mode of local domain map extractor incompatible with domain map extractor of B (TwoMatrixMultiplyBlock)");
+          TEUCHOS_TEST_FOR_EXCEPTION(btemp->Rows() != op1Rows, Xpetra::Exceptions::RuntimeError, "Number of block rows of local blocked operator is " << btemp->Rows() << " but should be " << op1Rows << ". (TwoMatrixMultiplyBlock)");
+          TEUCHOS_TEST_FOR_EXCEPTION(btemp->Cols() != op2Cols, Xpetra::Exceptions::RuntimeError, "Number of block cols of local blocked operator is " << btemp->Cols() << " but should be " << op2Cols << ". (TwoMatrixMultiplyBlock)");
+          TEUCHOS_TEST_FOR_EXCEPTION(btemp->getRangeMapExtractor()->getFullMap()->isSameAs(*(bop1RangeMap->getFullMap())) == false, Xpetra::Exceptions::RuntimeError, "Range map of local blocked operator should be same as first operator. (TwoMatrixMultiplyBlock)");
+          TEUCHOS_TEST_FOR_EXCEPTION(btemp->getDomainMapExtractor()->getFullMap()->isSameAs(*(bop2DomainMap->getFullMap())) == false, Xpetra::Exceptions::RuntimeError, "Domain map of local blocked operator should be same as second operator. (TwoMatrixMultiplyBlock)");
+          TEUCHOS_TEST_FOR_EXCEPTION(btemp->getRangeMapExtractor()->getThyraMode() != bop1RangeMap->getThyraMode(), Xpetra::Exceptions::RuntimeError, "Thyra mode of local range map extractor incompatible with range map extractor of A (TwoMatrixMultiplyBlock)");
+          TEUCHOS_TEST_FOR_EXCEPTION(btemp->getDomainMapExtractor()->getThyraMode() != bop2DomainMap->getThyraMode(), Xpetra::Exceptions::RuntimeError, "Thyra mode of local domain map extractor incompatible with domain map extractor of B (TwoMatrixMultiplyBlock)");
         }
 
         TEUCHOS_TEST_FOR_EXCEPTION(temp->isFillComplete() == false, Xpetra::Exceptions::RuntimeError, "Local block is not filled. (TwoMatrixMultiplyBlock)");
@@ -270,7 +285,11 @@ RCP<Xpetra::BlockedCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> MatrixM
       if (!Cij.is_null()) {
         if (Cij->isFillComplete())
           Cij->resumeFill();
-        Cij->fillComplete(B.getDomainMap(j), A.getRangeMap(i));
+
+        auto BjDomainMap = transposeB ? B.getRangeMap(j) : B.getDomainMap(j);
+        auto AiDomainMap = transposeA ? A.getDomainMap(i) : A.getRangeMap(i);
+        Cij->fillComplete(BjDomainMap, AiDomainMap);
+
         C->setMatrix(i, j, Cij);
       } else {
         C->setMatrix(i, j, Teuchos::null);


### PR DESCRIPTION
@trilinos/muelu 
@trilinos/teko
@trilinos/thyra
@trilinos/xpetra 

## Motivation
 * Support additional use-cases for block AMG approaches in MueLu.

## Testing
 * Unit testing needed for this to be considered ready to merge.

## Additional Information
  Work presented as part of the HPSF 2026 conference, see: [HPSF 2026 talk](https://hpsf2026.sched.com/event/2ESls/block-based-algebraic-multigrid-preconditioners-in-trilinosteko-malachi-phillips-sandia-national-laboratories) and [slides](https://static.sched.com/hosted_files/hpsf2026/43/malachi-hpsf-2026.pdf?_gl=1*1oynvs4*_gcl_au*Mjg1NDA0ODA2LjE3Njk3Mjg5OTcuMTYwMjM0NDMzOC4xNzczNDAwNjk3LjE3NzM0MDEwMzg.*FPAU*Mjg1NDA0ODA2LjE3Njk3Mjg5OTc.)

## Concerns

* This will change the current behavior of `MueLu::TekoSmoother`
