### PR TITLE
Tpetra: Change all sort occurrences in Tpetra to use wrappers in ImportUtil

### DIFF
--- a/packages/muelu/src/Utils/MueLu_CrsMatrixUtils.hpp
+++ b/packages/muelu/src/Utils/MueLu_CrsMatrixUtils.hpp
@@ -40,11 +40,8 @@ class CrsMatrixUtils {
                              const Teuchos::ArrayView<Scalar>& CRS_vals,
                              const UnderlyingLib lib) {
     if (lib == Xpetra::UseTpetra) {
-      Tpetra::Import_Util::sortCrsEntries(CRS_rowptr, CRS_colind, CRS_vals,
-                                          ::KokkosSparse::SortAlgorithm::DEFAULT);
+      Tpetra::Import_Util::sortCrsEntries(CRS_rowptr, CRS_colind, CRS_vals);
     }
-
-    return;
   }
 
   /// \brief Sort and merge the entries of the (raw CSR) matrix by column index
@@ -56,8 +53,6 @@ class CrsMatrixUtils {
     if (lib == Xpetra::UseTpetra) {
       Tpetra::Import_Util::sortAndMergeCrsEntries(CRS_rowptr, CRS_colind, CRS_vals);
     }
-
-    return;
   }
 
 };  // end class CrsMatrixUtils

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop.hpp
@@ -20,7 +20,7 @@
 #include "Teuchos_CommandLineProcessor.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_FancyOStream.hpp"
-#include "KokkosSparse_SortCrs.hpp"
+#include "Tpetra_Import_Util2.hpp"
 
 #include "fem_assembly_typedefs.hpp"
 #include "fem_assembly_MeshDatabase.hpp"
@@ -787,7 +787,7 @@ int executeTotalElementLoopSPKokkos_(const Teuchos::RCP<const Teuchos::Comm<int>
     }
     // The local graph is now fully constructed. Sort it and build the fill-complete CrsGraph.
     local_graph_type localGraph(localEntries, localRowptrs);
-    KokkosSparse::sort_crs_graph(localGraph);
+    Tpetra::Import_Util::sortCrsGraph(localGraph);
     timerElementLoopGraph = Teuchos::null;
     {
       TimeMonitor timer(*TimeMonitor::getNewTimer("2) FillComplete (Graph)"));

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
@@ -173,7 +173,7 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && ((CUDA_VERSION < 11000) || (CUDA_VERSION >= 11040))
   if constexpr (std::is_same_v<typename device_t::execution_space, Kokkos::Cuda>) {
     if (!KokkosSparse::isCrsGraphSorted(Bmerged.graph.row_map, Bmerged.graph.entries)) {
-      KokkosSparse::sort_crs_matrix(Bmerged);
+      Import_Util::sortCrsMatrix(Bmerged);
     }
   }
 #endif

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_ExtraKernels_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_ExtraKernels_def.hpp
@@ -263,7 +263,7 @@ void mult_A_B_newmatrix_LowThreadGustavsonKernel(CrsMatrixStruct<Scalar, LocalOr
   // Sort & set values
   if (params.is_null() || params->get("sort entries", true)) {
     // Tpetra's SpGEMM results in almost sorted matrices. Use shell sort.
-    Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC, ::KokkosSparse::SortAlgorithm::SHELL);
+    Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC);
   }
   C.setAllValues(row_mapC, entriesC, valuesC);
 }
@@ -659,7 +659,7 @@ void jacobi_A_B_newmatrix_LowThreadGustavsonKernel(Scalar omega,
   // Sort & set values
   if (params.is_null() || params->get("sort entries", true)) {
     // Tpetra's SpGEMM results in almost sorted matrices. Use shell sort.
-    Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC, ::KokkosSparse::SortAlgorithm::SHELL);
+    Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC);
   }
   C.setAllValues(row_mapC, entriesC, valuesC);
 }
@@ -1226,7 +1226,7 @@ static inline void mult_R_A_P_newmatrix_LowThreadGustavsonKernel(CrsMatrixStruct
 
   // Final sort & set of CRS arrays
   // Tpetra's SpGEMM results in almost sorted matrices. Use shell sort.
-  Import_Util::sortCrsEntries(rowmapAc, entriesAc, valuesAc, ::KokkosSparse::SortAlgorithm::SHELL);
+  Import_Util::sortCrsEntries(rowmapAc, entriesAc, valuesAc);
   // mfh 27 Sep 2016: This just sets pointers.
   Ac.setAllValues(rowmapAc, entriesAc, valuesAc);
 

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
@@ -248,7 +248,7 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
     // Sort & set values
     if (params.is_null() || params->get("sort entries", true)) {
       // Tpetra's OpenMP SpGEMM results in almost sorted matrices. Use shell sort.
-      Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC, ::KokkosSparse::SortAlgorithm::SHELL);
+      Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC);
     }
     C.setAllValues(row_mapC, entriesC, valuesC);
 
