### PR TITLE
FROSch: add numerical tol for detecting dirichletBoundaryDof

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_TwoLevelPreconditioner_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_TwoLevelPreconditioner_def.hpp
@@ -137,10 +137,11 @@ namespace FROSch {
         /////////////////////////////////////
         if (dirichletBoundaryDofs.is_null()) {
             FROSCH_DETAILTIMER_START_LEVELID(determineDirichletRowsTime,"Determine Dirichlet Rows");
+            typename ScalarTraits<SC>::magnitudeType tol = this->ParameterList_->get("DirichletBoundary Numerical Tolerance",1.0e-12);
 #ifdef FindOneEntryOnlyRowsGlobal_Matrix
-            dirichletBoundaryDofs = FindOneEntryOnlyRowsGlobal(this->K_.getConst(),repeatedMap);
+            dirichletBoundaryDofs = FindOneEntryOnlyRowsGlobal(this->K_.getConst(),repeatedMap, tol);
 #else
-            dirichletBoundaryDofs = FindOneEntryOnlyRowsGlobal(this->K_->getCrsGraph(),repeatedMap);
+            dirichletBoundaryDofs = FindOneEntryOnlyRowsGlobal(this->K_->getCrsGraph(),repeatedMap, tol);
 #endif
         }
 

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_decl.hpp
@@ -278,7 +278,8 @@ namespace FROSch {
 
     template <class SC,class LO,class GO,class NO>
     ArrayRCP<GO> FindOneEntryOnlyRowsGlobal(RCP<const Matrix<SC,LO,GO,NO> > matrix,
-                                            RCP<const Map<LO,GO,NO> > repeatedMap);
+                                            RCP<const Map<LO,GO,NO> > repeatedMap,
+                                            typename ScalarTraits<SC>::magnitudeType tol = 1.0e-12);
 
     template <class LO,class GO,class NO>
     ArrayRCP<GO> FindOneEntryOnlyRowsGlobal(RCP<const CrsGraph<LO,GO,NO> > graph,

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp
@@ -1319,7 +1319,8 @@ namespace FROSch {
 
     template <class SC,class LO,class GO,class NO>
     ArrayRCP<GO> FindOneEntryOnlyRowsGlobal(RCP<const Matrix<SC,LO,GO,NO> > matrix,
-                                            RCP<const Map<LO,GO,NO> > repeatedMap)
+                                            RCP<const Map<LO,GO,NO> > repeatedMap,
+                                            typename ScalarTraits<SC>::magnitudeType tol)
     {
         FROSCH_DETAILTIMER_START(findOneEntryOnlyRowsGlobalTime,"FindOneEntryOnlyRowsGlobal");
         RCP<Matrix<SC,LO,GO,NO> > repeatedMatrix = MatrixFactory<SC,LO,GO,NO>::Build(repeatedMap,2*matrix->getGlobalMaxNumRowEntries());
@@ -1341,7 +1342,7 @@ namespace FROSch {
                 tmp++;
             } else {
                 for (LO j=0; j<values.size(); j++) {
-                    if (fabs(values[j])<1.0e-12) {
+                    if (fabs(values[j])<tol) {
                         nnz--;
                     }
                 }


### PR DESCRIPTION


@trilinos/shylu 

## Motivation

This PR adds numerical tolerance for detecting dirichletBoundaryDof

## Related Issues
 * [FROSch tests failing](https://github.com/sandialabs/Albany/issues/1149)

## Testing

## Additional Information

This issue was exposed by this [commit](https://github.com/trilinos/Trilinos/commit/66d86c5affb5739b9b7dec5da2b507d6293e2591), which fixed the initialization issue.
