### PR TITLE
Run action that flags PRs to master via pull_request_target

### DIFF
--- a/.github/workflows/flag_prs_to_master.yml
+++ b/.github/workflows/flag_prs_to_master.yml
@@ -2,7 +2,7 @@ name: Flag PRs to master by adding the AT WIP keyword
 # Unless you are the autotester, of course
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
     branches: [master]
 
@@ -23,5 +23,5 @@ jobs:
       if: "!contains(github.event.sender.login,'snapshot-app[bot]')"
       with:
          message: |
-            You seem to have created a PR on master.  This is not allowed behavior, so we've blocked your PR.  Please switch your PR to target the develop branch and remove the AT: WIP label.
+            You seem to have created a PR on master.  This is not allowed behavior, so we've blocked your PR.  Please switch your PR to target the develop branch.
       


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Attempt to fix the Github Action that warns about PRs to master.