### PR TITLE
Tpetra: refactor duplicated `kokkos_kernels_mult_A_B_newmatrix`

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
@@ -39,11 +39,6 @@ struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosCudaWrapperNode> {
     (void)Bmerged;
 #endif
   }
-
-  template <class RowMapType, class EntriesType, class ValuesType>
-  static void sort_entries(const RowMapType& row_map, const EntriesType& entries, const ValuesType& values) {
-    Import_Util::sortCrsEntries(row_map, entries, values);
-  }
 };
 
 /*********************************************************************************************************/

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
@@ -21,10 +21,6 @@ struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosCudaWrapperNode> {
   static constexpr bool use_time_monitor = true;
   static std::string parameter_prefix() { return "cuda"; }
   static std::string algorithm_label() { return "Cuda"; }
-  static std::string wrapper_label() { return "CudaWrapper"; }
-  static std::string core_label() { return "CudaCore"; }
-  static std::string sort_label() { return "CudaSort"; }
-  static std::string esfc_label() { return "CudaESFC"; }
 
   template <class MatrixType>
   static void pre_spgemm(MatrixType& Bmerged) {

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
@@ -18,7 +18,7 @@ namespace MMdetails {
 
 template <>
 struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosCudaWrapperNode> {
-  static constexpr bool use_time_monitor = false;
+  static constexpr bool use_time_monitor = true;
   static std::string parameter_prefix() { return "cuda"; }
   static std::string algorithm_label() { return "Cuda"; }
   static std::string wrapper_label() { return "CudaWrapper"; }

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
@@ -18,6 +18,7 @@ namespace MMdetails {
 
 template <>
 struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosCudaWrapperNode> {
+  static constexpr bool use_time_monitor = false;
   static std::string parameter_prefix() { return "cuda"; }
   static std::string algorithm_label() { return "Cuda"; }
   static std::string wrapper_label() { return "CudaWrapper"; }

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
@@ -18,7 +18,6 @@ namespace MMdetails {
 
 template <>
 struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosCudaWrapperNode> {
-  static constexpr bool use_time_monitor = true;
   static std::string parameter_prefix() { return "cuda"; }
   static std::string algorithm_label() { return "Cuda"; }
 

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
@@ -16,6 +16,35 @@
 namespace Tpetra {
 namespace MMdetails {
 
+template <>
+struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosCudaWrapperNode> {
+  static std::string parameter_prefix() { return "cuda"; }
+  static std::string algorithm_label() { return "Cuda"; }
+  static std::string wrapper_label() { return "CudaWrapper"; }
+  static std::string core_label() { return "CudaCore"; }
+  static std::string sort_label() { return "CudaSort"; }
+  static std::string esfc_label() { return "CudaESFC"; }
+
+  template <class MatrixType>
+  static void pre_spgemm(MatrixType& Bmerged) {
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && ((CUDA_VERSION < 11000) || (CUDA_VERSION >= 11040))
+    using device_t = typename MatrixType::device_type;
+    if constexpr (std::is_same_v<typename device_t::execution_space, Kokkos::Cuda>) {
+      if (!KokkosSparse::isCrsGraphSorted(Bmerged.graph.row_map, Bmerged.graph.entries)) {
+        Import_Util::sortCrsMatrix(Bmerged);
+      }
+    }
+#else
+    (void)Bmerged;
+#endif
+  }
+
+  template <class RowMapType, class EntriesType, class ValuesType>
+  static void sort_entries(const RowMapType& row_map, const EntriesType& entries, const ValuesType& values) {
+    Import_Util::sortCrsEntries(row_map, entries, values);
+  }
+};
+
 /*********************************************************************************************************/
 // MMM KernelWrappers for Partial Specialization to CUDA
 template <class Scalar,
@@ -107,162 +136,8 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
                                                                                                                                                                Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::KokkosCudaWrapperNode> > Cimport,
                                                                                                                                                                const std::string& label,
                                                                                                                                                                const Teuchos::RCP<Teuchos::ParameterList>& params) {
-  using Teuchos::RCP;
-  using Teuchos::rcp;
-  RCP<Tpetra::Details::ProfilingRegion> MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix CudaWrapper"));
-
-  // Node-specific code
-  typedef Tpetra::KokkosCompat::KokkosCudaWrapperNode Node;
-  std::string nodename("Cuda");
-
-  // Lots and lots of typedefs
-  typedef typename Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::local_matrix_device_type KCRS;
-  typedef typename KCRS::device_type device_t;
-  typedef typename KCRS::StaticCrsGraphType graph_t;
-  typedef typename graph_t::row_map_type::non_const_type lno_view_t;
-  using int_view_t = Kokkos::View<int*, typename lno_view_t::array_layout, typename lno_view_t::memory_space, typename lno_view_t::memory_traits>;
-  typedef typename graph_t::row_map_type::const_type c_lno_view_t;
-  typedef typename graph_t::entries_type::non_const_type lno_nnz_view_t;
-  typedef typename KCRS::values_type::non_const_type scalar_view_t;
-  // typedef typename graph_t::row_map_type::const_type lno_view_t_const;
-
-  // Options
-  int team_work_size = 16;  // Defaults to 16 as per Deveci 12/7/16 - csiefer
-  std::string myalg("SPGEMM_DEFAULT");
-  if (!params.is_null()) {
-    if (params->isParameter("cuda: algorithm"))
-      myalg = params->get("cuda: algorithm", myalg);
-    if (params->isParameter("cuda: team work size"))
-      team_work_size = params->get("cuda: team work size", team_work_size);
-  }
-
-  // KokkosKernelsHandle
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle<
-      typename lno_view_t::const_value_type, typename lno_nnz_view_t::const_value_type, typename scalar_view_t::const_value_type,
-      typename device_t::execution_space, typename device_t::memory_space, typename device_t::memory_space>
-      KernelHandle;
-  using IntKernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<
-      typename int_view_t::const_value_type, typename lno_nnz_view_t::const_value_type, typename scalar_view_t::const_value_type,
-      typename device_t::execution_space, typename device_t::memory_space, typename device_t::memory_space>;
-
-  // Grab the  Kokkos::SparseCrsMatrices
-  const KCRS Amat = Aview.origMatrix->getLocalMatrixDevice();
-  const KCRS Bmat = Bview.origMatrix->getLocalMatrixDevice();
-
-  c_lno_view_t Arowptr         = Amat.graph.row_map,
-               Browptr         = Bmat.graph.row_map;
-  const lno_nnz_view_t Acolind = Amat.graph.entries,
-                       Bcolind = Bmat.graph.entries;
-  const scalar_view_t Avals    = Amat.values,
-                      Bvals    = Bmat.values;
-
-  // Get the algorithm mode
-  std::string alg = nodename + std::string(" algorithm");
-  //  printf("DEBUG: Using kernel: %s\n",myalg.c_str());
-  if (!params.is_null() && params->isParameter(alg)) myalg = params->get(alg, myalg);
-  KokkosSparse::SPGEMMAlgorithm alg_enum = KokkosSparse::StringToSPGEMMAlgorithm(myalg);
-
-  // Merge the B and Bimport matrices
-  KCRS Bmerged = Tpetra::MMdetails::merge_matrices(Aview, Bview, Acol2Brow, Acol2Irow, Bcol2Ccol, Icol2Ccol, C.getColMap()->getLocalNumElements());
-
-  // if Kokkos Kernels is going to use the cuSparse TPL for SpGEMM, this matrix
-  // needs to be sorted
-  // Try to mirror the Kokkos Kernels internal SpGEMM TPL use logic
-  // inspired by https://github.com/trilinos/Trilinos/pull/11709
-  // and https://github.com/kokkos/kokkos-kernels/pull/2008
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && ((CUDA_VERSION < 11000) || (CUDA_VERSION >= 11040))
-  if constexpr (std::is_same_v<typename device_t::execution_space, Kokkos::Cuda>) {
-    if (!KokkosSparse::isCrsGraphSorted(Bmerged.graph.row_map, Bmerged.graph.entries)) {
-      Import_Util::sortCrsMatrix(Bmerged);
-    }
-  }
-#endif
-
-  MM = Teuchos::null;
-  MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix CudaCore"));
-
-  // Do the multiply on whatever we've got
-  typename KernelHandle::nnz_lno_t AnumRows = Amat.numRows();
-  typename KernelHandle::nnz_lno_t BnumRows = Bmerged.numRows();
-  typename KernelHandle::nnz_lno_t BnumCols = Bmerged.numCols();
-
-  // regardless of whether integer row ptrs are used, need to ultimately produce the row pointer, entries, and values of the expected types
-  lno_view_t row_mapC(Kokkos::ViewAllocateWithoutInitializing("non_const_lno_row"), AnumRows + 1);
-  lno_nnz_view_t entriesC;
-  scalar_view_t valuesC;
-
-  Tpetra::Details::IntRowPtrHelper<decltype(Bmerged)> irph(Bmerged.nnz(), Bmerged.graph.row_map);
-  const bool useIntRowptrs =
-      irph.shouldUseIntRowptrs() &&
-      Aview.origMatrix->getApplyHelper()->shouldUseIntRowptrs();
-
-  if (useIntRowptrs) {
-    IntKernelHandle kh;
-    kh.create_spgemm_handle(alg_enum);
-    kh.set_team_work_size(team_work_size);
-
-    int_view_t int_row_mapC(Kokkos::ViewAllocateWithoutInitializing("non_const_int_row"), AnumRows + 1);
-
-    auto Aint = Aview.origMatrix->getApplyHelper()->getIntRowptrMatrix(Amat);
-    auto Bint = irph.getIntRowptrMatrix(Bmerged);
-
-    {
-      Tpetra::Details::ProfilingRegion MM2("TpetraExt: MMM: Newmatrix KokkosKernels symbolic int");
-      KokkosSparse::spgemm_symbolic(&kh, AnumRows, BnumRows, BnumCols, Aint.graph.row_map, Aint.graph.entries, false, Bint.graph.row_map, Bint.graph.entries, false, int_row_mapC);
-    }
-
-    Tpetra::Details::ProfilingRegion MM2("TpetraExt: MMM: Newmatrix KokkosKernels numeric int");
-
-    size_t c_nnz_size = kh.get_spgemm_handle()->get_c_nnz();
-    if (c_nnz_size) {
-      entriesC = lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
-      valuesC  = scalar_view_t(Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
-    }
-    KokkosSparse::spgemm_numeric(&kh, AnumRows, BnumRows, BnumCols, Aint.graph.row_map, Aint.graph.entries, Aint.values, false, Bint.graph.row_map, Bint.graph.entries, Bint.values, false, int_row_mapC, entriesC, valuesC);
-    // transfer the integer rowptrs back to the correct rowptr type
-    Kokkos::parallel_for(
-        int_row_mapC.size(), KOKKOS_LAMBDA(int i) { row_mapC(i) = int_row_mapC(i); });
-    kh.destroy_spgemm_handle();
-
-  } else {
-    KernelHandle kh;
-    kh.create_spgemm_handle(alg_enum);
-    kh.set_team_work_size(team_work_size);
-
-    {
-      Tpetra::Details::ProfilingRegion MM2("TpetraExt: Jacobi: Newmatrix KokkosKernels symbolic non-int");
-      KokkosSparse::spgemm_symbolic(&kh, AnumRows, BnumRows, BnumCols, Amat.graph.row_map, Amat.graph.entries, false, Bmerged.graph.row_map, Bmerged.graph.entries, false, row_mapC);
-    }
-
-    Tpetra::Details::ProfilingRegion MM2("TpetraExt: Jacobi: Newmatrix KokkosKernels numeric non-int");
-    size_t c_nnz_size = kh.get_spgemm_handle()->get_c_nnz();
-    if (c_nnz_size) {
-      entriesC = lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
-      valuesC  = scalar_view_t(Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
-    }
-
-    KokkosSparse::spgemm_numeric(&kh, AnumRows, BnumRows, BnumCols, Amat.graph.row_map, Amat.graph.entries, Amat.values, false, Bmerged.graph.row_map, Bmerged.graph.entries, Bmerged.values, false, row_mapC, entriesC, valuesC);
-
-    kh.destroy_spgemm_handle();
-  }
-
-  MM = Teuchos::null;
-  MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix CudaSort"));
-
-  // Sort & set values
-  if (params.is_null() || params->get("sort entries", true))
-    Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC);
-  C.setAllValues(row_mapC, entriesC, valuesC);
-
-  MM = Teuchos::null;
-  MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix CudaESFC"));
-
-  // Final Fillcomplete
-  RCP<Teuchos::ParameterList> labelList = rcp(new Teuchos::ParameterList);
-  labelList->set("Timer Label", label);
-  if (!params.is_null()) labelList->set("compute global constants", params->get("compute global constants", true));
-  RCP<const Export<LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::KokkosCudaWrapperNode> > dummyExport;
-  C.expertStaticFillComplete(Bview.origMatrix->getDomainMap(), Aview.origMatrix->getRangeMap(), Cimport, dummyExport, labelList);
+  Tpetra::MMdetails::kokkos_kernels_mult_A_B_newmatrix(
+      Aview, Bview, Acol2Brow, Acol2Irow, Bcol2Ccol, Icol2Ccol, C, Cimport, label, params);
 }
 
 /*********************************************************************************************************/

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_HIP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_HIP.hpp
@@ -18,6 +18,7 @@ namespace MMdetails {
 
 template <>
 struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosHIPWrapperNode> {
+  static constexpr bool use_time_monitor = false;
   static std::string parameter_prefix() { return "hip"; }
   static std::string algorithm_label() { return "HIP"; }
   static std::string wrapper_label() { return "HIPWrapper"; }

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_HIP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_HIP.hpp
@@ -18,7 +18,6 @@ namespace MMdetails {
 
 template <>
 struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosHIPWrapperNode> {
-  static constexpr bool use_time_monitor = true;
   static std::string parameter_prefix() { return "hip"; }
   static std::string algorithm_label() { return "HIP"; }
 

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_HIP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_HIP.hpp
@@ -18,7 +18,7 @@ namespace MMdetails {
 
 template <>
 struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosHIPWrapperNode> {
-  static constexpr bool use_time_monitor = false;
+  static constexpr bool use_time_monitor = true;
   static std::string parameter_prefix() { return "hip"; }
   static std::string algorithm_label() { return "HIP"; }
   static std::string wrapper_label() { return "HIPWrapper"; }

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_HIP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_HIP.hpp
@@ -28,11 +28,6 @@ struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosHIPWrapperNode> {
 
   template <class MatrixType>
   static void pre_spgemm(MatrixType&) {}
-
-  template <class RowMapType, class EntriesType, class ValuesType>
-  static void sort_entries(const RowMapType& row_map, const EntriesType& entries, const ValuesType& values) {
-    Import_Util::sortCrsEntries(row_map, entries, values);
-  }
 };
 
 /*********************************************************************************************************/

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_HIP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_HIP.hpp
@@ -21,10 +21,6 @@ struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosHIPWrapperNode> {
   static constexpr bool use_time_monitor = true;
   static std::string parameter_prefix() { return "hip"; }
   static std::string algorithm_label() { return "HIP"; }
-  static std::string wrapper_label() { return "HIPWrapper"; }
-  static std::string core_label() { return "HIP Core"; }
-  static std::string sort_label() { return "HIP Sort"; }
-  static std::string esfc_label() { return "HIP ESFC"; }
 
   template <class MatrixType>
   static void pre_spgemm(MatrixType&) {}

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_HIP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_HIP.hpp
@@ -16,6 +16,24 @@
 namespace Tpetra {
 namespace MMdetails {
 
+template <>
+struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosHIPWrapperNode> {
+  static std::string parameter_prefix() { return "hip"; }
+  static std::string algorithm_label() { return "HIP"; }
+  static std::string wrapper_label() { return "HIPWrapper"; }
+  static std::string core_label() { return "HIP Core"; }
+  static std::string sort_label() { return "HIP Sort"; }
+  static std::string esfc_label() { return "HIP ESFC"; }
+
+  template <class MatrixType>
+  static void pre_spgemm(MatrixType&) {}
+
+  template <class RowMapType, class EntriesType, class ValuesType>
+  static void sort_entries(const RowMapType& row_map, const EntriesType& entries, const ValuesType& values) {
+    Import_Util::sortCrsEntries(row_map, entries, values);
+  }
+};
+
 /*********************************************************************************************************/
 // MMM KernelWrappers for Partial Specialization to HIP
 template <class Scalar,
@@ -107,146 +125,8 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
                                                                                                                                                               Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::KokkosHIPWrapperNode> > Cimport,
                                                                                                                                                               const std::string& label,
                                                                                                                                                               const Teuchos::RCP<Teuchos::ParameterList>& params) {
-  // Node-specific code
-  typedef Tpetra::KokkosCompat::KokkosHIPWrapperNode Node;
-  std::string nodename("HIP");
-
-  // Lots and lots of typedefs
-  using Teuchos::RCP;
-  using Teuchos::rcp;
-  typedef typename Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::local_matrix_device_type KCRS;
-  typedef typename KCRS::device_type device_t;
-  typedef typename KCRS::StaticCrsGraphType graph_t;
-  typedef typename graph_t::row_map_type::non_const_type lno_view_t;
-  using int_view_t = Kokkos::View<int*, typename lno_view_t::array_layout, typename lno_view_t::memory_space, typename lno_view_t::memory_traits>;
-  typedef typename graph_t::row_map_type::const_type c_lno_view_t;
-  typedef typename graph_t::entries_type::non_const_type lno_nnz_view_t;
-  typedef typename KCRS::values_type::non_const_type scalar_view_t;
-  // typedef typename graph_t::row_map_type::const_type lno_view_t_const;
-
-  RCP<Tpetra::Details::ProfilingRegion> MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix HIPWrapper"));
-
-  // Options
-  int team_work_size = 16;  // Defaults to 16 as per Deveci 12/7/16 - csiefer
-  std::string myalg("SPGEMM_DEFAULT");
-  if (!params.is_null()) {
-    if (params->isParameter("hip: algorithm"))
-      myalg = params->get("hip: algorithm", myalg);
-    if (params->isParameter("hip: team work size"))
-      team_work_size = params->get("hip: team work size", team_work_size);
-  }
-
-  // KokkosKernelsHandle
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle<
-      typename lno_view_t::const_value_type, typename lno_nnz_view_t::const_value_type, typename scalar_view_t::const_value_type,
-      typename device_t::execution_space, typename device_t::memory_space, typename device_t::memory_space>
-      KernelHandle;
-  using IntKernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<
-      typename int_view_t::const_value_type, typename lno_nnz_view_t::const_value_type, typename scalar_view_t::const_value_type,
-      typename device_t::execution_space, typename device_t::memory_space, typename device_t::memory_space>;
-
-  // Grab the  Kokkos::SparseCrsMatrices
-  const KCRS Amat = Aview.origMatrix->getLocalMatrixDevice();
-  const KCRS Bmat = Bview.origMatrix->getLocalMatrixDevice();
-
-  c_lno_view_t Arowptr         = Amat.graph.row_map,
-               Browptr         = Bmat.graph.row_map;
-  const lno_nnz_view_t Acolind = Amat.graph.entries,
-                       Bcolind = Bmat.graph.entries;
-  const scalar_view_t Avals    = Amat.values,
-                      Bvals    = Bmat.values;
-
-  // Get the algorithm mode
-  std::string alg = nodename + std::string(" algorithm");
-  //  printf("DEBUG: Using kernel: %s\n",myalg.c_str());
-  if (!params.is_null() && params->isParameter(alg)) myalg = params->get(alg, myalg);
-  KokkosSparse::SPGEMMAlgorithm alg_enum = KokkosSparse::StringToSPGEMMAlgorithm(myalg);
-
-  // Merge the B and Bimport matrices
-  const KCRS Bmerged = Tpetra::MMdetails::merge_matrices(Aview, Bview, Acol2Brow, Acol2Irow, Bcol2Ccol, Icol2Ccol, C.getColMap()->getLocalNumElements());
-
-  MM = Teuchos::null;
-  MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix HIP Core"));
-
-  // Do the multiply on whatever we've got
-  typename KernelHandle::nnz_lno_t AnumRows = Amat.numRows();
-  typename KernelHandle::nnz_lno_t BnumRows = Bmerged.numRows();
-  typename KernelHandle::nnz_lno_t BnumCols = Bmerged.numCols();
-
-  // regardless of whether integer row ptrs are used, need to ultimately produce the row pointer, entries, and values of the expected types
-  lno_view_t row_mapC(Kokkos::ViewAllocateWithoutInitializing("non_const_lno_row"), AnumRows + 1);
-  lno_nnz_view_t entriesC;
-  scalar_view_t valuesC;
-
-  Tpetra::Details::IntRowPtrHelper<decltype(Bmerged)> irph(Bmerged.nnz(), Bmerged.graph.row_map);
-  const bool useIntRowptrs =
-      irph.shouldUseIntRowptrs() &&
-      Aview.origMatrix->getApplyHelper()->shouldUseIntRowptrs();
-
-  if (useIntRowptrs) {
-    IntKernelHandle kh;
-    kh.create_spgemm_handle(alg_enum);
-    kh.set_team_work_size(team_work_size);
-
-    int_view_t int_row_mapC(Kokkos::ViewAllocateWithoutInitializing("non_const_int_row"), AnumRows + 1);
-
-    auto Aint = Aview.origMatrix->getApplyHelper()->getIntRowptrMatrix(Amat);
-    auto Bint = irph.getIntRowptrMatrix(Bmerged);
-
-    {
-      Tpetra::Details::ProfilingRegion MM2("TpetraExt: MMM: Newmatrix KokkosKernels symbolic int");
-      KokkosSparse::spgemm_symbolic(&kh, AnumRows, BnumRows, BnumCols, Aint.graph.row_map, Aint.graph.entries, false, Bint.graph.row_map, Bint.graph.entries, false, int_row_mapC);
-    }
-    Tpetra::Details::ProfilingRegion MM2("TpetraExt: MMM: Newmatrix KokkosKernels numeric int");
-
-    size_t c_nnz_size = kh.get_spgemm_handle()->get_c_nnz();
-    if (c_nnz_size) {
-      entriesC = lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
-      valuesC  = scalar_view_t(Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
-    }
-    KokkosSparse::spgemm_numeric(&kh, AnumRows, BnumRows, BnumCols, Aint.graph.row_map, Aint.graph.entries, Aint.values, false, Bint.graph.row_map, Bint.graph.entries, Bint.values, false, int_row_mapC, entriesC, valuesC);
-    // transfer the integer rowptrs back to the correct rowptr type
-    Kokkos::parallel_for(
-        int_row_mapC.size(), KOKKOS_LAMBDA(int i) { row_mapC(i) = int_row_mapC(i); });
-    kh.destroy_spgemm_handle();
-  } else {
-    KernelHandle kh;
-    kh.create_spgemm_handle(alg_enum);
-    kh.set_team_work_size(team_work_size);
-
-    {
-      Tpetra::Details::ProfilingRegion MM2("TpetraExt: MMM: Newmatrix KokkosKernels symbolic non-int");
-      KokkosSparse::spgemm_symbolic(&kh, AnumRows, BnumRows, BnumCols, Amat.graph.row_map, Amat.graph.entries, false, Bmerged.graph.row_map, Bmerged.graph.entries, false, row_mapC);
-    }
-
-    size_t c_nnz_size = kh.get_spgemm_handle()->get_c_nnz();
-    if (c_nnz_size) {
-      entriesC = lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
-      valuesC  = scalar_view_t(Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
-    }
-
-    Tpetra::Details::ProfilingRegion MM2("TpetraExt: MMM: Newmatrix KokkosKernels numeric non-int");
-    KokkosSparse::spgemm_numeric(&kh, AnumRows, BnumRows, BnumCols, Amat.graph.row_map, Amat.graph.entries, Amat.values, false, Bmerged.graph.row_map, Bmerged.graph.entries, Bmerged.values, false, row_mapC, entriesC, valuesC);
-    kh.destroy_spgemm_handle();
-  }
-
-  MM = Teuchos::null;
-  MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix HIP Sort"));
-
-  // Sort & set values
-  if (params.is_null() || params->get("sort entries", true))
-    Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC);
-  C.setAllValues(row_mapC, entriesC, valuesC);
-
-  MM = Teuchos::null;
-  MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix HIP ESFC"));
-
-  // Final Fillcomplete
-  RCP<Teuchos::ParameterList> labelList = rcp(new Teuchos::ParameterList);
-  labelList->set("Timer Label", label);
-  if (!params.is_null()) labelList->set("compute global constants", params->get("compute global constants", true));
-  RCP<const Export<LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::KokkosHIPWrapperNode> > dummyExport;
-  C.expertStaticFillComplete(Bview.origMatrix->getDomainMap(), Aview.origMatrix->getRangeMap(), Cimport, dummyExport, labelList);
+  Tpetra::MMdetails::kokkos_kernels_mult_A_B_newmatrix(
+      Aview, Bview, Acol2Brow, Acol2Irow, Bcol2Ccol, Icol2Ccol, C, Cimport, label, params);
 }
 
 /*********************************************************************************************************/

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
@@ -19,10 +19,6 @@ struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosOpenMPWrapperNode>
   static constexpr bool use_time_monitor = true;
   static std::string parameter_prefix() { return "openmp"; }
   static std::string algorithm_label() { return "OpenMP"; }
-  static std::string wrapper_label() { return "OpenMPWrapper"; }
-  static std::string core_label() { return "OpenMPCore"; }
-  static std::string sort_label() { return "OpenMPSort"; }
-  static std::string esfc_label() { return "OpenMPESFC"; }
 
   template <class MatrixType>
   static void pre_spgemm(MatrixType&) {}

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
@@ -16,7 +16,6 @@ namespace MMdetails {
 
 template <>
 struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosOpenMPWrapperNode> {
-  static constexpr bool use_time_monitor = true;
   static std::string parameter_prefix() { return "openmp"; }
   static std::string algorithm_label() { return "OpenMP"; }
 

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
@@ -26,11 +26,6 @@ struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosOpenMPWrapperNode>
 
   template <class MatrixType>
   static void pre_spgemm(MatrixType&) {}
-
-  template <class RowMapType, class EntriesType, class ValuesType>
-  static void sort_entries(const RowMapType& row_map, const EntriesType& entries, const ValuesType& values) {
-    Import_Util::sortCrsEntries(row_map, entries, values);
-  }
 };
 
 /*********************************************************************************************************/

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
@@ -16,6 +16,7 @@ namespace MMdetails {
 
 template <>
 struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosOpenMPWrapperNode> {
+  static constexpr bool use_time_monitor = true;
   static std::string parameter_prefix() { return "openmp"; }
   static std::string algorithm_label() { return "OpenMP"; }
   static std::string wrapper_label() { return "OpenMPWrapper"; }

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
@@ -14,6 +14,24 @@
 namespace Tpetra {
 namespace MMdetails {
 
+template <>
+struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosOpenMPWrapperNode> {
+  static std::string parameter_prefix() { return "openmp"; }
+  static std::string algorithm_label() { return "OpenMP"; }
+  static std::string wrapper_label() { return "OpenMPWrapper"; }
+  static std::string core_label() { return "OpenMPCore"; }
+  static std::string sort_label() { return "OpenMPSort"; }
+  static std::string esfc_label() { return "OpenMPESFC"; }
+
+  template <class MatrixType>
+  static void pre_spgemm(MatrixType&) {}
+
+  template <class RowMapType, class EntriesType, class ValuesType>
+  static void sort_entries(const RowMapType& row_map, const EntriesType& entries, const ValuesType& values) {
+    Import_Util::sortCrsEntries(row_map, entries, values);
+  }
+};
+
 /*********************************************************************************************************/
 // MMM KernelWrappers for Partial Specialization to OpenMP
 template <class Scalar,
@@ -155,116 +173,20 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
                                                                                                                                                                  Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode> > Cimport,
                                                                                                                                                                  const std::string& label,
                                                                                                                                                                  const Teuchos::RCP<Teuchos::ParameterList>& params) {
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-  std::string prefix_mmm = std::string("TpetraExt ") + label + std::string(": ");
-  using Teuchos::TimeMonitor;
-  Teuchos::RCP<TimeMonitor> MM;
-#endif
-
-  // Node-specific code
-  std::string nodename("OpenMP");
-
-  // Lots and lots of typedefs
-  using Teuchos::RCP;
-  typedef typename Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode>::local_matrix_device_type KCRS;
-  typedef typename KCRS::device_type device_t;
-  typedef typename KCRS::StaticCrsGraphType graph_t;
-  typedef typename graph_t::row_map_type::non_const_type lno_view_t;
-  typedef typename graph_t::entries_type::non_const_type lno_nnz_view_t;
-  typedef typename KCRS::values_type::non_const_type scalar_view_t;
-
-  // Options
-  int team_work_size = 16;  // Defaults to 16 as per Deveci 12/7/16 - csiefer
   std::string myalg("SPGEMM_DEFAULT");
 
   if (!params.is_null()) {
     if (params->isParameter("openmp: algorithm"))
       myalg = params->get("openmp: algorithm", myalg);
-    if (params->isParameter("openmp: team work size"))
-      team_work_size = params->get("openmp: team work size", team_work_size);
   }
 
   if (myalg == "LTG") {
     // Use the LTG kernel if requested
     ::Tpetra::MatrixMatrix::ExtraKernels::mult_A_B_newmatrix_LowThreadGustavsonKernel(Aview, Bview, Acol2Brow, Acol2Irow, Bcol2Ccol, Icol2Ccol, C, Cimport, label, params);
   } else {
-    // Use the Kokkos-Kernels OpenMP Kernel
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix OpenMPWrapper"))));
-#endif
-    // KokkosKernelsHandle
-    typedef KokkosKernels::Experimental::KokkosKernelsHandle<
-        typename lno_view_t::const_value_type, typename lno_nnz_view_t::const_value_type, typename scalar_view_t::const_value_type,
-        typename device_t::execution_space, typename device_t::memory_space, typename device_t::memory_space>
-        KernelHandle;
-
-    // Grab the  Kokkos::SparseCrsMatrices
-    const KCRS Ak = Aview.origMatrix->getLocalMatrixDevice();
-    // const KCRS & Bk = Bview.origMatrix->getLocalMatrixDevice();
-
-    // Get the algorithm mode
-    std::string alg = nodename + std::string(" algorithm");
-    //  printf("DEBUG: Using kernel: %s\n",myalg.c_str());
-    if (!params.is_null() && params->isParameter(alg)) myalg = params->get(alg, myalg);
-    KokkosSparse::SPGEMMAlgorithm alg_enum = KokkosSparse::StringToSPGEMMAlgorithm(myalg);
-
-    // Merge the B and Bimport matrices
-    const KCRS Bmerged = Tpetra::MMdetails::merge_matrices(Aview, Bview, Acol2Brow, Acol2Irow, Bcol2Ccol, Icol2Ccol, C.getColMap()->getLocalNumElements());
-
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-    MM = Teuchos::null;
-    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix OpenMPCore"))));
-#endif
-
-    // Do the multiply on whatever we've got
-    typename KernelHandle::nnz_lno_t AnumRows = Ak.numRows();
-    //    typename KernelHandle::nnz_lno_t BnumRows = Bmerged->numRows();
-    //    typename KernelHandle::nnz_lno_t BnumCols = Bmerged->numCols();
-    typename KernelHandle::nnz_lno_t BnumRows = Bmerged.numRows();
-    typename KernelHandle::nnz_lno_t BnumCols = Bmerged.numCols();
-
-    lno_view_t row_mapC(Kokkos::ViewAllocateWithoutInitializing("non_const_lnow_row"), AnumRows + 1);
-    lno_nnz_view_t entriesC;
-    scalar_view_t valuesC;
-    KernelHandle kh;
-    kh.create_spgemm_handle(alg_enum);
-    kh.set_team_work_size(team_work_size);
-    //    KokkosSparse::spgemm_symbolic(&kh,AnumRows,BnumRows,BnumCols,Ak.graph.row_map,Ak.graph.entries,false,Bmerged->graph.row_map,Bmerged->graph.entries,false,row_mapC);
-    KokkosSparse::spgemm_symbolic(&kh, AnumRows, BnumRows, BnumCols, Ak.graph.row_map, Ak.graph.entries, false, Bmerged.graph.row_map, Bmerged.graph.entries, false, row_mapC);
-
-    size_t c_nnz_size = kh.get_spgemm_handle()->get_c_nnz();
-    if (c_nnz_size) {
-      entriesC = lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
-      valuesC  = scalar_view_t(Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
-    }
-    //    KokkosSparse::spgemm_numeric(&kh,AnumRows,BnumRows,BnumCols,Ak.graph.row_map,Ak.graph.entries,Ak.values,false,Bmerged->graph.row_map,Bmerged->graph.entries,Bmerged->values,false,row_mapC,entriesC,valuesC);
-    KokkosSparse::spgemm_numeric(&kh, AnumRows, BnumRows, BnumCols, Ak.graph.row_map, Ak.graph.entries, Ak.values, false, Bmerged.graph.row_map, Bmerged.graph.entries, Bmerged.values, false, row_mapC, entriesC, valuesC);
-    kh.destroy_spgemm_handle();
-
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-    MM = Teuchos::null;
-    MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix OpenMPSort"))));
-#endif
-    // Sort & set values
-    if (params.is_null() || params->get("sort entries", true)) {
-      // Tpetra's OpenMP SpGEMM results in almost sorted matrices. Use shell sort.
-      Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC);
-    }
-    C.setAllValues(row_mapC, entriesC, valuesC);
-
-  }  // end OMP KokkosKernels loop
-
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-  MM = Teuchos::null;
-  MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix OpenMPESFC"))));
-#endif
-
-  // Final Fillcomplete
-  RCP<Teuchos::ParameterList> labelList = rcp(new Teuchos::ParameterList);
-  labelList->set("Timer Label", label);
-  if (!params.is_null()) labelList->set("compute global constants", params->get("compute global constants", true));
-  RCP<const Export<LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode> > dummyExport;
-  C.expertStaticFillComplete(Bview.origMatrix->getDomainMap(), Aview.origMatrix->getRangeMap(), Cimport, dummyExport, labelList);
+    Tpetra::MMdetails::kokkos_kernels_mult_A_B_newmatrix(
+        Aview, Bview, Acol2Brow, Acol2Irow, Bcol2Ccol, Icol2Ccol, C, Cimport, label, params);
+  }
 
 #if 0
   {
@@ -588,7 +510,6 @@ void KernelWrappers2<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::
 
   // Sort & set values
   if (params.is_null() || params->get("sort entries", true)) {
-    // Tpetra's OpenMP SpGEMM results in almost sorted matrices. Use shell sort.
     Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC);
   }
   C.setAllValues(row_mapC, entriesC, valuesC);

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_SYCL.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_SYCL.hpp
@@ -28,11 +28,6 @@ struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosSYCLWrapperNode> {
 
   template <class MatrixType>
   static void pre_spgemm(MatrixType&) {}
-
-  template <class RowMapType, class EntriesType, class ValuesType>
-  static void sort_entries(const RowMapType& row_map, const EntriesType& entries, const ValuesType& values) {
-    Import_Util::sortCrsEntries(row_map, entries, values);
-  }
 };
 
 /*********************************************************************************************************/

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_SYCL.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_SYCL.hpp
@@ -18,6 +18,7 @@ namespace MMdetails {
 
 template <>
 struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosSYCLWrapperNode> {
+  static constexpr bool use_time_monitor = true;
   static std::string parameter_prefix() { return "sycl"; }
   static std::string algorithm_label() { return "SYCL"; }
   static std::string wrapper_label() { return "SYCLWrapper"; }

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_SYCL.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_SYCL.hpp
@@ -18,7 +18,6 @@ namespace MMdetails {
 
 template <>
 struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosSYCLWrapperNode> {
-  static constexpr bool use_time_monitor = true;
   static std::string parameter_prefix() { return "sycl"; }
   static std::string algorithm_label() { return "SYCL"; }
 

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_SYCL.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_SYCL.hpp
@@ -21,10 +21,6 @@ struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosSYCLWrapperNode> {
   static constexpr bool use_time_monitor = true;
   static std::string parameter_prefix() { return "sycl"; }
   static std::string algorithm_label() { return "SYCL"; }
-  static std::string wrapper_label() { return "SYCLWrapper"; }
-  static std::string core_label() { return "SYCLCore"; }
-  static std::string sort_label() { return "SYCLSort"; }
-  static std::string esfc_label() { return "SYCLESFC"; }
 
   template <class MatrixType>
   static void pre_spgemm(MatrixType&) {}

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_SYCL.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_SYCL.hpp
@@ -16,6 +16,24 @@
 namespace Tpetra {
 namespace MMdetails {
 
+template <>
+struct KokkosKernelsSPGEMMBackend<Tpetra::KokkosCompat::KokkosSYCLWrapperNode> {
+  static std::string parameter_prefix() { return "sycl"; }
+  static std::string algorithm_label() { return "SYCL"; }
+  static std::string wrapper_label() { return "SYCLWrapper"; }
+  static std::string core_label() { return "SYCLCore"; }
+  static std::string sort_label() { return "SYCLSort"; }
+  static std::string esfc_label() { return "SYCLESFC"; }
+
+  template <class MatrixType>
+  static void pre_spgemm(MatrixType&) {}
+
+  template <class RowMapType, class EntriesType, class ValuesType>
+  static void sort_entries(const RowMapType& row_map, const EntriesType& entries, const ValuesType& values) {
+    Import_Util::sortCrsEntries(row_map, entries, values);
+  }
+};
+
 /*********************************************************************************************************/
 // MMM KernelWrappers for Partial Specialization to SYCL
 template <class Scalar,
@@ -107,147 +125,8 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
                                                                                                                                                                Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::KokkosSYCLWrapperNode> > Cimport,
                                                                                                                                                                const std::string& label,
                                                                                                                                                                const Teuchos::RCP<Teuchos::ParameterList>& params) {
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-  std::string prefix_mmm = std::string("TpetraExt ") + label + std::string(": ");
-  using Teuchos::TimeMonitor;
-  Teuchos::RCP<TimeMonitor> MM = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix SYCLWrapper")))));
-#endif
-  // Node-specific code
-  typedef Tpetra::KokkosCompat::KokkosSYCLWrapperNode Node;
-  std::string nodename("SYCL");
-
-  // Lots and lots of typedefs
-  using Teuchos::RCP;
-  typedef typename Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::local_matrix_device_type KCRS;
-  typedef typename KCRS::device_type device_t;
-  typedef typename KCRS::StaticCrsGraphType graph_t;
-  typedef typename graph_t::row_map_type::non_const_type lno_view_t;
-  using int_view_t = Kokkos::View<int*, typename lno_view_t::array_layout, typename lno_view_t::memory_space, typename lno_view_t::memory_traits>;
-  typedef typename graph_t::row_map_type::const_type c_lno_view_t;
-  typedef typename graph_t::entries_type::non_const_type lno_nnz_view_t;
-  typedef typename KCRS::values_type::non_const_type scalar_view_t;
-  // typedef typename graph_t::row_map_type::const_type lno_view_t_const;
-
-  // Options
-  int team_work_size = 16;  // Defaults to 16 as per Deveci 12/7/16 - csiefer
-  std::string myalg("SPGEMM_DEFAULT");
-  if (!params.is_null()) {
-    if (params->isParameter("sycl: algorithm"))
-      myalg = params->get("sycl: algorithm", myalg);
-    if (params->isParameter("sycl: team work size"))
-      team_work_size = params->get("sycl: team work size", team_work_size);
-  }
-
-  // KokkosKernelsHandle
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle<
-      typename lno_view_t::const_value_type, typename lno_nnz_view_t::const_value_type, typename scalar_view_t::const_value_type,
-      typename device_t::execution_space, typename device_t::memory_space, typename device_t::memory_space>
-      KernelHandle;
-  using IntKernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<
-      typename int_view_t::const_value_type, typename lno_nnz_view_t::const_value_type, typename scalar_view_t::const_value_type,
-      typename device_t::execution_space, typename device_t::memory_space, typename device_t::memory_space>;
-
-  // Grab the  Kokkos::SparseCrsMatrices
-  const KCRS Amat = Aview.origMatrix->getLocalMatrixDevice();
-  const KCRS Bmat = Bview.origMatrix->getLocalMatrixDevice();
-
-  c_lno_view_t Arowptr         = Amat.graph.row_map,
-               Browptr         = Bmat.graph.row_map;
-  const lno_nnz_view_t Acolind = Amat.graph.entries,
-                       Bcolind = Bmat.graph.entries;
-  const scalar_view_t Avals    = Amat.values,
-                      Bvals    = Bmat.values;
-
-  // Get the algorithm mode
-  std::string alg = nodename + std::string(" algorithm");
-  //  printf("DEBUG: Using kernel: %s\n",myalg.c_str());
-  if (!params.is_null() && params->isParameter(alg)) myalg = params->get(alg, myalg);
-  KokkosSparse::SPGEMMAlgorithm alg_enum = KokkosSparse::StringToSPGEMMAlgorithm(myalg);
-
-  // Merge the B and Bimport matrices
-  const KCRS Bmerged = Tpetra::MMdetails::merge_matrices(Aview, Bview, Acol2Brow, Acol2Irow, Bcol2Ccol, Icol2Ccol, C.getColMap()->getLocalNumElements());
-
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-  MM = Teuchos::null;
-  MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix SYCLCore"))));
-#endif
-
-  // Do the multiply on whatever we've got
-  typename KernelHandle::nnz_lno_t AnumRows = Amat.numRows();
-  typename KernelHandle::nnz_lno_t BnumRows = Bmerged.numRows();
-  typename KernelHandle::nnz_lno_t BnumCols = Bmerged.numCols();
-
-  lno_view_t row_mapC(Kokkos::ViewAllocateWithoutInitializing("non_const_lno_row"), AnumRows + 1);
-  lno_nnz_view_t entriesC;
-  scalar_view_t valuesC;
-
-  // static_assert(std::is_void_v<typename KCRS::row_map_type::non_const_value_type>, "");
-  // static_assert(std::is_void_v<typename decltype(Bmerged)::row_map_type::non_const_value_type>, "");
-  Tpetra::Details::IntRowPtrHelper<decltype(Bmerged)> irph(Bmerged.nnz(), Bmerged.graph.row_map);
-  const bool useIntRowptrs =
-      irph.shouldUseIntRowptrs() &&
-      Aview.origMatrix->getApplyHelper()->shouldUseIntRowptrs();
-
-  if (useIntRowptrs) {
-    IntKernelHandle kh;
-    kh.create_spgemm_handle(alg_enum);
-    kh.set_team_work_size(team_work_size);
-
-    int_view_t int_row_mapC(Kokkos::ViewAllocateWithoutInitializing("non_const_int_row"), AnumRows + 1);
-
-    auto Aint = Aview.origMatrix->getApplyHelper()->getIntRowptrMatrix(Amat);
-    auto Bint = irph.getIntRowptrMatrix(Bmerged);
-    KokkosSparse::spgemm_symbolic(&kh, AnumRows, BnumRows, BnumCols, Aint.graph.row_map, Aint.graph.entries, false, Bint.graph.row_map, Bint.graph.entries, false, int_row_mapC);
-
-    size_t c_nnz_size = kh.get_spgemm_handle()->get_c_nnz();
-    if (c_nnz_size) {
-      entriesC = lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
-      valuesC  = scalar_view_t(Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
-    }
-    KokkosSparse::spgemm_numeric(&kh, AnumRows, BnumRows, BnumCols, Aint.graph.row_map, Aint.graph.entries, Aint.values, false, Bint.graph.row_map, Bint.graph.entries, Bint.values, false, int_row_mapC, entriesC, valuesC);
-    // transfer the integer rowptrs back to the correct rowptr type
-    Kokkos::parallel_for(
-        int_row_mapC.size(), KOKKOS_LAMBDA(int i) { row_mapC(i) = int_row_mapC(i); });
-    kh.destroy_spgemm_handle();
-
-  } else {
-    KernelHandle kh;
-    kh.create_spgemm_handle(alg_enum);
-    kh.set_team_work_size(team_work_size);
-
-    KokkosSparse::spgemm_symbolic(&kh, AnumRows, BnumRows, BnumCols, Amat.graph.row_map, Amat.graph.entries, false, Bmerged.graph.row_map, Bmerged.graph.entries, false, row_mapC);
-
-    size_t c_nnz_size = kh.get_spgemm_handle()->get_c_nnz();
-    if (c_nnz_size) {
-      entriesC = lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
-      valuesC  = scalar_view_t(Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
-    }
-
-    KokkosSparse::spgemm_numeric(&kh, AnumRows, BnumRows, BnumCols, Amat.graph.row_map, Amat.graph.entries, Amat.values, false, Bmerged.graph.row_map, Bmerged.graph.entries, Bmerged.values, false, row_mapC, entriesC, valuesC);
-    kh.destroy_spgemm_handle();
-  }
-
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-  MM = Teuchos::null;
-  MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix SYCLSort"))));
-#endif
-
-  // Sort & set values
-  if (params.is_null() || params->get("sort entries", true))
-    Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC);
-  C.setAllValues(row_mapC, entriesC, valuesC);
-
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-  MM = Teuchos::null;
-  MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix SYCLESFC"))));
-#endif
-
-  // Final Fillcomplete
-  RCP<Teuchos::ParameterList> labelList = rcp(new Teuchos::ParameterList);
-  labelList->set("Timer Label", label);
-  if (!params.is_null()) labelList->set("compute global constants", params->get("compute global constants", true));
-  RCP<const Export<LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::KokkosSYCLWrapperNode> > dummyExport;
-  C.expertStaticFillComplete(Bview.origMatrix->getDomainMap(), Aview.origMatrix->getRangeMap(), Cimport, dummyExport, labelList);
+  Tpetra::MMdetails::kokkos_kernels_mult_A_B_newmatrix(
+      Aview, Bview, Acol2Brow, Acol2Irow, Bcol2Ccol, Icol2Ccol, C, Cimport, label, params);
 }
 
 /*********************************************************************************************************/

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_decl.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_decl.hpp
@@ -462,6 +462,26 @@ template <class Scalar,
 void setMaxNumEntriesPerRow(
     CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Mview);
 
+template <class Node>
+struct KokkosKernelsSPGEMMBackend;
+
+template <class Scalar,
+          class LocalOrdinal,
+          class GlobalOrdinal,
+          class Node,
+          class LocalOrdinalViewType>
+void kokkos_kernels_mult_A_B_newmatrix(
+    CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Aview,
+    CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Bview,
+    const LocalOrdinalViewType& Acol2Brow,
+    const LocalOrdinalViewType& Acol2Irow,
+    const LocalOrdinalViewType& Bcol2Ccol,
+    const LocalOrdinalViewType& Icol2Ccol,
+    CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& C,
+    Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Node> > Cimport,
+    const std::string& label,
+    const Teuchos::RCP<Teuchos::ParameterList>& params);
+
 // MMM Kernel wrappers struct
 // Because C++ doesn't support partial template specialization of functions.
 template <class Scalar,

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -1272,7 +1272,7 @@ void kokkos_kernels_mult_A_B_newmatrix(
   }
 
   if (params.is_null() || params->get("sort entries", true))
-    backend_type::sort_entries(row_mapC, entriesC, valuesC);
+    Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC);
   C.setAllValues(row_mapC, entriesC, valuesC);
 
   if constexpr (backend_type::use_time_monitor) {

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -1158,10 +1158,10 @@ void kokkos_kernels_mult_A_B_newmatrix(
 
   if constexpr (backend_type::use_time_monitor) {
 #ifdef HAVE_TPETRA_MMM_TIMINGS
-    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::wrapper_label()))));
+    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::algorithm_label() + "Wrapper"))));
 #endif
   } else {
-    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::wrapper_label()));
+    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "Wrapper"));
   }
 
   int team_work_size = 16;
@@ -1189,11 +1189,11 @@ void kokkos_kernels_mult_A_B_newmatrix(
   if constexpr (backend_type::use_time_monitor) {
 #ifdef HAVE_TPETRA_MMM_TIMINGS
     timeMonitor = Teuchos::null;
-    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::core_label()))));
+    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::algorithm_label() + "Core"))));
 #endif
   } else {
     MM = Teuchos::null;
-    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::core_label()));
+    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "Core"));
   }
 
   typename KernelHandle::nnz_lno_t AnumRows = Amat.numRows();
@@ -1264,11 +1264,11 @@ void kokkos_kernels_mult_A_B_newmatrix(
   if constexpr (backend_type::use_time_monitor) {
 #ifdef HAVE_TPETRA_MMM_TIMINGS
     timeMonitor = Teuchos::null;
-    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::sort_label()))));
+    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::algorithm_label() + "Sort"))));
 #endif
   } else {
     MM = Teuchos::null;
-    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::sort_label()));
+    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "Sort"));
   }
 
   if (params.is_null() || params->get("sort entries", true))
