### PR TITLE
Tacho: improve performance of variant 0 ~ 2

### DIFF
--- a/packages/amesos2/src/Amesos2_Tacho_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Tacho_decl.hpp
@@ -207,6 +207,7 @@ private:
     int dofs_per_node;
     bool diag_shift;
     bool pivot_pert;
+    bool team_on_user_stream;
     // int num_kokkos_threads;
     // int max_num_superblocks;
   } data_;

--- a/packages/amesos2/src/Amesos2_Tacho_def.hpp
+++ b/packages/amesos2/src/Amesos2_Tacho_def.hpp
@@ -34,6 +34,7 @@ TachoSolver<Matrix,Vector>::TachoSolver(
   data_.pivot_pert = false; // Pertub small pivot
   data_.diag_shift = false; // Shift diagonal
   data_.verbose    = false; // verbose
+  data_.team_on_user_stream  = false; // use user stream-0 for team/batched kernels
   data_.small_problem_threshold_size = 1024;
 }
 
@@ -81,7 +82,7 @@ TachoSolver<Matrix,Vector>::symbolicFactorization_impl()
     data_.solver.setLevelSetOptionAlgorithmVariant(data_.variant);
     data_.solver.setSmallProblemThresholdsize(data_.small_problem_threshold_size);
     data_.solver.setVerbose(data_.verbose);
-    data_.solver.setLevelSetOptionNumStreams(data_.streams);
+    data_.solver.setLevelSetOptionNumStreams(data_.streams, data_.team_on_user_stream);
     // TODO: Confirm param options
     // data_.solver.setMaxNumberOfSuperblocks(data_.max_num_superblocks);
 
@@ -245,6 +246,8 @@ TachoSolver<Matrix,Vector>::setParameters_impl(const Teuchos::RCP<Teuchos::Param
   data_.verbose = parameterList->get<bool> ("verbose", false);
   // # of streams
   data_.streams = parameterList->get<int> ("num-streams", 1);
+  // use user stream-0 for batched kernels
+  data_.team_on_user_stream = parameterList->get<bool> ("team-on-user-stream", false);
   // DoFs / node
   data_.dofs_per_node = parameterList->get<int> ("dofs-per-node", 1);
   // Perturb tiny pivots
@@ -273,6 +276,7 @@ TachoSolver<Matrix,Vector>::getValidParameters_impl() const
     pl->set("dofs-per-node", 1, "DoFs per node");
     pl->set("perturb-pivot", false, "Perturb tiny pivots");
     pl->set("shift-diag", false, "Shift diagonal entries");
+    pl->set("team-on-user-stream", false, "Use user stream-0 for team/batched kernels");
 
     // TODO: Confirm param options
     // pl->set("kokkos-threads", 1, "Number of threads");
@@ -376,6 +380,7 @@ TachoSolver<Matrix,Vector>::describe_impl(Teuchos::FancyOStream &out,
   out << " > dofs-per-node = " << data_.dofs_per_node << std::endl;
   out << " > perturb-pivo  = " << (data_.pivot_pert ? "YES" : "NO") << std::endl;
   out << " > shift-diag    = " << (data_.diag_shift ? "YES" : "NO") << std::endl;
+  out << " > team-on-user-stream  = " << (data_.team_on_user_stream ? "YES" : "NO") << std::endl;
   out << " > small problem threshold size = " << data_.small_problem_threshold_size << std::endl;
   out << std::endl;
 }

--- a/packages/amesos2/src/Amesos2_Tacho_def.hpp
+++ b/packages/amesos2/src/Amesos2_Tacho_def.hpp
@@ -77,9 +77,6 @@ TachoSolver<Matrix,Vector>::symbolicFactorization_impl()
       this->matrixA_->returnColInd_kokkos_view(host_cols_view_);
     }
 
-    if (data_.diag_shift) {
-      data_.solver.shiftDiagonal();
-    }
     data_.solver.setSolutionMethod(data_.method);
     data_.solver.setLevelSetOptionAlgorithmVariant(data_.variant);
     data_.solver.setSmallProblemThresholdsize(data_.small_problem_threshold_size);
@@ -117,6 +114,9 @@ TachoSolver<Matrix,Vector>::numericFactorization_impl()
      device_value_type_array device_nzvals_temp;
      this->matrixA_->returnValues_kokkos_view(device_nzvals_temp);
      Kokkos::deep_copy(device_nzvals_view_, device_nzvals_temp);
