### PR TITLE
Belos: Fix Kokkos unmanged views in MvTransMv and MvTimesMatAddMv in BelosKokkosAdapter

### DIFF
--- a/packages/belos/kokkos/example/GCRODRComplexKokkosExFile.cpp
+++ b/packages/belos/kokkos/example/GCRODRComplexKokkosExFile.cpp
@@ -60,6 +60,7 @@ try {
   int numrhs = 1;            // number of right-hand sides to solve for
   int maxiters = -1;         // maximum number of iterations allowed per linear system
   int maxsubspace = 300;     // maximum number of blocks the solver can use for the subspace
+  int numRecycledBlocks = 20;
   int maxrestarts = 5;       // number of restarts allowed
   bool expresidual = false;  // use explicit residual
   std::string filename("mhd1280b.mtx"); // example matrix
@@ -109,12 +110,13 @@ try {
   belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
   belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
   belosList.set( "Num Blocks", maxsubspace);             // Maximum number of blocks in Krylov factorization
+  belosList.set( "Num Recycled Blocks", numRecycledBlocks );
   belosList.set( "Maximum Restarts", maxrestarts );      // Maximum number of restarts allowed
   belosList.set( "Explicit Residual Test", expresidual); // Use explicit residual
 
   if (verbose) {
     belosList.set( "Verbosity", Belos::Errors + Belos::Warnings +
-		   Belos::StatusTestDetails + Belos::FinalSummary + Belos::TimingDetails);
+               Belos::StatusTestDetails + Belos::FinalSummary + Belos::TimingDetails);
     if (frequency > 0)
       belosList.set( "Output Frequency", frequency );
   }
@@ -153,6 +155,7 @@ try {
   //
   Belos::ReturnType ret;
   ret = newSolver->solve();
+  int numIters1 = newSolver->getNumIters();
 
   //
   // Compute actual residuals.
@@ -172,12 +175,25 @@ try {
     if (actRes > tol) badRes = true;
   }
 
-  if (ret!=Belos::Converged || badRes) {
+  // Resolve linear system with same rhs and recycled space
+  X->MvInit(0.0);
+  newSolver->reset(Belos::Problem);
+  ret = newSolver->solve();
+  int numIters2 = newSolver->getNumIters();
+
+  // Resolve linear system (again) with same rhs and recycled space
+  X->MvInit(0.0);
+  newSolver->reset(Belos::Problem);
+  ret = newSolver->solve();
+  int numIters3 = newSolver->getNumIters();
+
+  //
+  if (ret!=Belos::Converged || badRes || numIters1 < numIters2 || numIters2 < numIters3) {
     success = false;
-    std::cout << std::endl << "ERROR:  Belos did not converge!" << std::endl;
+    std::cout << std::endl << "ERROR: Belos GCRODR TEST FAILED!" << std::endl;
   } else {
     success = true;
-    std::cout << std::endl << "SUCCESS:  Belos converged!" << std::endl;
+    std::cout << std::endl << "SUCCESS: Belos GCRRODRR TEST PASSED!" << std::endl;
   }
 
   }

--- a/packages/belos/kokkos/src/BelosKokkosAdapter.hpp
+++ b/packages/belos/kokkos/src/BelosKokkosAdapter.hpp
@@ -64,6 +64,10 @@ public:
         Kokkos::View<ScalarType**,Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
   using UMHostConstViewMatrixType =
         Kokkos::View<const ScalarType**,Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using UMHostViewMatrixType2 =
+        Kokkos::View<ScalarType**,Kokkos::LayoutStride, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using UMHostConstViewMatrixType2 =
+        Kokkos::View<const ScalarType**,Kokkos::LayoutStride, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
 protected:
   ViewMatrixType myView;
@@ -409,10 +413,28 @@ public:
       ConstViewVectorType Asub = Kokkos::subview(A_vec->GetInternalViewConst(), Kokkos::ALL, 0);
       KokkosBlas::axpby(scal1, Asub, beta, mysub);
     }
-    else{
-      UMHostConstViewMatrixType mat_h(B.values(), A_vec->GetInternalViewConst().extent(1), myView.extent(1));
+    else {
       ViewMatrixType mat_d(Kokkos::view_alloc(Kokkos::WithoutInitializing,"mat"), A_vec->GetInternalViewConst().extent(1), myView.extent(1));
-      Kokkos::deep_copy(mat_d, mat_h);
+      if (B.numRows() == B.stride()) {
+        UMHostConstViewMatrixType mat_h(B.values(), mat_d.extent(0), mat_d.extent(1));
+        Kokkos::deep_copy(mat_d, mat_h);
+      }
+      else {
+        Kokkos::LayoutStride layout(mat_d.extent(0), 1, mat_d.extent(1), B.stride());
+		UMHostConstViewMatrixType2 mat_h(B.values(), layout);   
+        constexpr bool DstExecCanAccessSrc = Kokkos::SpaceAccessibility<typename ViewMatrixType::device_type::execution_space,
+                                                                        typename UMHostConstViewMatrixType2::device_type::memory_space>::accessible;
+        constexpr bool SrcExecCanAccessDst = Kokkos::SpaceAccessibility<typename UMHostConstViewMatrixType2::device_type::execution_space,
+                                                                        typename ViewMatrixType::device_type::memory_space>::accessible;
+        if (!DstExecCanAccessSrc && !SrcExecCanAccessDst) {
+          Kokkos::View<ScalarType**,Kokkos::LayoutLeft, Kokkos::HostSpace> tmp_h(Kokkos::view_alloc(Kokkos::WithoutInitializing,"tmp_h"), mat_d.extent(0), mat_d.extent(1));
+          Kokkos::deep_copy(tmp_h, mat_h);
+          Kokkos::deep_copy(mat_d, tmp_h);
+        }
+        else {
+          Kokkos::deep_copy(mat_d, mat_h);
+        }
+      }
       if( myView.extent(1) == 1 ){ // B has only 1 col
           ConstViewVectorType Bsub = Kokkos::subview(mat_d, Kokkos::ALL, 0);
           ViewVectorType mysub = Kokkos::subview(myView, Kokkos::ALL, 0);
@@ -480,11 +502,29 @@ public:
    //     B(i,0) = soln(i);
    //   }
    // }
-    else{
-      UMHostViewMatrixType soln_h(B.values(), A_vec->GetInternalViewConst().extent(1), myView.extent(1));
+    else {
       ViewMatrixType soln_d(Kokkos::view_alloc(Kokkos::WithoutInitializing,"mat"), A_vec->GetInternalViewConst().extent(1), myView.extent(1));
       KokkosBlas::gemm("C", "N", alpha, A_vec->GetInternalViewConst(), myView, ScalarType(0.0), soln_d);
-      Kokkos::deep_copy(soln_h, soln_d);
+      if (B.numRows() == B.stride()) {
+        UMHostViewMatrixType soln_h(B.values(), soln_d.extent(0), soln_d.extent(1));
+        Kokkos::deep_copy(soln_h, soln_d);
+      }
+      else {
+        Kokkos::LayoutStride layout(soln_d.extent(0), 1, soln_d.extent(1), B.stride());
+		UMHostViewMatrixType2 soln_h(B.values(), layout);   
+        constexpr bool SrcExecCanAccessDst = Kokkos::SpaceAccessibility<typename ViewMatrixType::device_type::execution_space,
+                                                                        typename UMHostViewMatrixType2::device_type::memory_space>::accessible;
+        constexpr bool DstExecCanAccessSrc = Kokkos::SpaceAccessibility<typename UMHostViewMatrixType2::device_type::execution_space,
+                                                                        typename ViewMatrixType::device_type::memory_space>::accessible;
+        if (!DstExecCanAccessSrc && !SrcExecCanAccessDst) {
+          Kokkos::View<ScalarType**,Kokkos::LayoutLeft, Kokkos::HostSpace> tmp_h(Kokkos::view_alloc(Kokkos::WithoutInitializing,"tmp_h"), soln_d.extent(0), soln_d.extent(1));
+          Kokkos::deep_copy(tmp_h, soln_d);
+          Kokkos::deep_copy(soln_h, tmp_h);
+        }
+        else {
+          Kokkos::deep_copy(soln_h, soln_d);
+        }
+      }
     }
   }
 

--- a/packages/belos/kokkos/src/BelosKokkosAdapter.hpp
+++ b/packages/belos/kokkos/src/BelosKokkosAdapter.hpp
@@ -30,6 +30,51 @@
 #define BELOS_KOKKOS_ADAPTER_HPP
 namespace Belos {
 
+template<class SerialDenseMatrixType, class KokkosViewMatrixType >
+void copySerialDenseMatrix(const SerialDenseMatrixType& B, const KokkosViewMatrixType& KMat, const bool& KMat_to_B) {
+  using ScalarType = typename KokkosViewMatrixType::value_type;
+  using UMHostViewMatrixType =
+        Kokkos::View<ScalarType**,Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using UMHostViewMatrixType2 =
+        Kokkos::View<ScalarType**,Kokkos::LayoutStride, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  if (B.numRows() == B.stride()) {
+    UMHostViewMatrixType umB_h(B.values(), KMat.extent(0), KMat.extent(1));
+    if (KMat_to_B) {
+      Kokkos::deep_copy(umB_h, KMat);
+    }
+    else {
+      Kokkos::deep_copy(KMat, umB_h);
+    }
+  }
+  else {
+    Kokkos::LayoutStride layout(KMat.extent(0), 1, KMat.extent(1), B.stride());
+    UMHostViewMatrixType2 umB_h(B.values(), layout);   
+    constexpr bool KokkosExecCanAccessB = Kokkos::SpaceAccessibility<typename KokkosViewMatrixType::device_type::execution_space,
+                                                                     typename UMHostViewMatrixType2::device_type::memory_space>::accessible;
+    constexpr bool BExecCanAccessKokkos = Kokkos::SpaceAccessibility<typename UMHostViewMatrixType2::device_type::execution_space,
+                                                                     typename KokkosViewMatrixType::device_type::memory_space>::accessible;
+    if (!KokkosExecCanAccessB && !BExecCanAccessKokkos) {
+      Kokkos::View<ScalarType**,Kokkos::LayoutLeft, Kokkos::HostSpace> tmp_h(Kokkos::view_alloc(Kokkos::WithoutInitializing,"tmp_h"), KMat.extent(0), KMat.extent(1));
+      if (KMat_to_B) {
+        Kokkos::deep_copy(tmp_h, KMat);
+        Kokkos::deep_copy(umB_h, tmp_h);
+      }
+      else {
+        Kokkos::deep_copy(tmp_h, umB_h);
+        Kokkos::deep_copy(KMat, tmp_h);
+      }
+    }
+    else {
+      if (KMat_to_B) {
+        Kokkos::deep_copy(umB_h, KMat);
+      }
+      else {
+        Kokkos::deep_copy(KMat, umB_h);
+      }
+    }
+  }
+}
+
 //Forward class declaration of KokkosCrsOperator:
 template<class ScalarType, class OrdinalType, class Device>
 class KokkosCrsOperator;
@@ -60,14 +105,6 @@ public:
         Kokkos::View<ScalarType*,Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
   using UMHostConstViewVectorType =
         Kokkos::View<const ScalarType*,Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-  using UMHostViewMatrixType =
-        Kokkos::View<ScalarType**,Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-  using UMHostConstViewMatrixType =
-        Kokkos::View<const ScalarType**,Kokkos::LayoutLeft, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-  using UMHostViewMatrixType2 =
-        Kokkos::View<ScalarType**,Kokkos::LayoutStride, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-  using UMHostConstViewMatrixType2 =
-        Kokkos::View<const ScalarType**,Kokkos::LayoutStride, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
 protected:
   ViewMatrixType myView;
@@ -415,26 +452,7 @@ public:
     }
     else {
       ViewMatrixType mat_d(Kokkos::view_alloc(Kokkos::WithoutInitializing,"mat"), A_vec->GetInternalViewConst().extent(1), myView.extent(1));
-      if (B.numRows() == B.stride()) {
-        UMHostConstViewMatrixType mat_h(B.values(), mat_d.extent(0), mat_d.extent(1));
-        Kokkos::deep_copy(mat_d, mat_h);
-      }
-      else {
-        Kokkos::LayoutStride layout(mat_d.extent(0), 1, mat_d.extent(1), B.stride());
-		UMHostConstViewMatrixType2 mat_h(B.values(), layout);   
-        constexpr bool DstExecCanAccessSrc = Kokkos::SpaceAccessibility<typename ViewMatrixType::device_type::execution_space,
-                                                                        typename UMHostConstViewMatrixType2::device_type::memory_space>::accessible;
-        constexpr bool SrcExecCanAccessDst = Kokkos::SpaceAccessibility<typename UMHostConstViewMatrixType2::device_type::execution_space,
-                                                                        typename ViewMatrixType::device_type::memory_space>::accessible;
-        if (!DstExecCanAccessSrc && !SrcExecCanAccessDst) {
-          Kokkos::View<ScalarType**,Kokkos::LayoutLeft, Kokkos::HostSpace> tmp_h(Kokkos::view_alloc(Kokkos::WithoutInitializing,"tmp_h"), mat_d.extent(0), mat_d.extent(1));
-          Kokkos::deep_copy(tmp_h, mat_h);
-          Kokkos::deep_copy(mat_d, tmp_h);
-        }
-        else {
-          Kokkos::deep_copy(mat_d, mat_h);
-        }
-      }
+      copySerialDenseMatrix(B, mat_d, false);
       if( myView.extent(1) == 1 ){ // B has only 1 col
           ConstViewVectorType Bsub = Kokkos::subview(mat_d, Kokkos::ALL, 0);
           ViewVectorType mysub = Kokkos::subview(myView, Kokkos::ALL, 0);
@@ -505,26 +523,7 @@ public:
     else {
       ViewMatrixType soln_d(Kokkos::view_alloc(Kokkos::WithoutInitializing,"mat"), A_vec->GetInternalViewConst().extent(1), myView.extent(1));
       KokkosBlas::gemm("C", "N", alpha, A_vec->GetInternalViewConst(), myView, ScalarType(0.0), soln_d);
-      if (B.numRows() == B.stride()) {
-        UMHostViewMatrixType soln_h(B.values(), soln_d.extent(0), soln_d.extent(1));
-        Kokkos::deep_copy(soln_h, soln_d);
-      }
-      else {
-        Kokkos::LayoutStride layout(soln_d.extent(0), 1, soln_d.extent(1), B.stride());
-		UMHostViewMatrixType2 soln_h(B.values(), layout);   
-        constexpr bool SrcExecCanAccessDst = Kokkos::SpaceAccessibility<typename ViewMatrixType::device_type::execution_space,
-                                                                        typename UMHostViewMatrixType2::device_type::memory_space>::accessible;
-        constexpr bool DstExecCanAccessSrc = Kokkos::SpaceAccessibility<typename UMHostViewMatrixType2::device_type::execution_space,
-                                                                        typename ViewMatrixType::device_type::memory_space>::accessible;
-        if (!DstExecCanAccessSrc && !SrcExecCanAccessDst) {
-          Kokkos::View<ScalarType**,Kokkos::LayoutLeft, Kokkos::HostSpace> tmp_h(Kokkos::view_alloc(Kokkos::WithoutInitializing,"tmp_h"), soln_d.extent(0), soln_d.extent(1));
-          Kokkos::deep_copy(tmp_h, soln_d);
-          Kokkos::deep_copy(soln_h, tmp_h);
-        }
-        else {
-          Kokkos::deep_copy(soln_h, soln_d);
-        }
-      }
+      copySerialDenseMatrix(B, soln_d, true);
     }
   }
 


### PR DESCRIPTION
@trilinos/belos @hkthorn @cgcgcg 

This PR is to fix the issue #15192 . Kokkos unmanaged views with ```LayoutStride``` are used instead of ```LayoutLeft```.