@@ -1278,11 +1278,11 @@ void kokkos_kernels_mult_A_B_newmatrix(
   if constexpr (backend_type::use_time_monitor) {
 #ifdef HAVE_TPETRA_MMM_TIMINGS
     timeMonitor = Teuchos::null;
-    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::esfc_label()))));
+    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::algorithm_label() + "ESFC"))));
 #endif
   } else {
     MM = Teuchos::null;
-    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::esfc_label()));
+    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "ESFC"));
   }
 
   RCP<Teuchos::ParameterList> labelList = rcp(new Teuchos::ParameterList);

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -1104,6 +1104,17 @@ void Add(
 
 namespace MMdetails {
 
+// nvcc 12.3 and 12.4 report getApplyHelper() as inaccessible even if
+// CrsMatrix friends kokkos_kernels_mult_A_B_newmatrix. Use this non-template
+// wrapper instead. Someone had the same problem in 2011 here:
+// https://forums.developer.nvidia.com/t/24378.
+struct CrsMatrixApplyHelperAccess {
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  static auto get(const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& matrix) {
+    return matrix.getApplyHelper();
+  }
+};
+
 template <class Scalar,
           class LocalOrdinal,
           class GlobalOrdinal,
@@ -1196,7 +1207,7 @@ void kokkos_kernels_mult_A_B_newmatrix(
   Tpetra::Details::IntRowPtrHelper<decltype(Bmerged)> irph(Bmerged.nnz(), Bmerged.graph.row_map);
   const bool useIntRowptrs =
       irph.shouldUseIntRowptrs() &&
-      Aview.origMatrix->getApplyHelper()->shouldUseIntRowptrs();
+      CrsMatrixApplyHelperAccess::get(*Aview.origMatrix)->shouldUseIntRowptrs();
 
   if (useIntRowptrs) {
     IntKernelHandle kh;
@@ -1205,7 +1216,7 @@ void kokkos_kernels_mult_A_B_newmatrix(
 
     int_view_t int_row_mapC(Kokkos::ViewAllocateWithoutInitializing("non_const_int_row"), AnumRows + 1);
 
-    auto Aint = Aview.origMatrix->getApplyHelper()->getIntRowptrMatrix(Amat);
+    auto Aint = CrsMatrixApplyHelperAccess::get(*Aview.origMatrix)->getIntRowptrMatrix(Amat);
     auto Bint = irph.getIntRowptrMatrix(Bmerged);
 
     {

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -1138,8 +1138,20 @@ void kokkos_kernels_mult_A_B_newmatrix(
       typename int_view_t::const_value_type, typename lno_nnz_view_t::const_value_type, typename scalar_view_t::const_value_type,
       typename device_t::execution_space, typename device_t::memory_space, typename device_t::memory_space>;
 
-  RCP<Tpetra::Details::ProfilingRegion> MM =
-      rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::wrapper_label()));
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+  using Teuchos::TimeMonitor;
+  Teuchos::RCP<TimeMonitor> timeMonitor;
+  const std::string prefix_mmm = std::string("TpetraExt ") + label + std::string(": ");
+#endif
+  RCP<Tpetra::Details::ProfilingRegion> MM;
+
+  if constexpr (backend_type::use_time_monitor) {
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::wrapper_label()))));
+#endif
+  } else {
+    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::wrapper_label()));
+  }
 
   int team_work_size = 16;
   std::string myalg("SPGEMM_DEFAULT");
