### PR TITLE
MueLu: Fixing the diagonal issue

### DIFF
--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -1397,6 +1397,15 @@ Only used when tentative: calculate qr is set to false.</description>
     </parameter>
 
     <parameter>
+      <name>sa: diagonal replacement tolerance</name>
+      <type>double</type>
+      <default>-1.0</default>
+      <description>If not -1, use this value for deciding whether a diagonal value in prolongator smoothing is too small and should be replaced.</description>
+      <visible>false</visible>
+      <name-ML>not supported by ML</name-ML>
+    </parameter>
+
+    <parameter>
       <name>sa: rowsumabs diagonal replacement tolerance</name>
       <type>double</type>
       <default>-1.0</default>
@@ -1404,6 +1413,7 @@ Only used when tentative: calculate qr is set to false.</description>
       <visible>false</visible>
       <name-ML>not supported by ML</name-ML>
     </parameter>
+
 
     <parameter>
       <name>sa: rowsumabs use automatic diagonal tolerance</name>

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -311,6 +311,8 @@ Only used when tentative: calculate qr is set to false.}
         
 \cbb{sa: max eigenvalue}{double}{-1.0}{If not -1, use this value for lambdaMax(Dinv A) in prolongator smoothing instead of calculating it.}
         
+\cbb{sa: diagonal replacement tolerance}{double}{-1.0}{If not -1, use this value for deciding whether a diagonal value in prolongator smoothing is too small and should be replaced.}
+        
 \cbb{sa: rowsumabs diagonal replacement tolerance}{double}{-1.0}{If not -1, use this value for deciding whether a diagonal value in prolongator smoothing is too small and should be replaced.}
         
 \cbb{sa: rowsumabs use automatic diagonal tolerance}{bool}{false}{If true, choose replacement tolerance based on matrix diagonal absolute value average.}