+    }
+    if (data_.diag_shift) {
+      data_.solver.shiftDiagonal();
     }
     if (data_.pivot_pert) {
       data_.solver.useDefaultPivotTolerance();

--- a/packages/shylu/shylu_node/tacho/example/Tacho_ExampleDriver.hpp
+++ b/packages/shylu/shylu_node/tacho/example/Tacho_ExampleDriver.hpp
@@ -62,6 +62,7 @@ template <typename value_type> int driver(int argc, char *argv[]) {
   int device_solve_thres = 128;
   int variant = 0;
   int nstreams = 8;
+  bool team_on_user_stream = false;
   bool no_warmup = false;
   int niters = 1;
   int nfacts = 2;
@@ -93,6 +94,7 @@ template <typename value_type> int driver(int argc, char *argv[]) {
   opts.set_option<int>("device-solve-thres", "Device function is used above this subproblem size", &device_solve_thres);
   opts.set_option<int>("variant", "algorithm variant in levelset scheduling; 0, 1 and 2", &variant);
   opts.set_option<int>("nstreams", "# of streams used in CUDA; on host, it is ignored", &nstreams);
+  opts.set_option<bool>("team-on-user-stream", "Use stream-0 to launch team-kernels", &team_on_user_stream);
   opts.set_option<bool>("one-rhs", "Set RHS to be ones", &onesRHS);
   opts.set_option<bool>("random-rhs", "Set RHS to be random", &randomRHS);
   opts.set_option<bool>("no-warmup", "Flag to turn off warmup", &no_warmup);
@@ -138,7 +140,8 @@ template <typename value_type> int driver(int argc, char *argv[]) {
       std::cout << "   Using default Parameters " << std::endl;
     } else {
       std::cout << "   Using non default Parameters " << std::endl;
-      std::cout << "       # Streams:: " << nstreams << std::endl;
+      std::cout << "       # Streams:: " << nstreams
+                << (team_on_user_stream ? "(Team on stream-0)" : "(Team on default stream)") <<std::endl;
       std::cout << "    Small Poblem:: " << small_problem_thres << std::endl;
       std::cout << "   Device Thresh:: " << device_factor_thres << ", " << device_solve_thres << std::endl;
     }
@@ -229,7 +232,7 @@ template <typename value_type> int driver(int argc, char *argv[]) {
         solver.setGraphAlgorithmType(graph_algo_type);
       }
       /// levelset options
-      solver.setLevelSetOptionNumStreams(nstreams);
+      solver.setLevelSetOptionNumStreams(nstreams, team_on_user_stream);
       solver.setSmallProblemThresholdsize(small_problem_thres);
       solver.setLevelSetOptionDeviceFunctionThreshold(device_factor_thres, device_solve_thres);
       solver.storeExplicitTranspose(storeTranspose);

--- a/packages/shylu/shylu_node/tacho/example/Tacho_ExampleDriver.hpp
+++ b/packages/shylu/shylu_node/tacho/example/Tacho_ExampleDriver.hpp
@@ -84,6 +84,7 @@ template <typename value_type> int driver(int argc, char *argv[]) {
   opts.set_option<int>("graph-algo", "Type of graph algorithm (0: Natural, 1: AMD, 2: METIS)", &graph_algo_type);
   opts.set_option<bool>("store-trans", "Flag to store transpose", &storeTranspose);
   opts.set_option<bool>("perturb", "Flag to perturb tiny pivots", &perturbPivot);
+  opts.set_option<bool>("shift", "Flag to shift diagonal", &shiftDiag);
   opts.set_option<int>("nrhs", "Number of RHS vectors", &nrhs);
   opts.set_option<std::string>("method", "Solution method: ldl-nopiv, chol, ldl, lu", &method_name);
   opts.set_option<int>("small-problem-thres", "LAPACK is used smaller than this thres", &small_problem_thres);
@@ -210,6 +211,14 @@ template <typename value_type> int driver(int argc, char *argv[]) {
     solver.setVerbose(verbose);
     solver.setSolutionMethod(method);
     solver.setLevelSetOptionAlgorithmVariant(variant);
+    if (shiftDiag) {
+      if (verbose) std::cout << " > shift diagonals with a small pertubation" << std::endl;
+      solver.shiftDiagonal();
+    }
+    if (perturbPivot) {
+      if (verbose) std::cout << " > perturb tiny pivots" << std::endl;
+      solver.useDefaultPivotTolerance();
+    }
 
     if (!default_setup) {
       /// graph options
@@ -223,14 +232,6 @@ template <typename value_type> int driver(int argc, char *argv[]) {
       solver.setLevelSetOptionNumStreams(nstreams);
       solver.setSmallProblemThresholdsize(small_problem_thres);
       solver.setLevelSetOptionDeviceFunctionThreshold(device_factor_thres, device_solve_thres);
-      if (shiftDiag) {
-        if (verbose) std::cout << " > shift diagonals with a small pertubation" << std::endl;
-        solver.shiftDiagonal();
-      }
-      if (perturbPivot) {
-        if (verbose) std::cout << " > perturb tiny pivots" << std::endl;
-        solver.useDefaultPivotTolerance();
-      }
       solver.storeExplicitTranspose(storeTranspose);
       if (verbose) {
         if (storeTranspose) {
@@ -324,13 +325,16 @@ template <typename value_type> int driver(int argc, char *argv[]) {
         /// solve
         bool pass = true;
         double solve_time = 0.0;
+        mag_type shift = solver.currentShift();
         if (!no_warmup) {
           // warm-up
           timer.reset();
           solver.solve(x, b, t);
           solve_time = timer.seconds();
-          const double res = solver.computeRelativeResidual(values_on_device, x, b);
-          std::cout << "TachoSolver (warm-up): residual = " << res << " time " << solve_time << "\n";
+          const double res = solver.computeRelativeResidual(values_on_device, x, b, shift);
+          std::cout << "TachoSolver (warm-up): residual = " << res << " time " << solve_time;
+          if (shiftDiag) std::cout << " using shift = " << shift;
+          std::cout << "\n";
           if (res > tol) pass = false;
         }
 
@@ -345,9 +349,11 @@ template <typename value_type> int driver(int argc, char *argv[]) {
           solver.solve(x, b, t);
           solve_time += timer.seconds();
 #endif
-          const mag_type res = solver.computeRelativeResidual(values_on_device, x, b);
+          const mag_type res = solver.computeRelativeResidual(values_on_device, x, b, shift);
           if (res > tol) pass = false;
-          std::cout << "TachoSolver: residual = " << res << "\n";
+          std::cout << "TachoSolver: residual = " << res;
+          if (shiftDiag) std::cout << " using shift = " << shift;
+          std::cout << "\n";
         }
         if (!pass) success = false;
         std::cout << (pass ? " PASS" : " FAIL") << std::endl;

--- a/packages/shylu/shylu_node/tacho/src/Tacho_Driver.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_Driver.hpp
@@ -168,6 +168,7 @@ private:
   ordinal_type _device_solve_thres;  // bigger than this threshold, device function is used
   ordinal_type _variant;             // algorithmic variant in levelset 0: naive, 1: invert diagonals
   ordinal_type _nstreams;            // on cuda, multi streams are used
+  bool _team_on_user_stream;         // run team/batched kernel on user steram-0
 
   int _shift_diag;                   // shift diagonal with small perturbation
   mag_type _shift;
@@ -224,7 +225,7 @@ public:
   void setLevelSetOptionDeviceLevelCut(const ordinal_type device_level_cut);
   void setLevelSetOptionDeviceFunctionThreshold(const ordinal_type device_factor_thres,
                                                 const ordinal_type device_solve_thres);
-  void setLevelSetOptionNumStreams(const ordinal_type nstreams);
+  void setLevelSetOptionNumStreams(const ordinal_type nstreams, const bool team_on_user_stream = false);
   void setLevelSetOptionAlgorithmVariant(const ordinal_type variant);
 
   void shiftDiagonal(const int option = 1);

--- a/packages/shylu/shylu_node/tacho/src/Tacho_Driver.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_Driver.hpp
@@ -169,10 +169,11 @@ private:
   ordinal_type _variant;             // algorithmic variant in levelset 0: naive, 1: invert diagonals
   ordinal_type _nstreams;            // on cuda, multi streams are used
 
-  bool _shift_diag;                  // shift diagonal with small perturbation
+  int _shift_diag;                   // shift diagonal with small perturbation
   mag_type _shift;
   value_type_array _dv;
 
+  int _replace_tiny_pivot;           // replace tiny pivot
   mag_type _pivot_tol;               // tolerance for tiny pivot perturbation
   bool _store_transpose;             // store transpose explicitly
 
@@ -226,11 +227,11 @@ public:
   void setLevelSetOptionNumStreams(const ordinal_type nstreams);
   void setLevelSetOptionAlgorithmVariant(const ordinal_type variant);
 
-  void shiftDiagonal();
+  void shiftDiagonal(const int option = 1);
   mag_type currentShift() { return _shift; }
   void setPivotTolerance(const mag_type pivot_tol);
   void useNoPivotTolerance();
-  void useDefaultPivotTolerance();
+  void useDefaultPivotTolerance(const int option = 1);
   void storeExplicitTranspose(bool flag);
 
   ///

--- a/packages/shylu/shylu_node/tacho/src/Tacho_MatrixMarket.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_MatrixMarket.hpp
@@ -172,6 +172,13 @@ template <typename ValueType> struct MatrixMarket {
           return -1;
         }
         impl_read_value_from_file(file, cmplx, row, col, val);
+        if (row < mm_base || row > m-1+mm_base ||
+            col < mm_base || col > n-1+mm_base) {
+          std::cout << " ERROR: (" << row << ", " << col
+                    << ") out of row or col range for the " << m << "x" << n
+                    << " matrix with base = " << mm_base << std::endl << std::endl;
+          return -1;
+        }
 
         row -= mm_base;
         col -= mm_base;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Driver_Impl.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Driver_Impl.hpp
@@ -450,7 +450,6 @@ template <typename VT, typename DT> int Driver<VT, DT>::factorize(const value_ty
   const mag_type zero(0);
   mag_type shift(0.0);
   if (_shift_diag != 0 || _replace_tiny_pivot > 1) {
-    const value_type zero(0.0);
     const ordinal_type m = _m;
     Kokkos::RangePolicy<exec_space> range_policy(0, m);
 

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Driver_Impl.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Driver_Impl.hpp
@@ -35,7 +35,7 @@ Driver<VT, DT>::Driver()
       #else
       _variant(-1), // sequential by default
       #endif
-      _nstreams(16), _shift_diag(false), _shift(0.0), _pivot_tol(0.0),
+      _nstreams(16), _shift_diag(0), _shift(0.0), _replace_tiny_pivot(0), _pivot_tol(0.0),
 #if defined(KOKKOS_ENABLE_HIP)
       _store_transpose(true)
 #else
@@ -209,17 +209,22 @@ template <typename VT, typename DT> void Driver<VT, DT>::setPivotTolerance(const
   _pivot_tol = pivot_tol;
 }
 
-template <typename VT, typename DT> void Driver<VT, DT>::shiftDiagonal() {
-  _shift_diag = true;
+template <typename VT, typename DT> void Driver<VT, DT>::shiftDiagonal(const int option) {
+  _shift_diag = option;
 }
 
 template <typename VT, typename DT> void Driver<VT, DT>::useNoPivotTolerance() {
   _pivot_tol = 0.0;
 }
 
-template <typename VT, typename DT> void Driver<VT, DT>::useDefaultPivotTolerance() {
-  using arith_traits = ArithTraits<value_type>;
-  _pivot_tol = Kokkos::sqrt(arith_traits::epsilon());
+template <typename VT, typename DT> void Driver<VT, DT>::useDefaultPivotTolerance(const int option) {
+  _replace_tiny_pivot = option;
+  if (option == 1) {
+    using arith_traits = ArithTraits<value_type>;
+    _pivot_tol = Kokkos::sqrt(arith_traits::epsilon());
+  } else {
+    _pivot_tol = 0.0;
+  }
 }
 
 template <typename VT, typename DT> void Driver<VT, DT>::storeExplicitTranspose(bool flag) {
@@ -428,9 +433,6 @@ template <typename VT, typename DT> int Driver<VT, DT>::initialize() {
 
     factory.createObject(_N);
   }
-  if (_shift_diag) {
-    Kokkos::resize(_dv, _m);
-  }
   return 0;
 }
 
@@ -443,11 +445,16 @@ template <typename VT, typename DT> int Driver<VT, DT>::factorize(const value_ty
   if (method != _method) {
     setFactorizationMethod(method);
   }
+
+  const mag_type zero(0);
   mag_type shift(0.0);
-  if (_shift_diag) {
+  if (_shift_diag != 0 || _replace_tiny_pivot > 1) {
     const value_type zero(0.0);
     const ordinal_type m = _m;
     Kokkos::RangePolicy<exec_space> range_policy(0, m);
+
+    // resize workspace (flag may be set per factorization)
+    Kokkos::resize(_dv, _m);
 
     // Compute alpha = ||A||_2
     value_type alpha(zero);
@@ -468,33 +475,50 @@ template <typename VT, typename DT> int Driver<VT, DT>::factorize(const value_ty
       range_policy, KOKKOS_LAMBDA (int i, value_type &tmp) {
         tmp += dv(i);
       }, alpha);
-    // Compute shift = sqrt(eps * ||A||_2)
+    // Compute shift = sqrt(eps) * ||A||_2
     shift = Kokkos::sqrt(arith_traits::abs(alpha * arith_traits::epsilon()));
   }
+  // internally keep track of the current shift
+  if (_shift_diag != 0) {
+    _shift = shift;
+  } else {
+    _shift = zero;
+  }
+  // internally save the pivot tol
+  if (_replace_tiny_pivot > 1) {
+    _pivot_tol = shift;
+  } else if (_replace_tiny_pivot != 1) {
+    _pivot_tol = zero;
+  }
+
   if (_verbose) {
     switch (_method) {
     case LDL_nopiv: {
       printf("TachoSolver: Factorize LDL (no pivot)\n");
-      if (_shift_diag) printf(" > shifting diagonal by %.2e\n",shift);
       printf("=====================================\n");
+      if (_shift_diag != 0) printf(" > shifting diagonal by %.2e\n",_shift);
+      if (_replace_tiny_pivot != 0) printf( " > using pivot tol = %.2e\n",_pivot_tol);
       break;
     }
     case Cholesky: {
       printf("TachoSolver: Factorize Cholesky\n");
-      if (_shift_diag) printf(" > shifting diagonal by %.2e\n",shift);
       printf("===============================\n");
+      if (_shift_diag != 0) printf(" > shifting diagonal by %.2e\n",_shift);
+      if (_replace_tiny_pivot != 0) printf( " > using pivot tol = %.2e\n",_pivot_tol);
       break;
     }
     case LDL: {
       printf("TachoSolver: Factorize LDL\n");
-      if (_shift_diag) printf(" > shifting diagonal by %.2e\n",shift);
       printf("==========================\n");
+      if (_shift_diag != 0) printf(" > shifting diagonal by %.2e\n",_shift);
+      if (_replace_tiny_pivot != 0) printf( " > using pivot tol = %.2e\n",_pivot_tol);
       break;
     }
     case SymLU: {
       printf("TachoSolver: Factorize SymLU\n");
-      if (_shift_diag) printf(" > shifting diagonal by %.2e\n",shift);
       printf("============================\n");
+      if (_shift_diag != 0) printf(" > shifting diagonal by %.2e\n",_shift);
+      if (_replace_tiny_pivot != 0) printf( " > using pivot tol = %.2e\n",_pivot_tol);
       break;
     }
     }
@@ -502,11 +526,10 @@ template <typename VT, typename DT> int Driver<VT, DT>::factorize(const value_ty
       printf( " Small matrix\n" );
     }
   }
-  _shift = shift; // internally keep track of the current shift
   if (_m <= _small_problem_thres) {
-    factorize_small_host(ax, shift);
+    factorize_small_host(ax, _shift);
   } else {
-    _N->factorize(ax, _store_transpose, shift, _pivot_tol, _verbose);
+    _N->factorize(ax, _store_transpose, _shift, _pivot_tol, _verbose);
   }
   return 0;
 }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Driver_Impl.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Driver_Impl.hpp
@@ -35,7 +35,7 @@ Driver<VT, DT>::Driver()
       #else
       _variant(-1), // sequential by default
       #endif
-      _nstreams(16), _shift_diag(0), _shift(0.0), _replace_tiny_pivot(0), _pivot_tol(0.0),
+      _nstreams(16), _team_on_user_stream(false), _shift_diag(0), _shift(0.0), _replace_tiny_pivot(0), _pivot_tol(0.0),
 #if defined(KOKKOS_ENABLE_HIP)
       _store_transpose(true)
 #else
@@ -201,8 +201,9 @@ template <typename VT, typename DT> void Driver<VT, DT>::setLevelSetOptionAlgori
   _variant = variant;
 }
 
-template <typename VT, typename DT> void Driver<VT, DT>::setLevelSetOptionNumStreams(const ordinal_type nstreams) {
+template <typename VT, typename DT> void Driver<VT, DT>::setLevelSetOptionNumStreams(const ordinal_type nstreams, const bool team_on_user_stream) {
   _nstreams = nstreams;
+  _team_on_user_stream = team_on_user_stream;
 }
 
 template <typename VT, typename DT> void Driver<VT, DT>::setPivotTolerance(const mag_type pivot_tol) {
@@ -429,7 +430,7 @@ template <typename VT, typename DT> int Driver<VT, DT>::initialize() {
                           _blk_super_panel_colidx, _stree_parent, _stree_ptr, _stree_children, _stree_level, _stree_roots,
                           _verbose);
 
-    factory.setLevelSetMember(_variant, _device_level_cut, _device_factor_thres, _device_solve_thres, _store_transpose, _nstreams);
+    factory.setLevelSetMember(_variant, _device_level_cut, _device_factor_thres, _device_solve_thres, _store_transpose, _nstreams, _team_on_user_stream);
 
     factory.createObject(_N);
   }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Lapack_Team.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Lapack_Team.hpp
@@ -59,7 +59,7 @@ template <typename T> struct LapackTeam {
     }
 
     template <typename MemberType>
-    static KOKKOS_INLINE_FUNCTION void potrf_upper(const MemberType &member, const int m, const double tol,
+    static KOKKOS_INLINE_FUNCTION void potrf_upper(const MemberType &member, const double tol, const int m, 
                                                    T *KOKKOS_RESTRICT A,
                                                    const int as0, const int as1, int *info) {
       *info = 0;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_Factory.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_Factory.hpp
@@ -82,7 +82,8 @@ template <typename ValueType, typename DeviceType> class NumericToolsFactory;
   ordinal_type _device_level_cut;                                                                                      \
   ordinal_type _device_factor_thres;                                                                                   \
   ordinal_type _device_solve_thres;                                                                                    \
-  ordinal_type _nstreams
+  ordinal_type _nstreams;                                                                                              \
+  bool _team_on_user_stream
 
 #define TACHO_NUMERIC_TOOLS_FACTORY_SET_LEVELSET_MEMBER                                                                \
   do {                                                                                                                 \
@@ -92,6 +93,7 @@ template <typename ValueType, typename DeviceType> class NumericToolsFactory;
     _device_factor_thres = device_factor_thres;                                                                        \
     _device_solve_thres = device_solve_thres;                                                                          \
     _nstreams = nstreams;                                                                                              \
+    _team_on_user_stream = team_on_user_stream;                                                                        \
   } while (false)
 
 #define TACHO_NUMERIC_TOOLS_FACTORY_SERIAL_BODY                                                                        \
@@ -112,7 +114,7 @@ template <typename ValueType, typename DeviceType> class NumericToolsFactory;
                                              _gid_colidx, _sid_ptr, _sid_colidx, _blk_colidx, _stree_parent,            \
                                              _stree_ptr, _stree_children, _stree_level, _stree_roots);                  \
     numeric_tools_levelset_name *N = dynamic_cast<numeric_tools_levelset_name *>(object);                               \
-    N->initialize(_device_level_cut, _device_factor_thres, _device_solve_thres, _nstreams, _store_transpose, _verbose); \
+    N->initialize(_device_level_cut, _device_factor_thres, _device_solve_thres, _nstreams, _team_on_user_stream, _store_transpose, _verbose); \
   } while (false)
 
 ///
@@ -152,7 +154,7 @@ public:
 
   void setLevelSetMember(const ordinal_type variant, const ordinal_type device_level_cut,
                          const ordinal_type device_factor_thres, const ordinal_type device_solve_thres,
-                         const bool store_transpose, const ordinal_type nstreams) {
+                         const bool store_transpose, const ordinal_type nstreams, const bool team_on_user_stream) {
     TACHO_NUMERIC_TOOLS_FACTORY_SET_LEVELSET_MEMBER;
   }
 
@@ -222,7 +224,7 @@ public:
 
   void setLevelSetMember(const ordinal_type variant, const ordinal_type device_level_cut,
                          const ordinal_type device_factor_thres, const ordinal_type device_solve_thres,
-                         const bool store_transpose, const ordinal_type nstreams) {
+                         const bool store_transpose, const ordinal_type nstreams, const bool team_on_user_stream) {
     TACHO_NUMERIC_TOOLS_FACTORY_SET_LEVELSET_MEMBER;
   }
 
@@ -292,7 +294,7 @@ public:
 
   void setLevelSetMember(const ordinal_type variant, const ordinal_type device_level_cut,
                          const ordinal_type device_factor_thres, const ordinal_type device_solve_thres,
-                         const bool store_transpose, const ordinal_type nstreams) {
+                         const bool store_transpose, const ordinal_type nstreams, const bool team_on_user_stream) {
     TACHO_NUMERIC_TOOLS_FACTORY_SET_LEVELSET_MEMBER;
   }
 
@@ -357,7 +359,7 @@ public:
 
   void setLevelSetMember(const ordinal_type variant, const ordinal_type device_level_cut,
                          const ordinal_type device_factor_thres, const ordinal_type device_solve_thres,
-                         const bool store_transpose, const ordinal_type nstreams) {
+                         const bool store_transpose, const ordinal_type nstreams, const bool team_on_user_stream) {
     TACHO_NUMERIC_TOOLS_FACTORY_SET_LEVELSET_MEMBER;
   }
 
@@ -423,7 +425,7 @@ public:
 
   void setLevelSetMember(const ordinal_type variant, const ordinal_type device_level_cut,
                          const ordinal_type device_factor_thres, const ordinal_type device_solve_thres,
-                         const bool store_transpose, const ordinal_type nstreams) {
+                         const bool store_transpose, const ordinal_type nstreams, const bool team_on_user_stream) {
     TACHO_NUMERIC_TOOLS_FACTORY_SET_LEVELSET_MEMBER;
   }
 

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -777,7 +777,7 @@ public:
     _bufsize_factorize = 0;
     _bufsize_solve = 0;
     _nstreams = 0;
-    _team_on_user_stream = 0;
+    _team_on_user_stream = false;
     _keep_zeros = false;
     stat_level = stat_level();
   }
@@ -4948,7 +4948,7 @@ public:
 
               // copy from buffer to t
               Kokkos::parallel_for("update lower", policy_update_with_work_property, functor);
-              if (need_fence && (lvl > 0 && _h_num_device_calls_solve(lvl-1) > 0))
+              if (need_fence && (lvl == 0 || _h_num_device_calls_solve(lvl-1) > 0))
                 team_exec_instance.fence(); // sync default, for next device solve calls
               ++stat_level.n_kernel_launching;
             }
@@ -5330,7 +5330,7 @@ public:
             if (variant != 3) {
               Kokkos::parallel_for("update lower", policy_update_with_work_property, functor);
               ++stat_level.n_kernel_launching;
-              if (need_fence && (lvl > 0 && _h_num_device_calls_solve(lvl-1) > 0))
+              if (need_fence && (lvl == 0 || _h_num_device_calls_solve(lvl-1) > 0))
                 team_exec_instance.fence(); // synch update on default before next solve on device
             }
           }
@@ -5714,7 +5714,7 @@ public:
 
               Kokkos::parallel_for("update lower", policy_update_with_work_property, functor);
               ++stat_level.n_kernel_launching;
-              if (need_fence && (lvl > 0 && _h_num_device_calls_solve(lvl-1) > 0))
+              if (need_fence && (lvl == 0 || _h_num_device_calls_solve(lvl-1) > 0))
                 team_exec_instance.fence(); // synch update on default before next solve on device
             }
           }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -254,9 +254,9 @@ private:
 
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   stream_array_host _streams;
+#endif
   using exec_instance_array_host = std::vector<exec_space>;
   exec_instance_array_host _exec_instances;
-#endif
 
   ///
   /// statistics
@@ -811,12 +811,12 @@ public:
   }
 
   virtual ~NumericToolsLevelSet() {
-#if defined(KOKKOS_ENABLE_CUDA)
     /// kokkos execution space may fence and it uses the wrapped stream when it is deallocated   
     /// on cuda, deallocting streams first does not cause any errors while hip generates errors.
     /// here, we just follow the consistent destruction process as hip does.
     _exec_instances.clear();
 
+#if defined(KOKKOS_ENABLE_CUDA)
     if (_is_cusolver_dn_created) {
       _status = cusolverDnDestroy(_handle_lapack);
       checkDeviceLapackStatus("cusolverDnDestroy");
@@ -833,9 +833,6 @@ public:
     _streams.clear();
 #endif
 #if defined(KOKKOS_ENABLE_HIP)
-    /// kokkos execution space may fence and it uses the wrapped stream when it is deallocated   
-    _exec_instances.clear();
-
     if (_is_rocblas_created) {
       _status = rocblas_destroy_handle(_handle_lapack);
       checkDeviceLapackStatus("rocblasDestroy");
@@ -904,6 +901,11 @@ public:
     for (ordinal_type i = 0; i < _nstreams; ++i) {
       ExecSpaceFactory<exec_space>::createInstance(_streams[i], _exec_instances[i]);
     }
+#else
+    // just one default execution space..
+    _exec_instances.clear();
+    _exec_instances.resize(1);
+    _exec_instances[0] = exec_space();
 #endif
     if (verbose) {
       printf("Summary: CreateStream : %3d\n", _nstreams);
@@ -3329,12 +3331,7 @@ public:
         const UnmanagedViewType<nzvals_view> matD(s0.nzvalsD, _m);
 
         using policy_type = Kokkos::RangePolicy<exec_space>;
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
         const auto policy = policy_type(_exec_instances[0], 0, _m);
-#else
-        // TODO: initialize _exec_instance[0] as exec_space(); with serial build?
-        const auto policy = policy_type(0, _m);
-#endif
         Kokkos::parallel_for(
             policy, KOKKOS_LAMBDA(const ordinal_type &i) {
               for (ordinal_type j = 0; j < nrhs; j++) matY(i,j) = matY(i, j) / matD(i); 
@@ -4863,15 +4860,10 @@ public:
     timer.reset();
     allocateWorkspaceSolve(nrhs);
 
+    // execution spaces for non-device calls
     const bool need_fence = (!_team_on_user_stream || _nstreams > 1);
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     const auto perm_exec_instance = _exec_instances[0];
     const auto team_exec_instance = (_team_on_user_stream ? _exec_instances[0] : exec_space());
-#else
-    // TODO: initialize _exec_instance[0] as exec_space(); with serial build?
-    const auto perm_exec_instance = exec_space();
-    const auto team_exec_instance = perm_exec_instance;
-#endif
 
     // 0. permute (from METIS) and copy b -> t
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);
@@ -5248,14 +5240,10 @@ public:
     timer.reset();
     allocateWorkspaceSolve(nrhs);
 
+    // execution spaces for non-device calls
     const bool need_fence = (!_team_on_user_stream || _nstreams > 1);
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     const auto perm_exec_instance = _exec_instances[0];
     const auto team_exec_instance = (_team_on_user_stream ? _exec_instances[0] : exec_space());
-#else
-    const auto perm_exec_instance = exec_space();
-    const auto team_exec_instance = perm_exec_instance;
-#endif
 
     // 0. permute (from METIS) and copy b -> t
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);
@@ -5633,14 +5621,10 @@ public:
     timer.reset();
     allocateWorkspaceSolve(nrhs);
 
+    // execution spaces for non-device calls
     const bool need_fence = (!_team_on_user_stream || _nstreams > 1);
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     const auto perm_exec_instance = _exec_instances[0];
     const auto team_exec_instance = (_team_on_user_stream ? _exec_instances[0] : exec_space());
-#else
-    const auto perm_exec_instance = exec_space();
-    const auto team_exec_instance = perm_exec_instance;
-#endif
 
     // 0. permute (from METIS) and copy b -> t
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -4864,7 +4864,7 @@ public:
 
     // 0. permute (from METIS) and copy b -> t
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);
-    if (need_fence) exec_space().fence();
+    if (need_fence) perm_exec_instance.fence();
     stat.t_extra = timer.seconds();
 
     timer.reset();
@@ -4949,7 +4949,7 @@ public:
               // copy from buffer to t
               Kokkos::parallel_for("update lower", policy_update_with_work_property, functor);
               if (need_fence && (lvl > 0 && _h_num_device_calls_solve(lvl-1) > 0))
-                exec_space().fence(); // sync default, for next device solve calls
+                team_exec_instance.fence(); // sync default, for next device solve calls
               ++stat_level.n_kernel_launching;
             }
           }
@@ -5006,7 +5006,7 @@ public:
             if (variant != 3) {
               Kokkos::parallel_for("update upper", policy_update_with_work_property, functor);
               if (need_fence && _h_num_device_calls_solve(lvl) > 0)
-                exec_space().fence(); // sync default, before next device solve-upper calls
+                team_exec_instance.fence(); // sync default, before next device solve-upper calls
               ++stat_level.n_kernel_launching;
 
               if (lvl < _device_level_cut) {
@@ -5248,7 +5248,7 @@ public:
 
     // 0. permute (from METIS) and copy b -> t
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);
-    if(need_fence) exec_space().fence();
+    if(need_fence) perm_exec_instance.fence();
     stat.t_extra = timer.seconds();
 
     timer.reset();
@@ -5331,7 +5331,7 @@ public:
               Kokkos::parallel_for("update lower", policy_update_with_work_property, functor);
               ++stat_level.n_kernel_launching;
               if (need_fence && (lvl > 0 && _h_num_device_calls_solve(lvl-1) > 0))
-                exec_space().fence(); // synch update on default before next solve on device
+                team_exec_instance.fence(); // synch update on default before next solve on device
             }
           }
         }
@@ -5387,7 +5387,7 @@ public:
               Kokkos::parallel_for("update upper", policy_update_with_work_property, functor);
               ++stat_level.n_kernel_launching;
               if (need_fence && _h_num_device_calls_solve(lvl) > 0)
-                exec_space().fence(); // synch update befor solve on device
+                team_exec_instance.fence(); // synch update befor solve on device
 
               if (lvl < _device_level_cut) {
                 // do nothing
@@ -5715,7 +5715,7 @@ public:
               Kokkos::parallel_for("update lower", policy_update_with_work_property, functor);
               ++stat_level.n_kernel_launching;
               if (need_fence && (lvl > 0 && _h_num_device_calls_solve(lvl-1) > 0))
-                exec_space().fence(); // synch update on default before next solve on device
+                team_exec_instance.fence(); // synch update on default before next solve on device
             }
           }
         }
@@ -5771,7 +5771,7 @@ public:
               Kokkos::parallel_for("update upper", policy_update_with_work_property, functor);
               ++stat_level.n_kernel_launching;
               if (need_fence && _h_num_device_calls_solve(lvl) > 0)
-                exec_space().fence(); // synch update on default before solve on device
+                team_exec_instance.fence(); // synch update on default before solve on device
 
               if (lvl < _device_level_cut) {
                 // do nothing

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -4875,7 +4875,7 @@ public:
 
     // 0. permute (from METIS) and copy b -> t
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);
-    if (need_fence) perm_exec_instance.fence();
+    if (variant != 3 && need_fence) perm_exec_instance.fence();
     stat.t_extra = timer.seconds();
 
     timer.reset();
@@ -5044,7 +5044,7 @@ public:
     stat.t_solve = timer.seconds();
 
     // permute (from METIS) and copy t -> x
-    if (need_fence) Kokkos::fence(); // synch user or default streams
+    if (variant != 3 && need_fence) Kokkos::fence(); // synch user or default streams
     timer.reset();
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, t, _peri, x);
     perm_exec_instance.fence();
@@ -5259,7 +5259,7 @@ public:
 
     // 0. permute (from METIS) and copy b -> t
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);
-    if(need_fence) perm_exec_instance.fence();
+    if(variant != 3 && need_fence) perm_exec_instance.fence();
     stat.t_extra = timer.seconds();
 
     timer.reset();
@@ -5420,7 +5420,7 @@ public:
     stat.t_solve = timer.seconds();
 
     // permute (from METIS) and copy t -> x
-    if (need_fence) Kokkos::fence(); // synch user or default streams
+    if (variant != 3 && need_fence) Kokkos::fence(); // synch user or default streams
     timer.reset();
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, t, _peri, x);
     perm_exec_instance.fence();
@@ -5644,7 +5644,7 @@ public:
 
     // 0. permute (from METIS) and copy b -> t
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);
-    if (need_fence) perm_exec_instance.fence();
+    if (variant != 3 && need_fence) perm_exec_instance.fence();
     stat.t_extra = timer.seconds();
 
     timer.reset();
@@ -5808,7 +5808,7 @@ public:
     stat.t_solve = timer.seconds();
 
     // permute (from METIS) and copy t -> x
-    if (need_fence) Kokkos::fence();
+    if (variant != 3 && need_fence) Kokkos::fence();
     timer.reset();
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, t, _peri, x);
     perm_exec_instance.fence();

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -5036,6 +5036,7 @@ public:
     if (need_fence) Kokkos::fence(); // synch user or default streams
     timer.reset();
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, t, _peri, x);
+    perm_exec_instance.fence();
     stat.t_extra += timer.seconds();
 
     if (verbose) {
@@ -5411,6 +5412,7 @@ public:
     if (need_fence) Kokkos::fence(); // synch user or default streams
     timer.reset();
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, t, _peri, x);
+    perm_exec_instance.fence();
     stat.t_extra += timer.seconds();
 
     if (verbose) {
@@ -5798,7 +5800,7 @@ public:
     if (need_fence) Kokkos::fence();
     timer.reset();
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, t, _peri, x);
-    //perm_exec_instance.fence();
+    perm_exec_instance.fence();
     stat.t_extra += timer.seconds();
 
     if (verbose) {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -4852,10 +4852,13 @@ public:
     timer.reset();
     allocateWorkspaceSolve(nrhs);
 
+    const bool need_fence = (!_team_on_user_stream || _nstreams > 1);
+    const auto perm_exec_instance = _exec_instances[0];
+    const auto team_exec_instance = (_team_on_user_stream ? _exec_instances[0] : exec_space());
+
     // 0. permute (from METIS) and copy b -> t
-    const auto exec_instance = exec_space();
-    ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(exec_instance, b, _perm, t);
-    exec_space().fence();
+    ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);
+    if (need_fence) exec_space().fence();
     stat.t_extra = timer.seconds();
 
     timer.reset();