@@ -1163,8 +1175,15 @@ void kokkos_kernels_mult_A_B_newmatrix(
       Aview, Bview, Acol2Brow, Acol2Irow, Bcol2Ccol, Icol2Ccol, C.getColMap()->getLocalNumElements());
   backend_type::pre_spgemm(Bmerged);
 
-  MM = Teuchos::null;
-  MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::core_label()));
+  if constexpr (backend_type::use_time_monitor) {
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    timeMonitor = Teuchos::null;
+    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::core_label()))));
+#endif
+  } else {
+    MM = Teuchos::null;
+    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::core_label()));
+  }
 
   typename KernelHandle::nnz_lno_t AnumRows = Amat.numRows();
   typename KernelHandle::nnz_lno_t BnumRows = Bmerged.numRows();
@@ -1231,15 +1250,29 @@ void kokkos_kernels_mult_A_B_newmatrix(
     kh.destroy_spgemm_handle();
   }
 
-  MM = Teuchos::null;
-  MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::sort_label()));
+  if constexpr (backend_type::use_time_monitor) {
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    timeMonitor = Teuchos::null;
+    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::sort_label()))));
+#endif
+  } else {
+    MM = Teuchos::null;
+    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::sort_label()));
+  }
 
   if (params.is_null() || params->get("sort entries", true))
     backend_type::sort_entries(row_mapC, entriesC, valuesC);
   C.setAllValues(row_mapC, entriesC, valuesC);
 
