### PR TITLE
Framework: Skip checking merge commits for DCO

### DIFF
--- a/commonTools/test/utilities/check-commit-signoffs.sh
+++ b/commonTools/test/utilities/check-commit-signoffs.sh
@@ -11,6 +11,18 @@ estat=0
 for commit in $(git log --format=%H ${source_branch} --not ${target_branch})
 do
     echo "Processing commit ${commit}"
+
+    parent_count=$(git rev-list --parents -n 1 "${commit}" | wc -w)
+    if [ "${parent_count}" -gt 2 ]; then
+        msg=$(git show -s --format=%B "${commit}")
+
+        # GitHub merge commits start with “Merge pull request #<num> …”
+        if echo "${msg}" | grep -E -q '^Merge pull request #[0-9]+'; then
+            echo "  → Skipping GitHub merge commit"
+            continue
+        fi
+    fi
+
     git show -s --format=%B ${commit} | grep --extended-regexp --quiet "Signed-off-by:\s+\S+.*<\S+@\S+\.\S+>" \
     || { echo -e "Commit ${commit} does not contain the required DCO (https://developercertificate.org) sign-off!\nThe \"DCO\" check for this PR should have failed, and manual override is not permitted.\n" ; estat=1 ; }
 done


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Requiring a DCO for GitHub-generated (usually) merge commits is unnecessary, and causes issues if we need to merge branches into other branches (e.g. https://github.com/trilinos/Trilinos/pull/15196).

## Testing
Tested running the script with `master` and `develop` and the previously-flagged merge commits are no longer flagged.