### PR TITLE
Sacado:  Remove specializations of std::is_same/std::is_same_v

### DIFF
--- a/packages/sacado/src/Kokkos_LayoutContiguous.hpp
+++ b/packages/sacado/src/Kokkos_LayoutContiguous.hpp
@@ -18,6 +18,7 @@
 #endif
 #include "Kokkos_Core_fwd.hpp"
 #include "Kokkos_Layout.hpp"
+#include "Kokkos_DynRankView.hpp"
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_CORE
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_CORE
@@ -83,36 +84,123 @@ struct inner_layout< LayoutContiguous<Layout, Stride> > {
   typedef Layout type;
 };
 
+// Specialize DynRankDimTraits for LayoutContiguous.
+// Weirdly, we need a full specialization on bool for the non-legacy View impl case
+// because of this code in Kokkos_DynRankView.hpp (around line 429):
+// #ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+//   using drdtraits = Impl::DynRankDimTraits<typename view_type::specialize>;
+// #else
+//   using drdtraits = Impl::DynRankDimTraits<
+//       std::conditional_t<view_type::traits::impl_is_customized, bool, void>>;
+// #endif
+namespace Impl {
+  template <>
+#ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+  struct DynRankDimTraits<ViewSpecializeSacadoFadContiguous> {
+#else
+  struct DynRankDimTraits<bool> {
+#endif
+    using drdtraits = DynRankDimTraits<void>;
+    enum : size_t { unspecified = drdtraits::unspecified };
+
+    // Compute the rank of the view from the nonzero dimension arguments.
+    KOKKOS_INLINE_FUNCTION
+    static size_t computeRank(const size_t N0, const size_t N1, const size_t N2,
+                              const size_t N3, const size_t N4, const size_t N5,
+                              const size_t N6, const size_t N7) {
+      return drdtraits::computeRank(N0,N1,N2,N3,N4,N5,N6,N7);
+    }
+
+    // Compute the rank of the view from the nonzero layout arguments.
+    template <typename Layout>
+    KOKKOS_INLINE_FUNCTION static size_t computeRank(const Layout& layout) {
+      return drdtraits::computeRank(layout);
+    }
+
+    // Extra overload to match that for specialize types v2
+    template <typename Layout, typename... P>
+    KOKKOS_INLINE_FUNCTION static size_t computeRank(
+        const Kokkos::Impl::ViewCtorProp<P...>& prop ,
+        const Layout& layout) {
+      return drdtraits::computeRank(prop, layout);
+    }
+
+    // Create the layout for the rank-7 view.
+    // Because the underlying View is rank-7, preserve "unspecified" for
+    // dimension 8.
+
+    // Non-contiguous Layout
+    template <typename Layout>
+    KOKKOS_INLINE_FUNCTION static std::enable_if_t<
+        !(is_layout_contiguous<Layout>::value),
+        Layout>
+    createLayout(const Layout& layout,
+                size_t new_rank = unspecified) {
+      return drdtraits::createLayout(layout, new_rank);
+    }
+
+    // Contiguous Layout
+    template <typename Layout>
+    KOKKOS_INLINE_FUNCTION static std::enable_if_t<
+        (is_layout_contiguous<Layout>::value),
+        Layout >
+    createLayout(const Layout& layout,
+                size_t new_rank = unspecified) {
+      return Layout(drdtraits::createLayout(layout.base_layout(), new_rank));
+    }
+
+    // Extra overload to match that for specialize types
+    template <typename Traits, typename... P>
+    KOKKOS_INLINE_FUNCTION static std::enable_if_t<
+        !(is_layout_contiguous<typename Traits::array_layout>::value),
+        typename Traits::array_layout>
+    createLayout(const Kokkos::Impl::ViewCtorProp<P...>& prop,
+                typename Traits::array_layout layout) {
+      //return drdtraits::template createLayout<Traits,P...>(prop, layout);
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+      if constexpr (Traits::impl_is_customized &&
+                    !Kokkos::Impl::ViewCtorProp<P...>::has_accessor_arg) {
+        auto rank              = computeRank(prop, layout) - 1;
+        layout.dimension[rank] = unspecified;
+      }
+#endif
+      return createLayout(layout);
+    }
+
+    // Extra overload to match that for specialize types
+    template <typename Traits, typename... P>
+    KOKKOS_INLINE_FUNCTION static std::enable_if_t<
+        (is_layout_contiguous<typename Traits::array_layout>::value),
+        typename Traits::array_layout>
+    createLayout(const Kokkos::Impl::ViewCtorProp<P...>& prop,
+                typename Traits::array_layout layout) {
+      //return Layout(drdtraits::template createLayout<Traits,P...>(prop, layout.base_layout()));
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+      if constexpr (Traits::impl_is_customized &&
+                    !Kokkos::Impl::ViewCtorProp<P...>::has_accessor_arg) {
+        auto rank              = computeRank(prop, layout) - 1;
+        layout.dimension[rank] = unspecified;
+      }
+#endif
+      return createLayout(layout);
+    }
+
+    // Create a view from the given dimension arguments.
+    // This is only necessary because the shmem constructor doesn't take a layout.
+    //   NDE shmem View's are not compatible with the added view_alloc value_type
+    //   / fad_dim deduction functionality
+    template <typename ViewType, typename ViewArg>
+    static ViewType createView(const ViewArg& arg, const size_t N0,
+                              const size_t N1, const size_t N2, const size_t N3,
+                              const size_t N4, const size_t N5, const size_t N6,
+                              const size_t N7) {
+      return drdtraits::createView(arg, N0, N1, N2, N3, N4, N5, N6, N7);
+    }
+  };
+
+} // namespace Impl
+
 } // namespace Kokkos
