### PR TITLE
Framework: fix omitting _asan_ by CTEST_BUILD_NAME

### DIFF
--- a/cmake/SimpleTesting/cmake/ctest-stage-test.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-stage-test.cmake
@@ -5,6 +5,32 @@ include(${CMAKE_CURRENT_LIST_DIR}/ctest-functions.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/ctest-common.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/ctest-cdash-setup.cmake)
 
+macro(trilinos_ctest_compute_asan_memcheck_route)
+  set(TRILINOS_CTEST_USE_ASAN_MEMCHECK FALSE)
+  set(TRILINOS_CTEST_USE_ASAN_MEMCHECK_REASON "")
+  if(DEFINED CTEST_BUILD_NAME AND CTEST_BUILD_NAME MATCHES ".*_asan_.*")
+    set(TRILINOS_CTEST_USE_ASAN_MEMCHECK TRUE)
+    set(TRILINOS_CTEST_USE_ASAN_MEMCHECK_REASON "CTEST_BUILD_NAME matches .*_asan_.*")
+  endif()
+  if(DEFINED CTEST_BINARY_DIRECTORY)
+    set(_trilinos_genconfig_bn_file "${CTEST_BINARY_DIRECTORY}/genconfig_build_name.txt")
+    if(EXISTS "${_trilinos_genconfig_bn_file}")
+      file(READ "${_trilinos_genconfig_bn_file}" _trilinos_genconfig_bn_content)
+      string(STRIP "${_trilinos_genconfig_bn_content}" _trilinos_genconfig_bn_content)
+      if(_trilinos_genconfig_bn_content MATCHES ".*_asan_.*")
+        set(TRILINOS_CTEST_USE_ASAN_MEMCHECK TRUE)
+        if(TRILINOS_CTEST_USE_ASAN_MEMCHECK_REASON STREQUAL "")
+          set(TRILINOS_CTEST_USE_ASAN_MEMCHECK_REASON
+              "genconfig_build_name.txt matches .*_asan_.*")
+        else()
+          set(TRILINOS_CTEST_USE_ASAN_MEMCHECK_REASON
+              "${TRILINOS_CTEST_USE_ASAN_MEMCHECK_REASON}; genconfig_build_name.txt matches .*_asan_.*")
+        endif()
+      endif()
+    endif()
+  endif()
+endmacro()
+
 
 # -----------------------------------------------------------
 # -- Test
@@ -13,8 +39,11 @@ banner("START test step")
 
 set(STAGE_TEST_ERROR OFF)
 
+trilinos_ctest_compute_asan_memcheck_route()
+
 if(NOT SKIP_RUN_TESTS)
-    if(CTEST_BUILD_NAME MATCHES .*_asan_.*)
+    if(TRILINOS_CTEST_USE_ASAN_MEMCHECK)
+        message(">>> AddressSanitizer memcheck route: ${TRILINOS_CTEST_USE_ASAN_MEMCHECK_REASON}")
         set(CTEST_MEMORYCHECK_TYPE "AddressSanitizer")
         set(ENV{LSAN_OPTIONS} "suppressions=${CTEST_SOURCE_DIRECTORY}/packages/framework/asan_assets/lsan.supp")
         set(ENV{LD_PRELOAD} ${CTEST_SOURCE_DIRECTORY}/packages/framework/asan_assets/dummy_dlclose.so)
@@ -24,6 +53,7 @@ if(NOT SKIP_RUN_TESTS)
         unset(ENV{LD_PRELOAD})
         submit_by_parts( "MemCheck" )
     else()
+        message(">>> Plain ctest_test route (not AddressSanitizer memcheck)")
         ctest_test(PARALLEL_LEVEL ${TEST_PARALLEL_LEVEL}
                    CAPTURE_CMAKE_ERROR captured_cmake_error
                    RETURN_VALUE test_error)


### PR DESCRIPTION
@trilinos/framework

## Motivation

Proposed fix: treat the build as ASAN for the CTest memcheck branch if either `CTEST_BUILD_NAME` or `genconfig_build_name.txt` matches `.*_asan_.*` (see `ctest-stage-test.cmake`).

Why this can matter: `CTEST_BUILD_NAME` may follow `dashboard_build_name` and omit `_asan_` while GenConfig still selects ASAN (`TrilinosPRConfigurationBase.py`, `pullrequest_build_name`). The old test step only checked `CTEST_BUILD_NAME`. Then the memcheck branch could be skipped while `genconfig_build_name.txt` (written in `ctest-cdash-setup.cmake` from `GENCONFIG_BUILD_NAME`) still reflects an ASAN GenConfig name. The fix reads that file so the two sources cannot disagree silently.

## References

