### PR TITLE
MueLu: Add const Operator/CrsMatrix overloads for Tpetra preconditioner

### DIFF
--- a/packages/muelu/adapters/linear_solver_factory/MueLu_Details_LinearSolverFactory_def.hpp
+++ b/packages/muelu/adapters/linear_solver_factory/MueLu_Details_LinearSolverFactory_def.hpp
@@ -273,25 +273,21 @@ class LinearSolver<Tpetra::MultiVector<Scalar, LO, GO, Node>,
                                                                                     "set yet.  You must call setMatrix() with a nonnull matrix before you may "
                                                                                     "call this method.");
 
-      // TODO: We should not have to cast away the constness here
-      // TODO: See bug 6462
       if (params_ != Teuchos::null)
-        solver_ = CreateTpetraPreconditioner(rcp_const_cast<Tpetra::Operator<Scalar, LO, GO, Node> >(A_), *params_);
+        solver_ = CreateTpetraPreconditioner(A_, *params_);
       else
-        solver_ = CreateTpetraPreconditioner(rcp_const_cast<Tpetra::Operator<Scalar, LO, GO, Node> >(A_));
+        solver_ = CreateTpetraPreconditioner(A_);
     } else if (changedA_) {
       TEUCHOS_TEST_FOR_EXCEPTION(A_ == Teuchos::null, std::runtime_error, prefix << "The matrix has not been "
                                                                                     "set yet.  You must call setMatrix() with a nonnull matrix before you may "
                                                                                     "call this method.");
 
-      // TODO: We should not have to cast away the constness here
-      // TODO: See bug 6462
       RCP<const Tpetra::CrsMatrix<Scalar, LO, GO, Node> > helperMat;
       helperMat = rcp_dynamic_cast<const Tpetra::CrsMatrix<Scalar, LO, GO, Node> >(A_);
       TEUCHOS_TEST_FOR_EXCEPTION(helperMat.is_null(), std::runtime_error, prefix << "MueLu requires "
                                                                                     "a Tpetra::CrsMatrix, but the matrix you provided is of a "
                                                                                     "different type.  Please provide a Tpetra::CrsMatrix instead.");
-      ReuseTpetraPreconditioner(rcp_const_cast<Tpetra::CrsMatrix<Scalar, LO, GO, Node> >(helperMat), *solver_);
+      ReuseTpetraPreconditioner(helperMat, *solver_);
     }
 
     changedA_      = false;

--- a/packages/muelu/adapters/tpetra/MueLu_CreateTpetraPreconditioner.hpp
+++ b/packages/muelu/adapters/tpetra/MueLu_CreateTpetraPreconditioner.hpp
@@ -166,6 +166,37 @@ CreateTpetraPreconditioner(const Teuchos::RCP<Tpetra::Operator<Scalar, LocalOrdi
 }
 
 /*!
+  @overload
+  @brief Same as CreateTpetraPreconditioner(non-const Operator overload), but for callers that only hold
+  `Teuchos::RCP<const Tpetra::Operator>` (for example after setMatrix() on interfaces that store a const matrix).
+
+  @note `Teuchos::RCP<T>` and `Teuchos::RCP<const T>` are different types, so a `RCP<const Tpetra::Operator>`
+  does not match the overload taking `RCP<Tpetra::Operator>`.  This overload forwards to that implementation.
+*/
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+Teuchos::RCP<MueLu::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
+CreateTpetraPreconditioner(const Teuchos::RCP<const Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& inA,
+                           Teuchos::ParameterList& inParamList) {
+  return CreateTpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
+      Teuchos::rcp_const_cast<Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(inA), inParamList);
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+Teuchos::RCP<MueLu::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
+CreateTpetraPreconditioner(const Teuchos::RCP<const Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& inA,
+                           const std::string& xmlFileName) {
+  return CreateTpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
+      Teuchos::rcp_const_cast<Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(inA), xmlFileName);
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+Teuchos::RCP<MueLu::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
+CreateTpetraPreconditioner(const Teuchos::RCP<const Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& inA) {
+  Teuchos::ParameterList paramList;
+  return CreateTpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(inA, paramList);
+}
+
+/*!
   @brief Helper function to reuse an existing MueLu preconditioner.
   @ingroup MueLuAdapters
 
@@ -189,6 +220,18 @@ void ReuseTpetraPreconditioner(const Teuchos::RCP<Tpetra::CrsMatrix<Scalar, Loca
   MueLu::ReuseXpetraPreconditioner<SC, LO, GO, NO>(A, H);
 }
 
+/*!
+  @overload
+  @brief Same as ReuseTpetraPreconditioner(non-const CrsMatrix overload) for callers that only hold
+  `Teuchos::RCP<const Tpetra::CrsMatrix>`.
+*/
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void ReuseTpetraPreconditioner(const Teuchos::RCP<const Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& inA,
+                               MueLu::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Op) {
+  ReuseTpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
+      Teuchos::rcp_const_cast<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(inA), Op);
+}
+
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void ReuseTpetraPreconditioner(const Teuchos::RCP<Tpetra::BlockCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& inA,
                                MueLu::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Op) {
@@ -206,6 +249,18 @@ void ReuseTpetraPreconditioner(const Teuchos::RCP<Tpetra::BlockCrsMatrix<Scalar,
   RCP<Matrix> A = rcp(new Xpetra::CrsMatrixWrap<SC, LO, GO, NO>(temp));
 
   MueLu::ReuseXpetraPreconditioner<SC, LO, GO, NO>(A, H);
+}
+
+/*!
+  @overload
+  @brief Same as ReuseTpetraPreconditioner(non-const BlockCrsMatrix overload) for callers that only hold
+  `Teuchos::RCP<const Tpetra::BlockCrsMatrix>`.
+*/
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void ReuseTpetraPreconditioner(const Teuchos::RCP<const Tpetra::BlockCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& inA,
+                               MueLu::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>& Op) {
+  ReuseTpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
+      Teuchos::rcp_const_cast<Tpetra::BlockCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(inA), Op);
 }
 
 }  // namespace MueLu

