### PR TITLE
tpetra: InnerProductSpaceTraits compatibility update

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -24,7 +24,11 @@
 #include "Teuchos_DataAccess.hpp"
 #include "Teuchos_Range1D.hpp"
 #include "KokkosKernels_ArithTraits.hpp"
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_5
+#include "KokkosKernels_InnerProductSpaceTraits.hpp"
+#else
 #include "Kokkos_InnerProductSpaceTraits.hpp"
+#endif
 #include "Tpetra_KokkosRefactor_Details_MultiVectorLocalDeepCopy.hpp"
 #include "Tpetra_Access.hpp"
 #include "Tpetra_Details_WrappedDualView.hpp"
@@ -384,8 +388,13 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// This is usually the same as <tt>impl_scalar_type</tt>, but may
   /// differ if <tt>impl_scalar_type</tt> is e.g., an uncertainty
   /// quantification type from the Stokhos package.
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  using dot_type =
+      typename KokkosKernels::Details::InnerProductSpaceTraits<impl_scalar_type>::dot_type;
+#else
   using dot_type =
       typename Kokkos::Details::InnerProductSpaceTraits<impl_scalar_type>::dot_type;
+#endif
 
   /// \brief Type of a norm result.
   ///

--- a/packages/tpetra/core/test/CrsMatrix/assembleElement.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/assembleElement.cpp
@@ -13,7 +13,11 @@
 #include "Tpetra_Map.hpp"
 #include "Kokkos_Core.hpp"
 #include "KokkosKernels_ArithTraits.hpp"
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_5
+#include "KokkosKernels_InnerProductSpaceTraits.hpp"
+#else
 #include "Kokkos_InnerProductSpaceTraits.hpp"
+#endif
 #include "Tpetra_Details_crsMatrixAssembleElement.hpp"
 #include <typeinfo>  // methods on std::type_info
 #include <utility>   // std::pair


### PR DESCRIPTION
Compatibility update https://github.com/kokkos/kokkos-kernels/pull/3006 when compiling with Kokkos_ENABLE_DEPRECATED_CODE_5=OFF

Tested locally to confirm it resolves compilation errors

@trilinos/tpetra 

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
