### PR TITLE
Sacado:  Fix extent of as_scalar_view

### DIFF
--- a/packages/sacado/src/Sacado_Fad_Kokkos_View_Support.hpp
+++ b/packages/sacado/src/Sacado_Fad_Kokkos_View_Support.hpp
@@ -348,7 +348,7 @@ as_scalar_view(const Kokkos::View<DataType, Properties...> &view) {
     using value_type = typename view_t::value_type::value_type;
     return Kokkos::View<value_type *, Properties...>(
         view.data(),
-        view.mapping().required_span_size() * view.accessor().fad_size());
+        view.mapping().required_span_size() * (view.accessor().fad_size()+1));
   } else {
     return view;
   }

--- a/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
+++ b/packages/sacado/test/UnitTests/Fad_KokkosTests.hpp
@@ -485,6 +485,25 @@ struct AtomicAddKernel {
 };
 
 TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
+  Kokkos_View_Fad, AsScalarView, FadType, Layout, Device )
+{
+#if KOKKOS_VERSION >= 40799 && !defined (SACADO_DISABLE_FAD_VIEW_SPEC) && !defined(KOKKOS_ENABLE_IMPL_VIEW_LEGACY)
+  typedef Kokkos::View<FadType**,Layout,Device> ViewType;
+  typedef typename ViewType::size_type size_type;
+
+  const size_type num_rows = global_num_rows;
+  const size_type num_cols = global_num_cols;
+  const size_type fad_size = global_fad_size;
+
+  ViewType v("view", num_rows, num_cols, fad_size+1);
+  auto va = Sacado::as_scalar_view(v);
+
+  const size_type expected_extent = global_num_rows * global_num_cols * (global_fad_size + 1);
+  TEUCHOS_TEST_EQUALITY(va.extent(0), expected_extent, out, success);
+#endif
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
   Kokkos_View_Fad, Size, FadType, Layout, Device )
 {
   typedef Kokkos::View<FadType*,Layout,Device> ViewType;
@@ -2738,6 +2757,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(
 
 #define VIEW_FAD_TESTS_FLD( F, L, D )                                   \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, Size, F, L, D ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, AsScalarView, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, DeepCopy, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, DeepCopy_ConstantScalar, F, L, D ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( Kokkos_View_Fad, DeepCopy_ConstantZero, F, L, D ) \


### PR DESCRIPTION
Add the missing +1 when computing the extent of the resulting view.  Also add a test to verify correctness.