### PR TITLE
Xpetra, MueLu: Do not create strided maps unless needed

### DIFF
--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -2777,7 +2777,8 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupO
                                   << "instead of " << A.GetFixedBlockSize() << " (provided matrix)." << std::endl
                                   << "You may want to check \"number of equations\" (or \"PDE equations\" for factory style list) parameter." << std::endl;
 
-    A.SetFixedBlockSize(blockSize_, dofOffset_);
+    if ((blockSize_ != 1) || (dofOffset_ != 0))
+      A.SetFixedBlockSize(blockSize_, dofOffset_);
 
 #ifdef HAVE_MUELU_DEBUG
     MatrixUtils::checkLocalRowMapMatchesColMap(A);

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceAcFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceAcFactory_def.hpp
@@ -100,7 +100,8 @@ void RebalanceAcFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level 
       }
 
       if (!rebalancedAc.is_null()) {
-        rebalancedAc->SetFixedBlockSize(originalAc->GetFixedBlockSize());
+        if (originalAc->IsFixedBlockSizeSet())
+          rebalancedAc->SetFixedBlockSize(originalAc->GetFixedBlockSize());
         std::ostringstream oss;
         oss << "A_" << coarseLevel.GetLevelID();
         rebalancedAc->setObjectLabel(oss.str());

--- a/packages/muelu/src/Transfers/Energy-Minimization/MueLu_EminPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/MueLu_EminPFactory_def.hpp
@@ -265,9 +265,6 @@ void EminPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& fine
       RCP<const StridedMap> dMap = StridedMapFactory::Build(X->GetPattern()->getDomainMap(), stridingInfo);
 
       P->CreateView("stridedMaps", A->getRowMap("stridedMaps"), dMap);
-
-    } else {
-      P->CreateView("stridedMaps", P->getRangeMap(), P->getDomainMap());
     }
   }
 

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
@@ -275,8 +275,6 @@ void GeometricInterpolationPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     P = P_wrap;
     if (A->IsView("stridedMaps") == true) {
       P->CreateView("stridedMaps", A->getRowMap("stridedMaps"), stridedPointMap);
-    } else {
-      P->CreateView("stridedMaps", P->getRangeMap(), PointMap);
     }
   } else {
     // Create the prolongator matrix and its associated objects
@@ -289,8 +287,6 @@ void GeometricInterpolationPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     // set StridingInformation of P
     if (A->IsView("stridedMaps") == true)
       P->CreateView("stridedMaps", A->getRowMap("stridedMaps"), stridedDomainMap);
-    else
-      P->CreateView("stridedMaps", P->getRangeMap(), stridedDomainMap);
   }
 
 }  // BuildConstantP
@@ -463,8 +459,6 @@ void GeometricInterpolationPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   // set StridingInformation of P
   if (A->IsView("stridedMaps") == true) {
     P->CreateView("stridedMaps", A->getRowMap("stridedMaps"), stridedDomainMap);
-  } else {
-    P->CreateView("stridedMaps", P->getRangeMap(), stridedDomainMap);
   }
 
 }  // BuildLinearP

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_def.hpp
@@ -220,8 +220,6 @@ void TentativePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level&
   // coarsest levels.
   if (A->IsView("stridedMaps") == true)
     Ptentative->CreateView("stridedMaps", A->getRowMap("stridedMaps"), coarseMap);
