### PR TITLE
Tpetra Map: Allow to bypass global communication

### DIFF
--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_def.hpp
@@ -153,11 +153,14 @@ void TentativePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level&
     for (LO i = 0; i < numCoarseNodes; i++) {
       nodeList[i] = (elementAList[i * blkSize] - indexBase) / blkSize + indexBase;
     }
+    Teuchos::RCP<Teuchos::ParameterList> params = Teuchos::rcp(new Teuchos::ParameterList());
+    params->set("compute global constants", false);
     RCP<const Map> coarseCoordsMap = MapFactory::Build(fineCoords->getMap()->lib(),
-                                                       Teuchos::OrdinalTraits<Xpetra::global_size_t>::invalid(),
+                                                       blkSize * coarseMap->getGlobalNumElements(),
                                                        nodeList,
                                                        indexBase,
-                                                       fineCoords->getMap()->getComm());
+                                                       fineCoords->getMap()->getComm(),
+                                                       params);
     coarseCoords                   = RealValuedMultiVectorFactory::Build(coarseCoordsMap, numDimensions);
 
     // Create overlapped fine coordinates to reduce global communication

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -3071,7 +3071,7 @@ void import_and_extract_views(
         remoteRows[i] = targetMap->getGlobalElement(remoteLIDs[i]);
 
       remoteRowMap = rcp(new map_type(Teuchos::OrdinalTraits<global_size_t>::invalid(), remoteRows(),
-                                      rowMap->getIndexBase(), rowMap->getComm()));
+                                      rowMap->getIndexBase(), rowMap->getComm(), params));
       mode         = 1;
 
     } else if (prototypeImporter.is_null()) {
@@ -3090,7 +3090,7 @@ void import_and_extract_views(
       }
       remoteRows.resize(numRemote);
       remoteRowMap = rcp(new map_type(Teuchos::OrdinalTraits<global_size_t>::invalid(), remoteRows(),
-                                      rowMap->getIndexBase(), rowMap->getComm()));
+                                      rowMap->getIndexBase(), rowMap->getComm(), params));
       mode         = 2;
 
     } else {
@@ -3106,16 +3106,9 @@ void import_and_extract_views(
     }
 
     //
-    // Now we will import the needed remote rows of A, if the global maximum
-    // value of numRemote is greater than 0.
+    // Now we will import the needed remote rows of A, if the remoteRowMap has entries
     //
-    MM = Teuchos::null;
-    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: I&X Collective-0"));
-
-    global_size_t globalMaxNumRemote = 0;
-    Teuchos::reduceAll(*(rowMap->getComm()), Teuchos::REDUCE_MAX, (global_size_t)numRemote, Teuchos::outArg(globalMaxNumRemote));
-
-    if (globalMaxNumRemote > 0) {
+    if (!remoteRowMap.is_null() && (remoteRowMap->getGlobalNumElements() > 0)) {
       MM = Teuchos::null;
       MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: I&X Import-2"));
 
@@ -3282,14 +3275,11 @@ void import_and_extract_views(
     return;
   }
 
-  // Now we will import the needed remote rows of M, if the global maximum
-  // value of numRemote is greater than 0.
-  global_size_t globalMaxNumRemote = 0;
-  Teuchos::reduceAll(*(rowMap->getComm()), Teuchos::REDUCE_MAX, (global_size_t)numRemote, Teuchos::outArg(globalMaxNumRemote));
+  // Now we will import the needed remote rows of M, if the remoteRowMap has entries
 
   RCP<const import_type> importer;
 
-  if (globalMaxNumRemote > 0) {
+  if (!remoteRowMap.is_null() && (remoteRowMap->getGlobalNumElements() > 0)) {
     // Create an importer with target-map remoteRowMap and source-map rowMap.
     if (mode == 1)
       importer = prototypeImporter->createRemoteOnlyImport(remoteRowMap);

--- a/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
+++ b/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
@@ -6039,6 +6039,15 @@ class Writer {
     RCP<const map_type> domainMap = matrix.getDomainMap();
     RCP<const map_type> rangeMap  = matrix.getRangeMap();
 
+    if (!rowMap->haveGlobalConstants())
+      Teuchos::rcp_const_cast<map_type>(rowMap)->computeGlobalConstants();
+    if (!colMap->haveGlobalConstants())
+      Teuchos::rcp_const_cast<map_type>(colMap)->computeGlobalConstants();
+    if (!domainMap->haveGlobalConstants())
+      Teuchos::rcp_const_cast<map_type>(domainMap)->computeGlobalConstants();
+    if (!rangeMap->haveGlobalConstants())
+      Teuchos::rcp_const_cast<map_type>(rangeMap)->computeGlobalConstants();
+
     const global_size_t numRows = rangeMap->getMaxAllGlobalIndex() + 1 - rangeMap->getIndexBase();
     const global_size_t numCols = domainMap->getMaxAllGlobalIndex() + 1 - domainMap->getIndexBase();
 
@@ -6331,6 +6340,15 @@ class Writer {
     auto colMap    = graph.getColMap();
     auto domainMap = graph.getDomainMap();
     auto rangeMap  = graph.getRangeMap();
+
+    if (!rowMap->haveGlobalConstants())
+      Teuchos::rcp_const_cast<map_type>(rowMap)->computeGlobalConstants();
+    if (!colMap->haveGlobalConstants())
+      Teuchos::rcp_const_cast<map_type>(colMap)->computeGlobalConstants();
+    if (!domainMap->haveGlobalConstants())
+      Teuchos::rcp_const_cast<map_type>(domainMap)->computeGlobalConstants();
+    if (!rangeMap->haveGlobalConstants())
+      Teuchos::rcp_const_cast<map_type>(rangeMap)->computeGlobalConstants();
 
     const global_size_t numRows = rangeMap->getGlobalNumElements();
     const global_size_t numCols = domainMap->getGlobalNumElements();

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -6795,7 +6795,8 @@ void CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
                                                     CSR_colind_GID(),
                                                     BaseDomainMap,
                                                     TargetPids, RemotePids,
-                                                    MyColMap);
+                                                    MyColMap,
+                                                    params);
 
   /*******************************************************/
   /**** 4) Second communicator restriction phase      ****/

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -8258,7 +8258,8 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
                                                               BaseDomainMap,
                                                               TargetPids,
                                                               RemotePids,
-                                                              MyColMap);
+                                                              MyColMap,
+                                                              params);
     }
 
     if (verbose) {
@@ -8430,7 +8431,8 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
                                                         BaseDomainMap,
                                                         TargetPids_d,
                                                         RemotePids,
-                                                        MyColMap);
+                                                        MyColMap,
+                                                        params);
     }
 
     if (verbose) {

--- a/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
@@ -131,7 +131,8 @@ void lowCommunicationMakeColMapAndReindex(
     const Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& domainMapRCP,
     const Teuchos::ArrayView<const int>& owningPIDs,
     Teuchos::Array<int>& remotePIDs,
-    Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& colMap);
+    Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& colMap,
+    const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
 /// \brief lowCommunicationMakeColMapAndReindex
 ///
@@ -145,7 +146,8 @@ void lowCommunicationMakeColMapAndReindex(
     const Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& domainMapRCP,
     const Kokkos::View<const int*, typename Node::device_type> owningPIDs_view,
     Teuchos::Array<int>& remotePIDs,
-    Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& colMap);
+    Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& colMap,
+    const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
 /// \brief Generates an list of owning PIDs based on two transfer (aka import/export objects)
 /// Let:
@@ -582,7 +584,8 @@ void lowCommunicationMakeColMapAndReindexSerial(const Teuchos::ArrayView<const s
                                                 const Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& domainMapRCP,
                                                 const Teuchos::ArrayView<const int>& owningPIDs,
                                                 Teuchos::Array<int>& remotePIDs,
-                                                Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& colMap) {
+                                                Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& colMap,
+                                                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) {
   using Teuchos::rcp;
   typedef LocalOrdinal LO;
   typedef GlobalOrdinal GO;
@@ -681,9 +684,14 @@ void lowCommunicationMakeColMapAndReindexSerial(const Teuchos::ArrayView<const s
     }
   }
 
+  // Launch reduction to get global num entries in the column map
+  const LO numMyCols = NumLocalColGIDs + NumRemoteColGIDs;
+  GST numMyColsGST   = static_cast<GST>(numMyCols);
+  GST numGlobalCols;
+  auto req = Details::iallreduce(numMyColsGST, numGlobalCols, Teuchos::REDUCE_SUM, *domainMap.getComm());
+
   // Now build the array containing column GIDs
   // Build back end, containing remote GIDs, first
-  const LO numMyCols = NumLocalColGIDs + NumRemoteColGIDs;
   Teuchos::Array<GO> ColIndices;
   GO* RemoteColIndices = NULL;
   if (numMyCols > 0) {
@@ -781,9 +789,10 @@ void lowCommunicationMakeColMapAndReindexSerial(const Teuchos::ArrayView<const s
   }
 
   // Make column Map
-  const GST minus_one = Teuchos::OrdinalTraits<GST>::invalid();
-  colMap              = rcp(new map_type(minus_one, ColIndices, domainMap.getIndexBase(),
-                                         domainMap.getComm()));
+  req->wait();
+  colMap = rcp(new map_type(numGlobalCols, ColIndices, domainMap.getIndexBase(),
+                            domainMap.getComm(),
+                            params));
 
   // Low-cost reindex of the matrix
   for (size_t i = 0; i < numMyRows; ++i) {
@@ -811,7 +820,8 @@ void lowCommunicationMakeColMapAndReindex(
     const Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& domainMapRCP,
     const Teuchos::ArrayView<const int>& owningPIDs,
     Teuchos::Array<int>& remotePIDs,
-    Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& colMap) {
+    Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& colMap,
+    const Teuchos::RCP<Teuchos::ParameterList>& params) {
   using DT              = typename Node::device_type;
   using execution_space = typename DT::execution_space;
   execution_space exec;
@@ -826,7 +836,7 @@ void lowCommunicationMakeColMapAndReindex(
 
   typename decltype(colind_LID_view)::host_mirror_type colind_LID_host(colind_LID.getRawPtr(), colind_LID.size());
 
-  lowCommunicationMakeColMapAndReindex(rowptr_view, colind_LID_view, colind_GID_view, domainMapRCP, owningPIDs_view, remotePIDs, colMap);
+  lowCommunicationMakeColMapAndReindex(rowptr_view, colind_LID_view, colind_GID_view, domainMapRCP, owningPIDs_view, remotePIDs, colMap, params);
 
   // For now, we copy back into colind_LID_host (which also overwrites the colind_LID Teuchos array)
   // When colind_LID becomes a Kokkos View we can delete this
@@ -841,7 +851,8 @@ void lowCommunicationMakeColMapAndReindex(
     const Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& domainMapRCP,
     const Kokkos::View<const int*, typename Node::device_type> owningPIDs_view,
     Teuchos::Array<int>& remotePIDs,
-    Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& colMap) {
+    Teuchos::RCP<const Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& colMap,
+    const Teuchos::RCP<Teuchos::ParameterList>& params) {
   using Teuchos::rcp;
   typedef LocalOrdinal LO;
   typedef GlobalOrdinal GO;
@@ -973,9 +984,15 @@ void lowCommunicationMakeColMapAndReindex(
         numEnteredRemotes);
     TEUCHOS_ASSERT(numEnteredRemotes == NumRemoteColGIDs);
   }
+
+  // Launch reduction to get global num entries in the column map
+  const size_t numMyCols = NumLocalColGIDs + NumRemoteColGIDs;
+  GST numMyColsGST       = static_cast<GST>(numMyCols);
+  GST numGlobalCols;
+  auto req = Details::iallreduce(numMyColsGST, numGlobalCols, Teuchos::REDUCE_SUM, *domainMap.getComm());
+
   // Now build the array containing column GIDs
   // Build back end, containing remote GIDs, first
-  const size_t numMyCols = NumLocalColGIDs + NumRemoteColGIDs;
   Kokkos::View<GO*, DT> ColMapIndices(Kokkos::ViewAllocateWithoutInitializing("ColMapIndices"), numMyCols);
 
   // We don't need to load the back end of ColMapIndices or sort if there are no remote GIDs
@@ -1054,10 +1071,9 @@ void lowCommunicationMakeColMapAndReindex(
   }
 
   // Make column Map
-  const GST minus_one = Teuchos::OrdinalTraits<GST>::invalid();
-
-  colMap = rcp(new map_type(minus_one, ColMapIndices, domainMap.getIndexBase(),
-                            domainMap.getComm()));
+  req->wait();
+  colMap = rcp(new map_type(numGlobalCols, ColMapIndices, domainMap.getIndexBase(),
+                            domainMap.getComm(), params));
 
   // Fill out colind_LID using local map
   auto localColMap = colMap->getLocalMap();

--- a/packages/tpetra/core/src/Tpetra_Map_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_decl.hpp
@@ -15,6 +15,7 @@
 ///   nonmember constructors.
 
 #include "Tpetra_ConfigDefs.hpp"
+#include "Tpetra_Details_iallreduce.hpp"
 #include "Tpetra_Map_fwd.hpp"
 #include "Tpetra_Directory_fwd.hpp"
 #include "Tpetra_TieBreak_fwd.hpp"
@@ -191,9 +192,7 @@ namespace Tpetra {
 /// product functions produce small dense matrices that are required
 /// by all images.  Replicated local objects handle these
 /// situations.
-template <class LocalOrdinal,
-          class GlobalOrdinal,
-          class Node>
+template <class LocalOrdinal, class GlobalOrdinal, class Node>
 class Map : public Teuchos::Describable {
  public:
   //! @name Typedefs
@@ -355,6 +354,10 @@ class Map : public Teuchos::Describable {
    * std::invalid_argument on all processes in the given
    * communicator.
    *
+   * By default, global map constants are computed using global
+   * reductions. This communication can be skipped by setting
+   * "compute global constants" to false in the the parameterlist.
+   *
    * \param numGlobalElements [in] If <tt>numGlobalElements ==
    *   Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid()</tt>,
    *   the number of global elements will be computed (via a global
@@ -376,11 +379,16 @@ class Map : public Teuchos::Describable {
    * \param comm [in] Communicator over which to distribute the
    *   indices.  This constructor must be called as a collective
    *   over this communicator.
+   *
+   * \param params [in/out] Optional list of parameters.  If not
+   *   null, any missing parameters will be filled in with their
+   *   default values.
    */
   Map(const global_size_t numGlobalElements,
       const Kokkos::View<const global_ordinal_type*, device_type>& indexList,
       const global_ordinal_type indexBase,
-      const Teuchos::RCP<const Teuchos::Comm<int>>& comm);
+      const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+      const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
   /** \brief Constructor with arbitrary (possibly noncontiguous
    *   and/or nonuniform and/or overlapping) distribution, taking
@@ -399,6 +407,10 @@ class Map : public Teuchos::Describable {
    * build.  If it does check and any check fails, it will throw
    * std::invalid_argument on all processes in the given
    * communicator.
+   *
+   * By default, global map constants are computed using global
+   * reductions. This communication can be skipped by setting
+   * "compute global constants" to false in the the parameterlist.
    *
    * \param numGlobalElements [in] If <tt>numGlobalElements ==
    *   Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid()</tt>,
@@ -422,12 +434,17 @@ class Map : public Teuchos::Describable {
    *
    * \param comm [in] Communicator over which to distribute the
    *   elements.
+   *
+   * \param params [in/out] Optional list of parameters.  If not
+   *   null, any missing parameters will be filled in with their
+   *   default values.
    */
   Map(const global_size_t numGlobalElements,
       const global_ordinal_type indexList[],
       const local_ordinal_type indexListSize,
       const global_ordinal_type indexBase,
-      const Teuchos::RCP<const Teuchos::Comm<int>>& comm);
+      const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+      const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
   /** \brief Constructor with arbitrary (possibly noncontiguous
    *   and/or nonuniform and/or overlapping) distribution, taking
@@ -447,6 +464,10 @@ class Map : public Teuchos::Describable {
    * build.  If it does check and any check fails, it will throw
    * std::invalid_argument on all processes in the given
    * communicator.
+   *
+   * By default, global map constants are computed using global
+   * reductions. This communication can be skipped by setting
+   * "compute global constants" to false in the the parameterlist.
    *
    * \param numGlobalElements [in] If <tt>numGlobalElements ==
    *   Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid()</tt>,
@@ -469,11 +490,16 @@ class Map : public Teuchos::Describable {
    * \param comm [in] Communicator over which to distribute the
    *   indices.  This constructor must be called as a collective
    *   over this communicator.
+   *
+   * \param params [in/out] Optional list of parameters.  If not
+   *   null, any missing parameters will be filled in with their
+   *   default values.
    */
   Map(const global_size_t numGlobalElements,
       const Teuchos::ArrayView<const global_ordinal_type>& indexList,
       const global_ordinal_type indexBase,
-      const Teuchos::RCP<const Teuchos::Comm<int>>& comm);
+      const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+      const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
   /// \brief Default constructor (that does nothing).
   ///
@@ -603,6 +629,7 @@ class Map : public Teuchos::Describable {
   ///   assuming that you refer to the Map by value or reference,
   ///   not by Teuchos::RCP.
   global_ordinal_type getMinAllGlobalIndex() const {
+    TEUCHOS_TEST_FOR_EXCEPTION(!haveGlobalConstants(), std::logic_error, "\"Map::getMinAllGlobalIndex\" called, but global constants have not been computed with \"Map::computeGlobalConstants\".");
     return minAllGID_;
   }
 
@@ -612,6 +639,7 @@ class Map : public Teuchos::Describable {
   ///   assuming that you refer to the Map by value or reference,
   ///   not by Teuchos::RCP.
   global_ordinal_type getMaxAllGlobalIndex() const {
+    TEUCHOS_TEST_FOR_EXCEPTION(!haveGlobalConstants(), std::logic_error, "\"Map::getMaxAllGlobalIndex\" called, but global constants have not been computed with \"Map::computeGlobalConstants\".");
     return maxAllGID_;
   }
 
@@ -1093,7 +1121,8 @@ class Map : public Teuchos::Describable {
                          Kokkos::HostSpace,
                          Kokkos::MemoryUnmanaged>& entryList,
       const global_ordinal_type indexBase,
-      const Teuchos::RCP<const Teuchos::Comm<int>>& comm);
+      const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+      const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
  public:
   /// \brief Push the device data to host, if needed
@@ -1172,6 +1201,17 @@ class Map : public Teuchos::Describable {
   /// documentation of isDistributed() for a definition of these two
   /// mutually exclusive terms.
   bool distributed_;
+
+ private:
+  bool haveGlobalConstants_ = false;
+
+ public:
+  bool haveGlobalConstants() const { return haveGlobalConstants_; }
+
+  /// \brief Compute global constants for the map. This method needs
+  /// to be called collectively over all processes in the Map's
+  /// communicator.
+  void computeGlobalConstants();
 
   /// \brief A mapping from local IDs to global IDs.
   ///

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -28,10 +28,12 @@
 
 #include "Tpetra_Directory.hpp"  // must include for implicit instantiation to work
 #include "Tpetra_Details_Behavior.hpp"
+#include "Tpetra_Details_iallreduce.hpp"
 #include "Tpetra_Details_FixedHashTable.hpp"
 #include "Tpetra_Details_gathervPrint.hpp"
 #include "Tpetra_Details_printOnce.hpp"
 #include "Tpetra_Core.hpp"
+#include "Tpetra_Map_decl.hpp"
 #include "Tpetra_Util.hpp"
 #include "Tpetra_Details_mpiIsInitialized.hpp"
 #include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"  // teuchosCommIsAnMpiComm
@@ -146,6 +148,7 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
   ,  // trivially
   contiguous_(false)
   , distributed_(false)
+  , haveGlobalConstants_(true)
   ,  // no communicator yet
   directory_(new Directory<LocalOrdinal, GlobalOrdinal, Node>()) {
   Tpetra::Details::initializeKokkos();
@@ -300,14 +303,15 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
     distributed_     = false;
   }
 
-  minAllGID_          = indexBase;
-  maxAllGID_          = indexBase + numGlobalElements - 1;
-  indexBase_          = indexBase;
-  numGlobalElements_  = numGlobalElements;
-  numLocalElements_   = numLocalElements;
-  firstContiguousGID_ = minMyGID_;
-  lastContiguousGID_  = maxMyGID_;
-  contiguous_         = true;
+  minAllGID_           = indexBase;
+  maxAllGID_           = indexBase + numGlobalElements - 1;
+  indexBase_           = indexBase;
+  numGlobalElements_   = numGlobalElements;
+  numLocalElements_    = numLocalElements;
+  firstContiguousGID_  = minMyGID_;
+  lastContiguousGID_   = maxMyGID_;
+  contiguous_          = true;
+  haveGlobalConstants_ = true;
 
   // Create the Directory on demand in getRemoteIndexList().
   // setupDirectory ();
@@ -402,16 +406,17 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
       TEUCHOS_TEST_FOR_EXCEPTION(globalSum != debugGlobalSum, std::logic_error, exPfx << "globalSum = " << globalSum << " != debugGlobalSum = " << debugGlobalSum << suffix);
     }
   }
-  numLocalElements_   = numLocalElements;
-  indexBase_          = indexBase;
-  minAllGID_          = (numGlobalElements_ == 0) ? std::numeric_limits<GO>::max() : indexBase;
-  maxAllGID_          = (numGlobalElements_ == 0) ? std::numeric_limits<GO>::lowest() : indexBase + GO(numGlobalElements_) - GO(1);
-  minMyGID_           = (numLocalElements_ == 0) ? std::numeric_limits<GO>::max() : indexBase + GO(myOffset);
-  maxMyGID_           = (numLocalElements_ == 0) ? std::numeric_limits<GO>::lowest() : indexBase + myOffset + GO(numLocalElements) - GO(1);
-  firstContiguousGID_ = minMyGID_;
-  lastContiguousGID_  = maxMyGID_;
-  contiguous_         = true;
-  distributed_        = checkIsDist();
+  numLocalElements_    = numLocalElements;
+  indexBase_           = indexBase;
+  minAllGID_           = (numGlobalElements_ == 0) ? std::numeric_limits<GO>::max() : indexBase;
+  maxAllGID_           = (numGlobalElements_ == 0) ? std::numeric_limits<GO>::lowest() : indexBase + GO(numGlobalElements_) - GO(1);
+  minMyGID_            = (numLocalElements_ == 0) ? std::numeric_limits<GO>::max() : indexBase + GO(myOffset);
+  maxMyGID_            = (numLocalElements_ == 0) ? std::numeric_limits<GO>::lowest() : indexBase + myOffset + GO(numLocalElements) - GO(1);
+  firstContiguousGID_  = minMyGID_;
+  lastContiguousGID_   = maxMyGID_;
+  contiguous_          = true;
+  distributed_         = (comm->getSize() > 1);
+  haveGlobalConstants_ = true;
 
   // Create the Directory on demand in getRemoteIndexList().
   // setupDirectory ();
@@ -525,7 +530,8 @@ void Map<LocalOrdinal, GlobalOrdinal, Node>::
                            Kokkos::HostSpace,
                            Kokkos::MemoryUnmanaged>& entryList_host,
         const global_ordinal_type indexBase,
-        const Teuchos::RCP<const Teuchos::Comm<int>>& comm) {
+        const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+        const Teuchos::RCP<Teuchos::ParameterList>& params) {
   Tpetra::Details::ProfilingRegion pr("Map::initWithNonownedHostIndexList()");
 
   using Kokkos::LayoutLeft;
@@ -576,12 +582,14 @@ void Map<LocalOrdinal, GlobalOrdinal, Node>::
   // than a scan and broadcast, so this still saves time if users of
   // this Map don't ever need the Directory (i.e., if they never
   // call getRemoteIndexList on this Map).
+  std::shared_ptr<Details::CommRequest> req;
+  GST numLocalElementsGST;
   if (numGlobalElements != GSTI) {
     numGlobalElements_ = numGlobalElements;  // Use the user's value.
   } else {                                   // The user wants us to compute the sum.
-    reduceAll(*comm, REDUCE_SUM,
-              static_cast<GST>(numLocalElements),
-              outArg(numGlobalElements_));
+    numLocalElementsGST = static_cast<GST>(numLocalElements);
+    req                 = Details::iallreduce(numLocalElementsGST,
+                                              numGlobalElements_, REDUCE_SUM, *comm);
   }
 
   // mfh 20 Feb 2013: We've never quite done the right thing for
@@ -622,6 +630,7 @@ void Map<LocalOrdinal, GlobalOrdinal, Node>::
   // we could just expose this case explicitly as yet another Map
   // constructor, and avoid the trouble of detecting it.
   if (numLocalElements_ > 0) {
+    Tpetra::Details::ProfilingRegion prLcl("Map::initWithNonownedHostIndexList::local");
     // Find contiguous GID range, with the restriction that the
     // beginning of the range starts with the first entry.  While
     // doing so, fill in the LID -> GID table.
@@ -741,63 +750,17 @@ void Map<LocalOrdinal, GlobalOrdinal, Node>::
     // glMap_ was default constructed, so it's already empty.
   }
 
-  // Compute the min and max of all processes' GIDs.  If
-  // numLocalElements_ == 0 on this process, minMyGID_ and maxMyGID_
-  // are both indexBase_.  This is wrong, but fixing it would
-  // require either a fancy sparse all-reduce, or a custom reduction
-  // operator that ignores invalid values ("invalid" means
-  // Tpetra::Details::OrdinalTraits<GO>::invalid()).
-  //
-  // Also, while we're at it, use the same all-reduce to figure out
-  // if the Map is distributed.  "Distributed" means that there is
-  // at least one process with a number of local elements less than
-  // the number of global elements.
-  //
-  // We're computing the min and max of all processes' GIDs using a
-  // single MAX all-reduce, because min(x,y) = -max(-x,-y) (when x
-  // and y are signed).  (This lets us combine the min and max into
-  // a single all-reduce.)  If each process sets localDist=1 if its
-  // number of local elements is strictly less than the number of
-  // global elements, and localDist=0 otherwise, then a MAX
-  // all-reduce on localDist tells us if the Map is distributed (1
-  // if yes, 0 if no).  Thus, we can append localDist onto the end
-  // of the data and get the global result from the all-reduce.
-  if (std::numeric_limits<GO>::is_signed) {
-    // Does my process NOT own all the elements?
-    const GO localDist =
-        (as<GST>(numLocalElements_) < numGlobalElements_) ? 1 : 0;
-
-    GO minMaxInput[3];
-    minMaxInput[0] = -minMyGID_;
-    minMaxInput[1] = maxMyGID_;
-    minMaxInput[2] = localDist;
-
-    GO minMaxOutput[3];
-    minMaxOutput[0] = 0;
-    minMaxOutput[1] = 0;
-    minMaxOutput[2] = 0;
-    reduceAll<int, GO>(*comm, REDUCE_MAX, 3, minMaxInput, minMaxOutput);
-    minAllGID_          = -minMaxOutput[0];
-    maxAllGID_          = minMaxOutput[1];
-    const GO globalDist = minMaxOutput[2];
-    distributed_        = (comm_->getSize() > 1 && globalDist == 1);
-  } else {  // unsigned; use two reductions
-    // This is always correct, no matter the signedness of GO.
-    reduceAll<int, GO>(*comm_, REDUCE_MIN, minMyGID_, outArg(minAllGID_));
-    reduceAll<int, GO>(*comm_, REDUCE_MAX, maxMyGID_, outArg(maxAllGID_));
-    distributed_ = checkIsDist();
-  }
-
   contiguous_ = false;  // "Contiguous" is conservative.
 
-  TEUCHOS_TEST_FOR_EXCEPTION(
-      minAllGID_ < indexBase_,
-      std::invalid_argument,
-      "Tpetra::Map constructor (noncontiguous): "
-      "Minimum global ID = "
-          << minAllGID_ << " over all process(es) is "
-                           "less than the given indexBase = "
-          << indexBase_ << ".");
+  if (req) req->wait();
+
+  const bool callComputeGlobalConstants = params.get() == nullptr ||
+                                          params->get("compute global constants", true);
+
+  if (callComputeGlobalConstants)
+    computeGlobalConstants();
+  else
+    distributed_ = params->get("distributed", true) && (comm->getSize() > 1);
 
   // Create the Directory on demand in getRemoteIndexList().
   // setupDirectory ();
@@ -809,7 +772,8 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
         const GlobalOrdinal indexList[],
         const LocalOrdinal indexListSize,
         const GlobalOrdinal indexBase,
-        const Teuchos::RCP<const Teuchos::Comm<int>>& comm)
+        const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+        const Teuchos::RCP<Teuchos::ParameterList>& params)
   : comm_(comm)
   , uniform_(false)
   , directory_(new Directory<LocalOrdinal, GlobalOrdinal, Node>()) {
@@ -842,7 +806,7 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
                Kokkos::MemoryUnmanaged>
       inds(indsRaw, indexListSize);
   initWithNonownedHostIndexList(funcName, numGlobalElements, inds,
-                                indexBase, comm);
+                                indexBase, comm, params);
   if (verbose) {
     std::ostringstream os;
     os << *prefix << "Done" << endl;
@@ -855,7 +819,8 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
     Map(const global_size_t numGlobalElements,
         const Teuchos::ArrayView<const GlobalOrdinal>& entryList,
         const GlobalOrdinal indexBase,
-        const Teuchos::RCP<const Teuchos::Comm<int>>& comm)
+        const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+        const Teuchos::RCP<Teuchos::ParameterList>& params)
   : comm_(comm)
   , uniform_(false)
   , directory_(new Directory<LocalOrdinal, GlobalOrdinal, Node>()) {
@@ -889,7 +854,7 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
                Kokkos::MemoryUnmanaged>
       inds(indsRaw, numLclInds);
   initWithNonownedHostIndexList(funcName, numGlobalElements, inds,
-                                indexBase, comm);
+                                indexBase, comm, params);
   if (verbose) {
     std::ostringstream os;
     os << *prefix << "Done" << endl;
@@ -902,7 +867,8 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
     Map(const global_size_t numGlobalElements,
         const Kokkos::View<const GlobalOrdinal*, device_type>& entryList,
         const GlobalOrdinal indexBase,
-        const Teuchos::RCP<const Teuchos::Comm<int>>& comm)
+        const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+        const Teuchos::RCP<Teuchos::ParameterList>& params)
   : comm_(comm)
   , uniform_(false)
   , directory_(new Directory<LocalOrdinal, GlobalOrdinal, Node>()) {
@@ -924,7 +890,6 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
   using Teuchos::reduceAll;
   using Teuchos::typeName;
   using LO       = local_ordinal_type;
-  using GO       = global_ordinal_type;
   using GST      = global_size_t;
   const GST GSTI = Tpetra::Details::OrdinalTraits<GST>::invalid();
   const char funcName[] =
@@ -971,12 +936,14 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
   // than a scan and broadcast, so this still saves time if users of
   // this Map don't ever need the Directory (i.e., if they never
   // call getRemoteIndexList on this Map).
+  std::shared_ptr<Details::CommRequest> req;
+  GST numLocalElementsGST;
   if (numGlobalElements != GSTI) {
     numGlobalElements_ = numGlobalElements;  // Use the user's value.
   } else {                                   // The user wants us to compute the sum.
-    reduceAll(*comm, REDUCE_SUM,
-              static_cast<GST>(numLocalElements),
-              outArg(numGlobalElements_));
+    numLocalElementsGST = static_cast<GST>(numLocalElements);
+    req                 = Details::iallreduce(numLocalElementsGST,
+                                              numGlobalElements_, REDUCE_SUM, *comm);
   }
 
   // mfh 20 Feb 2013: We've never quite done the right thing for
@@ -1048,6 +1015,38 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
     // glMap_ was default constructed, so it's already empty.
   }
 
+  if (req) req->wait();
+
+  const bool callComputeGlobalConstants = params.get() == nullptr ||
+                                          params->get("compute global constants", true);
+
+  if (callComputeGlobalConstants)
+    computeGlobalConstants();
+  else
+    distributed_ = params->get("distributed", true) && (comm->getSize() > 1);
+
+  contiguous_ = false;  // "Contiguous" is conservative.
+
+  // Create the Directory on demand in getRemoteIndexList().
+  // setupDirectory ();
+
+  if (verbose) {
+    std::ostringstream os;
+    os << *prefix << "Done" << endl;
+    std::cerr << os.str();
+  }
+}
+
+template <class LocalOrdinal, class GlobalOrdinal, class Node>
+void Map<LocalOrdinal, GlobalOrdinal, Node>::computeGlobalConstants() {
+  using GO  = global_ordinal_type;
+  using GST = global_size_t;
+
+  if (haveGlobalConstants_)
+    return;
+
+  Tpetra::Details::ProfilingRegion pr("Tpetra::Map::computeGlobalConstants");
+
   // Compute the min and max of all processes' GIDs.  If
   // numLocalElements_ == 0 on this process, minMyGID_ and maxMyGID_
   // are both indexBase_.  This is wrong, but fixing it would
@@ -1069,33 +1068,22 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
   // all-reduce on localDist tells us if the Map is distributed (1
   // if yes, 0 if no).  Thus, we can append localDist onto the end
   // of the data and get the global result from the all-reduce.
-  if (std::numeric_limits<GO>::is_signed) {
-    // Does my process NOT own all the elements?
-    const GO localDist =
-        (as<GST>(numLocalElements_) < numGlobalElements_) ? 1 : 0;
+  Kokkos::View<GO*, Kokkos::HostSpace> minMaxInput(Kokkos::ViewAllocateWithoutInitializing("minMaxInput"), 3);
+  Kokkos::View<GO*, Kokkos::HostSpace> minMaxOutput(Kokkos::ViewAllocateWithoutInitializing("minMaxOutput"), 3);
 
-    GO minMaxInput[3];
-    minMaxInput[0] = -minMyGID_;
-    minMaxInput[1] = maxMyGID_;
-    minMaxInput[2] = localDist;
+  minMaxInput[0] = std::numeric_limits<GO>::max() - minMyGID_;
+  minMaxInput[1] = maxMyGID_;
+  minMaxInput[2] = std::numeric_limits<GO>::max() - static_cast<GO>(numLocalElements_);
 
-    GO minMaxOutput[3];
-    minMaxOutput[0] = 0;
-    minMaxOutput[1] = 0;
-    minMaxOutput[2] = 0;
-    reduceAll<int, GO>(*comm, REDUCE_MAX, 3, minMaxInput, minMaxOutput);
-    minAllGID_          = -minMaxOutput[0];
-    maxAllGID_          = minMaxOutput[1];
-    const GO globalDist = minMaxOutput[2];
-    distributed_        = (comm_->getSize() > 1 && globalDist == 1);
-  } else {  // unsigned; use two reductions
-    // This is always correct, no matter the signedness of GO.
-    reduceAll<int, GO>(*comm_, REDUCE_MIN, minMyGID_, outArg(minAllGID_));
-    reduceAll<int, GO>(*comm_, REDUCE_MAX, maxMyGID_, outArg(maxAllGID_));
-    distributed_ = checkIsDist();
-  }
+  Teuchos::reduceAll<int, GO>(*comm_, Teuchos::REDUCE_MAX, 3, minMaxInput.data(), minMaxOutput.data());
 
-  contiguous_ = false;  // "Contiguous" is conservative.
+  minAllGID_                   = std::numeric_limits<GO>::max() - minMaxOutput[0];
+  maxAllGID_                   = minMaxOutput[1];
+  const GO minNumLocalElements = std::numeric_limits<GO>::max() - minMaxOutput[2];
+
+  distributed_ = (comm_->getSize() > 1 && (static_cast<GST>(minNumLocalElements) < numGlobalElements_));
+
+  haveGlobalConstants_ = true;
 
   TEUCHOS_TEST_FOR_EXCEPTION(
       minAllGID_ < indexBase_,
@@ -1105,15 +1093,6 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
           << minAllGID_ << " over all process(es) is "
                            "less than the given indexBase = "
           << indexBase_ << ".");
-
-  // Create the Directory on demand in getRemoteIndexList().
-  // setupDirectory ();
-
-  if (verbose) {
-    std::ostringstream os;
-    os << *prefix << "Done" << endl;
-    std::cerr << os.str();
-  }
 }
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -1512,13 +1491,11 @@ bool Map<LocalOrdinal, GlobalOrdinal, Node>::
     // Two Maps are definitely NOT the same if they have different
     // global numbers of indices.
     return false;
-  } else if (getMinAllGlobalIndex() != map.getMinAllGlobalIndex() ||
-             getMaxAllGlobalIndex() != map.getMaxAllGlobalIndex() ||
-             getIndexBase() != map.getIndexBase()) {
+  } else if (haveGlobalConstants() && map.haveGlobalConstants() && (getMinAllGlobalIndex() != map.getMinAllGlobalIndex() || getMaxAllGlobalIndex() != map.getMaxAllGlobalIndex() || getIndexBase() != map.getIndexBase())) {
     // If the global min or max global index doesn't match, or if
     // the index base doesn't match, then the Maps aren't the same.
     return false;
-  } else if (isDistributed() != map.isDistributed()) {
+  } else if (haveGlobalConstants() && map.haveGlobalConstants() && (isDistributed() != map.isDistributed())) {
     // One Map is distributed and the other is not, which means that
     // the Maps aren't the same.
     return false;
@@ -1924,15 +1901,16 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
     // mfh 07 Oct 2016: Preserve original behavior, even though the
     // original index base may no longer be the globally min global
     // index.  See #616 for why this doesn't matter so much anymore.
-    newMap->indexBase_          = this->indexBase_;
-    newMap->numGlobalElements_  = this->numLocalElements_;
-    newMap->numLocalElements_   = this->numLocalElements_;
-    newMap->minMyGID_           = this->minMyGID_;
-    newMap->maxMyGID_           = this->maxMyGID_;
-    newMap->minAllGID_          = this->minMyGID_;
-    newMap->maxAllGID_          = this->maxMyGID_;
-    newMap->firstContiguousGID_ = this->firstContiguousGID_;
-    newMap->lastContiguousGID_  = this->lastContiguousGID_;
+    newMap->indexBase_           = this->indexBase_;
+    newMap->numGlobalElements_   = this->numLocalElements_;
+    newMap->numLocalElements_    = this->numLocalElements_;
+    newMap->minMyGID_            = this->minMyGID_;
+    newMap->maxMyGID_            = this->maxMyGID_;
+    newMap->minAllGID_           = this->minMyGID_;
+    newMap->maxAllGID_           = this->maxMyGID_;
+    newMap->firstContiguousGID_  = this->firstContiguousGID_;
+    newMap->lastContiguousGID_   = this->lastContiguousGID_;
+    newMap->haveGlobalConstants_ = this->haveGlobalConstants_;
     // Since the new communicator has only one process, neither
     // uniformity nor contiguity have changed.
     newMap->uniform_    = this->uniform_;
@@ -2034,22 +2012,25 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
     newComm = null;
   }
 
+  TEUCHOS_TEST_FOR_EXCEPTION(!haveGlobalConstants(), std::logic_error, "\"Map::removeEmptyProcesses\" called, but global constants have not been computed with \"Map::computeGlobalConstants\".");
+
   // Create the Map to return.
   if (newComm.is_null()) {
     return null;  // my process does not participate in the new Map
   } else {
     RCP<Map> map = rcp(new Map());
 
-    map->comm_               = newComm;
-    map->indexBase_          = indexBase_;
-    map->numGlobalElements_  = numGlobalElements_;
-    map->numLocalElements_   = numLocalElements_;
-    map->minMyGID_           = minMyGID_;
-    map->maxMyGID_           = maxMyGID_;
-    map->minAllGID_          = minAllGID_;
-    map->maxAllGID_          = maxAllGID_;
-    map->firstContiguousGID_ = firstContiguousGID_;
-    map->lastContiguousGID_  = lastContiguousGID_;
+    map->comm_                = newComm;
+    map->indexBase_           = indexBase_;
+    map->numGlobalElements_   = numGlobalElements_;
+    map->numLocalElements_    = numLocalElements_;
+    map->minMyGID_            = minMyGID_;
+    map->maxMyGID_            = maxMyGID_;
+    map->minAllGID_           = minAllGID_;
+    map->maxAllGID_           = maxAllGID_;
+    map->firstContiguousGID_  = firstContiguousGID_;
+    map->lastContiguousGID_   = lastContiguousGID_;
+    map->haveGlobalConstants_ = haveGlobalConstants_;
 
     // Uniformity and contiguity have not changed.  The directory
     // has changed, but we've taken care of that above.

--- a/packages/xpetra/src/Map/Xpetra_MapFactory_decl.hpp
+++ b/packages/xpetra/src/Map/Xpetra_MapFactory_decl.hpp
@@ -56,7 +56,8 @@ class MapFactory {
         global_size_t numGlobalElements,
         const Teuchos::ArrayView<const GlobalOrdinal>& elementList,
         GlobalOrdinal indexBase,
-        const Teuchos::RCP<const Teuchos::Comm<int>>& comm);
+        const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+        const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
   /*!
     @brief Map constructor generating degrees of freedom with numDofPerNode for given nodeMap
@@ -78,7 +79,8 @@ class MapFactory {
         global_size_t numGlobalElements,
         const Kokkos::View<const GlobalOrdinal*, typename Node::device_type>& indexList,
         GlobalOrdinal indexBase,
-        const Teuchos::RCP<const Teuchos::Comm<int>>& comm);
+        const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+        const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
   //! Create a locally replicated Map with the default node.
   static Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node>>

--- a/packages/xpetra/src/Map/Xpetra_MapFactory_def.hpp
+++ b/packages/xpetra/src/Map/Xpetra_MapFactory_def.hpp
@@ -59,11 +59,12 @@ MapFactory<LocalOrdinal, GlobalOrdinal, Node>::
           global_size_t numGlobalElements,
           const Teuchos::ArrayView<const GlobalOrdinal>& elementList,
           GlobalOrdinal indexBase,
-          const Teuchos::RCP<const Teuchos::Comm<int>>& comm) {
+          const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+          const Teuchos::RCP<Teuchos::ParameterList>& params) {
   XPETRA_MONITOR("MapFactory::Build");
 
   if (lib == UseTpetra)
-    return rcp(new TpetraMap<LocalOrdinal, GlobalOrdinal, Node>(numGlobalElements, elementList, indexBase, comm));
+    return rcp(new TpetraMap<LocalOrdinal, GlobalOrdinal, Node>(numGlobalElements, elementList, indexBase, comm, params));
 
   XPETRA_FACTORY_END;
 }
@@ -108,10 +109,11 @@ MapFactory<LocalOrdinal, GlobalOrdinal, Node>::
           global_size_t numGlobalElements,
           const Kokkos::View<const GlobalOrdinal*, typename Node::device_type>& indexList,
           GlobalOrdinal indexBase,
-          const Teuchos::RCP<const Teuchos::Comm<int>>& comm) {
+          const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+          const Teuchos::RCP<Teuchos::ParameterList>& params) {
   XPETRA_MONITOR("MapFactory::Build");
   if (lib == UseTpetra)
-    return rcp(new TpetraMap<LocalOrdinal, GlobalOrdinal, Node>(numGlobalElements, indexList, indexBase, comm));
+    return rcp(new TpetraMap<LocalOrdinal, GlobalOrdinal, Node>(numGlobalElements, indexList, indexBase, comm, params));
   XPETRA_FACTORY_END;
 }
 

--- a/packages/xpetra/src/Map/Xpetra_TpetraMap_decl.hpp
+++ b/packages/xpetra/src/Map/Xpetra_TpetraMap_decl.hpp
@@ -56,13 +56,15 @@ class TpetraMap
   TpetraMap(global_size_t numGlobalElements,
             const Teuchos::ArrayView<const GlobalOrdinal> &elementList,
             GlobalOrdinal indexBase,
-            const Teuchos::RCP<const Teuchos::Comm<int> > &comm);
+            const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
+            const Teuchos::RCP<Teuchos::ParameterList> &params = Teuchos::null);
 
   //! Constructor with user-defined arbitrary (possibly noncontiguous) distribution passed as a Kokkos::View.
   TpetraMap(global_size_t numGlobalElements,
             const Kokkos::View<const GlobalOrdinal *, typename Node::device_type> &indexList,
             GlobalOrdinal indexBase,
-            const Teuchos::RCP<const Teuchos::Comm<int> > &comm);
+            const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
+            const Teuchos::RCP<Teuchos::ParameterList> &params = Teuchos::null);
 
   //! Destructor
   ~TpetraMap();

--- a/packages/xpetra/src/Map/Xpetra_TpetraMap_def.hpp
+++ b/packages/xpetra/src/Map/Xpetra_TpetraMap_def.hpp
@@ -46,11 +46,13 @@ TpetraMap<LocalOrdinal, GlobalOrdinal, Node>::
     TpetraMap(global_size_t numGlobalElements,
               const Teuchos::ArrayView<const GlobalOrdinal> &elementList,
               GlobalOrdinal indexBase,
-              const Teuchos::RCP<const Teuchos::Comm<int> > &comm)
+              const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
+              const Teuchos::RCP<Teuchos::ParameterList> &params)
   : map_(Teuchos::rcp(new Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>(numGlobalElements,
                                                                          elementList,
                                                                          indexBase,
-                                                                         comm))) {}
+                                                                         comm,
+                                                                         params))) {}
 
 //! Constructor with user-defined arbitrary (possibly noncontiguous) distribution passed as a Kokkos::View.
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -58,11 +60,13 @@ TpetraMap<LocalOrdinal, GlobalOrdinal, Node>::
     TpetraMap(global_size_t numGlobalElements,
               const Kokkos::View<const GlobalOrdinal *, typename Node::device_type> &indexList,
               GlobalOrdinal indexBase,
-              const Teuchos::RCP<const Teuchos::Comm<int> > &comm)
+              const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
+              const Teuchos::RCP<Teuchos::ParameterList> &params)
   : map_(Teuchos::rcp(new Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>(numGlobalElements,
                                                                          indexList,
                                                                          indexBase,
-                                                                         comm))) {}
+                                                                         comm,
+                                                                         params))) {}
 
 //! Destructor.
 template <class LocalOrdinal, class GlobalOrdinal, class Node>


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
This PR builds on top of #15087 and should be merged after it.

Changes:
- Add an optional parameter list to the constructors of several `Tpetra::Map` constructors.
- Allow to bypass the computation of global constants in Map construction: min/max GIDs over all ranks.
- Remove unnecessary global reduction in `import_and_extract_views`. Skip global map constants for temporary objects in SpGEMM.
- Skip global constants in MueLu TentP.

I tested this locally by running Tpetra and MueLu tests. Let's see if the AT finds issues in other packages.