### PR TITLE
Teuchos: Unit tests: allow 'total 18 run 17 passed 17'; fixed unitialized bool (UB); RCP_test delete via D* fixed

### DIFF
--- a/packages/teuchos/core/src/Teuchos_any.hpp
+++ b/packages/teuchos/core/src/Teuchos_any.hpp
@@ -127,8 +127,9 @@ public:
     : content(0)
     {}
 
-  //! Templated constructor
-  template<typename ValueType>
+  //! Templated constructor (excluded for any/any& to prevent infinite recursion via holder<any>)
+  template<typename ValueType,
+    std::enable_if_t<!std::is_same_v<std::decay_t<ValueType>, any>, int> = 0>
   explicit any(ValueType&& value)
     : content(new holder<std::decay_t<ValueType>>(std::forward<ValueType>(value)))
     {}

--- a/packages/teuchos/core/test/MemoryManagement/RCP_test.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/RCP_test.cpp
@@ -251,7 +251,7 @@ int main( int argc, char* argv[] ) {
 
       // Manually clean up some memory
 
-      delete d_ptr1.release().get(); // Now d_ptr1.get() no longer points to a valid object but okay
+      delete static_cast<E*>(d_ptr1.release().get()); // Now d_ptr1.get() no longer points to a valid object but okay
       // as long as no other access to this object is attempted! (see below)
 #ifdef SHOW_RUN_TIME_ERROR_2
       TEUCHOS_TEST_FOR_EXCEPT( d_ptr1->D_g() == D_g_return ); // Should cause a segmentation fault since d_ptr.get() was deleted!

--- a/packages/teuchos/core/test/UnitTest/CMakeLists.txt
+++ b/packages/teuchos/core/test/UnitTest/CMakeLists.txt
@@ -38,15 +38,43 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT
   )
 