-  else
-    Ptentative->CreateView("stridedMaps", Ptentative->getRangeMap(), coarseMap);
 
   if (bTransferCoordinates_) {
     Set(coarseLevel, "Coordinates", coarseCoords);

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
@@ -497,8 +497,6 @@ void TentativePFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP
   // coarsest levels.
   if (A->IsView("stridedMaps") == true)
     Ptentative->CreateView("stridedMaps", A->getRowMap("stridedMaps"), coarseMap);
-  else
-    Ptentative->CreateView("stridedMaps", Ptentative->getRangeMap(), coarseMap);
 
   if (bTransferCoordinates_) {
     Set(coarseLevel, "Coordinates", coarseCoords);

--- a/packages/muelu/src/Utils/MueLu_IteratorOps.hpp
+++ b/packages/muelu/src/Utils/MueLu_IteratorOps.hpp
@@ -71,7 +71,8 @@ void Jacobi(
   // transfer striding information
   RCP<Xpetra::Matrix<SC, LO, GO, NO> > rcpA = Teuchos::rcp_const_cast<Xpetra::Matrix<SC, LO, GO, NO> >(Teuchos::rcpFromRef(A));
   RCP<Xpetra::Matrix<SC, LO, GO, NO> > rcpB = Teuchos::rcp_const_cast<Xpetra::Matrix<SC, LO, GO, NO> >(Teuchos::rcpFromRef(B));
-  C.CreateView("stridedMaps", rcpA, false, rcpB, false);  // TODO use references instead of RCPs
+  if (A.IsView("stridedMaps") || B.IsView("stridedMaps"))
+    C.CreateView("stridedMaps", rcpA, false, rcpB, false);  // TODO use references instead of RCPs
 }  // end Jacobi
 
 /*!
@@ -98,7 +99,8 @@ class IteratorOps {
     }
 
     MueLu::Jacobi<Scalar, LocalOrdinal, GlobalOrdinal, Node>(omega, Dinv, A, B, *C, true, true, label, params);
-    C->CreateView("stridedMaps", rcpFromRef(A), false, rcpFromRef(B), false);
+    if (A.IsView("stridedMaps") || B.IsView("stridedMaps"))
+      C->CreateView("stridedMaps", rcpFromRef(A), false, rcpFromRef(B), false);
 
     return C;
   }

--- a/packages/muelu/test/interface/ParameterListInterpreter.cpp
+++ b/packages/muelu/test/interface/ParameterListInterpreter.cpp
@@ -131,6 +131,7 @@ int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib& lib, int ar
 
       // Reset (potentially) cached value of the estimate
       A->SetMaxEigenvalueEstimate(-Teuchos::ScalarTraits<SC>::one());
+      if (A->IsView("stridedMaps")) A->RemoveView("stridedMaps");
 
       std::string xmlFile;
       std::string outFile;

--- a/packages/xpetra/src/Matrix/Xpetra_MatrixFactory2_decl.hpp
+++ b/packages/xpetra/src/Matrix/Xpetra_MatrixFactory2_decl.hpp
@@ -58,7 +58,7 @@ class MatrixFactory2<double, int, int, Node> {
     if (oldTCrsOp != Teuchos::null) {
       RCP<CrsMatrix> newTCrsOp(new TpetraCrsMatrix(*oldTCrsOp));
       RCP<CrsMatrixWrap> newOp(new CrsMatrixWrap(newTCrsOp));
-      if (setFixedBlockSize)
+      if (setFixedBlockSize && A->IsFixedBlockSizeSet())
         newOp->SetFixedBlockSize(A->GetFixedBlockSize());
       return newOp;
     }
@@ -91,7 +91,7 @@ class MatrixFactory2<double, int, long long, Node> {
     if (oldTCrsOp != Teuchos::null) {
       RCP<CrsMatrix> newTCrsOp(new TpetraCrsMatrix(*oldTCrsOp));
       RCP<CrsMatrixWrap> newOp(new CrsMatrixWrap(newTCrsOp));
-      if (setFixedBlockSize)
+      if (setFixedBlockSize && A->IsFixedBlockSizeSet())
         newOp->SetFixedBlockSize(A->GetFixedBlockSize());
       return newOp;
     }

--- a/packages/xpetra/src/Matrix/Xpetra_MatrixFactory2_def.hpp
+++ b/packages/xpetra/src/Matrix/Xpetra_MatrixFactory2_def.hpp
@@ -37,7 +37,7 @@ RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> MatrixFactory2<Sc
     if (oldTCrsOp != Teuchos::null) {
       RCP<TpetraCrsMatrix> newTCrsOp(new TpetraCrsMatrix(*oldTCrsOp));
       RCP<CrsMatrixWrap> newOp(new CrsMatrixWrap(Teuchos::as<RCP<CrsMatrix>>(newTCrsOp)));
-      if (setFixedBlockSize)
+      if (setFixedBlockSize && A->IsFixedBlockSizeSet())
         newOp->SetFixedBlockSize(A->GetFixedBlockSize());
 
       return newOp;

--- a/packages/xpetra/src/Utils/Xpetra_MatrixMatrix_def.hpp
+++ b/packages/xpetra/src/Utils/Xpetra_MatrixMatrix_def.hpp
@@ -112,7 +112,8 @@ void MatrixMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Multiply(const Mat
   // transfer striding information
   RCP<Matrix> rcpA = Teuchos::rcp_const_cast<Matrix>(Teuchos::rcpFromRef(A));
   RCP<Matrix> rcpB = Teuchos::rcp_const_cast<Matrix>(Teuchos::rcpFromRef(B));
-  C.CreateView("stridedMaps", rcpA, transposeA, rcpB, transposeB);  // TODO use references instead of RCPs
+  if (A.IsView("stridedMaps") || B.IsView("stridedMaps"))
+    C.CreateView("stridedMaps", rcpA, transposeA, rcpB, transposeB);  // TODO use references instead of RCPs
 }  // end Multiply
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Only create strided maps if they are actually needed.

The motivation for this change is that having strided maps triggers a global reduction in AmalgamationFactory.