-
-// FIXME This is evil and needs refactoring urgently.
-// Make LayoutContiguous<Layout> equivalent to Layout
-namespace std {
-
-  template <class Layout, unsigned Stride>
-  struct is_same< Kokkos::LayoutContiguous<Layout,Stride>, Layout> {
-    static const bool value = true;
-  };
-
-  template <class Layout, unsigned Stride>
-#if defined(KOKKOS_COMPILER_INTEL)
-  inline constexpr bool is_same_v< Kokkos::LayoutContiguous<Layout,Stride>, Layout> = is_same<Kokkos::LayoutContiguous<Layout,Stride>, Layout>::value;
-#else
-  static constexpr bool is_same_v< Kokkos::LayoutContiguous<Layout,Stride>, Layout> = is_same<Kokkos::LayoutContiguous<Layout,Stride>, Layout>::value;
-#endif
-
-  template <class Layout, unsigned Stride>
-  struct is_same< Layout, Kokkos::LayoutContiguous<Layout,Stride> > {
-    static const bool value = true;
-  };
-
-  template <class Layout, unsigned Stride>
-#if defined(KOKKOS_COMPILER_INTEL)
-  inline constexpr bool is_same_v< Layout, Kokkos::LayoutContiguous<Layout,Stride>> = is_same<Kokkos::LayoutContiguous<Layout,Stride>, Layout>::value;
-#else
-  static constexpr bool is_same_v< Layout, Kokkos::LayoutContiguous<Layout,Stride>> = is_same<Kokkos::LayoutContiguous<Layout,Stride>, Layout>::value;
-#endif
-}
 
 #include "View/Kokkos_ViewMapping.hpp"
 

--- a/packages/sacado/src/Kokkos_LayoutContiguous.hpp
+++ b/packages/sacado/src/Kokkos_LayoutContiguous.hpp
@@ -203,7 +203,7 @@ namespace Impl {
   template <typename Layout, unsigned Stride, typename iType>
   KOKKOS_INLINE_FUNCTION LayoutContiguous<Layout,Stride>
   reconstructLayout(const LayoutContiguous<Layout,Stride>& layout, iType dynrank) {
-    return LayoutContiguous<Layout,Stride>(reconsructLayout(layout.base_layout(), dynrank));
+    return LayoutContiguous<Layout,Stride>(reconstructLayout(layout.base_layout(), dynrank));
   }
 
 } // namespace Impl

--- a/packages/sacado/src/Kokkos_LayoutContiguous.hpp
+++ b/packages/sacado/src/Kokkos_LayoutContiguous.hpp
@@ -84,16 +84,17 @@ struct inner_layout< LayoutContiguous<Layout, Stride> > {
   typedef Layout type;
 };
 