--- a/packages/muelu/adapters/tpetra/MueLu_CreateTpetraPreconditioner.hpp
+++ b/packages/muelu/adapters/tpetra/MueLu_CreateTpetraPreconditioner.hpp
@@ -173,6 +173,11 @@ CreateTpetraPreconditioner(const Teuchos::RCP<Tpetra::Operator<Scalar, LocalOrdi
 
   @note `Teuchos::RCP<T>` and `Teuchos::RCP<const T>` are different types, so a `RCP<const Tpetra::Operator>`
   does not match the overload taking `RCP<Tpetra::Operator>`.  This overload forwards to that implementation.
+
+  @note This is a convenience wrapper and an incremental step, not a complete const-correct solution.
+  In particular, this overload currently forwards via @c rcp_const_cast, so it does not remove the long-term
+  technical debt of supporting APIs that natively accept @c Teuchos::RCP<const ...> without casting or
+  duplicating overload sets.
 */
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::RCP<MueLu::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>

--- a/packages/muelu/adapters/tpetra/MueLu_CreateTpetraPreconditioner.hpp
+++ b/packages/muelu/adapters/tpetra/MueLu_CreateTpetraPreconditioner.hpp
@@ -14,6 +14,7 @@
 //! @brief Various adapters that will create a MueLu preconditioner that is a Tpetra::Operator.
 
 #include <Teuchos_XMLParameterListHelpers.hpp>
+#include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_Operator.hpp>
 #include <Tpetra_RowMatrix.hpp>
 #include <Xpetra_TpetraBlockCrsMatrix.hpp>
@@ -194,6 +195,61 @@ Teuchos::RCP<MueLu::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
 CreateTpetraPreconditioner(const Teuchos::RCP<const Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& inA) {
   Teuchos::ParameterList paramList;
   return CreateTpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(inA, paramList);
+}
+
+/*!
+  @overload
+  @brief Disambiguates @c CreateTpetraPreconditioner for concrete matrix types.
+
+  A @c Teuchos::RCP<Tpetra::CrsMatrix> (or @c BlockCrsMatrix) converts implicitly both to
+  @c RCP<Tpetra::Operator> and to @c RCP<const Tpetra::Operator>, so overload resolution between
+  the non-const and const @c Operator entry points is ambiguous.  These overloads bind the
+  concrete matrix type and forward through @c RCP<Tpetra::Operator> to the original implementation.
+*/
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+Teuchos::RCP<MueLu::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
+CreateTpetraPreconditioner(const Teuchos::RCP<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& inA,
+                           Teuchos::ParameterList& inParamList) {
+  Teuchos::RCP<Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> op = inA;
+  return CreateTpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(op, inParamList);
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+Teuchos::RCP<MueLu::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
+CreateTpetraPreconditioner(const Teuchos::RCP<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& inA,
+                           const std::string& xmlFileName) {
+  Teuchos::RCP<Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> op = inA;
+  return CreateTpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(op, xmlFileName);
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+Teuchos::RCP<MueLu::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
+CreateTpetraPreconditioner(const Teuchos::RCP<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& inA) {
+  Teuchos::RCP<Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> op = inA;
+  return CreateTpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(op);
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+Teuchos::RCP<MueLu::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
+CreateTpetraPreconditioner(const Teuchos::RCP<Tpetra::BlockCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& inA,
+                           Teuchos::ParameterList& inParamList) {
+  Teuchos::RCP<Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> op = inA;
+  return CreateTpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(op, inParamList);
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+Teuchos::RCP<MueLu::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
+CreateTpetraPreconditioner(const Teuchos::RCP<Tpetra::BlockCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& inA,
+                           const std::string& xmlFileName) {
+  Teuchos::RCP<Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> op = inA;
+  return CreateTpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(op, xmlFileName);
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+Teuchos::RCP<MueLu::TpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
+CreateTpetraPreconditioner(const Teuchos::RCP<Tpetra::BlockCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& inA) {
+  Teuchos::RCP<Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>> op = inA;
+  return CreateTpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(op);
 }
 
 /*!

--- a/packages/muelu/src/Smoothers/MueLu_SmootherBase.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_SmootherBase.hpp
@@ -69,7 +69,7 @@ class SmootherBase : public virtual BaseClass {
   //@}
 
  private:
-  bool constructionSuccessful_;
+  bool constructionSuccessful_ = false;
   std::string constructionErrorMsg_;
 
 };  // class SmootherBase

--- a/packages/muelu/test/unit_tests/Adapters/LinearSolverAdapter.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/LinearSolverAdapter.cpp
@@ -1,0 +1,249 @@
+// @HEADER
+// *****************************************************************************
+//        MueLu: A package for multigrid based preconditioning
+//
+// Copyright 2012 NTESS and the MueLu contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#include <Teuchos_UnitTestHarness.hpp>
+#include <Teuchos_ScalarTraits.hpp>
+#include <Teuchos_ParameterList.hpp>
+
+#include <MueLu_TestHelpers.hpp>
+#include <MueLu_Version.hpp>
+
+#include <Xpetra_MultiVectorFactory.hpp>
+#include <Xpetra_CrsMatrixWrap.hpp>
+#include <Xpetra_TpetraMultiVector.hpp>
+
+#include <MueLu_Hierarchy.hpp>
+#include <MueLu_TpetraOperator.hpp>
+
+#include <MueLu_Details_LinearSolverFactory.hpp>
+#if defined(HAVE_MUELU_EXPLICIT_INSTANTIATION)
+#include <MueLu_Details_LinearSolverFactory_def.hpp>
+#endif
+
+namespace MueLuTests {
+
+// Integration-style coverage for MueLu::Details::LinearSolver (Tpetra): Stratimikos / Trilinos::Details path.
+// Exercises setMatrix -> numeric (with/without ParameterList) -> solve, then matrix update + numeric hitting
+// changedA_ + ReuseTpetraPreconditioner, and the negative reuse path (Operator that is not CrsMatrix).
+
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(LinearSolverAdapter, FullCycle_WithoutParameterList, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+#include <MueLu_UseShortNames.hpp>
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
+  out << "version: " << MueLu::Version() << std::endl;
+
+#if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
+  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
+  typedef MueLu::Details::LinearSolver<Tpetra::MultiVector<SC, LO, GO, NO>, tpetra_operator_type,
+                                       typename Teuchos::ScalarTraits<SC>::magnitudeType>
+      linear_solver_type;
+  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+
+  if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
+    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
+    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(729 * comm->getSize());
+    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+    RCP<const tpetra_operator_type> A  = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
+
+    linear_solver_type solver;
+    solver.setMatrix(A);
+    solver.numeric();
+
+    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    RCP<MultiVector> X   = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    RHS->setSeed(271828182);
+    RHS->randomize();
+    Teuchos::Array<magnitude_type> norms(1);
+    RHS->norm2(norms);
+    RHS->scale(1 / norms[0]);
+    X->putScalar((SC)0.0);
+
+    auto Xtp = Xpetra::toTpetra(X);
+    auto Btp = Xpetra::toTpetra(RHS);
+    solver.solve(*Xtp, *Btp);
+
+    X->norm2(norms);
+    out << "|| X ||_2 after solve = " << norms[0] << std::endl;
+    TEST_INEQUALITY(norms[0], magnitude_type(0));
+  } else {
+    out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
+  }
+#else
+  out << "Skipping test because some required packages are not enabled (Tpetra, Ifpack2, Amesos2)." << std::endl;
+#endif
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(LinearSolverAdapter, FullCycle_WithParameterList, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+#include <MueLu_UseShortNames.hpp>
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
+  out << "version: " << MueLu::Version() << std::endl;
+
+#if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
+  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
+  typedef MueLu::Details::LinearSolver<Tpetra::MultiVector<SC, LO, GO, NO>, tpetra_operator_type,
+                                       typename Teuchos::ScalarTraits<SC>::magnitudeType>
+      linear_solver_type;
+  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+
+  if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
+    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
+    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(729 * comm->getSize());
+    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+    RCP<const tpetra_operator_type> A  = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
+
+    Teuchos::ParameterList mueluList;
+    linear_solver_type solver;
+    solver.setMatrix(A);
+    solver.setParameters(Teuchos::rcp(new Teuchos::ParameterList(mueluList)));
+    solver.numeric();
+
+    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    RCP<MultiVector> X   = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    RHS->setSeed(314159265);
+    RHS->randomize();
+    Teuchos::Array<magnitude_type> norms(1);
+    RHS->norm2(norms);
+    RHS->scale(1 / norms[0]);
+    X->putScalar((SC)0.0);
+
+    auto Xtp = Xpetra::toTpetra(X);
+    auto Btp = Xpetra::toTpetra(RHS);
+    solver.solve(*Xtp, *Btp);
+
+    X->norm2(norms);
+    out << "|| X ||_2 after solve = " << norms[0] << std::endl;
+    TEST_INEQUALITY(norms[0], magnitude_type(0));
+  } else {
+    out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
+  }
+#else
+  out << "Skipping test because some required packages are not enabled (Tpetra, Ifpack2, Amesos2)." << std::endl;
+#endif
+}
+
+// Second setMatrix must use a different RCP (to a different CrsMatrix) so that changedA_ is set; same RCP with
+// in-place value updates does not trigger reuse in LinearSolver::setMatrix.
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(LinearSolverAdapter, MatrixUpdate_ReuseTpetraPreconditioner, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+#include <MueLu_UseShortNames.hpp>
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
+  out << "version: " << MueLu::Version() << std::endl;
+
+#if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
+  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
+  typedef MueLu::Details::LinearSolver<Tpetra::MultiVector<SC, LO, GO, NO>, tpetra_operator_type,
+                                       typename Teuchos::ScalarTraits<SC>::magnitudeType>
+      linear_solver_type;
+  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+
+  if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
+    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
+    const GO gblRows                   = static_cast<GO>(243 * comm->getSize());
+
+    RCP<Matrix> Op1 = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(gblRows);
+    RCP<Matrix> Op2 = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(gblRows);
+
+    RCP<tpetra_crsmatrix_type> tpA1    = Xpetra::toTpetra(Op1);
+    RCP<tpetra_crsmatrix_type> tpA2    = Xpetra::toTpetra(Op2);
+    RCP<const tpetra_operator_type> A1 = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA1);
+    RCP<const tpetra_operator_type> A2 = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA2);
+
+    Teuchos::ParameterList mueluList;
+    linear_solver_type solver;
+    solver.setMatrix(A1);
+    solver.setParameters(Teuchos::rcp(new Teuchos::ParameterList(mueluList)));
+    solver.numeric();
+
+    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op1->getRowMap(), 1);
+    RCP<MultiVector> X   = MultiVectorFactory::Build(Op1->getRowMap(), 1);
+    RHS->setSeed(846930886);
+    RHS->randomize();
+    Teuchos::Array<magnitude_type> norms(1);
+    RHS->norm2(norms);
+    RHS->scale(1 / norms[0]);
+    X->putScalar((SC)0.0);
+
+    solver.solve(*Xpetra::toTpetra(X), *Xpetra::toTpetra(RHS));
+
+    // New matrix handle → changedA_ → numeric() calls ReuseTpetraPreconditioner(helperMat, *solver_)
+    solver.setMatrix(A2);
+    solver.numeric();
+
+    X->putScalar((SC)0.0);
+    solver.solve(*Xpetra::toTpetra(X), *Xpetra::toTpetra(RHS));
+
+    X->norm2(norms);
+    out << "|| X ||_2 after second solve = " << norms[0] << std::endl;
+    TEST_INEQUALITY(norms[0], magnitude_type(0));
+  } else {
+    out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
+  }
+#else
+  out << "Skipping test because some required packages are not enabled (Tpetra, Ifpack2, Amesos2)." << std::endl;
+#endif
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(LinearSolverAdapter, ReuseWithNonCrsOperatorThrows, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+#include <MueLu_UseShortNames.hpp>
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
+  out << "version: " << MueLu::Version() << std::endl;
+
+#if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
+  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
+  typedef MueLu::TpetraOperator<SC, LO, GO, NO> muelu_tpetra_operator_type;
+  typedef MueLu::Details::LinearSolver<Tpetra::MultiVector<SC, LO, GO, NO>, tpetra_operator_type,
+                                       typename Teuchos::ScalarTraits<SC>::magnitudeType>
+      linear_solver_type;
+
+  if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
+    RCP<const Teuchos::Comm<int>> comm   = TestHelpers::Parameters::getDefaultComm();
+    RCP<Matrix> Op                       = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(243 * comm->getSize());
+    RCP<tpetra_crsmatrix_type> tpA       = Xpetra::toTpetra(Op);
+    RCP<const tpetra_operator_type> Acrs = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
+
+    linear_solver_type solver;
+    solver.setMatrix(Acrs);
+    solver.numeric();
+
+    RCP<Hierarchy> H = rcp(new Hierarchy());
+    H->setDefaultVerbLevel(Teuchos::VERB_NONE);
+    RCP<MueLu::Level> Finest = H->GetLevel();
+    Finest->setDefaultVerbLevel(Teuchos::VERB_NONE);
+    Finest->Set("A", Op);
+    H->Setup();
+
+    RCP<muelu_tpetra_operator_type> tOp = rcp(new muelu_tpetra_operator_type(H));
+    RCP<const tpetra_operator_type> AnonCrs =
+        Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tOp);
+
+    solver.setMatrix(AnonCrs);
+    TEST_THROW(solver.numeric(), std::runtime_error);
+  } else {
+    out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
+  }
+#else
+  out << "Skipping test because some required packages are not enabled (Tpetra, Ifpack2, Amesos2)." << std::endl;
+#endif
+}
+
+#define MUELU_ETI_GROUP(Scalar, LocalOrdinal, GlobalOrdinal, Node)                                                                             \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(LinearSolverAdapter, FullCycle_WithoutParameterList, Scalar, LocalOrdinal, GlobalOrdinal, Node)         \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(LinearSolverAdapter, FullCycle_WithParameterList, Scalar, LocalOrdinal, GlobalOrdinal, Node)            \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(LinearSolverAdapter, MatrixUpdate_ReuseTpetraPreconditioner, Scalar, LocalOrdinal, GlobalOrdinal, Node) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(LinearSolverAdapter, ReuseWithNonCrsOperatorThrows, Scalar, LocalOrdinal, GlobalOrdinal, Node)
+
+#include <MueLu_ETI_4arg.hpp>
+
+}  // namespace MueLuTests

--- a/packages/muelu/test/unit_tests/Adapters/TpetraOperatorAdapter.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/TpetraOperatorAdapter.cpp
@@ -187,12 +187,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
     RCP<tpetra_operator_type> opNonConst(tpA);
     RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
 
+    // CreateTpetraPreconditioner takes ParameterList by non-const reference and fills defaults in-place.
+    // Each build must receive a fresh copy of the user's list so const vs non-const paths start identical.
     Teuchos::ParameterList mueluList;
 
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, mueluList);
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, Teuchos::ParameterList(mueluList));
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, mueluList);
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, Teuchos::ParameterList(mueluList));
 
     RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
     RHS->setSeed(846930886);
@@ -243,8 +245,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
     RCP<tpetra_operator_type> opNonConst(tpA);
     RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
 
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst = MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst    = MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst);
+    Teuchos::ParameterList mueluList;
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, Teuchos::ParameterList(mueluList));
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, Teuchos::ParameterList(mueluList));
 
     RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
     RHS->setSeed(846930886);
@@ -299,9 +304,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
     Teuchos::ParameterList mueluList;
 
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, mueluList);
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, Teuchos::ParameterList(mueluList));
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, mueluList);
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, Teuchos::ParameterList(mueluList));
 
     RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
     RHS->setSeed(123456789);
@@ -354,9 +359,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
     Teuchos::ParameterList mueluList;
 
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, mueluList);
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, Teuchos::ParameterList(mueluList));
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, mueluList);
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, Teuchos::ParameterList(mueluList));
 
     const int levelsNC = precNonConst->GetHierarchy()->GetNumLevels();
     const int levelsC  = precConst->GetHierarchy()->GetNumLevels();
@@ -393,9 +398,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
     Teuchos::ParameterList mueluList;
 
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, mueluList);
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, Teuchos::ParameterList(mueluList));
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, mueluList);
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, Teuchos::ParameterList(mueluList));
 
     const int numVec     = 2;
     RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), numVec);
@@ -459,9 +464,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, ReuseTpetraPreconditioner_Cons
     Teuchos::ParameterList mueluList;
 
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, mueluList);
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, Teuchos::ParameterList(mueluList));
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, mueluList);
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, Teuchos::ParameterList(mueluList));
 
     // Same fine matrix, same reuse entry point: non-const vs const CrsMatrix handle.
     MueLu::ReuseTpetraPreconditioner(tpA, *precNonConst);
@@ -519,11 +524,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_RcpCrsMat
     Teuchos::ParameterList mueluList;
 
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precFromCrs =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(tpA, mueluList);
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(tpA, Teuchos::ParameterList(mueluList));
 
     RCP<tpetra_operator_type> opOnly(tpA);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precFromOp =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opOnly, mueluList);
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opOnly, Teuchos::ParameterList(mueluList));
 
     RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
     RHS->setSeed(846930886);

--- a/packages/muelu/test/unit_tests/Adapters/TpetraOperatorAdapter.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/TpetraOperatorAdapter.cpp
@@ -14,6 +14,8 @@
 #include <MueLu_Version.hpp>
 
 #include <Xpetra_MultiVectorFactory.hpp>
+#include <Xpetra_CrsMatrixWrap.hpp>
+#include <Xpetra_TpetraMultiVector.hpp>
 
 #include <MueLu_FactoryManagerBase.hpp>
 #include <MueLu_Hierarchy.hpp>
@@ -26,8 +28,8 @@
 #include <MueLu_SmootherFactory.hpp>
 #include <MueLu_TentativePFactory.hpp>
 #include <MueLu_AmesosSmoother.hpp>
-#include <MueLu_Utilities.hpp>
 #include <MueLu_TpetraOperator.hpp>
+#include <MueLu_CreateTpetraPreconditioner.hpp>
 
 namespace MueLuTests {
 
@@ -37,7 +39,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, Apply, Scalar, LocalOrdinal, G
   MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
   out << "version: " << MueLu::Version() << std::endl;
 
-  typedef MueLu::Utilities<SC, LO, GO, NO> Utils;
   typedef MueLu::TpetraOperator<SC, LO, GO, NO> muelu_tpetra_operator_type;
   typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
 
@@ -75,7 +76,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, Apply, Scalar, LocalOrdinal, G
 
     X1->putScalar((SC)0.0);
 
-    tH->apply(*(toTpetra(RHS1)), *(toTpetra(X1)));
+    tH->apply(*(Xpetra::toTpetra(RHS1)), *(Xpetra::toTpetra(X1)));
 
     X1->norm2(norms);
     out << "after apply, ||X1|| = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << norms[0] << std::endl;
@@ -116,9 +117,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, Getters, Scalar, LocalOrdinal,
   MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
   out << "version: " << MueLu::Version() << std::endl;
 
-  using Utils              = MueLu::Utilities<SC, LO, GO, NO>;
   using TpetraOperatorType = MueLu::TpetraOperator<SC, LO, GO, NO>;
-  using MagnitudeType      = typename Teuchos::ScalarTraits<SC>::magnitudeType;
 
   if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
     const auto Op = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(100);
@@ -166,9 +165,347 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, Getters, Scalar, LocalOrdinal,
   }
 }
 
-#define MUELU_ETI_GROUP(Scalar, LocalOrdinal, GlobalOrdinal, Node)                                       \
-  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, Apply, Scalar, LocalOrdinal, GlobalOrdinal, Node) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, Getters, Scalar, LocalOrdinal, GlobalOrdinal, Node)
+// Reproducer for Trilinos issue #15062: callers that only have Teuchos::RCP<const Tpetra::Operator>
+// could not use CreateTpetraPreconditioner without const_cast.  The overload taking RCP<const Operator>
+// must match the non-const overload (same MG iterate).
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOperator, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+#include <MueLu_UseShortNames.hpp>
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
+  out << "version: " << MueLu::Version() << std::endl;
+
+#if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
+  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
+  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+
+  if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
+    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
+    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(6561 * comm->getSize());
+    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+
+    RCP<tpetra_operator_type> opNonConst(tpA);
+    RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
+
+    Teuchos::ParameterList mueluList;
+
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, mueluList);
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, mueluList);
+
+    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    RHS->setSeed(846930886);
+    RHS->randomize();
+    Teuchos::Array<magnitude_type> norms(1);
+    RHS->norm2(norms);
+    RHS->scale(1 / norms[0]);
+
+    RCP<MultiVector> Xnc = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    RCP<MultiVector> Xc  = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    Xnc->putScalar((SC)0.0);
+    Xc->putScalar((SC)0.0);
+
+    precNonConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xnc)));
+    precConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xc)));
+
+    RCP<MultiVector> diff = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    diff->putScalar((SC)0.0);
+    diff->update(1.0, *Xnc, -1.0, *Xc, 0.0);
+    diff->norm2(norms);
+    out << "|| X_nonconst - X_const ||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << norms[0] << std::endl;
+    TEST_EQUALITY(norms[0] < 1e-10, true);
+  } else {
+    out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
+  }
+#else
+  out << "Skipping test because some required packages are not enabled (Tpetra, Ifpack2, Amesos2)." << std::endl;
+#endif
+}  // CreatePreconditioner_ConstOperator
+
+// CreateTpetraPreconditioner(inA) with no ParameterList: const vs non-const Operator overloads.
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOperator_NoParameterList, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+#include <MueLu_UseShortNames.hpp>
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
+  out << "version: " << MueLu::Version() << std::endl;
+
+#if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
+  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
+  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+
+  if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
+    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
+    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(6561 * comm->getSize());
+    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+
+    RCP<tpetra_operator_type> opNonConst(tpA);
+    RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
+
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst = MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst);
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst    = MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst);
+
+    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    RHS->setSeed(846930886);
+    RHS->randomize();
+    Teuchos::Array<magnitude_type> norms(1);
+    RHS->norm2(norms);
+    RHS->scale(1 / norms[0]);
+
+    RCP<MultiVector> Xnc = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    RCP<MultiVector> Xc  = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    Xnc->putScalar((SC)0.0);
+    Xc->putScalar((SC)0.0);
+
+    precNonConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xnc)));
+    precConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xc)));
+
+    RCP<MultiVector> diff = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    diff->putScalar((SC)0.0);
+    diff->update(1.0, *Xnc, -1.0, *Xc, 0.0);
+    diff->norm2(norms);
+    out << "|| X_nonconst - X_const ||_2 (no plist) = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << norms[0] << std::endl;
+    TEST_EQUALITY(norms[0] < 1e-10, true);
+  } else {
+    out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
+  }
+#else
+  out << "Skipping test because some required packages are not enabled (Tpetra, Ifpack2, Amesos2)." << std::endl;
+#endif
+}  // CreatePreconditioner_ConstOperator_NoParameterList
+
+// Smaller 1D problem (fewer rows per rank) to exercise the same const / non-const overload equivalence.
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOperator_SmallGrid, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+#include <MueLu_UseShortNames.hpp>
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
+  out << "version: " << MueLu::Version() << std::endl;
+
+#if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
+  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
+  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+
+  if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
+    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
+    const GO localRows                 = 243;
+    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(localRows * comm->getSize());
+    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+
+    RCP<tpetra_operator_type> opNonConst(tpA);
+    RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
+
+    Teuchos::ParameterList mueluList;
+
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, mueluList);
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, mueluList);
+
+    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    RHS->setSeed(123456789);
+    RHS->randomize();
+    Teuchos::Array<magnitude_type> norms(1);
+    RHS->norm2(norms);
+    RHS->scale(1 / norms[0]);
+
+    RCP<MultiVector> Xnc = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    RCP<MultiVector> Xc  = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    Xnc->putScalar((SC)0.0);
+    Xc->putScalar((SC)0.0);
+
+    precNonConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xnc)));
+    precConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xc)));
+
+    RCP<MultiVector> diff = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    diff->putScalar((SC)0.0);
+    diff->update(1.0, *Xnc, -1.0, *Xc, 0.0);
+    diff->norm2(norms);
+    out << "|| X_nonconst - X_const ||_2 (small grid) = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << norms[0] << std::endl;
+    TEST_EQUALITY(norms[0] < 1e-10, true);
+  } else {
+    out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
+  }
+#else
+  out << "Skipping test because some required packages are not enabled (Tpetra, Ifpack2, Amesos2)." << std::endl;
+#endif
+}  // CreatePreconditioner_ConstOperator_SmallGrid
+
+// Hierarchy depth from CreateTpetraPreconditioner must not depend on const vs non-const Operator handle.
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOperator_HierarchyLevels, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+#include <MueLu_UseShortNames.hpp>
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
+  out << "version: " << MueLu::Version() << std::endl;
+
+#if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
+  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
+
+  if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
+    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
+    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(2187 * comm->getSize());
+    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+
+    RCP<tpetra_operator_type> opNonConst(tpA);
+    RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
+
+    Teuchos::ParameterList mueluList;
+
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, mueluList);
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, mueluList);
+
+    const int levelsNC = precNonConst->GetHierarchy()->GetNumLevels();
+    const int levelsC  = precConst->GetHierarchy()->GetNumLevels();
+    out << "numLevels non-const handle: " << levelsNC << ", const handle: " << levelsC << std::endl;
+    TEST_EQUALITY(levelsNC, levelsC);
+  } else {
+    out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
+  }
+#else
+  out << "Skipping test because some required packages are not enabled (Tpetra, Ifpack2, Amesos2)." << std::endl;
+#endif
+}  // CreatePreconditioner_ConstOperator_HierarchyLevels
+
+// Two-column multivector: const vs non-const CreateTpetraPreconditioner apply must agree column-wise.
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOperator_TwoVectors, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+#include <MueLu_UseShortNames.hpp>
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
+  out << "version: " << MueLu::Version() << std::endl;
+
+#if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
+  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
+  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+
+  if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
+    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
+    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(729 * comm->getSize());
+    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+
+    RCP<tpetra_operator_type> opNonConst(tpA);
+    RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
+
+    Teuchos::ParameterList mueluList;
+
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, mueluList);
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, mueluList);
+
+    const int numVec     = 2;
+    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), numVec);
+    RHS->setSeed(97531);
+    RHS->randomize();
+    Teuchos::Array<magnitude_type> colNorms(numVec);
+    RHS->norm2(colNorms());
+    for (int j = 0; j < numVec; ++j) {
+      auto col = RHS->getVectorNonConst(j);
+      col->scale(1 / colNorms[j]);
+    }
+
+    RCP<MultiVector> Xnc = MultiVectorFactory::Build(Op->getRowMap(), numVec);
+    RCP<MultiVector> Xc  = MultiVectorFactory::Build(Op->getRowMap(), numVec);
+    Xnc->putScalar((SC)0.0);
+    Xc->putScalar((SC)0.0);
+
+    precNonConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xnc)));
+    precConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xc)));
+
+    RCP<MultiVector> diff = MultiVectorFactory::Build(Op->getRowMap(), numVec);
+    diff->putScalar((SC)0.0);
+    diff->update(1.0, *Xnc, -1.0, *Xc, 0.0);
+    Teuchos::Array<magnitude_type> diffNorms(numVec);
+    diff->norm2(diffNorms());
+    magnitude_type maxColDiff = Teuchos::ScalarTraits<magnitude_type>::zero();
+    for (int j = 0; j < numVec; ++j) {
+      if (diffNorms[j] > maxColDiff)
+        maxColDiff = diffNorms[j];
+    }
+    out << "max_j || (X_nc - X_c)_j ||_2 (2 vectors) = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << maxColDiff << std::endl;
+    TEST_EQUALITY(maxColDiff < 1e-10, true);
+  } else {
+    out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
+  }
+#else
+  out << "Skipping test because some required packages are not enabled (Tpetra, Ifpack2, Amesos2)." << std::endl;
+#endif
+}  // CreatePreconditioner_ConstOperator_TwoVectors
+
+// ReuseTpetraPreconditioner with RCP<const CrsMatrix> vs RCP<CrsMatrix> after the same fine-matrix update.
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, ReuseTpetraPreconditioner_ConstCrsMatrix, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+#include <MueLu_UseShortNames.hpp>
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
+  out << "version: " << MueLu::Version() << std::endl;
+
+#if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
+  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
+  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+
+  if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
+    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
+    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(2187 * comm->getSize());
+    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+
+    RCP<tpetra_operator_type> opNonConst(tpA);
+    RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
+
+    Teuchos::ParameterList mueluList;
+
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, mueluList);
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, mueluList);
+
+    // Same fine matrix, same reuse entry point: non-const vs const CrsMatrix handle.
+    MueLu::ReuseTpetraPreconditioner(tpA, *precNonConst);
+    RCP<const tpetra_crsmatrix_type> tpAconst = Teuchos::rcp_implicit_cast<const tpetra_crsmatrix_type>(tpA);
+    MueLu::ReuseTpetraPreconditioner(tpAconst, *precConst);
+
+    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    RHS->setSeed(314159265);
+    RHS->randomize();
+    Teuchos::Array<magnitude_type> norms(1);
+    RHS->norm2(norms);
+    RHS->scale(1 / norms[0]);
+
+    RCP<MultiVector> Xnc = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    RCP<MultiVector> Xc  = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    Xnc->putScalar((SC)0.0);
+    Xc->putScalar((SC)0.0);
+
+    precNonConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xnc)));
+    precConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xc)));
+
+    RCP<MultiVector> diff = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    diff->putScalar((SC)0.0);
+    diff->update(1.0, *Xnc, -1.0, *Xc, 0.0);
+    diff->norm2(norms);
+    out << "|| X_nonconst - X_const ||_2 (after reuse) = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << norms[0] << std::endl;
+    TEST_EQUALITY(norms[0] < 1e-10, true);
+  } else {
+    out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
+  }
+#else
+  out << "Skipping test because some required packages are not enabled (Tpetra, Ifpack2, Amesos2)." << std::endl;
+#endif
+}  // ReuseTpetraPreconditioner_ConstCrsMatrix
+
+#define MUELU_ETI_GROUP(Scalar, LocalOrdinal, GlobalOrdinal, Node)                                                                                    \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, Apply, Scalar, LocalOrdinal, GlobalOrdinal, Node)                                              \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, Getters, Scalar, LocalOrdinal, GlobalOrdinal, Node)                                            \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, CreatePreconditioner_ConstOperator, Scalar, LocalOrdinal, GlobalOrdinal, Node)                 \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, CreatePreconditioner_ConstOperator_NoParameterList, Scalar, LocalOrdinal, GlobalOrdinal, Node) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, CreatePreconditioner_ConstOperator_SmallGrid, Scalar, LocalOrdinal, GlobalOrdinal, Node)       \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, CreatePreconditioner_ConstOperator_HierarchyLevels, Scalar, LocalOrdinal, GlobalOrdinal, Node) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, CreatePreconditioner_ConstOperator_TwoVectors, Scalar, LocalOrdinal, GlobalOrdinal, Node)      \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, ReuseTpetraPreconditioner_ConstCrsMatrix, Scalar, LocalOrdinal, GlobalOrdinal, Node)
 
 #include <MueLu_ETI_4arg.hpp>
 

--- a/packages/muelu/test/unit_tests/Adapters/TpetraOperatorAdapter.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/TpetraOperatorAdapter.cpp
@@ -189,12 +189,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
 
     // CreateTpetraPreconditioner takes ParameterList by non-const reference and fills defaults in-place.
     // Each build must receive a fresh copy of the user's list so const vs non-const paths start identical.
+    // Copies must be named lvalues: a temporary ParameterList cannot bind to non-const ParameterList&.
     Teuchos::ParameterList mueluList;
 
+    Teuchos::ParameterList paramListNonConst(mueluList);
+    Teuchos::ParameterList paramListConst(mueluList);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, Teuchos::ParameterList(mueluList));
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, paramListNonConst);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, Teuchos::ParameterList(mueluList));
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, paramListConst);
 
     RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
     RHS->setSeed(846930886);
@@ -246,10 +249,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
     RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
 
     Teuchos::ParameterList mueluList;
+    Teuchos::ParameterList paramListNonConst(mueluList);
+    Teuchos::ParameterList paramListConst(mueluList);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, Teuchos::ParameterList(mueluList));
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, paramListNonConst);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, Teuchos::ParameterList(mueluList));
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, paramListConst);
 
     RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
     RHS->setSeed(846930886);
@@ -303,10 +308,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
 
     Teuchos::ParameterList mueluList;
 
+    Teuchos::ParameterList paramListNonConst(mueluList);
+    Teuchos::ParameterList paramListConst(mueluList);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, Teuchos::ParameterList(mueluList));
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, paramListNonConst);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, Teuchos::ParameterList(mueluList));
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, paramListConst);
 
     RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
     RHS->setSeed(123456789);
@@ -358,10 +365,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
 
     Teuchos::ParameterList mueluList;
 
+    Teuchos::ParameterList paramListNonConst(mueluList);
+    Teuchos::ParameterList paramListConst(mueluList);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, Teuchos::ParameterList(mueluList));
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, paramListNonConst);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, Teuchos::ParameterList(mueluList));
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, paramListConst);
 
     const int levelsNC = precNonConst->GetHierarchy()->GetNumLevels();
     const int levelsC  = precConst->GetHierarchy()->GetNumLevels();
@@ -397,10 +406,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
 
     Teuchos::ParameterList mueluList;
 
+    Teuchos::ParameterList paramListNonConst(mueluList);
+    Teuchos::ParameterList paramListConst(mueluList);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, Teuchos::ParameterList(mueluList));
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, paramListNonConst);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, Teuchos::ParameterList(mueluList));
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, paramListConst);
 
     const int numVec     = 2;
     RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), numVec);
@@ -463,10 +474,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, ReuseTpetraPreconditioner_Cons
 
     Teuchos::ParameterList mueluList;
 
+    Teuchos::ParameterList paramListNonConst(mueluList);
+    Teuchos::ParameterList paramListConst(mueluList);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, Teuchos::ParameterList(mueluList));
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, paramListNonConst);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, Teuchos::ParameterList(mueluList));
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, paramListConst);
 
     // Same fine matrix, same reuse entry point: non-const vs const CrsMatrix handle.
     MueLu::ReuseTpetraPreconditioner(tpA, *precNonConst);
@@ -523,12 +536,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_RcpCrsMat
 
     Teuchos::ParameterList mueluList;
 
+    Teuchos::ParameterList paramListFromCrs(mueluList);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precFromCrs =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(tpA, Teuchos::ParameterList(mueluList));
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(tpA, paramListFromCrs);
 
     RCP<tpetra_operator_type> opOnly(tpA);
+    Teuchos::ParameterList paramListFromOp(mueluList);
     RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precFromOp =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opOnly, Teuchos::ParameterList(mueluList));
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opOnly, paramListFromOp);
 
     RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
     RHS->setSeed(846930886);

--- a/packages/muelu/test/unit_tests/Adapters/TpetraOperatorAdapter.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/TpetraOperatorAdapter.cpp
@@ -497,6 +497,63 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, ReuseTpetraPreconditioner_Cons
 #endif
 }  // ReuseTpetraPreconditioner_ConstCrsMatrix
 
+// Regression: Teuchos::RCP<Tpetra::CrsMatrix> used to be ambiguous between the overloads taking
+// RCP<Tpetra::Operator> and RCP<const Tpetra::Operator> (e.g. Zoltan2 Sphynx).  The dedicated
+// RCP<CrsMatrix> overload must compile and agree with the RCP<Operator> entry point.
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_RcpCrsMatrixOverload, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+#include <MueLu_UseShortNames.hpp>
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
+  out << "version: " << MueLu::Version() << std::endl;
+
+#if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
+  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
+  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
+  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+
+  if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
+    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
+    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(6561 * comm->getSize());
+    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+
+    Teuchos::ParameterList mueluList;
+
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precFromCrs =
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(tpA, mueluList);
+
+    RCP<tpetra_operator_type> opOnly(tpA);
+    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precFromOp =
+        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opOnly, mueluList);
+
+    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    RHS->setSeed(846930886);
+    RHS->randomize();
+    Teuchos::Array<magnitude_type> norms(1);
+    RHS->norm2(norms);
+    RHS->scale(1 / norms[0]);
+
+    RCP<MultiVector> Xcrs = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    RCP<MultiVector> Xop  = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    Xcrs->putScalar((SC)0.0);
+    Xop->putScalar((SC)0.0);
+
+    precFromCrs->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xcrs)));
+    precFromOp->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xop)));
+
+    RCP<MultiVector> diff = MultiVectorFactory::Build(Op->getRowMap(), 1);
+    diff->putScalar(0.0);
+    diff->update(1.0, *Xcrs, -1.0, *Xop, 0.0);
+    diff->norm2(norms);
+    out << "|| X_rcp_crs - X_rcp_op ||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << norms[0] << std::endl;
+    TEST_EQUALITY(norms[0] < 1e-10, true);
+  } else {
+    out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
+  }
+#else
+  out << "Skipping test because some required packages are not enabled (Tpetra, Ifpack2, Amesos2)." << std::endl;
+#endif
+}  // CreatePreconditioner_RcpCrsMatrixOverload
+
 #define MUELU_ETI_GROUP(Scalar, LocalOrdinal, GlobalOrdinal, Node)                                                                                    \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, Apply, Scalar, LocalOrdinal, GlobalOrdinal, Node)                                              \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, Getters, Scalar, LocalOrdinal, GlobalOrdinal, Node)                                            \
@@ -505,7 +562,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, ReuseTpetraPreconditioner_Cons
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, CreatePreconditioner_ConstOperator_SmallGrid, Scalar, LocalOrdinal, GlobalOrdinal, Node)       \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, CreatePreconditioner_ConstOperator_HierarchyLevels, Scalar, LocalOrdinal, GlobalOrdinal, Node) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, CreatePreconditioner_ConstOperator_TwoVectors, Scalar, LocalOrdinal, GlobalOrdinal, Node)      \
-  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, ReuseTpetraPreconditioner_ConstCrsMatrix, Scalar, LocalOrdinal, GlobalOrdinal, Node)
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, ReuseTpetraPreconditioner_ConstCrsMatrix, Scalar, LocalOrdinal, GlobalOrdinal, Node)           \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(TpetraOperator, CreatePreconditioner_RcpCrsMatrixOverload, Scalar, LocalOrdinal, GlobalOrdinal, Node)
 
 #include <MueLu_ETI_4arg.hpp>
 

--- a/packages/muelu/test/unit_tests/Adapters/TpetraOperatorAdapter.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/TpetraOperatorAdapter.cpp
@@ -33,6 +33,167 @@
 
 namespace MueLuTests {
 
+namespace {  // helpers local to this translation unit, shared by the CreateTpetraPreconditioner
+             // const-overload tests added together with MueLu::CreateTpetraPreconditioner's
+             // RCP<const Tpetra::Operator> / RCP<CrsMatrix> overloads.
+
+// Small 1D-Poisson based fixture that exposes the handles every const-overload test needs:
+// the Xpetra matrix, its Tpetra::CrsMatrix view, and non-const / const Tpetra::Operator RCPs.
+// Also provides a few one-liner utilities (pair creation, random RHS, residual reduction)
+// so that each test is driven by a couple of lines plus its specific assertion tolerances.
+template <class SC, class LO, class GO, class NO>
+struct ConstOverloadFixture {
+  using magnitude_type             = typename Teuchos::ScalarTraits<SC>::magnitudeType;
+  using tpetra_crsmatrix_type      = Tpetra::CrsMatrix<SC, LO, GO, NO>;
+  using tpetra_operator_type       = Tpetra::Operator<SC, LO, GO, NO>;
+  using matrix_type                = Xpetra::Matrix<SC, LO, GO, NO>;
+  using multivector_type           = Xpetra::MultiVector<SC, LO, GO, NO>;
+  using multivector_factory_type   = Xpetra::MultiVectorFactory<SC, LO, GO, NO>;
+  using muelu_tpetra_operator_type = MueLu::TpetraOperator<SC, LO, GO, NO>;
+  using precond_pair               = std::pair<Teuchos::RCP<muelu_tpetra_operator_type>,
+                                               Teuchos::RCP<muelu_tpetra_operator_type>>;
+
+  Teuchos::RCP<matrix_type> Op;
+  Teuchos::RCP<tpetra_crsmatrix_type> tpA;
+  Teuchos::RCP<tpetra_operator_type> opNonConst;
+  Teuchos::RCP<const tpetra_operator_type> opConst;
+
+  explicit ConstOverloadFixture(GO rowsPerRank) {
+    auto comm  = TestHelpers::Parameters::getDefaultComm();
+    Op         = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(rowsPerRank * comm->getSize());
+    tpA        = Xpetra::toTpetra(Op);
+    opNonConst = Teuchos::rcp_implicit_cast<tpetra_operator_type>(tpA);
+    opConst    = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
+  }
+
+  // CreateTpetraPreconditioner takes ParameterList by non-const reference and fills defaults
+  // in place.  Both API paths therefore need their own fresh named lvalue copy of `base` so
+  // they start from identical configuration (temporary ParameterList cannot bind to ParameterList&).
+  precond_pair makeNonConstVsConstOperator(const Teuchos::ParameterList& base) const {
+    Teuchos::ParameterList listA(base), listB(base);
+    auto precA = MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, listA);
+    auto precB = MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, listB);
+    return std::make_pair(precA, precB);
+  }
+
+  // Compare the dedicated RCP<CrsMatrix> overload against the generic RCP<Operator> overload.
+  precond_pair makeCrsMatrixVsOperator(const Teuchos::ParameterList& base) const {
+    Teuchos::ParameterList listCrs(base), listOp(base);
+    auto precCrs = MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(tpA, listCrs);
+    auto precOp  = MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, listOp);
+    return std::make_pair(precCrs, precOp);
+  }
+
+  // Same fine matrix, reuse entry point tested with non-const vs const CrsMatrix handle.
+  void reuseOnConstNonConstCrsMatrix(muelu_tpetra_operator_type& precForNonConst,
+                                     muelu_tpetra_operator_type& precForConst) const {
+    MueLu::ReuseTpetraPreconditioner(tpA, precForNonConst);
+    Teuchos::RCP<const tpetra_crsmatrix_type> tpAconst =
+        Teuchos::rcp_implicit_cast<const tpetra_crsmatrix_type>(tpA);
+    MueLu::ReuseTpetraPreconditioner(tpAconst, precForConst);
+  }
+
+  // Normalized random RHS (per-column unit 2-norm).
+  Teuchos::RCP<multivector_type> makeRandomRHS(int numVec, unsigned int seed) const {
+    auto RHS = multivector_factory_type::Build(Op->getRowMap(), numVec);
+    RHS->setSeed(seed);
+    RHS->randomize();
+    Teuchos::Array<magnitude_type> colNorms(numVec);
+    RHS->norm2(colNorms());
+    for (int j = 0; j < numVec; ++j)
+      RHS->getVectorNonConst(j)->scale(Teuchos::ScalarTraits<magnitude_type>::one() / colNorms[j]);
+    return RHS;
+  }
+
+  Teuchos::RCP<multivector_type> makeZero(int numVec) const {
+    auto X = multivector_factory_type::Build(Op->getRowMap(), numVec);
+    X->putScalar(Teuchos::ScalarTraits<SC>::zero());
+    return X;
+  }
+
+  // Per-column relative residual ||A*X - RHS||_2 / ||RHS||_2.
+  Teuchos::Array<magnitude_type> residualReduction(const multivector_type& X,
+                                                   const multivector_type& RHS) const {
+    const int numVec = static_cast<int>(X.getNumVectors());
+    auto r           = multivector_factory_type::Build(Op->getRowMap(), numVec);
+    Op->apply(X, *r);
+    r->update(Teuchos::ScalarTraits<SC>::one(), RHS, -Teuchos::ScalarTraits<SC>::one());
+    Teuchos::Array<magnitude_type> rNorm(numVec), rhsNorm(numVec);
+    r->norm2(rNorm());
+    RHS.norm2(rhsNorm());
+    Teuchos::Array<magnitude_type> red(numVec);
+    for (int j = 0; j < numVec; ++j)
+      red[j] = rNorm[j] / rhsNorm[j];
+    return red;
+  }
+};
+
+// Apply precA and precB to `RHS` and verify API equivalence:
+//  (a) each preconditioner reduces the residual below `redMax`;
+//  (b) the two API paths agree per-column within `gapMax`;
+//  (c) both hierarchies have the same number of levels.
+// Two CreateTpetraPreconditioner calls build independent hierarchies, so bit-identical
+// behavior is NOT expected: UncoupledAggregation uses random graph coloring, so aggregate
+// counts on coarse levels can differ by a handful (e.g. 721 vs 722 on level 2), and the
+// SaPFactory eigenvalue estimate (PowerMethod) is nondeterministic across independent
+// setups (slightly different Prolongator damping factor).  Tolerances reflect that:
+// `redMax` is a "the preconditioner is not broken" bound, `gapMax` is a per-column
+// disagreement bound that absorbs aggregation-level randomness, not numerical noise.
+template <class SC, class LO, class GO, class NO>
+void expectEquivalentPreconditioner(Teuchos::FancyOStream& out,
+                                    bool& success,
+                                    const ConstOverloadFixture<SC, LO, GO, NO>& fx,
+                                    MueLu::TpetraOperator<SC, LO, GO, NO>& precA,
+                                    MueLu::TpetraOperator<SC, LO, GO, NO>& precB,
+                                    const Teuchos::RCP<Xpetra::MultiVector<SC, LO, GO, NO>>& RHS,
+                                    typename Teuchos::ScalarTraits<SC>::magnitudeType redMax,
+                                    typename Teuchos::ScalarTraits<SC>::magnitudeType gapMax,
+                                    const std::string& label) {
+  using magnitude_type = typename Teuchos::ScalarTraits<SC>::magnitudeType;
+  const int numVec     = static_cast<int>(RHS->getNumVectors());
+
+  auto Xa = fx.makeZero(numVec);
+  auto Xb = fx.makeZero(numVec);
+  precA.apply(*Xpetra::toTpetra(RHS), *Xpetra::toTpetra(Xa));
+  precB.apply(*Xpetra::toTpetra(RHS), *Xpetra::toTpetra(Xb));
+
+  const auto redA = fx.residualReduction(*Xa, *RHS);
+  const auto redB = fx.residualReduction(*Xb, *RHS);
+
+  const magnitude_type zero = Teuchos::ScalarTraits<magnitude_type>::zero();
+  magnitude_type maxRedA = zero, maxRedB = zero, maxGap = zero;
+  for (int j = 0; j < numVec; ++j) {
+    if (redA[j] > maxRedA) maxRedA = redA[j];
+    if (redB[j] > maxRedB) maxRedB = redB[j];
+    const magnitude_type gap = Teuchos::ScalarTraits<magnitude_type>::magnitude(redA[j] - redB[j]);
+    if (gap > maxGap) maxGap = gap;
+  }
+
+  out << label << ": max residual reduction A=" << std::setiosflags(std::ios::fixed)
+      << std::setprecision(10) << maxRedA << ", B=" << maxRedB
+      << ", max per-column gap=" << maxGap << std::endl;
+
+  TEUCHOS_TEST_EQUALITY(maxRedA < redMax, true, out, success);
+  TEUCHOS_TEST_EQUALITY(maxRedB < redMax, true, out, success);
+  TEUCHOS_TEST_EQUALITY(maxGap < gapMax, true, out, success);
+  TEUCHOS_TEST_EQUALITY(precA.GetHierarchy()->GetNumLevels(),
+                        precB.GetHierarchy()->GetNumLevels(), out, success);
+}
+
+template <class SC, class LO, class GO, class NO>
+void expectEquivalentHierarchyLevels(Teuchos::FancyOStream& out,
+                                     bool& success,
+                                     MueLu::TpetraOperator<SC, LO, GO, NO>& precA,
+                                     MueLu::TpetraOperator<SC, LO, GO, NO>& precB,
+                                     const std::string& label) {
+  const int levelsA = precA.GetHierarchy()->GetNumLevels();
+  const int levelsB = precB.GetHierarchy()->GetNumLevels();
+  out << label << ": numLevels A=" << levelsA << ", B=" << levelsB << std::endl;
+  TEUCHOS_TEST_EQUALITY(levelsA, levelsB, out, success);
+}
+
+}  // namespace
+
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, Apply, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
 #include <MueLu_UseShortNames.hpp>
   MUELU_TESTING_SET_OSTREAM;
@@ -166,8 +327,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, Getters, Scalar, LocalOrdinal,
 }
 
 // Reproducer for Trilinos issue #15062: callers that only have Teuchos::RCP<const Tpetra::Operator>
-// could not use CreateTpetraPreconditioner without const_cast.  The overload taking RCP<const Operator>
-// must match the non-const overload (same MG iterate).
+// could not use CreateTpetraPreconditioner without const_cast.  The overload taking
+// RCP<const Operator> must produce a preconditioner equivalent to the non-const overload.
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOperator, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
 #include <MueLu_UseShortNames.hpp>
   MUELU_TESTING_SET_OSTREAM;
@@ -175,51 +336,18 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
   out << "version: " << MueLu::Version() << std::endl;
 
 #if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
-  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
-  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
-  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+  using magnitude_type = typename Teuchos::ScalarTraits<SC>::magnitudeType;
 
   if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
-    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
-    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(6561 * comm->getSize());
-    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+    ConstOverloadFixture<SC, LO, GO, NO> fx(/*rowsPerRank=*/6561);
+    Teuchos::ParameterList baseList;
+    auto precs = fx.makeNonConstVsConstOperator(baseList);
+    auto RHS   = fx.makeRandomRHS(/*numVec=*/1, /*seed=*/846930886u);
 
-    RCP<tpetra_operator_type> opNonConst(tpA);
-    RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
-
-    // CreateTpetraPreconditioner takes ParameterList by non-const reference and fills defaults in-place.
-    // Each build must receive a fresh copy of the user's list so const vs non-const paths start identical.
-    // Copies must be named lvalues: a temporary ParameterList cannot bind to non-const ParameterList&.
-    Teuchos::ParameterList mueluList;
-
-    Teuchos::ParameterList paramListNonConst(mueluList);
-    Teuchos::ParameterList paramListConst(mueluList);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, paramListNonConst);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, paramListConst);
-
-    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    RHS->setSeed(846930886);
-    RHS->randomize();
-    Teuchos::Array<magnitude_type> norms(1);
-    RHS->norm2(norms);
-    RHS->scale(1 / norms[0]);
-
-    RCP<MultiVector> Xnc = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    RCP<MultiVector> Xc  = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    Xnc->putScalar((SC)0.0);
-    Xc->putScalar((SC)0.0);
-
-    precNonConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xnc)));
-    precConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xc)));
-
-    RCP<MultiVector> diff = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    diff->putScalar((SC)0.0);
-    diff->update(1.0, *Xnc, -1.0, *Xc, 0.0);
-    diff->norm2(norms);
-    out << "|| X_nonconst - X_const ||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << norms[0] << std::endl;
-    TEST_EQUALITY(norms[0] < 1e-10, true);
+    expectEquivalentPreconditioner(out, success, fx, *precs.first, *precs.second, RHS,
+                                   static_cast<magnitude_type>(0.95),
+                                   static_cast<magnitude_type>(0.15),
+                                   "CreatePreconditioner_ConstOperator");
   } else {
     out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
   }