-  MM = Teuchos::null;
-  MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::esfc_label()));
+  if constexpr (backend_type::use_time_monitor) {
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    timeMonitor = Teuchos::null;
+    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::esfc_label()))));
+#endif
+  } else {
+    MM = Teuchos::null;
+    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::esfc_label()));
+  }
 
   RCP<Teuchos::ParameterList> labelList = rcp(new Teuchos::ParameterList);
   labelList->set("Timer Label", label);

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -1151,7 +1151,7 @@ void kokkos_kernels_mult_A_B_newmatrix(
 
   const std::string wrapperLabel = "TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "Wrapper";
   RCP<Tpetra::Details::ProfilingRegion> MM =
-      rcp(new Tpetra::Details::ProfilingRegion(wrapperLabel.c_str()));
+      rcp(new Tpetra::Details::ProfilingRegion(wrapperLabel));
 
   int team_work_size = 16;
   std::string myalg("SPGEMM_DEFAULT");
@@ -1176,8 +1176,8 @@ void kokkos_kernels_mult_A_B_newmatrix(
   backend_type::pre_spgemm(Bmerged);
 
   const std::string coreLabel = "TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "Core";
-  MM = Teuchos::null;
-  MM = rcp(new Tpetra::Details::ProfilingRegion(coreLabel.c_str()));
+  MM                          = Teuchos::null;
+  MM                          = rcp(new Tpetra::Details::ProfilingRegion(coreLabel));
 
   typename KernelHandle::nnz_lno_t AnumRows = Amat.numRows();
   typename KernelHandle::nnz_lno_t BnumRows = Bmerged.numRows();
@@ -1245,16 +1245,16 @@ void kokkos_kernels_mult_A_B_newmatrix(
   }
 
   const std::string sortLabel = "TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "Sort";
-  MM = Teuchos::null;
-  MM = rcp(new Tpetra::Details::ProfilingRegion(sortLabel.c_str()));
+  MM                          = Teuchos::null;
+  MM                          = rcp(new Tpetra::Details::ProfilingRegion(sortLabel));
 
   if (params.is_null() || params->get("sort entries", true))
     Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC);
   C.setAllValues(row_mapC, entriesC, valuesC);
 
   const std::string esfcLabel = "TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "ESFC";
-  MM = Teuchos::null;
-  MM = rcp(new Tpetra::Details::ProfilingRegion(esfcLabel.c_str()));
+  MM                          = Teuchos::null;
+  MM                          = rcp(new Tpetra::Details::ProfilingRegion(esfcLabel));
 
   RCP<Teuchos::ParameterList> labelList = rcp(new Teuchos::ParameterList);
   labelList->set("Timer Label", label);

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -1104,6 +1104,151 @@ void Add(
 
 namespace MMdetails {
 
+template <class Scalar,
+          class LocalOrdinal,
+          class GlobalOrdinal,
+          class Node,
+          class LocalOrdinalViewType>
+void kokkos_kernels_mult_A_B_newmatrix(
+    CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Aview,
+    CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Bview,
+    const LocalOrdinalViewType& Acol2Brow,
+    const LocalOrdinalViewType& Acol2Irow,
+    const LocalOrdinalViewType& Bcol2Ccol,
+    const LocalOrdinalViewType& Icol2Ccol,
+    CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& C,
+    Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Node>> Cimport,
+    const std::string& label,
+    const Teuchos::RCP<Teuchos::ParameterList>& params) {
+  using backend_type = KokkosKernelsSPGEMMBackend<Node>;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  using KCRS           = typename Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::local_matrix_device_type;
+  using device_t       = typename KCRS::device_type;
+  using graph_t        = typename KCRS::StaticCrsGraphType;
+  using lno_view_t     = typename graph_t::row_map_type::non_const_type;
+  using int_view_t     = Kokkos::View<int*, typename lno_view_t::array_layout, typename lno_view_t::memory_space, typename lno_view_t::memory_traits>;
+  using lno_nnz_view_t = typename graph_t::entries_type::non_const_type;
+  using scalar_view_t  = typename KCRS::values_type::non_const_type;
+  using KernelHandle   = KokkosKernels::Experimental::KokkosKernelsHandle<
+      typename lno_view_t::const_value_type, typename lno_nnz_view_t::const_value_type, typename scalar_view_t::const_value_type,
+      typename device_t::execution_space, typename device_t::memory_space, typename device_t::memory_space>;
+  using IntKernelHandle = KokkosKernels::Experimental::KokkosKernelsHandle<
+      typename int_view_t::const_value_type, typename lno_nnz_view_t::const_value_type, typename scalar_view_t::const_value_type,
+      typename device_t::execution_space, typename device_t::memory_space, typename device_t::memory_space>;
+
+  RCP<Tpetra::Details::ProfilingRegion> MM =
+      rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::wrapper_label()));
+
+  int team_work_size = 16;
+  std::string myalg("SPGEMM_DEFAULT");
+  if (!params.is_null()) {
+    const std::string prefixedAlg  = backend_type::parameter_prefix() + ": algorithm";
+    const std::string prefixedTeam = backend_type::parameter_prefix() + ": team work size";
+    if (params->isParameter(prefixedAlg))
+      myalg = params->get(prefixedAlg, myalg);
+    if (params->isParameter(prefixedTeam))
+      team_work_size = params->get(prefixedTeam, team_work_size);
+  }
+
+  const KCRS Amat = Aview.origMatrix->getLocalMatrixDevice();
+
+  const std::string genericAlg = backend_type::algorithm_label() + " algorithm";
+  if (!params.is_null() && params->isParameter(genericAlg))
+    myalg = params->get(genericAlg, myalg);
+  KokkosSparse::SPGEMMAlgorithm alg_enum = KokkosSparse::StringToSPGEMMAlgorithm(myalg);
+
+  KCRS Bmerged = Tpetra::MMdetails::merge_matrices(
+      Aview, Bview, Acol2Brow, Acol2Irow, Bcol2Ccol, Icol2Ccol, C.getColMap()->getLocalNumElements());
+  backend_type::pre_spgemm(Bmerged);
+
+  MM = Teuchos::null;
+  MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::core_label()));
+
+  typename KernelHandle::nnz_lno_t AnumRows = Amat.numRows();
+  typename KernelHandle::nnz_lno_t BnumRows = Bmerged.numRows();
+  typename KernelHandle::nnz_lno_t BnumCols = Bmerged.numCols();
+
+  lno_view_t row_mapC(Kokkos::ViewAllocateWithoutInitializing("non_const_lno_row"), AnumRows + 1);
+  lno_nnz_view_t entriesC;
+  scalar_view_t valuesC;
+
+  Tpetra::Details::IntRowPtrHelper<decltype(Bmerged)> irph(Bmerged.nnz(), Bmerged.graph.row_map);
+  const bool useIntRowptrs =
+      irph.shouldUseIntRowptrs() &&
+      Aview.origMatrix->getApplyHelper()->shouldUseIntRowptrs();
+
+  if (useIntRowptrs) {
+    IntKernelHandle kh;
+    kh.create_spgemm_handle(alg_enum);
+    kh.set_team_work_size(team_work_size);
+
+    int_view_t int_row_mapC(Kokkos::ViewAllocateWithoutInitializing("non_const_int_row"), AnumRows + 1);
+
+    auto Aint = Aview.origMatrix->getApplyHelper()->getIntRowptrMatrix(Amat);
+    auto Bint = irph.getIntRowptrMatrix(Bmerged);
+
+    {
+      Tpetra::Details::ProfilingRegion MM2("TpetraExt: MMM: Newmatrix KokkosKernels symbolic int");
+      KokkosSparse::spgemm_symbolic(
+          &kh, AnumRows, BnumRows, BnumCols, Aint.graph.row_map, Aint.graph.entries, false, Bint.graph.row_map, Bint.graph.entries, false, int_row_mapC);
+    }
+
+    Tpetra::Details::ProfilingRegion MM2("TpetraExt: MMM: Newmatrix KokkosKernels numeric int");
+    size_t c_nnz_size = kh.get_spgemm_handle()->get_c_nnz();
+    if (c_nnz_size) {
+      entriesC = lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
+      valuesC  = scalar_view_t(Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
+    }
+    KokkosSparse::spgemm_numeric(
+        &kh, AnumRows, BnumRows, BnumCols, Aint.graph.row_map, Aint.graph.entries, Aint.values, false,
+        Bint.graph.row_map, Bint.graph.entries, Bint.values, false, int_row_mapC, entriesC, valuesC);
+    Kokkos::parallel_for(
+        int_row_mapC.size(), KOKKOS_LAMBDA(const int i) { row_mapC(i) = int_row_mapC(i); });
+    kh.destroy_spgemm_handle();
+
+  } else {
+    KernelHandle kh;
+    kh.create_spgemm_handle(alg_enum);
+    kh.set_team_work_size(team_work_size);
+
+    {
+      Tpetra::Details::ProfilingRegion MM2("TpetraExt: MMM: Newmatrix KokkosKernels symbolic non-int");
+      KokkosSparse::spgemm_symbolic(
+          &kh, AnumRows, BnumRows, BnumCols, Amat.graph.row_map, Amat.graph.entries, false, Bmerged.graph.row_map, Bmerged.graph.entries, false, row_mapC);
+    }
+
+    Tpetra::Details::ProfilingRegion MM2("TpetraExt: MMM: Newmatrix KokkosKernels numeric non-int");
+    size_t c_nnz_size = kh.get_spgemm_handle()->get_c_nnz();
+    if (c_nnz_size) {
+      entriesC = lno_nnz_view_t(Kokkos::ViewAllocateWithoutInitializing("entriesC"), c_nnz_size);
+      valuesC  = scalar_view_t(Kokkos::ViewAllocateWithoutInitializing("valuesC"), c_nnz_size);
+    }
+    KokkosSparse::spgemm_numeric(
+        &kh, AnumRows, BnumRows, BnumCols, Amat.graph.row_map, Amat.graph.entries, Amat.values, false,
+        Bmerged.graph.row_map, Bmerged.graph.entries, Bmerged.values, false, row_mapC, entriesC, valuesC);
+    kh.destroy_spgemm_handle();
+  }
+
+  MM = Teuchos::null;
+  MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::sort_label()));
+
+  if (params.is_null() || params->get("sort entries", true))
+    backend_type::sort_entries(row_mapC, entriesC, valuesC);
+  C.setAllValues(row_mapC, entriesC, valuesC);
+
+  MM = Teuchos::null;
+  MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::esfc_label()));
+
+  RCP<Teuchos::ParameterList> labelList = rcp(new Teuchos::ParameterList);
+  labelList->set("Timer Label", label);
+  if (!params.is_null())
+    labelList->set("compute global constants", params->get("compute global constants", true));
+  RCP<const Export<LocalOrdinal, GlobalOrdinal, Node>> dummyExport;
+  C.expertStaticFillComplete(Bview.origMatrix->getDomainMap(), Aview.origMatrix->getRangeMap(), Cimport, dummyExport, labelList);
+}
+
 /*********************************************************************************************************/
 //// Prints MMM-style statistics on communication done with an Import or Export object
 // template <class TransferType>

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -1149,20 +1149,9 @@ void kokkos_kernels_mult_A_B_newmatrix(
       typename int_view_t::const_value_type, typename lno_nnz_view_t::const_value_type, typename scalar_view_t::const_value_type,
       typename device_t::execution_space, typename device_t::memory_space, typename device_t::memory_space>;
 
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-  using Teuchos::TimeMonitor;
-  Teuchos::RCP<TimeMonitor> timeMonitor;
-  const std::string prefix_mmm = std::string("TpetraExt ") + label + std::string(": ");
-#endif
-  RCP<Tpetra::Details::ProfilingRegion> MM;
-
-  if constexpr (backend_type::use_time_monitor) {
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::algorithm_label() + "Wrapper"))));
-#endif
-  } else {
-    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "Wrapper"));
-  }
+  const std::string wrapperLabel = "TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "Wrapper";
+  RCP<Tpetra::Details::ProfilingRegion> MM =
+      rcp(new Tpetra::Details::ProfilingRegion(wrapperLabel.c_str()));
 
   int team_work_size = 16;
   std::string myalg("SPGEMM_DEFAULT");
