### PR TITLE
Sacado: resolve clang compiler warning about mismatch class/struct in forward declaration of GeneralFad

### DIFF
--- a/packages/sacado/src/Sacado_Fad_Kokkos_View_Support.hpp
+++ b/packages/sacado/src/Sacado_Fad_Kokkos_View_Support.hpp
@@ -226,7 +226,7 @@ KOKKOS_INLINE_FUNCTION size_t allocation_size_from_mapping_and_accessor(
   return mapping.required_span_size() * element_size;
 }
 
-template <class StorageType> struct GeneralFad;
+template <class StorageType> class GeneralFad;
 
 template <class T, class LayoutType, class DeviceType, class MemoryTraits>
 KOKKOS_INLINE_FUNCTION constexpr auto customize_view_arguments(


### PR DESCRIPTION
@trilinos/sacado

Otherwise, you get warnings in clang like:

```
Sacado_Fad_Exp_GeneralFad.hpp:30:5: warning: 'GeneralFad' defined as a class template here but previously declared as a struct template; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
   30 |     class GeneralFad :
      |     ^
Sacado_Fad_Kokkos_View_Support.hpp:229:30: note: did you mean class here?
  229 | template <class StorageType> struct GeneralFad;
      |                              ^~~~~~
      |                              class
```