### PR TITLE
Move CMake logic from snapshotted Kokkos package to Trilinos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,9 @@ SET(Trilinos_MUST_FIND_ALL_TPL_LIBS_DEFAULT TRUE)
 # Some CMake and TriBiTS tweaks just for Trilinos
 include(TrilinosTweaks)
 
+# Set some Kokkos options that differ from Kokkos defaults
+include(TrilinosKokkosSettings)
+
 # Do all of the processing for this Tribits project
 TRIBITS_PROJECT()
 

--- a/cmake/TrilinosKokkosSettings.cmake
+++ b/cmake/TrilinosKokkosSettings.cmake
@@ -1,0 +1,44 @@
+set(Kokkos_ENABLE_COMPLEX_ALIGN OFF CACHE BOOL "Whether to align Kokkos::complex to 2*alignof(RealType)")
+
+# Enable serial backed for all builds
+set(Kokkos_ENABLE_SERIAL ON CACHE BOOL "Whether to build Serial backend" FORCE)
+
+# Trilinos_ENABLE_OpenMP -> Kokkos_ENABLE_OPENMP
+if(NOT "${Trilinos_ENABLE_OpenMP}" STREQUAL "")
+  set(Kokkos_ENABLE_OPENMP ${Trilinos_ENABLE_OpenMP} CACHE BOOL "Whether to build OpenMP backend" FORCE)
+else()
+  set(Kokkos_ENABLE_OPENMP OFF CACHE BOOL "Whether to build OpenMP backend")
+endif()
+
+# TPL_ENABLE_CUDA -> Kokkos_ENABLE_CUDA
+if(NOT "${TPL_ENABLE_CUDA}" STREQUAL "")
+  set(Kokkos_ENABLE_CUDA ${TPL_ENABLE_CUDA} CACHE BOOL "Whether to build CUDA backend" FORCE)
+else()
+  set(Kokkos_ENABLE_CUDA OFF CACHE BOOL "Whether to build CUDA backend")
+endif()
+
+# TPL_ENABLE_HPX -> Kokkos_ENABLE_HPX
+if(NOT "${TPL_ENABLE_HPX}" STREQUAL "")
+  set(Kokkos_ENABLE_HPX ${TPL_ENABLE_HPX} CACHE BOOL "Whether to build HPX backend" FORCE)
+else()
+  set(Kokkos_ENABLE_HPX OFF CACHE BOOL "Whether to build HPX backend")
+endif()
+
+
+# If only the Serial backend is enabled, turn off atomic bypass, unless the user set that option.
+# These variables are undefined if the user did not set them.
+if(Kokkos_ENABLE_SERIAL
+  AND NOT Kokkos_ENABLE_OPENMP
+  AND NOT Kokkos_ENABLE_THREADS
+  AND NOT Kokkos_ENABLE_HPX
+  AND NOT Kokkos_ENABLE_CUDA
+  AND NOT Kokkos_ENABLE_HIP
+  AND NOT Kokkos_ENABLE_SYCL
+  AND NOT Kokkos_ENABLE_OPENACC
+)
+  if(NOT DEFINED Kokkos_ENABLE_ATOMICS_BYPASS)
+    set(Kokkos_ENABLE_ATOMICS_BYPASS ON
+      CACHE BOOL "Whether to make atomics non-atomic for non-threaded MPI-only use cases" FORCE
+    )
+  endif()
+endif()

--- a/packages/kokkos/cmake/Dependencies.cmake
+++ b/packages/kokkos/cmake/Dependencies.cmake
@@ -1,3 +1,3 @@
-tribits_package_define_dependencies(LIB_OPTIONAL_TPLS Pthread CUDA HWLOC DLlib)
+tribits_package_define_dependencies(LIB_OPTIONAL_TPLS Pthread CUDA HWLOC DLlib quadmath)
 
 tribits_tpl_tentatively_enable(DLlib)

--- a/packages/kokkos/cmake/kokkos_configure_trilinos.cmake
+++ b/packages/kokkos/cmake/kokkos_configure_trilinos.cmake
@@ -1,65 +1,13 @@
 if(CMAKE_PROJECT_NAME STREQUAL "Trilinos")
-  set(Kokkos_ENABLE_SERIAL ON CACHE BOOL "Whether to build Serial backend" FORCE)
 