@@ -4906,8 +4909,8 @@ public:
               policy_update = team_policy_update(pcnt, 1, 1);
             } else {
               const ordinal_type idx = lvl > half_level;
-              policy_solve = team_policy_solve(pcnt, team_size_solve[idx], vector_size_solve[idx]);
-              policy_update = team_policy_update(pcnt, team_size_update[idx], vector_size_update[idx]);
+              policy_solve = team_policy_solve(team_exec_instance, pcnt, team_size_solve[idx], vector_size_solve[idx]);
+              policy_update = team_policy_update(team_exec_instance, pcnt, team_size_update[idx], vector_size_update[idx]);
             }
 #if defined(TACHO_ENABLE_SOLVE_CHOLESKY_USE_LIGHT_KERNEL)
             const auto policy_solve_with_work_property =
@@ -4934,12 +4937,12 @@ public:
               solveCholeskyLowerOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
             }
             if (variant != 3) {
-              if (_h_num_device_calls_solve(lvl) > 0)
+              if (need_fence && _h_num_device_calls_solve(lvl) > 0)
                 Kokkos::fence(); // synch device calls before batched update
 
               // copy from buffer to t
               Kokkos::parallel_for("update lower", policy_update_with_work_property, functor);
-              if (lvl == 0 || _h_num_device_calls_solve(lvl-1) > 0)
+              if (need_fence && _h_num_device_calls_solve(lvl-1) > 0)
                 exec_space().fence(); // sync default, for next device solve calls
               ++stat_level.n_kernel_launching;
             }
