### PR TITLE
TriBITS: Fix Windows MS-MPI TPL_MPI_LIBRARIES and MPI::all_libs

### DIFF
--- a/cmake/tribits/core/std_tpls/FindTPLMPI.cmake
+++ b/cmake/tribits/core/std_tpls/FindTPLMPI.cmake
@@ -17,7 +17,30 @@ if(WIN32 AND TPL_ENABLE_MPI)
   find_package(MPI)
   include_directories(${MPI_INCLUDE_PATH})
   global_set(TPL_MPI_INCLUDE_DIRS ${MPI_INCLUDE_PATH})
-  global_set(TPL_MPI_LIBRARIES ${MPI_LIBRARIES})
+  # FindMPI often leaves MPI_LIBRARIES empty on Windows while MPI_C/CXX_LIBRARIES
+  # hold msmpi.lib.  Also, global_set() does not use FORCE, so avoid leaving a
+  # stale empty TPL_MPI_LIBRARIES in the cache from an earlier configure.
+  set(_tpl_mpi_link_libs "")
+  if(MPI_LIBRARIES)
+    set(_tpl_mpi_link_libs "${MPI_LIBRARIES}")
+  elseif(MPI_CXX_LIBRARIES)
+    set(_tpl_mpi_link_libs "${MPI_CXX_LIBRARIES}")
+  elseif(MPI_C_LIBRARIES)
+    set(_tpl_mpi_link_libs "${MPI_C_LIBRARIES}")
+  endif()
+  if(_tpl_mpi_link_libs)
+    set(TPL_MPI_LIBRARIES "${_tpl_mpi_link_libs}" CACHE INTERNAL "" FORCE)
+  endif()
+  # When MPI_LIBRARY_NAMES is empty, tribits_tpl_find_include_dirs_and_libraries(MPI)
+  # calls global_null_set(TPL_MPI_LIBRARIES) and clears the cache.  If FindMPI
+  # already produced MPI::MPI_C / MPI::MPI_CXX, create MPI::all_libs here so
+  # that generic finder is skipped.
+  if(MPI_C_FOUND AND MPI_CXX_FOUND AND NOT TARGET MPI::all_libs)
+    tribits_extpkg_create_imported_all_libs_target_and_config_file(
+      MPI
+      INNER_FIND_PACKAGE_NAME MPI
+      IMPORTED_TARGETS_FOR_ALL_LIBS MPI::MPI_C MPI::MPI_CXX)
+  endif()
 endif()
 
 # Don't allow calling find_package(MPI) by default.  Force the user to set


### PR DESCRIPTION
@trilinos/Trilinos

## Motivation

`FindMPI` on Windows may put `msmpi.lib` only in `MPI_C_LIBRARIES` / `MPI_CXX_LIBRARIES`, not in `MPI_LIBRARIES`. `FindTPLMPI.cmake` forwarded only the latter and left `MPI::all_libs` unset when prefind is off, so `tribits_tpl_find_include_dirs_and_libraries(MPI)` ran and `global_null_set(TPL_MPI_LIBRARIES)` cleared the cache-link dropped `msmpi` (`LNK2019`). The patch copies from whichever variable is set and creates `MPI::all_libs` after `find_package(MPI)` so that finder is skipped.

## Related Issues

- #14816

## Parent Commit

sha1: 11138c74a22ddc962f55a9feae33e3e0ba1010c2

## Testing

### Environment

| Item       | Value                                                                   |
| ---------- | ----------------------------------------------------------------------- |
| OS         | Windows 11 Pro, Build 26100                                             |
| CPU        | Intel Core i9-12900H (20 logical cores)                                 |
| CMake      | 3.31.2                                                                  |
| MSVC       | 19.44.35211 (VS 2022 Community)                                         |
| Ninja      | 1.12.1                                                                  |
| MPI        | 10.0 Microsoft MPI (SDK under `Program Files (x86)\Microsoft SDKs\MPI`) |
| Build type | Release, shared libs, C++20                                             |
| Packages   | Kokkos, Teuchos (`Trilinos_ENABLE_ALL_PACKAGES=OFF`)                    |

### Proofs

#### After fix

