### PR TITLE
Teuchos: SystemInformation_UnitTests fixed set/unset environment variables via different APIs (Win32API/POSIX) + const qualifier for operator==

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -214,7 +214,7 @@ public:
   struct TimeInfo {
     TimeInfo():time(0.0), stdDev(0.0), count(0), updates(0), running(false){}
     TimeInfo(BaseTimer* t): time(t->accumulation_), stdDev(t->timePerCallStdDev()), count(t->count_started_), updates(t->count_updates_), running(t->running()) {}
-    bool operator ==(const TimeInfo& ti)
+    bool operator ==(const TimeInfo& ti) const
     {return (time == ti.time) &&
             (stdDev == ti.stdDev) &&
             (count == ti.count) &&

--- a/packages/teuchos/core/test/UnitTest/SystemInformation_UnitTests.cpp
+++ b/packages/teuchos/core/test/UnitTest/SystemInformation_UnitTests.cpp
@@ -7,11 +7,58 @@
 // *****************************************************************************
 // @HEADER
 
+#include <cstdlib>
+#include <cstring>
+#include <utility>
+
 #include "Teuchos_UnitTestHarness.hpp"
 #include "Teuchos_SystemInformation.hpp"
-#include <stdlib.h>
 
 namespace {
+
+// setenv/unsetenv are POSIX; MSVC CRT provides _putenv_s instead.
+// Other Windows toolchains (e.g. MinGW) may still expose setenv/unsetenv.
+#if defined(_MSC_VER)
+void teuchosTestSetEnv(const char* name, const char* value, int overwrite)
+{
+  if(name == nullptr || value == nullptr || std::strchr(name, '=') != nullptr) {
+    return;
+  }
+  if(overwrite == 0) {
+    char* buf{};
+    size_t bufSize{};
+    if(_dupenv_s(std::addressof(buf), std::addressof(bufSize), name) == 0 && buf != nullptr) {
+      std::free(buf);
+      return;
+    }
+  }
+  (void)_putenv_s(name, value);
+}
+
+void teuchosTestUnsetEnv(const char* name)
+{
+  if(name == nullptr || std::strchr(name, '=') != nullptr) {
+    return;
+  }
+  (void)_putenv_s(name, "");
+}
+#else  // !defined(_MSC_VER)
+void teuchosTestSetEnv(const char* name, const char* value, int overwrite)
+{
+  if(name == nullptr || value == nullptr || std::strchr(name, '=') != nullptr) {
+    return;
+  }
+  (void)setenv(name, value, overwrite);
+}
+
+void teuchosTestUnsetEnv(const char* name)
+{
+  if(name == nullptr || std::strchr(name, '=') != nullptr) {
+    return;
+  }
+  (void)unsetenv(name);
+}
+#endif
 
 
 TEUCHOS_UNIT_TEST( SystemInformation, Commands )
@@ -32,13 +79,13 @@ TEUCHOS_UNIT_TEST( SystemInformation, EnvVariables ) {
     TEST_EQUALITY_CONST(values["BLAH_BLAH"], "NOT SET");
   }
 
-  setenv("BLAH_BLAH", "test", 1);
+  teuchosTestSetEnv("BLAH_BLAH", "test", 1);
   {
     auto values = Teuchos::SystemInformation::collectSystemInformation();
     TEST_ASSERT(values.find("BLAH_BLAH") != values.end());
     TEST_EQUALITY_CONST(values["BLAH_BLAH"], "test");
   }
-  unsetenv("BLAH_BLAH");
+  teuchosTestUnsetEnv("BLAH_BLAH");
 }
 
 

--- a/packages/teuchos/core/test/UnitTest/SystemInformation_UnitTests.cpp
+++ b/packages/teuchos/core/test/UnitTest/SystemInformation_UnitTests.cpp
@@ -7,12 +7,12 @@
 // *****************************************************************************
 // @HEADER
 
-#include <cstdlib>
-#include <cstring>
-#include <utility>
 
 #include "Teuchos_UnitTestHarness.hpp"
 #include "Teuchos_SystemInformation.hpp"
+#include <cstdlib>
+#include <cstring>
+#include <utility>
 
 namespace {
 


### PR DESCRIPTION
@trilinos/teuchos

## Motivation

This patch is prior to separate usage of Win32API and POSIX to set and unset the system variables.

## Related Issues

#14816

## References

- [MSDN C-runtime-lib envs funcs](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/putenv-s-wputenv-s?view=msvc-170)

## Testing

### Environment

| Item       | Value                                   |
| ---------- | --------------------------------------- |
| OS         | Windows 11 Pro, Build 26100             |
| CPU        | Intel Core i9-12900H (20 logical cores) |
| CMake      | 3.31.2                                  |
| MSVC       | 19.44.35211 (VS 2022 Community)         |
| Ninja      | 1.12.1                                  |
| Build type | Release, shared libs, C++20             |

### Proofs

Configuration: [configure-output-msvc2022-ninja-serial.log](https://github.com/user-attachments/files/27559460/configure-output-msvc2022-ninja-serial.log)
Compilation: [compilation-output-msvc2022-ninja-serial.log.err.log](https://github.com/user-attachments/files/27559459/compilation-output-msvc2022-ninja-serial.log.err.log)
Compilation errors: [compilation-output-msvc2022-ninja-serial.log](https://github.com/user-attachments/files/27559458/compilation-output-msvc2022-ninja-serial.log)

### Reproducer

1. Install deps

```cmd
cd C:\
git clone https://github.com/microsoft/vcpkg
vcpkg install blas:x64-windows
vcpkg install lapack:x64-windows
vcpkg install lapack-reference:x64-windows
```

2. Use [build.ps1.txt](https://github.com/user-attachments/files/27559767/build.ps1.txt)

### Result

Faced with another problems, will figure out later...
Probably I will need to extend this PR to fix all the possible issues on Windows compilation for tests.

```log
FAILED: packages/teuchos/comm/test/StackedTimer/CMakeFiles/TeuchosComm_stacked_timer.dir/stacked_timer.cpp.obj
C:\PROGRA~1\MICROS~3\2022\COMMUN~1\VC\Tools\MSVC\1444~1.352\bin\HostX64\x64\cl.exe  /nologo /TP -DKOKKOS_DEPENDENCE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -ID:\Develop\Trilinos\bteuchos -ID:\Develop\Trilinos\cmake\tribits\win_interface\include -ID:\Develop\Trilinos\packages\teuchos\comm\test\StackedTimer -ID:\Develop\Trilinos\packages\teuchos\comm\src -ID:\Develop\Trilinos\bteuchos\packages\teuchos\comm\src -ID:\Develop\Trilinos\bteuchos\packages\teuchos\core\src -ID:\Develop\Trilinos\packages\teuchos\core\src -ID:\Develop\Trilinos\bteuchos\packages\kokkos -ID:\Develop\Trilinos\bteuchos\packages\kokkos\core\src -ID:\Develop\Trilinos\packages\kokkos\core\src -ID:\Develop\Trilinos\bteuchos\packages\kokkos\containers\src -ID:\Develop\Trilinos\packages\kokkos\containers\src -ID:\Develop\Trilinos\bteuchos\packages\kokkos\algorithms\src -ID:\Develop\Trilinos\packages\kokkos\algorithms\src -ID:\Develop\Trilinos\bteuchos\packages\kokkos\simd\src -ID:\Develop\Trilinos\packages\kokkos\simd\src -ID:\Develop\Trilinos\packages\teuchos\parameterlist\src -ID:\Develop\Trilinos\bteuchos\packages\teuchos\parameterlist\src -ID:\Develop\Trilinos\packages\teuchos\parser\src -external:ID:\Develop\Trilinos\packages\kokkos\tpls\desul\include -external:ID:\Develop\Trilinos\packages\kokkos\tpls\mdspan\include -external:W0 /DWIN32 /D_WINDOWS /w /EHsc /bigobj /MD /O2 /Ob2 /DNDEBUG /EHsc /bigobj /Zc:preprocessor -std:c++20 -MD /Zc:preprocessor /showIncludes /Fopackages\teuchos\comm\test\StackedTimer\CMakeFiles\TeuchosComm_stacked_timer.dir\stacked_timer.cpp.obj /Fdpackages\teuchos\comm\test\StackedTimer\CMakeFiles\TeuchosComm_stacked_timer.dir\ /FS -c D:\Develop\Trilinos\packages\teuchos\comm\test\StackedTimer\stacked_timer.cpp
D:\Develop\Trilinos\packages\teuchos\comm\test\StackedTimer\stacked_timer.cpp(740): error C2666: 'Teuchos::BaseTimer::TimeInfo::operator ==': overloaded functions have similar conversions
...
D:\Develop\Trilinos\packages\teuchos\comm\test\StackedTimer\stacked_timer.cpp(747): error C2737: 'l_result': const object must be initialized
D:\Develop\Trilinos\packages\teuchos\comm\test\StackedTimer\stacked_timer.cpp(749): error C2666: 'Teuchos::BaseTimer::TimeInfo::operator ==': overloaded functions have similar conversions
...
```