@@ -586,7 +586,7 @@ void KernelWrappers2<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::
   // Sort & set values
   if (params.is_null() || params->get("sort entries", true)) {
     // Tpetra's OpenMP SpGEMM results in almost sorted matrices. Use shell sort.
-    Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC, ::KokkosSparse::SortAlgorithm::SHELL);
+    Import_Util::sortCrsEntries(row_mapC, entriesC, valuesC);
   }
   C.setAllValues(row_mapC, entriesC, valuesC);
 

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -807,7 +807,7 @@ void add(const Scalar& alpha,
                          ConvertGlobalToLocalFunctor<LocalOrdinal, GlobalOrdinal,
                                                      col_inds_array, global_col_inds_array,
                                                      typename map_type::local_map_type>(localColinds, globalColinds, CcolMap->getLocalMap()));
-    Import_Util::sortCrsEntries(rowptrs, localColinds, vals, ::KokkosSparse::SortAlgorithm::SHELL);
+    Import_Util::sortCrsEntries(rowptrs, localColinds, vals);
     C.setAllValues(rowptrs, localColinds, vals);
     C.fillComplete(CDomainMap, CRangeMap, params);
     if (!doFillComplete)
@@ -2101,7 +2101,7 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Node, LocalOrdinalViewT
     // Final sort & set of CRS arrays
     if (params.is_null() || params->get("sort entries", true)) {
       // Tpetra's serial SpGEMM results in almost sorted matrices. Use shell sort.
-      Import_Util::sortCrsEntries(Crowptr, Ccolind, Cvals, ::KokkosSparse::SortAlgorithm::SHELL);
+      Import_Util::sortCrsEntries(Crowptr, Ccolind, Cvals);
     }
     C.setAllValues(Crowptr, Ccolind, Cvals);
   }
@@ -2721,7 +2721,7 @@ void KernelWrappers2<Scalar, LocalOrdinal, GlobalOrdinal, Node, LocalOrdinalView
     // Final sort & set of CRS arrays
     if (params.is_null() || params->get("sort entries", true)) {
       // Tpetra's serial SpGEMM results in almost sorted matrices. Use shell sort.
-      Import_Util::sortCrsEntries(Crowptr, Ccolind, Cvals, ::KokkosSparse::SortAlgorithm::SHELL);
+      Import_Util::sortCrsEntries(Crowptr, Ccolind, Cvals);
     }
     C.setAllValues(Crowptr, Ccolind, Cvals);
   }

--- a/packages/tpetra/core/ext/TpetraExt_TripleMatrixMultiply_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_TripleMatrixMultiply_def.hpp
@@ -1082,8 +1082,7 @@ void KernelWrappers3<Scalar, LocalOrdinal, GlobalOrdinal, Node, LocalOrdinalView
 
   // Final sort & set of CRS arrays
   if (params.is_null() || params->get("sort entries", true))
-    Import_Util::sortCrsEntries(Crowptr_dev, Ccolind_dev, Cvals_dev,
-                                ::KokkosSparse::SortAlgorithm::DEFAULT);
+    Import_Util::sortCrsEntries(Crowptr_dev, Ccolind_dev, Cvals_dev);
   Ac.setAllValues(Crowptr_dev, Ccolind_dev, Cvals_dev);
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
@@ -1674,8 +1673,7 @@ void KernelWrappers3MMM<Scalar, LocalOrdinal, GlobalOrdinal, Node>::mult_PT_A_P_
   //
   // TODO (mfh 27 Sep 2016) Will the thread-parallel "local" sparse
   // matrix-matrix multiply routine sort the entries for us?
-  Import_Util::sortCrsEntries(Acrowptr_RCP(), Accolind_RCP(), Acvals_RCP(),
-                              ::KokkosSparse::SortAlgorithm::SHELL);
+  Import_Util::sortCrsEntries(Acrowptr_RCP(), Accolind_RCP(), Acvals_RCP());
 
   // mfh 27 Sep 2016: This just sets pointers.
   Ac.setAllValues(Acrowptr_RCP, Accolind_RCP, Acvals_RCP);