-// Specialize DynRankDimTraits for LayoutContiguous.
-// Weirdly, we need a full specialization on bool for the non-legacy View impl case
-// because of this code in Kokkos_DynRankView.hpp (around line 429):
-// #ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
-//   using drdtraits = Impl::DynRankDimTraits<typename view_type::specialize>;
-// #else
-//   using drdtraits = Impl::DynRankDimTraits<
-//       std::conditional_t<view_type::traits::impl_is_customized, bool, void>>;
-// #endif
 namespace Impl {
+
+  // Specialize DynRankDimTraits for LayoutContiguous.
+  // Weirdly, we need a full specialization on bool for the non-legacy View impl case
+  // because of this code in Kokkos_DynRankView.hpp (around line 429):
+  // #ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+  //   using drdtraits = Impl::DynRankDimTraits<typename view_type::specialize>;
+  // #else
+  //   using drdtraits = Impl::DynRankDimTraits<
+  //       std::conditional_t<view_type::traits::impl_is_customized, bool, void>>;
+  // #endif
   template <>
 #ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
   struct DynRankDimTraits<ViewSpecializeSacadoFadContiguous> {
@@ -197,6 +198,13 @@ namespace Impl {
       return drdtraits::createView(arg, N0, N1, N2, N3, N4, N5, N6, N7);
     }
   };
+
+  // Overload reconstructLayout for LayoutContiguous
+  template <typename Layout, unsigned Stride, typename iType>
+  KOKKOS_INLINE_FUNCTION LayoutContiguous<Layout,Stride>
+  reconstructLayout(const LayoutContiguous<Layout,Stride>& layout, iType dynrank) {
+    return LayoutContiguous<Layout,Stride>(reconsructLayout(layout.base_layout(), dynrank));
+  }
 
 } // namespace Impl
 

--- a/packages/sacado/src/Sacado_Fad_Kokkos_Specialization.hpp
+++ b/packages/sacado/src/Sacado_Fad_Kokkos_Specialization.hpp
@@ -148,6 +148,33 @@ subview(const DynRankView<D, Kokkos::LayoutContiguous<LayoutSrc, StrideSrc>,
   }
 }
 
+// Helper function to create a mapping for subdynrankview that avoids calling SubT::layout()
+// (which doesn't work correctly for LayoutContiguous<LayoutStride> and is slated for removal)
+template<class MapT, class SubT, size_t ... Idx>
+KOKKOS_INLINE_FUNCTION MapT
+create_subdynrankview_mapping(const SubT& sub, std::index_sequence<Idx...>) {
+  using return_layout_t = typename MapT::layout_type;
+  using exts_t = typename MapT::extents_type;
+  using idx_t = typename MapT::index_type;
+  const exts_t extents((Idx<SubT::rank() ? sub.extent(Idx):1)...);
+  if constexpr (std::is_same_v<return_layout_t, layout_stride>)
+  {
+    idx_t strides[7] = {(Idx<SubT::rank() ? sub.stride(Idx):1)...};
+    return MapT(mdspan_non_standard_tag(), extents, strides);
+  } else if constexpr(std::is_same_v<return_layout_t, Kokkos::Experimental::layout_left_padded<Kokkos::dynamic_extent> > ||
+                      std::is_same_v<return_layout_t, Kokkos::Experimental::layout_right_padded<Kokkos::dynamic_extent> >)
+  {
+    idx_t stride = 1;
+    if constexpr (SubT::rank() > 1) {
+      if constexpr(std::is_same_v<return_layout_t, Kokkos::Experimental::layout_left_padded<Kokkos::dynamic_extent> >)
+        stride = sub.stride(1);
+      else
+        stride = sub.stride(SubT::rank()-2);
+    }
+    return MapT(extents, stride);
+  }
+}
+
 template <class T, class LayoutSrc, unsigned StrideSrc, class... DRVArgs,
           class SubArg0 = int, class SubArg1 = int, class SubArg2 = int,
           class SubArg3 = int, class SubArg4 = int, class SubArg5 = int,
@@ -175,18 +202,11 @@ subdynrankview(const DynRankView<T, LayoutContiguous<LayoutSrc, StrideSrc>,
                                     // StrideSrc>,
       typename sub_t::device_type, typename sub_t::memory_traits>;
 
-  auto layout = sub.layout().base_layout();
-  for (int i = new_rank; i < 8; i++)
-    layout.dimension[i] = 1;
-  if constexpr (std::is_same_v<decltype(layout), LayoutStride>)
-    for (int i = new_rank; i < 8; i++)
-      layout.stride[i] = 1;
-
+  using return_map_t = typename return_type::mapping_type;
   return return_type{
       typename return_type::view_type(
           sub.data_handle(),
-          Impl::mapping_from_array_layout<typename return_type::mapping_type>(
-              layout),
+          create_subdynrankview_mapping<return_map_t>(sub, std::make_index_sequence<7>()),
           sub.accessor()),
       new_rank};
 }
@@ -615,30 +635,6 @@ void deep_copy_view(const Kokkos::View<DstArgs...> &dst, const SrcT &src) {
   Kokkos::fence();
 }
 
