### PR TITLE
Ifpack2: Add optional equilibration step to additive Schwarz

### DIFF
--- a/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_decl.hpp
@@ -818,6 +818,9 @@ class AdditiveSchwarz : virtual public Preconditioner<typename MatrixType::scala
   std::string ReorderingAlgorithm_ = "none";
   //! Whether to filter singleton rows.
   bool FilterSingletons_ = false;
+  //! Whether to equilibrate the innermost reduced reordered local matrix
+  //! using row/column 1-norm scaling.
+  bool EquilibrateSubdomainMatrix_ = false;
   //! Matrix from which singleton rows have been filtered.
   Teuchos::RCP<row_matrix_type> SingletonMatrix_;
   //! The number of iterations to be done.

--- a/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_def.hpp
@@ -636,8 +636,18 @@ void AdditiveSchwarz<MatrixType, LocalInverseType>::
     resetMultiVecIfNeeded(reduced_reordered_B_, additiveSchwarzFilter->getRowMap(), numVectors, true);
     resetMultiVecIfNeeded(reduced_reordered_Y_, additiveSchwarzFilter->getRowMap(), numVectors, true);
     additiveSchwarzFilter->CreateReducedProblem(OverlappingB, OverlappingY, *reduced_reordered_B_);
+
+    if (additiveSchwarzFilter->isEquilibrated()) {
+      additiveSchwarzFilter->scaleReducedRHS(*reduced_reordered_B_);
+    }
+
     // Apply inner solver
     Inverse_->solve(*reduced_reordered_Y_, *reduced_reordered_B_);
