### PR TITLE
FROSch: Fix build without Thyra

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/CMakeLists.txt
+++ b/packages/shylu/shylu_dd/frosch/src/CMakeLists.txt
@@ -57,10 +57,6 @@ TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 APPEND_SET(HEADERS
   Adapters/Stratimikos_FROSch_decl.hpp
   Adapters/Stratimikos_FROSch_def.hpp
-  Adapters/Thyra_FROSchFactory_decl.hpp
-  Adapters/Thyra_FROSchFactory_def.hpp
-  Adapters/Thyra_FROSchLinearOp_decl.hpp
-  Adapters/Thyra_FROSchLinearOp_def.hpp
   Adapters/FROSch_TpetraPreconditioner_decl.hpp
   Adapters/FROSch_TpetraPreconditioner_def.hpp
   CoarseSpaces/FROSch_CoarseSpace_decl.hpp
@@ -135,10 +131,6 @@ APPEND_SET(HEADERS
   SolverInterfaces/FROSch_Solver_def.hpp
   SolverInterfaces/FROSch_SolverFactory_decl.hpp
   SolverInterfaces/FROSch_SolverFactory_def.hpp
-  SolverInterfaces/FROSch_ThyraPreconditioner_decl.hpp
-  SolverInterfaces/FROSch_ThyraPreconditioner_def.hpp
-  SolverInterfaces/FROSch_ThyraSolver_decl.hpp
-  SolverInterfaces/FROSch_ThyraSolver_def.hpp
   Tools/FROSch_ExtractSubmatrices_decl.hpp
   Tools/FROSch_ExtractSubmatrices_def.hpp
   Tools/FROSch_Output.h
@@ -149,6 +141,20 @@ APPEND_SET(HEADERS
   Tools/FROSch_Tools_def.hpp
   Tools/FROSch_Types.h
 )
+
+ASSERT_DEFINED(${PACKAGE_NAME}_ENABLE_Thyra)
+IF (${PACKAGE_NAME}_ENABLE_Thyra)
+  APPEND_SET(HEADERS
+    Adapters/Thyra_FROSchFactory_decl.hpp
+    Adapters/Thyra_FROSchFactory_def.hpp
+    Adapters/Thyra_FROSchLinearOp_decl.hpp
+    Adapters/Thyra_FROSchLinearOp_def.hpp
+    SolverInterfaces/FROSch_ThyraPreconditioner_decl.hpp
+    SolverInterfaces/FROSch_ThyraPreconditioner_def.hpp
+    SolverInterfaces/FROSch_ThyraSolver_decl.hpp
+    SolverInterfaces/FROSch_ThyraSolver_def.hpp
+  )
+ENDIF()
 
 # Set sources
 

--- a/packages/shylu/shylu_dd/frosch/src/SolverInterfaces/FROSch_SolverFactory_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SolverInterfaces/FROSch_SolverFactory_def.hpp
@@ -12,7 +12,9 @@
 
 #include "FROSch_SolverFactory_decl.hpp"
 
+#if defined(HAVE_SHYLU_DDFROSCH_THYRA) && defined(HAVE_SHYLU_DDFROSCH_STRATIMIKOS)
 #include "Stratimikos_FROSch_def.hpp"
+#endif
 
 
 namespace FROSch {

--- a/packages/shylu/shylu_dd/frosch/test/SolverFactory/main.cpp
+++ b/packages/shylu/shylu_dd/frosch/test/SolverFactory/main.cpp
@@ -42,7 +42,6 @@ using namespace std;
 using namespace Teuchos;
 using namespace Xpetra;
 using namespace FROSch;
-using namespace Thyra;
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
@trilinos/shylu 

## Motivation
FROSch build fails if Thyra is disabled. This should fix it.