### PR TITLE
Framework: Clean options for nightly builds

### DIFF
--- a/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
+++ b/packages/framework/pr_tools/PullRequestLinuxDriverTest.py
@@ -44,7 +44,7 @@ def parse_args():
                           dest="target_branch_name",
                           action='store',
                           help='Branch to merge into',
-                          required=True)
+                          required=False)
 
     required.add_argument('--genconfig-build-name',
                           dest="genconfig_build_name",
@@ -56,7 +56,7 @@ def parse_args():
                           dest="pullrequest_number",
                           action='store',
                           help='The github PR number',
-                          required=True)
+                          required=False)
 
     required.add_argument('--source-dir',
                           dest="source_dir",

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -836,7 +836,12 @@ class TrilinosPRConfigurationBase(object):
             self.message("+" + "-"*68 + "+")
             self.message("|   S K I P P I N G   `packageEnables.cmake`   G E N E R A T I O N")
             self.message("+" + "-"*68 + "+")
-
+            self.message("Creating dummy packageEnables.cmake and "
+                         "package_subproject_list.cmake for CTest drivers.")
+            with open(self.arg_filename_packageenables, 'w'):
+                pass
+            with open(self.arg_filename_subprojects, 'w'):
+                pass
         else:
             self.message("+" + "-"*68 + "+")
             self.message("|   G e n e r a t e   `packageEnables.cmake`   S T A R T I N G")

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -322,14 +322,19 @@ class TrilinosPRConfigurationBase(object):
         """
         return self.args.pullrequest_build_name
 
+    @property
+    def arg_genconfig_build_name(self):
+        """
+        The key used for the GenConfig config_specs.ini mapping.
+        """
+        return self.args.genconfig_build_name
 
     @property
     def arg_pr_genconfig_job_name(self):
         """
-        The Jenkins job name that is executing this Pull Request test.
-        Default is to use the value in args.pullrequest_build_name.
+        Deprecated, left for backwards compatibility.
         """
-        return self.args.genconfig_build_name
+        return self.arg_genconfig_build_name
 
     @property
     def arg_dashboard_build_name(self):
@@ -524,11 +529,11 @@ class TrilinosPRConfigurationBase(object):
         if self.arg_dashboard_build_name:
             output = self.arg_dashboard_build_name
         elif "Pull Request" in self.arg_pullrequest_cdash_track:
-            output = f"PR-{self.arg_pullrequest_number}-test-{self.arg_pr_genconfig_job_name}"
+            output = f"PR-{self.arg_pullrequest_number}-test-{self.arg_genconfig_build_name}"
             if self.arg_jenkins_job_number:
                 output = f"{output}-{self.arg_jenkins_job_number}"
         else:
-            output = self.arg_pr_genconfig_job_name
+            output = self.arg_genconfig_build_name
         return output
 
 
@@ -749,7 +754,7 @@ class TrilinosPRConfigurationBase(object):
         self.message("--- arg_pr_env_config_file      = {}".format(self.arg_pr_env_config_file))
         self.message("--- arg_pr_gen_config_file      = {}".format(self.arg_pr_gen_config_file))
         self.message("--- arg_pr_jenkins_job_name     = {}".format(self.arg_pr_jenkins_job_name))
-        self.message("--- arg_pr_genconfig_job_name   = {}".format(self.arg_pr_genconfig_job_name))
+        self.message("--- arg_genconfig_build_name   = {}".format(self.arg_genconfig_build_name))
         self.message("--- arg_dashboard_build_name    = {}".format(self.arg_dashboard_build_name))
         self.message("--- arg_pullrequest_number      = {}".format(self.arg_pullrequest_number))
         self.message("--- arg_pullrequest_cdash_track = {}".format(self.arg_pullrequest_cdash_track))
@@ -776,7 +781,7 @@ class TrilinosPRConfigurationBase(object):
         self.message("+" + "-"*68 + "+")
         self.message("|   E N V I R O N M E N T   S E T   U P   S T A R T")
         self.message("+" + "-"*68 + "+")
-        tr_env = LoadEnv([self.arg_pr_genconfig_job_name, "--force"],
+        tr_env = LoadEnv([self.arg_genconfig_build_name, "--force"],
                          load_env_ini_file=Path(self.arg_pr_env_config_file))
         tr_env.load_set_environment()
 

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -832,7 +832,7 @@ class TrilinosPRConfigurationBase(object):
         self.message("|   E N V I R O N M E N T   S E T   U P   C O M P L E T E")
         self.message("+" + "-"*68 + "+")
 
-        if self.arg_skip_create_packageenables:
+        if self.arg_skip_create_packageenables or self.arg_genconfig_build_name.endswith("_all"):
             self.message("+" + "-"*68 + "+")
             self.message("|   S K I P P I N G   `packageEnables.cmake`   G E N E R A T I O N")
             self.message("+" + "-"*68 + "+")

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationInstallation.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationInstallation.py
@@ -44,7 +44,7 @@ class TrilinosPRConfigurationInstallation(TrilinosPRConfigurationBase):
                              "--force",
                              "--cmake-fragment",
                              os.path.join(self.arg_workspace_dir, self.config_script),
-                             self.arg_pr_genconfig_job_name
+                             self.arg_genconfig_build_name
                              ]
         genconfig_inifile = Path(self.arg_pr_gen_config_file)
 

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
@@ -54,15 +54,6 @@ class TrilinosPRConfigurationStandard(TrilinosPRConfigurationBase):
         if not self.args.dry_run:
             gc.write_cmake_fragment()
 
-        if self.arg_skip_create_packageenables:
-            print("Optional --skip_create_packageenables found. " +
-                    "Creating dummy packageEnables.cmake and package_subproject_list.cmake " +
-                    "for CTest drivers.")
-            with open(self.arg_filename_packageenables, 'w'):
-                pass
-            with open(self.arg_filename_subprojects, 'w'):
-                pass
-
         # Execute the call to ctest.
         cmd = ['ctest',
                 "-V",

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
@@ -43,7 +43,7 @@ class TrilinosPRConfigurationStandard(TrilinosPRConfigurationBase):
                              "--force",
                              "--cmake-fragment",
                              os.path.join(self.arg_workspace_dir, self.config_script),
-                             self.arg_pr_genconfig_job_name
+                             self.arg_genconfig_build_name
                              ]
 
         genconfig_inifile = Path(self.arg_pr_gen_config_file)

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -684,7 +684,7 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
     def test_TrilinosPRConfigurationBase_prepare_test_skip_create_package_enables_file(self):
         """
         Test that the prepare_test method does not call the member function create_package_enables_file
-        when skip_create_packageenables is True
+        when skip_create_packageenables is True, but ensure the expected files are still present.
         """
         args = self.dummy_args()
         args.skip_create_packageenables = True
@@ -694,6 +694,8 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         pr_config.prepare_test()
 
         pr_config.create_package_enables_file.assert_not_called()
+        self.assertTrue(os.path.isfile(pr_config.arg_filename_packageenables))
+        self.assertTrue(os.path.isfile(pr_config.arg_filename_subprojects))
 
 
     def test_TrilinosPRConfigurationBase_prepare_test_FAIL(self):

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -698,6 +698,23 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         self.assertTrue(os.path.isfile(pr_config.arg_filename_subprojects))
 
 
+    def test_TrilinosPRConfigurationBase_prepare_test_all_enabled_skips_packageenables(self):
+        """
+        Test that the prepare_test method does not call the member function create_package_enables_file
+        if the GenConfig key would enable all packages (no need to decide which packages then).
+        """
+        args = self.dummy_args()
+        args.genconfig_build_name = "rhel8_sems-gnu-openmpi_release_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_all"
+        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
+
+        pr_config.create_package_enables_file = Mock()
+        pr_config.prepare_test()
+
+        pr_config.create_package_enables_file.assert_not_called()
+        self.assertTrue(os.path.isfile(pr_config.arg_filename_packageenables))
+        self.assertTrue(os.path.isfile(pr_config.arg_filename_subprojects))
+
+
     def test_TrilinosPRConfigurationBase_prepare_test_FAIL(self):
         """
         Test the prepare_test method where it would fail due to


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Want to reduce required options so that it's easier to call the tool in nightly build use cases (specifically nightly builds are currently throwing an error because they don't pass `--pullrequest-number`).

I did some other small cleanup and increased test coverage marginally on the PR tooling while I was in there as well.

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-747
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-753