@@ -4982,8 +4985,8 @@ public:
               policy_update = team_policy_update(pcnt, 1, 1);
             } else {
               const ordinal_type idx = lvl > half_level;
-              policy_solve = team_policy_solve(pcnt, team_size_solve[idx], vector_size_solve[idx]);
-              policy_update = team_policy_update(pcnt, team_size_update[idx], vector_size_update[idx]);
+              policy_solve = team_policy_solve(team_exec_instance, pcnt, team_size_solve[idx], vector_size_solve[idx]);
+              policy_update = team_policy_update(team_exec_instance, pcnt, team_size_update[idx], vector_size_update[idx]);
             }
 #if defined(TACHO_ENABLE_SOLVE_CHOLESKY_USE_LIGHT_KERNEL)
             const auto policy_solve_with_work_property =
@@ -4996,7 +4999,7 @@ public:
 #endif
             if (variant != 3) {
               Kokkos::parallel_for("update upper", policy_update_with_work_property, functor);
-              if (_h_num_device_calls_solve(lvl) > 0)
+              if (need_fence && _h_num_device_calls_solve(lvl) > 0)
                 exec_space().fence(); // sync default, before next device solve-upper calls
               ++stat_level.n_kernel_launching;
 
@@ -5014,7 +5017,7 @@ public:
             } else {
               solveCholeskyUpperOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
             }
-            if (_h_num_device_calls_solve(lvl) > 0 || 1+lvl == _team_serial_level_cut)
+            if (need_fence && _h_num_device_calls_solve(lvl) > 0)
               Kokkos::fence(); // synch device calls before next update
           }
         }
@@ -5024,9 +5027,9 @@ public:
     stat.t_solve = timer.seconds();
 
     // permute (from METIS) and copy t -> x
-    Kokkos::fence(); // synch user or default streams
+    if (need_fence) Kokkos::fence(); // synch user or default streams
     timer.reset();
-    ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(exec_instance, t, _peri, x);
+    ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, t, _peri, x);
     stat.t_extra += timer.seconds();
 
     if (verbose) {
@@ -5778,7 +5781,7 @@ public:
     if (need_fence) Kokkos::fence();
     timer.reset();
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, t, _peri, x);
-    perm_exec_instance.fence();
+    //perm_exec_instance.fence();
     stat.t_extra += timer.seconds();
 
     if (verbose) {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -161,6 +161,7 @@ private:
 
   ordinal_type_array_host _h_factorize_mode, _h_solve_mode;
   ordinal_type_array _factorize_mode, _solve_mode;
+  ordinal_type_array_host _h_num_device_calls_factor, _h_num_device_calls_solve;
 
   // level details on host
   ordinal_type _nlevel;
@@ -260,6 +261,7 @@ private:
   /// statistics
   ///
   struct {
+    int n_level;
     int n_device_factorize, n_team_factorize, n_kernel_launching_factorize;
     int n_device_solve, n_team_solve, n_kernel_launching_solve;
     int n_kernel_launching;
@@ -322,6 +324,7 @@ private:
     printf("             peak memory used:                                %10.3f MB\n", stat.m_peak / kilo / kilo);
     printf("\n");
     printf("  Compute Mode in Factorize with a Threshold(%d)\n", _device_factorize_thres);
+    printf("             # of levels:                                     %6d\n", _nlevel);
     printf("             # of subproblems using device functions:         %6d\n", stat_level.n_device_factorize);
     printf("             # of subproblems using team functions:           %6d\n", stat_level.n_team_factorize);
     printf("             total # of subproblems:                          %6d\n",
@@ -418,6 +421,7 @@ public:
   inline void initialize(const ordinal_type device_level_cut, const ordinal_type device_factorize_thres,
                          const ordinal_type device_solve_thres, const int nstreams_in = 1,
                          const bool store_transpose = false, const ordinal_type verbose = 0) {
+    stat_level.n_level = 0;
     stat_level.n_device_factorize = 0;
     stat_level.n_device_solve = 0;
     stat_level.n_team_factorize = 0;
@@ -446,6 +450,7 @@ public:
         _nlevel = max(_stree_level(sid), _nlevel);
       ++_nlevel;
     }
+    stat_level.n_level = _nlevel;
 
     // create level ptr
     _h_level_ptr = size_type_array_host("h_level_ptr", _nlevel + 1);
@@ -636,8 +641,14 @@ public:
     _h_solve_mode = ordinal_type_array_host(do_not_initialize_tag("h_solve_mode"), _nsupernodes);
     Kokkos::deep_copy(_h_solve_mode, -1);
 
+    _h_num_device_calls_factor = ordinal_type_array_host(do_not_initialize_tag("h_num_device_calls_factor"), _nlevel);
+    _h_num_device_calls_solve = ordinal_type_array_host(do_not_initialize_tag("h_num_device_calls_solve"), _nlevel);
+
     if (_device_level_cut > 0) {
       for (ordinal_type lvl = 0; lvl < _device_level_cut; ++lvl) {
+        _h_num_device_calls_solve(lvl) = 0;
+        _h_num_device_calls_factor(lvl) = 0;
+
         const ordinal_type pbeg = _h_level_ptr(lvl), pend = _h_level_ptr(lvl + 1);
         for (ordinal_type p = pbeg; p < pend; ++p) {
           const ordinal_type sid = _h_level_sids(p);
@@ -645,6 +656,15 @@ public:
           _h_factorize_mode(sid) = 0;
           ++stat_level.n_device_solve;
           ++stat_level.n_device_factorize;
+
+          const auto s = _h_supernodes(sid);
+          const ordinal_type m = s.m;
+          if (m > _device_solve_thres) {
+            _h_num_device_calls_solve(lvl) ++;
+          }
+          if (m > _device_factorize_thres) {
+            _h_num_device_calls_factor(lvl) ++;
+          }
         }
       }
     }
@@ -652,6 +672,9 @@ public:
     _team_serial_level_cut = _nlevel;
     {
       for (ordinal_type lvl = _device_level_cut; lvl < _team_serial_level_cut; ++lvl) {
+        _h_num_device_calls_solve(lvl) = 0;
+        _h_num_device_calls_factor(lvl) = 0;
+
         const ordinal_type pbeg = _h_level_ptr(lvl), pend = _h_level_ptr(lvl + 1);
         for (ordinal_type p = pbeg; p < pend; ++p) {
           const ordinal_type sid = _h_level_sids(p);
@@ -659,6 +682,7 @@ public:
           const ordinal_type m = s.m;    //, n_m = s.n-s.m;
           if (m > _device_solve_thres) { // || n > _device_solve_thres)
             _h_solve_mode(sid) = 0;
+            _h_num_device_calls_solve(lvl) ++;
             ++stat_level.n_device_solve;
           } else {
             _h_solve_mode(sid) = 1;
@@ -666,6 +690,7 @@ public:
           }
           if (m > _device_factorize_thres) { // || n_m > _device_factorize_thres)
             _h_factorize_mode(sid) = 0;
+            _h_num_device_calls_factor(lvl) ++;
             ++stat_level.n_device_factorize;
           } else {
             _h_factorize_mode(sid) = 1;
@@ -964,9 +989,9 @@ public:
                   handle_blas, minus_one, ATR, T, zero, ABR);
               checkDeviceBlasStatus("gemm");
             }
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -1055,9 +1080,9 @@ public:
               _status = Copy<Algo::OnDevice>::invoke(exec_instance, ATL, T);
               checkDeviceBlasStatus("Copy");
             }
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -1165,9 +1190,9 @@ public:
               });
               checkDeviceBlasStatus("trsm");
             }
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -1268,9 +1293,9 @@ public:
               _status = Herk<Uplo::Upper, Trans::ConjTranspose, Algo::OnDevice>::invoke(handle_blas, minus_one, ATR,
                                                                                         zero, ABR);
             }
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -1375,9 +1400,9 @@ public:
               _status = Copy<Algo::OnDevice>::invoke(exec_instance, ATL, T);
               checkDeviceBlasStatus("Copy");
             }
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -1490,9 +1515,9 @@ public:
                   handle_blas, Diag::NonUnit(), one, T, ATL);
               checkDeviceBlasStatus("trsm");
             }
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -1797,12 +1822,13 @@ public:
   /// 
   /// LU
   ///
-  inline void factorizeLU_OnDeviceVar0(const ordinal_type pbeg, const ordinal_type pend,
-                                       const size_type_array_host &h_buf_factor_ptr, const value_type_array &work) {
+  inline int factorizeLU_OnDeviceVar0(const ordinal_type pbeg, const ordinal_type pend,
+                                      const size_type_array_host &h_buf_factor_ptr, const value_type_array &work) {
     const value_type one(1), minus_one(-1), zero(0);
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     ordinal_type q(0);
 #endif
+    int num_device_calls = 0;
     exec_space exec_instance;
     for (ordinal_type p = pbeg; p < pend; ++p) {
       const ordinal_type sid = _h_level_sids(p);
@@ -1855,18 +1881,21 @@ public:
                                                                                              ABL, ATR, zero, ABR);
               checkDeviceBlasStatus("gemm");
             }
+            num_device_calls ++;
           }
         }
       }
     }
+    return num_device_calls;
   }
 
-  inline void factorizeLU_OnDeviceVar1(const ordinal_type pbeg, const ordinal_type pend,
-                                       const size_type_array_host &h_buf_factor_ptr, const value_type_array &work) {
+  inline int factorizeLU_OnDeviceVar1(const ordinal_type pbeg, const ordinal_type pend,
+                                      const size_type_array_host &h_buf_factor_ptr, const value_type_array &work) {
     const value_type one(1), minus_one(-1), zero(0);
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     ordinal_type q(0);
 #endif
+    int num_device_calls = 0;
     exec_space exec_instance;
     for (ordinal_type p = pbeg; p < pend; ++p) {
       const ordinal_type sid = _h_level_sids(p);
@@ -1949,18 +1978,21 @@ public:
                   handle_blas, Diag::Unit(), one, T, ATL2);
               checkDeviceBlasStatus("trsm");
             }
+            num_device_calls ++;
           }
         }
       }
     }
+    return num_device_calls;
   }
 
-  inline void factorizeLU_OnDeviceVar2(const ordinal_type pbeg, const ordinal_type pend,
-                                       const size_type_array_host &h_buf_factor_ptr, const value_type_array &work) {
+  inline int factorizeLU_OnDeviceVar2(const ordinal_type pbeg, const ordinal_type pend,
+                                      const size_type_array_host &h_buf_factor_ptr, const value_type_array &work) {
     const value_type one(1), minus_one(-1), zero(0);
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     ordinal_type q(0);
 #endif
+    int num_device_calls = 0;
     exec_space exec_instance;
     for (ordinal_type p = pbeg; p < pend; ++p) {
       const ordinal_type sid = _h_level_sids(p);
@@ -2044,25 +2076,28 @@ public:
                   handle_blas, Diag::Unit(), one, T, ATL2);
               checkDeviceBlasStatus("trsm");
             }
+            num_device_calls ++;
           }
         }
       }
     }
+    return num_device_calls;
   }
 
-  inline void factorizeLU_OnDevice(const ordinal_type pbeg, const ordinal_type pend,
-                                   const size_type_array_host &h_buf_factor_ptr, const value_type_array &work) {
+  inline int factorizeLU_OnDevice(const ordinal_type pbeg, const ordinal_type pend,
+                                  const size_type_array_host &h_buf_factor_ptr, const value_type_array &work) {
     if (variant == 0)
-      factorizeLU_OnDeviceVar0(pbeg, pend, h_buf_factor_ptr, work);
+      return factorizeLU_OnDeviceVar0(pbeg, pend, h_buf_factor_ptr, work);
     else if (variant == 1)
-      factorizeLU_OnDeviceVar1(pbeg, pend, h_buf_factor_ptr, work);
+      return factorizeLU_OnDeviceVar1(pbeg, pend, h_buf_factor_ptr, work);
     else if (variant == 2 || variant == 3)
-      factorizeLU_OnDeviceVar2(pbeg, pend, h_buf_factor_ptr, work);
+      return factorizeLU_OnDeviceVar2(pbeg, pend, h_buf_factor_ptr, work);
     else {
       std::string msg = "Error: LevelSetTools::factorizeLU_OnDevice, algorithm variant ("
                         + std::to_string(variant) + ") is not supported.\n";
       TACHO_TEST_FOR_EXCEPTION(true, std::logic_error, msg.c_str());
     }
+    return 0;
   }
 
   ///
@@ -2686,12 +2721,13 @@ public:
       const size_type buf_span = _buf.span();
 
       if (buf_extent > buf_span) {
+        printf("solve(%d < %d): work resize\n",buf_extent, buf_span);
         if (_buf.span() > 0) track_free(buf_span * sizeof(value_type));
         Kokkos::resize(_buf, buf_extent);
         track_alloc(_buf.span() * sizeof(value_type));
       }
       if (nrhs > _nrhs) {
-        // update pointer to solver-workspace with differet nrhs
+        // update **pointer** to solver-workspace with differet nrhs
         const Kokkos::RangePolicy<exec_space> policy(0, _buf_solve_ptr.extent(0));
         const auto buf_solve_nrhs_ptr = _buf_solve_nrhs_ptr;
         const auto buf_solve_ptr = _buf_solve_ptr;
@@ -3127,9 +3163,11 @@ public:
             // Apply D^{-1} on off-diagonal
             _status = Scale_BlockInverseDiagonals<Side::Left, Algo::OnDevice>::invoke(exec_instance, ATL, tT);
             checkDeviceBlasStatus("scale");
+
+            // increment num device calls
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -3192,9 +3230,11 @@ public:
             // Apply D^{-1} on off-diagonal
             _status = Scale_BlockInverseDiagonals<Side::Left, Algo::OnDevice>::invoke(exec_instance, ATL, bT);
             checkDeviceBlasStatus("scale");
+
+            // increment num device calls
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -3248,9 +3288,11 @@ public:
             UnmanagedViewType<value_type_matrix> ATL(aptr, m, m);
             _status = Scale_BlockInverseDiagonals<Side::Left, Algo::OnDevice>::invoke(exec_instance, ATL, dx);
             checkDeviceBlasStatus("scale");
+
+            // increment num device calls
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -3334,9 +3376,11 @@ public:
             _status =
                 Trsv<Uplo::Upper, Trans::NoTranspose, Algo::OnDevice>::invoke(handle_blas, Diag::Unit(), ATL, tT);
             checkDeviceBlasStatus("trsv");
+
+            // increment num device calls
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -3396,9 +3440,11 @@ public:
 
             _status = Copy<Algo::OnDevice>::invoke(exec_instance, tT, bT);
             checkDeviceBlasStatus("Copy");
+
+            // increment num device calls
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -3444,9 +3490,11 @@ public:
 
             _status = Trmv<Uplo::Upper, Trans::NoTranspose, Algo::OnDevice>::invoke(handle_blas, Diag::Unit(), AT, b, tT);
             checkDeviceBlasStatus("trmv");
+
+            // increment num device calls
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -3517,9 +3565,10 @@ public:
               _status = Gemv<Trans::ConjTranspose, Algo::OnDevice>::invoke(handle_blas, minus_one, ATR, tT, zero, bB);
               checkDeviceBlasStatus("gemv");
             }
+            // increment num device calls
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -3572,9 +3621,10 @@ public:
               _status = Gemv<Trans::ConjTranspose, Algo::OnDevice>::invoke(handle_blas, minus_one, ATR, bT, zero, bB);
               checkDeviceBlasStatus("gemv");
             }
