### PR TITLE
SEACAS: fix unit-tests cmake logic

### DIFF
--- a/packages/seacas/libraries/exodus/test/CMakeLists.txt
+++ b/packages/seacas/libraries/exodus/test/CMakeLists.txt
@@ -154,8 +154,10 @@ IF ( NETCDF_NCDUMP_BINARY )
   #       when built with shareable libraries on some platforms....
 
   FOREACH ( testName ${cbind_OLDTESTS} )
-    TRIBITS_ADD_EXECUTABLE( ${testName} NOEXEPREFIX NOEXESUFFIX SOURCES ${testName}.c LINKER_LANGUAGE CXX)
-    set_property(TARGET ${testName} PROPERTY C_STANDARD 99)
+    TRIBITS_ADD_EXECUTABLE( ${testName} NOEXEPREFIX NOEXESUFFIX SOURCES ${testName}.c LINKER_LANGUAGE CXX ADDED_EXE_TARGET_NAME_OUT ${testName}_TARGET_NAME )
+    IF ( ${testName}_TARGET_NAME )
+      set_property(TARGET ${testName} PROPERTY C_STANDARD 99)
+    ENDIF()
   ENDFOREACH ( testName )
 
   TRIBITS_ADD_TEST(


### PR DESCRIPTION
The current cmake logic unconditionally applies properties to unit-test targets without checking that the target is actually created which leads to failures especially for performance test builds.

@trilinos/seacas 

## Motivation
 * seacas fails to configure when only the performance test category is enabled

## Related Issues
 * N/A

## Stakeholder Feedback
 * As the stakeholder, this fixes my problem

## Testing
 * Tested on Sandia machine, Trilinos configures and compiles after the fix is applied


