### PR TITLE
Framework: Change AddressSanitizer builds to debug

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,8 +33,8 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       target-runner-labels: "['self-hosted', 'clang-19.1.6-openmpi-4.1.6', '20251204']"
-      genconfig-string: "rhel_clang-openmpi_release-debug_shared_no-kokkos-arch_asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all"
+      genconfig-string: "rhel_clang-openmpi_debug_shared_no-kokkos-arch_asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all"
       cdash-track: "Nightly"
-      dashboard-build-name: ${AT2_IMAGE}_release-debug_shared_address-sanitizer
+      dashboard-build-name: ${AT2_IMAGE}_debug_shared_address-sanitizer
       max-cores-allowed: 29
       num-concurrent-tests: 16

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1229,8 +1229,9 @@ use TEST_DISABLES|CLANG
 use rhel_clang-openmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL
 
-[rhel_clang-openmpi_release-debug_shared_no-kokkos-arch_asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+[rhel_clang-openmpi_debug_shared_no-kokkos-arch_asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel_clang-openmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all
+use BUILD-TYPE|DEBUG
 use USE-ASAN|YES
 
 [rhel_oneapi-intelmpi_release-debug_shared_no-kokkos-arch_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables]


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Want actionable info from ASan, so need debug symbols.

Should give us actual traces instead of:
```
Direct leak of 4816 byte(s) in 7 object(s) allocated from:
    #0 0x55bd05d44ebf in malloc /tmp/runner/spack-stage/spack-stage-llvm-19.1.6-o5u336nwvgjplzuzrhqrp2jeesgrdwky/spack-src/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x7fa2e3dc5f69  (<unknown module>)

```

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-753
