### PR TITLE
Ifpack2: replace forbidden KOKKOS_IMPL_CUDA_SAFE_CALL with own implementation

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
@@ -12,6 +12,10 @@
 
 #include "Ifpack2_BlockHelper_Timers.hpp"
 
+#if defined(KOKKOS_ENABLE_CUDA) && defined(IFPACK2_BLOCKHELPER_ENABLE_PROFILE)
+#include "Ifpack2_CudaSafeCall.hpp"
+#endif
+
 namespace Ifpack2 {
 
 namespace BlockHelperDetails {
@@ -182,10 +186,10 @@ struct ExecutionSpaceFactory<Kokkos::Experimental::SYCL> {
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(IFPACK2_BLOCKHELPER_ENABLE_PROFILE)
 #define IFPACK2_BLOCKHELPER_PROFILER_REGION_BEGIN \
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaProfilerStart());
+  IFPACK2_IMPL_CUDA_SAFE_CALL(cudaProfilerStart());
 
 #define IFPACK2_BLOCKHELPER_PROFILER_REGION_END \
-  { KOKKOS_IMPL_CUDA_SAFE_CALL(cudaProfilerStop()); }
+  { IFPACK2_IMPL_CUDA_SAFE_CALL(cudaProfilerStop()); }
 #else
 /// later put vtune profiler region
 #define IFPACK2_BLOCKHELPER_PROFILER_REGION_BEGIN

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -57,6 +57,7 @@
 // #undef  IFPACK2_BLOCKTRIDICONTAINER_ENABLE_PROFILE
 #if defined(KOKKOS_ENABLE_CUDA) && defined(IFPACK2_BLOCKTRIDICONTAINER_ENABLE_PROFILE)
 #include "cuda_profiler_api.h"
+#include "Ifpack2_CudaSafeCall.hpp"
 #endif
 
 // I am not 100% sure about the mpi 3 on cuda
@@ -149,10 +150,10 @@ struct BlockTridiagScalarType<double> {
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(IFPACK2_BLOCKTRIDICONTAINER_ENABLE_PROFILE)
 #define IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN \
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaProfilerStart());
+  IFPACK2_IMPL_CUDA_SAFE_CALL(cudaProfilerStart());
 
 #define IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END \
-  { KOKKOS_IMPL_CUDA_SAFE_CALL(cudaProfilerStop()); }
+  { IFPACK2_IMPL_CUDA_SAFE_CALL(cudaProfilerStop()); }
 #else
 /// later put vtune profiler region
 #define IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN

--- a/packages/ifpack2/src/Ifpack2_CudaSafeCall.hpp
+++ b/packages/ifpack2/src/Ifpack2_CudaSafeCall.hpp
@@ -43,8 +43,9 @@ namespace Impl {
 #ifndef KOKKOS_COMPILER_NVHPC
 [[noreturn]]
 #endif
-inline void cuda_internal_error_abort(cudaError e, const char *name, const char *file,
-                                      int line) {
+inline void
+cuda_internal_error_abort(cudaError e, const char *name, const char *file,
+                          int line) {
   std::ostringstream out;
   out << name << " error( " << cudaGetErrorName(e) << "): " << cudaGetErrorString(e);
   if (file) {

--- a/packages/ifpack2/src/Ifpack2_CudaSafeCall.hpp
+++ b/packages/ifpack2/src/Ifpack2_CudaSafeCall.hpp
@@ -1,0 +1,85 @@
+// @HEADER
+// *****************************************************************************
+//       Ifpack2: Templated Object-Oriented Algebraic Preconditioner Package
+//
+// Copyright 2009 NTESS and the Ifpack2 contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef IFPACK2_CUDA_SAFE_CALL_HPP
+#define IFPACK2_CUDA_SAFE_CALL_HPP
+
+// Error handling below follows Kokkos::Impl::cuda_internal_safe_call and
+// KOKKOS_IMPL_CUDA_SAFE_CALL; Ifpack2 defines its own helpers because
+// KOKKOS_IMPL_* macros are not part of Kokkos' supported API.
+// Source: https://github.com/kokkos/kokkos/blob/develop/core/src/Cuda/Kokkos_Cuda_Error.hpp
+
+#include <Kokkos_Macros.hpp>
+
+#if defined(KOKKOS_ENABLE_CUDA)
+
+#include <Kokkos_Abort.hpp>
+
+#include <cuda_runtime.h>
+
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace Ifpack2 {
+namespace Impl {
+
+[[noreturn]] inline void cuda_internal_error_throw(cudaError e, const char *name,
+                                                   const char *file, int line) {
+  std::ostringstream out;
+  out << name << " error( " << cudaGetErrorName(e) << "): " << cudaGetErrorString(e);
+  if (file) {
+    out << " " << file << ":" << line;
+  }
+  throw std::runtime_error(out.str());
+}
+
+#ifndef KOKKOS_COMPILER_NVHPC
+[[noreturn]]
+#endif
+inline void cuda_internal_error_abort(cudaError e, const char *name, const char *file,
+                                      int line) {
+  std::ostringstream out;
+  out << name << " error( " << cudaGetErrorName(e) << "): " << cudaGetErrorString(e);
+  if (file) {
+    out << " " << file << ":" << line;
+  }
+  Kokkos::abort(out.str().c_str());
+}
+
+inline void cuda_internal_safe_call(cudaError e, const char *name, const char *file,
+                                    int line) {
+  switch (e) {
+    case cudaSuccess:
+      break;
+    case cudaErrorIllegalAddress:
+    case cudaErrorAssert:
+    case cudaErrorHardwareStackError:
+    case cudaErrorIllegalInstruction:
+    case cudaErrorMisalignedAddress:
+    case cudaErrorInvalidAddressSpace:
+    case cudaErrorInvalidPc:
+    case cudaErrorLaunchFailure:
+      cuda_internal_error_abort(e, name, file, line);
+      break;
+    default:
+      cuda_internal_error_throw(e, name, file, line);
+      break;
+  }
+}
+
+}  // namespace Impl
+}  // namespace Ifpack2
+
+#define IFPACK2_IMPL_CUDA_SAFE_CALL(call) \
+  Ifpack2::Impl::cuda_internal_safe_call(call, #call, __FILE__, __LINE__)
+
+#endif  // KOKKOS_ENABLE_CUDA
+
+#endif  // IFPACK2_CUDA_SAFE_CALL_HPP

--- a/packages/ifpack2/test/unit_tests/CMakeLists.txt
+++ b/packages/ifpack2/test/unit_tests/CMakeLists.txt
@@ -41,6 +41,7 @@ Ifpack2_UnitTestAmesos2solver.cpp
 Ifpack2_UnitTestBlockRelaxation.cpp
 Ifpack2_UnitTestChebyshev.cpp
 Ifpack2_UnitTestContainer.cpp
+Ifpack2_UnitTestCudaSafeCall.cpp
 Ifpack2_UnitTestCreateOverlapGraph.cpp
 Ifpack2_UnitTestDenseSolver.cpp
 Ifpack2_UnitTestDiagonal.cpp
@@ -59,10 +60,6 @@ Ifpack2_UnitTestRILUK.cpp
 Ifpack2_UnitTestTemplate.cpp
 Ifpack2_UnitTestTriDiSolver.cpp
 )
-
-IF(Kokkos_ENABLE_CUDA)
-  APPEND_SET(SOURCES Ifpack2_UnitTestCudaSafeCall.cpp)
-ENDIF()
 
 IF(${PACKAGE_NAME}_ENABLE_HYPRE AND ${PACKAGE_NAME}_ENABLE_MPI)
   APPEND_SET(SOURCES Ifpack2_UnitTestHypre.cpp)

--- a/packages/ifpack2/test/unit_tests/CMakeLists.txt
+++ b/packages/ifpack2/test/unit_tests/CMakeLists.txt
@@ -60,6 +60,10 @@ Ifpack2_UnitTestTemplate.cpp
 Ifpack2_UnitTestTriDiSolver.cpp
 )
 
+IF(Kokkos_ENABLE_CUDA)
+  APPEND_SET(SOURCES Ifpack2_UnitTestCudaSafeCall.cpp)
+ENDIF()
+
 IF(${PACKAGE_NAME}_ENABLE_HYPRE AND ${PACKAGE_NAME}_ENABLE_MPI)
   APPEND_SET(SOURCES Ifpack2_UnitTestHypre.cpp)
 ENDIF()

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestCudaSafeCall.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestCudaSafeCall.cpp
@@ -8,16 +8,24 @@
 // @HEADER
 
 /*! \file Ifpack2_UnitTestCudaSafeCall.cpp
-    \brief Unit tests for \c IFPACK2_IMPL_CUDA_SAFE_CALL (CUDA builds only).
+    \brief Unit tests for \c IFPACK2_IMPL_CUDA_SAFE_CALL when \c KOKKOS_ENABLE_CUDA is defined.
 */
 
-#include <Teuchos_ConfigDefs.hpp>
+// Ifpack2_ConfigDefs pulls in Kokkos; KOKKOS_ENABLE_CUDA must be visible before the #if below.
 #include <Ifpack2_ConfigDefs.hpp>
 #include <Teuchos_UnitTestHarness.hpp>
 
+#if defined(KOKKOS_ENABLE_CUDA)
+
 #include "Ifpack2_CudaSafeCall.hpp"
 
+#include <limits>
+#include <string>
+
 namespace {
+
+//! Clear any pending CUDA sticky error so later tests see a clean runtime state.
+inline void clearCudaLastError() { (void)cudaGetLastError(); }
 
 TEUCHOS_UNIT_TEST(CudaSafeCall, MacroSuccessPath) {
   int nDevices = -1;
@@ -30,4 +38,62 @@ TEUCHOS_UNIT_TEST(CudaSafeCall, DirectCallCudaSuccess) {
   Ifpack2::Impl::cuda_internal_safe_call(cudaSuccess, "cudaSuccess", __FILE__, __LINE__);
 }
 
+TEUCHOS_UNIT_TEST(CudaSafeCall, DirectCallInvalidValueThrows) {
+  TEST_THROW(Ifpack2::Impl::cuda_internal_safe_call(cudaErrorInvalidValue, "synthetic_InvalidValue",
+                                                    __FILE__, __LINE__),
+             std::runtime_error);
+}
+
+TEUCHOS_UNIT_TEST(CudaSafeCall, DirectCallInvalidDeviceThrows) {
+  TEST_THROW(Ifpack2::Impl::cuda_internal_safe_call(cudaErrorInvalidDevice, "synthetic_InvalidDevice",
+                                                    __FILE__, __LINE__),
+             std::runtime_error);
+}
+
+TEUCHOS_UNIT_TEST(CudaSafeCall, DirectCallErrorMessageFormat) {
+  bool caught = false;
+  try {
+    Ifpack2::Impl::cuda_internal_safe_call(cudaErrorInvalidValue, "tag_for_message_test", __FILE__,
+                                           __LINE__);
+  } catch (const std::runtime_error &err) {
+    caught = true;
+    const std::string msg(err.what());
+    TEST_ASSERT(msg.find("tag_for_message_test") != std::string::npos);
+    TEST_ASSERT(msg.find("cudaErrorInvalidValue") != std::string::npos);
+    TEST_ASSERT(msg.find("Ifpack2_UnitTestCudaSafeCall.cpp") != std::string::npos);
+  }
+  TEST_ASSERT(caught);
+}
+
+TEUCHOS_UNIT_TEST(CudaSafeCall, MacroInvalidDeviceThrows) {
+  const int badDevice = std::numeric_limits<int>::max();
+  TEST_THROW(IFPACK2_IMPL_CUDA_SAFE_CALL(cudaSetDevice(badDevice)), std::runtime_error);
+  clearCudaLastError();
+}
+
+TEUCHOS_UNIT_TEST(CudaSafeCall, MacroErrorMessageContainsStringifiedCall) {
+  bool caught         = false;
+  const int badDevice = std::numeric_limits<int>::max();
+  try {
+    IFPACK2_IMPL_CUDA_SAFE_CALL(cudaSetDevice(badDevice));
+  } catch (const std::runtime_error &err) {
+    caught = true;
+    const std::string msg(err.what());
+    TEST_ASSERT(msg.find("cudaSetDevice") != std::string::npos);
+  }
+  TEST_ASSERT(caught);
+  clearCudaLastError();
+}
+
+TEUCHOS_UNIT_TEST(CudaSafeCall, MacroSuccessAfterClearedError) {
+  const int badDevice = std::numeric_limits<int>::max();
+  TEST_THROW(IFPACK2_IMPL_CUDA_SAFE_CALL(cudaSetDevice(badDevice)), std::runtime_error);
+  clearCudaLastError();
+  int nDevices = -1;
+  TEST_NOTHROW(IFPACK2_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&nDevices)));
+  TEST_ASSERT(nDevices >= 0);
+}
+
 }  // namespace
+
+#endif /* KOKKOS_ENABLE_CUDA */

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestCudaSafeCall.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestCudaSafeCall.cpp
@@ -1,0 +1,33 @@
+// @HEADER
+// *****************************************************************************
+//       Ifpack2: Templated Object-Oriented Algebraic Preconditioner Package
+//
+// Copyright 2009 NTESS and the Ifpack2 contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/*! \file Ifpack2_UnitTestCudaSafeCall.cpp
+    \brief Unit tests for \c IFPACK2_IMPL_CUDA_SAFE_CALL (CUDA builds only).
+*/
+
+#include <Teuchos_ConfigDefs.hpp>
+#include <Ifpack2_ConfigDefs.hpp>
+#include <Teuchos_UnitTestHarness.hpp>
+
+#include "Ifpack2_CudaSafeCall.hpp"
+
+namespace {
+
+TEUCHOS_UNIT_TEST(CudaSafeCall, MacroSuccessPath) {
+  int nDevices = -1;
+  IFPACK2_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&nDevices));
+  TEST_INEQUALITY(nDevices, -1);
+  TEST_ASSERT(nDevices >= 0);
+}
+
+TEUCHOS_UNIT_TEST(CudaSafeCall, DirectCallCudaSuccess) {
+  Ifpack2::Impl::cuda_internal_safe_call(cudaSuccess, "cudaSuccess", __FILE__, __LINE__);
+}
+
+}  // namespace


### PR DESCRIPTION
@trilinos/ifpack2

## Ifpack2: replace `KOKKOS_IMPL_CUDA_SAFE_CALL` in optional CUDA profiler hooks

### Motivation

Macros and entities under the **`KOKKOS_IMPL_*` prefix and `Kokkos::Impl`** are **reserved for Kokkos internals**. They are **not** part of the supported public API and may **change or disappear without notice** between Kokkos releases (including point releases). Downstream packages must not depend on them.

This is spelled out in the Kokkos documentation: [Backwards & Future Compatibility](https://kokkos.org/kokkos-core-wiki/ProgrammingGuide/Compatibility.html) (linked from [#15073](https://github.com/trilinos/Trilinos/issues/15073) by @dalg24).

Ifpack2 previously used `KOKKOS_IMPL_CUDA_SAFE_CALL` in optional CUDA profiling regions (`cudaProfilerStart` / `cudaProfilerStop`). That usage was replaced with a local `IFPACK2_IMPL_CUDA_SAFE_CALL` and matching error-handling logic so Ifpack2 stays compatible with Kokkos’ supported surface.

### Related issues

- Closes [#15073](https://github.com/trilinos/Trilinos/issues/15073)

### What changed

- Added `packages/ifpack2/src/Ifpack2_CudaSafeCall.hpp` with `IFPACK2_IMPL_CUDA_SAFE_CALL` and host-side error handling aligned with `Kokkos::Impl::cuda_internal_safe_call` (see [Kokkos `Kokkos_Cuda_Error.hpp`](https://github.com/kokkos/kokkos/blob/develop/core/src/Cuda/Kokkos_Cuda_Error.hpp)); fatal CUDA error codes use `Kokkos::abort`, others throw `std::runtime_error` with the same style of message as Kokkos.
- `Ifpack2_BlockHelper.hpp` and `Ifpack2_BlockTriDiContainer_impl.hpp` now use `IFPACK2_IMPL_CUDA_SAFE_CALL` only inside the existing `KOKKOS_ENABLE_CUDA` + package profiling macro guards; `#include "Ifpack2_CudaSafeCall.hpp"` is conditional on those same guards (include order: `BlockHelper` pulls the header before `namespace Ifpack2`; `BlockTriDiContainer_impl` includes it alongside `cuda_profiler_api.h` in the same `#if` block—`Ifpack2_CudaSafeCall.hpp` already brings in `<cuda_runtime.h>`; no extra profiler header is required in `BlockHelper`).

**No change** to default builds: profiling remains opt-in via `IFPACK2_BLOCKHELPER_ENABLE_PROFILE` / `IFPACK2_BLOCKTRIDICONTAINER_ENABLE_PROFILE`.

- **Install / CMake:** `Ifpack2_CudaSafeCall.hpp` is picked up for installation with the other public headers via the existing `APPEND_GLOB(HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)` in `packages/ifpack2/src/CMakeLists.txt` (no separate `HEADERS` line required).

- **Tests:** when `Kokkos_ENABLE_CUDA` is on, `Ifpack2_UnitTestCudaSafeCall.cpp` is added to `Ifpack2_unit_tests` (success-path checks only).

### Testing

I downloaded and installed CUDA 13.2 from the [NVIDIA website](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=24.04&target_type=deb_local) ([more detailed instructions](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#meta-packages)) and then ran the following commands to build Ifpack2.

```bash
PATH="/usr/local/cuda-13.2/bin:$PATH" && \
SAN="-fsanitize=address -fsanitize=undefined -fsanitize=leak -fno-omit-frame-pointer -g" && \
CUDA_ROOT="/usr/local/cuda-13.2" && \
cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug \
  -DCUDAToolkit_ROOT="${CUDA_ROOT}" \
  -DCMAKE_CUDA_COMPILER="${CUDA_ROOT}/bin/nvcc" \
  -DCMAKE_PREFIX_PATH="${CUDA_ROOT}" \
  -DTrilinos_ENABLE_OpenMP=ON \
  -DTPL_ENABLE_MPI=ON \
  -DTPL_ENABLE_CUDA=ON \
  -DKokkos_ENABLE_CUDA=ON \
  -DKokkos_ENABLE_CUDA_LAMBDA=ON \
  -DTPL_ENABLE_CUSPARSE=ON \
  -DKokkos_ARCH_ADA89=ON \
  -DCMAKE_C_COMPILER=mpicc \
  -DCMAKE_CXX_COMPILER=mpicxx \
  -DCMAKE_CXX_FLAGS="$SAN" \
  -DCMAKE_EXE_LINKER_FLAGS="$SAN" \
  -DCMAKE_SHARED_LINKER_FLAGS="$SAN" \
  -DTrilinos_ENABLE_Ifpack2=ON \
  -DIfpack2_ENABLE_TESTS=ON \
  -DCMAKE_CXX_STANDARD=20 \
  -S ~/Documents/Work/Trilinos \
  -B ~/Documents/Work/Trilinos/build-sanitize-cuda && \
cmake --build ./build-sanitize-cuda/ -j$(nproc) --target Ifpack2_unit_tests

./build-sanitize-cuda/packages/ifpack2/test/unit_tests/Ifpack2_unit_tests.exe
```

### Output

**Why CUDA tests did not run successfully on this machine**

- The build uses the **CUDA 13.2 toolkit** (user-mode runtime from that install). The **installed NVIDIA kernel driver** is only in the **CUDA 12.x** compatibility band for this GPU (e.g. `nvidia-smi` reports **CUDA Version: 12.8** as the driver’s supported ceiling). That is **too old for the 13.2 runtime** linked into the binary, so calls such as `cudaGetDeviceCount` and Kokkos CUDA initialization fail with **`cudaErrorInsufficientDriver`** (“CUDA driver version is insufficient for CUDA runtime version”). Tweaking `PATH` / `LD_LIBRARY_PATH` cannot fix a driver/runtime major mismatch.
- I did **not** pursue a **newer system-wide proprietary driver** to match CUDA 13.2: on this laptop the driver is tied to the normal desktop, display, and power path, and upgrading it for a one-off build risks regressions I’m not willing to take on the primary system. A **separate** fix would be rebuilding against a **CUDA 12.x** toolkit aligned with the current driver (or running GPU tests on CI / another host with a supported pairing).
- **Locally verified:** **OpenMP-only** `Ifpack2_unit_tests` (no CUDA) pass; the CUDA build **compiles**; runtime GPU execution is blocked only by the environment above, not by the code changes in this PR.

```log
PATH="/usr/local/cuda-13.2/bin:$PATH" LD_LIBRARY_PATH="/usr/local/cuda-13.2/targets/x86_64-linux/lib:${LD_LIBRARY_PATH}" ASAN_OPTIONS=detect_leaks=0 ./build-sanitize-cuda/packages/ifpack2/test/unit_tests/Ifpack2_unit_tests.exe
Teuchos::GlobalMPISession::GlobalMPISession(): started processor with name loveit0-Nitro-AN515-58 and rank 0!

***
*** Unit test suite ...
***


Sorting tests by group name then by the order they were added ... (time = 0.000316)

Running unit tests ...

0. CudaSafeCall_MacroSuccessPath_UnitTest ... 
 
 p=0: *** Caught standard std::exception of type 'std::runtime_error' :
 
  cudaGetDeviceCount(&nDevices) error( cudaErrorInsufficientDriver): CUDA driver version is insufficient for CUDA runtime version /home/loveit0/Documents/Work/Trilinos/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestCudaSafeCall.cpp:24
 [FAILED]  (0.000319 sec) CudaSafeCall_MacroSuccessPath_UnitTest
 Location: /home/loveit0/Documents/Work/Trilinos/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestCudaSafeCall.cpp:22
 
1. CudaSafeCall_DirectCallCudaSuccess_UnitTest ... [Passed] (4.84e-06 sec)
2. DenseSolver_double_int_longlong_LapackComparison_UnitTest ... 
 Ifpack2::Version(): Ifpack2 VOTD
 Creating Maps
 
 p=0: *** Caught standard std::exception of type 'std::runtime_error' :
 
  cudaGetDeviceCount(&count) error( cudaErrorInsufficientDriver): CUDA driver version is insufficient for CUDA runtime version /home/loveit0/Documents/Work/Trilinos/packages/kokkos/core/src/impl/Kokkos_Core.cpp:119
 [FAILED]  (0.00325 sec) DenseSolver_double_int_longlong_LapackComparison_UnitTest
 Location: /home/loveit0/Documents/Work/Trilinos/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestDenseSolver.cpp:26
 
3. Ifpack2Amesos2Wrapper_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test0_UnitTest ... 
 Ifpack2 Amesos2 wrapper: Test0
 
 p=0: *** Caught standard std::exception of type 'std::runtime_error' :
 
  cudaGetDeviceCount(&count) error( cudaErrorInsufficientDriver): CUDA driver version is insufficient for CUDA runtime version /home/loveit0/Documents/Work/Trilinos/packages/kokkos/core/src/impl/Kokkos_Core.cpp:119
 [FAILED]  (0.000871 sec) Ifpack2Amesos2Wrapper_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test0_UnitTest
 Location: /home/loveit0/Documents/Work/Trilinos/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAmesos2solver.cpp:36
 
4. Ifpack2Amesos2Wrapper_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test1_UnitTest ... 
 Ifpack2 Amesos2 wrapper: Test1
 
 p=0: *** Caught standard std::exception of type 'std::runtime_error' :
 
  cudaGetDeviceCount(&count) error( cudaErrorInsufficientDriver): CUDA driver version is insufficient for CUDA runtime version /home/loveit0/Documents/Work/Trilinos/packages/kokkos/core/src/impl/Kokkos_Core.cpp:119
 [FAILED]  (0.000806 sec) Ifpack2Amesos2Wrapper_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test1_UnitTest
 Location: /home/loveit0/Documents/Work/Trilinos/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAmesos2solver.cpp:135
...
62. Ifpack2Relaxation_double_int_longlong_ClusterMTSGS_UnitTest ... 
 Ifpack2::Version(): Ifpack2 VOTD
 
 p=0: *** Caught standard std::exception of type 'std::runtime_error' :
 
  cudaGetDeviceCount(&count) error( cudaErrorInsufficientDriver): CUDA driver version is insufficient for CUDA runtime version /home/loveit0/Documents/Work/Trilinos/packages/kokkos/core/src/impl/Kokkos_Core.cpp:119
 [FAILED]  (0.000591 sec) Ifpack2Relaxation_double_int_longlong_ClusterMTSGS_UnitTest
 Location: /home/loveit0/Documents/Work/Trilinos/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRelaxation.cpp:1207
 
63. TriDiSolver_double_int_longlong_LapackComparison_UnitTest ... 
 Ifpack2::Version(): Ifpack2 VOTD
 Creating Maps
 
 p=0: *** Caught standard std::exception of type 'std::runtime_error' :
 
  cudaGetDeviceCount(&count) error( cudaErrorInsufficientDriver): CUDA driver version is insufficient for CUDA runtime version /home/loveit0/Documents/Work/Trilinos/packages/kokkos/core/src/impl/Kokkos_Core.cpp:119
 [FAILED]  (0.000594 sec) TriDiSolver_double_int_longlong_LapackComparison_UnitTest
 Location: /home/loveit0/Documents/Work/Trilinos/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestTriDiSolver.cpp:28
 

The following tests FAILED:
    0. CudaSafeCall_MacroSuccessPath_UnitTest ... 
    2. DenseSolver_double_int_longlong_LapackComparison_UnitTest ... 
    3. Ifpack2Amesos2Wrapper_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test0_UnitTest ... 
    4. Ifpack2Amesos2Wrapper_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test1_UnitTest ... 
    5. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test0_UnitTest ... 
    6. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test1_UnitTest ... 
    7. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test2_UnitTest ... 
    8. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_TriDi_UnitTest ... 
    9. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_LinePartition_UnitTest ... 
    10. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_OverlappingPartition_UnitTest ... 
    11. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_BandedContainer_UnitTest ... 
    12. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_BlockedBandedContainer_UnitTest ... 
    13. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_TestDiagonalBlockCrsMatrix_UnitTest ... 
    14. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_TestBlockContainers_UnitTest ... 
    15. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_TestBlockContainersDecoupled_UnitTest ... 
    16. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_TestContainersDofsDecoupled_UnitTest ... 
    17. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_TestLowerTriangularBlockCrsMatrix_UnitTest ... 
    18. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_TestUpperTriangularBlockCrsMatrix_UnitTest ... 
    19. Ifpack2Chebyshev_double_int_longlong_Test0_UnitTest ... 
    20. Ifpack2CreateOverlapGraph_int_longlong_OverlapGraphTest0_UnitTest ... 
    21. Ifpack2Diagonal_double_int_longlong_Test0_UnitTest ... 
    22. Ifpack2Diagonal_double_int_longlong_Test1_UnitTest ... 
    23. Ifpack2Factory_double_int_longlong_Test0_UnitTest ... 
    24. Ifpack2Factory_double_int_longlong_BlockCrs_UnitTest ... 
    25. Ifpack2Filtering_double_int_longlong_Test0_UnitTest ... 
    31. Ifpack2ILUT_double_int_longlong_Test0_UnitTest ... 
    32. Ifpack2ILUT_double_int_longlong_Test1_UnitTest ... 
    33. Ifpack2ILUT_double_int_longlong_Test2_UnitTest ... 
    34. Ifpack2ILUT_double_int_longlong_Test3_UnitTest ... 
    35. Ifpack2IlukGraph_int_longlong_IlukGraphTest0_UnitTest ... 
    36. Ifpack2MDF_double_int_longlong_Test0_UnitTest ... 
    37. Ifpack2MDF_double_int_longlong_Test1_UnitTest ... 
    38. Ifpack2MDF_double_int_longlong_Test2_UnitTest ... 
    39. Ifpack2OverlapGraph_int_longlong_OverlapGraphTest0_UnitTest ... 
    42. Ifpack2OverlappingRowMatrix_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_reducedMatvec_UnitTest ... 
    44. Ifpack2Partitioning_double_int_longlong_Test0_UnitTest ... 
    45. Ifpack2RILUK_double_int_longlong_Parallel_UnitTest ... 
    46. Ifpack2RILUK_double_int_longlong_ParallelReuse_UnitTest ... 
    47. Ifpack2Relaxation_double_int_longlong_Test0_UnitTest ... 
    48. Ifpack2Relaxation_double_int_longlong_Test1_UnitTest ... 
    49. Ifpack2Relaxation_double_int_longlong_Test2_UnitTest ... 
    50. Ifpack2Relaxation_double_int_longlong_Test3_UnitTest ... 
    51. Ifpack2Relaxation_double_int_longlong_Test4_UnitTest ... 
    52. Ifpack2Relaxation_double_int_longlong_Richardson_UnitTest ... 
    55. Ifpack2Relaxation_double_int_longlong_NotCrsMatrix_UnitTest ... 
    56. Ifpack2Relaxation_double_int_longlong_TestDiagonalBlockCrsMatrix_UnitTest ... 
    57. Ifpack2Relaxation_double_int_longlong_TestLowerTriangularBlockCrsMatrix_UnitTest ... 
    58. Ifpack2Relaxation_double_int_longlong_TestUpperTriangularBlockCrsMatrix_UnitTest ... 
    59. Ifpack2Relaxation_double_int_longlong_GS_Crs_UnitTest ... 
    60. Ifpack2Relaxation_double_int_longlong_MTSGS_UnitTest ... 
    61. Ifpack2Relaxation_double_int_longlong_MTSGS_LongRows_UnitTest ... 
    62. Ifpack2Relaxation_double_int_longlong_ClusterMTSGS_UnitTest ... 
    63. TriDiSolver_double_int_longlong_LapackComparison_UnitTest ... 

Total Time: 0.0499 sec

Summary: total = 64, run = 64, passed = 11, failed = 53

End Result: TEST FAILED
```

But OpenMP (separate build without CUDA) passes:

```log
./build-sanitize/packages/ifpack2/test/unit_tests/Ifpack2_unit_tests.exe 
Teuchos::GlobalMPISession::GlobalMPISession(): started processor with name loveit0-Nitro-AN515-58 and rank 0!

***
*** Unit test suite ...
***


Sorting tests by group name then by the order they were added ... (time = 0.000346)

Running unit tests ...

0. DenseSolver_double_int_longlong_LapackComparison_UnitTest ... [Passed] (0.0112 sec)
1. Ifpack2Amesos2Wrapper_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test0_UnitTest ... [Passed] (0.00298 sec)
2. Ifpack2Amesos2Wrapper_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test1_UnitTest ... [Passed] (0.00197 sec)
3. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test0_UnitTest ... [Passed] (0.0195 sec)
4. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test1_UnitTest ... [Passed] (0.0206 sec)
5. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test2_UnitTest ... [Passed] (0.0252 sec)
6. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_TriDi_UnitTest ... [Passed] (0.00347 sec)
7. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_LinePartition_UnitTest ... [Passed] (0.00852 sec)
8. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_OverlappingPartition_UnitTest ... [Passed] (0.2 sec)
9. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_BandedContainer_UnitTest ... [Passed] (0.0153 sec)
10. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_BlockedBandedContainer_UnitTest ... [Passed] (0.00403 sec)
11. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_TestDiagonalBlockCrsMatrix_UnitTest ... [Passed] (0.00619 sec)
12. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_TestBlockContainers_UnitTest ... [Passed] (0.0262 sec)
13. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_TestBlockContainersDecoupled_UnitTest ... [Passed] (0.0291 sec)
14. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_TestContainersDofsDecoupled_UnitTest ... [Passed] (0.0199 sec)
15. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_TestLowerTriangularBlockCrsMatrix_UnitTest ... [Passed] (0.00503 sec)
16. Ifpack2BlockRelaxation_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_TestUpperTriangularBlockCrsMatrix_UnitTest ... [Passed] (0.00429 sec)
17. Ifpack2Chebyshev_double_int_longlong_Test0_UnitTest ... Allocated new vector for diagonal extraction
makeInverseDiagonal: The matrix's diagonal entries all have positive real part (this is good for Chebyshev).
 powerMethodWithInitGuess:
  Original norm1(x): 2.10672, norm2(x): 1.08145
  norm1(x.scale(one/norm)): 1.94806
  PowerMethod using spectral radius route
  Iteration 0
  lambdaMaxOld: 0
  lambdaMax: 1.402
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 1
  Iteration 1
  lambdaMaxOld: 1.402
  lambdaMax: 1.54107
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.0902417
  Iteration 2
  lambdaMaxOld: 1.54107
  lambdaMax: 1.59255
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.0323257
  Iteration 3
  lambdaMaxOld: 1.59255
  lambdaMax: 1.63344
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.0250316
  Iteration 4
  lambdaMaxOld: 1.63344
  lambdaMax: 1.67441
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.0244704
  Iteration 5
  lambdaMaxOld: 1.67441
  lambdaMax: 1.71474
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.0235198
  Iteration 6
  lambdaMaxOld: 1.71474
  lambdaMax: 1.75169
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.0210961
  Iteration 7
  lambdaMaxOld: 1.75169
  lambdaMax: 1.78299
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.0175523
  Iteration 8
  lambdaMaxOld: 1.78299
  lambdaMax: 1.80768
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.0136567
  Iteration 9
  lambdaMaxOld: 1.80768
  lambdaMax: 1.82606
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.0100654
  Iteration 10
  lambdaMaxOld: 1.82606
  lambdaMax: 1.83915
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.00712113
  Iteration 11
  lambdaMaxOld: 1.83915
  lambdaMax: 1.84819
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.00489192
  Iteration 12
  lambdaMaxOld: 1.84819
  lambdaMax: 1.8543
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.00329244
  Iteration 13
  lambdaMaxOld: 1.8543
  lambdaMax: 1.85836
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.00218537
  Iteration 14
  lambdaMaxOld: 1.85836
  lambdaMax: 1.86104
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.00143716
  Iteration 15
  lambdaMaxOld: 1.86104
  lambdaMax: 1.86279
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.000939344
  Iteration 16
  lambdaMaxOld: 1.86279
  lambdaMax: 1.86393
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.00061151
  Iteration 17
  lambdaMaxOld: 1.86393
  lambdaMax: 1.86467
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.000397051
  Iteration 18
  lambdaMaxOld: 1.86467
  lambdaMax: 1.86515
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.000257366
  Iteration 19
  lambdaMaxOld: 1.86515
  lambdaMax: 1.86546
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.000166639
  Iteration 20
  lambdaMaxOld: 1.86546
  lambdaMax: 1.86566
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 0.000107818
  Iteration 21
  lambdaMaxOld: 1.86566
  lambdaMax: 1.86579
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 6.97281e-05
  Iteration 22
  lambdaMaxOld: 1.86579
  lambdaMax: 1.86587
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 4.50809e-05
  Iteration 23
  lambdaMaxOld: 1.86587
  lambdaMax: 1.86593
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 2.91403e-05
  Iteration 24
  lambdaMaxOld: 1.86593
  lambdaMax: 1.86596
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 1.88339e-05
  Iteration 25
  lambdaMaxOld: 1.86596
  lambdaMax: 1.86598
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 1.21717e-05
  Iteration 26
  lambdaMaxOld: 1.86598
  lambdaMax: 1.866
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 7.86575e-06
  Iteration 27
  lambdaMaxOld: 1.866
  lambdaMax: 1.86601
  |lambdaMax-lambdaMaxOld|/|lambdaMax|: 5.08293e-06
  Iteration 28
  lambdaMax: 1.86601
  lambdaMax: 1.86602
  Power method terminated after 30 iterations.
Reusing pre-existing vector for diagonal extraction
makeInverseDiagonal: The matrix's diagonal entries all have positive real part (this is good for Chebyshev).
cgMethod:
 cgMethodWithInitGuess:
  Iteration 0
 diag[0]     = 1.32049
 rHz = 0.22154
 alpha = 0.757296
 beta = 0.141799
  Iteration 1
 diag[1]     = 0.477043
 offdiag[0] = -0.497246
 rHz = 0.375033
 alpha = 3.45067
 beta = 1.69285
  Iteration 2
 diag[2]     = 1.49299
 offdiag[1] = -0.377056
 rHz = 0.0732406
 alpha = 0.997603
 beta = 0.195291
  Iteration 3
 diag[3]     = 0.901567
 offdiag[2] = -0.442979
 rHz = 0.0119727
 alpha = 1.41682
 beta = 0.163471
  Iteration 4
 diag[4]     = 0.807914
 offdiag[3] = -0.285369
 rHz = 3.69117e-32
 alpha = 1.44397
 beta = 3.08297e-30
  Iteration 5
 diag[5]     = 1.5909
 offdiag[4] = -1.21598e-15
 rHz = 8.77043e-34
 alpha = 0.628574
 beta = 0.0237606
  Iteration 6
 diag[6]     = 0.941032
 offdiag[5] = -0.245229
 rHz = 6.70588e-34
 alpha = 1.10714
 beta = 0.764601
  Iteration 7
 diag[7]     = 0.972494
 offdiag[6] = -0.789799
 rHz = 9.71596e-35
 alpha = 3.54757
 beta = 0.144887
  Iteration 8
 diag[8]     = 0.711477
 offdiag[7] = -0.107296
 rHz = 1.35966e-35
 alpha = 1.49112
 beta = 0.139941
  Iteration 9
 diag[9]     = 0.784095
 offdiag[8] = -0.250876
 rHz = 9.45252e-63
 alpha = 1.44876
 beta = 6.95213e-28
[Passed] (0.0228 sec)
18. Ifpack2CreateOverlapGraph_int_longlong_OverlapGraphTest0_UnitTest ... [Passed] (0.00134 sec)
19. Ifpack2Diagonal_double_int_longlong_Test0_UnitTest ... [Passed] (0.00292 sec)
20. Ifpack2Diagonal_double_int_longlong_Test1_UnitTest ... [Passed] (0.00194 sec)
21. Ifpack2Factory_double_int_longlong_Test0_UnitTest ... [Passed] (0.0162 sec)
22. Ifpack2Factory_double_int_longlong_BlockCrs_UnitTest ... [Passed] (0.0113 sec)
23. Ifpack2Filtering_double_int_longlong_Test0_UnitTest ... [Passed] (0.00758 sec)
24. Ifpack2Group0_double_Ifpack2Test0_UnitTest ... [Passed] (2.34e-05 sec)
25. Ifpack2Heap_double_int_Test1_UnitTest ... [Passed] (4.4e-05 sec)
26. Ifpack2Heap_double_int_Test3_UnitTest ... [Passed] (5.81e-05 sec)
27. Ifpack2Heap_float_int_Test1_UnitTest ... [Passed] (3.56e-05 sec)
28. Ifpack2Heap_float_int_Test3_UnitTest ... [Passed] (4.87e-05 sec)
29. Ifpack2ILUT_double_int_longlong_Test0_UnitTest ... ||x_init||=2.23607
||y||=0
||y_final||=1.11803
[Passed] (0.00689 sec)
30. Ifpack2ILUT_double_int_longlong_Test1_UnitTest ... [Passed] (0.00668 sec)
31. Ifpack2ILUT_double_int_longlong_Test2_UnitTest ... [Passed] (0.0115 sec)
32. Ifpack2ILUT_double_int_longlong_Test3_UnitTest ... [Passed] (0.00317 sec)
33. Ifpack2IlukGraph_int_longlong_IlukGraphTest0_UnitTest ... [Passed] (0.0119 sec)
34. Ifpack2MDF_double_int_longlong_Test0_UnitTest ... [Passed] (0.0137 sec)
35. Ifpack2MDF_double_int_longlong_Test1_UnitTest ... [Passed] (0.0246 sec)
36. Ifpack2MDF_double_int_longlong_Test2_UnitTest ... [Passed] (0.0166 sec)
37. Ifpack2OverlapGraph_int_longlong_OverlapGraphTest0_UnitTest ... [Passed] (0.00168 sec)
38. Ifpack2OverlappingRowMatrix_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_Test0_UnitTest ... [Passed] (0.000259 sec)
39. Ifpack2OverlappingRowMatrix_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_getLocalDiag_UnitTest ... [Passed] (8e-06 sec)
40. Ifpack2OverlappingRowMatrix_default_scalar_type_default_local_ordinal_type_default_global_ordinal_type_reducedMatvec_UnitTest ... [Passed] (8.43e-05 sec)
41. Ifpack2Parameters_Test0_UnitTest ... [Passed] (0.00142 sec)
42. Ifpack2Partitioning_double_int_longlong_Test0_UnitTest ... [Passed] (0.00415 sec)
43. Ifpack2RILUK_double_int_longlong_Parallel_UnitTest ... [Passed] (0.0127 sec)
44. Ifpack2RILUK_double_int_longlong_ParallelReuse_UnitTest ... [Passed] (0.0184 sec)
45. Ifpack2Relaxation_double_int_longlong_Test0_UnitTest ... [Passed] (0.00528 sec)
46. Ifpack2Relaxation_double_int_longlong_Test1_UnitTest ... [Passed] (0.00367 sec)
47. Ifpack2Relaxation_double_int_longlong_Test2_UnitTest ... [Passed] (0.00514 sec)
48. Ifpack2Relaxation_double_int_longlong_Test3_UnitTest ... [Passed] (0.00345 sec)
49. Ifpack2Relaxation_double_int_longlong_Test4_UnitTest ... [Passed] (0.00478 sec)
50. Ifpack2Relaxation_double_int_longlong_Richardson_UnitTest ... [Passed] (0.00289 sec)
51. Ifpack2Relaxation_double_int_longlong_SymGaussSeidelZeroRows_UnitTest ... [Passed] (1.94e-05 sec)
52. Ifpack2Relaxation_double_int_longlong_LocalSymGaussSeidelZeroRows_UnitTest ... [Passed] (8.24e-06 sec)
53. Ifpack2Relaxation_double_int_longlong_NotCrsMatrix_UnitTest ... [Passed] (0.00581 sec)
54. Ifpack2Relaxation_double_int_longlong_TestDiagonalBlockCrsMatrix_UnitTest ... [Passed] (0.0134 sec)
55. Ifpack2Relaxation_double_int_longlong_TestLowerTriangularBlockCrsMatrix_UnitTest ... [Passed] (0.00808 sec)
56. Ifpack2Relaxation_double_int_longlong_TestUpperTriangularBlockCrsMatrix_UnitTest ... [Passed] (0.024 sec)
57. Ifpack2Relaxation_double_int_longlong_GS_Crs_UnitTest ... [Passed] (0.0272 sec)
58. Ifpack2Relaxation_double_int_longlong_MTSGS_UnitTest ... [Passed] (0.0351 sec)
59. Ifpack2Relaxation_double_int_longlong_MTSGS_LongRows_UnitTest ... [Passed] (0.0387 sec)
60. Ifpack2Relaxation_double_int_longlong_ClusterMTSGS_UnitTest ... [Passed] (0.0197 sec)
61. TriDiSolver_double_int_longlong_LapackComparison_UnitTest ... [Passed] (0.00551 sec)

Total Time: 0.808 sec

Summary: total = 62, run = 62, passed = 62, failed = 0

End Result: TEST PASSED

=================================================================
==1036225==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 688 byte(s) in 1 object(s) allocated from:
    #0 0x753ae6efd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x753ae65a88e8 in ompi_op_base_op_select (/usr/lib/x86_64-linux-gnu/libmpi.so.40+0xda8e8) (BuildId: f45ae4118efa2894cd78b735f1028555c254f7c2)
    #2 0x753ae651cf29 in ompi_op_init (/usr/lib/x86_64-linux-gnu/libmpi.so.40+0x4ef29) (BuildId: f45ae4118efa2894cd78b735f1028555c254f7c2)
    #3 0x753ae65ba21c in ompi_mpi_init (/usr/lib/x86_64-linux-gnu/libmpi.so.40+0xec21c) (BuildId: f45ae4118efa2894cd78b735f1028555c254f7c2)
    #4 0x753ae6550d81 in MPI_Init (/usr/lib/x86_64-linux-gnu/libmpi.so.40+0x82d81) (BuildId: f45ae4118efa2894cd78b735f1028555c254f7c2)
    #5 0x612255ca4513 in Teuchos::GlobalMPISession::GlobalMPISession(int*, char***, std::ostream*) /home/loveit0/Documents/Work/Trilinos/packages/teuchos/core/src/Teuchos_GlobalMPISession.cpp:67
    #6 0x61224d3f1c55 in main /home/loveit0/Documents/Work/Trilinos/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestMain.cpp:38
    #7 0x753ae562a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #8 0x753ae562a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #9 0x61224d3f1ab4 in _start (/home/loveit0/Documents/Work/Trilinos/build-sanitize/packages/ifpack2/test/unit_tests/Ifpack2_unit_tests.exe+0x1866fab4) (BuildId: c426e212f4c99749e583076a71c7abc54b66331a)
...
Indirect leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x753ae6efd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x753ae60eba87  (/usr/lib/x86_64-linux-gnu/libhwloc.so.15+0x8a87) (BuildId: a3560ac1dd1965c2da0a8fe8201219a3e4d274ee)
    #2 0x753adde4ddd3  (<unknown module>)
    #3 0x753adde5357b  (<unknown module>)
    #4 0x753ade051a92  (<unknown module>)
    #5 0x753adf390e85  (<unknown module>)
    #6 0x753ae61dc159 in orte_init (/usr/lib/x86_64-linux-gnu/libopen-rte.so.40+0x98159) (BuildId: 4826ba55e31afbea8999110028f71f74e46cf626)
    #7 0x753ae65b9eeb in ompi_mpi_init (/usr/lib/x86_64-linux-gnu/libmpi.so.40+0xebeeb) (BuildId: f45ae4118efa2894cd78b735f1028555c254f7c2)
    #8 0x753ae6550d81 in MPI_Init (/usr/lib/x86_64-linux-gnu/libmpi.so.40+0x82d81) (BuildId: f45ae4118efa2894cd78b735f1028555c254f7c2)
    #9 0x612255ca4513 in Teuchos::GlobalMPISession::GlobalMPISession(int*, char***, std::ostream*) /home/loveit0/Documents/Work/Trilinos/packages/teuchos/core/src/Teuchos_GlobalMPISession.cpp:67
    #10 0x61224d3f1c55 in main /home/loveit0/Documents/Work/Trilinos/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestMain.cpp:38
    #11 0x753ae562a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #12 0x753ae562a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #13 0x61224d3f1ab4 in _start (/home/loveit0/Documents/Work/Trilinos/build-sanitize/packages/ifpack2/test/unit_tests/Ifpack2_unit_tests.exe+0x1866fab4) (BuildId: c426e212f4c99749e583076a71c7abc54b66331a)

SUMMARY: AddressSanitizer: 15081 byte(s) leaked in 95 allocation(s).
```

Also, as we can see there are a lot of leaks from OMP, but I guess, that it's ok and we can use `ASAN_OPTIONS=detect_leaks=0`.

### Additional information

- Suggested review: @ndellingwood (cc from the issue).
- **Follow-up (out of scope for this PR):** other Trilinos packages may still use `KOKKOS_IMPL_CUDA_SAFE_CALL`; a repo-wide search excluding `packages/kokkos/` could be noted on the issue for a separate cleanup, e.g. `grep -r "KOKKOS_IMPL_CUDA_SAFE_CALL" packages/ --include="*.hpp" --include="*.cpp" | grep -v "^packages/kokkos/"`:

```bash
grep -r "KOKKOS_IMPL_CUDA_SAFE_CALL" packages/ --include="*.hpp" --include="*.cpp" | grep -v "^packages/kokkos/"
packages/sacado/src/Sacado_DynamicArrayTraits.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL( cudaMalloc( &f.pool_device, sizeof(pool_t) ) );
packages/sacado/src/Sacado_DynamicArrayTraits.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL( cudaMemcpy( f.pool_device, pool,
packages/sacado/src/Sacado_DynamicArrayTraits.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL( cudaFree( (void*) Impl::global_sacado_cuda_memory_pool_device ) );
packages/sacado/src/Sacado_DynamicArrayTraits.hpp:        KOKKOS_IMPL_CUDA_SAFE_CALL( cudaMallocManaged( (void**) &m, sz*sizeof(T), cudaMemAttachGlobal ) );
packages/sacado/src/Sacado_DynamicArrayTraits.hpp:        KOKKOS_IMPL_CUDA_SAFE_CALL( cudaFree(m) );
packages/ifpack2/src/Ifpack2_CudaSafeCall.hpp:// KOKKOS_IMPL_CUDA_SAFE_CALL; Ifpack2 defines its own helpers because
packages/kokkos-kernels/sparse/src/KokkosSparse_spgemm_handle.hpp:      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(buffer3));
packages/kokkos-kernels/sparse/src/KokkosSparse_spgemm_handle.hpp:      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(buffer4));
packages/kokkos-kernels/sparse/src/KokkosSparse_spgemm_handle.hpp:      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(buffer5));
packages/kokkos-kernels/sparse/src/KokkosSparse_spmv_handle.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeAsync(buffer, exec.cuda_stream()));
packages/kokkos-kernels/sparse/src/KokkosSparse_sptrsv_handle.hpp:        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(pBuffer));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMallocAsync(&subhandle->buffer, subhandle->bufferSize, exec.cuda_stream()));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&subhandle->buffer, subhandle->bufferSize));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_numeric_tpl_spec_decl.hpp:      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&h->buffer5, h->bufferSize5));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spmv_sellmatrix_tpl_spec_decl.hpp:  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMallocAsync(&buffer, bufferSize, exec.cuda_stream()));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spmv_sellmatrix_tpl_spec_decl.hpp:  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeAsync(buffer, exec.cuda_stream()));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp:  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&buffer1, bufferSize1));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp:  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&buffer2, bufferSize2));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp:  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(buffer1));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_noreuse_tpl_spec_decl.hpp:  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(buffer2));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&buffer1, bufferSize1));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&buffer2, bufferSize2));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&h->buffer3, h->bufferSize3));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&h->buffer4, h->bufferSize4));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(buffer2));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(buffer1));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&dummyEntries, C_nnz * sizeof(Ordinal)));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&dummyValues, C_nnz * sizeof(Scalar)));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&h->buffer5, h->bufferSize5));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(dummyValues));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(dummyEntries));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&h->buffer3, h->bufferSize3));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&h->buffer4, h->bufferSize4));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:      KOKKOS_IMPL_CUDA_SAFE_CALL(
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&dummyEntries_C, sizeof(ordinal_type) * C_nnz));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&dummyValues_C, sizeof(scalar_type) * C_nnz));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(dummyValues_C));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(dummyEntries_C));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(dummyValues_AB));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemcpy(&nnzC, row_mapC.data() + m, sizeof(int), cudaMemcpyDeviceToHost));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spgemm_symbolic_tpl_spec_decl.hpp:      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemcpy(&baseC, row_mapC.data(), sizeof(int), cudaMemcpyDeviceToHost));
packages/kokkos-kernels/sparse/tpls/KokkosSparse_spmv_mv_tpl_spec_decl.hpp:    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&subhandle->buffer, subhandle->bufferSize));
packages/kokkos-kernels/sparse/impl/KokkosSparse_sptrsv_cuSPARSE_impl.hpp:      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void **)&(h->pBuffer), pBufferSize));
packages/kokkos-kernels/perf_test/sparse/KokkosSparse_spmv_struct_tuning.cpp:      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&dBuffer, bufferSize));
packages/kokkos-kernels/perf_test/sparse/KokkosSparse_spmv_struct_tuning.cpp:      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(dBuffer));
packages/kokkos-kernels/perf_test/sparse/KokkosSparse_spadd.cpp:        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void**)&cusparseBuffer, bufferSize));
packages/kokkos-kernels/perf_test/sparse/KokkosSparse_spadd.cpp:    if (params.use_cusparse) KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(cusparseBuffer));
```