@@ -228,7 +356,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
 #endif
 }  // CreatePreconditioner_ConstOperator
 
-// CreateTpetraPreconditioner(inA) with no ParameterList: const vs non-const Operator overloads.
+// CreateTpetraPreconditioner(inA) with a default-constructed (empty) ParameterList must
+// likewise be equivalent across the non-const / const Operator overloads.
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOperator_NoParameterList, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
 #include <MueLu_UseShortNames.hpp>
   MUELU_TESTING_SET_OSTREAM;
@@ -236,47 +365,18 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
   out << "version: " << MueLu::Version() << std::endl;
 
 #if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
-  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
-  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
-  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+  using magnitude_type = typename Teuchos::ScalarTraits<SC>::magnitudeType;
 
   if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
-    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
-    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(6561 * comm->getSize());
-    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+    ConstOverloadFixture<SC, LO, GO, NO> fx(/*rowsPerRank=*/6561);
+    Teuchos::ParameterList baseList;
+    auto precs = fx.makeNonConstVsConstOperator(baseList);
+    auto RHS   = fx.makeRandomRHS(/*numVec=*/1, /*seed=*/846930886u);
 
-    RCP<tpetra_operator_type> opNonConst(tpA);
-    RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
-
-    Teuchos::ParameterList mueluList;
-    Teuchos::ParameterList paramListNonConst(mueluList);
-    Teuchos::ParameterList paramListConst(mueluList);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, paramListNonConst);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, paramListConst);
-
-    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    RHS->setSeed(846930886);
-    RHS->randomize();
-    Teuchos::Array<magnitude_type> norms(1);
-    RHS->norm2(norms);
-    RHS->scale(1 / norms[0]);
-
-    RCP<MultiVector> Xnc = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    RCP<MultiVector> Xc  = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    Xnc->putScalar((SC)0.0);
-    Xc->putScalar((SC)0.0);
-
-    precNonConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xnc)));
-    precConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xc)));
-
-    RCP<MultiVector> diff = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    diff->putScalar((SC)0.0);
-    diff->update(1.0, *Xnc, -1.0, *Xc, 0.0);
-    diff->norm2(norms);
-    out << "|| X_nonconst - X_const ||_2 (no plist) = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << norms[0] << std::endl;
-    TEST_EQUALITY(norms[0] < 1e-10, true);
+    expectEquivalentPreconditioner(out, success, fx, *precs.first, *precs.second, RHS,
+                                   static_cast<magnitude_type>(0.95),
+                                   static_cast<magnitude_type>(0.15),
+                                   "CreatePreconditioner_ConstOperator_NoParameterList");
   } else {
     out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
   }