-template <size_t ... Idx, class SrcT, class... SrcArgs>
-void resize_view(std::index_sequence<Idx...>,
-                 Kokkos::View<SrcT, SrcArgs...> &src,
-                 const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                 const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                 const size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                 const size_t n3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                 const size_t n4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                 const size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                 const size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
-                 const size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG) {
-  using view_t = Kokkos::View<SrcT, SrcArgs...>;
-  const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
-  bool size_mismatch = ((new_extents[Idx] != src.extent(Idx)) || ... || false);
-  if (size_mismatch) {
-    using exec_space = typename view_t::execution_space;
-    auto dst = view_t(src.label(), new_extents[Idx]..., static_cast<size_t>(src.accessor().fad_size() + 1));
-    Kokkos::fence();
-    Sacado::Impl::deep_copy(exec_space(), Kokkos::subview(dst, Kokkos::pair(0lu, Kokkos::min(new_extents[Idx], src.extent(Idx)))...),
-                                          Kokkos::subview(src, Kokkos::pair(0lu, Kokkos::min(new_extents[Idx], src.extent(Idx)))...));
-    Kokkos::fence();
-    src = dst;
-  }
-}
 } // namespace Impl
 } // namespace Sacado
 
@@ -693,6 +689,44 @@ void deep_copy(const Kokkos::View<Sacado::Fad::Exp::GeneralFad<DstT> ******,
                SrcT val) {
   Sacado::Impl::deep_copy_view(src, val);
 }
+
+} // namespace Kokkos
+#endif // SACADO_VIEW_CUDA_HIERARCHICAL
+
+// Overloads of resize are required for all layouts, not just hierarchical
+
+namespace Sacado {
+namespace Impl {
+
+template <size_t ... Idx, class SrcT, class... SrcArgs>
+void resize_view(std::index_sequence<Idx...>,
+                 Kokkos::View<SrcT, SrcArgs...> &src,
+                 const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                 const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                 const size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                 const size_t n3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                 const size_t n4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                 const size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                 const size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+                 const size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG) {
+  using view_t = Kokkos::View<SrcT, SrcArgs...>;
+  const size_t new_extents[8] = {n0, n1, n2, n3, n4, n5, n6, n7};
+  bool size_mismatch = ((new_extents[Idx] != src.extent(Idx)) || ... || false);
+  if (size_mismatch) {
+    using exec_space = typename view_t::execution_space;
+    auto dst = view_t(src.label(), new_extents[Idx]..., static_cast<size_t>(src.accessor().fad_size() + 1));
+    Kokkos::fence();
+    Sacado::Impl::deep_copy(exec_space(), Kokkos::subview(dst, Kokkos::pair(0lu, Kokkos::min(new_extents[Idx], src.extent(Idx)))...),
+                                          Kokkos::subview(src, Kokkos::pair(0lu, Kokkos::min(new_extents[Idx], src.extent(Idx)))...));
+    Kokkos::fence();
+    src = dst;
+  }
+}
+
+}
+}
+
+namespace Kokkos {
 
 template <class SrcT, class... SrcArgs>
 void resize(Kokkos::View<Sacado::Fad::Exp::GeneralFad<SrcT>, SrcArgs...> &src,
@@ -797,4 +831,3 @@ void resize(
   Sacado::Impl::resize_view(std::make_index_sequence<7>(), src, n0, n1, n2, n3, n4, n5, n6, n7);
 }
 } // namespace Kokkos
-#endif // SACADO_VIEW_CUDA_HIERARCHICAL

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
@@ -1476,7 +1476,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   Kokkos_View_Fad, DynRankDimensionScalar, FadType, Layout, Device )
 {
-  typedef Kokkos::DynRankView<double,Layout,Device> DoubleViewType;
+  typedef typename Kokkos::inner_layout<Layout>::type DoubleLayout; // extract inner layout from LayoutContiguous
+  typedef Kokkos::DynRankView<double,DoubleLayout,Device> DoubleViewType;
   typedef Kokkos::DynRankView<FadType,Layout,Device> FadViewType;
   typedef typename FadViewType::size_type size_type;
 


### PR DESCRIPTION
This removes specializaions for std::is_same/std::is_same_v for LayoutContiguous.  The code for handling subdynrankview() correctly was written by @crtrott.

For issue #15036.

The things that were needed for this were:
  1. Remove the specializations for LayoutContiguous
  2. Enable resize overloads for both regular layout and LayoutContiguous specializations
  3. Add specialization of DynRankDimTraits
  4. Fix subdynrankview to not call layout()

The Sacado tests all pass.  But notifying @rppawlo in case this breaks anything in downstream codes.

@crtrott can you look at the specialization I had to make for DynRankDimTraits?  I thought this was weird how it needed a specialization on bool for the new view implementation.