--- a/packages/muelu/src/Interface/MueLu_ML2MueLuParameterTranslator.cpp
+++ b/packages/muelu/src/Interface/MueLu_ML2MueLuParameterTranslator.cpp
@@ -14,7 +14,7 @@ using Teuchos::ParameterList;
 
 namespace MueLu {
 
-std::string ML2MueLuParameterTranslator::GetSmootherFactory(const Teuchos::ParameterList &paramList, Teuchos::ParameterList &adaptingParamList, const std::string &pname, const std::string &value) {
+std::string ML2MueLuParameterTranslator::GetSmootherFactory(const Teuchos::ParameterList& paramList, Teuchos::ParameterList& adaptingParamList, const std::string& pname, const std::string& value) {
   TEUCHOS_TEST_FOR_EXCEPTION(pname != "coarse: type" && pname != "coarse: list" && pname != "smoother: type" && pname.find("smoother: list", 0) != 0,
                              Exceptions::RuntimeError,
                              "MueLu::MLParameterListInterpreter::Setup(): Only \"coarse: type\", \"smoother: type\" or \"smoother: list\" (\"coarse: list\") are "
@@ -300,7 +300,7 @@ std::string ML2MueLuParameterTranslator::GetSmootherFactory(const Teuchos::Param
   return mueluss.str();
 }
 
-std::string ML2MueLuParameterTranslator::SetParameterList(const Teuchos::ParameterList &paramList_in, const std::string &defaultVals) {
+std::string ML2MueLuParameterTranslator::SetParameterList(const Teuchos::ParameterList& paramList_in, const std::string& defaultVals) {
   Teuchos::ParameterList paramList = paramList_in;
 
   RCP<Teuchos::FancyOStream> out = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));  // TODO: use internal out (GetOStream())
@@ -377,10 +377,13 @@ std::string ML2MueLuParameterTranslator::SetParameterList(const Teuchos::Paramet
   // make sure that MueLu's drop tol matches ML's
   mueluss << "<Parameter name=\"aggregation: use ml scaling of drop tol\"      type=\"bool\"     value=\"true\"/>" << std::endl;
 
+  // make sure that MueLu's SaP diagonal behavior matches ML's
+  mueluss << "<Parameter name=\"sa: diagonal replacement tolerance\"      type=\"double\"     value=\"0.0\"/>" << std::endl;
+
   // loop over all ML parameters in provided parameter list
   for (ParameterList::ConstIterator param = paramListWithSubList.begin(); param != paramListWithSubList.end(); ++param) {
     // extract ML parameter name
-    const std::string &pname = paramListWithSubList.name(param);
+    const std::string& pname = paramListWithSubList.name(param);
 
     // Short circuit the "parameterlist: syntax" parameter
     // We want to remove this to make sure that createXpetraPreconditioner doesn't re-call translate()
@@ -492,8 +495,8 @@ std::string ML2MueLuParameterTranslator::SetParameterList(const Teuchos::Paramet
   return mueluss.str();
 }
 
-static void ML_OverwriteDefaults(ParameterList &inList, ParameterList &List, bool OverWrite) {
-  ParameterList *coarseList = 0;
+static void ML_OverwriteDefaults(ParameterList& inList, ParameterList& List, bool OverWrite) {
+  ParameterList* coarseList = 0;
   // Don't create the coarse list if it doesn't already exist!
   if (inList.isSublist("coarse: list"))
     coarseList = &(inList.sublist("coarse: list"));
@@ -508,15 +511,15 @@ static void ML_OverwriteDefaults(ParameterList &inList, ParameterList &List, boo
   }
 }  // ML_OverwriteDefaults()
 
-static int UpdateList(Teuchos::ParameterList &source, Teuchos::ParameterList &dest, bool OverWrite) {
+static int UpdateList(Teuchos::ParameterList& source, Teuchos::ParameterList& dest, bool OverWrite) {
   for (Teuchos::ParameterList::ConstIterator param = source.begin(); param != source.end(); param++)
     if (dest.isParameter(source.name(param)) == false || OverWrite)
       dest.setEntry(source.name(param), source.entry(param));
   return 0;
 }
 
-int ML2MueLuParameterTranslator::SetDefaults(std::string ProblemType, Teuchos::ParameterList &List,
-                                             int *ioptions, double *iparams, const bool OverWrite) {
+int ML2MueLuParameterTranslator::SetDefaults(std::string ProblemType, Teuchos::ParameterList& List,
+                                             int* ioptions, double* iparams, const bool OverWrite) {
   Teuchos::RCP<std::vector<int> > options;
   Teuchos::RCP<std::vector<double> > params;
 
@@ -564,9 +567,9 @@ int ML2MueLuParameterTranslator::SetDefaults(std::string ProblemType, Teuchos::P
   return (0);
 }
 
-int ML2MueLuParameterTranslator::SetDefaultsSA(ParameterList &inList,
-                                               Teuchos::RCP<std::vector<int> > & /* options */,
-                                               Teuchos::RCP<std::vector<double> > & /* params */,
+int ML2MueLuParameterTranslator::SetDefaultsSA(ParameterList& inList,
+                                               Teuchos::RCP<std::vector<int> >& /* options */,
+                                               Teuchos::RCP<std::vector<double> >& /* params */,
                                                bool OverWrite) {
   ParameterList List;
   inList.setName("SA default values");
@@ -598,9 +601,9 @@ int ML2MueLuParameterTranslator::SetDefaultsSA(ParameterList &inList,
   return 0;
 }  // ML2MueLuParameterTranslator::SetDefaultsSA()
 
-int ML2MueLuParameterTranslator::SetDefaultsDD(ParameterList &inList,
-                                               Teuchos::RCP<std::vector<int> > &options,
-                                               Teuchos::RCP<std::vector<double> > &params,
+int ML2MueLuParameterTranslator::SetDefaultsDD(ParameterList& inList,
+                                               Teuchos::RCP<std::vector<int> >& options,
+                                               Teuchos::RCP<std::vector<double> >& params,
                                                bool OverWrite) {
   ParameterList List;
 
@@ -639,9 +642,9 @@ int ML2MueLuParameterTranslator::SetDefaultsDD(ParameterList &inList,
   return 0;
 }  // ML2MueLuParameterTranslator::SetDefaultsDD()
 
-int ML2MueLuParameterTranslator::SetDefaultsDD_3Levels(ParameterList &inList,
-                                                       Teuchos::RCP<std::vector<int> > &options,
-                                                       Teuchos::RCP<std::vector<double> > &params,
+int ML2MueLuParameterTranslator::SetDefaultsDD_3Levels(ParameterList& inList,
+                                                       Teuchos::RCP<std::vector<int> >& options,
+                                                       Teuchos::RCP<std::vector<double> >& params,
                                                        bool OverWrite) {
   ParameterList List;
 
@@ -682,9 +685,9 @@ int ML2MueLuParameterTranslator::SetDefaultsDD_3Levels(ParameterList &inList,
   return 0;
 }  // ML2MueLuParameterTranslator::SetDefaultsDD_3Levels()
 
-int ML2MueLuParameterTranslator::SetDefaultsMaxwell(ParameterList &inList,
-                                                    Teuchos::RCP<std::vector<int> > & /* options */,
-                                                    Teuchos::RCP<std::vector<double> > & /* params */,
+int ML2MueLuParameterTranslator::SetDefaultsMaxwell(ParameterList& inList,
+                                                    Teuchos::RCP<std::vector<int> >& /* options */,
+                                                    Teuchos::RCP<std::vector<double> >& /* params */,
                                                     bool OverWrite) {
   ParameterList List;
 
@@ -724,9 +727,9 @@ int ML2MueLuParameterTranslator::SetDefaultsMaxwell(ParameterList &inList,
   return 0;
 }  // ML2MueLuParameterTranslator::SetDefaultsMaxwell()
 
-int ML2MueLuParameterTranslator::SetDefaultsNSSA(ParameterList &inList,
-                                                 Teuchos::RCP<std::vector<int> > & /* options */,
-                                                 Teuchos::RCP<std::vector<double> > & /* params */,
+int ML2MueLuParameterTranslator::SetDefaultsNSSA(ParameterList& inList,
+                                                 Teuchos::RCP<std::vector<int> >& /* options */,
+                                                 Teuchos::RCP<std::vector<double> >& /* params */,
                                                  bool OverWrite) {
   ParameterList List;
 
@@ -758,9 +761,9 @@ int ML2MueLuParameterTranslator::SetDefaultsNSSA(ParameterList &inList,
   return 0;
 }  // ML2MueLuParameterTranslator::SetDefaultsNSSA()
 
-int ML2MueLuParameterTranslator::SetDefaultsDD_LU(ParameterList &inList,
-                                                  Teuchos::RCP<std::vector<int> > &options,
-                                                  Teuchos::RCP<std::vector<double> > &params,
+int ML2MueLuParameterTranslator::SetDefaultsDD_LU(ParameterList& inList,
+                                                  Teuchos::RCP<std::vector<int> >& options,
+                                                  Teuchos::RCP<std::vector<double> >& params,
                                                   bool OverWrite) {
   ParameterList List;
 
@@ -800,9 +803,9 @@ int ML2MueLuParameterTranslator::SetDefaultsDD_LU(ParameterList &inList,
   return 0;
 }  // ML2MueLuParameterTranslator::SetDefaultsDD_LU()
 
-int ML2MueLuParameterTranslator::SetDefaultsDD_3Levels_LU(ParameterList &inList,
-                                                          Teuchos::RCP<std::vector<int> > &options,
-                                                          Teuchos::RCP<std::vector<double> > &params,
+int ML2MueLuParameterTranslator::SetDefaultsDD_3Levels_LU(ParameterList& inList,
+                                                          Teuchos::RCP<std::vector<int> >& options,
+                                                          Teuchos::RCP<std::vector<double> >& params,
                                                           bool OverWrite) {
   ParameterList List;
 
@@ -836,9 +839,9 @@ int ML2MueLuParameterTranslator::SetDefaultsDD_3Levels_LU(ParameterList &inList,
   return 0;
 }  // ML2MueLuParameterTranslator::SetDefaultsDD_3Levels_LU()
 
-int ML2MueLuParameterTranslator::SetDefaultsClassicalAMG(ParameterList &inList,
-                                                         Teuchos::RCP<std::vector<int> > & /* options */,
-                                                         Teuchos::RCP<std::vector<double> > & /* params */,
+int ML2MueLuParameterTranslator::SetDefaultsClassicalAMG(ParameterList& inList,
+                                                         Teuchos::RCP<std::vector<int> >& /* options */,
+                                                         Teuchos::RCP<std::vector<double> >& /* params */,
                                                          bool OverWrite) {
   ParameterList List;
 
@@ -864,12 +867,12 @@ int ML2MueLuParameterTranslator::SetDefaultsClassicalAMG(ParameterList &inList,
   return 0;
 }  // ML2MueLuParameterTranslator::SetDefaultsClassicalAMG()
 
-int ML2MueLuParameterTranslator::SetDefaultsRefMaxwell(Teuchos::ParameterList &inList, bool OverWrite) {
+int ML2MueLuParameterTranslator::SetDefaultsRefMaxwell(Teuchos::ParameterList& inList, bool OverWrite) {
   /* Sublists */
   Teuchos::ParameterList ListRF, List11, List11c, List22, dummy;
-  Teuchos::ParameterList &List11_  = inList.sublist("refmaxwell: 11list");
-  Teuchos::ParameterList &List22_  = inList.sublist("refmaxwell: 22list");
-  Teuchos::ParameterList &List11c_ = List11_.sublist("edge matrix free: coarse");
+  Teuchos::ParameterList& List11_  = inList.sublist("refmaxwell: 11list");
+  Teuchos::ParameterList& List22_  = inList.sublist("refmaxwell: 22list");
+  Teuchos::ParameterList& List11c_ = List11_.sublist("edge matrix free: coarse");
 
   /* Build Teuchos List: (1,1) coarse */
   SetDefaults("SA", List11c);

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -2208,6 +2208,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   test_and_set_param_2list<bool>(paramList, defaultList, "sa: calculate eigenvalue estimate", Pparams);
   test_and_set_param_2list<double>(paramList, defaultList, "sa: max eigenvalue", Pparams);
   test_and_set_param_2list<int>(paramList, defaultList, "sa: eigenvalue estimate num iterations", Pparams);
+  test_and_set_param_2list<double>(paramList, defaultList, "sa: diagonal replacement tolerance", Pparams);
   test_and_set_param_2list<bool>(paramList, defaultList, "sa: use rowsumabs diagonal scaling", Pparams);
   test_and_set_param_2list<double>(paramList, defaultList, "sa: rowsumabs diagonal replacement tolerance", Pparams);
   test_and_set_param_2list<double>(paramList, defaultList, "sa: rowsumabs diagonal replacement value", Pparams);

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -96,6 +96,7 @@ namespace MueLu {
     if (name == "sa: use rowsumabs diagonal scaling") { ss << "<Parameter name=\"sa: use rowsumabs diagonal scaling\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
     if (name == "sa: enforce constraints") { ss << "<Parameter name=\"sa: enforce constraints\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
     if (name == "sa: max eigenvalue") { ss << "<Parameter name=\"sa: max eigenvalue\" type=\"double\" value=" << value << "/>"; return ss.str(); }      
+    if (name == "sa: diagonal replacement tolerance") { ss << "<Parameter name=\"sa: diagonal replacement tolerance\" type=\"double\" value=" << value << "/>"; return ss.str(); }      
     if (name == "sa: rowsumabs diagonal replacement tolerance") { ss << "<Parameter name=\"sa: rowsumabs diagonal replacement tolerance\" type=\"double\" value=" << value << "/>"; return ss.str(); }      
     if (name == "sa: rowsumabs use automatic diagonal tolerance") { ss << "<Parameter name=\"sa: rowsumabs use automatic diagonal tolerance\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
     if (name == "sa: rowsumabs diagonal replacement value") { ss << "<Parameter name=\"sa: rowsumabs diagonal replacement value\" type=\"double\" value=" << value << "/>"; return ss.str(); }      
@@ -279,6 +280,7 @@ namespace MueLu {
   "<Parameter name=\"sa: use rowsumabs diagonal scaling\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"sa: enforce constraints\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"sa: max eigenvalue\" type=\"double\" value=\"-1.0\"/>"
+  "<Parameter name=\"sa: diagonal replacement tolerance\" type=\"double\" value=\"-1.0\"/>"
   "<Parameter name=\"sa: rowsumabs diagonal replacement tolerance\" type=\"double\" value=\"-1.0\"/>"
   "<Parameter name=\"sa: rowsumabs use automatic diagonal tolerance\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"sa: rowsumabs diagonal replacement value\" type=\"double\" value=\"0.0\"/>"
@@ -837,6 +839,8 @@ namespace MueLu {
          ("not supported by ML","sa: enforce constraints")
       
          ("not supported by ML","sa: max eigenvalue")
+      
+         ("not supported by ML","sa: diagonal replacement tolerance")
       
          ("not supported by ML","sa: rowsumabs diagonal replacement tolerance")
       

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_def.hpp
@@ -47,6 +47,7 @@ RCP<const ParameterList> SaPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   SET_VALID_ENTRY("sa: enforce constraints");
   SET_VALID_ENTRY("tentative: calculate qr");
   SET_VALID_ENTRY("sa: max eigenvalue");
+  SET_VALID_ENTRY("sa: diagonal replacement tolerance");
   SET_VALID_ENTRY("sa: rowsumabs diagonal replacement tolerance");
   SET_VALID_ENTRY("sa: rowsumabs diagonal replacement value");
   SET_VALID_ENTRY("sa: rowsumabs replace single entry row with zero");
@@ -154,8 +155,11 @@ void SaPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& fineLe
   const bool doQRStep                      = pL.get<bool>("tentative: calculate qr");
   const bool enforceConstraints            = pL.get<bool>("sa: enforce constraints");
   const MT userDefinedMaxEigen             = as<MT>(pL.get<double>("sa: max eigenvalue"));
-  double dTol                              = pL.get<double>("sa: rowsumabs diagonal replacement tolerance");
-  const MT diagonalReplacementTolerance    = (dTol == as<double>(-1) ? Teuchos::ScalarTraits<MT>::eps() * 100 : as<MT>(pL.get<double>("sa: rowsumabs diagonal replacement tolerance")));
+  double dTol                              = pL.get<double>("sa: diagonal replacement tolerance");
+  double dTol_rs                           = pL.get<double>("sa: rowsumabs diagonal replacement tolerance");
+  const MT diagonalReplacementTolerance    = (dTol == as<double>(-1) ? Teuchos::ScalarTraits<MT>::eps() * 100 : as<MT>(pL.get<double>("sa: diagonal replacement tolerance")));
+  const MT diagonalReplacementTolerance_rs = (dTol_rs == as<double>(-1) ? Teuchos::ScalarTraits<MT>::eps() * 100 : as<MT>(pL.get<double>("sa: rowsumabs diagonal replacement tolerance")));
+
   const SC diagonalReplacementValue        = as<SC>(pL.get<double>("sa: rowsumabs diagonal replacement value"));
   const bool replaceSingleEntryRowWithZero = pL.get<bool>("sa: rowsumabs replace single entry row with zero");
   const bool useAutomaticDiagTol           = pL.get<bool>("sa: rowsumabs use automatic diagonal tolerance");
@@ -180,7 +184,7 @@ void SaPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& fineLe
           if (useAbsValueRowSum) {
             const bool returnReciprocal = true;
             invDiag                     = Utilities::GetLumpedMatrixDiagonal(*A, returnReciprocal,
-                                                                             diagonalReplacementTolerance,
+                                                                             diagonalReplacementTolerance_rs,
                                                                              diagonalReplacementValue,
                                                                              replaceSingleEntryRowWithZero,
                                                                              useAutomaticDiagTol);
@@ -188,7 +192,7 @@ void SaPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& fineLe
                                        "SaPFactory: eigenvalue estimate: diagonal reciprocal is null.");
             lambdaMax = Utilities::PowerMethod(*A, invDiag, maxEigenIterations, stopTol);
           } else
-            lambdaMax = Utilities::PowerMethod(*A, true, maxEigenIterations, stopTol);
+            lambdaMax = Utilities::PowerMethod(*A, true, maxEigenIterations, stopTol, diagonalReplacementTolerance);
           A->SetMaxEigenvalueEstimate(lambdaMax);
         } else {
           GetOStream(Statistics1) << "Using cached max eigenvalue estimate" << std::endl;
@@ -208,7 +212,7 @@ void SaPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& fineLe
           GetOStream(Runtime0) << "Using rowsumabs diagonal" << std::endl;
           const bool returnReciprocal = true;
           invDiag                     = Utilities::GetLumpedMatrixDiagonal(*A, returnReciprocal,
-                                                                           diagonalReplacementTolerance,
+                                                                           diagonalReplacementTolerance_rs,
                                                                            diagonalReplacementValue,
                                                                            replaceSingleEntryRowWithZero,
                                                                            useAutomaticDiagTol);
@@ -292,7 +296,7 @@ void SaPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& fineLe
           if (useAbsValueRowSum) {
             const bool returnReciprocal = true;
             invDiag                     = Utilities::GetLumpedMatrixDiagonal(*CurlCurl, returnReciprocal,
-                                                                             diagonalReplacementTolerance,
+                                                                             diagonalReplacementTolerance_rs,
                                                                              diagonalReplacementValue,
                                                                              replaceSingleEntryRowWithZero,
                                                                              useAutomaticDiagTol);
@@ -300,7 +304,7 @@ void SaPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& fineLe
                                        "SaPFactory: eigenvalue estimate: diagonal reciprocal is null.");
             lambdaMax = Utilities::PowerMethod(*CurlCurl, invDiag, maxEigenIterations, stopTol);
           } else
-            lambdaMax = Utilities::PowerMethod(*CurlCurl, true, maxEigenIterations, stopTol);
+            lambdaMax = Utilities::PowerMethod(*CurlCurl, true, maxEigenIterations, stopTol, diagonalReplacementTolerance);
           CurlCurl->SetMaxEigenvalueEstimate(lambdaMax);
         } else {
           GetOStream(Statistics1) << "Using cached max eigenvalue estimate" << std::endl;
@@ -316,7 +320,7 @@ void SaPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& fineLe
         GetOStream(Runtime0) << "Using rowsumabs diagonal" << std::endl;
         const bool returnReciprocal = true;
         invDiag                     = Utilities::GetLumpedMatrixDiagonal(*CurlCurl, returnReciprocal,
-                                                                         diagonalReplacementTolerance,
+                                                                         diagonalReplacementTolerance_rs,
                                                                          diagonalReplacementValue,
                                                                          replaceSingleEntryRowWithZero,
                                                                          useAutomaticDiagTol);

--- a/packages/muelu/src/Utils/MueLu_UtilitiesBase_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_UtilitiesBase_decl.hpp
@@ -195,13 +195,14 @@ class UtilitiesBase {
     @param scaleByDiag if true, estimate the largest eigenvalue of \f$ D^; A \f$.
     @param niters maximum number of iterations
     @param tolerance stopping tolerance
+    @param diagonalReplacementTolernace tolernace for assuming the diagonal is zero
     @verbose if true, print iteration information
     @seed  seed for randomizing initial guess
 
     (Shamelessly grabbed from tpetra/examples.)
   */
   static Scalar PowerMethod(const Matrix& A, bool scaleByDiag = true,
-                            LocalOrdinal niters = 10, Magnitude tolerance = 1e-2, bool verbose = false, unsigned int seed = 123);
+                            LocalOrdinal niters = 10, Magnitude tolerance = 1e-2, Magnitude diagonalReplacementTol = Teuchos::ScalarTraits<Scalar>::eps() * 100, bool verbose = false, unsigned int seed = 123);
 
   /*! @brief Power method.
 

--- a/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
@@ -940,14 +940,14 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 Scalar
 UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     PowerMethod(const Matrix& A, bool scaleByDiag,
-                LocalOrdinal niters, typename Teuchos::ScalarTraits<Scalar>::magnitudeType tolerance, bool verbose, unsigned int seed) {
+                LocalOrdinal niters, typename Teuchos::ScalarTraits<Scalar>::magnitudeType tolerance, typename Teuchos::ScalarTraits<Scalar>::magnitudeType diagonalReplacementTolerance, bool verbose, unsigned int seed) {
   TEUCHOS_TEST_FOR_EXCEPTION(!(A.getRangeMap()->isSameAs(*(A.getDomainMap()))), Exceptions::Incompatible,
                              "Utils::PowerMethod: operator must have domain and range maps that are equivalent.");
 
   // power iteration
   RCP<Vector> diagInvVec;
   if (scaleByDiag) {
-    diagInvVec = GetMatrixDiagonalInverse(A);
+    diagInvVec = GetMatrixDiagonalInverse(A, diagonalReplacementTolerance);
   }
 
   Scalar lambda = PowerMethod(A, diagInvVec, niters, tolerance, verbose, seed);

--- a/packages/muelu/test/unit_tests/ML2MueLuParameterTranslator.cpp
+++ b/packages/muelu/test/unit_tests/ML2MueLuParameterTranslator.cpp
@@ -76,6 +76,7 @@ TEUCHOS_UNIT_TEST(ML2MueLuParameterTranslator, SA_plus_translate) {
   goldList.set("max levels", 10);
   goldList.set("cycle type", "V");
   goldList.set("sa: damping factor", 1.333);
+  goldList.set("sa: diagonal replacement tolerance", 0.);
   goldList.set("sa: eigenvalue estimate num iterations", 10);
   goldList.set("smoother: type", "RELAXATION");
   goldList.set("smoother: pre or post", "both");


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Instead of using a hardcoded tolerance of 100*eps for detecting small entries in the eigenvalue estimate of diagonal smoothing, add a configurable parameter. The default value does not change. Set a value of 0 in the ML2MueLu translator. 

I cherry picked the original commit by @csiefer2  over to develop.