@@ -1186,15 +1175,9 @@ void kokkos_kernels_mult_A_B_newmatrix(
       Aview, Bview, Acol2Brow, Acol2Irow, Bcol2Ccol, Icol2Ccol, C.getColMap()->getLocalNumElements());
   backend_type::pre_spgemm(Bmerged);
 
-  if constexpr (backend_type::use_time_monitor) {
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-    timeMonitor = Teuchos::null;
-    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::algorithm_label() + "Core"))));
-#endif
-  } else {
-    MM = Teuchos::null;
-    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "Core"));
-  }
+  const std::string coreLabel = "TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "Core";
+  MM = Teuchos::null;
+  MM = rcp(new Tpetra::Details::ProfilingRegion(coreLabel.c_str()));
 
   typename KernelHandle::nnz_lno_t AnumRows = Amat.numRows();
   typename KernelHandle::nnz_lno_t BnumRows = Bmerged.numRows();
@@ -1261,29 +1244,17 @@ void kokkos_kernels_mult_A_B_newmatrix(
     kh.destroy_spgemm_handle();
   }
 
-  if constexpr (backend_type::use_time_monitor) {
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-    timeMonitor = Teuchos::null;
-    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::algorithm_label() + "Sort"))));
-#endif
-  } else {
-    MM = Teuchos::null;
-    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "Sort"));
-  }
+  const std::string sortLabel = "TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "Sort";
+  MM = Teuchos::null;
+  MM = rcp(new Tpetra::Details::ProfilingRegion(sortLabel.c_str()));
 
   if (params.is_null() || params->get("sort entries", true))
     Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC);
   C.setAllValues(row_mapC, entriesC, valuesC);
 