Configuration output: [configure-output-msvc2022-ninja-mpi.log](https://github.com/user-attachments/files/27600563/configure-output-msvc2022-ninja-mpi.log)
Compilation output: [compilation-output-msvc2022-ninja-mpi.log](https://github.com/user-attachments/files/27600556/compilation-output-msvc2022-ninja-mpi.log)
Ctest output: [ctest-output-msvc2022-ninja-mpi.log](https://github.com/user-attachments/files/27601334/ctest-output-msvc2022-ninja-mpi.log)

### What broke

1. `CMakeCache.txt`: `TPL_MPI_LIBRARIES` cleared

```txt
TPL_MPI_LIBRARIES:INTERNAL=
```

2. `build.ninja`: link line for `teuchoscore.dll` had no MS-MPI

```txt
  LINK_LIBRARIES = packages\kokkos\containers\src\kokkoscontainers.lib  packages\kokkos\algorithms\src\kokkosalgorithms.lib  packages\kokkos\simd\src\kokkossimd.lib  packages\kokkos\core\src\kokkoscore.lib  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib
```

3. Linker (`LNK2019` / `LNK1120`)

```log
Teuchos_GlobalMPISession.cpp.obj : error LNK2019: unresolved external symbol MPI_Barrier referenced in function "public: static void __cdecl Teuchos::GlobalMPISession::barrier(void)" (?barrier@GlobalMPISession@Teuchos@@SAXXZ)
Teuchos_GlobalMPISession.cpp.obj : error LNK2019: unresolved external symbol MPI_Allgather referenced in function "public: static void __cdecl Teuchos::GlobalMPISession::allGather(int,class Teuchos::ArrayView<int> const &)" (?allGather@GlobalMPISession@Teuchos@@SAXHAEBV?$ArrayView@H@2@@Z)
Teuchos_GlobalMPISession.cpp.obj : error LNK2019: unresolved external symbol MPI_Allreduce referenced in function "public: static int __cdecl Teuchos::GlobalMPISession::sum(int)" (?sum@GlobalMPISession@Teuchos@@SAHH@Z)
Teuchos_GlobalMPISession.cpp.obj : error LNK2019: unresolved external symbol MPI_Comm_size referenced in function "private: static void __cdecl Teuchos::GlobalMPISession::initialize(class std::basic_ostream<char,struct std::char_traits<char> > *)" (?initialize@GlobalMPISession@Teuchos@@CAXPEAV?$basic_ostream@DU?$char_traits@D@std@@@std@@@Z)
Teuchos_GlobalMPISession.cpp.obj : error LNK2019: unresolved external symbol MPI_Comm_rank referenced in function "private: static void __cdecl Teuchos::GlobalMPISession::initialize(class std::basic_ostream<char,struct std::char_traits<char> > *)" (?initialize@GlobalMPISession@Teuchos@@CAXPEAV?$basic_ostream@DU?$char_traits@D@std@@@std@@@Z)
Teuchos_GlobalMPISession.cpp.obj : error LNK2019: unresolved external symbol MPI_Get_processor_name referenced in function "public: __cdecl Teuchos::GlobalMPISession::GlobalMPISession(int *,char * * *,class std::basic_ostream<char,struct std::char_traits<char> > *)" (??0GlobalMPISession@Teuchos@@QEAA@PEAHPEAPEAPEADPEAV?$basic_ostream@DU?$char_traits@D@std@@@std@@@Z)
Teuchos_GlobalMPISession.cpp.obj : error LNK2019: unresolved external symbol MPI_Init referenced in function "public: __cdecl Teuchos::GlobalMPISession::GlobalMPISession(int *,char * * *,class std::basic_ostream<char,struct std::char_traits<char> > *)" (??0GlobalMPISession@Teuchos@@QEAA@PEAHPEAPEAPEADPEAV?$basic_ostream@DU?$char_traits@D@std@@@std@@@Z)
Teuchos_GlobalMPISession.cpp.obj : error LNK2019: unresolved external symbol MPI_Finalize referenced in function "public: __cdecl Teuchos::GlobalMPISession::~GlobalMPISession(void)" (??1GlobalMPISession@Teuchos@@QEAA@XZ)
Teuchos_GlobalMPISession.cpp.obj : error LNK2019: unresolved external symbol MPI_Initialized referenced in function "public: __cdecl Teuchos::GlobalMPISession::GlobalMPISession(int *,char * * *,class std::basic_ostream<char,struct std::char_traits<char> > *)" (??0GlobalMPISession@Teuchos@@QEAA@PEAHPEAPEAPEADPEAV?$basic_ostream@DU?$char_traits@D@std@@@std@@@Z)
Teuchos_Time.cpp.obj : error LNK2001: unresolved external symbol MPI_Initialized
Teuchos_GlobalMPISession.cpp.obj : error LNK2019: unresolved external symbol MPI_Abort referenced in function "public: static void __cdecl Teuchos::GlobalMPISession::abort(void)" (?abort@GlobalMPISession@Teuchos@@SAXXZ)
Teuchos_Time.cpp.obj : error LNK2019: unresolved external symbol MPI_Wtime referenced in function "public: void __cdecl Teuchos::Time::start(bool)" (?start@Time@Teuchos@@QEAAX_N@Z)
packages\teuchos\core\src\teuchoscore.dll : fatal error LNK1120: 11 unresolved externals
```

### After changes

**1. `CMakeCache.txt`: `TPL_MPI_LIBRARIES` populated**

```text
TPL_MPI_LIBRARIES:INTERNAL=C:/Program Files (x86)/Microsoft SDKs/MPI/Lib/x64/msmpi.lib
```

**2. `build.ninja`: same target, `LINK_LIBRARIES` includes `msmpi.lib`**

```text
  LINK_LIBRARIES = packages\kokkos\containers\src\kokkoscontainers.lib  packages\kokkos\algorithms\src\kokkosalgorithms.lib  packages\kokkos\simd\src\kokkossimd.lib  packages\kokkos\core\src\kokkoscore.lib  "C:\Program Files (x86)\Microsoft SDKs\MPI\Lib\x64\msmpi.lib"  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib
```

(The `build ... teuchoscore.dll` rule’s `|` inputs also list `C$:\Program$ Files$ (x86)\Microsoft$ SDKs\MPI\Lib\x64\msmpi.lib` after reconfigure.)