### PR TITLE
TrilinosCouplings: Use basis functions compatible with Shards topology

### DIFF
--- a/packages/trilinoscouplings/examples/scaling/example_Poisson_stk.cpp
+++ b/packages/trilinoscouplings/examples/scaling/example_Poisson_stk.cpp
@@ -251,6 +251,7 @@ int TestMultiLevelPreconditioner(char ProblemType[],
                                  Teuchos::RCP<Tpetra_MultiVector> & b,
                                  Teuchos::RCP<Tpetra_MultiVector> & uh,
 				 Teuchos::RCP<Tpetra_MultiVector> & coords,
+                                 Teuchos::RCP<Tpetra_CrsMatrix>   & MassMatrix,
                                  double & TotalErrorResidual,
                                  double & TotalErrorExactSol);
 
@@ -376,6 +377,12 @@ int main_(int argc, char *argv[]) {
   clp.setOption ("matrixFilename", &matrixFilename, "If nonempty, dump the "
 		  "generated matrix to that file in MatrixMarket format.");
 
+  // If massmatFilename is nonempty, dump the mass matrix to that file
+  // in MatrixMarket format.
+  std::string massmatFilename;
+  clp.setOption ("massmatFilename", &massmatFilename, "If nonempty, dump the "
+		  "generated mass matrix to that file in MatrixMarket format.");
+
   // If rhsFilename is nonempty, dump the rhs to that file
   // in MatrixMarket format.
   std::string rhsFilename;
@@ -394,6 +401,8 @@ int main_(int argc, char *argv[]) {
   clp.setOption ("coordsFilename", &coordsFilename, "If nonempty, dump the "
 		  "generated coordinates to that file in MatrixMarket format.");
 
+  bool buildMassMatrix = false;
+  clp.setOption("buildMassMat", "dontBuildMassMat", &buildMassMatrix, "build a mass matrix");
 
 
   switch (clp.parse(argc, argv)) {
@@ -783,6 +792,8 @@ int main_(int argc, char *argv[]) {
   /**********************************************************************************/
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("5) Matrix/RHS Assembly")));
   RCP<Tpetra_FECrsMatrix> StiffMatrix = rcp(new Tpetra_FECrsMatrix(StiffGraph));
+  RCP<Tpetra_FECrsMatrix> MassMatrix;
+  if (buildMassMatrix) MassMatrix = rcp(new Tpetra_FECrsMatrix(StiffGraph));
 
   // Define desired workset size and count how many worksets there are on this processor's mesh block
   //int desiredWorksetSize = numElems;                   // change to desired workset size!
@@ -801,10 +812,10 @@ int main_(int argc, char *argv[]) {
   }
 
 
-
   // Start assembly
   RCP<Tpetra_FEMultiVector> rhsVector = rcp (new Tpetra_FEMultiVector(globalMapG,StiffGraph->getImporter(),1));
-  Tpetra::beginAssembly(*StiffMatrix,*rhsVector);
+  if (buildMassMatrix) Tpetra::beginAssembly(*MassMatrix,*StiffMatrix,*rhsVector);
+  else  Tpetra::beginAssembly(*StiffMatrix,*rhsVector);
 
   // Right now, this loop only increments once:
   //   numWorkset = 1
@@ -866,6 +877,9 @@ int main_(int argc, char *argv[]) {
 
     // Containers for workset contributions to the discretization matrix and the right hand side
     Intrepid2ScalarView worksetStiffMatrix ("worksetStiffMatrix", worksetSize, numFieldsG, numFieldsG);
+    Intrepid2ScalarView worksetMassMatrix;
+    if (buildMassMatrix)
+      worksetMassMatrix  = Intrepid2ScalarView("worksetMassMatrix" , worksetSize, numFieldsG, numFieldsG);
     Intrepid2ScalarView worksetRHS         ("worksetRHS", worksetSize, numFieldsG);
 
 
@@ -936,6 +950,12 @@ int main_(int argc, char *argv[]) {
                                        worksetBasisValuesWeighted);
 
     /**********************************************************************************/
+    /*                         Compute Mass Matrix                                    */
+    /**********************************************************************************/
+    if (buildMassMatrix)
+       Intrepid2FSTools::integrate(worksetMassMatrix, worksetBasisValues,worksetBasisValuesWeighted);
+
+    /**********************************************************************************/
     /***************************** STATISTICS (Part II) ******************************/
     /**********************************************************************************/
     /*
@@ -973,6 +993,11 @@ int main_(int argc, char *argv[]) {
             Teuchos::Array<SC> val(1); val[0] = operatorMatrixContribution;
             StiffMatrix->sumIntoGlobalValues(globalRow, col(), val());
 
+            if (buildMassMatrix) {
+              double MassMatrixContribution = worksetMassMatrix(worksetCellOrdinal, cellRow, cellCol);
+              Teuchos::Array<SC> massval(1); massval[0] = MassMatrixContribution;
+              MassMatrix->sumIntoGlobalValues(globalRow,  col(), massval());
+            }
           }// end cell col loop
 
         }// end cell row loop
@@ -986,7 +1011,8 @@ int main_(int argc, char *argv[]) {
   }// end workset loop
 
 
-  Tpetra::endAssembly(*StiffMatrix,*rhsVector);
+  if (buildMassMatrix) Tpetra::endAssembly(*MassMatrix,*StiffMatrix,*rhsVector);
+  else Tpetra::endAssembly(*StiffMatrix,*rhsVector);
 
 /**********************************************************************************/
 /***************************** STATISTICS (Part IIb) ******************************/
@@ -1048,6 +1074,9 @@ int main_(int argc, char *argv[]) {
     if (matrixFilename != "") {
       writer_type::writeSparseFile (matrixFilename, StiffMatrix);
     }
+    if ( (massmatFilename != "") && buildMassMatrix ) {
+      writer_type::writeSparseFile (massmatFilename, MassMatrix);
+    }
     if (rhsFilename != "") {
       writer_type::writeDenseFile (rhsFilename, rhsVector);
     }
@@ -1091,12 +1120,17 @@ int main_(int argc, char *argv[]) {
 
   Teuchos::RCP<Tpetra_CrsMatrix> Acrs = Teuchos::rcp_dynamic_cast<Tpetra_CrsMatrix>(StiffMatrix);
   Teuchos::RCP<Tpetra_MultiVector> rhsMV = Teuchos::rcp_dynamic_cast<Tpetra_MultiVector>(rhsVector);
+  Teuchos::RCP<Tpetra_CrsMatrix> Mcrs;
+
+  if (buildMassMatrix) {
+    Mcrs = Teuchos::rcp_dynamic_cast<Tpetra_CrsMatrix>(MassMatrix);
+  }
   tm = Teuchos::null;
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("8) Linear solve")));
-  TestMultiLevelPreconditioner(probType,             MLList,
-                               Acrs,                 exactNodalVals,
-                               rhsMV,                lhsVector, nCoord,
-                               TotalErrorResidual,   TotalErrorExactSol);
+  TestMultiLevelPreconditioner(probType,           MLList,
+                               Acrs,               exactNodalVals,
+                               rhsMV,              lhsVector, nCoord, Mcrs,
+                               TotalErrorResidual, TotalErrorExactSol);
 
    // Timer Output
    tm = Teuchos::null;
@@ -1339,6 +1373,7 @@ int TestMultiLevelPreconditioner(char ProblemType[],
                                  Teuchos::RCP<Tpetra_MultiVector> & b,
                                  Teuchos::RCP<Tpetra_MultiVector> & uh,
 				 Teuchos::RCP<Tpetra_MultiVector> & coords,
+                                 Teuchos::RCP<Tpetra_CrsMatrix> & MassMatrix,
                                  double & TotalErrorResidual,
                                  double & TotalErrorExactSol)
 {
@@ -1361,6 +1396,10 @@ int TestMultiLevelPreconditioner(char ProblemType[],
     mueluParams = MLList.sublist("MueLu");
   // Xpetrify coordinates
   mueluParams.sublist("user data").set("Coordinates",Xpetra::toXpetra(coords));
+  // Future versions of muelu can use a mass matrix (or a mass matrix inverse)
+  // to define a strength-of-connection matrix that guides coarsening decisions
+  if (!MassMatrix.is_null())
+    mueluParams.sublist("user data").set("M",Xpetra::toXpetra(MassMatrix));
   if(A->getMap()->getComm()->getRank()==0)
     std::cout<<"*** MueLu Params ***" <<std::endl<<mueluParams<<std::endl;
 

--- a/packages/trilinoscouplings/examples/scaling/example_Poisson_stk.cpp
+++ b/packages/trilinoscouplings/examples/scaling/example_Poisson_stk.cpp
@@ -258,16 +258,14 @@ int TestMultiLevelPreconditioner(char ProblemType[],
 /************* FUNCTION DECLARATIONS FOR SIMPLE BASIS FACTORY *********************/
 /**********************************************************************************/
 
-/** \brief  Simple factory that chooses basis function based on cell topology.
+/** \brief  Simple factory that chooses HGRAD basis function based on cell topology.
 
     \param  cellTopology  [in]    Shards cell topology
-    \param  order         [in]    basis function order, currently unused
-    \param  basis         [out]   pointer to Intrepid basis
 
     \return Intrepid basis
  */
-
-int getDimension(const ShardsCellTopology & cellTopology);
+template<typename DeviceType, typename Scalar>
+Teuchos::RCP<Intrepid2::Basis<DeviceType, Scalar, Scalar> > getHGradBasis(const ShardsCellTopology & cellTopology);
 
 /**********************************************************************************/
 /**********************************************************************************/
@@ -669,10 +667,8 @@ int main_(int argc, char *argv[]) {
   /**********************************************************************************/
 
   // Select basis from the cell topology
-  int order = 1;
-  spaceDim = getDimension(cellType);
-  auto HGradBasis = Intrepid2::getBasis<Intrepid2::DerivedNodalBasisFamily<device_type> >(cellType, Intrepid2::FUNCTION_SPACE_HGRAD, order);
-
+  spaceDim = cellType.getDimension();
+  auto HGradBasis = getHGradBasis<device_type,SC>(cellType);
 
   int numFieldsG = HGradBasis->getCardinality();
 
@@ -1407,18 +1403,19 @@ int TestMultiLevelPreconditioner(char ProblemType[],
 /**********************************************************************************/
 
 
-int getDimension( const ShardsCellTopology & cellTopology) {
+template<typename DeviceType, typename Scalar>
+Teuchos::RCP<Intrepid2::Basis<DeviceType, Scalar, Scalar> > getHGradBasis( const ShardsCellTopology & cellTopology) {
+  Teuchos::RCP<Intrepid2::Basis<DeviceType, Scalar, Scalar> > r_val;
   switch (cellTopology.getKey()) {
-  case shards::Tetrahedron<4>::key:
-  case shards::Hexahedron<8>::key:
-    return 3;
-  case shards::Triangle<3>::key:
-  case shards::Quadrilateral<4>::key:
-    return 2;
-  default:
-    TEUCHOS_TEST_FOR_EXCEPTION(1,std::invalid_argument,
-			       "Unknown cell topology for basis selction. Please use Hexahedron_8 or Tetrahedron_4, Quadrilateral_4 or Triangle_3");
+    case shards::Triangle<3>::key:      r_val = Teuchos::rcp(new Intrepid2::Basis_HGRAD_TRI_C1_FEM    <DeviceType,Scalar,Scalar>()); break;
+    case shards::Quadrilateral<4>::key: r_val = Teuchos::rcp(new Intrepid2::Basis_HGRAD_QUAD_C1_FEM   <DeviceType,Scalar,Scalar>()); break;
+    case shards::Tetrahedron<4>::key:   r_val = Teuchos::rcp(new Intrepid2::Basis_HGRAD_TET_C1_FEM    <DeviceType,Scalar,Scalar>()); break;
+    case shards::Hexahedron<8>::key:    r_val = Teuchos::rcp(new Intrepid2::Basis_HGRAD_HEX_C1_FEM    <DeviceType,Scalar,Scalar>()); break;
+    default:
+      TEUCHOS_TEST_FOR_EXCEPTION(1,std::invalid_argument,
+              "Unexpected cell topology for basis selction. Please use Hexahedron_8 or Tetrahedron_4, Quadrilateral_4 or Triangle_3");
   }
+  return r_val;
 }
 
 


### PR DESCRIPTION
During the switch to Intrepid2, basis functions `HGRAD_Cn` were used instead of the original `HGRAD_C1`.
`HGRAD_C1` functions order the DoFs according to the underlying STK/Shards topology. However, `HGRAD_Cn`, even for n=1, order the DoFs differently. For backward compatibility and for avoiding issues when transferring the fields onto and from the mesh, we restore the `HGRAD_C1` basis functions.

@rstumin, thanks for exposing the issue and triaging.

@rstumin added optional assembly of mass matrix.

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/trilinoscouplings 

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
