### PR TITLE
Framework: Use shell to handle variable defaulting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
         description: 'Max cores allowed that is detected on the system.'
         required: false
         type: number
+        default: -1
       ctest-drop-site:
         required: false
         type: string
@@ -34,10 +35,12 @@ on:
         description: 'Number of concurrent tests allowed in CTest.'
         required: false
         type: number
+        default: -1
       slots-per-gpu:
         description: 'On a GPU machine, this is number of slots allowed per GPU. (e.g. 4 allows 4 MPI ranks per GPU)'
         required: false
         type: number
+        default: -1
       extra-pr-driver-args:
         description: 'Extra arguments to be used when calling PullRequestLinuxDriverTest.py'
         required: false
@@ -101,6 +104,28 @@ jobs:
 
           echo "image: ${AT2_IMAGE_FULLPATH:-${AT2_IMAGE:-unknown}}"
           type python
+
+          if [ "${{ inputs.num-concurrent-tests }}" != "-1" ]
+          then
+            num_concurrent_tests="--num-concurrent-tests ${{ inputs.num-concurrent-tests }}"
+          else
+            num_concurrent_tests=""
+          fi
+
+          if [ "${{ inputs.max-cores-allowed }}" != "-1" ]
+          then
+            max_cores_allowed="--max-cores-allowed ${{ inputs.max-cores-allowed }}"
+          else
+            max_cores_allowed=""
+          fi
+
+          if [ "${{ inputs.slots-per-gpu }}" != "-1" ]
+          then
+            slots_per_gpu="--slots-per-gpu ${{ inputs.slots-per-gpu }}"
+          else
+            slots_per_gpu=""
+          fi
+
           python3 ${TRILINOS_DIR}/packages/framework/pr_tools/PullRequestLinuxDriverTest.py \
             --genconfig-build-name ${{ inputs.genconfig-string }} \
             ${{ inputs.target-branch && '--target-branch-name ' || '' }}${{ inputs.target-branch }} \
@@ -116,9 +141,9 @@ jobs:
             --pullrequest-cdash-track ${{ inputs.cdash-track }} \
             --filename-subprojects ./package_subproject_list.cmake \
             --filename-packageenables ./packageEnables.cmake \
-            ${{ inputs.max-cores-allowed && '--max-cores-allowed ' || '' }}${{ inputs.max-cores-allowed }} \
-            ${{ inputs.num-concurrent-tests && '--num-concurrent-tests ' || '' }}${{ inputs.num-concurrent-tests }} \
-            ${{ inputs.slots-per-gpu && '--slots-per-gpu ' || '' }}${{ inputs.slots-per-gpu }} \
+            ${num_concurrent_tests} \
+            ${max_cores_allowed} \
+            ${slots_per_gpu} \
             ${{ inputs.extra-pr-driver-args }}
       - name: Filtered build error logs
         if: success() || failure()


### PR DESCRIPTION
@trilinos/framework 

## Motivation
I can't figure out a nicer way to handle this on the GHA side while preserving the numeric type on the input (which I like as a helpful input check).  Do it in the shell instead, unfortunately.
