### PR TITLE
PyTrilinos2: fixed undefined 'rank' issue

### DIFF
--- a/packages/PyTrilinos2/test/Stratimikos.py
+++ b/packages/PyTrilinos2/test/Stratimikos.py
@@ -252,6 +252,8 @@ def main():
 
 
 if __name__ == "__main__":
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
     # initialize kokkos
     defaultNode = Tpetra.Map.defaults['Node']
     if defaultNode in ('cuda', 'cuda_uvm', 'hip', 'hip_managed'):


### PR DESCRIPTION
@trilinos/pytrilinos2

## Motivation

Undefined `rank` in Python tests is a `NameError`/[Undefined variable](https://docs.basedpyright.com/v1.32.1/configuration/config-files/#reportUndefinedVariable). Simple solution - define `rank` as made for example in `exampleCG.py`. Here is the simple check with `flake8` tool:

```bash
flake8 --count --statistics --max-line-length=120 ./packages/PyTrilinos2/test/Stratimikos.py
./packages/PyTrilinos2/test/Stratimikos.py:23:121: E501 line too long (259 > 120 characters)
./packages/PyTrilinos2/test/Stratimikos.py:32:1: E722 do not use bare 'except'
./packages/PyTrilinos2/test/Stratimikos.py:77:121: E501 line too long (133 > 120 characters)
./packages/PyTrilinos2/test/Stratimikos.py:236:86: E703 statement ends with a semicolon
./packages/PyTrilinos2/test/Stratimikos.py:260:44: F821 undefined name 'rank'
2     E501 line too long (259 > 120 characters)
1     E703 statement ends with a semicolon
1     E722 do not use bare 'except'
1     F821 undefined name 'rank'
5
```

## Testing

Simple testing using the mentioned tool:

```bash
flake8 --count --statistics --max-line-length=300 ./packages/PyTrilinos2/test/Stratimikos.py > a.txt
flake8 --count --statistics --max-line-length=300 ./packages/PyTrilinos2/test/Stratimikos.with.undefined.rank.py > b.txt
diff a.txt b.txt
echo "diff exit: $?"
rm -rfv a.txt b.txt

1,2c1,3
< ./packages/PyTrilinos2/test/Stratimikos.py:32:1: E722 do not use bare 'except'
< ./packages/PyTrilinos2/test/Stratimikos.py:236:86: E703 statement ends with a semicolon
---
> ./packages/PyTrilinos2/test/Stratimikos.with.undefined.rank.py:32:1: E722 do not use bare 'except'
> ./packages/PyTrilinos2/test/Stratimikos.with.undefined.rank.py:236:86: E703 statement ends with a semicolon
> ./packages/PyTrilinos2/test/Stratimikos.with.undefined.rank.py:258:44: F821 undefined name 'rank'
5c6,7
< 2
---
> 1     F821 undefined name 'rank'
> 3
diff exit: 1
removed 'a.txt'
removed 'b.txt'
```