-IF (${PARENT_PACKAGE_NAME}_ENABLE_COMPLEX AND ${PARENT_PACKAGE_NAME}_ENABLE_FLOAT)
-  SET(PASS_STRING "Summary: total = 19, run = 18, passed = 18, failed = 0")
-ELSEIF (${PARENT_PACKAGE_NAME}_ENABLE_COMPLEX AND NOT ${PARENT_PACKAGE_NAME}_ENABLE_FLOAT)
-  SET(PASS_STRING "Summary: total = 17, run = 16, passed = 16, failed = 0")
-ELSEIF (NOT ${PARENT_PACKAGE_NAME}_ENABLE_COMPLEX AND ${PARENT_PACKAGE_NAME}_ENABLE_FLOAT)
-  SET(PASS_STRING "Summary: total = 17, run = 16, passed = 16, failed = 0")
-ELSEIF (NOT ${PARENT_PACKAGE_NAME}_ENABLE_COMPLEX AND NOT ${PARENT_PACKAGE_NAME}_ENABLE_FLOAT)
-  SET(PASS_STRING "Summary: total = 16, run = 15, passed = 15, failed = 0")
-ENDIF()
+# PASS_REGULAR_EXPRESSION below must mirror the binary's "Summary"
+# line byte-for-byte. The binary's test count is fixed at compile time by
+# HAVE_TEUCHOS_INST_* (see Teuchos_UnitTestHelpers.hpp), not by the higher-
+# level ${PARENT_PACKAGE_NAME}_ENABLE_{COMPLEX,FLOAT}, from which the INST_*
+# values are only derived as defaults. The two diverge whenever the user
+# overrides Trilinos_ENABLE_COMPLEX_{FLOAT,DOUBLE} or ${PARENT_PACKAGE_NAME}_INST_*
+# directly (see packages/teuchos/CMakeLists.txt). Concrete trap: the default
+# Teuchos_INST_COMPLEX_FLOAT for (ENABLE_COMPLEX=ON, ENABLE_FLOAT=OFF) is OFF,
+# so an _ENABLE_*-based prediction overcounts by one for that very common
+# configuration. Predicting from _INST_* makes the divergence impossible by
+# construction.
+#
+# Base count = 16, justified by the unconditional registrations:
+#   Int_UnitTests.cpp           2  Basic, Assignment
+#   PrintDouble_UnitTests.cpp   1  Basic
+#   vector_UnitTests.cpp       12  4 tests * {int, float, double}; the type
+#                                  set is hard-coded and ignores *_INST_FLOAT
+#   TemplateFunc_UnitTests.cpp  1  double leg of
+#                                  TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT_SCALAR_TYPES,
+#                                  which has no HAVE_TEUCHOS_INST_DOUBLE guard
+set(Simple_UnitTests_total 16)
+if (${PARENT_PACKAGE_NAME}_INST_FLOAT)
+  math(EXPR Simple_UnitTests_total "${Simple_UnitTests_total} + 1")
+endif()
+if (${PARENT_PACKAGE_NAME}_INST_COMPLEX_FLOAT)
+  math(EXPR Simple_UnitTests_total "${Simple_UnitTests_total} + 1")
+endif()
+if (${PARENT_PACKAGE_NAME}_INST_COMPLEX_DOUBLE)
+  math(EXPR Simple_UnitTests_total "${Simple_UnitTests_total} + 1")
+endif()
+
+# run = total - 1: the minus_one variant filters exactly vector<float>::constAt
+# (see ARGS below), which is part of the unconditional base above and is
+# therefore guaranteed to be present in every supported configuration.
+math(EXPR Simple_UnitTests_run "${Simple_UnitTests_total} - 1")
+set(PASS_STRING
+  "Summary: total = ${Simple_UnitTests_total}, run = ${Simple_UnitTests_run}, passed = ${Simple_UnitTests_run}, failed = 0")
 
 
 TRIBITS_ADD_TEST(

--- a/packages/teuchos/parser/src/Teuchos_FiniteAutomaton.cpp
+++ b/packages/teuchos/parser/src/Teuchos_FiniteAutomaton.cpp
@@ -412,12 +412,10 @@ void simplify(FiniteAutomaton& result, FiniteAutomaton const& fa) {
   FiniteAutomaton next = fa;
   int nstates_next = get_nstates(next);
   int nstates;
-  int i = 0;
   do {
     swap(prev, next);
     nstates = nstates_next;
     simplify_once(next, prev);
-    ++i;
     nstates_next = get_nstates(next);
   } while (nstates_next < nstates);
   swap(result, next);

--- a/packages/teuchos/parser/src/Teuchos_FiniteAutomaton.hpp
+++ b/packages/teuchos/parser/src/Teuchos_FiniteAutomaton.hpp
@@ -33,7 +33,7 @@ extern template struct Table<int>;
 struct FiniteAutomaton {
   Table<int> table;
   std::vector<int> accepted_tokens;
-  bool is_deterministic;
+  bool is_deterministic = false;
   FiniteAutomaton() {}
   FiniteAutomaton(int nsymbols_init, bool is_deterministic_init, int nstates_reserve);
   void swap(FiniteAutomaton& other);


### PR DESCRIPTION
@trilinos/teuchos

## Motivation

Allow string 'Summary: total = 18, run = 17, passed = 17, failed = 0' when execute ctest.

## Related Issues/PRs

#14816
#15245

## Parent Commit

sha1: 2bad5d0f74bbcd787b234191baa54bfb77fa1958

## Testing

```cmd
set PATH=D:\Develop\Trilinos\btomp\packages\kokkos\containers\src;D:\Develop\Trilinos\btomp\packages\kokkos\core\src;D:\Develop\Trilinos\btomp\packages\teuchos\comm\src;D:\Develop\Trilinos\btomp\packages\teuchos\core\src;D:\Develop\Trilinos\btomp\packages\teuchos\kokkoscomm\src;D:\Develop\Trilinos\btomp\packages\teuchos\kokkoscompat\src;D:\Develop\Trilinos\btomp\packages\teuchos\numerics\src;D:\Develop\Trilinos\btomp\packages\teuchos\parameterlist\src;D:\Develop\Trilinos\btomp\packages\teuchos\parser\src;D:\Develop\Trilinos\btomp\packages\teuchos\remainder\src;D:\Develop\Trilinos\btomp\packages\teuchos\parameterlist\test\ParameterList;%PATH%
set PATH=D:\local\LLVM\lib\clang\21\lib\windows;%PATH%
```

> 2 `set` commands was done on purpose, because Windows cmd can show: `The input line is too long.`, but the best way is of course to place all the .dlls to one dir to not to overflow the `PATH` and specify only this one dir.
> `set PATH=D:\local\LLVM\lib\clang\21\lib\windows;%PATH%` needed for `clang_rt.asan_dynamic-x86_64.dll`, because this build was with address sanitizer.

Ctest output before: [ctest-output-clangcl-ninja-openmp-TeuchosCore_Simple_UnitTests_minus_one.before.log](https://github.com/user-attachments/files/27607685/ctest-output-clangcl-ninja-openmp-TeuchosCore_Simple_UnitTests_minus_one.before.log)
Ctest output after: [ctest-output-clangcl-ninja-openmp-TeuchosCore_Simple_UnitTests_minus_one.after.log](https://github.com/user-attachments/files/27607686/ctest-output-clangcl-ninja-openmp-TeuchosCore_Simple_UnitTests_minus_one.after.log)

## Environment

| Item       | Value                                   |
| ---------- | --------------------------------------- |
| OS         | Windows 11 Pro, Build 26100             |
| CPU        | Intel Core i9-12900H (20 logical cores) |
| CMake      | 3.31.2                                  |
| clang-cl   | 21.1.5;x86_64-pc-windows-msvc;thread-model:posix          |
| Ninja      | 1.12.1                                  |
| Build type | Release, shared libs, C++20             |

## Reproducer

The `build.ps1` updated to support sanitizer: [build.ps1.txt](https://github.com/user-attachments/files/27607970/build.ps1.txt)

## Additional Information

### Hint for anyone how to check dependencies with developer command prompt

<details><summary>👇</summary>

```log
D:\Develop\Trilinos\btomp>dumpbin /dependents D:\Develop\Trilinos\btomp\packages\teuchos\core\test\UnitTest\TeuchosCore_Simple_UnitTests.exe
Microsoft (R) COFF/PE Dumper Version 14.44.35211.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file D:\Develop\Trilinos\btomp\packages\teuchos\core\test\UnitTest\TeuchosCore_Simple_UnitTests.exe

File Type: EXECUTABLE IMAGE

  Image has the following dependencies:

    clang_rt.asan_dynamic-x86_64.dll
    teuchoscore.dll
    MSVCP140.dll
    VCRUNTIME140.dll
    api-ms-win-crt-time-l1-1-0.dll
    api-ms-win-crt-heap-l1-1-0.dll
    api-ms-win-crt-string-l1-1-0.dll
    api-ms-win-crt-runtime-l1-1-0.dll
    api-ms-win-crt-convert-l1-1-0.dll
    api-ms-win-crt-math-l1-1-0.dll
    api-ms-win-crt-stdio-l1-1-0.dll
    api-ms-win-crt-locale-l1-1-0.dll
    KERNEL32.dll

  Summary

        1000 .INTR
        1000 .WEAK
        8000 .data
        2000 .pdata
       17000 .rdata
        1000 .reloc
        1000 .rsrc
       2D000 .text
```

</details>

As a premise to the next fix I want to pay attention on `SEGFAULT`ing `TeuchosParser_Parser_UnitTests`. Unfortunately, Windows do not provide really good information about segmentation faults even if sanitizer is turned on. Also, Windows does not provide any sanitizers like Linux, for example, TSan or MSan (if I do not mistake, or doing smth wrong, but really can't find full analogues as in Linux).

Here is the ctest log with address sanitizer:

```log
D:\Develop\Trilinos\btomp>ctest -V --output-on-failure -R TeuchosParser_Parser_UnitTests
UpdateCTestConfiguration  from :D:/Develop/Trilinos/btomp/DartConfiguration.tcl
Parse Config file:D:/Develop/Trilinos/btomp/DartConfiguration.tcl
 Add coverage exclude regular expressions.
UpdateCTestConfiguration  from :D:/Develop/Trilinos/btomp/DartConfiguration.tcl
Parse Config file:D:/Develop/Trilinos/btomp/DartConfiguration.tcl
Test project D:/Develop/Trilinos/btomp
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 51
    Start 51: TeuchosParser_Parser_UnitTests

51: Test command: D:\Develop\Trilinos\btomp\packages\teuchos\parser\test\TeuchosParser_Parser_UnitTests.exe
51: Working Directory: D:/Develop/Trilinos/btomp/packages/teuchos/parser/test
51: Test timeout computed to be: 1500
51: WARNING: found 1 unrecognized flag(s):
51:     print_stacktrace
51: ==65260==AddressSanitizer: libc interceptors initialized
51: || `[0x11e217580000, 0x7fffffffffff]` || HighMem    ||
51: || `[0x041e5a430000, 0x11e21757ffff]` || HighShadow ||
51: || `[0x021e5a430000, 0x041e5a42ffff]` || ShadowGap  ||
51: || `[0x01e217580000, 0x021e5a42ffff]` || LowShadow  ||
51: || `[0x000000000000, 0x01e21757ffff]` || LowMem     ||
51: MemToShadow(shadow): 0x021e5a430000 0x0225e2a05fff 0x0265e2a06000 0x041e5a42ffff
51: redzone=16
51: max_redzone=2048
51: quarantine_size_mb=256M
51: thread_local_quarantine_size_kb=1024K
51: malloc_context_size=30
51: SHADOW_SCALE: 3
51: SHADOW_GRANULARITY: 8
51: SHADOW_OFFSET: 0x01e217580000
51: ==65260==T0: stack [0x0081fc000000,0x0081fc100000) size 0x100000; local=0x0081fc0fe99c
51: ==65260==AddressSanitizer Init done
51: Teuchos::GlobalMPISession::GlobalMPISession(): started serial run
1/1 Test #51: TeuchosParser_Parser_UnitTests ...***Exception: SegFault  2.64 sec
WARNING: found 1 unrecognized flag(s):
    print_stacktrace
==65260==AddressSanitizer: libc interceptors initialized
|| `[0x11e217580000, 0x7fffffffffff]` || HighMem    ||
|| `[0x041e5a430000, 0x11e21757ffff]` || HighShadow ||
|| `[0x021e5a430000, 0x041e5a42ffff]` || ShadowGap  ||
|| `[0x01e217580000, 0x021e5a42ffff]` || LowShadow  ||
|| `[0x000000000000, 0x01e21757ffff]` || LowMem     ||
MemToShadow(shadow): 0x021e5a430000 0x0225e2a05fff 0x0265e2a06000 0x041e5a42ffff
redzone=16
max_redzone=2048
quarantine_size_mb=256M
thread_local_quarantine_size_kb=1024K
malloc_context_size=30
SHADOW_SCALE: 3
SHADOW_GRANULARITY: 8
SHADOW_OFFSET: 0x01e217580000
==65260==T0: stack [0x0081fc000000,0x0081fc100000) size 0x100000; local=0x0081fc0fe99c
==65260==AddressSanitizer Init done
Teuchos::GlobalMPISession::GlobalMPISession(): started serial run


0% tests passed, 1 tests failed out of 1

Subproject Time Summary:
Teuchos    =   2.64 sec*proc (1 test)

Total Test time (real) =   2.70 sec

The following tests FAILED:
         51 - TeuchosParser_Parser_UnitTests (SEGFAULT)         Teuchos
Errors while running CTest
```

## Question

- Is it ok in `packages/teuchos/parser/test/unit_tests.cpp` uses C va-args for regex_reader (63fd67d9a9d990b0d1d4d4ff7dfe480a5d8ac3db)? I see that it's a backport to support compilation on C++98. Does it make sense to use `<initializer_list>` from C++11 instead of C va-args?