+            // increment num device calls
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -3617,9 +3667,11 @@ public:
 
             _status = Gemv<Trans::ConjTranspose, Algo::OnDevice>::invoke(handle_blas, one, AT, tT, zero, b);
             checkDeviceBlasStatus("gemv");
+
+            // increment num device calls
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -3672,7 +3724,7 @@ public:
           const ordinal_type m = s.m, n = s.n, n_m = n - m;
           if (m > 0) {
             value_type *aptr = s.u_buf, *bptr = _buf.data() + h_buf_solve_ptr(p - pbeg);
-            ;
+
             const UnmanagedViewType<value_type_matrix> ATL(aptr, m, m);
             aptr += m * m;
             const UnmanagedViewType<value_type_matrix> bB(bptr, n_m, nrhs);
@@ -3688,9 +3740,11 @@ public:
             _status =
                 Trsv<Uplo::Upper, Trans::NoTranspose, Algo::OnDevice>::invoke(handle_blas, Diag::NonUnit(), ATL, tT);
             checkDeviceBlasStatus("trsv");
+
+            // increment num device calls
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -3746,9 +3800,11 @@ public:
 
             _status = Copy<Algo::OnDevice>::invoke(exec_instance, tT, bT);
             checkDeviceBlasStatus("Copy");
+
+            // increment num device calls
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -3790,9 +3846,11 @@ public:
 
             _status = Gemv<Trans::NoTranspose, Algo::OnDevice>::invoke(handle_blas, one, AT, b, zero, tT);
             checkDeviceBlasStatus("gemv");
+
+            // increment num device calls
+            num_device_calls ++;
           }
         }
-        num_device_calls ++;
       }
     }
     return num_device_calls;
@@ -4235,13 +4293,14 @@ public:
   /// 
   /// LU Lower
   ///
-  inline void solveLU_LowerOnDeviceVar0(const ordinal_type pbeg, const ordinal_type pend,
-                                        const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
+  inline int solveLU_LowerOnDeviceVar0(const ordinal_type pbeg, const ordinal_type pend,
+                                       const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
     const ordinal_type nrhs = t.extent(1);
     const value_type minus_one(-1), zero(0);
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     ordinal_type q(0);
 #endif
+    int num_device_calls = 0;
     exec_space exec_instance;
     for (ordinal_type p = pbeg; p < pend; ++p) {
       const ordinal_type sid = _h_level_sids(p);
@@ -4281,19 +4340,22 @@ public:
               _status = Gemv<Trans::NoTranspose, Algo::OnDevice>::invoke(handle_blas, minus_one, ABL, tT, zero, bB);
               checkDeviceBlasStatus("gemv");
             }
+            num_device_calls ++;
           }
         }
       }
     }
+    return num_device_calls;
   }
 
-  inline void solveLU_LowerOnDeviceVar1(const ordinal_type pbeg, const ordinal_type pend,
-                                        const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
+  inline int solveLU_LowerOnDeviceVar1(const ordinal_type pbeg, const ordinal_type pend,
+                                       const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
     const ordinal_type nrhs = t.extent(1);
     const value_type one(1), minus_one(-1), zero(0);
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     ordinal_type q(0);
 #endif
+    int num_device_calls = 0;
     exec_space exec_instance;
     for (ordinal_type p = pbeg; p < pend; ++p) {
       const ordinal_type sid = _h_level_sids(p);
@@ -4339,19 +4401,22 @@ public:
               _status = Gemv<Trans::NoTranspose, Algo::OnDevice>::invoke(handle_blas, minus_one, ABL, tT, zero, bB);
               checkDeviceBlasStatus("gemv");
             }
+            num_device_calls ++;
           }
         }
       }
     }
+    return num_device_calls;
   }
 
-  inline void solveLU_LowerOnDeviceVar2(const ordinal_type pbeg, const ordinal_type pend,
-                                        const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
+  inline int solveLU_LowerOnDeviceVar2(const ordinal_type pbeg, const ordinal_type pend,
+                                       const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
     const ordinal_type nrhs = t.extent(1);
     const value_type one(1), zero(0);
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     ordinal_type q(0);
 #endif
+    int num_device_calls = 0;
     exec_space exec_instance;
     for (ordinal_type p = pbeg; p < pend; ++p) {
       const ordinal_type sid = _h_level_sids(p);
@@ -4387,21 +4452,23 @@ public:
             }
             _status = Gemv<Trans::NoTranspose, Algo::OnDevice>::invoke(handle_blas, one, AL, tT, zero, b);
             checkDeviceBlasStatus("gemv");
+            num_device_calls ++;
           }
         }
       }
     }
+    return num_device_calls;
   }
 
-  inline void solveLU_LowerOnDevice(const ordinal_type lvl, const ordinal_type nlvls,
-                                    const ordinal_type pbeg, const ordinal_type pend,
-                                    const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
+  inline int solveLU_LowerOnDevice(const ordinal_type lvl, const ordinal_type nlvls,
+                                   const ordinal_type pbeg, const ordinal_type pend,
+                                   const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
     if (variant == 0)
-      solveLU_LowerOnDeviceVar0(pbeg, pend, h_buf_solve_ptr, t);
+      return solveLU_LowerOnDeviceVar0(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 1)
-      solveLU_LowerOnDeviceVar1(pbeg, pend, h_buf_solve_ptr, t);
+      return solveLU_LowerOnDeviceVar1(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 2)
-      solveLU_LowerOnDeviceVar2(pbeg, pend, h_buf_solve_ptr, t);
+      return solveLU_LowerOnDeviceVar2(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 3) {
       // L (stored by cols) incorporate partial-pivoting
       solveGenericLowerOnDeviceVar2_SpMV(lvl, nlvls, pbeg, t);
@@ -4410,18 +4477,20 @@ public:
                         + std::to_string(variant) + ") is not supported.\n";
       TACHO_TEST_FOR_EXCEPTION(true, std::logic_error, msg.c_str());
     }
+    return 0;
   }
 
   /// 
-  /// LDL Upper
+  /// LU Upper
   ///
-  inline void solveLU_UpperOnDeviceVar0(const ordinal_type pbeg, const ordinal_type pend,
-                                        const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
+  inline int solveLU_UpperOnDeviceVar0(const ordinal_type pbeg, const ordinal_type pend,
+                                       const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
     const ordinal_type nrhs = t.extent(1);
     const value_type minus_one(-1), one(1);
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     ordinal_type q(0);
 #endif
+    int num_device_calls = 0;
     for (ordinal_type p = pbeg; p < pend; ++p) {
       const ordinal_type sid = _h_level_sids(p);
       if (_h_solve_mode(sid) == 0) {
@@ -4455,18 +4524,21 @@ public:
                 Trsv<Uplo::Upper, Trans::NoTranspose, Algo::OnDevice>::invoke(handle_blas, Diag::NonUnit(), ATL, tT);
             checkDeviceBlasStatus("trsv");
           }
+          num_device_calls ++;
         }
       }
     }
+    return num_device_calls;
   }
 
-  inline void solveLU_UpperOnDeviceVar1(const ordinal_type pbeg, const ordinal_type pend,
-                                        const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
+  inline int solveLU_UpperOnDeviceVar1(const ordinal_type pbeg, const ordinal_type pend,
+                                       const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
     const ordinal_type nrhs = t.extent(1);
     const value_type minus_one(-1), one(1), zero(0);
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     ordinal_type q(0);
 #endif
+    int num_device_calls = 0;
     exec_space exec_instance;
     for (ordinal_type p = pbeg; p < pend; ++p) {
       const ordinal_type sid = _h_level_sids(p);
@@ -4504,19 +4576,22 @@ public:
 
             _status = Gemv<Trans::NoTranspose, Algo::OnDevice>::invoke(handle_blas, one, ATL, bT, zero, tT);
             checkDeviceBlasStatus("gemv");
+            num_device_calls ++;
           }
         }
       }
     }
+    return num_device_calls;
   }
 
-  inline void solveLU_UpperOnDeviceVar2(const ordinal_type pbeg, const ordinal_type pend,
-                                        const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
+  inline int solveLU_UpperOnDeviceVar2(const ordinal_type pbeg, const ordinal_type pend,
+                                       const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
     const ordinal_type nrhs = t.extent(1);
     const value_type one(1), zero(0);
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     ordinal_type q(0);
 #endif
+    int num_device_calls = 0;
     for (ordinal_type p = pbeg; p < pend; ++p) {
       const ordinal_type sid = _h_level_sids(p);
       if (_h_solve_mode(sid) == 0) {
@@ -4542,21 +4617,23 @@ public:
             const auto tT = Kokkos::subview(t, range_type(offm, offm + m), Kokkos::ALL());
             _status = Gemv<Trans::NoTranspose, Algo::OnDevice>::invoke(handle_blas, one, AT, b, zero, tT);
             checkDeviceBlasStatus("gemv");
+            num_device_calls ++;
           }
         }
       }
     }
+    return num_device_calls;
   }
 