@@ -285,7 +385,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
 #endif
 }  // CreatePreconditioner_ConstOperator_NoParameterList
 
-// Smaller 1D problem (fewer rows per rank) to exercise the same const / non-const overload equivalence.
+// Smaller 1D problem (fewer rows per rank).  Residual reduction is looser on a shallow grid.
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOperator_SmallGrid, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
 #include <MueLu_UseShortNames.hpp>
   MUELU_TESTING_SET_OSTREAM;
@@ -293,49 +393,18 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
   out << "version: " << MueLu::Version() << std::endl;
 
 #if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
-  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
-  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
-  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+  using magnitude_type = typename Teuchos::ScalarTraits<SC>::magnitudeType;
 
   if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
-    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
-    const GO localRows                 = 243;
-    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(localRows * comm->getSize());
-    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+    ConstOverloadFixture<SC, LO, GO, NO> fx(/*rowsPerRank=*/243);
+    Teuchos::ParameterList baseList;
+    auto precs = fx.makeNonConstVsConstOperator(baseList);
+    auto RHS   = fx.makeRandomRHS(/*numVec=*/1, /*seed=*/123456789u);
 
-    RCP<tpetra_operator_type> opNonConst(tpA);
-    RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
-
-    Teuchos::ParameterList mueluList;
-
-    Teuchos::ParameterList paramListNonConst(mueluList);
-    Teuchos::ParameterList paramListConst(mueluList);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, paramListNonConst);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, paramListConst);
-
-    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    RHS->setSeed(123456789);
-    RHS->randomize();
-    Teuchos::Array<magnitude_type> norms(1);
-    RHS->norm2(norms);
-    RHS->scale(1 / norms[0]);
-
-    RCP<MultiVector> Xnc = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    RCP<MultiVector> Xc  = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    Xnc->putScalar((SC)0.0);
-    Xc->putScalar((SC)0.0);
-
-    precNonConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xnc)));
-    precConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xc)));
-
-    RCP<MultiVector> diff = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    diff->putScalar((SC)0.0);
-    diff->update(1.0, *Xnc, -1.0, *Xc, 0.0);
-    diff->norm2(norms);
-    out << "|| X_nonconst - X_const ||_2 (small grid) = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << norms[0] << std::endl;
-    TEST_EQUALITY(norms[0] < 1e-10, true);
+    expectEquivalentPreconditioner(out, success, fx, *precs.first, *precs.second, RHS,
+                                   static_cast<magnitude_type>(0.95),
+                                   static_cast<magnitude_type>(0.15),
+                                   "CreatePreconditioner_ConstOperator_SmallGrid");
   } else {
     out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
   }
