### PR TITLE
Framework: Determine AddressSanitizer in PR tooling

### DIFF
--- a/cmake/SimpleTesting/README.md
+++ b/cmake/SimpleTesting/README.md
@@ -39,6 +39,7 @@ from being include more than once in an include chain.
 | `PARALLEL_LEVEL`           | STRING |    NO     | `<num cores>`                                 |                                                                    |
 | `TEST_PARALLEL_LEVEL`      | STRING |    NO     | `${PARALLEL_LEVEL}`                           |                                                                    |
 | `SKIP_RUN_TESTS`           | BOOL   |    NO     | OFF                                           | Skip running any tests (any tests enabled will still compile)      |
+| `ENABLE_ASAN`              | BOOL   |    NO     | OFF                                           | Turn on logic for AddressSanitizer (e.g. use `ctest_memtest()`)    |
 
 
 1. It might worthwhile to remove `build_root` since it's only used to create `build_dir` IF `build_dir` is not passed in

--- a/cmake/SimpleTesting/cmake/ctest-common.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-common.cmake
@@ -73,7 +73,11 @@ if( NOT DEFINED skip_upload_config_files )
 endif()
 
 if( NOT DEFINED SKIP_RUN_TESTS )
-    set (SKIP_RUN_TESTS OFF)
+    set ( SKIP_RUN_TESTS OFF )
+endif()
+
+if( NOT DEFINED ENABLE_ASAN )
+    set ( ENABLE_ASAN OFF )
 endif()
 
 # -----------------------------------------------------------

--- a/cmake/SimpleTesting/cmake/ctest-stage-test.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-stage-test.cmake
@@ -14,7 +14,7 @@ banner("START test step")
 set(STAGE_TEST_ERROR OFF)
 
 if(NOT SKIP_RUN_TESTS)
-    if(CTEST_BUILD_NAME MATCHES .*_asan_.*)
+    if(ENABLE_ASAN)
         set(CTEST_MEMORYCHECK_TYPE "AddressSanitizer")
         set(ENV{LSAN_OPTIONS} "suppressions=${CTEST_SOURCE_DIRECTORY}/packages/framework/asan_assets/lsan.supp")
         set(ENV{LD_PRELOAD} ${CTEST_SOURCE_DIRECTORY}/packages/framework/asan_assets/dummy_dlclose.so)

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -371,6 +371,13 @@ class TrilinosPRConfigurationBase(object):
     # --------------------
 
     @property
+    def using_address_sanitizer(self):
+        """
+        Determine whether LLVM AddressSanitizer is being used.
+        """
+        return "_asan_" in self.arg_genconfig_build_name
+
+    @property
     def working_directory_ctest(self):
         """
         Generate the working directory for where we should launch the CTest command from.

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationStandard.py
@@ -74,6 +74,7 @@ class TrilinosPRConfigurationStandard(TrilinosPRConfigurationBase):
                f"-DCTEST_DROP_SITE:STRING={self.arg_ctest_drop_site}",
                 "-DUSE_EXPLICIT_TRILINOS_CACHEFILE:BOOL=" + ("ON" if self.arg_use_explicit_cachefile else "OFF"),
                 "-DSKIP_RUN_TESTS:BOOL=" + ("ON" if self.arg_skip_run_tests else "OFF"),
+                "-DENABLE_ASAN:BOOL=" + ("ON" if self.using_address_sanitizer else "OFF"),
              ]
 
         if self.arg_extra_configure_args:

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/config-specs.ini
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/config-specs.ini
@@ -228,3 +228,6 @@
 
 [rhel8_sems-gnu-openmpi_release_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-package-enables]
 opt-set-cmake-var UNUSED : UNUSED
+
+[rhel8_sems-gnu-openmpi_release_static_no-kokkos-arch_asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-package-enables]
+opt-set-cmake-var UNUSED : UNUSED

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationBase.py
@@ -715,6 +715,28 @@ class TrilinosPRConfigurationTest(unittest.TestCase):
         self.assertTrue(os.path.isfile(pr_config.arg_filename_subprojects))
 
 
+    def test_TrilinosPRConfigurationBase_using_asan_true(self):
+        """
+        Test that the `using_address_sanitizer` property is True if the build key contains `_asan_`.
+        """
+        args = self.dummy_args()
+        args.genconfig_build_name = "rhel8_sems-gnu-openmpi_release_static_no-kokkos-arch_asan_no-complex_no-fpic_mpi_no-pt_no-rdc_all"
+        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
+
+        self.assertTrue(pr_config.using_address_sanitizer)
+
+
+    def test_TrilinosPRConfigurationBase_using_asan_false(self):
+        """
+        Test that the `using_address_sanitizer` property is False if the build key contains `_no-asan_`.
+        """
+        args = self.dummy_args()
+        args.genconfig_build_name = "rhel8_sems-gnu-openmpi_release_static_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_all"
+        pr_config = trilinosprhelpers.TrilinosPRConfigurationBase(args)
+
+        self.assertFalse(pr_config.using_address_sanitizer)
+
+
     def test_TrilinosPRConfigurationBase_prepare_test_FAIL(self):
         """
         Test the prepare_test method where it would fail due to

--- a/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationStandard.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/unittests/test_TrilinosPRConfigurationStandard.py
@@ -213,6 +213,33 @@ class TrilinosPRConfigurationStandardTest(TestCase):
                                "generatedPRFragment.cmake"))
 
 
+    def test_AddressSanitizer_enabled(self):
+        """
+        Test that AddressSanitizer option gets propagated correctly.
+        """
+        print("")
+        args = self.dummy_args()
+        args.genconfig_build_name = "rhel8_sems-gnu-openmpi_release_static_no-kokkos-arch_asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-package-enables"
+        pr_config = trilinosprhelpers.TrilinosPRConfigurationStandard(args)
+
+        # prepare step
+        ret = pr_config.prepare_test()
+        self.assertEqual(ret, 0)
+        self.mock_cpu_count.assert_called()
+
+        # execute step
+        ret = pr_config.execute_test()
+        self.mock_chdir.assert_called_once()
+        self.mock_subprocess_check_call.assert_called()
+        self.assertEqual(ret, 0)
+        self.assertTrue(Path(os.path.join(args.workspace_dir,
+                                          "generatedPRFragment.cmake")).is_file())
+        os.unlink(os.path.join(args.workspace_dir,
+                               "generatedPRFragment.cmake"))
+
+        self.assertIn("-DENABLE_ASAN:BOOL=ON", self.mock_subprocess_check_call.call_args_list[-1][0][0])
+
+
     def test_TrilinosPRConfigurationStandardDryRun(self):
         """
         Test the Standard Configuration


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Whether or not ASan is being used (and thusly `ctest_memcheck()` should be used) is keyed off of the GenConfig build ID.  We previously assumed that would always be in the CDash build name, which is no longer true. The place we know the GenConfig build ID is in the Python-based PR tooling, so pass the ASan enablement explicitly down to CTest.

## Related Issues
Replaces https://github.com/trilinos/Trilinos/pull/15176
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-753