### PR TITLE
Ifpack2: do not run btds tests with complex and AVX512

### DIFF
--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockTriDiContainer.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockTriDiContainer.cpp
@@ -25,6 +25,8 @@
 #include "Ifpack2_UnitTestBlockTriDiContainerUtil.hpp"
 #include "Ifpack2_ETIHelperMacros.h"
 
+#include "KokkosBatched_Vector_SIMD.hpp"
+
 struct Input {
   Teuchos::RCP<const Teuchos::Comm<int> > comm;
   bool quiet, teuchos_test_btds, teuchos_test_jacobi, contiguous, verbose;
@@ -217,6 +219,15 @@ static LO run_teuchos_tests(const Input& in, Teuchos::FancyOStream& out, bool& s
   typedef LO Int;
   typedef tif_utest::BlockCrsMatrixMaker<Scalar, LO, GO> bcmm;
   typedef tif_utest::BlockTriDiContainerTester<Scalar, LO, GO> btdct;
+
+  if constexpr (KokkosKernels::ArithTraits<Scalar>::is_complex) {
+#if defined(KOKKOSBATCHED_IMPL_ENABLE_AVX) && defined(__AVX512F__)
+    if (in.comm->getRank() == 0) {
+      std::cout << "Skipping SIMD<Kokkos::complex<>> tests" << std::endl;
+    }
+    return 0;
+#endif
+  }
 
   tif_utest::BTDC_MatrixCache<Scalar, LO, GO> matrixCache;
 


### PR DESCRIPTION
Kokkos Kernels vector simd does not support SIMD<Kokkos::complex<>> correctly and should not be relied upon.
This PR provides a fix for issue #11969

@trilinos/ifpack2 

## Motivation
 * We have failures in the BlockTriDiagonal solver tests due to mis-use of vectorization with complex types. Since these are not used in practice we will just skip these tests.

## Related Issues
 * Closes #11969 
 * Other relations: related to Kokkos Kernels [#2622](https://github.com/kokkos/kokkos-kernels/issues/2622)

## Stakeholder Feedback
 * @vbrunini mentioned that SPARC does not run with these complex types so disabling partially the test is fine.

## Testing
 * tested on blake with and without ARCH_SKX which turns on and off AVX512 features
