### PR TITLE
Tpetra: FIx grammar in error message

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -4051,7 +4051,7 @@ CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
                                           "indices from global to local, we encountered "
               << lclNumErrs
               << " ind" << (pluralNumErrs ? "ices" : "ex")
-              << " that do" << (pluralNumErrs ? "es" : "")
+              << " that do" << (pluralNumErrs ? "" : "es")
               << " not live in the column Map on this process." << endl;
     }
 


### PR DESCRIPTION
@trilinos/tpetra>

## Motivation
Singular and plural versions were swapped for the second part of the error message.