@@ -352,30 +421,13 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
   out << "version: " << MueLu::Version() << std::endl;
 
 #if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
-  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
-  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
-
   if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
-    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
-    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(2187 * comm->getSize());
-    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+    ConstOverloadFixture<SC, LO, GO, NO> fx(/*rowsPerRank=*/2187);
+    Teuchos::ParameterList baseList;
+    auto precs = fx.makeNonConstVsConstOperator(baseList);
 
-    RCP<tpetra_operator_type> opNonConst(tpA);
-    RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
-
-    Teuchos::ParameterList mueluList;
-
-    Teuchos::ParameterList paramListNonConst(mueluList);
-    Teuchos::ParameterList paramListConst(mueluList);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, paramListNonConst);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, paramListConst);
-
-    const int levelsNC = precNonConst->GetHierarchy()->GetNumLevels();
-    const int levelsC  = precConst->GetHierarchy()->GetNumLevels();
-    out << "numLevels non-const handle: " << levelsNC << ", const handle: " << levelsC << std::endl;
-    TEST_EQUALITY(levelsNC, levelsC);
+    expectEquivalentHierarchyLevels(out, success, *precs.first, *precs.second,
+                                    "CreatePreconditioner_ConstOperator_HierarchyLevels");
   } else {
     out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
   }