+
+    if (additiveSchwarzFilter->isEquilibrated()) {
+      additiveSchwarzFilter->unscaleReducedLHS(*reduced_reordered_Y_);
+    }
+
     // Scatter ReducedY back to non-singleton rows of OverlappingY, according to the reordering.
     additiveSchwarzFilter->UpdateLHS(*reduced_reordered_Y_, OverlappingY);
   } else {
@@ -838,6 +848,9 @@ void AdditiveSchwarz<MatrixType, LocalInverseType>::
   // singletons should help for PDE problems with Dirichlet BCs.
   FilterSingletons_ = plist->get("schwarz: filter singletons", FilterSingletons_);
 
+  EquilibrateSubdomainMatrix_ =
+      plist->get("schwarz: subdomain 1-norm equilibration", EquilibrateSubdomainMatrix_);
+
   // Allow for damped Schwarz updates
   getParamTryingTypes<scalar_type, scalar_type, double>(UpdateDamping_, *plist, "schwarz: update damping", prefix);
 
@@ -908,12 +921,13 @@ AdditiveSchwarz<MatrixType, LocalInverseType>::
   using Teuchos::rcp_const_cast;
 
   if (validParams_.is_null()) {
-    const int overlapLevel          = 0;
-    const bool useReordering        = false;
-    const bool filterSingletons     = false;
-    const int numIterations         = 1;
-    const bool zeroStartingSolution = true;
-    const scalar_type updateDamping = Teuchos::ScalarTraits<scalar_type>::one();
+    const int overlapLevel                = 0;
+    const bool useReordering              = false;
+    const bool filterSingletons           = false;
+    const bool equilibrateSubdomainMatrix = false;
+    const int numIterations               = 1;
+    const bool zeroStartingSolution       = true;
+    const scalar_type updateDamping       = Teuchos::ScalarTraits<scalar_type>::one();
     ParameterList reorderingSublist;
     reorderingSublist.set("order_method", std::string("rcm"));
 
@@ -930,6 +944,7 @@ AdditiveSchwarz<MatrixType, LocalInverseType>::
     plist->set("schwarz: num iterations", numIterations);
     plist->set("schwarz: zero starting solution", zeroStartingSolution);
     plist->set("schwarz: update damping", updateDamping);
+    plist->set("schwarz: subdomain 1-norm equilibration", equilibrateSubdomainMatrix);
 
     // FIXME (mfh 18 Nov 2013) Get valid parameters from inner solver.
     //        JJH The inner solver should handle its own validation.
@@ -1453,9 +1468,9 @@ void AdditiveSchwarz<MatrixType, LocalInverseType>::setup() {
       Teuchos::TimeMonitor t(*Teuchos::TimeMonitor::getNewTimer("Filter construction"));
       RCP<Details::AdditiveSchwarzFilter<MatrixType>> asf;
       if (OverlappingMatrix_.is_null())
-        asf = rcp(new Details::AdditiveSchwarzFilter<MatrixType>(matrixCrs, perm, revperm, FilterSingletons_));
+        asf = rcp(new Details::AdditiveSchwarzFilter<MatrixType>(matrixCrs, perm, revperm, FilterSingletons_, EquilibrateSubdomainMatrix_));
       else
-        asf = rcp(new Details::AdditiveSchwarzFilter<MatrixType>(OverlappingMatrix_, perm, revperm, FilterSingletons_));
+        asf = rcp(new Details::AdditiveSchwarzFilter<MatrixType>(OverlappingMatrix_, perm, revperm, FilterSingletons_, EquilibrateSubdomainMatrix_));
       innerMatrix_ = asf;
     }
 

--- a/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_decl.hpp
@@ -92,6 +92,8 @@ class AdditiveSchwarzFilter : public Ifpack2::Details::RowMatrix<MatrixType> {
   /// \param perm [in] Forward permutation of A's rows and columns.
   /// \param reverseperm [in] Reverse permutation of A's rows and columns.
   /// \param filterSingletons [in] If true, remove rows that have no local neighbors.
+  /// \param useEquilibration [in] If true, apply row/column 1-norm equilibration to the matrix.
+  ///                              This may improve the numerical stability of the subdomain solver.
   ///
   /// It must make sense to apply the given permutation to both the
   /// rows and columns.  This means that the row and column Maps must

--- a/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_decl.hpp
@@ -20,6 +20,8 @@ This is essentially a fusion of LocalFilter, AdditiveSchwarzFilter and Singleton
 
 #include "Ifpack2_ConfigDefs.hpp"
 #include "Ifpack2_Details_RowMatrix.hpp"
+#include "Tpetra_computeRowAndColumnOneNorms.hpp"
+#include "Tpetra_leftAndOrRightScaleCrsMatrix.hpp"
 #include "Ifpack2_OverlappingRowMatrix.hpp"
 
 namespace Ifpack2 {
@@ -103,7 +105,8 @@ class AdditiveSchwarzFilter : public Ifpack2::Details::RowMatrix<MatrixType> {
   AdditiveSchwarzFilter(const Teuchos::RCP<const row_matrix_type>& A,
                         const Teuchos::ArrayRCP<local_ordinal_type>& perm,
                         const Teuchos::ArrayRCP<local_ordinal_type>& reverseperm,
-                        bool filterSingletons);
+                        bool filterSingletons,
+                        bool useEquilibration);
 
   //! Update the filtered matrix in response to A's values changing (A's structure isn't allowed to change, though)
   void updateMatrixValues();
@@ -344,7 +347,8 @@ class AdditiveSchwarzFilter : public Ifpack2::Details::RowMatrix<MatrixType> {
   void setup(const Teuchos::RCP<const row_matrix_type>& A_unfiltered,
              const Teuchos::ArrayRCP<local_ordinal_type>& perm,
              const Teuchos::ArrayRCP<local_ordinal_type>& reverseperm,
-             bool filterSingletons);
+             bool filterSingletons,
+             bool useEquilibration);
 
   /// \brief Fill the entries/values in the local matrix, and from that construct A_.
   ///
@@ -378,6 +382,12 @@ class AdditiveSchwarzFilter : public Ifpack2::Details::RowMatrix<MatrixType> {
   static bool
   mapPairsAreFitted(const row_matrix_type& A);
 
+  void computeAndApplyEquilibration();
+  void scaleReducedRHS(mv_type& B) const;
+  void unscaleReducedLHS(mv_type& Y) const;
+
+  bool isEquilibrated() const { return UseEquilibration_; };
+
   //! Pointer to the matrix to be preconditioned.
   Teuchos::RCP<const row_matrix_type> A_unfiltered_;
   //! Filtered and reordered matrix.
@@ -398,6 +408,10 @@ class AdditiveSchwarzFilter : public Ifpack2::Details::RowMatrix<MatrixType> {
 
   //! Row, col, domain and range map of this locally filtered matrix (it's square and non-distributed)
   Teuchos::RCP<const map_type> localMap_;
+
+  bool UseEquilibration_;
+  decltype(Tpetra::computeRowAndColumnOneNorms(
+      std::declval<const crs_matrix_type&>(), false)) equilResult_;
 };
 
 }  // namespace Details

--- a/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_decl.hpp
@@ -356,6 +356,11 @@ class AdditiveSchwarzFilter : public Ifpack2::Details::RowMatrix<MatrixType> {
   /// Used by both the constructor and updateMatrixValues().
   void fillLocalMatrix(local_matrix_type localMatrix);
 
+  void scaleReducedRHS(mv_type& B) const;
+  void unscaleReducedLHS(mv_type& Y) const;
+
+  bool isEquilibrated() const { return UseEquilibration_; };
+
   //@}
 
  private:
@@ -383,10 +388,6 @@ class AdditiveSchwarzFilter : public Ifpack2::Details::RowMatrix<MatrixType> {
   mapPairsAreFitted(const row_matrix_type& A);
 
   void computeAndApplyEquilibration();
-  void scaleReducedRHS(mv_type& B) const;
-  void unscaleReducedLHS(mv_type& Y) const;
-
-  bool isEquilibrated() const { return UseEquilibration_; };
 
   //! Pointer to the matrix to be preconditioned.
   Teuchos::RCP<const row_matrix_type> A_unfiltered_;

--- a/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_decl.hpp
@@ -356,9 +356,13 @@ class AdditiveSchwarzFilter : public Ifpack2::Details::RowMatrix<MatrixType> {
   /// Used by both the constructor and updateMatrixValues().
   void fillLocalMatrix(local_matrix_type localMatrix);
 
+  //! Scale the reduced reordered right-hand side in place before the inner solve.
   void scaleReducedRHS(mv_type& B) const;
+
+  //! Undo solution scaling in place after the inner solve.
   void unscaleReducedLHS(mv_type& Y) const;
 
+  //! Whether row/column 1-norm equilibration is enabled.
   bool isEquilibrated() const { return UseEquilibration_; };
 
   //@}
@@ -387,6 +391,7 @@ class AdditiveSchwarzFilter : public Ifpack2::Details::RowMatrix<MatrixType> {
   static bool
   mapPairsAreFitted(const row_matrix_type& A);
 
+  //! Compute row/column 1-norm scaling factors for \c A_ and scale \c A_ in place.
   void computeAndApplyEquilibration();
 
   //! Pointer to the matrix to be preconditioned.
@@ -410,7 +415,10 @@ class AdditiveSchwarzFilter : public Ifpack2::Details::RowMatrix<MatrixType> {
   //! Row, col, domain and range map of this locally filtered matrix (it's square and non-distributed)
   Teuchos::RCP<const map_type> localMap_;
 
+  //! Whether to apply row/column 1-norm equilibration to the filtered local matrix \c A_.
   bool UseEquilibration_;
+
+  //! Cached row/column 1-norm scaling data for the current filtered local matrix \c A_.
   decltype(Tpetra::computeRowAndColumnOneNorms(
       std::declval<const crs_matrix_type&>(), false)) equilResult_;
 };

--- a/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_def.hpp
@@ -762,15 +762,17 @@ class ElementWiseDivide<ViewType1,
     using mag_type = typename KAT::mag_type;
     using KAM      = KokkosKernels::ArithTraits<mag_type>;
 
-    for (IndexType j = 0; j < static_cast<IndexType>(X_.extent(1)); ++j) {
-      if (takeAbsoluteValueOfScalingFactors) {
-        const mag_type scalFactAbs  = KAT::abs(scalingFactors_(i));
-        const mag_type scalFinalVal = takeSquareRootsOfScalingFactors ? KAM::sqrt(scalFactAbs) : scalFactAbs;
-        X_(i, j)                    = X_(i, j) / scalFinalVal;
-      } else {
-        const val_type scalFact     = scalingFactors_(i);
-        const val_type scalFinalVal = takeSquareRootsOfScalingFactors ? KAT::sqrt(scalFact) : scalFact;
-        X_(i, j)                    = X_(i, j) / scalFinalVal;
+    if (takeAbsoluteValueOfScalingFactors) {
+      const mag_type scalFactAbs  = KAT::abs(scalingFactors_(i));
+      const mag_type scalFinalVal = takeSquareRootsOfScalingFactors ? KAM::sqrt(scalFactAbs) : scalFactAbs;
+      for (IndexType j = 0; j < static_cast<IndexType>(X_.extent(1)); ++j) {
+        X_(i, j) = X_(i, j) / scalFinalVal;
+      }
+    } else {
+      const val_type scalFact     = scalingFactors_(i);
+      const val_type scalFinalVal = takeSquareRootsOfScalingFactors ? KAT::sqrt(scalFact) : scalFact;
+      for (IndexType j = 0; j < static_cast<IndexType>(X_.extent(1)); ++j) {
+        X_(i, j) = X_(i, j) / scalFinalVal;
       }
     }
   }

--- a/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_def.hpp
@@ -667,10 +667,8 @@ void AdditiveSchwarzFilter<MatrixType>::computeAndApplyEquilibration() {
 
   equilResult_ = Tpetra::computeRowAndColumnOneNorms(*A_, false);
 
-  using execution_space = typename crs_matrix_type::execution_space;
-  using range_type      = Kokkos::RangePolicy<execution_space, local_ordinal_type>;
-  using mag_type        = typename decltype(equilResult_)::mag_type;
-  using KAT             = KokkosKernels::ArithTraits<mag_type>;
+  using range_type = Kokkos::RangePolicy<execution_space, local_ordinal_type>;
+  using KAT        = KokkosKernels::ArithTraits<mag_type>;
 
   auto rowNorms = equilResult_.rowNorms;
   auto colScalingFactors =

--- a/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_def.hpp
@@ -661,14 +661,35 @@ bool AdditiveSchwarzFilter<MatrixType>::
   return map1.isLocallyFitted(map2);
 }
 
+namespace {  // anonymous
+
+template <class ViewType, class LO>
+void replaceZerosWithOnes(const ViewType& v) {
+  using execution_space = typename ViewType::device_type::execution_space;
+  using range_type      = Kokkos::RangePolicy<execution_space, LO>;
+  using value_type      = typename ViewType::non_const_value_type;
+  using KAT             = KokkosKernels::ArithTraits<value_type>;
+
+  const LO n = static_cast<LO>(v.extent(0));
+  Kokkos::parallel_for(
+      "Ifpack2::AdditiveSchwarzFilter::replaceZerosWithOnes",
+      range_type(0, n),
+      KOKKOS_LAMBDA(const LO i) {
+        if (v(i) == KAT::zero()) {
+          v(i) = KAT::one();
+        }
+      });
+}
+
+}  // end anonymous namespace
+
 template <class MatrixType>
 void AdditiveSchwarzFilter<MatrixType>::computeAndApplyEquilibration() {
   if (!UseEquilibration_) return;
 
   equilResult_ = Tpetra::computeRowAndColumnOneNorms(*A_, false);
 
-  using range_type = Kokkos::RangePolicy<execution_space, local_ordinal_type>;
-  using KAT        = KokkosKernels::ArithTraits<mag_type>;
+  using KAT = KokkosKernels::ArithTraits<mag_type>;
 
   auto rowNorms = equilResult_.rowNorms;
   auto colScalingFactors =
@@ -684,20 +705,13 @@ void AdditiveSchwarzFilter<MatrixType>::computeAndApplyEquilibration() {
     return;
   }
 
-  const local_ordinal_type numRows =
-      static_cast<local_ordinal_type>(rowNorms.extent(0));
-
-  Kokkos::parallel_for(
-      "Ifpack2::AdditiveSchwarzFilter::sanitizeNorms",
-      range_type(0, numRows),
-      KOKKOS_LAMBDA(const local_ordinal_type i) {
-        if (rowNorms(i) == KAT::zero()) {
-          rowNorms(i) = KAT::one();
-        }
-        if (colScalingFactors(i) == KAT::zero()) {
-          colScalingFactors(i) = KAT::one();
-        }
-      });
+  // Tpetra's scaling helpers leave division-by-zero handling to the caller.
+  // Replace any zero scaling factors by one so that those rows/columns are left
+  // unchanged by equilibration.
+  if (equilResult_.foundZeroRowNorm) {
+    replaceZerosWithOnes<decltype(rowNorms), local_ordinal_type>(rowNorms);
+  }
+  replaceZerosWithOnes<decltype(colScalingFactors), local_ordinal_type>(colScalingFactors);
 
   Tpetra::leftAndOrRightScaleCrsMatrix(*A_,
                                        equilResult_.rowNorms,

--- a/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_def.hpp
@@ -12,6 +12,8 @@
 
 #include "Ifpack2_Details_AdditiveSchwarzFilter_decl.hpp"
 #include "Ifpack2_Details_Behavior.hpp"
+#include "Tpetra_computeRowAndColumnOneNorms.hpp"
+#include "Tpetra_leftAndOrRightScaleCrsMatrix.hpp"
 #include "KokkosKernels_Sorting.hpp"
 #include "KokkosSparse_SortCrs.hpp"
 #include "Kokkos_Bitset.hpp"
@@ -24,8 +26,9 @@ AdditiveSchwarzFilter<MatrixType>::
     AdditiveSchwarzFilter(const Teuchos::RCP<const row_matrix_type>& A_unfiltered,
                           const Teuchos::ArrayRCP<local_ordinal_type>& perm,
                           const Teuchos::ArrayRCP<local_ordinal_type>& reverseperm,
-                          bool filterSingletons) {
-  setup(A_unfiltered, perm, reverseperm, filterSingletons);
+                          bool filterSingletons,
+                          bool useEquilibration) {
+  setup(A_unfiltered, perm, reverseperm, filterSingletons, useEquilibration);
 }
 
 template <class MatrixType>
@@ -33,7 +36,8 @@ void AdditiveSchwarzFilter<MatrixType>::
     setup(const Teuchos::RCP<const row_matrix_type>& A_unfiltered,
           const Teuchos::ArrayRCP<local_ordinal_type>& perm,
           const Teuchos::ArrayRCP<local_ordinal_type>& reverseperm,
-          bool filterSingletons) {
+          bool filterSingletons,
+          bool useEquilibration) {
   using Teuchos::RCP;
   using Teuchos::rcp;
   using Teuchos::rcp_dynamic_cast;
@@ -263,6 +267,11 @@ void AdditiveSchwarzFilter<MatrixType>::
   // It also needs to compute local constants (maxNumRowEntries) but this should be a
   // cheap operation relative to what this constructor already did.
   A_ = rcp(new crs_matrix_type(localMap_, localMap_, localMatrix, crsParams));
+
+  UseEquilibration_ = useEquilibration;
+  if (UseEquilibration_) {
+    computeAndApplyEquilibration();
+  }
 }
 
 template <class MatrixType>
@@ -275,6 +284,10 @@ void AdditiveSchwarzFilter<MatrixType>::updateMatrixValues() {
   // Copy new values from A_unfiltered to the local matrix, and then reconstruct A_.
   fillLocalMatrix(localMatrix);
   A_->setAllValues(localMatrix.graph.row_map, localMatrix.graph.entries, localMatrix.values);
+
+  if (UseEquilibration_) {
+    computeAndApplyEquilibration();
+  }
 }
 
 template <class MatrixType>
@@ -646,6 +659,43 @@ template <class MatrixType>
 bool AdditiveSchwarzFilter<MatrixType>::
     mapPairIsFitted(const map_type& map1, const map_type& map2) {
   return map1.isLocallyFitted(map2);
+}
+
+template <class MatrixType>
+void AdditiveSchwarzFilter<MatrixType>::computeAndApplyEquilibration() {
+  if (!UseEquilibration_) return;
+
+  equilResult_           = Tpetra::computeRowAndColumnOneNorms(*A_, false);
+  auto colScalingFactors = equilResult_.assumeSymmetric
+                               ? equilResult_.colNorms
+                               : equilResult_.rowScaledColNorms;
+
+  Tpetra::leftAndOrRightScaleCrsMatrix(*A_,
+                                       equilResult_.rowNorms,
+                                       colScalingFactors,
+                                       true,
+                                       true,
+                                       equilResult_.assumeSymmetric,
+                                       Tpetra::SCALING_DIVIDE);
+}
+
+template <class MatrixType>
+void AdditiveSchwarzFilter<MatrixType>::scaleReducedRHS(mv_type& B) const {
+  if (!UseEquilibration_) return;
+  const bool takeSquareRootsOfScalingFactors = false;
+  elementWiseDivideMultiVector(B, equilResult_.rowNorms,
+                               takeSquareRootsOfScalingFactors);
+}
+
+template <class MatrixType>
+void AdditiveSchwarzFilter<MatrixType>::unscaleReducedLHS(mv_type& Y) const {
+  if (!UseEquilibration_) return;
+  auto colScalingFactors =
+      equilResult_.assumeSymmetric ? equilResult_.colNorms
+                                   : equilResult_.rowScaledColNorms;
+  const bool takeSquareRootsOfScalingFactors = false;
+  elementWiseDivideMultiVector(Y, colScalingFactors,
+                               takeSquareRootsOfScalingFactors);
 }
 
 }  // namespace Details

--- a/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_def.hpp
@@ -665,10 +665,41 @@ template <class MatrixType>
 void AdditiveSchwarzFilter<MatrixType>::computeAndApplyEquilibration() {
   if (!UseEquilibration_) return;
 
-  equilResult_           = Tpetra::computeRowAndColumnOneNorms(*A_, false);
-  auto colScalingFactors = equilResult_.assumeSymmetric
-                               ? equilResult_.colNorms
-                               : equilResult_.rowScaledColNorms;
+  equilResult_ = Tpetra::computeRowAndColumnOneNorms(*A_, false);
+
+  using execution_space = typename crs_matrix_type::execution_space;
+  using range_type      = Kokkos::RangePolicy<execution_space, local_ordinal_type>;
+  using mag_type        = typename decltype(equilResult_)::mag_type;
+  using KAT             = KokkosKernels::ArithTraits<mag_type>;
+
+  auto rowNorms = equilResult_.rowNorms;
+  auto colScalingFactors =
+      equilResult_.assumeSymmetric ? equilResult_.colNorms
+                                   : equilResult_.rowScaledColNorms;
+
+  // If the matrix contains NaN or Inf, disable equilibration by replacing all
+  // scaling factors with one.  This avoids introducing more NaN/Inf values by
+  // dividing through invalid scaling factors.
+  if (equilResult_.foundNan || equilResult_.foundInf) {
+    Kokkos::deep_copy(rowNorms, KAT::one());
+    Kokkos::deep_copy(colScalingFactors, KAT::one());
+    return;
+  }
+
+  const local_ordinal_type numRows =
+      static_cast<local_ordinal_type>(rowNorms.extent(0));
+
+  Kokkos::parallel_for(
+      "Ifpack2::AdditiveSchwarzFilter::sanitizeNorms",
+      range_type(0, numRows),
+      KOKKOS_LAMBDA(const local_ordinal_type i) {
+        if (rowNorms(i) == KAT::zero()) {
+          rowNorms(i) = KAT::one();
+        }
+        if (colScalingFactors(i) == KAT::zero()) {
+          colScalingFactors(i) = KAT::one();
+        }
+      });
 
   Tpetra::leftAndOrRightScaleCrsMatrix(*A_,
                                        equilResult_.rowNorms,

--- a/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_AdditiveSchwarzFilter_def.hpp
@@ -679,6 +679,186 @@ void AdditiveSchwarzFilter<MatrixType>::computeAndApplyEquilibration() {
                                        Tpetra::SCALING_DIVIDE);
 }
 
+namespace {
+template <class ViewType1,
+          class ViewType2,
+          class IndexType,
+          const bool takeSquareRootsOfScalingFactors,
+          const bool takeAbsoluteValueOfScalingFactors =
+              !std::is_same<
+                  typename KokkosKernels::ArithTraits<
+                      typename ViewType1::non_const_value_type>::mag_type,
+                  typename ViewType2::non_const_value_type>::value,
+          const int rank = ViewType1::rank>
+class ElementWiseDivide {
+};
+template <class ViewType1,
+          class ViewType2,
+          class IndexType,
+          const bool takeSquareRootsOfScalingFactors,
+          const bool takeAbsoluteValueOfScalingFactors>
+class ElementWiseDivide<ViewType1,
+                        ViewType2,
+                        IndexType,
+                        takeSquareRootsOfScalingFactors,
+                        takeAbsoluteValueOfScalingFactors,
+                        1> {
+ public:
+  static_assert(ViewType1::rank == 1,
+                "ViewType1 must be a rank-1 "
+                "Kokkos::View in order to use this specialization.");
+
+  ElementWiseDivide(const ViewType1& X,
+                    const ViewType2& scalingFactors)
+    : X_(X)
+    , scalingFactors_(scalingFactors) {}
+
+  KOKKOS_INLINE_FUNCTION void operator()(const IndexType i) const {
+    using val_type = typename ViewType2::non_const_value_type;
+    using KAT      = KokkosKernels::ArithTraits<val_type>;
+    using mag_type = typename KAT::mag_type;
+    using KAM      = KokkosKernels::ArithTraits<mag_type>;
+
+    if (takeAbsoluteValueOfScalingFactors) {
+      const mag_type scalFactAbs  = KAT::abs(scalingFactors_(i));
+      const mag_type scalFinalVal = takeSquareRootsOfScalingFactors ? KAM::sqrt(scalFactAbs) : scalFactAbs;
+      X_(i)                       = X_(i) / scalFinalVal;
+    } else {
+      const val_type scalFact     = scalingFactors_(i);
+      const val_type scalFinalVal = takeSquareRootsOfScalingFactors ? KAT::sqrt(scalFact) : scalFact;
+      X_(i)                       = X_(i) / scalFinalVal;
+    }
+  }
+
+ private:
+  ViewType1 X_;
+  typename ViewType2::const_type scalingFactors_;
+};
+
+template <class ViewType1,
+          class ViewType2,
+          class IndexType,
+          const bool takeSquareRootsOfScalingFactors,
+          const bool takeAbsoluteValueOfScalingFactors>
+class ElementWiseDivide<ViewType1,
+                        ViewType2,
+                        IndexType,
+                        takeSquareRootsOfScalingFactors,
+                        takeAbsoluteValueOfScalingFactors,
+                        2> {
+ public:
+  static_assert(ViewType1::rank == 2,
+                "ViewType1 must be a rank-2 "
+                "Kokkos::View in order to use this specialization.");
+
+  ElementWiseDivide(const ViewType1& X,
+                    const ViewType2& scalingFactors)
+    : X_(X)
+    , scalingFactors_(scalingFactors) {}
+
+  KOKKOS_INLINE_FUNCTION void operator()(const IndexType i) const {
+    using val_type = typename ViewType2::non_const_value_type;
+    using KAT      = KokkosKernels::ArithTraits<val_type>;
+    using mag_type = typename KAT::mag_type;
+    using KAM      = KokkosKernels::ArithTraits<mag_type>;
+
+    for (IndexType j = 0; j < static_cast<IndexType>(X_.extent(1)); ++j) {
+      if (takeAbsoluteValueOfScalingFactors) {
+        const mag_type scalFactAbs  = KAT::abs(scalingFactors_(i));
+        const mag_type scalFinalVal = takeSquareRootsOfScalingFactors ? KAM::sqrt(scalFactAbs) : scalFactAbs;
+        X_(i, j)                    = X_(i, j) / scalFinalVal;
+      } else {
+        const val_type scalFact     = scalingFactors_(i);
+        const val_type scalFinalVal = takeSquareRootsOfScalingFactors ? KAT::sqrt(scalFact) : scalFact;
+        X_(i, j)                    = X_(i, j) / scalFinalVal;
+      }
+    }
+  }
+
+ private:
+  ViewType1 X_;
+  typename ViewType2::const_type scalingFactors_;
+};
+
+template <class MultiVectorViewType,
+          class ScalingFactorsViewType,
+          class IndexType>
+void elementWiseDivide(const MultiVectorViewType& X,
+                       const ScalingFactorsViewType& scalingFactors,
+                       const IndexType numRows,
+                       const bool takeSquareRootsOfScalingFactors,
+                       const bool takeAbsoluteValueOfScalingFactors =
+                           !std::is_same<
+                               typename KokkosKernels::ArithTraits<
+                                   typename MultiVectorViewType::non_const_value_type>::mag_type,
+                               typename ScalingFactorsViewType::non_const_value_type>::value) {
+  using execution_space = typename MultiVectorViewType::device_type::execution_space;
+  using range_type      = Kokkos::RangePolicy<execution_space, IndexType>;
+
+  if (takeAbsoluteValueOfScalingFactors) {
+    constexpr bool takeAbsVal = true;
+    if (takeSquareRootsOfScalingFactors) {
+      constexpr bool takeSquareRoots = true;
+      using functor_type             = ElementWiseDivide<MultiVectorViewType,
+                                             ScalingFactorsViewType, IndexType, takeSquareRoots, takeAbsVal>;
+      Kokkos::parallel_for("elementWiseDivide",
+                           range_type(0, numRows),
+                           functor_type(X, scalingFactors));
+    } else {
+      constexpr bool takeSquareRoots = false;
+      using functor_type             = ElementWiseDivide<MultiVectorViewType,
+                                             ScalingFactorsViewType, IndexType, takeSquareRoots, takeAbsVal>;
+      Kokkos::parallel_for("elementWiseDivide",
+                           range_type(0, numRows),
+                           functor_type(X, scalingFactors));
+    }
+  } else {
+    constexpr bool takeAbsVal = false;
+    if (takeSquareRootsOfScalingFactors) {
+      constexpr bool takeSquareRoots = true;
+      using functor_type             = ElementWiseDivide<MultiVectorViewType,
+                                             ScalingFactorsViewType, IndexType, takeSquareRoots, takeAbsVal>;
+      Kokkos::parallel_for("elementWiseDivide",
+                           range_type(0, numRows),
+                           functor_type(X, scalingFactors));
+    } else {
+      constexpr bool takeSquareRoots = false;
+      using functor_type             = ElementWiseDivide<MultiVectorViewType,
+                                             ScalingFactorsViewType, IndexType, takeSquareRoots, takeAbsVal>;
+      Kokkos::parallel_for("elementWiseDivide",
+                           range_type(0, numRows),
+                           functor_type(X, scalingFactors));
+    }
+  }
+}
+
+template <class MultiVectorType, class ScalingFactorsViewType>
+void elementWiseDivideMultiVector(MultiVectorType& X,
+                                  const ScalingFactorsViewType& scalingFactors,
+                                  const bool takeSquareRootsOfScalingFactors,
+                                  const bool takeAbsoluteValueOfScalingFactors =
+                                      !std::is_same<
+                                          typename KokkosKernels::ArithTraits<
+                                              typename MultiVectorType::scalar_type>::mag_type,
+                                          typename ScalingFactorsViewType::non_const_value_type>::value) {
+  using index_type            = typename MultiVectorType::local_ordinal_type;
+  const index_type lclNumRows = static_cast<index_type>(X.getLocalLength());
+
+  auto X_lcl = X.getLocalViewDevice(Tpetra::Access::ReadWrite);
+  if (static_cast<std::size_t>(X.getNumVectors()) == std::size_t(1)) {
+    using pair_type = Kokkos::pair<index_type, index_type>;
+    auto X_lcl_1d   = Kokkos::subview(X_lcl, pair_type(0, lclNumRows), 0);
+    elementWiseDivide(X_lcl_1d, scalingFactors, lclNumRows,
+                      takeSquareRootsOfScalingFactors,
+                      takeAbsoluteValueOfScalingFactors);
+  } else {
+    elementWiseDivide(X_lcl, scalingFactors, lclNumRows,
+                      takeSquareRootsOfScalingFactors,
+                      takeAbsoluteValueOfScalingFactors);
+  }
+}
+}  // namespace
+
 template <class MatrixType>
 void AdditiveSchwarzFilter<MatrixType>::scaleReducedRHS(mv_type& B) const {
   if (!UseEquilibration_) return;

--- a/packages/ifpack2/test/belos/CMakeLists.txt
+++ b/packages/ifpack2/test/belos/CMakeLists.txt
@@ -85,6 +85,7 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(Ifpack2BelosCopyFiles
   test_4_RILUK_4streams_nos1_hb.xml
   test_4_RILUK_2streams_rcm_nos1_hb.xml
   test_4_RILUK_4streams_rcm_nos1_hb.xml
+  test_schwarz_equil_nos1_hb.xml
   test_schwarz_RILUK_2streams_rcb_nos1_hb.xml
   test_schwarz_RILUK_4streams_rcb_nos1_hb.xml
   test_Jacobi_coords_nos1_hb.xml
@@ -464,6 +465,15 @@ TRIBITS_ADD_TEST(
   ARGS "--xml_file=test_4_RILUK_4streams_rcm_nos1_hb.xml"
   COMM serial mpi
   NUM_MPI_PROCS 4
+  STANDARD_PASS_OUTPUT
+)
+
+TRIBITS_ADD_TEST(
+  tif_belos
+  NAME SCHWARZ_RILUK_equil_hb_belos
+  ARGS "--xml_file=test_schwarz_equil_nos1_hb.xml"
+  COMM serial mpi
+  NUM_MPI_PROCS 2
   STANDARD_PASS_OUTPUT
 )
 

--- a/packages/ifpack2/test/belos/test_schwarz_equil_nos1_hb.xml
+++ b/packages/ifpack2/test/belos/test_schwarz_equil_nos1_hb.xml
@@ -1,0 +1,31 @@
+<ParameterList name="test_params">
+  <Parameter name="hb_file" type="string" value="nos1.rsa"/>
+
+  <Parameter name="solver_type" type="string" value="PseudoBlockGmres"/>
+  <ParameterList name="Belos">
+    <!-- "Num Blocks" is the krylov subspace size, or iters-per-restart. -->
+    <Parameter name="Num Blocks" type="int" value="300"/>
+    <Parameter name="Verbosity" type="int" value="33"/>
+    <Parameter name="Maximum Iterations" type="int" value="1000"/>
+    <Parameter name="Maximum Restarts" type="int" value="20"/>
+    <Parameter name="Orthogonalization" type="string" value="ICGS"/>
+    <Parameter name="Output Style" type="int" value="1"/>
+    <Parameter name="Output Frequency" type="int" value="1"/>
+    <Parameter name="Convergence Tolerance" type="double" value="1e-06"/>
+  </ParameterList>
+
+  <Parameter name="Preconditioner Side" type="string" value="Right"/>
+  <Parameter name="Ifpack2::Preconditioner" type="string" value="SCHWARZ"/>
+  <ParameterList name="Ifpack2">
+    <Parameter name="schwarz: overlap level" type="int" value="0"/>
+    <Parameter name="schwarz: combine mode" type="string" value="ZERO"/>
+    <Parameter name="schwarz: use reordering" type="bool" value="false"/>
+    <Parameter name="schwarz: subdomain 1-norm equilibration" type="bool" value="true"/>
+    <Parameter name="subdomain solver name" type="string" value="RILUK"/>
+    <ParameterList name="subdomain solver parameters">
+      <Parameter name="fact: iluk level-of-fill" type="int" value="2"/>
+    </ParameterList>
+  </ParameterList>
+
+  <Parameter name="expectNumIters" type="int" value="300"/>
+</ParameterList>

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
@@ -1450,6 +1450,132 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, FastILDL, Scalar, Loca
   TEST_COMPARE_FLOATING_ARRAYS(yview, zview, 4 * STS::eps());
 }
 
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, EquilNoOverlap, Scalar, LO, GO) {
+  typedef Tpetra::CrsMatrix<Scalar, LO, GO, Node> crs_matrix_type;
+  typedef Tpetra::Map<LO, GO, Node> map_type;
+  typedef Tpetra::MultiVector<Scalar, LO, GO, Node> MV;
+  typedef Tpetra::RowMatrix<Scalar, LO, GO, Node> row_matrix_type;
+  typedef Teuchos::ScalarTraits<Scalar> STS;
+
+  out << "Ifpack2::AdditiveSchwarz: EquilNoOverlap" << endl;
+  Teuchos::OSTab tab1(out);
+
+  const Tpetra::global_size_t num_rows_per_proc = 10;
+
+  RCP<const map_type> rowmap =
+      tif_utest::create_tpetra_map<LO, GO, Node>(num_rows_per_proc);
+  RCP<const crs_matrix_type> crsmatrix =
+      tif_utest::create_banded_matrix<Scalar, LO, GO, Node>(rowmap, 3);
+
+  // Input vector
+  MV x(rowmap, 2);
+  x.randomize();
+
+  // Parameters without equilibration
+  Teuchos::ParameterList paramsBase;
+  paramsBase.set("inner preconditioner name", "DENSE");
+  paramsBase.set("schwarz: overlap level", 0);
+  paramsBase.set("schwarz: combine mode", "ZERO");
+  paramsBase.set("schwarz: use reordering", false);
+  paramsBase.set("schwarz: subdomain 1-norm equilibration", false);
+
+  // Parameters with equilibration
+  Teuchos::ParameterList paramsEquil = paramsBase;
+  paramsEquil.set("schwarz: subdomain 1-norm equilibration", true);
+
+  Ifpack2::AdditiveSchwarz<row_matrix_type> precBase(crsmatrix);
+  Ifpack2::AdditiveSchwarz<row_matrix_type> precEquil(crsmatrix);
+
+  TEST_NOTHROW(precBase.setParameters(paramsBase));
+  TEST_NOTHROW(precEquil.setParameters(paramsEquil));
+
+  TEST_NOTHROW(precBase.initialize());
+  TEST_NOTHROW(precEquil.initialize());
+
+  TEST_NOTHROW(precBase.compute());
+  TEST_NOTHROW(precEquil.compute());
+
+  MV yBase(rowmap, 2), yEquil(rowmap, 2);
+
+  TEST_NOTHROW(precBase.apply(x, yBase));
+  TEST_NOTHROW(precEquil.apply(x, yEquil));
+
+  Teuchos::ArrayRCP<const Scalar> yBaseView  = yBase.get1dView();
+  Teuchos::ArrayRCP<const Scalar> yEquilView = yEquil.get1dView();
+
+  TEST_COMPARE_FLOATING_ARRAYS(
+      yBaseView, yEquilView,
+      100 * STS::eps());
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, EquilReorder, Scalar, LO, GO) {
+  typedef Tpetra::CrsMatrix<Scalar, LO, GO, Node> crs_matrix_type;
+  typedef Tpetra::Map<LO, GO, Node> map_type;
+  typedef Tpetra::MultiVector<Scalar, LO, GO, Node> MV;
+  typedef Tpetra::RowMatrix<Scalar, LO, GO, Node> row_matrix_type;
+  typedef Teuchos::ScalarTraits<Scalar> STS;
+
+  out << "Ifpack2::AdditiveSchwarz: EquilReorder" << endl;
+  Teuchos::OSTab tab1(out);
+
+  const Tpetra::global_size_t num_rows_per_proc = 10;
+
+  RCP<const map_type> rowmap =
+      tif_utest::create_tpetra_map<LO, GO, Node>(num_rows_per_proc);
+
+  // Use a matrix with some off-diagonal structure so overlap/reordering matter.
+  RCP<const crs_matrix_type> crsmatrix =
+      tif_utest::create_banded_matrix<Scalar, LO, GO, Node>(rowmap, 5);
+
+  MV x(rowmap, 2);
+  x.randomize();
+
+  Teuchos::ParameterList paramsBase;
+  paramsBase.set("inner preconditioner name", "DENSE");
+  paramsBase.set("schwarz: overlap level", 1);
+  paramsBase.set("schwarz: combine mode", "ZERO");
+  paramsBase.set("schwarz: subdomain 1-norm equilibration", false);
+
+#if defined(HAVE_IFPACK2_XPETRA) && defined(HAVE_IFPACK2_ZOLTAN2)
+  paramsBase.set("schwarz: use reordering", true);
+  {
+    Teuchos::ParameterList zlist;
+    zlist.set("order_method", "rcm");
+    zlist.set("order_method_type", "local");
+    paramsBase.set("schwarz: reordering list", zlist);
+  }
+#else
+  paramsBase.set("schwarz: use reordering", false);
+#endif
+
+  Teuchos::ParameterList paramsEquil = paramsBase;
+  paramsEquil.set("schwarz: subdomain 1-norm equilibration", true);
+
+  Ifpack2::AdditiveSchwarz<row_matrix_type> precBase(crsmatrix);
+  Ifpack2::AdditiveSchwarz<row_matrix_type> precEquil(crsmatrix);
+
+  TEST_NOTHROW(precBase.setParameters(paramsBase));
+  TEST_NOTHROW(precEquil.setParameters(paramsEquil));
+
+  TEST_NOTHROW(precBase.initialize());
+  TEST_NOTHROW(precEquil.initialize());
+
+  TEST_NOTHROW(precBase.compute());
+  TEST_NOTHROW(precEquil.compute());
+
+  MV yBase(rowmap, 2), yEquil(rowmap, 2);
+
+  TEST_NOTHROW(precBase.apply(x, yBase));
+  TEST_NOTHROW(precEquil.apply(x, yEquil));
+
+  Teuchos::ArrayRCP<const Scalar> yBaseView  = yBase.get1dView();
+  Teuchos::ArrayRCP<const Scalar> yEquilView = yEquil.get1dView();
+
+  TEST_COMPARE_FLOATING_ARRAYS(
+      yBaseView, yEquilView,
+      200 * STS::eps());
+}
+
 #if defined(HAVE_IFPACK2_AMESOS2) and defined(HAVE_IFPACK2_XPETRA) and (defined(HAVE_AMESOS2_SUPERLU) || defined(HAVE_AMESOS2_KLU2))
 
 #define IFPACK2_AMESOS2_SUPERLU_SCALAR_ORDINAL(Scalar, LocalOrdinal, GlobalOrdinal) \
@@ -1479,6 +1605,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, FastILDL, Scalar, Loca
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(Ifpack2AdditiveSchwarz, ILU_NonOverlap, Scalar, LocalOrdinal, GlobalOrdinal)     \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(Ifpack2AdditiveSchwarz, SGS_NonOverlap, Scalar, LocalOrdinal, GlobalOrdinal)     \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(Ifpack2AdditiveSchwarz, SGS_Overlap, Scalar, LocalOrdinal, GlobalOrdinal)        \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(Ifpack2AdditiveSchwarz, EquilNoOverlap, Scalar, LocalOrdinal, GlobalOrdinal)     \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(Ifpack2AdditiveSchwarz, EquilReorder, Scalar, LocalOrdinal, GlobalOrdinal)       \
   IFPACK2_AMESOS2_SUPERLU_SCALAR_ORDINAL(Scalar, LocalOrdinal, GlobalOrdinal)                                           \
   IFPACK2_FASTILU_SCALAR_ORDINAL(Scalar, LocalOrdinal, GlobalOrdinal)
 

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
@@ -40,6 +40,7 @@
 #include "Tpetra_RowMatrix.hpp"
 #include "Teuchos_CommHelpers.hpp"
 #include "MatrixMarket_Tpetra.hpp"
+#include "Tpetra_leftAndOrRightScaleCrsMatrix.hpp"
 
 namespace {  // (anonymous)
 
@@ -1450,131 +1451,154 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, FastILDL, Scalar, Loca
   TEST_COMPARE_FLOATING_ARRAYS(yview, zview, 4 * STS::eps());
 }
 
-TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, EquilNoOverlap, Scalar, LO, GO) {
+#ifdef HAVE_IFPACK2_XPETRA
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, EquilImprovesParIlutOnNonsymScaledTriDiag, Scalar, LO, GO) {
   typedef Tpetra::CrsMatrix<Scalar, LO, GO, Node> crs_matrix_type;
   typedef Tpetra::Map<LO, GO, Node> map_type;
   typedef Tpetra::MultiVector<Scalar, LO, GO, Node> MV;
+  typedef Tpetra::Vector<Scalar, LO, GO, Node> vec_type;
   typedef Tpetra::RowMatrix<Scalar, LO, GO, Node> row_matrix_type;
   typedef Teuchos::ScalarTraits<Scalar> STS;
+  typedef typename STS::magnitudeType mag_type;
 
-  out << "Ifpack2::AdditiveSchwarz: EquilNoOverlap" << endl;
+  using Teuchos::ParameterList;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  out << "Ifpack2::AdditiveSchwarz: EquilImprovesParIlutOnNonsymScaledTriDiag" << endl;
   Teuchos::OSTab tab1(out);
 
-  const Tpetra::global_size_t num_rows_per_proc = 10;
-
+  const Tpetra::global_size_t num_rows_per_proc = 50;
   RCP<const map_type> rowmap =
       tif_utest::create_tpetra_map<LO, GO, Node>(num_rows_per_proc);
-  RCP<const crs_matrix_type> crsmatrix =
-      tif_utest::create_banded_matrix<Scalar, LO, GO, Node>(rowmap, 3);
+  auto A = Teuchos::rcp_const_cast<crs_matrix_type>(tif_utest::create_test_matrix<Scalar, LO, GO, Node>(rowmap));
 
-  // Input vector
-  MV x(rowmap, 2);
-  x.randomize();
-
-  // Parameters without equilibration
-  Teuchos::ParameterList paramsBase;
-  paramsBase.set("inner preconditioner name", "DENSE");
-  paramsBase.set("schwarz: overlap level", 0);
-  paramsBase.set("schwarz: combine mode", "ZERO");
-  paramsBase.set("schwarz: use reordering", false);
-  paramsBase.set("schwarz: subdomain 1-norm equilibration", false);
-
-  // Parameters with equilibration
-  Teuchos::ParameterList paramsEquil = paramsBase;
-  paramsEquil.set("schwarz: subdomain 1-norm equilibration", true);
-
-  Ifpack2::AdditiveSchwarz<row_matrix_type> precBase(crsmatrix);
-  Ifpack2::AdditiveSchwarz<row_matrix_type> precEquil(crsmatrix);
-
-  TEST_NOTHROW(precBase.setParameters(paramsBase));
-  TEST_NOTHROW(precEquil.setParameters(paramsEquil));
-
-  TEST_NOTHROW(precBase.initialize());
-  TEST_NOTHROW(precEquil.initialize());
-
-  TEST_NOTHROW(precBase.compute());
-  TEST_NOTHROW(precEquil.compute());
-
-  MV yBase(rowmap, 2), yEquil(rowmap, 2);
-
-  TEST_NOTHROW(precBase.apply(x, yBase));
-  TEST_NOTHROW(precEquil.apply(x, yEquil));
-
-  Teuchos::ArrayRCP<const Scalar> yBaseView  = yBase.get1dView();
-  Teuchos::ArrayRCP<const Scalar> yEquilView = yEquil.get1dView();
-
-  TEST_COMPARE_FLOATING_ARRAYS(
-      yBaseView, yEquilView,
-      100 * STS::eps());
-}
-
-TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, EquilReorder, Scalar, LO, GO) {
-  typedef Tpetra::CrsMatrix<Scalar, LO, GO, Node> crs_matrix_type;
-  typedef Tpetra::Map<LO, GO, Node> map_type;
-  typedef Tpetra::MultiVector<Scalar, LO, GO, Node> MV;
-  typedef Tpetra::RowMatrix<Scalar, LO, GO, Node> row_matrix_type;
-  typedef Teuchos::ScalarTraits<Scalar> STS;
-
-  out << "Ifpack2::AdditiveSchwarz: EquilReorder" << endl;
-  Teuchos::OSTab tab1(out);
-
-  const Tpetra::global_size_t num_rows_per_proc = 10;
-
-  RCP<const map_type> rowmap =
-      tif_utest::create_tpetra_map<LO, GO, Node>(num_rows_per_proc);
-
-  // Use a matrix with some off-diagonal structure so overlap/reordering matter.
-  RCP<const crs_matrix_type> crsmatrix =
-      tif_utest::create_banded_matrix<Scalar, LO, GO, Node>(rowmap, 5);
-
-  MV x(rowmap, 2);
-  x.randomize();
-
-  Teuchos::ParameterList paramsBase;
-  paramsBase.set("inner preconditioner name", "DENSE");
-  paramsBase.set("schwarz: overlap level", 1);
-  paramsBase.set("schwarz: combine mode", "ZERO");
-  paramsBase.set("schwarz: subdomain 1-norm equilibration", false);
-
-#if defined(HAVE_IFPACK2_XPETRA) && defined(HAVE_IFPACK2_ZOLTAN2)
-  paramsBase.set("schwarz: use reordering", true);
+  // Apply nonsymmetric scaling: A <- D_left * A * D_right.
+  vec_type dLeft(rowmap), dRight(rowmap);
   {
-    Teuchos::ParameterList zlist;
-    zlist.set("order_method", "rcm");
-    zlist.set("order_method_type", "local");
-    paramsBase.set("schwarz: reordering list", zlist);
+    auto dLeftView  = dLeft.getLocalViewHost(Tpetra::Access::ReadWrite);
+    auto dRightView = dRight.getLocalViewHost(Tpetra::Access::ReadWrite);
+
+    const GO indexBase     = rowmap->getIndexBase();
+    const GO globalNumRows = static_cast<GO>(rowmap->getGlobalNumElements());
+
+    for (LO lclRow = 0; lclRow < static_cast<LO>(rowmap->getLocalNumElements()); ++lclRow) {
+      const GO gblRow = rowmap->getGlobalElement(lclRow);
+      const double t =
+          (globalNumRows <= 1) ? 0.0 : double(gblRow - indexBase) / double(globalNumRows - 1);
+
+      // Opposing scalings induce strong row/column imbalance.
+      const double leftExponent  = -6.0 + 12.0 * t;
+      const double rightExponent = 6.0 + 12.0 * t;
+
+      dLeftView(lclRow, 0)  = Scalar(std::pow(10.0, leftExponent));
+      dRightView(lclRow, 0) = Scalar(std::pow(10.0, rightExponent));
+    }
   }
-#else
-  paramsBase.set("schwarz: use reordering", false);
+
+  {
+    auto dLeft2d  = dLeft.getLocalViewDevice(Tpetra::Access::ReadOnly);
+    auto dRight2d = dRight.getLocalViewDevice(Tpetra::Access::ReadOnly);
+    auto dLeft1d  = Kokkos::subview(dLeft2d, Kokkos::ALL(), 0);
+    auto dRight1d = Kokkos::subview(dRight2d, Kokkos::ALL(), 0);
+    // A <- D_left * A * D_right
+    TEST_NOTHROW(
+        Tpetra::leftAndOrRightScaleCrsMatrix(
+            *A, dLeft1d, dRight1d,
+            true, true, false, Tpetra::SCALING_MULTIPLY));
+  }
+
+  // Random RHS exposes approximation-quality differences.
+  MV b(rowmap, 1);
+  b.randomize();
+
+  for (const int overlapLevel : {0, 1}) {
+    if (rowmap->getComm()->getSize() == 1 && overlapLevel > 0) {
+      out << "Skipping overlap > 0 case in serial." << endl;
+      continue;
+    }
+
+    for (const bool useReordering : {false, true}) {
+#if !defined(HAVE_IFPACK2_ZOLTAN2)
+      if (useReordering) {
+        continue;
+      }
 #endif
 
-  Teuchos::ParameterList paramsEquil = paramsBase;
-  paramsEquil.set("schwarz: subdomain 1-norm equilibration", true);
+      out << "Case: overlap = " << overlapLevel
+          << ", useReordering = " << std::boolalpha << useReordering
+          << endl;
 
-  Ifpack2::AdditiveSchwarz<row_matrix_type> precBase(crsmatrix);
-  Ifpack2::AdditiveSchwarz<row_matrix_type> precEquil(crsmatrix);
+      ParameterList paramsBase;
+      paramsBase.set("subdomain solver name", "RILUK");
+      paramsBase.set("schwarz: overlap level", overlapLevel);
+      paramsBase.set("schwarz: combine mode", "ZERO");
+      paramsBase.set("schwarz: use reordering", useReordering);
+      paramsBase.set("schwarz: zero starting solution", true);
+      paramsBase.set("schwarz: subdomain 1-norm equilibration", false);
 
-  TEST_NOTHROW(precBase.setParameters(paramsBase));
-  TEST_NOTHROW(precEquil.setParameters(paramsEquil));
+#if defined(HAVE_IFPACK2_XPETRA) && defined(HAVE_IFPACK2_ZOLTAN2)
+      if (useReordering) {
+        ParameterList zlist;
+        zlist.set("order_method", "rcm");
+        zlist.set("order_method_type", "local");
+        paramsBase.set("schwarz: reordering list", zlist);
+      }
+#endif
 
-  TEST_NOTHROW(precBase.initialize());
-  TEST_NOTHROW(precEquil.initialize());
+      ParameterList paramsEquil = paramsBase;
+      paramsEquil.set("schwarz: subdomain 1-norm equilibration", true);
 
-  TEST_NOTHROW(precBase.compute());
-  TEST_NOTHROW(precEquil.compute());
+      // No equilibration run
+      Ifpack2::AdditiveSchwarz<row_matrix_type> precBase(A);
 
-  MV yBase(rowmap, 2), yEquil(rowmap, 2);
+      TEST_NOTHROW(precBase.setParameters(paramsBase));
+      TEST_NOTHROW(precBase.initialize());
+      TEST_NOTHROW(precBase.compute());
 
-  TEST_NOTHROW(precBase.apply(x, yBase));
-  TEST_NOTHROW(precEquil.apply(x, yEquil));
+      MV yBase(rowmap, 1);
+      yBase.putScalar(STS::zero());
 
-  Teuchos::ArrayRCP<const Scalar> yBaseView  = yBase.get1dView();
-  Teuchos::ArrayRCP<const Scalar> yEquilView = yEquil.get1dView();
+      TEST_NOTHROW(precBase.apply(b, yBase));
 
-  TEST_COMPARE_FLOATING_ARRAYS(
-      yBaseView, yEquilView,
-      200 * STS::eps());
+      MV rBase(b, Teuchos::Copy);
+      A->apply(yBase, rBase, Teuchos::NO_TRANS, -STS::one(), STS::one());
+
+      // Equilibration run
+      Ifpack2::AdditiveSchwarz<row_matrix_type> precEquil(A);
+
+      TEST_NOTHROW(precEquil.setParameters(paramsEquil));
+      TEST_NOTHROW(precEquil.initialize());
+      TEST_NOTHROW(precEquil.compute());
+
+      MV yEquil(rowmap, 1);
+      yEquil.putScalar(STS::zero());
+
+      TEST_NOTHROW(precEquil.apply(b, yEquil));
+
+      MV rEquil(b, Teuchos::Copy);
+      A->apply(yEquil, rEquil, Teuchos::NO_TRANS, -STS::one(), STS::one());
+
+      Teuchos::Array<mag_type> normBase(1), normEquil(1), normB(1);
+      rBase.norm2(normBase());
+      rEquil.norm2(normEquil());
+      b.norm2(normB());
+
+      cout << "  ||b||_2          = " << normB[0] << endl;
+      cout << "  ||r_base||_2     = " << normBase[0] << endl;
+      cout << "  ||r_equil||_2    = " << normEquil[0] << endl;
+      cout << "  ratio equil/base = " << (normEquil[0] / normBase[0]) << endl;
+
+      auto capNormRatio = mag_type(0.9);
+      TEST_ASSERT(normEquil[0] / normBase[0] < capNormRatio);
+    }
+  }
 }
+#define IFPACK2_EQUILIBRATION_SCALAR_ORDINAL(Scalar, LocalOrdinal, GlobalOrdinal) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(Ifpack2AdditiveSchwarz, EquilImprovesParIlutOnNonsymScaledTriDiag, Scalar, LocalOrdinal, GlobalOrdinal)
+#else
+#define IFPACK2_EQUILIBRATION_SCALAR_ORDINAL(Scalar, LocalOrdinal, GlobalOrdinal)
+#endif  // HAVE_IFPACK2_XPETRA
 
 #if defined(HAVE_IFPACK2_AMESOS2) and defined(HAVE_IFPACK2_XPETRA) and (defined(HAVE_AMESOS2_SUPERLU) || defined(HAVE_AMESOS2_KLU2))
 
@@ -1605,8 +1629,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, EquilReorder, Scalar, 
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(Ifpack2AdditiveSchwarz, ILU_NonOverlap, Scalar, LocalOrdinal, GlobalOrdinal)     \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(Ifpack2AdditiveSchwarz, SGS_NonOverlap, Scalar, LocalOrdinal, GlobalOrdinal)     \
   TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(Ifpack2AdditiveSchwarz, SGS_Overlap, Scalar, LocalOrdinal, GlobalOrdinal)        \
-  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(Ifpack2AdditiveSchwarz, EquilNoOverlap, Scalar, LocalOrdinal, GlobalOrdinal)     \
-  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(Ifpack2AdditiveSchwarz, EquilReorder, Scalar, LocalOrdinal, GlobalOrdinal)       \
+  IFPACK2_EQUILIBRATION_SCALAR_ORDINAL(Scalar, LocalOrdinal, GlobalOrdinal)                                             \
   IFPACK2_AMESOS2_SUPERLU_SCALAR_ORDINAL(Scalar, LocalOrdinal, GlobalOrdinal)                                           \
   IFPACK2_FASTILU_SCALAR_ORDINAL(Scalar, LocalOrdinal, GlobalOrdinal)
 

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
@@ -1584,10 +1584,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, EquilImprovesParIlutOn
       rEquil.norm2(normEquil());
       b.norm2(normB());
 
-      cout << "  ||b||_2          = " << normB[0] << endl;
-      cout << "  ||r_base||_2     = " << normBase[0] << endl;
-      cout << "  ||r_equil||_2    = " << normEquil[0] << endl;
-      cout << "  ratio equil/base = " << (normEquil[0] / normBase[0]) << endl;
+      out << "  ||b||_2          = " << normB[0] << endl;
+      out << "  ||r_base||_2     = " << normBase[0] << endl;
+      out << "  ||r_equil||_2    = " << normEquil[0] << endl;
+      out << "  ratio equil/base = " << (normEquil[0] / normBase[0]) << endl;
 
       auto capNormRatio = mag_type(0.9);
       TEST_ASSERT(normEquil[0] / normBase[0] < capNormRatio);

--- a/packages/stokhos/src/CMakeLists.txt
+++ b/packages/stokhos/src/CMakeLists.txt
@@ -842,6 +842,7 @@ IF (Stokhos_ENABLE_Sacado)
         replaceDiagonalCrsMatrix
         BlockCrsMatrix_Helpers
         computeRowAndColumnOneNorms
+        leftAndOrRightScaleCrsMatrix
         )
       SET(TPETRAEXT_ETI_CLASSES
         MatrixMatrix


### PR DESCRIPTION
@trilinos/ifpack2 

The idea here is to improve the numerical stability of iterated LU algorithms like par_ilut by allowing an equilibration step prior to the subdomain inverse construction. We do this by constructing row/column scalings $D_i^{(r)}$ and $D_i^{(c)}$.

```math
M^{-1}_{\mathrm{RAS,eq}}
=
\sum_{i=1}^N
\widetilde{R}_i^T\,
D_i^{(c)}
\left(D_i^{(r)} R_i A R_i^T D_i^{(c)}\right)^{-1}
D_i^{(r)}\,
R_i
```