### PR TITLE
Belos: implement "Keep Hessenberg" for BlockFGmresIter

### DIFF
--- a/packages/belos/src/BelosBlockFGmresIter.hpp
+++ b/packages/belos/src/BelosBlockFGmresIter.hpp
@@ -274,6 +274,11 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   // generated without the right-hand side or solution vectors.
   bool stateStorageInitialized_;
 
+  // keepHessenberg_ specifies that the upper Hessenberg matrix should be stored separately
+  // from the QR-factored least squares system (R_).  When false, H_ and R_ point to the
+  // same object and only the QR-rotated form is available via getState().
+  bool keepHessenberg_;
+
   // Current subspace dimension, and number of iterations performed.
   int curDim_, iter_;
 
@@ -312,9 +317,16 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
     numBlocks_(0),
     initialized_(false),
     stateStorageInitialized_(false),
+    keepHessenberg_(false),
     curDim_(0),
     iter_(0)
   {
+    // Find out whether we are saving the Hessenberg matrix separately from R.
+    if (om_->isVerbosity(Debug))
+      keepHessenberg_ = true;
+    else
+      keepHessenberg_ = params.get("Keep Hessenberg", false);
+
     // Get the maximum number of blocks allowed for this Krylov subspace
     TEUCHOS_TEST_FOR_EXCEPTION(
       ! params.isParameter ("Num Blocks"), std::invalid_argument,
@@ -426,16 +438,29 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
           }
         }
 