@@ -392,58 +444,18 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
   out << "version: " << MueLu::Version() << std::endl;
 
 #if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
-  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
-  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
-  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+  using magnitude_type = typename Teuchos::ScalarTraits<SC>::magnitudeType;
 
   if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
-    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
-    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(729 * comm->getSize());
-    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+    ConstOverloadFixture<SC, LO, GO, NO> fx(/*rowsPerRank=*/729);
+    Teuchos::ParameterList baseList;
+    auto precs = fx.makeNonConstVsConstOperator(baseList);
+    auto RHS   = fx.makeRandomRHS(/*numVec=*/2, /*seed=*/97531u);
 
-    RCP<tpetra_operator_type> opNonConst(tpA);
-    RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
-
-    Teuchos::ParameterList mueluList;
-
-    Teuchos::ParameterList paramListNonConst(mueluList);
-    Teuchos::ParameterList paramListConst(mueluList);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, paramListNonConst);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, paramListConst);
-
-    const int numVec     = 2;
-    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), numVec);
-    RHS->setSeed(97531);
-    RHS->randomize();
-    Teuchos::Array<magnitude_type> colNorms(numVec);
-    RHS->norm2(colNorms());
-    for (int j = 0; j < numVec; ++j) {
-      auto col = RHS->getVectorNonConst(j);
-      col->scale(1 / colNorms[j]);
-    }
-
-    RCP<MultiVector> Xnc = MultiVectorFactory::Build(Op->getRowMap(), numVec);
-    RCP<MultiVector> Xc  = MultiVectorFactory::Build(Op->getRowMap(), numVec);
-    Xnc->putScalar((SC)0.0);
-    Xc->putScalar((SC)0.0);
-
-    precNonConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xnc)));
-    precConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xc)));
-
-    RCP<MultiVector> diff = MultiVectorFactory::Build(Op->getRowMap(), numVec);
-    diff->putScalar((SC)0.0);
-    diff->update(1.0, *Xnc, -1.0, *Xc, 0.0);
-    Teuchos::Array<magnitude_type> diffNorms(numVec);
-    diff->norm2(diffNorms());
-    magnitude_type maxColDiff = Teuchos::ScalarTraits<magnitude_type>::zero();
-    for (int j = 0; j < numVec; ++j) {
-      if (diffNorms[j] > maxColDiff)
-        maxColDiff = diffNorms[j];
-    }
-    out << "max_j || (X_nc - X_c)_j ||_2 (2 vectors) = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << maxColDiff << std::endl;
-    TEST_EQUALITY(maxColDiff < 1e-10, true);
+    expectEquivalentPreconditioner(out, success, fx, *precs.first, *precs.second, RHS,
+                                   static_cast<magnitude_type>(0.95),
+                                   static_cast<magnitude_type>(0.15),
+                                   "CreatePreconditioner_ConstOperator_TwoVectors");
   } else {
     out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
   }
