### PR TITLE
Teuchos SystemInformation: Record size of executable

### DIFF
--- a/packages/teuchos/core/src/Teuchos_SystemInformation.cpp
+++ b/packages/teuchos/core/src/Teuchos_SystemInformation.cpp
@@ -12,9 +12,7 @@
 #include "Teuchos_StrUtils.hpp"
 #include "Teuchos_TestForException.hpp"
 
-#if !defined(__GNUC__) || (__GNUC__ >= 10)
 #include <filesystem>
-#endif
 #include <iostream>
 #include <stdexcept>
 #include <set>
@@ -219,21 +217,20 @@ void initializeCollection() {
                                "environment variable TEUCHOS_USER_COMMANDS");
   }
 
-#if !defined(__GNUC__) || (__GNUC__ >= 10)
   try {
     const std::string executable = std::filesystem::canonical("/proc/self/exe").string();
     if (!executable.empty()) {
       registerCommand("ldd", "ldd " + executable, "ldd");
+      registerCommand("stat", "stat --printf %s " + executable, "stat");
     }
   } catch (std::filesystem::filesystem_error &) {
     // ignore
   }
-#endif
 
   // CPUs
   registerCommand("lscpu");
 
-  // temperature sensore
+  // temperature sensors
   registerCommand("sensors");
 
   // OpenMP


### PR DESCRIPTION
@trilinos/teuchos 

## Motivation
Record the size of the executable. I would like to use this to track the impact of ETI work.

I also removed some compile guards. I guess we'll see if they are still required..