### PR TITLE
MueLu: Cleaning uninitialized boolean data members

### DIFF
--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_MatrixConstruction.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_MatrixConstruction.hpp
@@ -649,7 +649,6 @@ class VectorCountingFunctor<local_matrix_type, functor_type> {
   rowptr_type filtered_rowptr;
   rowptr_type graph_rowptr;
 
-  bool firstFunctor;
   functor_type functor;
 
 #ifdef MUELU_COALESCE_DROP_DEBUG

--- a/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_decl.hpp
@@ -177,9 +177,6 @@ class Ifpack2Smoother : public SmootherPrototype<Scalar, LocalOrdinal, GlobalOrd
   Scalar SetupChebyshevEigenvalues(Level& currentLevel, const std::string& matrixName, const std::string& label, Teuchos::ParameterList& paramList) const;
 
  private:
-  //!
-  bool constructionSuccessful_;
-
   //! ifpack2-specific key phrase that denote smoother type
   std::string type_;
 


### PR DESCRIPTION
@trilinos/muelu

## Motivation

Tests for recent changes about `lambdaMax` from #15157 were failed on Hopper90 and ROCm 6.2 GPUs.
Before these tests, the problem with `std::complex<double>` (and I suppose `<float>` too) as a Scalar type in `SaPFactory` was unknown.

## Relates Issues

- #15156
- #15157

## Testing

```bash
TRILINOS_SRC_DIR="$(pwd)" && \
\
TARGET_BUILD_TYPE="Debug"                                                          && \
TARGET_PACKAGE="muelu"                                                             && \
TARGET_PACKAGE_OFFICIAL="MueLu"                                                    && \
TARGET_TEST_DIR="unit_tests_kokkos"                                                && \
TARGET_TEST="${TARGET_PACKAGE_OFFICIAL}_UnitTests_kokkos.exe"                      && \
\
PATH="/usr/local/cuda-12.8/bin:$PATH"   && \
CUDA_ROOT="/usr/local/cuda-12.8"        && \
\
BUILD_DIR="$TRILINOS_SRC_DIR/build_${TARGET_PACKAGE}-fixed"                               && \
mkdir -pv $BUILD_DIR                                                                      && \
TARGET_TEST_BIN="$BUILD_DIR/packages/$TARGET_PACKAGE/test/$TARGET_TEST_DIR/$TARGET_TEST"  && \
\
UNIT_TESTS_SRC_DIR="$TRILINOS_SRC_DIR/packages/$TARGET_PACKAGE/test/unit_tests/" && \
\
SAN="-fsanitize=address,undefined,leak -fno-omit-frame-pointer -g" && \
CXXFLAGS="$SAN"                                                    && \
LDFLAGS="$SAN"                                                     && \
\
ENABLE_SANITIZERS="ON"   && \
ENABLE_OMP="ON"          && \
ENABLE_MPI="ON"          && \
ENABLE_CUDA="OFF"        && \
ENABLE_COMPLEX="ON"      && \
\
if [ "$ENABLE_SANITIZERS" == "OFF" ]; then    \
  SAN="";                                     \
fi                                         && \
\
cmake -G Ninja \
  -DBUILD_SHARED_LIBS=ON                        \
  -DCMAKE_C_COMPILER=$(which mpicc)             \
  -DCMAKE_CXX_COMPILER=$(which mpicxx)          \
  -DCMAKE_BUILD_TYPE=${TARGET_BUILD_TYPE}       \
  -DCMAKE_CXX_STANDARD=20                       \
  -DCMAKE_CXX_FLAGS="$SAN"                      \
  -DCMAKE_EXE_LINKER_FLAGS="$SAN"               \
  -DCMAKE_SHARED_LINKER_FLAGS="$SAN"            \
  -DCMAKE_PREFIX_PATH="${CUDA_ROOT}"            \
  -DCMAKE_CUDA_COMPILER="${CUDA_ROOT}/bin/nvcc" \
  \
  -DTrilinos_ENABLE_COMPLEX=${ENABLE_COMPLEX} \
  \
  -DCUDAToolkit_ROOT="${CUDA_ROOT}"           \
  -DKokkos_ENABLE_CUDA=${ENABLE_CUDA}         \
  -DKokkos_ENABLE_CUDA_LAMBDA=${ENABLE_CUDA}  \
  -DKokkos_ARCH_NATIVE=${ENABLE_CUDA}         \
  -DTPL_ENABLE_CUDA=${ENABLE_CUDA}            \
  -DTPL_ENABLE_CUSPARSE=${ENABLE_CUDA}        \
  \
  -DTPL_ENABLE_MPI=${ENABLE_MPI}  \
  \
  -DTrilinos_ENABLE_OpenMP=${ENABLE_OMP}            \
  -DKokkos_ENABLE_OPENMP=${ENABLE_OMP}              \
  -DTrilinos_ENABLE_${TARGET_PACKAGE_OFFICIAL}=ON   \
  -D${TARGET_PACKAGE_OFFICIAL}_ENABLE_TESTS=ON      \
  \
  -S $TRILINOS_SRC_DIR      \
  -B $BUILD_DIR          && \
  \
cmake --build $BUILD_DIR -j$(nproc) --target $TARGET_TEST && \
(cd $TRILINOS_SRC_DIR/packages/$TARGET_PACKAGE/test/$TARGET_TEST_DIR/ && \
ASAN_OPTIONS=detect_leaks=0 LSAN_OPTIONS=detect_leaks=0 $TARGET_TEST_BIN)
```

If there is no changes (and without second change about `lambdaMax` from #15157), but with new tests we have this output:
[without-fixes.txt](https://github.com/user-attachments/files/27048337/without-fixes.txt)

After little changes including existing changes from #15157, we have this output:
[with-fixes.txt](https://github.com/user-attachments/files/27048341/with-fixes.txt)

## Additional information

Also were fixed all the UB warnings like these:

```log
/home/loveit0/Documents/Work/Trilinos/packages/muelu/src/Graph/MatrixTransformation/MueLu_MatrixConstruction.hpp:633:7: runtime error: load of value 65, which is not a valid value for type 'bool'
/home/loveit0/Documents/Work/Trilinos/packages/muelu/src/Graph/MatrixTransformation/MueLu_MatrixConstruction.hpp:633:7: runtime error: load of value 100, which is not a valid value for type 'bool'
/home/loveit0/Documents/Work/Trilinos/packages/muelu/src/Graph/MatrixTransformation/MueLu_MatrixConstruction.hpp:633:7: runtime error: load of value 64, which is not a valid value for type 'bool'
```