-        // Generate H_ only if it doesn't exist, otherwise resize it.
-        if (H_ == Teuchos::null) {
-          H_ = rcp (new SDM (newsd, newsd-blockSize_));
+        // R_ holds the QR-factored least squares system. Always allocated.
+        if (R_ == Teuchos::null) {
+          R_ = rcp (new SDM (newsd, newsd-blockSize_));
         }
         else {
-          H_->shapeUninitialized (newsd, newsd - blockSize_);
+          R_->shapeUninitialized (newsd, newsd - blockSize_);
         }
 
-        // TODO:  Insert logic so that Hessenberg matrix can be saved and reduced matrix is stored in R_
-        //R_ = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( newsd, newsd-blockSize_ ) );
+        // H_ holds the raw (pre-QR) upper Hessenberg matrix.
+        // When keepHessenberg_ is false, H_ and R_ point to the same object
+        // (matching BlockGmresIter behavior).
+        if (keepHessenberg_) {
+          if (H_ == Teuchos::null) {
+            H_ = rcp (new SDM (newsd, newsd-blockSize_));
+          }
+          else {
+            H_->shapeUninitialized (newsd, newsd - blockSize_);
+          }
+        }
+        else {
+          H_ = R_;
+        }
+
         // Generate z_ only if it doesn't exist, otherwise resize it.
         if (z_ == Teuchos::null) {
           z_ = rcp (new SDM (newsd, blockSize_));
@@ -476,7 +501,7 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
       // Solve the least squares problem.
       blas.TRSM (Teuchos::LEFT_SIDE, Teuchos::UPPER_TRI, Teuchos::NO_TRANS,
                  Teuchos::NON_UNIT_DIAG, curDim_, blockSize_, one,
-                 H_->values (), H_->stride (), y.values (), y.stride ());
+                 R_->values (), R_->stride (), y.values (), y.stride ());
 
       // Compute the current update.
       std::vector<int> index (curDim_);
@@ -668,13 +693,14 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
       Array<RCP<const MV> > AVprev (1, Vprev);
 
       // Get a view of the part of the Hessenberg matrix needed to hold the ortho coeffs.
+      // Ortho always writes into H_ (the raw Hessenberg).
       RCP<SDM> subH = rcp (new SDM (View, *H_, lclDim, blockSize_, 0, curDim_));
       Array<RCP<SDM> > AsubH;
       AsubH.append (subH);
 
       // Get a view of the part of the Hessenberg matrix needed to hold the norm coeffs.
-      RCP<SDM> subR = rcp (new SDM (View, *H_, blockSize_, blockSize_, lclDim, curDim_));
-      const int rank = ortho_->projectAndNormalize (*Vnext, AsubH, subR, AVprev);
+      RCP<SDM> subH2 = rcp (new SDM (View, *H_, blockSize_, blockSize_, lclDim, curDim_));
+      const int rank = ortho_->projectAndNormalize (*Vnext, AsubH, subH2, AVprev);
       TEUCHOS_TEST_FOR_EXCEPTION(
         rank != blockSize_, GmresIterationOrthoFailure,
         "Belos::BlockFGmresIter::iterate(): After orthogonalization, the new "
@@ -682,10 +708,19 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
         << " vector" << (blockSize_ != 1 ? "s" : "")
         << ", but its rank is " << rank << ".");
 
+      // If keeping the Hessenberg separately, copy the new columns into R_
+      // before updateLSQR() overwrites them with the QR factorization.
+      if (keepHessenberg_) {
+        RCP<SDM> subR = rcp (new SDM (View, *R_, lclDim, blockSize_, 0, curDim_));
+        subR->assign (*subH);
+        RCP<SDM> subR2 = rcp (new SDM (View, *R_, blockSize_, blockSize_, lclDim, curDim_));
+        subR2->assign (*subH2);
+      }
+
       //
       // V has been extended, and H has been extended.
       //
-      // Update the QR factorization of the upper Hessenberg matrix
+      // Update the QR factorization of the upper Hessenberg matrix (applied to R_).
       //
       updateLSQR ();
       //
@@ -726,11 +761,11 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
       // QR factorization of upper Hessenberg matrix using Givens rotations
       for (int i = 0; i < curDim; ++i) {
         // Apply previous Givens rotations to new column of Hessenberg matrix
-        blas.ROT (1, &(*H_)(i, curDim), 1, &(*H_)(i+1, curDim), 1, &cs[i], &sn[i]);
+        blas.ROT (1, &(*R_)(i, curDim), 1, &(*R_)(i+1, curDim), 1, &cs[i], &sn[i]);
       }
       // Calculate new Givens rotation
-      blas.ROTG (&(*H_)(curDim, curDim), &(*H_)(curDim+1, curDim), &cs[curDim], &sn[curDim]);
-      (*H_)(curDim+1, curDim) = zero;
+      blas.ROTG (&(*R_)(curDim, curDim), &(*R_)(curDim+1, curDim), &cs[curDim], &sn[curDim]);
+      (*R_)(curDim+1, curDim) = zero;
 
       // Update RHS w/ new transformation
       blas.ROT (1, &(*z_)(curDim,0), 1, &(*z_)(curDim+1,0), 1, &cs[curDim], &sn[curDim]);
@@ -740,44 +775,44 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
       for (int j = 0; j < blockSize_; ++j) {
         // Apply previous Householder reflectors to new block of Hessenberg matrix
         for (int i = 0; i < curDim + j; ++i) {
-          sigma = blas.DOT (blockSize_, &(*H_)(i+1,i), 1, &(*H_)(i+1,curDim+j), 1);
-          sigma += (*H_)(i,curDim+j);
+          sigma = blas.DOT (blockSize_, &(*R_)(i+1,i), 1, &(*R_)(i+1,curDim+j), 1);
+          sigma += (*R_)(i,curDim+j);
           sigma *= beta[i];
-          blas.AXPY (blockSize_, ScalarType(-sigma), &(*H_)(i+1,i), 1, &(*H_)(i+1,curDim+j), 1);
-          (*H_)(i,curDim+j) -= sigma;
+          blas.AXPY (blockSize_, ScalarType(-sigma), &(*R_)(i+1,i), 1, &(*R_)(i+1,curDim+j), 1);
+          (*R_)(i,curDim+j) -= sigma;
         }
 
         // Compute new Householder reflector
-        const int maxidx = blas.IAMAX (blockSize_+1, &(*H_)(curDim+j,curDim+j), 1);
-        maxelem = (*H_)(curDim + j + maxidx - 1, curDim + j);
+        const int maxidx = blas.IAMAX (blockSize_+1, &(*R_)(curDim+j,curDim+j), 1);
+        maxelem = (*R_)(curDim + j + maxidx - 1, curDim + j);
         for (int i = 0; i < blockSize_ + 1; ++i) {
-          (*H_)(curDim+j+i,curDim+j) /= maxelem;
+          (*R_)(curDim+j+i,curDim+j) /= maxelem;
         }
-        sigma = blas.DOT (blockSize_, &(*H_)(curDim + j + 1, curDim + j), 1,
-                          &(*H_)(curDim + j + 1, curDim + j), 1);
+        sigma = blas.DOT (blockSize_, &(*R_)(curDim + j + 1, curDim + j), 1,
+                          &(*R_)(curDim + j + 1, curDim + j), 1);
         if (sigma == zero) {
           beta[curDim + j] = zero;
         } else {
-          mu = STS::squareroot ((*H_)(curDim+j,curDim+j)*(*H_)(curDim+j,curDim+j)+sigma);
-          if (STS::real ((*H_)(curDim + j, curDim + j)) < STM::zero ()) {
-            vscale = (*H_)(curDim+j,curDim+j) - mu;
+          mu = STS::squareroot ((*R_)(curDim+j,curDim+j)*(*R_)(curDim+j,curDim+j)+sigma);
+          if (STS::real ((*R_)(curDim + j, curDim + j)) < STM::zero ()) {
+            vscale = (*R_)(curDim+j,curDim+j) - mu;
           } else {
-            vscale = -sigma / ((*H_)(curDim+j, curDim+j) + mu);
+            vscale = -sigma / ((*R_)(curDim+j, curDim+j) + mu);
           }
           beta[curDim+j] = two * vscale * vscale / (sigma + vscale*vscale);
-          (*H_)(curDim+j, curDim+j) = maxelem*mu;
+          (*R_)(curDim+j, curDim+j) = maxelem*mu;
           for (int i = 0; i < blockSize_; ++i) {
-            (*H_)(curDim+j+1+i,curDim+j) /= vscale;
+            (*R_)(curDim+j+1+i,curDim+j) /= vscale;
           }
         }
 
         // Apply new Householder reflector to the right-hand side.
         for (int i = 0; i < blockSize_; ++i) {
-          sigma = blas.DOT (blockSize_, &(*H_)(curDim+j+1,curDim+j),
+          sigma = blas.DOT (blockSize_, &(*R_)(curDim+j+1,curDim+j),
                             1, &(*z_)(curDim+j+1,i), 1);
           sigma += (*z_)(curDim+j,i);
           sigma *= beta[curDim+j];
-          blas.AXPY (blockSize_, ScalarType(-sigma), &(*H_)(curDim+j+1,curDim+j),
+          blas.AXPY (blockSize_, ScalarType(-sigma), &(*R_)(curDim+j+1,curDim+j),
                      1, &(*z_)(curDim+j+1,i), 1);
           (*z_)(curDim+j,i) -= sigma;
         }

--- a/packages/belos/src/BelosBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGmresSolMgr.hpp
@@ -296,6 +296,7 @@ private:
   static constexpr bool adaptiveBlockSize_default_ = true;
   static constexpr bool showMaxResNormOnly_default_ = false;
   static constexpr bool flexibleGmres_default_ = false;
+  static constexpr bool keepHessenberg_default_ = false;
   static constexpr bool expResTest_default_ = false;
   static constexpr int blockSize_default_ = 1;
   static constexpr int numBlocks_default_ = 300;
@@ -311,7 +312,7 @@ private:
   MagnitudeType convtol_, orthoKappa_, achievedTol_;
   int maxRestarts_, maxIters_, numIters_;
   int blockSize_, numBlocks_, verbosity_, outputStyle_, outputFreq_;
-  bool adaptiveBlockSize_, showMaxResNormOnly_, isFlexible_, expResTest_;
+  bool adaptiveBlockSize_, showMaxResNormOnly_, isFlexible_, keepHessenberg_, expResTest_;
   std::string orthoType_;
   std::string impResScale_, expResScale_;
 
@@ -343,6 +344,7 @@ BlockGmresSolMgr<ScalarType,MV,OP>::BlockGmresSolMgr() :
   adaptiveBlockSize_(adaptiveBlockSize_default_),
   showMaxResNormOnly_(showMaxResNormOnly_default_),
   isFlexible_(flexibleGmres_default_),
+  keepHessenberg_(keepHessenberg_default_),
   expResTest_(expResTest_default_),
   orthoType_(orthoType_default_),
   impResScale_(impResScale_default_),
@@ -375,6 +377,7 @@ BlockGmresSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
   adaptiveBlockSize_(adaptiveBlockSize_default_),
   showMaxResNormOnly_(showMaxResNormOnly_default_),
   isFlexible_(flexibleGmres_default_),
+  keepHessenberg_(keepHessenberg_default_),
   expResTest_(expResTest_default_),
   orthoType_(orthoType_default_),
   impResScale_(impResScale_default_),
@@ -441,6 +444,10 @@ BlockGmresSolMgr<ScalarType,MV,OP>::getValidParameters() const
     pl->set("Flexible Gmres", static_cast<bool>(flexibleGmres_default_),
       "Whether the solver manager should use the flexible variant\n"
       "of GMRES.");
+    pl->set("Keep Hessenberg", static_cast<bool>(keepHessenberg_default_),
+      "Whether the raw upper Hessenberg matrix should be stored separately\n"
+      "from the QR-factored least squares system. Useful for harmonic Ritz\n"
+      "pair computation from the GMRES iteration state.");
     pl->set("Explicit Residual Test", static_cast<bool>(expResTest_default_),
       "Whether the explicitly computed residual should be used in the convergence test.");
     pl->set("Implicit Residual Scaling", static_cast<const char *>(impResScale_default_),
@@ -534,6 +541,12 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuch
         ortho_->setLabel( label_ );
       }
     }
+  }
+
+  // Determine whether the raw Hessenberg should be stored separately from R.
+  if (params->isParameter("Keep Hessenberg")) {
+    keepHessenberg_ = Teuchos::getParameter<bool>(*params,"Keep Hessenberg");
+    params_->set("Keep Hessenberg", keepHessenberg_);
   }
 
   // Determine whether this solver should be "flexible".
@@ -903,6 +916,7 @@ ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
   // Parameter list
   Teuchos::ParameterList plist;
   plist.set("Block Size",blockSize_);
+  plist.set("Keep Hessenberg",keepHessenberg_);
 
   ptrdiff_t dim = MVT::GetGlobalLength( *(problem_->getRHS()) );
   if (blockSize_*static_cast<ptrdiff_t>(numBlocks_) > dim) {

--- a/packages/belos/tpetra/test/BlockGmres/CMakeLists.txt
+++ b/packages/belos/tpetra/test/BlockGmres/CMakeLists.txt
@@ -66,6 +66,14 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_BlockFGMRES_keep_hessenberg_test
+  SOURCES test_bl_fgmres_keep_hessenberg.cpp
+  ARGS "--verbose"
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Tpetra_HybridGMRES_hb_test
   SOURCES test_hybrid_gmres_hb.cpp
   ARGS "--verbose --max-degree=10 --poly-type=Arnoldi"

--- a/packages/belos/tpetra/test/BlockGmres/test_bl_fgmres_keep_hessenberg.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_bl_fgmres_keep_hessenberg.cpp
@@ -1,0 +1,305 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// Test for "Keep Hessenberg" feature in BlockFGmresIter / BlockGmresSolMgr.
+//
+// When "Flexible Gmres" = true and "Keep Hessenberg" = true, getState().H
+// must hold the raw (pre-QR) upper Hessenberg matrix and getState().R must
+// hold the QR-rotated upper triangular factor.  They must be distinct objects
+// with distinct values: H has nonzero subdiagonal entries; R does not.
+//
+// When "Keep Hessenberg" = false (the default), H and R must agree — there
+// is only one matrix and it contains the QR-factored form.
+//
+// The test uses a simple n x n tridiagonal matrix so no external data files
+// are needed.
+//
+
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosBlockGmresSolMgr.hpp"
+#include "BelosBlockFGmresIter.hpp"
+#include "BelosGmresIteration.hpp"
+#include "BelosStatusTest.hpp"
+#include "BelosTypes.hpp"
+
+#include "Tpetra_Core.hpp"
+#include "Tpetra_CrsMatrix.hpp"
+#include "Tpetra_Map.hpp"
+#include "Tpetra_MultiVector.hpp"
+
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_ParameterList.hpp"
+#include "Teuchos_SerialDenseMatrix.hpp"
+#include "Teuchos_StandardCatchMacros.hpp"
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+
+// -----------------------------------------------------------------------
+// StatusTest that snapshots H and R from BlockFGmresIter after each
+// iteration.  Returns Undefined so it never affects convergence decisions.
+// -----------------------------------------------------------------------
+template <class SC, class MV, class OP>
+class HessenbergCapture : public Belos::StatusTest<SC, MV, OP> {
+ public:
+  using State = Belos::GmresIterationState<SC, MV>;
+
+  int                                     curDim = 0;
+  bool                                    sawFGmresIter = false;
+  RCP<Teuchos::SerialDenseMatrix<int,SC>> H;   // deep copy of raw Hessenberg
+  RCP<Teuchos::SerialDenseMatrix<int,SC>> R;   // deep copy of QR-rotated R
+
+  Belos::StatusType checkStatus(Belos::Iteration<SC, MV, OP>* it) override {
+    auto* fg = dynamic_cast<Belos::BlockFGmresIter<SC, MV, OP>*>(it);
+    if (fg) {
+      sawFGmresIter = true;
+      State s = fg->getState();
+      if (s.curDim > 0) {
+        curDim = s.curDim;
+        if (s.H)
+          H = rcp(new Teuchos::SerialDenseMatrix<int,SC>(*s.H));
+        if (s.R)
+          R = rcp(new Teuchos::SerialDenseMatrix<int,SC>(*s.R));
+      }
+    }
+    return Belos::Undefined;
+  }
+  Belos::StatusType getStatus() const override { return Belos::Undefined; }
+  void reset() override {
+    curDim = 0; sawFGmresIter = false; H = Teuchos::null; R = Teuchos::null;
+  }
+  void print(std::ostream& os, int indent = 0) const override {
+    os << std::string(indent, ' ') << "HessenbergCapture\n";
+  }
+};
+
+// -----------------------------------------------------------------------
+// Build an n x n tridiagonal CrsMatrix: diag = d, off-diag = o
+// -----------------------------------------------------------------------
+template <class SC, class LO, class GO, class NT>
+RCP<Tpetra::CrsMatrix<SC,LO,GO,NT>>
+buildTridiagonal(RCP<const Tpetra::Map<LO,GO,NT>> map, SC d, SC o)
+{
+  auto A = rcp(new Tpetra::CrsMatrix<SC,LO,GO,NT>(map, 3));
+  const GO N = static_cast<GO>(map->getGlobalNumElements());
+  for (LO i = 0; i < static_cast<LO>(map->getLocalNumElements()); ++i) {
+    GO g = map->getGlobalElement(i);
+    if (g > 0)
+      A->insertGlobalValues(g, Teuchos::tuple(g-1), Teuchos::tuple(o));
+    A->insertGlobalValues(g, Teuchos::tuple(g), Teuchos::tuple(d));
+    if (g < N - 1)
+      A->insertGlobalValues(g, Teuchos::tuple(g+1), Teuchos::tuple(o));
+  }
+  A->fillComplete();
+  return A;
+}
+
+// -----------------------------------------------------------------------
+// Run the test for one combination of keepHessenberg flag and restart size.
+// numBlocks controls the Krylov subspace size before restart; setting it
+// smaller than the iterations needed forces at least one restart.
+// Returns true if all assertions pass.
+// -----------------------------------------------------------------------
+template <class SC>
+bool runCase(bool keepHessenberg, int numBlocks, bool verbose)
+{
+  using LO  = typename Tpetra::MultiVector<SC>::local_ordinal_type;
+  using GO  = typename Tpetra::MultiVector<SC>::global_ordinal_type;
+  using NT  = typename Tpetra::MultiVector<SC>::node_type;
+  using MV  = Tpetra::MultiVector<SC,LO,GO,NT>;
+  using OP  = Tpetra::Operator<SC,LO,GO,NT>;
+  using SDM = Teuchos::SerialDenseMatrix<int,SC>;
+  using STS = Teuchos::ScalarTraits<SC>;
+  using MT  = typename STS::magnitudeType;
+  using STM = Teuchos::ScalarTraits<MT>;
+
+  auto comm = Tpetra::getDefaultComm();
+  const int me = comm->getRank();
+
+  // Use a larger system when forcing restarts so convergence needs more
+  // iterations than numBlocks.
+  const GO n = (numBlocks < 20) ? 200 : 20;
+  auto map = rcp(new Tpetra::Map<LO,GO,NT>(n, 0, comm));
+  auto A   = buildTridiagonal<SC,LO,GO,NT>(map, SC(4), SC(-1));
+
+  auto b = rcp(new MV(map, 1));
+  auto x = rcp(new MV(map, 1));
+  b->putScalar(STS::one());
+  x->putScalar(STS::zero());
+
+  // Provide a trivial (identity) right preconditioner so BlockGmresSolMgr
+  // keeps isFlexible_=true and instantiates BlockFGmresIter rather than
+  // falling back to BlockGmresIter when no right prec is present.
+  auto I = rcp(new Tpetra::CrsMatrix<SC,LO,GO,NT>(map, 1));
+  for (LO i = 0; i < static_cast<LO>(map->getLocalNumElements()); ++i) {
+    GO g = map->getGlobalElement(i);
+    I->insertGlobalValues(g, Teuchos::tuple(g), Teuchos::tuple(STS::one()));
+  }
+  I->fillComplete();
+
+  auto problem = rcp(new Belos::LinearProblem<SC,MV,OP>(A, x, b));
+  problem->setRightPrec(I);
+  problem->setProblem();
+
+  auto params = rcp(new Teuchos::ParameterList);
+  params->set("Num Blocks",            numBlocks);
+  params->set("Maximum Restarts",      50);
+  params->set("Maximum Iterations",   5000);
+  params->set("Convergence Tolerance", MT(1e-10));
+  params->set("Flexible Gmres",        true);
+  params->set("Keep Hessenberg",       keepHessenberg);
+  params->set("Verbosity",             Belos::Errors);
+
+  auto capture = rcp(new HessenbergCapture<SC,MV,OP>());
+  Belos::BlockGmresSolMgr<SC,MV,OP> solver(problem, params);
+  solver.setDebugStatusTest(capture);
+
+  Belos::ReturnType ret = solver.solve();
+
+  if (ret != Belos::Converged) {
+    if (me == 0)
+      std::cerr << "  FAIL: solver did not converge.\n";
+    return false;
+  }
+
+  const int numIters = solver.getNumIters();
+
+  // If a small numBlocks was requested, verify that the solver actually
+  // restarted (total iterations must exceed the restart cycle length).
+  if (numBlocks < 20) {
+    if (numIters <= numBlocks) {
+      if (me == 0)
+        std::cerr << "  FAIL (restart test): solver converged in " << numIters
+                  << " iterations without restarting (numBlocks = " << numBlocks << ")."
+                     " Increase problem size or tighten tolerance.\n";
+      return false;
+    }
+    if (verbose && me == 0)
+      std::cout << "  Confirmed restart: converged in " << numIters
+                << " iterations with numBlocks = " << numBlocks << ".\n";
+  }
+
+  if (!capture->sawFGmresIter) {
+    if (me == 0)
+      std::cerr << "  FAIL: solver did not use BlockFGmresIter (dynamic_cast never succeeded)."
+                   " Check that isFlexible_=true and a right preconditioner is set.\n";
+    return false;
+  }
+
+  const int dim = capture->curDim;
+  if (dim <= 0) {
+    if (me == 0)
+      std::cerr << "  FAIL: no iteration state captured (curDim = " << dim << ").\n";
+    return false;
+  }
+  if (!capture->H || !capture->R) {
+    if (me == 0)
+      std::cerr << "  FAIL: H or R is null after solve.\n";
+    return false;
+  }
+
+  const SDM& H = *capture->H;
+  const SDM& R = *capture->R;
+
+  if (keepHessenberg) {
+    // H must have at least one nonzero subdiagonal entry (raw Hessenberg).
+    // R must have all subdiagonal entries equal to zero (QR-rotated).
+    bool H_has_subdiag         = false;
+    bool R_has_nonzero_subdiag = false;
+    for (int j = 0; j < dim; ++j) {
+      if (STS::magnitude(H(j+1, j)) > STM::zero())  H_has_subdiag = true;
+      if (STS::magnitude(R(j+1, j)) > MT(1e-14))    R_has_nonzero_subdiag = true;
+    }
+    if (!H_has_subdiag) {
+      if (me == 0)
+        std::cerr << "  FAIL (Keep Hessenberg=true): H has no nonzero subdiagonal entries.\n";
+      return false;
+    }
+    if (R_has_nonzero_subdiag) {
+      if (me == 0)
+        std::cerr << "  FAIL (Keep Hessenberg=true): R has nonzero subdiagonal entries.\n";
+      return false;
+    }
+    if (verbose && me == 0)
+      std::cout << "  PASS (Keep Hessenberg=true): H has subdiagonals; R is upper triangular."
+                   " (" << numIters << " iters)\n";
+  } else {
+    // H and R must agree pointwise (same object, both hold the QR-rotated form).
+    MT maxdiff = STM::zero();
+    for (int j = 0; j < dim; ++j)
+      for (int i = 0; i < H.numRows() && i <= j+1; ++i)
+        maxdiff = std::max(maxdiff, STS::magnitude(H(i,j) - R(i,j)));
+
+    if (maxdiff > MT(1e-14)) {
+      if (me == 0)
+        std::cerr << "  FAIL (Keep Hessenberg=false): H and R differ (max |H-R| = "
+                  << maxdiff << ").\n";
+      return false;
+    }
+    // R must also be upper triangular.
+    bool R_has_nonzero_subdiag = false;
+    for (int j = 0; j < dim; ++j)
+      if (STS::magnitude(R(j+1, j)) > MT(1e-14))
+        R_has_nonzero_subdiag = true;
+    if (R_has_nonzero_subdiag) {
+      if (me == 0)
+        std::cerr << "  FAIL (Keep Hessenberg=false): R has nonzero subdiagonal entries.\n";
+      return false;
+    }
+    if (verbose && me == 0)
+      std::cout << "  PASS (Keep Hessenberg=false): H == R, both upper triangular.\n";
+  }
+
+  return true;
+}
+
+int main(int argc, char* argv[])
+{
+  Tpetra::ScopeGuard tpetraScope(&argc, &argv);
+
+  bool verbose = false;
+  bool success = false;
+
+  try {
+    auto comm = Tpetra::getDefaultComm();
+    const int me = comm->getRank();
+
+    for (int i = 1; i < argc; ++i)
+      if (std::string(argv[i]) == "--verbose")
+        verbose = true;
+
+    bool ok = true;
+
+    if (verbose && me == 0)
+      std::cout << "\nCase 1: Keep Hessenberg = true (no restart)\n";
+    ok &= runCase<double>(true,  30, verbose);
+
+    if (verbose && me == 0)
+      std::cout << "\nCase 2: Keep Hessenberg = false (no restart)\n";
+    ok &= runCase<double>(false, 30, verbose);
+
+    if (verbose && me == 0)
+      std::cout << "\nCase 3: Keep Hessenberg = true (forced restart, numBlocks=10)\n";
+    ok &= runCase<double>(true,  10, verbose);
+
+    success = ok;
+
+    if (me == 0) {
+      if (success)
+        std::cout << "\nEnd Result: TEST PASSED\n";
+      else
+        std::cout << "\nEnd Result: TEST FAILED\n";
+    }
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return success ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Motivation

`BlockGmresIter` already stored the raw upper Hessenberg (`H_`) and the QR-factored least-squares system (`R_`) as separate objects when the `"Keep Hessenberg"` parameter was set. `BlockFGmresIter` did not implement this. `H_` and `R_` were the same object, and a TODO comment in `setStateSize()` marked the work as unfinished. The raw Hessenberg is needed to compute harmonic Ritz pairs from the FGMRES Krylov subspace, which can be used to adaptively reconfigure block preconditioners between solves.

## Related Issues

Closes #15117

## Testing

Added `test_bl_fgmres_keep_hessenberg.cpp`: verifies that with the flag on, `H` has nonzero subdiagonal entries and `R` is upper triangular; that with the flag off, `H` and `R` agree pointwise (backward-compatible behavior); and that the feature survives a restart cycle. Existing `Tpetra_BlockFGMRES_hb_test` continues to pass.

## Additional Information

Changes:
- `BelosBlockFGmresIter`: add `keepHessenberg_` flag read from params; allocate `H_` and `R_` as distinct matrices when the flag is true; copy ortho output into `R_` before `updateLSQR()` so QR rotations operate on `R_` while `H_` retains the raw Hessenberg; fix TRSM in `getCurrentUpdate()` to use `R_` not `H_` (latent bug: previously harmless because `H_` and `R_` were always the same object).
- `BelosBlockGmresSolMgr`: read `"Keep Hessenberg"` parameter and forward it to the iterator parameter list. This was missing for both the flexible and non-flexible paths, making the feature effectively unreachable from user-facing params.

## AI Use
Developed with the assistance of Claude (`claude-sonnet-4-6` by Anthropic).