-  inline void solveLU_UpperOnDevice(const ordinal_type lvl, const ordinal_type nlvls,
-                                    const ordinal_type pbeg, const ordinal_type pend,
-                                    const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
+  inline int solveLU_UpperOnDevice(const ordinal_type lvl, const ordinal_type nlvls,
+                                   const ordinal_type pbeg, const ordinal_type pend,
+                                   const size_type_array_host &h_buf_solve_ptr, const value_type_matrix &t) {
     if (variant == 0)
-      solveLU_UpperOnDeviceVar0(pbeg, pend, h_buf_solve_ptr, t);
+      return solveLU_UpperOnDeviceVar0(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 1)
-      solveLU_UpperOnDeviceVar1(pbeg, pend, h_buf_solve_ptr, t);
+      return solveLU_UpperOnDeviceVar1(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 2)
-      solveLU_UpperOnDeviceVar2(pbeg, pend, h_buf_solve_ptr, t);
+      return solveLU_UpperOnDeviceVar2(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 3) {
       solveGenericUpperOnDeviceVar2_SpMV(lvl, nlvls, pbeg, t);
     } else {
@@ -4564,6 +4641,7 @@ public:
                         + std::to_string(variant) + ") is not supported.\n";
       TACHO_TEST_FOR_EXCEPTION(true, std::logic_error, msg.c_str());
     }
+    return 0;
   }
 
   ///
@@ -4576,6 +4654,7 @@ public:
   inline void factorizeCholesky(const value_type_array &ax, const bool store_transpose,
                                 const mag_type shift, const mag_type pivot_tol,
                                 const ordinal_type verbose) {
+
     constexpr bool is_host = std::is_same<exec_memory_space, Kokkos::HostSpace>::value;
     Kokkos::Timer timer;
     Kokkos::Timer tick;
@@ -4585,6 +4664,7 @@ public:
 
     timer.reset();
     if (_buf.span() < size_t(_bufsize_factorize)) {
+      printf("factor(%d < %d): buf resize\n",_buf.span(), _bufsize_factorize);
       if (_buf.span() > 0) track_free(_buf.span() * sizeof(value_type));
       Kokkos::resize(_buf, _bufsize_factorize);
       track_alloc(_buf.span() * sizeof(value_type));
@@ -4594,6 +4674,7 @@ public:
     {
       size_type worksize = _worksize * (_nstreams + 1);
       if (size_t(worksize) > _work.span()) {
+        printf("factor(%d < %d): work resize\n",_work.span(), worksize);
         if (_work.span() > 0) track_free(_work.span() * sizeof(value_type));
         Kokkos::resize(_work, worksize);
         track_alloc(_work.span() * sizeof(value_type));
@@ -4694,12 +4775,11 @@ public:
             if (verbose) {
               Kokkos::fence(); tick.reset();
             }
-            int num_device_calls = 0;
             const auto h_buf_factor_ptr = Kokkos::subview(_h_buf_factor_ptr, range_buf_factor_ptr);
             if (this->getSolutionMethod() == 0) {
-              num_device_calls = factorizeNoPivotLDLOnDevice(pbeg, pend, h_buf_factor_ptr, _work);
+              factorizeNoPivotLDLOnDevice(pbeg, pend, h_buf_factor_ptr, _work);
             } else {
-              num_device_calls = factorizeCholeskyOnDevice(pbeg, pend, h_buf_factor_ptr, _work);
+              factorizeCholeskyOnDevice(pbeg, pend, h_buf_factor_ptr, _work);
             }
             if (verbose) {
               Kokkos::fence(); time_device += tick.seconds();
@@ -4710,10 +4790,12 @@ public:
             if (rval != 0) {
               TACHO_TEST_FOR_EXCEPTION(true, std::runtime_error, "POTRF (team) returns non-zero error code.");
             }
-            if (num_device_calls > 0)
-                Kokkos::fence(); // sync device-calls
+            if (_h_num_device_calls_factor(lvl) > 0)
+              Kokkos::fence(); // sync device-calls before calling update
+
             Kokkos::parallel_for("update factor", policy_update, functor);
-            exec_space().fence(); // sync default, for potential device calls
+            if (lvl == 0 || _h_num_device_calls_factor(lvl-1) > 0)
+              exec_space().fence(); // sync default, before next device factor calls
             if (verbose) {
               Kokkos::fence(); time_update += tick.seconds();
             }
@@ -4842,20 +4924,20 @@ public:
                 ++stat_level.n_kernel_launching;
               }
             }
-            int num_device_calls = 0;
             const auto h_buf_solve_ptr = Kokkos::subview(_h_buf_solve_nrhs_ptr, range_solve_buf_ptr);
             if (this->getSolutionMethod() == 0) {
-              num_device_calls = solveNoPivotLDLLowerOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
+              solveNoPivotLDLLowerOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
             } else {
-              num_device_calls = solveCholeskyLowerOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
+              solveCholeskyLowerOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
             }
             if (variant != 3) {
-              if (num_device_calls > 0)
-                Kokkos::fence(); // synch device calls
+              if (_h_num_device_calls_solve(lvl) > 0)
+                Kokkos::fence(); // synch device calls before batched update
 
               // copy from buffer to t
               Kokkos::parallel_for("update lower", policy_update_with_work_property, functor);
-              exec_space().fence(); // sync default, for potential device-calls
+              if (lvl == 0 || _h_num_device_calls_solve(lvl-1) > 0)
+                exec_space().fence(); // sync default, for next device solve calls
               ++stat_level.n_kernel_launching;
             }
           }
@@ -4911,7 +4993,8 @@ public:
 #endif
             if (variant != 3) {
               Kokkos::parallel_for("update upper", policy_update_with_work_property, functor);
-              exec_space().fence(); // sync default, for potential device-calls
+              if (_h_num_device_calls_solve(lvl) > 0)
+                exec_space().fence(); // sync default, before next device solve-upper calls
               ++stat_level.n_kernel_launching;
 
               if (lvl < _device_level_cut) {
@@ -4919,19 +5002,17 @@ public:
                 // Kokkos::parallel_for("solve upper", policy_solve, functor);
               } else {
                 Kokkos::parallel_for("solve upper", policy_solve_with_work_property, functor);
-                ++stat_level.n_kernel_launching;
+                ++stat_level.n_kernel_launching; // no need to synch because synched after next update if needed
               }
             }
-            int num_device_calls = 0;
             const auto h_buf_solve_ptr = Kokkos::subview(_h_buf_solve_nrhs_ptr, range_solve_buf_ptr);
             if (this->getSolutionMethod() == 0) {
-              num_device_calls = solveNoPivotLDLUpperOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
+              solveNoPivotLDLUpperOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
             } else {
-              num_device_calls = solveCholeskyUpperOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
+              solveCholeskyUpperOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
             }
-            if (num_device_calls > 0 || 1+lvl == _team_serial_level_cut) {
-              Kokkos::fence();
-            }
+            if (_h_num_device_calls_solve(lvl) > 0 || 1+lvl == _team_serial_level_cut)
+              Kokkos::fence(); // synch device calls before next update
           }
         }
       } /// end of upper tri solve
@@ -5097,7 +5178,7 @@ public:
             exec_space().fence();
             ++stat_level.n_kernel_launching;
           }
-	  // NOTE: device info not needed on host?
+          // NOTE: device info not needed on host?
           //const auto exec_instance = exec_space();
           //Kokkos::deep_copy(exec_instance, _h_supernodes, _info.supernodes);
         }
@@ -5452,16 +5533,18 @@ public:
             if (rval != 0) {
               TACHO_TEST_FOR_EXCEPTION(rval, std::runtime_error, "GETRF (team) returns non-zero error code.");
             }
-            Kokkos::fence(); // sync device calls
+            if (_h_num_device_calls_factor(lvl) > 0)
+              Kokkos::fence(); // sync device calls before update
 
             Kokkos::parallel_for("update factor", policy_update, functor);
             if (verbose) {
               Kokkos::fence(); time_update += tick.seconds();
             }
-            exec_space().fence();
+            if (lvl == 0 || _h_num_device_calls_factor(lvl-1) > 0)
+              exec_space().fence(); // synch default before the next device factor call
             ++stat_level.n_kernel_launching;
           }
-	  // NOTE: device info not needed on host?
+          // NOTE: device info not needed on host?
           //const auto exec_instance = exec_space();
           //Kokkos::deep_copy(exec_instance, _h_supernodes, _info.supernodes);
         }
@@ -5590,11 +5673,13 @@ public:
             const auto h_buf_solve_ptr = Kokkos::subview(_h_buf_solve_nrhs_ptr, range_solve_buf_ptr);
             solveLU_LowerOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
             if (variant != 3) {
-              Kokkos::fence();
+              if (_h_num_device_calls_solve(lvl) > 0)
+                Kokkos::fence(); // synch device calls before update
 
               Kokkos::parallel_for("update lower", policy_update_with_work_property, functor);
               ++stat_level.n_kernel_launching;
-              exec_space().fence();
+              if (lvl == 0 || _h_num_device_calls_solve(lvl-1) > 0) // TODO: synch if batched-call at lvl=0
+                exec_space().fence(); // synch default before next device solve call
             }
           }
         }
@@ -5649,7 +5734,8 @@ public:
             if (variant != 3) {
               Kokkos::parallel_for("update upper", policy_update_with_work_property, functor);
               ++stat_level.n_kernel_launching;
-              exec_space().fence();
+              if (_h_num_device_calls_solve(lvl) > 0)
+                exec_space().fence(); // synch default before next device solve calls
 
               if (lvl < _device_level_cut) {
                 // do nothing
@@ -5662,7 +5748,10 @@ public:
             const auto h_buf_solve_ptr = Kokkos::subview(_h_buf_solve_nrhs_ptr, range_solve_buf_ptr);
             solveLU_UpperOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
             if (variant != 3) {
-              Kokkos::fence();
+              if (_h_num_device_calls_solve(lvl) > 0)
+                Kokkos::fence(); // synch device before the next update call
+              //else if (lvl == _team_serial_level_cut-1 || _h_num_device_calls_solve(lvl+1) > 0)
+              //  exec_space().fence(); // synch bached solve-upper calls
             }
           }
         }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -857,9 +857,10 @@ public:
   inline void createStream(const ordinal_type nstreams, const ordinal_type verbose = 0) {
     // # of streams needs to be at least 1
     if (nstreams <= 0) return;
-
     _nstreams = nstreams;
-    if (_streams.size() == size_t(nstreams)) return;
+
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+    if (_streams.size() == size_t(nstreams)) return; // nothing to do
 
 #if defined(KOKKOS_ENABLE_CUDA)
     // destroy previously created streams
@@ -897,7 +898,7 @@ public:
       checkDeviceBlasStatus("rocblasSetStream(handles[qid])");
     }
 #endif
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+    // reinitialize execution instances with the streams
     _exec_instances.clear();
     _exec_instances.resize(_nstreams);
     for (ordinal_type i = 0; i < _nstreams; ++i) {
@@ -4853,8 +4854,13 @@ public:
     allocateWorkspaceSolve(nrhs);
 
     const bool need_fence = (!_team_on_user_stream || _nstreams > 1);
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     const auto perm_exec_instance = _exec_instances[0];
     const auto team_exec_instance = (_team_on_user_stream ? _exec_instances[0] : exec_space());
+#else
+    const auto perm_exec_instance = exec_space();
+    const auto team_exec_instance = perm_exec_instance;
+#endif
 
     // 0. permute (from METIS) and copy b -> t
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);
@@ -4942,7 +4948,7 @@ public:
 
               // copy from buffer to t
               Kokkos::parallel_for("update lower", policy_update_with_work_property, functor);
-              if (need_fence && _h_num_device_calls_solve(lvl-1) > 0)
+              if (need_fence && (lvl > 0 && _h_num_device_calls_solve(lvl-1) > 0))
                 exec_space().fence(); // sync default, for next device solve calls
               ++stat_level.n_kernel_launching;
             }
@@ -5231,8 +5237,13 @@ public:
     allocateWorkspaceSolve(nrhs);
 
     const bool need_fence = (!_team_on_user_stream || _nstreams > 1);
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     const auto perm_exec_instance = _exec_instances[0];
     const auto team_exec_instance = (_team_on_user_stream ? _exec_instances[0] : exec_space());
+#else
+    const auto perm_exec_instance = exec_space();
+    const auto team_exec_instance = perm_exec_instance;
+#endif
 
     // 0. permute (from METIS) and copy b -> t
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);
@@ -5610,8 +5621,14 @@ public:
     allocateWorkspaceSolve(nrhs);
 
     const bool need_fence = (!_team_on_user_stream || _nstreams > 1);
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
     const auto perm_exec_instance = _exec_instances[0];
     const auto team_exec_instance = (_team_on_user_stream ? _exec_instances[0] : exec_space());
+#else
+    const auto perm_exec_instance = exec_space();
+    const auto team_exec_instance = perm_exec_instance;
+#endif
+
     // 0. permute (from METIS) and copy b -> t
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);
     if (need_fence) perm_exec_instance.fence();
@@ -5695,7 +5712,7 @@ public:
 
               Kokkos::parallel_for("update lower", policy_update_with_work_property, functor);
               ++stat_level.n_kernel_launching;
-              if (need_fence && (lvl == 0 || _h_num_device_calls_solve(lvl-1) > 0))
+              if (need_fence && (lvl > 0 && _h_num_device_calls_solve(lvl-1) > 0))
                 exec_space().fence(); // synch update on default before next solve on device
             }
           }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -849,16 +849,18 @@ public:
   inline void createStream(const ordinal_type nstreams, const ordinal_type verbose = 0) {
     // # of streams needs to be at least 1
     if (nstreams <= 0) return;
-#if defined(KOKKOS_ENABLE_CUDA)
+
     _nstreams = nstreams;
     if (_streams.size() == size_t(nstreams)) return;
+
+#if defined(KOKKOS_ENABLE_CUDA)
     // destroy previously created streams
     for (size_t i = 0; i < _streams.size(); ++i) {
       _status = cudaStreamDestroy(_streams[i]);
       checkDeviceStatus("cudaStreamDestroy");
     }
-    // new streams
     _streams.clear();
+    // new streams
     _streams.resize(_nstreams);
     for (ordinal_type i = 0; i < _nstreams; ++i) {
       _status = cudaStreamCreateWithFlags(&_streams[i], cudaStreamNonBlocking);
@@ -866,13 +868,10 @@ public:
     }
 #endif
 #if defined(KOKKOS_ENABLE_HIP)
-    _nstreams = nstreams;
-    if (_streams.size() == size_t(nstreams)) return;
     // destroy previously created streams
     for (size_t i = 0; i < _streams.size(); ++i) {
       _status = rocblas_destroy_handle(_handles[i]);
       checkDeviceLapackStatus("rocblasDestroy");
-
       _status = hipStreamDestroy(_streams[i]);
       checkDeviceStatus("hipStreamDestroy");
     }
@@ -896,13 +895,12 @@ public:
     for (ordinal_type i = 0; i < _nstreams; ++i) {
       ExecSpaceFactory<exec_space>::createInstance(_streams[i], _exec_instances[i]);
     }
-
+#endif
     if (verbose) {
       printf("Summary: CreateStream : %3d\n", _nstreams);
       printf("===========================\n");
       fflush(stdout);
     }
-#endif
   }
 
   inline void setStreamOnHandle(const ordinal_type qid) {
@@ -2721,7 +2719,6 @@ public:
       const size_type buf_span = _buf.span();
 
       if (buf_extent > buf_span) {
-        printf("solve(%d < %d): work resize\n",buf_extent, buf_span);
         if (_buf.span() > 0) track_free(buf_span * sizeof(value_type));
         Kokkos::resize(_buf, buf_extent);
         track_alloc(_buf.span() * sizeof(value_type));
@@ -4308,8 +4305,8 @@ public:
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
         const ordinal_type qid = q % _nstreams;
         blas_handle_type handle_blas = getBlasHandle(qid);
-        setStreamOnHandle(qid);
         exec_instance = _exec_instances[qid];
+        setStreamOnHandle(qid);
         ++q;
 #else
         blas_handle_type handle_blas = getBlasHandle();
@@ -4664,7 +4661,6 @@ public:
 
     timer.reset();
     if (_buf.span() < size_t(_bufsize_factorize)) {
-      printf("factor(%d < %d): buf resize\n",_buf.span(), _bufsize_factorize);
       if (_buf.span() > 0) track_free(_buf.span() * sizeof(value_type));
       Kokkos::resize(_buf, _bufsize_factorize);
       track_alloc(_buf.span() * sizeof(value_type));
@@ -4674,7 +4670,6 @@ public:
     {
       size_type worksize = _worksize * (_nstreams + 1);
       if (size_t(worksize) > _work.span()) {
-        printf("factor(%d < %d): work resize\n",_work.span(), worksize);
         if (_work.span() > 0) track_free(_work.span() * sizeof(value_type));
         Kokkos::resize(_work, worksize);
         track_alloc(_work.span() * sizeof(value_type));
@@ -5021,6 +5016,7 @@ public:
     stat.t_solve = timer.seconds();
 
     // permute (from METIS) and copy t -> x
+    Kokkos::fence(); // synch user or default streams
     timer.reset();
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(exec_instance, t, _peri, x);
     stat.t_extra += timer.seconds();
@@ -5383,6 +5379,7 @@ public:
     stat.t_solve = timer.seconds();
 
     // permute (from METIS) and copy t -> x
+    Kokkos::fence(); // synch user or default streams
     timer.reset();
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(exec_instance, t, _peri, x);
     stat.t_extra += timer.seconds();
@@ -5594,10 +5591,14 @@ public:
     timer.reset();
     allocateWorkspaceSolve(nrhs);
 
+    const bool batch_on_stream0 = true; // TODO: add user-parameter
+    const bool need_fence = (!batch_on_stream0 || _nstreams > 1);
+
+    const auto perm_exec_instance = _exec_instances[0];
+    const auto team_exec_instance = (batch_on_stream0 ? _exec_instances[0] : exec_space());
     // 0. permute (from METIS) and copy b -> t
-    const auto exec_instance = exec_space();
-    ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(exec_instance, b, _perm, t);
-    exec_instance.fence();
+    ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);
+    if (need_fence) perm_exec_instance.fence();
     stat.t_extra = timer.seconds();
 
     timer.reset();
@@ -5649,8 +5650,8 @@ public:
               policy_update = team_policy_update(pcnt, 1, 1);
             } else {
               const ordinal_type idx = lvl > half_level;
-              policy_solve = team_policy_solve(pcnt, team_size_solve[idx], vector_size_solve[idx]);
-              policy_update = team_policy_update(pcnt, team_size_update[idx], vector_size_update[idx]);
+              policy_solve = team_policy_solve(team_exec_instance, pcnt, team_size_solve[idx], vector_size_solve[idx]);
+              policy_update = team_policy_update(team_exec_instance, pcnt, team_size_update[idx], vector_size_update[idx]);
             }
 #if defined(TACHO_ENABLE_SOLVE_CHOLESKY_USE_LIGHT_KERNEL)
             const auto policy_solve_with_work_property =
@@ -5673,13 +5674,13 @@ public:
             const auto h_buf_solve_ptr = Kokkos::subview(_h_buf_solve_nrhs_ptr, range_solve_buf_ptr);
             solveLU_LowerOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
             if (variant != 3) {
-              if (_h_num_device_calls_solve(lvl) > 0)
-                Kokkos::fence(); // synch device calls before update
+              if (need_fence && _h_num_device_calls_solve(lvl) > 0)
+                Kokkos::fence(); // synch solve device before update
 
               Kokkos::parallel_for("update lower", policy_update_with_work_property, functor);
               ++stat_level.n_kernel_launching;
-              if (lvl == 0 || _h_num_device_calls_solve(lvl-1) > 0) // TODO: synch if batched-call at lvl=0
-                exec_space().fence(); // synch default before next device solve call
+              if (need_fence && (lvl == 0 || _h_num_device_calls_solve(lvl-1) > 0)) // TODO: synch if batched-call at lvl=0
+                exec_space().fence(); // synch update on default before next solve on device
             }
           }
         }
@@ -5719,8 +5720,8 @@ public:
               policy_update = team_policy_update(pcnt, 1, 1);
             } else {
               const ordinal_type idx = lvl > half_level;
-              policy_solve = team_policy_solve(pcnt, team_size_solve[idx], vector_size_solve[idx]);
-              policy_update = team_policy_update(pcnt, team_size_update[idx], vector_size_update[idx]);
+              policy_solve = team_policy_solve(team_exec_instance, pcnt, team_size_solve[idx], vector_size_solve[idx]);
+              policy_update = team_policy_update(team_exec_instance, pcnt, team_size_update[idx], vector_size_update[idx]);
             }
 #if defined(TACHO_ENABLE_SOLVE_CHOLESKY_USE_LIGHT_KERNEL)
             const auto policy_solve_with_work_property =
