### PR TITLE
MueLu: Replace #ifdef HAVE_MUELU_DEBUG with Behavior::debug()

### DIFF
--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -91,6 +91,8 @@
 #include "MueLu_IntrepidPCoarsenFactory.hpp"
 #endif
 
+#include "MueLu_Behavior.hpp"
+
 #include <unordered_set>
 
 namespace MueLu {
@@ -2779,9 +2781,8 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupO
 
     A.SetFixedBlockSize(blockSize_, dofOffset_);
 
-#ifdef HAVE_MUELU_DEBUG
-    MatrixUtils::checkLocalRowMapMatchesColMap(A);
-#endif  // HAVE_MUELU_DEBUG
+    if (Behavior::debug())
+      MatrixUtils::checkLocalRowMapMatchesColMap(A);
 
   } catch (std::bad_cast&) {
     this->GetOStream(Warnings0) << "Skipping setting block size as the operator is not a matrix" << std::endl;

--- a/packages/muelu/src/Misc/MueLu_LocalOrdinalTransferFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_LocalOrdinalTransferFactory_def.hpp
@@ -22,6 +22,7 @@
 
 #include "MueLu_Level.hpp"
 #include "MueLu_Monitor.hpp"
+#include "MueLu_Behavior.hpp"
 
 namespace MueLu {
 
@@ -107,40 +108,40 @@ void LocalOrdinalTransferFactory<LocalOrdinal, GlobalOrdinal, Node>::BuildFC(Lev
     }
   }
 
-#ifdef HAVE_MUELU_DEBUG
-  size_t error_count = 0;
-  {
-    RCP<LocalOrdinalVector> coarseTVghosted;
-    RCP<const Import> importer = P->getImporter();
-    if (!importer.is_null()) {
-      coarseTVghosted = LocalOrdinalVectorFactory::Build(P->getColMap(), 1);
-      coarseTVghosted->doImport(*coarseTV, *importer, Xpetra::INSERT);
-    } else {
-      coarseTVghosted = coarseTV;
-    }
-    ArrayRCP<LO> coarseDataGhosted = coarseTVghosted->getDataNonConst(0);
-    for (LO col = 0; col < (LO)P->getColMap()->getLocalNumElements(); col++) {
-      if (coarseDataGhosted[col] == LO_INVALID)
-        error_count++;
-    }
-    for (LO row = 0; row < (LO)P->getLocalNumRows(); row++) {
-      LO fineNumber = fineData[row];
-      ArrayView<const LO> indices;
-      P->getLocalRowView(row, indices);
-      for (LO j = 0; j < (LO)indices.size(); j++) {
-        if (coarseDataGhosted[indices[j]] != fineNumber)
+  if (Behavior::debug()) {
+    size_t error_count = 0;
+    {
+      RCP<LocalOrdinalVector> coarseTVghosted;
+      RCP<const Import> importer = P->getImporter();
+      if (!importer.is_null()) {
+        coarseTVghosted = LocalOrdinalVectorFactory::Build(P->getColMap(), 1);
+        coarseTVghosted->doImport(*coarseTV, *importer, Xpetra::INSERT);
+      } else {
+        coarseTVghosted = coarseTV;
+      }
+      ArrayRCP<LO> coarseDataGhosted = coarseTVghosted->getDataNonConst(0);
+      for (LO col = 0; col < (LO)P->getColMap()->getLocalNumElements(); col++) {
+        if (coarseDataGhosted[col] == LO_INVALID)
           error_count++;
       }
+      for (LO row = 0; row < (LO)P->getLocalNumRows(); row++) {
+        LO fineNumber = fineData[row];
+        ArrayView<const LO> indices;
+        P->getLocalRowView(row, indices);
+        for (LO j = 0; j < (LO)indices.size(); j++) {
+          if (coarseDataGhosted[indices[j]] != fineNumber)
+            error_count++;
+        }
+      }
+    }
+
+    // Error checking:  All nodes in an aggregate must share a local ordinal
+    if (error_count > 0) {
+      std::ostringstream ofs;
+      ofs << "LocalOrdinalTransferFactory(" << TransferVecName_ << "): ERROR:  Each coarse dof must have a unique LO value.  We had " << std::to_string(error_count) << " unknowns that did not match.";
+      throw std::runtime_error(ofs.str());
     }
   }
-
-  // Error checking:  All nodes in an aggregate must share a local ordinal
-  if (error_count > 0) {
-    std::ostringstream ofs;
-    ofs << "LocalOrdinalTransferFactory(" << TransferVecName_ << "): ERROR:  Each coarse dof must have a unique LO value.  We had " << std::to_string(error_count) << " unknowns that did not match.";
-    throw std::runtime_error(ofs.str());
-  }
-#endif
 
   Set<RCP<LocalOrdinalVector> >(coarseLevel, TransferVecName_, coarseTV);
 }

--- a/packages/muelu/src/Misc/MueLu_RAPFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_RAPFactory_def.hpp
@@ -23,6 +23,7 @@
 #include "MueLu_MasterList.hpp"
 #include "MueLu_Monitor.hpp"
 #include "MueLu_PerfUtils.hpp"
+#include "MueLu_Behavior.hpp"
 
 namespace MueLu {
 
@@ -301,9 +302,8 @@ void RAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level& fineLev
     }
   }
 
-#ifdef HAVE_MUELU_DEBUG
-  MatrixUtils::checkLocalRowMapMatchesColMap(*Ac);
-#endif  // HAVE_MUELU_DEBUG
+  if (Behavior::debug())
+    MatrixUtils::checkLocalRowMapMatchesColMap(*Ac);
 
   if (transferFacts_.begin() != transferFacts_.end()) {
     SubFactoryMonitor m(*this, "Projections", coarseLevel);

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -32,6 +32,7 @@
 #include "MueLu_PFactory.hpp"
 #include "MueLu_SmootherFactory.hpp"
 #include "MueLu_SmootherBase.hpp"
+#include "MueLu_Behavior.hpp"
 
 #include "Teuchos_TimeMonitor.hpp"
 
@@ -776,8 +777,7 @@ ConvergenceStatus Hierarchy<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Iterate(
   MagnitudeType prevNorm = STS::magnitude(STS::one()), curNorm = STS::magnitude(STS::one());
   rate_ = 1.0;
 
-  for (LO i = 1; i <= nIts; i++) {
-#ifdef HAVE_MUELU_DEBUG
+  if (Behavior::debug()) {
     if (A->getDomainMap()->isCompatible(*(X.getMap())) == false) {
       std::ostringstream ss;
       ss << "Level " << startLevel << ": level A's domain map is not compatible with X";
@@ -789,7 +789,6 @@ ConvergenceStatus Hierarchy<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Iterate(
       ss << "Level " << startLevel << ": level A's range map is not compatible with B";
       throw Exceptions::Incompatible(ss.str());
     }
-#endif
   }
 
   bool emptyFineSolve = true;

--- a/packages/muelu/src/MueCentral/MueLu_Level.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_Level.cpp
@@ -12,6 +12,7 @@
 #include "MueLu_Level.hpp"
 
 #include "MueLu_FactoryManagerBase.hpp"
+#include "MueLu_Behavior.hpp"
 
 namespace MueLu {
 
@@ -421,9 +422,8 @@ void Level::print(std::ostream& out, const VerbLevel verbLevel) const {
       } else {
         std::ostringstream oss;
         oss << factory->ShortClassName() << "[" << factory->GetID() << "]";
-#ifdef HAVE_MUELU_DEBUG
-        oss << "(" << factory << ")";
-#endif
+        if (Behavior::debug())
+          oss << "(" << factory << ")";
         outputter.outputField(oss.str());
       }
 
@@ -501,10 +501,8 @@ void Level::print(std::ostream& out, const VerbLevel verbLevel) const {
       for (container_type::const_iterator ct = requestedBy.begin(); ct != requestedBy.end(); ct++) {
         if (ct != requestedBy.begin()) ss << ",";
         ss << ct->first->ShortClassName() << "[" << ct->first->GetID() << "]";
-#ifdef HAVE_MUELU_DEBUG
-        ss << "(" << ct->first << ")";
-#endif
-
+        if (Behavior::debug())
+          ss << "(" << ct->first << ")";
         if (ct->second > 1) ss << "x" << ct->second;
       }
       outputter.outputField(ss.str());

--- a/packages/muelu/src/Operators/MueLu_Maxwell1_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_Maxwell1_def.hpp
@@ -38,6 +38,7 @@
 #include <MueLu_CreateXpetraPreconditioner.hpp>
 #include <MueLu_ML2MueLuParameterTranslator.hpp>
 #include <MueLu_RefMaxwellSmoother.hpp>
+#include "MueLu_Behavior.hpp"
 
 #ifdef HAVE_MUELU_CUDA
 #include "cuda_profiler_api.h"
@@ -806,14 +807,14 @@ void Maxwell1<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   // some pre-conditions
   TEUCHOS_ASSERT(D0_Matrix != Teuchos::null);
 
-#ifdef HAVE_MUELU_DEBUG
-  if (!Kn_Matrix.is_null()) {
-    TEUCHOS_ASSERT(Kn_Matrix->getDomainMap()->isSameAs(*D0_Matrix->getDomainMap()));
-    TEUCHOS_ASSERT(Kn_Matrix->getRangeMap()->isSameAs(*D0_Matrix->getDomainMap()));
-  }
+  if (Behavior::debug()) {
+    if (!Kn_Matrix.is_null()) {
+      TEUCHOS_ASSERT(Kn_Matrix->getDomainMap()->isSameAs(*D0_Matrix->getDomainMap()));
+      TEUCHOS_ASSERT(Kn_Matrix->getRangeMap()->isSameAs(*D0_Matrix->getDomainMap()));
+    }
 
-  TEUCHOS_ASSERT(D0_Matrix->getRangeMap()->isSameAs(*D0_Matrix->getRowMap()));
-#endif
+    TEUCHOS_ASSERT(D0_Matrix->getRangeMap()->isSameAs(*D0_Matrix->getRowMap()));
+  }
 
   Hierarchy11_   = Teuchos::null;
   Hierarchy22_   = Teuchos::null;

--- a/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
@@ -52,6 +52,7 @@
 #include "MueLu_RebalanceAcFactory.hpp"
 #include "MueLu_RebalanceTransferFactory.hpp"
 
+#include "MueLu_Behavior.hpp"
 #include "MueLu_VerbosityLevel.hpp"
 
 #include <MueLu_CreateXpetraPreconditioner.hpp>
@@ -2663,61 +2664,60 @@ void RefMaxwell<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     TEUCHOS_ASSERT(invMk_2_invAlpha != Teuchos::null);
   }
 
-#ifdef HAVE_MUELU_DEBUG
+  if (Behavior::debug()) {
+    TEUCHOS_ASSERT(D0->getRangeMap()->isSameAs(*D0->getRowMap()));
 
-  TEUCHOS_ASSERT(D0->getRangeMap()->isSameAs(*D0->getRowMap()));
+    // M1_beta is square
+    TEUCHOS_ASSERT(M1_beta->getDomainMap()->isSameAs(*M1_beta->getRangeMap()));
+    TEUCHOS_ASSERT(M1_beta->getDomainMap()->isSameAs(*M1_beta->getRowMap()));
 
-  // M1_beta is square
-  TEUCHOS_ASSERT(M1_beta->getDomainMap()->isSameAs(*M1_beta->getRangeMap()));
-  TEUCHOS_ASSERT(M1_beta->getDomainMap()->isSameAs(*M1_beta->getRowMap()));
+    // M1_beta is consistent with D0
+    TEUCHOS_ASSERT(M1_beta->getDomainMap()->isSameAs(*D0->getRangeMap()));
 
-  // M1_beta is consistent with D0
-  TEUCHOS_ASSERT(M1_beta->getDomainMap()->isSameAs(*D0->getRangeMap()));
+    if (k >= 2) {
+      // M1_alpha is square
+      TEUCHOS_ASSERT(M1_alpha->getDomainMap()->isSameAs(*M1_alpha->getRangeMap()));
+      TEUCHOS_ASSERT(M1_alpha->getDomainMap()->isSameAs(*M1_alpha->getRowMap()));
 
-  if (k >= 2) {
-    // M1_alpha is square
-    TEUCHOS_ASSERT(M1_alpha->getDomainMap()->isSameAs(*M1_alpha->getRangeMap()));
-    TEUCHOS_ASSERT(M1_alpha->getDomainMap()->isSameAs(*M1_alpha->getRowMap()));
+      // M1_alpha is consistent with D0
+      TEUCHOS_ASSERT(M1_alpha->getDomainMap()->isSameAs(*D0->getRangeMap()));
+    }
 
-    // M1_alpha is consistent with D0
-    TEUCHOS_ASSERT(M1_alpha->getDomainMap()->isSameAs(*D0->getRangeMap()))
+    if (!disable_addon_) {
+      // Mk_one is square
+      TEUCHOS_ASSERT(Mk_one->getDomainMap()->isSameAs(*Mk_one->getRangeMap()));
+      TEUCHOS_ASSERT(Mk_one->getDomainMap()->isSameAs(*Mk_one->getRowMap()));
+
+      // Mk_one is consistent with Dk_1
+      TEUCHOS_ASSERT(Mk_one->getDomainMap()->isSameAs(*Dk_1->getRangeMap()));
+
+      // invMk_1_invBeta is square
+      TEUCHOS_ASSERT(invMk_1_invBeta->getDomainMap()->isSameAs(*invMk_1_invBeta->getRangeMap()));
+      TEUCHOS_ASSERT(invMk_1_invBeta->getDomainMap()->isSameAs(*invMk_1_invBeta->getRowMap()));
+
+      // invMk_1_invBeta is consistent with Dk_1
+      TEUCHOS_ASSERT(invMk_1_invBeta->getDomainMap()->isSameAs(*Dk_1->getDomainMap()));
+    }
+
+    if ((k >= 2) && !disable_addon_22_) {
+      // Mk_1_one is square
+      TEUCHOS_ASSERT(Mk_1_one->getDomainMap()->isSameAs(*Mk_1_one->getRangeMap()));
+      TEUCHOS_ASSERT(Mk_1_one->getDomainMap()->isSameAs(*Mk_1_one->getRowMap()));
+
+      // Mk_1_one is consistent with Dk_1
+      TEUCHOS_ASSERT(Mk_1_one->getDomainMap()->isSameAs(*Dk_1->getDomainMap()));
+
+      // Mk_1_one is consistent with Dk_2
+      TEUCHOS_ASSERT(Mk_1_one->getDomainMap()->isSameAs(*Dk_2->getRangeMap()));
+
+      // invMk_2_invAlpha is square
+      TEUCHOS_ASSERT(invMk_2_invAlpha->getDomainMap()->isSameAs(*invMk_2_invAlpha->getRangeMap()));
+      TEUCHOS_ASSERT(invMk_2_invAlpha->getDomainMap()->isSameAs(*invMk_2_invAlpha->getRowMap()));
+
+      // invMk_2_invAlpha is consistent with Dk_2
+      TEUCHOS_ASSERT(invMk_2_invAlpha->getDomainMap()->isSameAs(*Dk_2->getDomainMap()));
+    }
   }
-
-  if (!disable_addon_) {
-    // Mk_one is square
-    TEUCHOS_ASSERT(Mk_one->getDomainMap()->isSameAs(*Mk_one->getRangeMap()));
-    TEUCHOS_ASSERT(Mk_one->getDomainMap()->isSameAs(*Mk_one->getRowMap()));
-
-    // Mk_one is consistent with Dk_1
-    TEUCHOS_ASSERT(Mk_one->getDomainMap()->isSameAs(*Dk_1->getRangeMap()));
-
-    // invMk_1_invBeta is square
-    TEUCHOS_ASSERT(invMk_1_invBeta->getDomainMap()->isSameAs(*invMk_1_invBeta->getRangeMap()));
-    TEUCHOS_ASSERT(invMk_1_invBeta->getDomainMap()->isSameAs(*invMk_1_invBeta->getRowMap()));
-
-    // invMk_1_invBeta is consistent with Dk_1
-    TEUCHOS_ASSERT(Mk_one->getDomainMap()->isSameAs(*Dk_1->getRangeMap()));
-  }
-
-  if ((k >= 2) && !disable_addon_22_) {
-    // Mk_1_one is square
-    TEUCHOS_ASSERT(Mk_1_one->getDomainMap()->isSameAs(*Mk_1_one->getRangeMap()));
-    TEUCHOS_ASSERT(Mk_1_one->getDomainMap()->isSameAs(*Mk_1_one->getRowMap()));
-
-    // Mk_1_one is consistent with Dk_1
-    TEUCHOS_ASSERT(Mk_1_one->getDomainMap()->isSameAs(*Dk_1->getDomainMap()));
-
-    // Mk_1_one is consistent with Dk_2
-    TEUCHOS_ASSERT(Mk_1_one->getDomainMap()->isSameAs(*Dk_2->getRangeMap()));
-
-    // invMk_2_invAlpha is square
-    TEUCHOS_ASSERT(invMk_2_invAlpha->getDomainMap()->isSameAs(*invMk_2_invAlpha->getRangeMap()));
-    TEUCHOS_ASSERT(invMk_2_invAlpha->getDomainMap()->isSameAs(*invMk_2_invAlpha->getRowMap()));
-
-    // invMk_2_invAlpha is consistent with Dk_2
-    TEUCHOS_ASSERT(invMk_2_invAlpha->getDomainMap()->isSameAs(*Dk_2->getDomainMap()));
-  }
-#endif
 
   D0_ = D0;
   if (Dk_1->getRowMap()->lib() == Xpetra::UseTpetra) {

--- a/packages/muelu/src/Operators/MueLu_XpetraOperator_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_XpetraOperator_def.hpp
@@ -11,6 +11,7 @@
 #define MUELU_XPETRAOPERATOR_DEF_HPP
 
 #include "MueLu_XpetraOperator_decl.hpp"
+#include "MueLu_Behavior.hpp"
 
 namespace MueLu {
 
@@ -52,20 +53,16 @@ void XpetraOperator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
           Scalar /* beta */) const {
   TEUCHOS_TEST_FOR_EXCEPTION(mode != Teuchos::NO_TRANS, std::logic_error, "MueLu::XpetraOperator does not support applying the adjoint operator");
   try {
-#ifdef HAVE_MUELU_DEBUG
-    typedef Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> Matrix;
-    RCP<Matrix> A = Hierarchy_->GetLevel(0)->template Get<RCP<Matrix> >("A");
+    if (Behavior::debug()) {
+      using Matrix  = Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+      RCP<Matrix> A = Hierarchy_->GetLevel(0)->template Get<RCP<Matrix> >("A");
 
-    // X is supposed to live in the range map of the operator (const rhs = B)
-    RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Xop =
-        Xpetra::MultiVectorFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(A->getRangeMap(), X.getNumVectors());
-    RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Yop =
-        Xpetra::MultiVectorFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(A->getDomainMap(), Y.getNumVectors());
-    TEUCHOS_TEST_FOR_EXCEPTION(A->getRangeMap()->isSameAs(*(Xop->getMap())) == false, std::logic_error,
-                               "MueLu::XpetraOperator::apply: map of X is incompatible with range map of A");
-    TEUCHOS_TEST_FOR_EXCEPTION(A->getDomainMap()->isSameAs(*(Yop->getMap())) == false, std::logic_error,
-                               "MueLu::XpetraOperator::apply: map of Y is incompatible with domain map of A");
-#endif
+      // X is supposed to live in the range map of the operator (const rhs = B)
+      TEUCHOS_TEST_FOR_EXCEPTION(A->getRangeMap()->isSameAs(*(X.getMap())) == false, std::logic_error,
+                                 "MueLu::XpetraOperator::apply: map of X is incompatible with range map of A");
+      TEUCHOS_TEST_FOR_EXCEPTION(A->getDomainMap()->isSameAs(*(Y.getMap())) == false, std::logic_error,
+                                 "MueLu::XpetraOperator::apply: map of Y is incompatible with domain map of A");
+    }
     Hierarchy_->Iterate(X, Y, 1, true);
   } catch (std::exception& e) {
     // FIXME add message and rethrow

--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_def.hpp
@@ -42,6 +42,7 @@
 #include "MueLu_PerfUtils.hpp"
 
 #include "MueLu_RepartitionUtilities.hpp"
+#include "MueLu_Behavior.hpp"
 
 namespace MueLu {
 
@@ -216,24 +217,24 @@ void RepartitionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level&
   //  * If a processor owns a partition, that partition number is equal to the processor rank
   //  * The decomposition vector contains the partitions ids that the corresponding GID belongs to
 
-#ifdef HAVE_MUELU_DEBUG
-  int myRank = comm->getRank();
-  ArrayRCP<const GO> decompEntries;
-  if (decomposition->getLocalLength() > 0)
-    decompEntries = decomposition->getData(0);
+  if (Behavior::debug()) {
+    int myRank = comm->getRank();
+    ArrayRCP<const GO> decompEntries;
+    if (decomposition->getLocalLength() > 0)
+      decompEntries = decomposition->getData(0);
 
-  // Test range of partition ids
-  int incorrectRank = -1;
-  for (int i = 0; i < decompEntries.size(); i++)
-    if (decompEntries[i] >= numProcs || decompEntries[i] < 0) {
-      incorrectRank = myRank;
-      break;
-    }
+    // Test range of partition ids
+    int incorrectRank = -1;
+    for (int i = 0; i < decompEntries.size(); i++)
+      if (decompEntries[i] >= numProcs || decompEntries[i] < 0) {
+        incorrectRank = myRank;
+        break;
+      }
 
-  int incorrectGlobalRank = -1;
-  MueLu_maxAll(comm, incorrectRank, incorrectGlobalRank);
-  TEUCHOS_TEST_FOR_EXCEPTION(incorrectGlobalRank > -1, Exceptions::RuntimeError, "pid " + Teuchos::toString(incorrectGlobalRank) + " encountered a partition number is that out-of-range");
-#endif
+    int incorrectGlobalRank = -1;
+    MueLu_maxAll(comm, incorrectRank, incorrectGlobalRank);
+    TEUCHOS_TEST_FOR_EXCEPTION(incorrectGlobalRank > -1, Exceptions::RuntimeError, "pid " + Teuchos::toString(incorrectGlobalRank) + " encountered a partition number is that out-of-range");
+  }
 
   // Step 1: Construct GIDs
   Array<GO> myGIDs;

--- a/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_def.hpp
@@ -27,6 +27,7 @@
 #include "MueLu_Level.hpp"
 #include "MueLu_Exceptions.hpp"
 #include "MueLu_Monitor.hpp"
+#include "MueLu_Behavior.hpp"
 
 namespace MueLu {
 
@@ -162,15 +163,15 @@ Zoltan2Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::ComputeDecompositio
     // Check that the number of local coordinates is consistent with the #rows in A
     TEUCHOS_TEST_FOR_EXCEPTION(rowMap->getLocalNumElements() / blkSize != coords->getLocalLength(), Exceptions::Incompatible,
                                "Coordinate vector length (" + toString(coords->getLocalLength()) << " is incompatible with number of block rows in A (" + toString(rowMap->getLocalNumElements() / blkSize) + "The vector length should be the same as the number of mesh points.");
-#ifdef HAVE_MUELU_DEBUG
-    GO indexBase = rowMap->getIndexBase();
-    // Make sure that logical blocks in row map coincide with logical nodes in coordinates map
-    ArrayView<const GO> rowElements    = rowMap->getLocalElementList();
-    ArrayView<const GO> coordsElements = map->getLocalElementList();
-    for (LO i = 0; i < Teuchos::as<LO>(numElements); i++)
-      TEUCHOS_TEST_FOR_EXCEPTION((coordsElements[i] - indexBase) * blkSize + indexBase != rowElements[i * blkSize],
-                                 Exceptions::RuntimeError, "i = " << i << ", coords GID = " << coordsElements[i] << ", row GID = " << rowElements[i * blkSize] << ", blkSize = " << blkSize << std::endl);
-#endif
+    if (Behavior::debug()) {
+      GO indexBase = rowMap->getIndexBase();
+      // Make sure that logical blocks in row map coincide with logical nodes in coordinates map
+      ArrayView<const GO> rowElements    = rowMap->getLocalElementList();
+      ArrayView<const GO> coordsElements = map->getLocalElementList();
+      for (LO i = 0; i < Teuchos::as<LO>(numElements); i++)
+        TEUCHOS_TEST_FOR_EXCEPTION((coordsElements[i] - indexBase) * blkSize + indexBase != rowElements[i * blkSize],
+                                   Exceptions::RuntimeError, "i = " << i << ", coords GID = " << coordsElements[i] << ", row GID = " << rowElements[i * blkSize] << ", blkSize = " << blkSize << std::endl);
+    }
 
     typedef Zoltan2::XpetraMultiVectorAdapter<RealValuedMultiVector> InputAdapterType;
     typedef Zoltan2::PartitioningProblem<InputAdapterType> ProblemType;

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedDirectSolver_def.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_BlockedDirectSolver_def.hpp
@@ -31,6 +31,7 @@
 #include "MueLu_Level.hpp"
 #include "MueLu_Monitor.hpp"
 #include "MueLu_DirectSolver.hpp"
+#include "MueLu_Behavior.hpp"
 
 namespace MueLu {
 
@@ -94,19 +95,19 @@ void BlockedDirectSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Apply(Multi
   RCP<BlockedMultiVector> bX       = Teuchos::rcp_dynamic_cast<BlockedMultiVector>(rcpX);
   RCP<const BlockedMultiVector> bB = Teuchos::rcp_dynamic_cast<const BlockedMultiVector>(rcpB);
 
-#ifdef HAVE_MUELU_DEBUG
-  RCP<BlockedCrsMatrix> bA = Teuchos::rcp_dynamic_cast<BlockedCrsMatrix>(A_);
-  if (bB.is_null() == false) {
-    // TEUCHOS_TEST_FOR_EXCEPTION(A_->getRangeMap()->isSameAs(*(B.getMap())) == false, Exceptions::RuntimeError, "MueLu::BlockedDirectSolver::Apply(): The map of RHS vector B is not the same as range map of the blocked operator A. Please check the map of B and A.");
-  } else {
-    TEUCHOS_TEST_FOR_EXCEPTION(bA->getFullRangeMap()->isSameAs(*(B.getMap())) == false, Exceptions::RuntimeError, "MueLu::BlockedDirectSolver::Apply(): The map of RHS vector B is not the same as range map of the blocked operator A. Please check the map of B and A.");
+  if (Behavior::debug()) {
+    RCP<BlockedCrsMatrix> bA = Teuchos::rcp_dynamic_cast<BlockedCrsMatrix>(A_);
+    if (bB.is_null() == false) {
+      // TEUCHOS_TEST_FOR_EXCEPTION(A_->getRangeMap()->isSameAs(*(B.getMap())) == false, Exceptions::RuntimeError, "MueLu::BlockedDirectSolver::Apply(): The map of RHS vector B is not the same as range map of the blocked operator A. Please check the map of B and A.");
+    } else {
+      TEUCHOS_TEST_FOR_EXCEPTION(bA->getFullRangeMap()->isSameAs(*(B.getMap())) == false, Exceptions::RuntimeError, "MueLu::BlockedDirectSolver::Apply(): The map of RHS vector B is not the same as range map of the blocked operator A. Please check the map of B and A.");
+    }
+    if (bX.is_null() == false) {
+      // TEUCHOS_TEST_FOR_EXCEPTION(A_->getDomainMap()->isSameAs(*(X.getMap())) == false, Exceptions::RuntimeError, "MueLu::BlockedDirectSolver::Apply(): The map of the solution vector X is not the same as domain map of the blocked operator A. Please check the map of X and A.");
+    } else {
+      TEUCHOS_TEST_FOR_EXCEPTION(bA->getFullDomainMap()->isSameAs(*(X.getMap())) == false, Exceptions::RuntimeError, "MueLu::BlockedDirectSolver::Apply(): The map of the solution vector X is not the same as domain map of the blocked operator A. Please check the map of X and A.");
+    }
   }
-  if (bX.is_null() == false) {
-    // TEUCHOS_TEST_FOR_EXCEPTION(A_->getDomainMap()->isSameAs(*(X.getMap())) == false, Exceptions::RuntimeError, "MueLu::BlockedDirectSolver::Apply(): The map of the solution vector X is not the same as domain map of the blocked operator A. Please check the map of X and A.");
-  } else {
-    TEUCHOS_TEST_FOR_EXCEPTION(bA->getFullDomainMap()->isSameAs(*(X.getMap())) == false, Exceptions::RuntimeError, "MueLu::BlockedDirectSolver::Apply(): The map of the solution vector X is not the same as domain map of the blocked operator A. Please check the map of X and A.");
-  }
-#endif
 
   if (bB.is_null() == true && bX.is_null() == true) {
     // standard case (neither B nor X are blocked)

--- a/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
@@ -38,6 +38,7 @@
 
 #include <KokkosKernels_Handle.hpp>
 #include <KokkosGraph_RCM.hpp>
+#include "MueLu_Behavior.hpp"
 
 namespace MueLu {
 
@@ -1245,9 +1246,8 @@ void UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   LocalOrdinal numRows    = A.getLocalNumRows();
   LocalOrdinal numVectors = RHS.getNumVectors();
   TEUCHOS_ASSERT_EQUALITY(numVectors, Teuchos::as<LocalOrdinal>(InitialGuess.getNumVectors()));
-#ifdef MUELU_DEBUG
-  TEUCHOS_ASSERT(RHS.getMap()->isCompatible(InitialGuess.getMap()));
-#endif
+  if (Behavior::debug())
+    TEUCHOS_ASSERT(RHS.getMap()->isCompatible(*InitialGuess.getMap()));
 
   auto lclRHS          = RHS.getLocalViewDevice(Tpetra::Access::ReadOnly);
   auto lclInitialGuess = InitialGuess.getLocalViewDevice(Tpetra::Access::ReadWrite);


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Replace a couple of `#ifdef HAVE_MUELU_DEBUG` with `Behavior::debug()`. There are a quite a few spots left that use `HAVE_MUELU_DEBUG`, but they might have impacts on runtime, even if the debug variable isn't set.