@@ -452,7 +464,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_ConstOper
 #endif
 }  // CreatePreconditioner_ConstOperator_TwoVectors
 
-// ReuseTpetraPreconditioner with RCP<const CrsMatrix> vs RCP<CrsMatrix> after the same fine-matrix update.
+// ReuseTpetraPreconditioner with RCP<const CrsMatrix> vs RCP<CrsMatrix> on the same fine matrix.
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, ReuseTpetraPreconditioner_ConstCrsMatrix, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
 #include <MueLu_UseShortNames.hpp>
   MUELU_TESTING_SET_OSTREAM;
@@ -460,53 +472,19 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, ReuseTpetraPreconditioner_Cons
   out << "version: " << MueLu::Version() << std::endl;
 
 #if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
-  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
-  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
-  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+  using magnitude_type = typename Teuchos::ScalarTraits<SC>::magnitudeType;
 
   if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
-    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
-    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(2187 * comm->getSize());
-    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+    ConstOverloadFixture<SC, LO, GO, NO> fx(/*rowsPerRank=*/2187);
+    Teuchos::ParameterList baseList;
+    auto precs = fx.makeNonConstVsConstOperator(baseList);
+    fx.reuseOnConstNonConstCrsMatrix(*precs.first, *precs.second);
 
-    RCP<tpetra_operator_type> opNonConst(tpA);
-    RCP<const tpetra_operator_type> opConst = Teuchos::rcp_implicit_cast<const tpetra_operator_type>(tpA);
-
-    Teuchos::ParameterList mueluList;
-
-    Teuchos::ParameterList paramListNonConst(mueluList);
-    Teuchos::ParameterList paramListConst(mueluList);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precNonConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opNonConst, paramListNonConst);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precConst =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opConst, paramListConst);
-
-    // Same fine matrix, same reuse entry point: non-const vs const CrsMatrix handle.
-    MueLu::ReuseTpetraPreconditioner(tpA, *precNonConst);
-    RCP<const tpetra_crsmatrix_type> tpAconst = Teuchos::rcp_implicit_cast<const tpetra_crsmatrix_type>(tpA);
-    MueLu::ReuseTpetraPreconditioner(tpAconst, *precConst);
-
-    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    RHS->setSeed(314159265);
-    RHS->randomize();
-    Teuchos::Array<magnitude_type> norms(1);
-    RHS->norm2(norms);
-    RHS->scale(1 / norms[0]);
-
-    RCP<MultiVector> Xnc = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    RCP<MultiVector> Xc  = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    Xnc->putScalar((SC)0.0);
-    Xc->putScalar((SC)0.0);
-
-    precNonConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xnc)));
-    precConst->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xc)));
-
-    RCP<MultiVector> diff = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    diff->putScalar((SC)0.0);
-    diff->update(1.0, *Xnc, -1.0, *Xc, 0.0);
-    diff->norm2(norms);
-    out << "|| X_nonconst - X_const ||_2 (after reuse) = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << norms[0] << std::endl;
-    TEST_EQUALITY(norms[0] < 1e-10, true);
+    auto RHS = fx.makeRandomRHS(/*numVec=*/1, /*seed=*/314159265u);
+    expectEquivalentPreconditioner(out, success, fx, *precs.first, *precs.second, RHS,
+                                   static_cast<magnitude_type>(0.95),
+                                   static_cast<magnitude_type>(0.15),
+                                   "ReuseTpetraPreconditioner_ConstCrsMatrix");
   } else {
     out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
   }
@@ -525,47 +503,18 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TpetraOperator, CreatePreconditioner_RcpCrsMat
   out << "version: " << MueLu::Version() << std::endl;
 
 #if defined(HAVE_MUELU_IFPACK2) && defined(HAVE_MUELU_AMESOS2)
-  typedef Tpetra::CrsMatrix<SC, LO, GO, NO> tpetra_crsmatrix_type;
-  typedef Tpetra::Operator<SC, LO, GO, NO> tpetra_operator_type;
-  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+  using magnitude_type = typename Teuchos::ScalarTraits<SC>::magnitudeType;
 
   if (TestHelpers::Parameters::getLib() == Xpetra::UseTpetra) {
-    RCP<const Teuchos::Comm<int>> comm = TestHelpers::Parameters::getDefaultComm();
-    RCP<Matrix> Op                     = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(6561 * comm->getSize());
-    RCP<tpetra_crsmatrix_type> tpA     = Xpetra::toTpetra(Op);
+    ConstOverloadFixture<SC, LO, GO, NO> fx(/*rowsPerRank=*/6561);
+    Teuchos::ParameterList baseList;
+    auto precs = fx.makeCrsMatrixVsOperator(baseList);
+    auto RHS   = fx.makeRandomRHS(/*numVec=*/1, /*seed=*/846930886u);
 
-    Teuchos::ParameterList mueluList;
-
-    Teuchos::ParameterList paramListFromCrs(mueluList);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precFromCrs =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(tpA, paramListFromCrs);
-
-    RCP<tpetra_operator_type> opOnly(tpA);
-    Teuchos::ParameterList paramListFromOp(mueluList);
-    RCP<MueLu::TpetraOperator<SC, LO, GO, NO>> precFromOp =
-        MueLu::CreateTpetraPreconditioner<SC, LO, GO, NO>(opOnly, paramListFromOp);
-
-    RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    RHS->setSeed(846930886);
-    RHS->randomize();
-    Teuchos::Array<magnitude_type> norms(1);
-    RHS->norm2(norms);
-    RHS->scale(1 / norms[0]);
-
-    RCP<MultiVector> Xcrs = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    RCP<MultiVector> Xop  = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    Xcrs->putScalar((SC)0.0);
-    Xop->putScalar((SC)0.0);
-
-    precFromCrs->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xcrs)));
-    precFromOp->apply(*(Xpetra::toTpetra(RHS)), *(Xpetra::toTpetra(Xop)));
-
-    RCP<MultiVector> diff = MultiVectorFactory::Build(Op->getRowMap(), 1);
-    diff->putScalar(0.0);
-    diff->update(1.0, *Xcrs, -1.0, *Xop, 0.0);
-    diff->norm2(norms);
-    out << "|| X_rcp_crs - X_rcp_op ||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) << norms[0] << std::endl;
-    TEST_EQUALITY(norms[0] < 1e-10, true);
+    expectEquivalentPreconditioner(out, success, fx, *precs.first, *precs.second, RHS,
+                                   static_cast<magnitude_type>(0.95),
+                                   static_cast<magnitude_type>(0.15),
+                                   "CreatePreconditioner_RcpCrsMatrixOverload");
   } else {
     out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;
   }

