### PR TITLE
Framework: Do not pass Actions options if values not set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,6 @@ on:
         required: false
         type: string
 
-# Cancels any in progress 'workflows' associated with this workflow ref
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build-test:
     runs-on: ${{ fromJson(inputs.target-runner-labels) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
         description: 'Max cores allowed that is detected on the system.'
         required: false
         type: number
-        default: 12
+        default:
       ctest-drop-site:
         required: false
         type: string
@@ -35,12 +35,12 @@ on:
         description: 'Number of concurrent tests allowed in CTest.'
         required: false
         type: number
-        default: -1
+        default:
       slots-per-gpu:
         description: 'On a GPU machine, this is number of slots allowed per GPU. (e.g. 4 allows 4 MPI ranks per GPU)'
         required: false
         type: number
-        default: 0
+        default:
       extra-pr-driver-args:
         description: 'Extra arguments to be used when calling PullRequestLinuxDriverTest.py'
         required: false
@@ -110,23 +110,23 @@ jobs:
           echo "image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}"
           type python
           python3 ${TRILINOS_DIR}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
-            --target-branch-name ${{ inputs.target-branch }} \
             --genconfig-build-name ${{ inputs.genconfig-string }} \
-            --pullrequest-number ${{ github.event.pull_request.number }} \
+            ${{ inputs.target-branch && '--target-branch-name ' || '' }}${{ inputs.target-branch }} \
+            ${{ github.event.pull_request && '--pullrequest-number ' || '' }}${{ github.event.pull_request.number }} \
             --pullrequest-env-config-file ${TRILINOS_DIR}/packages/framework/pr_tools/trilinos_pr.ini \
             --pullrequest-gen-config-file ${TRILINOS_DIR}/packages/framework/GenConfig/src/gen-config.ini \
             --workspace-dir ${TRILINOS_DIR}/../ \
             --source-dir ${TRILINOS_DIR} \
             --build-dir ${BUILD_DIR} \
-            --dashboard-build-name=${{ inputs.dashboard-build-name }} \
+            ${{ inputs.dashboard-build-name && '--dashboard-build-name ' || '' }}${{ inputs.dashboard-build-name }} \
             --ctest-driver ${TRILINOS_DIR}/cmake/SimpleTesting/cmake/ctest-driver.cmake \
             --ctest-drop-site ${{ inputs.ctest-drop-site }} \
             --pullrequest-cdash-track ${{ inputs.cdash-track }} \
             --filename-subprojects ./package_subproject_list.cmake \
             --filename-packageenables ./packageEnables.cmake \
-            --max-cores-allowed=${{ inputs.max-cores-allowed }} \
-            --num-concurrent-tests=${{ inputs.num-concurrent-tests }} \
-            --slots-per-gpu=${{ inputs.slots-per-gpu }} \
+            ${{ inputs.max-cores-allowed && '--max-cores-allowed ' || '' }}${{ inputs.max-cores-allowed }} \
+            ${{ inputs.num-concurrent-tests && '--num-concurrent-tests ' || '' }}${{ inputs.num-concurrent-tests }} \
+            ${{ inputs.slots-per-gpu && '--slots-per-gpu ' || '' }}${{ inputs.slots-per-gpu }} \
             ${{ inputs.extra-pr-driver-args }}
       - name: Filtered build error logs
         if: success() || failure()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,7 @@ permissions:
 # TODO:
 # - Cancel any job runs with previous successful runs (working tree hash)
 
+
 jobs:
   cuda-kokkos-bounds-check:
     uses: ./.github/workflows/ci.yml


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Prevent this error: 
```
PullRequestLinuxDriverTest.py: error: argument --pullrequest-number: expected one argument
```

For any of the input parameters to the `ci` action that are not either passed or sensibly defaulted, do not pass the option itself down to the PR testing tool, otherwise the parser will complain.

While I don't love the syntax, it keeps the defaults in the PR script where appropriate, and simplifies the passed command where parameters are not set.

Also set up the concurrency to cancel in-progress runs so that we get fewer queue waits for redundant builds.

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-753
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-747