-  if constexpr (backend_type::use_time_monitor) {
-#ifdef HAVE_TPETRA_MMM_TIMINGS
-    timeMonitor = Teuchos::null;
-    timeMonitor = rcp(new TimeMonitor(*(TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix ") + backend_type::algorithm_label() + "ESFC"))));
-#endif
-  } else {
-    MM = Teuchos::null;
-    MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "ESFC"));
-  }
+  const std::string esfcLabel = "TpetraExt: MMM: Newmatrix " + backend_type::algorithm_label() + "ESFC";
+  MM = Teuchos::null;
+  MM = rcp(new Tpetra::Details::ProfilingRegion(esfcLabel.c_str()));
 
   RCP<Teuchos::ParameterList> labelList = rcp(new Teuchos::ParameterList);
   labelList->set("Timer Label", label);

--- a/packages/tpetra/core/src/TpetraExt_MatrixMatrix_fwd.hpp
+++ b/packages/tpetra/core/src/TpetraExt_MatrixMatrix_fwd.hpp
@@ -64,6 +64,9 @@ class BlockCrsMatrixStruct;
 
 namespace MMdetails {
 
+// Provides narrowly scoped access to CrsMatrix's cached apply helper.
+struct CrsMatrixApplyHelperAccess;
+
 // Other functions
 template <class Scalar,
           class LocalOrdinal,

--- a/packages/tpetra/core/src/TpetraExt_MatrixMatrix_fwd.hpp
+++ b/packages/tpetra/core/src/TpetraExt_MatrixMatrix_fwd.hpp
@@ -89,6 +89,23 @@ void import_and_extract_views(
     Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Node> > prototypeImporter = Teuchos::null,
     bool userAssertsThereAreNoRemotes                                                = false);
 
+template <class Scalar,
+          class LocalOrdinal,
+          class GlobalOrdinal,
+          class Node,
+          class LocalOrdinalViewType>
+void kokkos_kernels_mult_A_B_newmatrix(
+    CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Aview,
+    CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Bview,
+    const LocalOrdinalViewType& Acol2Brow,
+    const LocalOrdinalViewType& Acol2Irow,
+    const LocalOrdinalViewType& Bcol2Ccol,
+    const LocalOrdinalViewType& Icol2Ccol,
+    CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& C,
+    Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Node> > Cimport,
+    const std::string& label                           = std::string(),
+    const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
+
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node, class LocalOrdinalViewType>
 struct KernelWrappers;
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node, class LocalOrdinalViewType>

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -3937,6 +3937,20 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
       bool userAssertsThereAreNoRemotes,
       const std::string& label,
       const Teuchos::RCP<Teuchos::ParameterList>& params);
+  // Friend the shared MatrixMatrix SpGEMM helper introduced by the backend
+  // refactor so it can reuse the cached integer row pointers.
+  template <typename S, typename LO, typename GO, typename NODE, typename LOV>
+  friend void Tpetra::MMdetails::kokkos_kernels_mult_A_B_newmatrix(
+      CrsMatrixStruct<S, LO, GO, NODE>& Aview,
+      CrsMatrixStruct<S, LO, GO, NODE>& Bview,
+      const LOV& Acol2Brow,
+      const LOV& Acol2Irow,
+      const LOV& Bcol2Ccol,
+      const LOV& Icol2Ccol,
+      CrsMatrix<S, LO, GO, NODE>& C,
+      Teuchos::RCP<const Import<LO, GO, NODE> > Cimport,
+      const std::string& label,
+      const Teuchos::RCP<Teuchos::ParameterList>& params);
 
   /// \brief Swaps the data from *this with the data and maps from crsMatrix
   ///

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -3927,6 +3927,15 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   friend struct Tpetra::MMdetails::KernelWrappers;
   template <typename S, typename LO, typename GO, typename NODE, typename LOV>
   friend struct Tpetra::MMdetails::KernelWrappers2;
+  // Really we want to friend:
+  // template <typename S, typename LO, typename GO, typename NODE, typename LOV>
+  // friend void Tpetra::MMdetails::kokkos_kernels_mult_A_B_newmatrix(...),
+  // but nvcc seemingly doesn't reliably honor this friendship (because it's a template class?)
+  // Instead, we defined a little non-template wrapper class over by kokkos_kernels_mult_A_B_newmatrix so we
+  // can friend that here instead, which seems to work.
+  // This is needed so kokkos_kernels_mult_A_B_newmatrix can access the lazy integer row pointer
+  // helpers
+  friend struct Tpetra::MMdetails::CrsMatrixApplyHelperAccess;
 
   // friend Matrix Matrix utility function that needs to access integer-typed rowptrs
   friend void Tpetra::MMdetails::import_and_extract_views<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
@@ -3935,20 +3944,6 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
       CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Aview,
       Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Node> > prototypeImporter,
       bool userAssertsThereAreNoRemotes,
-      const std::string& label,
-      const Teuchos::RCP<Teuchos::ParameterList>& params);
-  // Friend the shared MatrixMatrix SpGEMM helper introduced by the backend
-  // refactor so it can reuse the cached integer row pointers.
-  template <typename S, typename LO, typename GO, typename NODE, typename LOV>
-  friend void Tpetra::MMdetails::kokkos_kernels_mult_A_B_newmatrix(
-      CrsMatrixStruct<S, LO, GO, NODE>& Aview,
-      CrsMatrixStruct<S, LO, GO, NODE>& Bview,
-      const LOV& Acol2Brow,
-      const LOV& Acol2Irow,
-      const LOV& Bcol2Ccol,
-      const LOV& Icol2Ccol,
-      CrsMatrix<S, LO, GO, NODE>& C,
-      Teuchos::RCP<const Import<LO, GO, NODE> > Cimport,
       const std::string& label,
       const Teuchos::RCP<Teuchos::ParameterList>& params);
 

--- a/packages/tpetra/core/src/Tpetra_Details_Profiling.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Profiling.cpp
@@ -32,6 +32,10 @@ ProfilingRegion::ProfilingRegion(const char name[]) {
     tm = Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer(name)));
 }
 
