### PR TITLE
commonTools: Fix compilation with Intel 2025 compiler by adding missi…

### DIFF
--- a/commonTools/gtest/gtest/gtest-all.cc
+++ b/commonTools/gtest/gtest/gtest-all.cc
@@ -318,6 +318,7 @@ GTEST_DISABLE_MSC_WARNINGS_POP_()  //  4251
 #include <wctype.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <iomanip>
 #include <limits>
 #include <list>


### PR DESCRIPTION
@trilinos/commontools

Duplicate of #15134 for #14833 (@cgcgcg, @sebrowne, @VictorEijkhout, @brian-kelley).

### Motivation

The bundled gtest (`commonTools/gtest/gtest/gtest-all.cc`) uses `uintptr_t` without explicitly including `<cstdint>`. Older compiler toolchains would pull in this type transitively through other system headers, but Intel 2025 (`icpx` / `mpicxx`) does not, resulting in a hard compilation error:

```
gtest-all.cc:9037:26: error: unknown type name 'uintptr_t'; did you mean 'intptr_t'?
  9037 |         reinterpret_cast<uintptr_t>(stack_top) % kMaxStackAlignment == 0);
       |                          ^~~~~~~~~
       |                          intptr_t
```

Per the C++ standard, `uintptr_t` is an *optional* type defined in `<cstdint>` - so any code relying on it must include that header explicitly. Modern versions of upstream gtest already do this; the bundled copy predates that fix.

### Related issues

- Closes #14833

### What changed

Added `#include <cstdint>` at the top of `commonTools/gtest/gtest/gtest-all.cc`. **No logic changes.**

### Testing

Verified that `kokkoscore` (and dependent packages with `Trilinos_ENABLE_TESTS=ON`) now compile successfully under Intel 2025.1 (`icpx`) on TACC Stampede3. No existing test results affected.

### Additional information

The long-term fix would be upgrading the bundled gtest to a current upstream release, which already includes this and other portability improvements. This one-line patch is a minimal targeted workaround for the Intel 2025 toolchain until that larger update happens.

This class of breakage is not unique to Intel - GCC 15 similarly tightened implicit-include handling, so the same error can appear there as well.