--- a/packages/tpetra/core/src/Tpetra_CrsGraphTransposer_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraphTransposer_def.hpp
@@ -20,6 +20,7 @@
 #include "KokkosSparse_Utils.hpp"
 #include "KokkosKernels_Handle.hpp"
 #include "KokkosSparse_spadd.hpp"
+#include "Tpetra_Import_Util2.hpp"
 
 namespace Tpetra {
 
@@ -310,7 +311,7 @@ CrsGraphTransposer<LocalOrdinal, GlobalOrdinal, Node>::
 
   bool sort = true;
   if (sort)
-    KokkosSparse::sort_crs_graph<execution_space, row_ptrs_array, col_inds_array>(rowptrsSym, colindsSym);
+    Import_Util::sortCrsEntries(rowptrsSym, colindsSym);
 
   local_graph_device_type lclGraphSym = local_graph_device_type(colindsSym, rowptrsSym);
 
@@ -407,11 +408,7 @@ CrsGraphTransposer<LocalOrdinal, GlobalOrdinal, Node>::
       lclGraphT_rowmap, lclGraphT_entries);
 
   if (sort)
-    KokkosSparse::sort_crs_graph<
-        typename local_graph_device_type::execution_space,
-        rowmap_t, entries_t>(
-        lclGraphT_rowmap,
-        lclGraphT_entries);
+    Import_Util::sortCrsEntries(lclGraphT_rowmap, lclGraphT_entries);
 
   // And construct the transpose local_graph_device_type
   local_graph_device_type lclGraphT = local_graph_device_type(lclGraphT_entries, lclGraphT_rowmap);

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -4234,7 +4234,7 @@ void CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
       if (!sorted) {
         // For this to work correctly, we require that the unused column entries have been filled
         // with indices that get ordered last.
-        KokkosSparse::sort_crs_graph(rowptr, colinds);
+        Import_Util::sortCrsEntries(rowptr, colinds);
         this->indicesAreSorted_ = true;  // we just sorted every row
       }
       if (!merged) {
@@ -4246,7 +4246,7 @@ void CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
       auto rowptr  = rowPtrsPacked_dev_;
       auto colinds = lclIndsPacked_wdv.getDeviceView(Access::ReadWrite);
       if (!sorted && merged) {
-        KokkosSparse::sort_crs_graph(rowptr, colinds);
+        Import_Util::sortCrsEntries(rowptr, colinds);
         this->indicesAreSorted_ = true;  // we just sorted every row
       } else {
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(true, std::logic_error,
@@ -6824,8 +6824,7 @@ void CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   if ((!reverseMode && xferAsImport != nullptr) ||
       (reverseMode && xferAsExport != nullptr)) {
     Import_Util::sortCrsEntries(CSR_rowptr(),
-                                CSR_colind_LID(),
-                                ::KokkosSparse::SortAlgorithm::DEFAULT);
+                                CSR_colind_LID());
   } else if ((!reverseMode && xferAsExport != nullptr) ||
              (reverseMode && xferAsImport != nullptr)) {
     Import_Util::sortAndMergeCrsEntries(CSR_rowptr(),

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -4503,7 +4503,7 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     if (!sorted) {
       // For this to work correctly, we require that the unused column entries have been filled
       // with indices that get ordered last.
-      Import_Util::sortCrsEntries(rowptr, colinds, values, ::KokkosSparse::SortAlgorithm::DEFAULT);
+      Import_Util::sortCrsEntries(rowptr, colinds, values);
       graph.indicesAreSorted_ = true;  // we just sorted every row
     }
     if (!merged) {
@@ -8317,8 +8317,7 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       Tpetra::Details::ProfilingRegion MMrc("Tpetra TAFC sortCrsEntries");
       Import_Util::sortCrsEntries(CSR_rowptr(),
                                   CSR_colind_LID(),
-                                  CSR_vals(),
-                                  ::KokkosSparse::SortAlgorithm::DEFAULT);
+                                  CSR_vals());
     } else if ((!reverseMode && xferAsExport != nullptr) ||
                (reverseMode && xferAsImport != nullptr)) {
       if (verbose) {
@@ -8492,8 +8491,7 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       Tpetra::Details::ProfilingRegion MMrc("Tpetra TAFC sortCrsEntries");
       Import_Util::sortCrsEntries(CSR_rowptr_d,
                                   CSR_colind_LID_d,
-                                  CSR_vals_d,
-                                  ::KokkosSparse::SortAlgorithm::DEFAULT);
+                                  CSR_vals_d);
     } else if ((!reverseMode && xferAsExport != nullptr) ||
                (reverseMode && xferAsImport != nullptr)) {
       if (verbose) {

--- a/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
@@ -75,24 +75,26 @@ namespace Import_Util {
 template <typename Scalar, typename Ordinal>
 void sortCrsEntries(const Teuchos::ArrayView<size_t>& CRS_rowptr,
                     const Teuchos::ArrayView<Ordinal>& CRS_colind,
-                    const Teuchos::ArrayView<Scalar>& CRS_vals,
-                    const ::KokkosSparse::SortAlgorithm option = ::KokkosSparse::SortAlgorithm::DEFAULT);
+                    const Teuchos::ArrayView<Scalar>& CRS_vals);
 
 template <typename Ordinal>
 void sortCrsEntries(const Teuchos::ArrayView<size_t>& CRS_rowptr,
-                    const Teuchos::ArrayView<Ordinal>& CRS_colind,
-                    const ::KokkosSparse::SortAlgorithm option = ::KokkosSparse::SortAlgorithm::DEFAULT);
+                    const Teuchos::ArrayView<Ordinal>& CRS_colind);
 
 template <typename rowptr_array_type, typename colind_array_type, typename vals_array_type>
 void sortCrsEntries(const rowptr_array_type& CRS_rowptr,
                     const colind_array_type& CRS_colind,
-                    const vals_array_type& CRS_vals,
-                    const ::KokkosSparse::SortAlgorithm option = ::KokkosSparse::SortAlgorithm::DEFAULT);
+                    const vals_array_type& CRS_vals);
 
 template <typename rowptr_array_type, typename colind_array_type>
 void sortCrsEntries(const rowptr_array_type& CRS_rowptr,
-                    const colind_array_type& CRS_colind,
-                    const ::KokkosSparse::SortAlgorithm option = ::KokkosSparse::SortAlgorithm::DEFAULT);
+                    const colind_array_type& CRS_colind);
+
+template <typename local_crs_matrix>
+void sortCrsMatrix(local_crs_matrix& lclMatrix);
+
+template <typename local_crs_graph>
+void sortCrsGraph(local_crs_graph& lclGraph);
 
 /// \brief Sort and merge the entries of the (raw CSR) matrix by
 ///   column index within each row.
@@ -460,37 +462,59 @@ void reverseNeighborDiscovery(const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdina
 template <typename Scalar, typename Ordinal>
 void sortCrsEntries(const Teuchos::ArrayView<size_t>& CRS_rowptr,
                     const Teuchos::ArrayView<Ordinal>& CRS_colind,
-                    const Teuchos::ArrayView<Scalar>& CRS_vals,
-                    const ::KokkosSparse::SortAlgorithm option) {
+                    const Teuchos::ArrayView<Scalar>& CRS_vals) {
   auto rowptr_k = Kokkos::View<size_t*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>(CRS_rowptr.data(), CRS_rowptr.size());
   auto colind_k = Kokkos::View<Ordinal*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>(CRS_colind.data(), CRS_colind.size());
   auto vals_k   = Kokkos::View<Scalar*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>(CRS_vals.data(), CRS_vals.size());
-  sortCrsEntries(rowptr_k, colind_k, vals_k, option);
+  sortCrsEntries(rowptr_k, colind_k, vals_k);
 }
 
 template <typename Ordinal>
 void sortCrsEntries(const Teuchos::ArrayView<size_t>& CRS_rowptr,
-                    const Teuchos::ArrayView<Ordinal>& CRS_colind,
-                    const ::KokkosSparse::SortAlgorithm option) {
+                    const Teuchos::ArrayView<Ordinal>& CRS_colind) {
   auto rowptr_k = Kokkos::View<size_t*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>(CRS_rowptr.data(), CRS_rowptr.size());
   auto colind_k = Kokkos::View<Ordinal*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>(CRS_colind.data(), CRS_colind.size());
-  sortCrsEntries(rowptr_k, colind_k, option);
+  sortCrsEntries(rowptr_k, colind_k);
 }
 
 template <typename rowptr_array_type, typename colind_array_type, typename vals_array_type>
 void sortCrsEntries(const rowptr_array_type& CRS_rowptr,
                     const colind_array_type& CRS_colind,
-                    const vals_array_type& CRS_vals,
-                    const ::KokkosSparse::SortAlgorithm option) {
+                    const vals_array_type& CRS_vals) {
+  KokkosSparse::SortAlgorithm option = KokkosSparse::SortAlgorithm::DEFAULT;
+  static constexpr bool is_cpu       = std::is_same_v<typename rowptr_array_type::memory_space, Kokkos::HostSpace>;
+  if constexpr (is_cpu)
+    option = KokkosSparse::SortAlgorithm::SHELL;
   KokkosSparse::sort_crs_matrix(CRS_rowptr, CRS_colind, CRS_vals,
                                 KokkosKernels::ArithTraits<typename colind_array_type::non_const_value_type>::max(),
                                 option);
 }
 
+template <typename local_crs_matrix>
+void sortCrsMatrix(local_crs_matrix& lclMatrix) {
+  KokkosSparse::SortAlgorithm option = KokkosSparse::SortAlgorithm::DEFAULT;
+  static constexpr bool is_cpu       = std::is_same_v<typename local_crs_matrix::device_type::memory_space, Kokkos::HostSpace>;
+  if constexpr (is_cpu)
+    option = KokkosSparse::SortAlgorithm::SHELL;
+  KokkosSparse::sort_crs_matrix(lclMatrix, option);
+}
+
+template <typename local_crs_graph>
+void sortCrsGraph(local_crs_graph& lclGraph) {
+  KokkosSparse::SortAlgorithm option = KokkosSparse::SortAlgorithm::DEFAULT;
+  static constexpr bool is_cpu       = std::is_same_v<typename local_crs_graph::device_type::memory_space, Kokkos::HostSpace>;
+  if constexpr (is_cpu)
+    option = KokkosSparse::SortAlgorithm::SHELL;
+  KokkosSparse::sort_crs_graph(lclGraph, KokkosKernels::ArithTraits<typename local_crs_graph::entries_type::non_const_value_type>::max(), option);
+}
+
 template <typename rowptr_array_type, typename colind_array_type>
 void sortCrsEntries(const rowptr_array_type& CRS_rowptr,
-                    const colind_array_type& CRS_colind,
-                    const ::KokkosSparse::SortAlgorithm option) {
+                    const colind_array_type& CRS_colind) {
+  KokkosSparse::SortAlgorithm option = KokkosSparse::SortAlgorithm::DEFAULT;
+  static constexpr bool is_cpu       = std::is_same_v<typename rowptr_array_type::memory_space, Kokkos::HostSpace>;
+  if constexpr (is_cpu)
+    option = KokkosSparse::SortAlgorithm::SHELL;
   KokkosSparse::sort_crs_graph(CRS_rowptr, CRS_colind,
                                KokkosKernels::ArithTraits<typename colind_array_type::non_const_value_type>::max(),
                                option);

--- a/packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp
@@ -19,7 +19,6 @@
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
 #include "KokkosSparse_Utils.hpp"
-#include "KokkosSparse_SortCrs.hpp"
 
 namespace Tpetra {
 
@@ -128,12 +127,8 @@ RowMatrixTransposer<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
   local_matrix_device_type lclMatrix          = crsMatrix->getLocalMatrixDevice();
   local_matrix_device_type lclTransposeMatrix = KokkosSparse::Impl::transpose_matrix(lclMatrix);
-  if (sort) {
-    if constexpr (Node::is_cpu)
-      Import_Util::sortCrsEntries(lclTransposeMatrix.graph.row_map, lclTransposeMatrix.graph.entries, lclTransposeMatrix.values, ::KokkosSparse::SortAlgorithm::SHELL);
-    else
-      Import_Util::sortCrsEntries(lclTransposeMatrix.graph.row_map, lclTransposeMatrix.graph.entries, lclTransposeMatrix.values);
-  }
+  if (sort)
+    Import_Util::sortCrsMatrix(lclTransposeMatrix);
 
   // Prebuild the importers and exporters the no-communication way,
   // flipping the importers and exporters around.
@@ -248,7 +243,7 @@ BlockCrsMatrixTransposer<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     local_matrix_device_type lclTransposeMatrix = KokkosSparse::Impl::transpose_bsr_matrix(lclMatrix);
 
     // BlockCrs requires that we sort stuff
-    KokkosSparse::sort_crs_matrix(lclTransposeMatrix);
+    Import_Util::sortCrsMatrix(lclTransposeMatrix);
     values = lclTransposeMatrix.values;
 
     // Prebuild the importers and exporters the no-communication way,


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
This allows to switch all on-host sorting to use SHELL.