+ProfilingRegion::ProfilingRegion(const std::string& name)
+  : ProfilingRegion(name.c_str()) {
+}
+
 ProfilingRegion::ProfilingRegion(const char name[], const char group[]) {
   kokkos_region_active_ = false;
   const bool timeit     = Behavior::timing(group);

--- a/packages/tpetra/core/src/Tpetra_Details_Profiling.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Profiling.hpp
@@ -17,6 +17,7 @@
 #include "TpetraCore_config.h"
 #include "Teuchos_TimeMonitor.hpp"
 #include "Teuchos_RCP.hpp"
+#include <string>
 
 namespace Tpetra {
 namespace Details {
@@ -73,6 +74,8 @@ class ProfilingRegion {
   ProfilingRegion();
   //! Open region to profile; name the region \c name.
   ProfilingRegion(const char name[]);
+  //! Open region to profile; name the region \c name.
+  ProfilingRegion(const std::string& name);
   //! Open region to profile, if the group name \c group is enabled by the
   //! TPETRA_TIMING variable; name the region \c name.
   ProfilingRegion(const char name[], const char group[]);


### PR DESCRIPTION
Motivation: reducing backend-specific boilerplate

* Move copy-pasted `kokkos_kernels_mult_A_B_newmatrix` into common implementation.
* Add small specializations for backend-specific labels and a pre-spgemm hook so CUDA can sort rows first
* forward declaration in TpetraExt_MatrixMatrix_decl.hpp
* OpenMP LTG alternate algorithm still works as before
* Shift all timers in the affected code from TimeMonitor to `Details::ProfilingRegion`
* This also changes the style of hip labels slightly to align them with CUDA / OpenMP / SYCL: `HIP x` -> `HIPx`

