### PR TITLE
MueLu: Add missing resize for levelManagers_

### DIFF
--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -515,6 +515,7 @@ bool Hierarchy<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Setup(int coarseLevel
       Levels_[nextLevelID - 2]->Release(*coarseFact);
     }
     Levels_.resize(actualNumLevels);
+    levelManagers_.resize(actualNumLevels);
   }
 
   // I think this is the proper place for graph so that it shows every dependence


### PR DESCRIPTION
@trilinos/muelu 

This resolves a corner-case where all the rows of a matrix are flagged as Dirichlet during aggregation. As a result, only the first level is constructed. However, there is a size mismatch between `Hierarchy::Levels_` and `Hierarchy::levelManagers_` on subsequent re-use, triggering the following throw:

```
<path-to-trilinos>/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp:541:
  Throw number = 5
  Throw test that evaluated to true: levelManagers_.size() != numLevels
  Hierarchy::SetupRe: 1 levels, but  2 level factory managers
```