-  if(NOT ${Trilinos_ENABLE_OpenMP} STREQUAL "")
-    set(Kokkos_ENABLE_OPENMP ${Trilinos_ENABLE_OpenMP} CACHE BOOL "Whether to build OpenMP backend" FORCE)
-  else()
-    set(Kokkos_ENABLE_OPENMP OFF CACHE BOOL "Whether to build OpenMP backend" FORCE)
-  endif()
+  # Trilinos sets some TPL dependency options using different names.
+  # We handle the translation here.
+  # This can cause issues if Trilinos is built against an external Kokkos.
 
-  if(NOT ${TPL_ENABLE_CUDA} STREQUAL "")
-    set(Kokkos_ENABLE_CUDA ${TPL_ENABLE_CUDA} CACHE BOOL "Whether to build CUDA backend" FORCE)
-  else()
-    set(Kokkos_ENABLE_CUDA OFF CACHE BOOL "Whether to build CUDA backend" FORCE)
-  endif()
+  ASSERT_DEFINED(Kokkos_ENABLE_quadmath)
+  set(Kokkos_ENABLE_LIBQUADMATH ${Kokkos_ENABLE_quadmath} CACHE BOOL "Whether to enable the LIBQUADMATH library" FORCE)
 
-  if(NOT ${TPL_ENABLE_HPX} STREQUAL "")
-    set(Kokkos_ENABLE_HPX ${TPL_ENABLE_HPX} CACHE BOOL "Whether to build HPX backend" FORCE)
-  else()
-    set(Kokkos_ENABLE_HPX OFF CACHE BOOL "Whether to build HPX backend" FORCE)
-  endif()
+  ASSERT_DEFINED(Kokkos_ENABLE_DLlib)
+  set(Kokkos_ENABLE_LIBDL ${Kokkos_ENABLE_DLlib} CACHE BOOL "Whether to enable the LIBDL library" FORCE)
 
-  if(NOT ${TPL_ENABLE_quadmath} STREQUAL "")
-    set(Kokkos_ENABLE_LIBQUADMATH ${TPL_ENABLE_quadmath} CACHE BOOL "Whether to enable the LIBQUADMATH library" FORCE)
-  else()
-    set(Kokkos_ENABLE_LIBQUADMATH OFF CACHE BOOL "Whether to enable the LIBQUADMATH library" FORCE)
-  endif()
-
-  if(NOT ${TPL_ENABLE_DLlib} STREQUAL "")
-    set(Kokkos_ENABLE_LIBDL ${TPL_ENABLE_DLlib} CACHE BOOL "Whether to enable the LIBDL library" FORCE)
-  else()
-    set(Kokkos_ENABLE_LIBDL OFF CACHE BOOL "Whether to enable the LIBDL library" FORCE)
-  endif()
-
-  set(Kokkos_ENABLE_COMPLEX_ALIGN OFF CACHE BOOL "Whether to align Kokkos::complex to 2*alignof(RealType)")
-
-  # FIXME_TRILINOS We run into problems when trying to use an external GTest in Trilinos CI
-  set(CMAKE_DISABLE_FIND_PACKAGE_GTest ON)
-
-  assert_defined(
-    Kokkos_ENABLE_SERIAL
-    Kokkos_ENABLE_OPENMP
-    Kokkos_ENABLE_THREADS
-    Kokkos_ENABLE_HPX
-    Kokkos_ENABLE_CUDA
-    Kokkos_ENABLE_HIP
-    Kokkos_ENABLE_SYCL
-    Kokkos_ENABLE_OPENACC
-  )
-
-  if(Kokkos_ENABLE_SERIAL
-     AND NOT Kokkos_ENABLE_OPENMP
-     AND NOT Kokkos_ENABLE_THREADS
-     AND NOT Kokkos_ENABLE_HPX
-     AND NOT Kokkos_ENABLE_CUDA
-     AND NOT Kokkos_ENABLE_HIP
-     AND NOT Kokkos_ENABLE_SYCL
-     AND NOT Kokkos_ENABLE_OPENACC
-  )
-    if(NOT DEFINED Kokkos_ENABLE_ATOMICS_BYPASS)
-      set(Kokkos_ENABLE_ATOMICS_BYPASS ON
-          CACHE BOOL "Whether to make atomics non-atomic for non-threaded MPI-only use cases" FORCE
-      )
-    endif()
-  endif()
 endif()


### PR DESCRIPTION
@trilinos/kokkos

## Motivation
Move CMake logic from the snapshotted Kokkos package to Trilinos. Hopefully this will make it less awkward to deal with Trilinos specifc deviations from Kokkos defaults. Add a missing optional dependency on quadmath to Kokkos.

## Testing
In a serial build I saw no difference in the CMakeCache.txt before and after the change. Let's see how badly the AT will fail...