Analyzing #15171 suggested an idea.

## Testing

Testing represented as a simple bash script with copy of cmake snippet from actual changes:

```bash
#!/usr/bin/env bash
# Legacy: only CTEST_BUILD_NAME matches .*_asan_.*
# Current: same + genconfig_build_name.txt (logic mirrors ctest-stage-test.cmake macro)
set -euo pipefail

td="$(mktemp -d)"
trap 'rm -rf "$td"' EXIT
mkdir -p "$td/b"

gc_asan='rhel_clang-openmpi_debug_shared_no-kokkos-arch_asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all'
gc_noasan='rhel_clang-openmpi_debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all'
dash='container_20251204_debug_shared_address-sanitizer'
pr='PR-1-test-rhel_clang-openmpi_debug_shared_no-kokkos-arch_asan_x-1'

legacy="$td/legacy.cmake"
cat >"$legacy" <<'EOF'
if(NOT DEFINED CTEST_BUILD_NAME)
  message(FATAL_ERROR "CTEST_BUILD_NAME")
endif()
set(_v FALSE)
if(CTEST_BUILD_NAME MATCHES ".*_asan_.*")
  set(_v TRUE)
endif()
message("legacy_use_asan_memcheck=${_v}")
EOF

check="$td/check.cmake"
cat >"$check" <<'EOF'
if(NOT DEFINED CTEST_BINARY_DIRECTORY)
  message(FATAL_ERROR "CTEST_BINARY_DIRECTORY")
endif()
if(NOT DEFINED CTEST_BUILD_NAME)
  message(FATAL_ERROR "CTEST_BUILD_NAME")
endif()
set(TRILINOS_CTEST_USE_ASAN_MEMCHECK FALSE)
set(TRILINOS_CTEST_USE_ASAN_MEMCHECK_REASON "")
if(CTEST_BUILD_NAME MATCHES ".*_asan_.*")
  set(TRILINOS_CTEST_USE_ASAN_MEMCHECK TRUE)
  set(TRILINOS_CTEST_USE_ASAN_MEMCHECK_REASON "CTEST_BUILD_NAME matches .*_asan_.*")
endif()
set(_f "${CTEST_BINARY_DIRECTORY}/genconfig_build_name.txt")
if(EXISTS "${_f}")
  file(READ "${_f}" _c)
  string(STRIP "${_c}" _c)
  if(_c MATCHES ".*_asan_.*")
    set(TRILINOS_CTEST_USE_ASAN_MEMCHECK TRUE)
    if(TRILINOS_CTEST_USE_ASAN_MEMCHECK_REASON STREQUAL "")
      set(TRILINOS_CTEST_USE_ASAN_MEMCHECK_REASON "genconfig_build_name.txt matches .*_asan_.*")
    else()
      set(TRILINOS_CTEST_USE_ASAN_MEMCHECK_REASON "${TRILINOS_CTEST_USE_ASAN_MEMCHECK_REASON}; genconfig_build_name.txt matches .*_asan_.*")
    endif()
  endif()
endif()
message("use=${TRILINOS_CTEST_USE_ASAN_MEMCHECK} reason=${TRILINOS_CTEST_USE_ASAN_MEMCHECK_REASON}")
EOF

printf '%s\n' "1 legacy dash+genconfig(_asan_)"
printf '%s\n' "$gc_asan" >"$td/b/genconfig_build_name.txt"
cmake -DCTEST_BUILD_NAME="$dash" -P "$legacy"

printf '%s\n' "2 route dash+genconfig(_asan_)"
cmake -DCTEST_BINARY_DIRECTORY="$td/b" -DCTEST_BUILD_NAME="$dash" -P "$check"

printf '%s\n' "3 route dash+genconfig(no-asan)"
printf '%s\n' "$gc_noasan" >"$td/b/genconfig_build_name.txt"
cmake -DCTEST_BINARY_DIRECTORY="$td/b" -DCTEST_BUILD_NAME="$dash" -P "$check"

printf '%s\n' "4 route prname(_asan_)+no genconfig file"
rm -f "$td/b/genconfig_build_name.txt"
cmake -DCTEST_BINARY_DIRECTORY="$td/b" -DCTEST_BUILD_NAME="$pr" -P "$check"
```

Output:

```bash
1 legacy dash+genconfig(_asan_)
legacy_use_asan_memcheck=FALSE
2 route dash+genconfig(_asan_)
use=TRUE reason=genconfig_build_name.txt matches .*_asan_.*
3 route dash+genconfig(no-asan)
use=FALSE reason=
4 route prname(_asan_)+no genconfig file
use=TRUE reason=CTEST_BUILD_NAME matches .*_asan_.*
```