### PR TITLE
Tribits: fix variadic assert_defined()

### DIFF
--- a/cmake/tribits/core/package_arch/TribitsPackageSetupCompilerFlags.cmake
+++ b/cmake/tribits/core/package_arch/TribitsPackageSetupCompilerFlags.cmake
@@ -121,12 +121,12 @@ macro(tribits_setup_compiler_flags  PACKAGE_NAME_IN)
 
   assert_defined(PARSE_CLEANED)
 
-  assert_defined(${PROJECT_NAME}_ENABLE_C ${PROJECT_NAME}_ENABLE_C_DEBUG_COMPILE_FLAGS)
+  assert_defined(${PROJECT_NAME}_ENABLE_C)
   if (PARSE_CLEANED AND ${PROJECT_NAME}_ENABLE_STRONG_C_COMPILE_WARNINGS)
     tribits_apply_warnings_as_error_flags_lang(C)
   endif()
 
-  assert_defined(${PROJECT_NAME}_ENABLE_CXX ${PROJECT_NAME}_ENABLE_CXX_DEBUG_COMPILE_FLAGS)
+  assert_defined(${PROJECT_NAME}_ENABLE_CXX)
   if (PARSE_CLEANED AND ${PROJECT_NAME}_ENABLE_STRONG_CXX_COMPILE_WARNINGS)
     tribits_apply_warnings_as_error_flags_lang(CXX)
   endif()

--- a/cmake/tribits/core/utils/AssertDefined.cmake
+++ b/cmake/tribits/core/utils/AssertDefined.cmake
@@ -43,8 +43,8 @@
 # same.  This is the best that can be done in CMake unfortunately to catch
 # usage of misspelled undefined variables.
 #
-function(assert_defined VARS)
-  foreach(VAR ${VARS})
+function(assert_defined)
+  foreach(VAR ${ARGV})
     if(NOT DEFINED ${VAR})
       message(SEND_ERROR "Error, the variable ${VAR} is not defined!")
     endif()

--- a/cmake/tribits/core/utils/AssertDefined.cmake
+++ b/cmake/tribits/core/utils/AssertDefined.cmake
@@ -10,12 +10,12 @@
 
 # @FUNCTION: assert_defined()
 #
-# Assert that a variable is defined and if not call ``message(SEND_ERROR
+# Assert that one or more variables are defined and if not call ``message(SEND_ERROR
 # ...)``.
 #
 # Usage::
 #
-#   assert_defined(<varName>)
+#   assert_defined(<varName1> [, <varName2>, ...])
 #
 # This is used to get around the problem of CMake not asserting the
 # dereferencing of undefined variables.  For example, how does one know if one
@@ -50,7 +50,3 @@ function(assert_defined)
     endif()
   endforeach()
 endfunction()
-
-# ToDo: The VARS arg This really needs to be replaced with ${ARGV}.  I fear
-# that only the first arg passed in is asserted.  However, to change this now
-# is breaking backward compatibility.


### PR DESCRIPTION
@trilinos/tribits

## Motivation
``assert_defined()`` allows you to pass any number of variable names to check, but in practice it only checks the first one (see #15114). We use it with multiple arguments in a lot of Trilinos packages. This PR changes it to use the special ``ARGV`` to capture all the arguments.

@bartlettroscoe This is probably not be the right place to make permanent TriBITS changes; should I backport to https://github.com/TriBITSPub/TriBITS ?

## Testing
Tested locally. With this change,

```
#SET(mything ON)
SET(mything2 OFF)
assert_defined(mything mything2)
```
and
```
SET(mything ON)
#SET(mything2 OFF)
assert_defined(mything mything2)
```
each print that mything or mything2 are not defined, respectively. Before, the second case would silently pass.

**Update:** I didn't notice this TODO at the bottom of the file:
```
# ToDo: The VARS arg This really needs to be replaced with ${ARGV}.  I fear
# that only the first arg passed in is asserted.  However, to change this now
# is breaking backward compatibility.
```
Is the backward compatibility referring to Trilinos itself here? If it's intended to support only one argument, we should check that ``$ARGC == 0`` to enforce that, and might as well get rid of this foreach.