### PR TITLE
FROSch: set default tol value for FindOneEntryOnlyRowsGlobal to be zero

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
@@ -82,6 +82,7 @@ namespace FROSch {
         }
         FROSCH_ASSERT(AssembledBasisMap_->getMaxAllGlobalIndex()==AssembledBasisMapUnique_->getMaxAllGlobalIndex(),"FROSch::CoarseSpace: AssembledBasisMap_->getMaxAllGlobalIndex()!=AssembledBasisMapUnique_->getMaxAllGlobalIndex()");
         FROSCH_ASSERT(AssembledBasisMap_->getMinAllGlobalIndex()==AssembledBasisMapUnique_->getMinAllGlobalIndex(),"FROSch::CoarseSpace: AssembledBasisMap_->getMinAllGlobalIndex()!=AssembledBasisMapUnique_->getMinAllGlobalIndex()");
+        FROSCH_ASSERT(GO(AssembledBasisMapUnique_->getGlobalNumElements())>0,"FROSch::CoarseSpace: No basis function found for AssembledBasisMapUnique");
         FROSCH_ASSERT(GO(AssembledBasisMapUnique_->getGlobalNumElements())==GO(AssembledBasisMapUnique_->getMaxAllGlobalIndex()+1),"FROSch::CoarseSpace: AssembledBasisMapUnique_->getGlobalNumElements()!=(AssembledBasisMapUnique_->getMaxAllGlobalIndex()+1)");
 
         // Basis

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_TwoLevelPreconditioner_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_TwoLevelPreconditioner_def.hpp
@@ -135,15 +135,15 @@ namespace FROSch {
         /////////////////////////////////////
         // Determine dirichletBoundaryDofs //
         /////////////////////////////////////
-        /*if (dirichletBoundaryDofs.is_null()) {
+        if (dirichletBoundaryDofs.is_null()) {
             FROSCH_DETAILTIMER_START_LEVELID(determineDirichletRowsTime,"Determine Dirichlet Rows");
-            typename ScalarTraits<SC>::magnitudeType tol = this->ParameterList_->get("DirichletBoundary Numerical Tolerance",1.0e-12);
+            typename ScalarTraits<SC>::magnitudeType tol = this->ParameterList_->get("DirichletBoundary Numerical Tolerance",0.0);
 #ifdef FindOneEntryOnlyRowsGlobal_Matrix
             dirichletBoundaryDofs = FindOneEntryOnlyRowsGlobal(this->K_.getConst(),repeatedMap, tol);
 #else
             dirichletBoundaryDofs = FindOneEntryOnlyRowsGlobal(this->K_->getCrsGraph(),repeatedMap, tol);
 #endif
-        }*/
+        }
 
         ////////////////////////////////////
         // Initialize OverlappingOperator //

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_TwoLevelPreconditioner_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzPreconditioners/FROSch_TwoLevelPreconditioner_def.hpp
@@ -135,7 +135,7 @@ namespace FROSch {
         /////////////////////////////////////
         // Determine dirichletBoundaryDofs //
         /////////////////////////////////////
-        if (dirichletBoundaryDofs.is_null()) {
+        /*if (dirichletBoundaryDofs.is_null()) {
             FROSCH_DETAILTIMER_START_LEVELID(determineDirichletRowsTime,"Determine Dirichlet Rows");
             typename ScalarTraits<SC>::magnitudeType tol = this->ParameterList_->get("DirichletBoundary Numerical Tolerance",1.0e-12);
 #ifdef FindOneEntryOnlyRowsGlobal_Matrix
@@ -143,7 +143,7 @@ namespace FROSch {
 #else
             dirichletBoundaryDofs = FindOneEntryOnlyRowsGlobal(this->K_->getCrsGraph(),repeatedMap, tol);
 #endif
-        }
+        }*/
 
         ////////////////////////////////////
         // Initialize OverlappingOperator //

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_decl.hpp
@@ -279,7 +279,7 @@ namespace FROSch {
     template <class SC,class LO,class GO,class NO>
     ArrayRCP<GO> FindOneEntryOnlyRowsGlobal(RCP<const Matrix<SC,LO,GO,NO> > matrix,
                                             RCP<const Map<LO,GO,NO> > repeatedMap,
-                                            typename ScalarTraits<SC>::magnitudeType tol = 1.0e-12);
+                                            typename ScalarTraits<SC>::magnitudeType tol = 0.0);
 
     template <class LO,class GO,class NO>
     ArrayRCP<GO> FindOneEntryOnlyRowsGlobal(RCP<const CrsGraph<LO,GO,NO> > graph,

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp
@@ -1327,6 +1327,7 @@ namespace FROSch {
         RCP<Import<LO,GO,NO> > scatter = ImportFactory<LO,GO,NO>::Build(matrix->getRowMap(),repeatedMap);
         repeatedMatrix->doImport(*matrix,*scatter,ADD);
 
+        typename ScalarTraits<SC>::magnitudeType zero (0.0);
         ArrayRCP<GO> oneEntryOnlyRows(repeatedMatrix->getLocalNumRows());
         LO tmp = 0;
         LO nnz;
@@ -1340,7 +1341,7 @@ namespace FROSch {
             if (indices.size()==1) {
                 oneEntryOnlyRows[tmp] = row;
                 tmp++;
-            } else {
+            } else if (tol > zero) {
                 for (LO j=0; j<values.size(); j++) {
                     if (fabs(values[j])<tol) {
                         nnz--;


### PR DESCRIPTION

@trilinos/shylu 

## Motivation

This PR change the default tolerance used by FindOneEntryOnlyRowsGlobal for dirichletBoundaryDofs to be zero (it used to be 1.0e-12)

## Related Issues
 * [FROSch tests failing](https://github.com/sandialabs/Albany/issues/1149)