### PR TITLE
tpetra: iallreduceImpl update for Kokkos_ENABLE_DEPRECATED_CODE_5=OFF

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_iallreduce.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_iallreduce.hpp
@@ -220,7 +220,9 @@ iallreduceImpl(const InputViewType& sendbuf,
                const OutputViewType& recvbuf,
                const ::Teuchos::EReductionType,
                const ::Teuchos::Comm<int>&) {
-  Kokkos::deep_copy(recvbuf, sendbuf);
+  // Avoid deep_copy precond violation if views are identical
+  if (recvbuf !=  sendbuf)
+    Kokkos::deep_copy(recvbuf, sendbuf);
   return emptyCommRequest();
 }
 

--- a/packages/tpetra/core/src/Tpetra_Details_iallreduce.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_iallreduce.hpp
@@ -221,7 +221,7 @@ iallreduceImpl(const InputViewType& sendbuf,
                const ::Teuchos::EReductionType,
                const ::Teuchos::Comm<int>&) {
   // Avoid deep_copy precond violation if views are identical
-  if (recvbuf !=  sendbuf)
+  if (recvbuf != sendbuf)
     Kokkos::deep_copy(recvbuf, sendbuf);
   return emptyCommRequest();
 }

--- a/packages/tpetra/core/src/Tpetra_Details_iallreduce.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_iallreduce.hpp
@@ -164,7 +164,9 @@ iallreduceImpl(const InputViewType& sendbuf,
                const ::Teuchos::Comm<int>& comm) {
   using Packet = typename InputViewType::non_const_value_type;
   if (comm.getSize() == 1) {
-    Kokkos::deep_copy(recvbuf, sendbuf);
+    // Avoid deep_copy precond violation if views are identical
+    if (recvbuf != sendbuf)
+      Kokkos::deep_copy(recvbuf, sendbuf);
     return emptyCommRequest();
   }
   Packet examplePacket;


### PR DESCRIPTION
In iallreduceImpl, check that Views are not identical before calling deep_copy

This is a compatibility update following https://github.com/kokkos/kokkos/pull/9055 with Kokkos_ENABLE_DEPRECATED_CODE_5=OFF to avoid a deep_copy precondition violation

@trilinos/tpetra 

Resolves runtime failures:
```
...
19:04:44 0. idot_basic_UnitTest ... Test Tpetra::Vector inputs and raw pointer output
19:04:44 About to call idot
19:04:44 Kokkos ERROR: deep_copy() source and destination View arguments are identical
...
```

I tested in a local build with `Kokkos_ENABLE_DEPRECATED_CODE_5=OFF` to confirm this change resolves the failure

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