--- a/packages/muelu/test/unit_tests/Adapters/TpetraOperatorAdapter.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/TpetraOperatorAdapter.cpp
@@ -51,7 +51,7 @@ struct ConstOverloadFixture {
   using multivector_factory_type   = Xpetra::MultiVectorFactory<SC, LO, GO, NO>;
   using muelu_tpetra_operator_type = MueLu::TpetraOperator<SC, LO, GO, NO>;
   using precond_pair               = std::pair<Teuchos::RCP<muelu_tpetra_operator_type>,
-                                               Teuchos::RCP<muelu_tpetra_operator_type>>;
+                                 Teuchos::RCP<muelu_tpetra_operator_type>>;
 
   Teuchos::RCP<matrix_type> Op;
   Teuchos::RCP<tpetra_crsmatrix_type> tpA;

--- a/packages/muelu/test/unit_tests/CMakeLists.txt
+++ b/packages/muelu/test/unit_tests/CMakeLists.txt
@@ -19,6 +19,7 @@ TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../../src/Smoothers)
 TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../../src/Smoothers/BlockedSmoothers)
 TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../../src/Utils)
 TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../../adapters)
+TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../../adapters/linear_solver_factory)
 TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/Smoothers)
 TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../../research/regionMG/src)
 
@@ -153,7 +154,7 @@ ENDIF()
 
 ### Tests that require other Trilinos packages
 
-APPEND_SET(SOURCES Adapters/TpetraOperatorAdapter.cpp)
+APPEND_SET(SOURCES Adapters/TpetraOperatorAdapter.cpp Adapters/LinearSolverAdapter.cpp)
 
 IF(${PACKAGE_NAME}_ENABLE_Ifpack2)
   APPEND_SET(SOURCES Smoothers/Ifpack2Smoother.cpp)


### PR DESCRIPTION
@trilinos/muelu

## Motivation

Right now `MueLu::CreateTpetraPreconditioner` only had overloads taking `RCP<Tpetra::Operator>` (non-const). In practice you often only have `RCP<const Tpetra::Operator>` - same situation as in [#15062](https://github.com/trilinos/Trilinos/issues/15062). The usual workaround is `const_cast`, which works but is not great for downstream code (deal.II hit this too, see [dealii/dealii#19317](https://github.com/dealii/dealii/pull/19317)).

This PR adds overloads that take `RCP<const Tpetra::Operator>` (and const `CrsMatrix` / `BlockCrsMatrix` for `ReuseTpetraPreconditioner`) and forward to the existing code with `Teuchos::rcp_const_cast` - same idea as elsewhere in Teuchos-style when `RCP<const T>` and `RCP<T>` are different types.

I also added/extended unit tests under `packages/muelu/test/unit_tests/Adapters/` for the Tpetra operator + linear solver adapter paths. After syncing with upstream, some old helpers (`Op2NonConstTpetraCrs`, `MV2TpetraMV`, …) disappeared from `MueLu::Utilities`, so the tests now use `Xpetra::toTpetra` instead.

## Related issues

- Closes [#15062](https://github.com/trilinos/Trilinos/issues/15062)
- Extra context: [dealii/dealii#19317](https://github.com/dealii/dealii/pull/19317)

## What this PR does and what it does **not** do

**Does:** Lets downstream call `CreateTpetraPreconditioner` / `ReuseTpetraPreconditioner` with `RCP<const …>` **without hand-written `const_cast` in application code**. Overload resolution is real (`RCP<const T>` vs `RCP<T>` are different types).

**Does not (yet):** The implementation still forwards with `Teuchos::rcp_const_cast` into the same non-const paths as before. So this fixes the **API / ergonomics** problem from the issue; it is **not** a full internal const-correct redesign of the whole MueLu stack (that would be follow-up work).

## Compilation and run tests (example of my way)

```bash
SAN="-fsanitize=address,undefined,leak -fno-omit-frame-pointer -g"

export CXXFLAGS="$SAN"

export LDFLAGS="$SAN"

cmake \
  -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_CXX_COMPILER=mpicxx \
  -DCMAKE_C_COMPILER=mpicc \
  -DCMAKE_CXX_FLAGS="$SAN" \
  -DCMAKE_EXE_LINKER_FLAGS="$SAN" \
  -DCMAKE_SHARED_LINKER_FLAGS="$SAN" \
  -DTrilinos_ENABLE_MueLu=ON \
  -DTrilinos_ENABLE_TESTS=ON \
  -DCMAKE_CXX_STANDARD=20 \
  /home/loveit0/Documents/Work/Trilinos
  
cmake --build . -j"$(nproc)" --target MueLu_UnitTests

./packages/muelu/test/unit_tests/MueLu_UnitTests.exe --group='LinearSolverAdapter*' && ./packages/muelu/test/unit_tests/MueLu_UnitTests.exe --group='TpetraOperator*'
```

**Output for my case (Ubuntu 24.04 GCC-13.3.0 GLIBC-2.42 GLIBCXX-3.4.33)**:

```
./packages/muelu/test/unit_tests/MueLu_UnitTests.exe --group='LinearSolverAdapter*' && ./packages/muelu/test/unit_tests/MueLu_UnitTests.exe --group='TpetraOperator*'
Teuchos::GlobalMPISession::GlobalMPISession(): started serial run

***
*** Unit test suite ...
***


Sorting tests by group name then by the order they were added ... (time = 0.000963)

Running unit tests ...

/home/loveit0/Documents/Work/Trilinos/packages/muelu/test/unit_tests/../../src/Smoothers/MueLu_SmootherBase.hpp:32:7: runtime error: load of value 190, which is not a valid value for type 'bool'
140. LinearSolverAdapter_double_int_longlong_Tpetra_KokkosCompat_KokkosSerialWrapperNode_FullCycle_WithoutParameterList_UnitTest ... [Passed] (0.113 sec)
141. LinearSolverAdapter_double_int_longlong_Tpetra_KokkosCompat_KokkosSerialWrapperNode_FullCycle_WithParameterList_UnitTest ... [Passed] (0.0911 sec)
142. LinearSolverAdapter_double_int_longlong_Tpetra_KokkosCompat_KokkosSerialWrapperNode_MatrixUpdate_ReuseTpetraPreconditioner_UnitTest ... [Passed] (0.0997 sec)
143. LinearSolverAdapter_double_int_longlong_Tpetra_KokkosCompat_KokkosSerialWrapperNode_ReuseWithNonCrsOperatorThrows_UnitTest ... [Passed] (0.107 sec)

Total Time: 0.412 sec

Summary: total = 270, run = 4, passed = 4, failed = 0

End Result: TEST PASSED
Teuchos::GlobalMPISession::GlobalMPISession(): started serial run

***
*** Unit test suite ...
***


Sorting tests by group name then by the order they were added ... (time = 0.000972)

Running unit tests ...

/home/loveit0/Documents/Work/Trilinos/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_decl.hpp:51:7: runtime error: load of value 190, which is not a valid value for type 'bool'
/home/loveit0/Documents/Work/Trilinos/packages/muelu/test/unit_tests/../../src/Smoothers/MueLu_SmootherBase.hpp:32:7: runtime error: load of value 190, which is not a valid value for type 'bool'
242. TpetraOperator_double_int_longlong_Tpetra_KokkosCompat_KokkosSerialWrapperNode_Apply_UnitTest ... [Passed] (0.422 sec)
243. TpetraOperator_double_int_longlong_Tpetra_KokkosCompat_KokkosSerialWrapperNode_Getters_UnitTest ... [Passed] (0.00988 sec)
244. TpetraOperator_double_int_longlong_Tpetra_KokkosCompat_KokkosSerialWrapperNode_CreatePreconditioner_ConstOperator_UnitTest ... [Passed] (0.825 sec)
245. TpetraOperator_double_int_longlong_Tpetra_KokkosCompat_KokkosSerialWrapperNode_CreatePreconditioner_ConstOperator_NoParameterList_UnitTest ... [Passed] (0.831 sec)
246. TpetraOperator_double_int_longlong_Tpetra_KokkosCompat_KokkosSerialWrapperNode_CreatePreconditioner_ConstOperator_SmallGrid_UnitTest ... [Passed] (0.171 sec)
247. TpetraOperator_double_int_longlong_Tpetra_KokkosCompat_KokkosSerialWrapperNode_CreatePreconditioner_ConstOperator_HierarchyLevels_UnitTest ... [Passed] (0.333 sec)
248. TpetraOperator_double_int_longlong_Tpetra_KokkosCompat_KokkosSerialWrapperNode_CreatePreconditioner_ConstOperator_TwoVectors_UnitTest ... [Passed] (0.177 sec)
249. TpetraOperator_double_int_longlong_Tpetra_KokkosCompat_KokkosSerialWrapperNode_ReuseTpetraPreconditioner_ConstCrsMatrix_UnitTest ... [Passed] (0.516 sec)

Total Time: 3.29 sec

Summary: total = 270, run = 8, passed = 8, failed = 0

End Result: TEST PASSED
```

Also, as you can see tests have UB, but exactly not for this PR, I guess.

## Additional information

Main files: `MueLu_CreateTpetraPreconditioner.hpp`, small tweak in `MueLu_Details_LinearSolverFactory_def.hpp`, adapter tests + `CMakeLists.txt`.

The const overloads still delegate to the old implementation via `rcp_const_cast`; removing that completely would mean threading const through more of the stack - possible follow-up, not this PR.


