### PR TITLE
Tpetra, MueLu: Matrix-matrix reuse that discards non-existent entries

### DIFF
--- a/packages/muelu/src/Transfers/Energy-Minimization/MueLu_FlatOperator_decl.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/MueLu_FlatOperator_decl.hpp
@@ -13,8 +13,6 @@
 #include "MueLu_Constraint.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Xpetra_Map.hpp"
-#include "Xpetra_MapFactory.hpp"
-#include "Xpetra_MatrixMatrix.hpp"
 #include "Xpetra_MultiVector.hpp"
 #include "Xpetra_Operator.hpp"
 

--- a/packages/muelu/src/Transfers/Energy-Minimization/MueLu_FlatOperator_def.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/MueLu_FlatOperator_def.hpp
@@ -11,6 +11,9 @@
 #define MUELU_FLATOPERATOR_DEF_HPP
 
 #include "MueLu_FlatOperator_decl.hpp"
+#include "Xpetra_MapFactory.hpp"
+#include "Xpetra_MatrixFactory.hpp"
+#include "Xpetra_MatrixMatrix.hpp"
 
 namespace MueLu {
 
@@ -51,9 +54,14 @@ void FlatOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     Kokkos::deep_copy(lclMat.values, Kokkos::subview(lclVec, Kokkos::ALL(), 0));
   }
 
-  RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> AP;
-  AP = Xpetra::MatrixMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Multiply(*mat_, false, *tempMat_, false, AP, GetOStream(Runtime0), true, true);
-  constraint_->AssignMatrixEntriesToVector(*AP, Y);
+  RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> AP = Xpetra::MatrixFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(constraint_->GetPattern());
+  auto params                                                       = Teuchos::rcp(new Teuchos::ParameterList());
+  params->set("MM Throw For Non-Existent Entries", false);
+
+  AP = Xpetra::MatrixMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Multiply(*mat_, false, *tempMat_, false, AP, GetOStream(Runtime0), true, true, "", params);
+
+  Kokkos::deep_copy(Kokkos::subview(Y.getLocalViewDevice(Tpetra::Access::OverwriteAll), Kokkos::ALL(), 0),
+                    AP->getLocalMatrixDevice().values);
 }
 }  // namespace MueLu
 #endif

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
@@ -286,6 +286,13 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
 
   using Teuchos::RCP;
   using Teuchos::rcp;
+
+  // By default, if A*B results in an entry that is not supported by the graph of C, we throw.
+  // This option allows to override this behavior and silently ignores such entries.
+  bool throwOnInsert = true;
+  if (!params.is_null() && params->isType<bool>("MM Throw For Non-Existent Entries"))
+    throwOnInsert = params->get<bool>("MM Throw For Non-Existent Entries");
+
   RCP<Tpetra::Details::ProfilingRegion> MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Reuse SerialCore"));
 
   // Lots and lots of typedefs
@@ -391,11 +398,13 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
           LO Bkj = Bcolind[j];
           LO Cij = Bcol2Ccol[Bkj];
 