@@ -5734,8 +5735,8 @@ public:
             if (variant != 3) {
               Kokkos::parallel_for("update upper", policy_update_with_work_property, functor);
               ++stat_level.n_kernel_launching;
-              if (_h_num_device_calls_solve(lvl) > 0)
-                exec_space().fence(); // synch default before next device solve calls
+              if (need_fence && _h_num_device_calls_solve(lvl) > 0)
+                exec_space().fence(); // synch update on default before solve on device
 
               if (lvl < _device_level_cut) {
                 // do nothing
@@ -5748,8 +5749,8 @@ public:
             const auto h_buf_solve_ptr = Kokkos::subview(_h_buf_solve_nrhs_ptr, range_solve_buf_ptr);
             solveLU_UpperOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
             if (variant != 3) {
-              if (_h_num_device_calls_solve(lvl) > 0)
-                Kokkos::fence(); // synch device before the next update call
+              if (need_fence && _h_num_device_calls_solve(lvl) > 0)
+                Kokkos::fence(); // synch solve on device before the next update on default
               //else if (lvl == _team_serial_level_cut-1 || _h_num_device_calls_solve(lvl+1) > 0)
               //  exec_space().fence(); // synch bached solve-upper calls
             }
@@ -5761,9 +5762,10 @@ public:
     stat.t_solve = timer.seconds();
 
     // permute (from METIS) and copy t -> x
+    if (need_fence) Kokkos::fence();
     timer.reset();
-    ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(exec_instance, t, _peri, x);
-    exec_instance.fence();
+    ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, t, _peri, x);
+    perm_exec_instance.fence();
     stat.t_extra += timer.seconds();
 
     if (verbose) {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -206,6 +206,7 @@ private:
 
   // cuda stream
   int _nstreams;
+  bool _team_on_user_stream;
 
   // workspace for SpMV
   bool _is_spmv_extracted;
@@ -419,7 +420,7 @@ public:
   /// initialization / release
   ///
   inline void initialize(const ordinal_type device_level_cut, const ordinal_type device_factorize_thres,
-                         const ordinal_type device_solve_thres, const int nstreams_in = 1,
+                         const ordinal_type device_solve_thres, const int nstreams_in = 1, const bool team_on_user_stream = false,
                          const bool store_transpose = false, const ordinal_type verbose = 0) {
     stat_level.n_level = 0;
     stat_level.n_device_factorize = 0;
@@ -706,6 +707,7 @@ public:
     _solve_mode = Kokkos::create_mirror_view_and_copy(exec_memory_space(), _h_solve_mode);
     track_alloc(_solve_mode.span() * sizeof(ordinal_type));
 
+    _team_on_user_stream = team_on_user_stream;
     createStream(nstreams, verbose);
     if (variant == 3 && _keep_zeros) {
       // compress each partitioned inverse at each level into CRS matrix
@@ -737,6 +739,10 @@ public:
       }
       }
       print_stat_init();
+      printf("  Execution Mode\n");
+      printf("             # of streams:                                      %d\n",nstreams);
+      printf("               Team kernels on %s\n",(_team_on_user_stream ? "User Stream-0" : "Default Stream"));
+      printf("\n");
       fflush(stdout);
     }
   }
@@ -771,6 +777,7 @@ public:
     _bufsize_factorize = 0;
     _bufsize_solve = 0;
     _nstreams = 0;
+    _team_on_user_stream = 0;
     _keep_zeros = false;
     stat_level = stat_level();
   }
@@ -792,6 +799,7 @@ public:
                   blk_colidx, stree_parent, stree_ptr, stree_children, stree_level, stree_roots) {
     _keep_zeros = false;
     _nstreams = 0;
+    _team_on_user_stream = false;
     _is_spmv_extracted = 0;
 #if defined(KOKKOS_ENABLE_CUDA)
     _is_cublas_created = 0;
@@ -5219,10 +5227,13 @@ public:
     timer.reset();
     allocateWorkspaceSolve(nrhs);
 
+    const bool need_fence = (!_team_on_user_stream || _nstreams > 1);
+    const auto perm_exec_instance = _exec_instances[0];
+    const auto team_exec_instance = (_team_on_user_stream ? _exec_instances[0] : exec_space());
+
     // 0. permute (from METIS) and copy b -> t
-    const auto exec_instance = exec_space();
-    ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(exec_instance, b, _perm, t);
-    exec_space().fence();
+    ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);
+    if(need_fence) exec_space().fence();
     stat.t_extra = timer.seconds();
 
     timer.reset();
@@ -5275,8 +5286,8 @@ public:
               policy_update = team_policy_update(pcnt, 1, 1);
             } else {
               const ordinal_type idx = lvl > half_level;
-              policy_solve = team_policy_solve(pcnt, team_size_solve[idx], vector_size_solve[idx]);
-              policy_update = team_policy_update(pcnt, team_size_update[idx], vector_size_update[idx]);
+              policy_solve = team_policy_solve(team_exec_instance, pcnt, team_size_solve[idx], vector_size_solve[idx]);
+              policy_update = team_policy_update(team_exec_instance, pcnt, team_size_update[idx], vector_size_update[idx]);
             }
 #if defined(TACHO_ENABLE_SOLVE_CHOLESKY_USE_LIGHT_KERNEL)
             const auto policy_solve_with_work_property =
@@ -5298,12 +5309,14 @@ public:
             }
             const auto h_buf_solve_ptr = Kokkos::subview(_h_buf_solve_nrhs_ptr, range_solve_buf_ptr);
             solveLDL_LowerOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
-            Kokkos::fence();
+            if (need_fence && _h_num_device_calls_solve(lvl) > 0)
+              Kokkos::fence(); // fence solve on device before updating on default
 
             if (variant != 3) {
               Kokkos::parallel_for("update lower", policy_update_with_work_property, functor);
               ++stat_level.n_kernel_launching;
-              exec_space().fence();
+              if (need_fence && (lvl > 0 && _h_num_device_calls_solve(lvl-1) > 0))
+                exec_space().fence(); // synch update on default before next solve on device
             }
           }
         }
@@ -5343,8 +5356,8 @@ public:
               policy_update = team_policy_update(pcnt, 1, 1);
             } else {
               const ordinal_type idx = lvl > half_level;
-              policy_solve = team_policy_solve(pcnt, team_size_solve[idx], vector_size_solve[idx]);
-              policy_update = team_policy_update(pcnt, team_size_update[idx], vector_size_update[idx]);
+              policy_solve = team_policy_solve(team_exec_instance, pcnt, team_size_solve[idx], vector_size_solve[idx]);
+              policy_update = team_policy_update(team_exec_instance, pcnt, team_size_update[idx], vector_size_update[idx]);
             }
 #if defined(TACHO_ENABLE_SOLVE_CHOLESKY_USE_LIGHT_KERNEL)
             const auto policy_solve_with_work_property =
@@ -5358,7 +5371,8 @@ public:
             if (variant != 3) {
               Kokkos::parallel_for("update upper", policy_update_with_work_property, functor);
               ++stat_level.n_kernel_launching;
-              exec_space().fence();
+              if (need_fence && _h_num_device_calls_solve(lvl) > 0)
+                exec_space().fence(); // synch update befor solve on device
 
               if (lvl < _device_level_cut) {
                 // do nothing
@@ -5371,7 +5385,8 @@ public:
 
             const auto h_buf_solve_ptr = Kokkos::subview(_h_buf_solve_nrhs_ptr, range_solve_buf_ptr);
             solveLDL_UpperOnDevice(lvl, _team_serial_level_cut, pbeg, pend, h_buf_solve_ptr, t);
-            Kokkos::fence();
+            if (need_fence && _h_num_device_calls_solve(lvl) > 0)
+              Kokkos::fence(); // synch solve on device before next update
           }
         }
       } /// end of upper tri solve
@@ -5379,9 +5394,9 @@ public:
     stat.t_solve = timer.seconds();
 
     // permute (from METIS) and copy t -> x
-    Kokkos::fence(); // synch user or default streams
+    if (need_fence) Kokkos::fence(); // synch user or default streams
     timer.reset();
-    ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(exec_instance, t, _peri, x);
+    ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, t, _peri, x);
     stat.t_extra += timer.seconds();
 
     if (verbose) {
@@ -5591,11 +5606,9 @@ public:
     timer.reset();
     allocateWorkspaceSolve(nrhs);
 
-    const bool batch_on_stream0 = true; // TODO: add user-parameter
-    const bool need_fence = (!batch_on_stream0 || _nstreams > 1);
-
+    const bool need_fence = (!_team_on_user_stream || _nstreams > 1);
     const auto perm_exec_instance = _exec_instances[0];
-    const auto team_exec_instance = (batch_on_stream0 ? _exec_instances[0] : exec_space());
+    const auto team_exec_instance = (_team_on_user_stream ? _exec_instances[0] : exec_space());
     // 0. permute (from METIS) and copy b -> t
     ApplyPermutation<Side::Left, Trans::NoTranspose, Algo::OnDevice>::invoke(perm_exec_instance, b, _perm, t);
     if (need_fence) perm_exec_instance.fence();
@@ -5679,7 +5692,7 @@ public:
 
               Kokkos::parallel_for("update lower", policy_update_with_work_property, functor);
               ++stat_level.n_kernel_launching;
-              if (need_fence && (lvl == 0 || _h_num_device_calls_solve(lvl-1) > 0)) // TODO: synch if batched-call at lvl=0
+              if (need_fence && (lvl == 0 || _h_num_device_calls_solve(lvl-1) > 0))
                 exec_space().fence(); // synch update on default before next solve on device
             }
           }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -2147,6 +2147,8 @@ public:
     }
     // create cusparse handle
     cusparseCreate(&cusparseHandle);
+    // attach handle to stream-0
+    cusparseSetStream(cusparseHandle, _streams[0]);
     // attach to Cusparse data struct
     cusparseCreateDnMat(&matW, m, nrhs, ldw, (void*)(_w_vec.data()), computeType, CUSPARSE_ORDER_COL);
     cusparseCreateDnVec(&vecW, m, (void*)(_w_vec.data()), computeType);
@@ -2162,21 +2164,24 @@ public:
     }
     // create rocsparse handle
     _status = rocsparse_create_handle(&rocsparseHandle);
