### PR TITLE
Ifpack2: Remove Kokkos safe call macros

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
@@ -182,10 +182,10 @@ struct ExecutionSpaceFactory<Kokkos::Experimental::SYCL> {
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(IFPACK2_BLOCKHELPER_ENABLE_PROFILE)
 #define IFPACK2_BLOCKHELPER_PROFILER_REGION_BEGIN \
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaProfilerStart());
+  cudaProfilerStart();
 
 #define IFPACK2_BLOCKHELPER_PROFILER_REGION_END \
-  { KOKKOS_IMPL_CUDA_SAFE_CALL(cudaProfilerStop()); }
+  { cudaProfilerStop(); }
 #else
 /// later put vtune profiler region
 #define IFPACK2_BLOCKHELPER_PROFILER_REGION_BEGIN

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -149,10 +149,10 @@ struct BlockTridiagScalarType<double> {
 
 #if defined(KOKKOS_ENABLE_CUDA) && defined(IFPACK2_BLOCKTRIDICONTAINER_ENABLE_PROFILE)
 #define IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN \
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaProfilerStart());
+  cudaProfilerStart();
 
 #define IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END \
-  { KOKKOS_IMPL_CUDA_SAFE_CALL(cudaProfilerStop()); }
+  { cudaProfilerStop(); }
 #else
 /// later put vtune profiler region
 #define IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN


### PR DESCRIPTION
@trilinos/ifpack2 

## Motivation
Don't use Kokkos internal functionality. See #15073. PR #15150 instead lifts the macro from Kokkos, but that's probably not needed in this case.