-          TEUCHOS_TEST_FOR_EXCEPTION(c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip,
-                                     std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
-                                                                                          << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
-
-          Cvals[c_status[Cij]] += Aval * Bvals[j];
+          const bool badInsert = c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip;
+          if (!badInsert)
+            Cvals[c_status[Cij]] += Aval * Bvals[j];
+          else if (throwOnInsert)
+            TEUCHOS_TEST_FOR_EXCEPTION(badInsert,
+                                       std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
+                                                                                            << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
         }
 
       } else {
@@ -405,11 +414,13 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
           LO Ikj = Icolind[j];
           LO Cij = Icol2Ccol[Ikj];
 
-          TEUCHOS_TEST_FOR_EXCEPTION(c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip,
-                                     std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
-                                                                                          << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
-
-          Cvals[c_status[Cij]] += Aval * Ivals[j];
+          const bool badInsert = c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip;
+          if (!badInsert)
+            Cvals[c_status[Cij]] += Aval * Ivals[j];
+          else if (throwOnInsert)
+            TEUCHOS_TEST_FOR_EXCEPTION(badInsert,
+                                       std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
+                                                                                            << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
         }
       }
     }

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_ExtraKernels_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_ExtraKernels_def.hpp
@@ -283,6 +283,12 @@ void mult_A_B_reuse_LowThreadGustavsonKernel(CrsMatrixStruct<Scalar, LocalOrdina
                                              Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode> > Cimport,
                                              const std::string& label,
                                              const Teuchos::RCP<Teuchos::ParameterList>& params) {
+  // By default, if A*B results in an entry that is not supported by the graph of C, we throw.
+  // This option allows to override this behavior and silently ignores such entries.
+  bool throwOnInsert = true;
+  if (!params.is_null() && params->isType<bool>("MM Throw For Non-Existent Entries"))
+    throwOnInsert = params->get<bool>("MM Throw For Non-Existent Entries");
+
 #ifdef HAVE_TPETRA_MMM_TIMINGS
   std::string prefix_mmm = std::string("TpetraExt ") + label + std::string(": ");
   using Teuchos::TimeMonitor;
@@ -390,11 +396,13 @@ void mult_A_B_reuse_LowThreadGustavsonKernel(CrsMatrixStruct<Scalar, LocalOrdina
             LO Bkj = Bcolind(j);
             LO Cij = Bcol2Ccol(Bkj);
 
-            TEUCHOS_TEST_FOR_EXCEPTION(c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip,
-                                       std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
-                                                                                            << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
-
-            Cvals(c_status[Cij]) += Aval * Bvals(j);
+            const bool badInsert = c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip;
+            if (!badInsert)
+              Cvals(c_status[Cij]) += Aval * Bvals(j);
+            else if (throwOnInsert)
+              TEUCHOS_TEST_FOR_EXCEPTION(badInsert,
+                                         std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
+                                                                                              << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
           }
         } else {
           // Remote matrix
@@ -403,11 +411,13 @@ void mult_A_B_reuse_LowThreadGustavsonKernel(CrsMatrixStruct<Scalar, LocalOrdina
             LO Ikj = Icolind(j);
             LO Cij = Icol2Ccol(Ikj);
 
-            TEUCHOS_TEST_FOR_EXCEPTION(c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip,
-                                       std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
-                                                                                            << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
-
-            Cvals(c_status[Cij]) += Aval * Ivals(j);
+            const bool badInsert = c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip;
+            if (!badInsert)
+              Cvals(c_status[Cij]) += Aval * Ivals(j);
+            else if (throwOnInsert)
+              TEUCHOS_TEST_FOR_EXCEPTION(badInsert,
+                                         std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
+                                                                                              << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
           }
         }
       }

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_HIP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_HIP.hpp
@@ -269,6 +269,12 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
   using Teuchos::RCP;
   using Teuchos::rcp;
 
+  // By default, if A*B results in an entry that is not supported by the graph of C, we throw.
+  // This option allows to override this behavior and silently ignores such entries.
+  bool throwOnInsert = true;
+  if (!params.is_null() && params->isType<bool>("MM Throw For Non-Existent Entries"))
+    throwOnInsert = params->get<bool>("MM Throw For Non-Existent Entries");
+
   RCP<Tpetra::Details::ProfilingRegion> MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: MMM: Reuse SerialCore"));
 
   // Lots and lots of typedefs
@@ -373,11 +379,13 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
           LO Bkj = Bcolind[j];
           LO Cij = Bcol2Ccol[Bkj];
 
-          TEUCHOS_TEST_FOR_EXCEPTION(c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip,
-                                     std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
-                                                                                          << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
-
-          Cvals[c_status[Cij]] += Aval * Bvals[j];
+          const bool badInsert = c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip;
+          if (!badInsert)
+            Cvals[c_status[Cij]] += Aval * Bvals[j];
+          else if (throwOnInsert)
+            TEUCHOS_TEST_FOR_EXCEPTION(badInsert,
+                                       std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
+                                                                                            << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
         }
 
       } else {
@@ -387,11 +395,13 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
           LO Ikj = Icolind[j];
           LO Cij = Icol2Ccol[Ikj];
 
-          TEUCHOS_TEST_FOR_EXCEPTION(c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip,
-                                     std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
-                                                                                          << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
-
-          Cvals[c_status[Cij]] += Aval * Ivals[j];
+          const bool badInsert = c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip;
+          if (!badInsert)
+            Cvals[c_status[Cij]] += Aval * Ivals[j];
+          else if (throwOnInsert)
+            TEUCHOS_TEST_FOR_EXCEPTION(badInsert,
+                                       std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
+                                                                                            << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
         }
       }
     }

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_SYCL.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_SYCL.hpp
@@ -269,6 +269,12 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
   // FIXME: Right now, this is a cut-and-paste of the serial kernel
   typedef Tpetra::KokkosCompat::KokkosSYCLWrapperNode Node;
 
+  // By default, if A*B results in an entry that is not supported by the graph of C, we throw.
+  // This option allows to override this behavior and silently ignores such entries.
+  bool throwOnInsert = true;
+  if (!params.is_null() && params->isType<bool>("MM Throw For Non-Existent Entries"))
+    throwOnInsert = params->get<bool>("MM Throw For Non-Existent Entries");
+
 #ifdef HAVE_TPETRA_MMM_TIMINGS
   std::string prefix_mmm = std::string("TpetraExt ") + label + std::string(": ");
   using Teuchos::TimeMonitor;
@@ -386,11 +392,13 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
           LO Bkj = Bcolind[j];
           LO Cij = Bcol2Ccol[Bkj];
 
-          TEUCHOS_TEST_FOR_EXCEPTION(c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip,
-                                     std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
-                                                                                          << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
-
-          Cvals[c_status[Cij]] += Aval * Bvals[j];
+          const bool badInsert = c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip;
+          if (!badInsert)
+            Cvals[c_status[Cij]] += Aval * Bvals[j];
+          else if (throwOnInsert)
+            TEUCHOS_TEST_FOR_EXCEPTION(badInsert,
+                                       std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
+                                                                                            << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
         }
 
       } else {
@@ -400,11 +408,13 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Tpetra::KokkosCompat::K
           LO Ikj = Icolind[j];
           LO Cij = Icol2Ccol[Ikj];
 
-          TEUCHOS_TEST_FOR_EXCEPTION(c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip,
-                                     std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
-                                                                                          << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
-
-          Cvals[c_status[Cij]] += Aval * Ivals[j];
+          const bool badInsert = c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip;
+          if (!badInsert)
+            Cvals[c_status[Cij]] += Aval * Ivals[j];
+          else if (throwOnInsert)
+            TEUCHOS_TEST_FOR_EXCEPTION(badInsert,
+                                       std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
+                                                                                            << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
         }
       }
     }

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -2233,7 +2233,7 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Node, LocalOrdinalViewT
                                                                                                                     CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& C,
                                                                                                                     Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Node>> /* Cimport */,
                                                                                                                     const std::string& label,
-                                                                                                                    const Teuchos::RCP<Teuchos::ParameterList>& /* params */) {
+                                                                                                                    const Teuchos::RCP<Teuchos::ParameterList>& params) {
   using Teuchos::RCP;
   using Teuchos::rcp;
 
@@ -2252,6 +2252,12 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Node, LocalOrdinalViewT
   const size_t ST_INVALID = Teuchos::OrdinalTraits<LO>::invalid();
   const LO LO_INVALID     = Teuchos::OrdinalTraits<LO>::invalid();
   const SC SC_ZERO        = Teuchos::ScalarTraits<Scalar>::zero();
+
+  // By default, if A*B results in an entry that is not supported by the graph of C, we throw.
+  // This option allows to override this behavior and silently ignores such entries.
+  bool throwOnInsert = true;
+  if (!params.is_null() && params->isType<bool>("MM Throw For Non-Existent Entries"))
+    throwOnInsert = params->get<bool>("MM Throw For Non-Existent Entries");
 
   Tpetra::Details::ProfilingRegion MM("TpetraExt: MMM: Reuse SerialCore");
   (void)label;
@@ -2320,11 +2326,13 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Node, LocalOrdinalViewT
           LO Bkj = Bcolind[j];
           LO Cij = Bcol2Ccol[Bkj];
 
-          TEUCHOS_TEST_FOR_EXCEPTION(c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip,
-                                     std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
-                                                                                          << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
-
-          Cvals[c_status[Cij]] += Aval * Bvals[j];
+          const bool badInsert = c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip;
+          if (!badInsert)
+            Cvals[c_status[Cij]] += Aval * Bvals[j];
+          else if (throwOnInsert)
+            TEUCHOS_TEST_FOR_EXCEPTION(badInsert,
+                                       std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
+                                                                                            << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
         }
 
       } else {
@@ -2334,11 +2342,13 @@ void KernelWrappers<Scalar, LocalOrdinal, GlobalOrdinal, Node, LocalOrdinalViewT
           LO Ikj = Icolind[j];
           LO Cij = Icol2Ccol[Ikj];
 
-          TEUCHOS_TEST_FOR_EXCEPTION(c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip,
-                                     std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
-                                                                                          << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
-
-          Cvals[c_status[Cij]] += Aval * Ivals[j];
+          const bool badInsert = c_status[Cij] < OLD_ip || c_status[Cij] >= CSR_ip;
+          if (!badInsert)
+            Cvals[c_status[Cij]] += Aval * Ivals[j];
+          else if (throwOnInsert)
+            TEUCHOS_TEST_FOR_EXCEPTION(badInsert,
+                                       std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph "
+                                                                                            << "(c_status = " << c_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
         }
       }
     }


### PR DESCRIPTION
@trilinos/tpetra @trilinos/muelu 

## Motivation
- Tpetra: Add a new option "MM Throw For Non-Existent Entries" to the matrix-matrix reuse code path. If the option is set to false entries of $A B$ that are not supported by the graph of $C$ are silently ignored. The default behavior (throwing an exception) does not change.
- MueLu: Use it in `FlatOperator` which is used within energy minimization. We already know the desired sparsity pattern of the matrix product. Using the new code path in Tpetra we can skip the construction of the graph of the product and subsequent filtering of matrix entries.