### PR TITLE
Add simple configure scripts for Trilinos

### DIFF
--- a/sampleScripts/simple-genconfig-scripts/clang-genconfig/README.md
+++ b/sampleScripts/simple-genconfig-scripts/clang-genconfig/README.md
@@ -1,0 +1,45 @@
+# Official Trilinos clang GenConfig configuration
+
+This configuration matches the exact configuration that Trilinos uses for its
+clang PR and nightly builds that run out of this container.
+
+To do a configuration of Trilinos, on the host, get the GenCongif files with:
+
+```bash
+cd Trilinos/
+./packages/framework/get_dependencies.sh
+```
+
+Then, inside of the container, create the build dir with:
+
+```bash
+cd /mounted_from_host/Trilinos/
+mkdir -p BUILDS/clang-19-genconfig
+cd BUILDS/clang-19-genconfig/
+ln -s ../../sampleScripts/simple-genconfig-scripts/clang-genconfig/* .
+```
+
+Then, inside of the container, you can configure and build any Trilinos package with:
+
+```bash
+cd /mounted_from_host/Trilinos/BUILDS/clang-19-genconfig/
+. load-env.sh [--ci-mode]  # Will drop you into a new shell unless you pass in --ci-mode
+./do-configure -DTrilinos_ENABLE_Tpetra=ON  # Or any other Trilinos packages you want
+ninja -j $(($(nproc)/2))
+ctest -j $(($(nproc)/2))
+```
+
+You can also build and submit to the default internal SNL CDash site with:
+
+```bash
+make dashboard
+```
+
+Or, if you are working on an external machine using an externally built Trilinos container, you can use:
+
+```bash
+./do-configure-mycdash -DTrilinos_ENABLE_Tpetra=ON
+make dashboard
+```
+
+(see the STDOUT for where that is going and the link to the build).

--- a/sampleScripts/simple-genconfig-scripts/clang-genconfig/do-configure
+++ b/sampleScripts/simple-genconfig-scripts/clang-genconfig/do-configure
@@ -1,0 +1,4 @@
+#!/bin/bash
+./do-configure.base \
+-DTrilinos_ENABLE_TESTS=ON \
+"$@"

--- a/sampleScripts/simple-genconfig-scripts/clang-genconfig/do-configure-mycdash
+++ b/sampleScripts/simple-genconfig-scripts/clang-genconfig/do-configure-mycdash
@@ -1,0 +1,9 @@
+#!/bin/bash
+./do-configure.base \
+-DTrilinos_ENABLE_TESTS=ON \
+-DCTEST_SITE=$(cat /etc/hostname) \
+-DCTEST_DROP_SITE="my.cdash.org" \
+-DCTEST_PROJECT_NAME="Trilinos" \
+-DCTEST_DROP_LOCATION="/submit.php?project=ExternalTrilinos" \
+-DTRIBITS_2ND_CTEST_DROP_SITE="" \
+"$@"

--- a/sampleScripts/simple-genconfig-scripts/clang-genconfig/do-configure.base
+++ b/sampleScripts/simple-genconfig-scripts/clang-genconfig/do-configure.base
@@ -1,0 +1,17 @@
+#!/bin/bash
+if [[ -e CMakeCache.txt ]] ; then
+  rm  CMakeCache.txt
+fi
+if [[ -d CMakeFiles ]] ; then
+  rm -r CMakeFiles
+fi  
+cmake \
+-GNinja \
+-C GenConfigSettings.cmake \
+-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+-D CTEST_BUILD_NAME=clang-$(clang++ --version | head -1 | cut -d ' ' -f 3)-mpich-$(mpirun --version | head -1 | cut -d ' ' -f 4)-$(git branch --show-current) \
+-D CTEST_BUILD_FLAGS=-j$(nproc) \
+-D CTEST_PARALLEL_LEVEL=$(nproc) \
+-D Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES=OFF \
+"$@" \
+../..

--- a/sampleScripts/simple-genconfig-scripts/clang-genconfig/load-env.sh
+++ b/sampleScripts/simple-genconfig-scripts/clang-genconfig/load-env.sh
@@ -1,0 +1,8 @@
+source /home/runner/.bashrc
+export TRILINOS_DIR=$(realpath ../..)
+source ${TRILINOS_DIR}/packages/framework/GenConfig/gen-config.sh \
+  rhel_clang-openmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables \
+  --cmake-fragment GenConfigSettings.cmake \
+  --force -y \
+  "$@" \
+  ${TRILINOS_DIR}

--- a/sampleScripts/simple-genconfig-scripts/clang-simple/README.md
+++ b/sampleScripts/simple-genconfig-scripts/clang-simple/README.md
@@ -1,0 +1,28 @@
+# Simple Trilinos build configuration using Trilinos clang-19 container
+
+This build configuration enables a lot of Trilinos without using GenConfig.  The
+purpose is to be a very simple configuration that is easy to understand and work
+with.
+
+To do a configuration of Trilinos, create a build directory and sym-link in these files:
+
+```bash
+cd Trilinos/
+mkdir -p BUILDS/clang-19-simple
+cd BUILDS/clang-19-simple/
+ln -s ../../sampleScripts/simple-genconfig-scripts/clang-simple/* .
+```
+
+Then to configure Trilinos like:
+
+```bash
+. load-env.sh
+./do-configure -DTrilinos_ENABLE_Tpetra=ON  # Or whatever packages you want
+```
+
+Then you are ready to build, run tests, etc. with:
+
+```bash
+ninja -j $(($(nproc)/2))
+ctest -j $(($(nproc)/2))
+```

--- a/sampleScripts/simple-genconfig-scripts/clang-simple/do-configure
+++ b/sampleScripts/simple-genconfig-scripts/clang-simple/do-configure
@@ -1,0 +1,4 @@
+#!/bin/bash
+./do-configure.base \
+-DTrilinos_ENABLE_TESTS=ON \
+"$@"

--- a/sampleScripts/simple-genconfig-scripts/clang-simple/do-configure.base
+++ b/sampleScripts/simple-genconfig-scripts/clang-simple/do-configure.base
@@ -1,0 +1,13 @@
+#!/bin/bash
+rm -rf CMakeCache.txt CMakeFiles
+cmake \
+-GNinja \
+-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+-DTPL_ENABLE_MPI=ON \
+-DTrilinos_ENABLE_Fortran=OFF \
+-DCMAKE_C_COMPILER=$(which mpicc) \
+-DCMAKE_CXX_COMPILER=$(which mpicxx) \
+-D CTEST_BUILD_FLAGS=-j$(nproc) \
+-D CTEST_PARALLEL_LEVEL=$(nproc) \
+"$@" \
+../..

--- a/sampleScripts/simple-genconfig-scripts/clang-simple/load-env.sh
+++ b/sampleScripts/simple-genconfig-scripts/clang-simple/load-env.sh
@@ -1,0 +1,3 @@
+if [[ -e /home/runner/.bashrc ]] ; then
+  . /home/runner/.bashrc
+fi


### PR DESCRIPTION
Make it easy for people to configure Trilinos using a container image (or otherwise).  I need this to make it very easy to configure and build Trilinos once you have a container image.  I have my own branch but merging this to Trilinos 'develop' will make this more accessible.
