### PR TITLE
MueLu: Fix setting 'repartition: use subcommunicators' in MultiPhys

### DIFF
--- a/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_MultiPhys_def.hpp
@@ -133,7 +133,7 @@ void MultiPhys<Scalar, LocalOrdinal, GlobalOrdinal, Node>::compute(bool reuse) {
     arrayOfParamLists_[iii]->set("repartition: explicit via new copy rebalance P and R", true);
 
     if (paramListMultiphysics_->isParameter("repartition: use subcommunicators"))
-      arrayOfParamLists_[iii]->set("repartition: use subcommunicators", paramListMultiphysics_->isParameter("repartition: use subcommunicators"));
+      arrayOfParamLists_[iii]->set("repartition: use subcommunicators", paramListMultiphysics_->get<bool>("repartition: use subcommunicators"));
     else
       arrayOfParamLists_[iii]->set("repartition: use subcommunicators", true);
   }


### PR DESCRIPTION
@trilinos/muelu 