-    checkDeviceBlasStatus("rocblas_create_handle");
+    checkDeviceBlasStatus("rocsparse_create_handle");
+    // attach handle to stream-0
+    rocsparse_set_stream(rocsparseHandle, _streams[0]);
+    checkDeviceBlasStatus("rocsparse_create_handle");
     // attach to Rocsparse data struct
     _status = rocsparse_create_dnmat_descr(&matW, m, nrhs, ldw, (void*)(_w_vec.data()), rocsparse_compute_type, rocsparse_order_column);
-    checkDeviceBlasStatus("rocblas_dnmat_descr");
+    checkDeviceBlasStatus("rocsparse_dnmat_descr");
     _status = rocsparse_create_dnvec_descr(&vecW, m, (void*)(_w_vec.data()), rocsparse_compute_type);
-    checkDeviceBlasStatus("rocblas_dnmat_descr");
+    checkDeviceBlasStatus("rocsparse_dnmat_descr");
     // also to T, to be destroyed before each SpMV call
     _status = rocsparse_create_dnmat_descr(&matL, m, nrhs, ldw, (void*)(_w_vec.data()), rocsparse_compute_type, rocsparse_order_column);
-    checkDeviceBlasStatus("rocblas_dnmat_descr");
+    checkDeviceBlasStatus("rocsparse_dnmat_descr");
     _status = rocsparse_create_dnvec_descr(&vecL, m, (void*)(_w_vec.data()), rocsparse_compute_type);
-    checkDeviceBlasStatus("rocblas_dnmat_descr");
+    checkDeviceBlasStatus("rocsparse_dnvec_descr");
     _status = rocsparse_create_dnmat_descr(&matU, m, nrhs, ldw, (void*)(_w_vec.data()), rocsparse_compute_type, rocsparse_order_column);
-    checkDeviceBlasStatus("rocblas_dnmat_descr");
+    checkDeviceBlasStatus("rocsparse_dnmat_descr");
     _status = rocsparse_create_dnvec_descr(&vecU, m, (void*)(_w_vec.data()), rocsparse_compute_type);
-    checkDeviceBlasStatus("rocblas_dnmat_descr");
+    checkDeviceBlasStatus("rocsparse_dnvec_descr");
 #endif
 #endif
 
@@ -3324,7 +3329,12 @@ public:
         const UnmanagedViewType<nzvals_view> matD(s0.nzvalsD, _m);
 
         using policy_type = Kokkos::RangePolicy<exec_space>;
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+        const auto policy = policy_type(_exec_instances[0], 0, _m);
+#else
+        // TODO: initialize _exec_instance[0] as exec_space(); with serial build?
         const auto policy = policy_type(0, _m);
+#endif
         Kokkos::parallel_for(
             policy, KOKKOS_LAMBDA(const ordinal_type &i) {
               for (ordinal_type j = 0; j < nrhs; j++) matY(i,j) = matY(i, j) / matD(i); 
@@ -4858,6 +4868,7 @@ public:
     const auto perm_exec_instance = _exec_instances[0];
     const auto team_exec_instance = (_team_on_user_stream ? _exec_instances[0] : exec_space());
 #else
+    // TODO: initialize _exec_instance[0] as exec_space(); with serial build?
     const auto perm_exec_instance = exec_space();
     const auto team_exec_instance = perm_exec_instance;
 #endif

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_SymbolicTools.cpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_SymbolicTools.cpp
@@ -1046,6 +1046,7 @@ void SymbolicTools::evaporateSymbolicFactors(const ordinal_type_array &aw, const
   if (verbose) {
     printf("Summary: EvaporateSymbolicFactors\n");
     printf("=================================\n");
+    printf( "  Using %d ~ %d DoFs / grid\n",minval, maxval);
 
     // const double kilo(1024);
     switch (verbose) {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Util.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Util.hpp
@@ -546,6 +546,20 @@ template <> struct ExecSpaceFactory<Kokkos::HIP> {
 };
 #endif
 
+#if defined(KOKKOS_ENABLE_CUDA)
+template <typename ExecSpace>
+struct ExecSpaceHelper {
+  static cudaStream_t getStream(ExecSpace &exec_instance) {
+    return 0;
+  }
+};
+
+template <> struct ExecSpaceHelper<Kokkos::Cuda> {
+  static cudaStream_t getStream(Kokkos::Cuda & exec_instance) {
+    return exec_instance.cuda_stream();
+  }
+};
+#endif
 } // namespace Tacho
 
 #endif

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Util.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Util.hpp
@@ -546,20 +546,6 @@ template <> struct ExecSpaceFactory<Kokkos::HIP> {
 };
 #endif
 
-#if defined(KOKKOS_ENABLE_CUDA)
-template <typename ExecSpace>
-struct ExecSpaceHelper {
-  static cudaStream_t getStream(ExecSpace &exec_instance) {
-    return 0;
-  }
-};
-
-template <> struct ExecSpaceHelper<Kokkos::Cuda> {
-  static cudaStream_t getStream(Kokkos::Cuda & exec_instance) {
-    return exec_instance.cuda_stream();
-  }
-};
-#endif
 } // namespace Tacho
 
 #endif

--- a/packages/shylu/shylu_node/tacho/unit-test/Tacho_TestSolver.cpp
+++ b/packages/shylu/shylu_node/tacho/unit-test/Tacho_TestSolver.cpp
@@ -69,7 +69,8 @@ int generate2dLaplace(const int nx, CrsMatrixBaseTypeHost &A) {
 // main test driver
 template <typename value_type>
 int driver(const std::string file, const std::string method_name, const int variant, const int nrhs,
-           const bool store_transpose = false, const bool single_solve = true, const bool single_setup = true) {
+           const bool store_transpose = false, const bool single_solve = true, const bool single_setup = true,
+           const bool team_on_user_stream = false) {
   int nx = 100;
   int method = 1; // 1 - Chol, 2 - LDL, 3 - SymLU
   if (method_name == "ldl-nopiv")
@@ -135,6 +136,12 @@ int driver(const std::string file, const std::string method_name, const int vari
       std::cout << "  > Using explicit transpose " << std::endl;
       solver.storeExplicitTranspose(true);
     }
+    if (team_on_user_stream) {
+      /// one-stream
+      std::cout << " Using user stream-0 for team/batched kernels" << std::endl;
+      solver.setLevelSetOptionNumStreams(1, team_on_user_stream);
+    }
+    std::cout << std::endl;
 
     /// levelset options
     ///  forcing to have a few device factor/solve tasks
@@ -238,6 +245,10 @@ TEST( Solver, Chol ) {
   EXPECT_EQ(driver<double>(file, "chol", 2, 5), 0);
   EXPECT_EQ(driver<double>(file, "chol", 3, 5), 0);
   EXPECT_EQ(driver<double>(file, "chol", 3, 5, true), 0);
+  // > one-stream
+  EXPECT_EQ(driver<double>(file, "chol", 0, 1, false, true, true, true), 0);
+  EXPECT_EQ(driver<double>(file, "chol", 1, 1, false, true, true, true), 0);
+  EXPECT_EQ(driver<double>(file, "chol", 2, 1, false, true, true, true), 0);
   #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
   // > sequential path
   EXPECT_EQ(driver<double>(file, "chol", -1, 1), 0);
@@ -267,6 +278,10 @@ TEST( Solver, LU ) {
   EXPECT_EQ(driver<double>(file, "lu", 2, 5, false, false), 0);
   EXPECT_EQ(driver<double>(file, "lu", 3, 5, false, false), 0);
   EXPECT_EQ(driver<double>(file, "lu", 3, 5, false, false, false), 0); // multiple symbolic calls
+  // > one-stream
+  EXPECT_EQ(driver<double>(file, "lu", 0, 1, false, true, true, true), 0);
+  EXPECT_EQ(driver<double>(file, "lu", 1, 1, false, true, true, true), 0);
+  EXPECT_EQ(driver<double>(file, "lu", 2, 1, false, true, true, true), 0);
   #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
   // > sequential path
   EXPECT_EQ(driver<double>(file, "lu", -1, 1), 0);
@@ -295,6 +310,10 @@ TEST( Solver, LDL ) {
   EXPECT_EQ(driver<double>(file, "ldl", 1, 5, false, false), 0);
   EXPECT_EQ(driver<double>(file, "ldl", 2, 5, false, false), 0);
   EXPECT_EQ(driver<double>(file, "ldl", 3, 5, false, false), 0);
+  // > one-stream
+  EXPECT_EQ(driver<double>(file, "ldl", 0, 1, false, true, true, true), 0);
+  EXPECT_EQ(driver<double>(file, "ldl", 1, 1, false, true, true, true), 0);
+  EXPECT_EQ(driver<double>(file, "ldl", 2, 1, false, true, true, true), 0);
   #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
   // > sequential path
   EXPECT_EQ(driver<double>(file, "ldl", -1, 1), 0);

--- a/packages/shylu/shylu_node/tacho/unit-test/Tacho_TestSolver.cpp
+++ b/packages/shylu/shylu_node/tacho/unit-test/Tacho_TestSolver.cpp
@@ -135,8 +135,6 @@ int driver(const std::string file, const std::string method_name, const int vari
       std::cout << "  > Using explicit transpose " << std::endl;
       solver.storeExplicitTranspose(true);
     }
-    /// test "shift diag" code path
-    solver.shiftDiagonal();
 
     /// levelset options
     ///  forcing to have a few device factor/solve tasks
@@ -153,7 +151,7 @@ int driver(const std::string file, const std::string method_name, const int vari
       if(r_val == 0) {
         r_val = solver.initialize();
       }
-      int num_solves = (single_solve ? 1 : 5); // number of numeric + solve calls
+      int num_solves = 5; // number of numeric + solve calls
       for (int step = 0; step < num_solves && r_val == 0; step++) {
         if (step > 0) {
           // perturb the first element (diagonal if Laplace), on host
@@ -161,11 +159,20 @@ int driver(const std::string file, const std::string method_name, const int vari
         }
         // copy A to device
         Kokkos::deep_copy(values_on_device, A.Values());
+        if (step%2 == 0) {
+          /// > test "shift diag" code path
+          solver.shiftDiagonal(1);
+          solver.useDefaultPivotTolerance(0);
+        } else {
+          /// > test "replace tiny pivot" code path
+          solver.shiftDiagonal(0);
+          solver.useDefaultPivotTolerance(1);
+        }
         /// do numerical factorization
         if (single_solve) {
           r_val = solver.factorize(values_on_device);
         } else {
-          if (step%2 == 1) {
+          if (single_solve || step%2 == 1) {
             // User-specified method
             r_val = solver.factorize(values_on_device);
           } else {
@@ -174,12 +181,13 @@ int driver(const std::string file, const std::string method_name, const int vari
           }
         }
         typename Tacho::ArithTraits<value_type>::mag_type shift = solver.currentShift();
-        std::cout << "  > Diagonal entries shifted by " << shift << std::endl;
+        std::cout << "  > Diagonal entries shifted by " << shift << std::endl << std::endl;
 
         /// solve
-        DenseMultiVectorType b("b", A.NumRows(), nrhs), // rhs multivector
-          x("x", A.NumRows(), nrhs),                    // solution multivector
-          t("t", A.NumRows(), nrhs);                    // temp workspace (store permuted rhs)
+        int nrhs_s = (step == 0 ? 1 : nrhs);
+        DenseMultiVectorType b("b", A.NumRows(), nrhs_s), // rhs multivector
+          x("x", A.NumRows(), nrhs_s),                    // solution multivector
+          t("t", A.NumRows(), nrhs_s);                    // temp workspace (store permuted rhs)
         if(r_val == 0) {
           const value_type zero(0.0);
           const value_type one (1.0);

--- a/packages/shylu/shylu_node/tacho/unit-test/Tacho_TestSolver.cpp
+++ b/packages/shylu/shylu_node/tacho/unit-test/Tacho_TestSolver.cpp
@@ -152,6 +152,9 @@ int driver(const std::string file, const std::string method_name, const int vari
     auto values_on_device = Kokkos::create_mirror_view(typename device_type::memory_space(), A.Values());
 
     int num_setups = (single_setup ? 1 : 2); // number of symbolic calls
+    DenseMultiVectorType b("b", A.NumRows(), 1), // rhs multivector
+      x("x", A.NumRows(), 1),                    // solution multivector
+      t("t", A.NumRows(), 1);                    // temp workspace (store permuted rhs)
     for (int s = 0; s < num_setups; s++) {
       /// initialize
       r_val = solver.analyze(A.NumRows(), A.RowPtr(), A.Cols());
@@ -191,10 +194,12 @@ int driver(const std::string file, const std::string method_name, const int vari
         std::cout << "  > Diagonal entries shifted by " << shift << std::endl << std::endl;
 
         /// solve
-        int nrhs_s = (step == 0 ? 1 : nrhs);
-        DenseMultiVectorType b("b", A.NumRows(), nrhs_s), // rhs multivector
-          x("x", A.NumRows(), nrhs_s),                    // solution multivector
-          t("t", A.NumRows(), nrhs_s);                    // temp workspace (store permuted rhs)
+        if (step == 1) {
+          // first solve with one RHS, and then with "nrhs" for the rest
+          Kokkos::resize(b, A.NumRows(), nrhs); // rhs multivector
+          Kokkos::resize(x, A.NumRows(), nrhs); // solution multivector
+          Kokkos::resize(t, A.NumRows(), nrhs); // temp workspace (store permuted rhs)
+        }
         if(r_val == 0) {
           const value_type zero(0.0);
           const value_type one (1.0);


### PR DESCRIPTION

@trilinos/shylu 

## Motivation

This PR aims to improve the performance of variants 0~2 of Tacho SpTRSV
-  fence only if needed based on symbolic analysis
- add option to run all the kernels in one stream (to avoid fence)

## Related Issues

## Stakeholder Feedback

## Testing
 * add this code path to the unit-test.

## Additional Information
