### PR TITLE
Sacado:  Remove std::is_same specialization for LayoutNatural.

### DIFF
--- a/packages/sacado/src/Kokkos_LayoutNatural.hpp
+++ b/packages/sacado/src/Kokkos_LayoutNatural.hpp
@@ -64,21 +64,6 @@ struct inner_layout< LayoutNatural<Layout> > {
 
 } // namespace Kokkos
 
-// Make LayoutNatural<Layout> equivalent to Layout
-namespace std {
-
-  template <class Layout>
-  struct is_same< Kokkos::LayoutNatural<Layout>, Layout> {
-    static const bool value = true;
-  };
-
-  template <class Layout>
-  struct is_same< Layout, Kokkos::LayoutNatural<Layout> > {
-    static const bool value = true;
-  };
-
-}
-
 #include "View/Kokkos_ViewMapping.hpp"
 
 namespace Kokkos {


### PR DESCRIPTION
Removes `std::is_same` specialization for `LayoutNatural` that was missed in #15129.  For issues #15036 and #15098.