### PR TITLE
MueLu: Extend ComboPDriver to support a wider variety of use-cases

### DIFF
--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -308,7 +308,7 @@ TRIBITS_ADD_TEST(
 TRIBITS_ADD_TEST(
   ComboPDriver
   NAME "ComboPTest"
-  ARGS "--linAlgebra=Tpetra --its=9"
+  ARGS "--linAlgebra=Tpetra --its=9 --xml=comboP.xml --nblks=4 --matrix=multiPhys4x4.mat --auxFiles=aux1.mat,aux2.mat,aux1.mat,aux2.mat --coordFiles=coords1.mat,coords2.mat,coords1.mat,coords2.mat --nullFiles=null1.mat,null2.mat,null1.mat,null2.mat"
   NUM_MPI_PROCS 4
   COMM mpi
   PASS_REGULAR_EXPRESSION "Belos converged"

--- a/packages/muelu/test/scaling/ComboPDriver.cpp
+++ b/packages/muelu/test/scaling/ComboPDriver.cpp
@@ -7,270 +7,456 @@
 // *****************************************************************************
 // @HEADER
 
+#include <algorithm>
+#include <cctype>
+#include <fstream>
 #include <iostream>
+#include <numeric>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 // Teuchos
-#include <Teuchos_RCP.hpp>
-#include <Teuchos_ParameterList.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_DefaultComm.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+#include <Teuchos_OrdinalTraits.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_RCP.hpp>
 #include <Teuchos_StandardCatchMacros.hpp>
+#include <Teuchos_TimeMonitor.hpp>
 #include <Teuchos_XMLParameterListHelpers.hpp>
 
+// MueLu
 #include <MueLu_Exceptions.hpp>
-#include <MueLu_ParameterListInterpreter.hpp>
-
-#include "MueLu_SemiCoarsenPFactory.hpp"  // for semi-coarsening constants
-#include <MueLu_TestHelpers.hpp>
 #include <MueLu_MultiPhys.hpp>
+#include <MueLu_ParameterListInterpreter.hpp>
+#include <MueLu_TestHelpers.hpp>
+#include "MueLu_SemiCoarsenPFactory.hpp"
 
-/**********************************************************************************/
-/* CREATE INITAL MATRIX                                                           */
-/**********************************************************************************/
+// Xpetra
+#include <Xpetra_IO.hpp>
 #include <Xpetra_Map.hpp>
 #include <Xpetra_MapFactory.hpp>
-#include <Xpetra_CrsMatrixWrap.hpp>
-#include <Xpetra_Vector.hpp>
-#include <Xpetra_MultiVectorFactory.hpp>
-#include <Xpetra_VectorFactory.hpp>
+#include <Xpetra_Matrix.hpp>
+#include <Xpetra_MultiVector.hpp>
 #include <Xpetra_Parameters.hpp>
-
-// Galeri
-#include <Galeri_XpetraParameters.hpp>
-#include <Galeri_XpetraProblemFactory.hpp>
-#include <Galeri_XpetraUtils.hpp>
+#include <Xpetra_Vector.hpp>
+#include <Xpetra_VectorFactory.hpp>
 
 #ifdef HAVE_MUELU_BELOS
 #include <BelosConfigDefs.hpp>
 #include <BelosLinearProblem.hpp>
 #include <BelosSolverFactory.hpp>
 #include <BelosTpetraAdapter.hpp>
-#include <BelosXpetraAdapter.hpp>  // => This header defines Belos::XpetraOp
+#include <BelosXpetraAdapter.hpp>
 #endif
+
 #define FOURBYFOUR
 
-#include <unistd.h>
-/**********************************************************************************/
+namespace {
+
+std::string defaultSuffix() {
+#ifdef BIGVERSION
+  return "big";
+#else
+  return "";
+#endif
+}
+
+int defaultBlockCount() {
+#ifdef FOURBYFOUR
+  return 4;
+#else
+  return 2;
+#endif
+}
+
+std::string defaultMultiPhysFile(const std::string& suffix) {
+#ifdef FOURBYFOUR
+  return "multiPhys4x4" + suffix + ".mat";
+#else
+  return "multiPhys2x2" + suffix + ".mat";
+#endif
+}
+
+std::string trim(std::string s) {
+  auto notSpace = [](unsigned char ch) { return !std::isspace(ch); };
+
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), notSpace));
+  s.erase(std::find_if(s.rbegin(), s.rend(), notSpace).base(), s.end());
+
+  return s;
+}
+
+std::string normalizeOptionalFilename(std::string value) {
+  value = trim(std::move(value));
+
+  if (value == "none" || value == "null" ||
+      value == "NONE" || value == "NULL") {
+    return "";
+  }
+
+  return value;
+}
+
+std::vector<std::string> splitCommaSeparated(const std::string& input) {
+  if (input.empty()) {
+    return {};
+  }
+
+  std::vector<std::string> result;
+  std::size_t start = 0;
+
+  while (true) {
+    const auto pos = input.find(',', start);
+    if (pos == std::string::npos) {
+      result.emplace_back(trim(input.substr(start)));
+      break;
+    }
+
+    result.emplace_back(trim(input.substr(start, pos - start)));
+    start = pos + 1;
+  }
+
+  return result;
+}
+
+int readDimensionFromMatFile(const std::string& filename) {
+  std::ifstream in(filename);
+  if (!in.is_open()) {
+    throw std::runtime_error("File not found: " + filename);
+  }
+
+  std::string line;
+  while (std::getline(in, line)) {
+    line = trim(line);
+
+    if (line.empty()) {
+      continue;
+    }
+
+    if (line[0] == '%') {
+      continue;
+    }
+
+    std::istringstream iss(line);
+    int nRows = 0;
+    int nCols = 0;
+    int nnz   = 0;
+
+    if (!(iss >> nRows >> nCols)) {
+      throw std::runtime_error("Failed to parse matrix dimension line from file: " + filename);
+    }
+
+    (void)nnz;
+    return nRows;
+  }
+
+  throw std::runtime_error("Failed to locate matrix dimension line in file: " + filename);
+}
+
+struct BlockSpec {
+  std::string auxFile;
+  std::string coordsFile;
+  std::string nullFile;
+  std::string materialFile;
+};
+
+struct DriverOptions {
+  std::string suffix        = defaultSuffix();
+  std::string xmlFile       = "comboP.xml";
+  std::string multiPhysFile = defaultMultiPhysFile(defaultSuffix());
+  int nBlks                 = defaultBlockCount();
+  int expectedIters         = 50;
+  std::vector<BlockSpec> blocks;
+  double tolerance  = 1e-6;
+  int maxIterations = 100;
+};
+
+DriverOptions makeDefaultOptions() {
+  DriverOptions opts;
+  const auto s = opts.suffix;
+
+#ifdef FOURBYFOUR
+  opts.blocks = {
+      {"aux1" + s + ".mat", "coords1" + s + ".mat", "null1" + s + ".mat", ""},
+      {"aux2" + s + ".mat", "coords2" + s + ".mat", "null2" + s + ".mat", ""},
+      {"aux1" + s + ".mat", "coords1" + s + ".mat", "null1" + s + ".mat", ""},
+      {"aux2" + s + ".mat", "coords2" + s + ".mat", "null2" + s + ".mat", ""}};
+#else
+  opts.blocks = {
+      {"aux1" + s + ".mat", "coords1" + s + ".mat", "null1" + s + ".mat", ""},
+      {"aux2" + s + ".mat", "coords2" + s + ".mat", "null2" + s + ".mat", ""}};
+#endif
+
+  return opts;
+}
+
+void parseCommandLine(Teuchos::CommandLineProcessor& clp, int argc, char* argv[], DriverOptions& opts) {
+  std::string auxFilesArg;
+  std::string coordFilesArg;
+  std::string nullFilesArg;
+  std::string materialFilesArg;
+
+  clp.setOption("xml", &opts.xmlFile, "XML parameter file");
+  clp.setOption("matrix", &opts.multiPhysFile, "Multiphysics matrix file");
+  clp.setOption("nblks", &opts.nBlks, "Number of multiphysics blocks");
+  clp.setOption("its", &opts.expectedIters, "Expected maximum iteration count for success");
+  clp.setOption("tol", &opts.tolerance, "Target residual reduction for convergence");
+  clp.setOption("max-its", &opts.maxIterations, "Maximum number of iterations");
+  clp.setOption("auxFiles", &auxFilesArg, "Comma-separated auxiliary matrix files");
+  clp.setOption("coordFiles", &coordFilesArg, "Comma-separated coordinate multivector files (empty entry allowed)");
+  clp.setOption("nullFiles", &nullFilesArg, "Comma-separated nullspace multivector files (empty entry allowed)");
+  clp.setOption("materialFiles", &materialFilesArg, "Comma-separated material multivector files (empty entry allowed)");
+
+  const auto parseResult = clp.parse(argc, argv);
+  if (parseResult != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+    throw std::runtime_error("Command line parsing failed");
+  }
+
+  if (opts.nBlks <= 0) {
+    throw std::runtime_error("nBlks must be positive");
+  }
+
+  std::vector<BlockSpec> blocks;
+  if (static_cast<int>(opts.blocks.size()) == opts.nBlks) {
+    blocks = opts.blocks;
+  } else {
+    blocks.assign(opts.nBlks, BlockSpec{});
+  }
+
+  const auto assignList = [&](const std::string& arg,
+                              const std::string& fieldName,
+                              auto setter) {
+    if (trim(arg).empty()) {
+      return;
+    }
+
+    auto values = splitCommaSeparated(arg);
+    if (static_cast<int>(values.size()) != opts.nBlks) {
+      throw std::runtime_error("Expected " + fieldName + " list to have length " +
+                               std::to_string(opts.nBlks) + ", but got " +
+                               std::to_string(values.size()));
+    }
+
+    for (int i = 0; i < opts.nBlks; ++i) {
+      setter(blocks[i], normalizeOptionalFilename(values[i]));
+    }
+  };
+
+  assignList(auxFilesArg, "auxFiles", [](BlockSpec& b, const std::string& v) { b.auxFile = v; });
+  assignList(coordFilesArg, "coordFiles", [](BlockSpec& b, const std::string& v) { b.coordsFile = v; });
+  assignList(nullFilesArg, "nullFiles", [](BlockSpec& b, const std::string& v) { b.nullFile = v; });
+  assignList(materialFilesArg, "materialFiles", [](BlockSpec& b, const std::string& v) { b.materialFile = v; });
+
+  for (int i = 0; i < opts.nBlks; ++i) {
+    if (blocks[i].auxFile.empty()) {
+      throw std::runtime_error("Auxiliary matrix file for block " + std::to_string(i) +
+                               " must not be empty");
+    }
+  }
+
+  opts.blocks = std::move(blocks);
+}
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int argc, char *argv[]) {
+Teuchos::RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
+readOptionalMultiVector(
+    const std::string& filename,
+    const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& map) {
+  if (filename.empty()) {
+    return Teuchos::null;
+  }
+
+  return Xpetra::IO<Scalar, LocalOrdinal, GlobalOrdinal, Node>::ReadMultiVector(filename, map);
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+Teuchos::RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,
+                                 LocalOrdinal, GlobalOrdinal, Node>>
+readOptionalCoordinateMultiVector(
+    const std::string& filename,
+    const Teuchos::RCP<const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>>& map) {
+  using magnitude_type = typename Teuchos::ScalarTraits<Scalar>::magnitudeType;
+
+  if (filename.empty()) {
+    return Teuchos::null;
+  }
+
+  return Xpetra::IO<magnitude_type, LocalOrdinal, GlobalOrdinal, Node>::ReadMultiVector(filename, map);
+}
+
+}  // namespace
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib lib, int argc, char* argv[]) {
 #include <MueLu_UseShortNames.hpp>
 
-#ifdef BIGVERSION
-  std::string suffix("big");
-#else
-  std::string suffix("");
-#endif
-  Teuchos::oblackholestream blackhole;
+  using SC = Scalar;
+  using LO = LocalOrdinal;
+  using GO = GlobalOrdinal;
+  using NO = Node;
+
+  using STS                   = Teuchos::ScalarTraits<SC>;
+  using Magnitude             = typename STS::magnitudeType;
+  using Coordinate            = typename Teuchos::ScalarTraits<SC>::coordinateType;
+  using RealValuedMultiVector = Xpetra::MultiVector<Coordinate, LO, GO, NO>;
 
   bool success = true;
   bool verbose = true;
+
   try {
-    Teuchos::RCP<const Teuchos::Comm<int>> comm = Teuchos::DefaultComm<int>::getComm();
+    const auto comm = Teuchos::DefaultComm<int>::getComm();
 
-    // Four different versions of essentially the same problem can be run.
-    // depending on whether or not FOURBYFOUR is defined and whether or not
-    // BIGVERSION is defined  BIGVERSION just uses a finer mesh than the
-    // standard version. Data for the big and the 2x2 versions is kept
-    // in https://gitlab-ex.sandia.gov/muelu/mueludata in multiphys directory
-    // In the description below we use terms like
-    // filename[big].mat.  When BIGVERSION is defined, this refers to
-    // filenamebig.mat while it refers to filename.mat when BIGVERSION is not
-    // defined.  FOURBYFOUR decides whether or not a 4x4 or a 2x2 block system
-    // is solved.
-    //
-    // The 2 x 2 block system
-    //
-    // [ A  B ; C  D]
-    //
-    // Presently, the file multiPhys2x2[big].mat is read to define the entries of A, B, C, D.
-    // A is supposed to be a 2D elasticity problem while D is a Laplace operator. In particular,
-    // the map for D has one DoF per node while the map for A has 2 DoFs per node. Currently,
-    // the B and C associated with multiPhys2x2[big].mat are both zero. The larger version
-    // of this problem (when FOURBYFOUR is defined) just replicates this system
-    //
-    //             [ A  B 0  0 ; C  D 0 0 ;  0 0 A  B ; 0  0 C  D ]
-    //
-    // and the file read is multiPhys4x4[big].mat.
-    //
-    // AMG is first applied twice for the regular problem. Specifically, the
-    // file aux1[big].mat defines an auxiliary system that AMG is applied to.
-    // This auxiliary matrix should have the same dimensions as A. The file
-    // aux2[big].mat defines a 2nd auxiliary system that AMG is applied to.
-    // This auxiliary matrix should have the same dimensions as D. The grid
-    // transfer for the 2x2 matrix is a block diagonal matrix
-    //
-    //       [  P1  0  ; 0  P2 ]
-    //
-    // where P1 is pulled out of the hierarchy for aux1[big].mat and P2 is pulled
-    // out of the hieararchy for aux2[big].mat (on each level). For the 4x4
-    // version, 4 hierarchies are built and a 4x4 block diagonal prolongator
-    // is constructed.
-    //
-    // Additionally, the files coords*[big].mat and null*[big].mat are ready to
-    // define the auxiliary coordinates and null spaces needed by the AMG
-    // algorithm. For our specific problem, the meshes for the elasticity
-    // and the Poisson operator partially overlap (as this is similar
-    // to what happens on some ARIA ablation problems).
+    auto opts = makeDefaultOptions();
+    parseCommandLine(clp, argc, argv, opts);
 
-    int nElas, nPois;
+    std::vector<GO> blockDims(opts.nBlks, 0);
+    for (int i = 0; i < opts.nBlks; ++i) {
+      blockDims[i] = static_cast<GO>(readDimensionFromMatFile(opts.blocks[i].auxFile));
+    }
 
-    // read in sizes of elasticity and Poisson problem
+    const GO expectedMultiPhysDim =
+        std::accumulate(blockDims.begin(), blockDims.end(), static_cast<GO>(0));
 
-    FILE *fp = fopen(std::string("aux1" + suffix + ".mat").c_str(), "r");
-    if (fp == NULL) {
-      std::cout << "\nERROR:  File aux1" + suffix + ".mat not found" << std::endl;
+    const GO actualMultiPhysDim =
+        static_cast<GO>(readDimensionFromMatFile(opts.multiPhysFile));
+
+    if (actualMultiPhysDim != expectedMultiPhysDim) {
+      if (comm->getRank() == 0) {
+        std::cerr << "ERROR: multiphysics matrix dimension is "
+                  << actualMultiPhysDim
+                  << ", expected " << expectedMultiPhysDim
+                  << std::endl;
+      }
       return EXIT_FAILURE;
     }
 
-    int ch;
-    int ret_val = 0;
-    (void)ret_val;  // suppress fscanf return value and unused variable warnings
-    while ((ch = getc(fp)) != '\n')
-      ;
-    ret_val = fscanf(fp, "%d", &nElas);
+    std::vector<Teuchos::RCP<const Map>> nodeMaps(opts.nBlks);
+    std::vector<Teuchos::RCP<const Map>> dofMaps(opts.nBlks);
+    std::vector<GO> blockOffsets(opts.nBlks, 0);
 
-    fp = fopen(std::string("aux2" + suffix + ".mat").c_str(), "r");
-    if (fp == NULL) {
-      std::cout << "\nERROR:  File aux2" + suffix + ".mat not found" << std::endl;
-      return EXIT_FAILURE;
+    for (int i = 1; i < opts.nBlks; ++i) {
+      blockOffsets[i] = blockOffsets[i - 1] + blockDims[i - 1];
     }
-    while ((ch = getc(fp)) != '\n')
-      ;
-    ret_val = fscanf(fp, "%d", &nPois);
-    fclose(fp);
 
-    // check that multiphysics problem and aux matrices are consistent with respect to sizes
+    for (int i = 0; i < opts.nBlks; ++i) {
+      const GO blockDim = blockDims[i];
 
-    int itemp;
+      GO nodalCount = blockDim;
 
-#ifdef FOURBYFOUR
-    fp = fopen(std::string("multiPhys4x4" + suffix + ".mat").c_str(), "r");
-    if (fp == NULL) {
-      std::cout << "\nERROR:  File multiPhys4x4" + suffix + ".mat not found" << std::endl;
-      return EXIT_FAILURE;
+      if (!opts.blocks[i].coordsFile.empty()) {
+        const GO probeSize  = blockDim;
+        const auto probeMap = MapFactory::Build(lib, probeSize, 0, comm);
+        auto coordsProbe =
+            Xpetra::IO<Magnitude, LO, GO, NO>::ReadMultiVector(opts.blocks[i].coordsFile, probeMap);
+
+        nodalCount = static_cast<GO>(coordsProbe->getMap()->getGlobalNumElements());
+
+        if (nodalCount <= 0) {
+          throw std::runtime_error("Invalid nodal count inferred from coordinates for block " +
+                                   std::to_string(i));
+        }
+
+        if (blockDim % nodalCount != 0) {
+          throw std::runtime_error(
+              "Cannot infer integer dofs-per-node for block " + std::to_string(i) +
+              ": block dimension " + std::to_string(blockDim) +
+              " is not divisible by coordinate map size " + std::to_string(nodalCount));
+        }
+      }
+
+      nodeMaps[i] = MapFactory::Build(lib, nodalCount, 0, comm);
+
+      const GO dofsPerNode = blockDim / nodalCount;
+      if (dofsPerNode == 1) {
+        dofMaps[i] = nodeMaps[i];
+      } else {
+        dofMaps[i] = Xpetra::MapFactory<LO, GO, NO>::Build(
+            nodeMaps[i], static_cast<size_t>(dofsPerNode));
+      }
     }
-    while ((ch = getc(fp)) != '\n')
-      ;
-    ret_val = fscanf(fp, "%d", &itemp);
-    if (itemp != nElas + nPois + nElas + nPois) {
-      std::cout << "\nERROR:  multiPhys4x4" + suffix + ".mat dimension is" << itemp << "was expecting it to be " << 2 * (nElas + nPois) << std::endl;
-      return EXIT_FAILURE;
+
+    Teuchos::Array<GO> gidsCombo;
+    {
+      std::size_t localTotal = 0;
+      for (int i = 0; i < opts.nBlks; ++i) {
+        localTotal += dofMaps[i]->getLocalNumElements();
+      }
+
+      gidsCombo.resize(localTotal);
+
+      std::size_t cursor = 0;
+      for (int i = 0; i < opts.nBlks; ++i) {
+        const auto localGids = dofMaps[i]->getLocalElementList();
+        for (int j = 0; j < static_cast<int>(localGids.size()); ++j) {
+          gidsCombo[cursor++] = localGids[j] + blockOffsets[i];
+        }
+      }
     }
-#else
-    fp = fopen(std::string("multiPhys2x2" + suffix + ".mat").c_str(), "r");
-    if (fp == NULL) {
-      std::cout << "\nERROR:  File multiPhys2x2" + suffix + ".mat not found" << std::endl;
-      return EXIT_FAILURE;
+
+    const auto mapMultiPhysA =
+        Xpetra::MapFactory<LO, GO, NO>::Build(
+            lib,
+            Teuchos::OrdinalTraits<Xpetra::global_size_t>::invalid(),
+            gidsCombo,
+            0,
+            comm);
+
+    auto multiPhysA = Xpetra::IO<SC, LO, GO, NO>::Read(opts.multiPhysFile, mapMultiPhysA);
+
+    Teuchos::ArrayRCP<Teuchos::RCP<Matrix>> arrayOfAuxMatrices(opts.nBlks);
+    Teuchos::ArrayRCP<Teuchos::RCP<RealValuedMultiVector>> arrayOfCoords(opts.nBlks);
+    Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfNullspaces(opts.nBlks);
+    Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfMaterials(opts.nBlks);
+
+    for (int i = 0; i < opts.nBlks; ++i) {
+      arrayOfAuxMatrices[i] = Xpetra::IO<SC, LO, GO, NO>::Read(opts.blocks[i].auxFile, dofMaps[i]);
+
+      arrayOfCoords[i] = readOptionalCoordinateMultiVector<SC, LO, GO, NO>(
+          opts.blocks[i].coordsFile, nodeMaps[i]);
+
+      arrayOfNullspaces[i] = readOptionalMultiVector<SC, LO, GO, NO>(
+          opts.blocks[i].nullFile, dofMaps[i]);
+
+      arrayOfMaterials[i] = readOptionalMultiVector<SC, LO, GO, NO>(
+          opts.blocks[i].materialFile, dofMaps[i]);
     }
-    while ((ch = getc(fp)) != '\n')
-      ;
-    ret_val = fscanf(fp, "%d", &itemp);
-    if (itemp != nElas + nPois) {
-      std::cout << "\nERROR:  multiPhys2x2" + suffix + ".mat dimension is" << itemp << "was expecting it to be " << (nElas + nPois) << std::endl;
-      return EXIT_FAILURE;
-    }
-#endif
-
-    Teuchos::RCP<const Map> mapPois            = MapFactory::Build(lib, nPois, 0, comm);
-    Teuchos::RCP<const Map> mapElas1DofPerNode = MapFactory::Build(lib, nElas / 2, 0, comm);
-    Teuchos::RCP<const Map> mapElas2DofPerNode = Xpetra::MapFactory<LO, GO, Node>::Build(mapElas1DofPerNode, 2);
-
-    Teuchos::ArrayView<const GO> GIDsElas2DofPerNode = mapElas2DofPerNode->getLocalElementList();
-    Teuchos::ArrayView<const GO> GIDsPois            = mapPois->getLocalElementList();
-
-#ifdef FOURBYFOUR
-    Teuchos::Array<GO> GIDsCombo(2 * (GIDsElas2DofPerNode.size() + GIDsPois.size()));
-#else
-    Teuchos::Array<GO> GIDsCombo(GIDsElas2DofPerNode.size() + GIDsPois.size());
-#endif
-
-    for (int ii = 0; ii < GIDsElas2DofPerNode.size(); ii++) GIDsCombo[ii] = GIDsElas2DofPerNode[ii];
-    for (int ii = 0; ii < GIDsPois.size(); ii++) GIDsCombo[ii + GIDsElas2DofPerNode.size()] = GIDsPois[ii] + nElas;
-#ifdef FOURBYFOUR
-    for (int ii = 0; ii < GIDsElas2DofPerNode.size(); ii++) GIDsCombo[ii + GIDsElas2DofPerNode.size() + GIDsPois.size()] = GIDsElas2DofPerNode[ii] + nElas + nPois;
-    for (int ii = 0; ii < GIDsPois.size(); ii++) GIDsCombo[ii + 2 * GIDsElas2DofPerNode.size() + GIDsPois.size()] = GIDsPois[ii] + 2 * nElas + nPois;
-#endif
-
-    Teuchos::RCP<const Map> mapMultiPhysA = Xpetra::MapFactory<LO, GO, Node>::Build(lib, Teuchos::OrdinalTraits<Xpetra::global_size_t>::invalid(), GIDsCombo, mapElas2DofPerNode->getIndexBase(), comm);
-#ifdef FOURBYFOUR
-    Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> multiPhysA = Xpetra::IO<SC, LO, GO, Node>::Read("multiPhys4x4" + suffix + ".mat", mapMultiPhysA);
-#else
-    Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> multiPhysA = Xpetra::IO<SC, LO, GO, Node>::Read("multiPhys2x2" + suffix + ".mat", mapMultiPhysA);
-#endif
-
-    // To solve the block system a block diagonal auxiliary operator such as
-    //
-    //     [ aux1    0     0      0 ]
-    //     [ 0    aux1     0      0 ]
-    //     [ 0       0  aux1      0 ]
-    //     [ 0       0     0   aux2 ]
-    //
-    //
-    // is used in conjunction with multiple invocations of Hierarchy Setup
-
-    Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> aux1 = Xpetra::IO<SC, LO, GO, Node>::Read("aux1" + suffix + ".mat", mapElas2DofPerNode);
-    Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> aux2 = Xpetra::IO<SC, LO, GO, Node>::Read("aux2" + suffix + ".mat", mapPois);
-
-    typedef Teuchos::ScalarTraits<SC> STS;
-    typedef typename STS::magnitudeType real_type;
-    typedef typename Teuchos::ScalarTraits<Scalar>::coordinateType coordinate_type;
-    typedef Xpetra::MultiVector<real_type, LO, GO, NO> RealValuedMultiVector;
-    typedef Xpetra::MultiVectorFactory<coordinate_type, LO, GO, NO> RealValuedMultiVectorFactory;
-
-    Teuchos::RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType, LocalOrdinal, GlobalOrdinal, Node>> elasCoords = Xpetra::IO<real_type, LO, GO, Node>::ReadMultiVector("coords1" + suffix + ".mat", mapElas1DofPerNode);
-    Teuchos::RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType, LocalOrdinal, GlobalOrdinal, Node>> poisCoords = Xpetra::IO<real_type, LO, GO, Node>::ReadMultiVector("coords2" + suffix + ".mat", mapPois);
-
-    Teuchos::RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>> nullspace1 = Xpetra::IO<SC, LO, GO, Node>::ReadMultiVector("null1" + suffix + ".mat", mapElas2DofPerNode);
-    Teuchos::RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>> nullspace2 = Xpetra::IO<SC, LO, GO, Node>::ReadMultiVector("null2" + suffix + ".mat", mapPois);
-
-    // Note: Entries of arrayOfNullspaces[] may be set to null.
-#ifdef FOURBYFOUR
-    Teuchos::ArrayRCP<Teuchos::RCP<Matrix>> arrayOfAuxMatrices(4);
-    Teuchos::ArrayRCP<Teuchos::RCP<RealValuedMultiVector>> arrayOfCoords(4);
-    Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfNullspaces(4);
-
-    arrayOfAuxMatrices[2] = aux1;
-    arrayOfAuxMatrices[3] = aux2;
-    arrayOfCoords[2]      = elasCoords;
-    arrayOfCoords[3]      = poisCoords;
-    arrayOfNullspaces[2]  = nullspace1;
-    arrayOfNullspaces[3]  = nullspace2;
-#else
-    Teuchos::ArrayRCP<Teuchos::RCP<Matrix>> arrayOfAuxMatrices(2);
-    Teuchos::ArrayRCP<Teuchos::RCP<RealValuedMultiVector>> arrayOfCoords(2);
-    Teuchos::ArrayRCP<Teuchos::RCP<MultiVector>> arrayOfNullspaces(2);
-#endif
-
-    arrayOfAuxMatrices[0] = aux1;
-    arrayOfAuxMatrices[1] = aux2;
-    arrayOfCoords[0]      = elasCoords;
-    arrayOfCoords[1]      = poisCoords;
-    arrayOfNullspaces[0]  = nullspace1;
-    arrayOfNullspaces[1]  = nullspace2;
 
     Teuchos::ParameterList comboList;
-    Teuchos::updateParametersFromXmlFileAndBroadcast("comboP.xml", Teuchos::Ptr<Teuchos::ParameterList>(&comboList), *comm);
-#ifdef FOURBYFOUR
-    Teuchos::RCP<Operator> preconditioner = rcp(new MueLu::MultiPhys<SC, LO, GO, NO>(multiPhysA, arrayOfAuxMatrices, arrayOfNullspaces, arrayOfCoords, 4, comboList, true));
-#else
-    Teuchos::RCP<Operator> preconditioner = rcp(new MueLu::MultiPhys<SC, LO, GO, NO>(multiPhysA, arrayOfAuxMatrices, arrayOfNullspaces, arrayOfCoords, 2, comboList, true));
-#endif
+    Teuchos::updateParametersFromXmlFileAndBroadcast(
+        opts.xmlFile,
+        Teuchos::Ptr<Teuchos::ParameterList>(&comboList),
+        *comm);
 
-    Teuchos::RCP<Teuchos::TimeMonitor> globalTimeMonitor = Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Timings: Global Time")));
+    auto preconditioner = Teuchos::rcp(
+        new MueLu::MultiPhys<SC, LO, GO, NO>(
+            multiPhysA,
+            arrayOfAuxMatrices,
+            arrayOfNullspaces,
+            arrayOfCoords,
+            opts.nBlks,
+            comboList,
+            true,
+            arrayOfMaterials,
+            true));
 
-    // =========================================================================
-    // System solution (Ax = b)
-    // =========================================================================
-    typedef Teuchos::ScalarTraits<SC> STS;
-    SC zero = STS::zero(), one = STS::one();
+    auto globalTimeMonitor =
+        Teuchos::rcp(new Teuchos::TimeMonitor(
+            *Teuchos::TimeMonitor::getNewTimer("Timings: Global Time")));
 
-    Teuchos::RCP<Vector> X = VectorFactory::Build(multiPhysA->getRowMap());
-    Teuchos::RCP<Vector> B = VectorFactory::Build(multiPhysA->getRowMap());
+#ifdef HAVE_MUELU_BELOS
+    const SC zero = STS::zero();
+    const SC one  = STS::one();
+
+    auto X = VectorFactory::Build(multiPhysA->getRowMap());
+    auto B = VectorFactory::Build(multiPhysA->getRowMap());
 
     {
-      // set seed for reproducibility
       Utilities::SetRandomSeed(*comm);
       X->randomize();
       multiPhysA->apply(*X, *B, Teuchos::NO_TRANS, one, zero);
@@ -281,55 +467,69 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
       X->putScalar(zero);
     }
 
-    // Belos linear problem
-    typedef MultiVector MV;
-    typedef Belos::OperatorT<MV> OP;
+    using MV = MultiVector;
+    using OP = Belos::OperatorT<MV>;
 
-    Teuchos::RCP<OP> belosOp                                    = Teuchos::rcp(new Belos::XpetraOp<SC, LO, GO, NO>(multiPhysA));
-    Teuchos::RCP<OP> belosPrecOp                                = Teuchos::rcp(new Belos::XpetraOp<SC, LO, GO, NO>(preconditioner));  // Turns a Xpetra::Matrix object into a Belos operator
-    Teuchos::RCP<Belos::LinearProblem<SC, MV, OP>> belosProblem = rcp(new Belos::LinearProblem<SC, MV, OP>(belosOp, X, B));
+    auto belosOp     = Teuchos::rcp(new Belos::XpetraOp<SC, LO, GO, NO>(multiPhysA));
+    auto belosPrecOp = Teuchos::rcp(new Belos::XpetraOp<SC, LO, GO, NO>(preconditioner));
+
+    auto belosProblem =
+        Teuchos::rcp(new Belos::LinearProblem<SC, MV, OP>(belosOp, X, B));
     belosProblem->setRightPrec(belosPrecOp);
-    bool set = belosProblem->setProblem();
-    if (set == false) {
-      std::cout << "\nERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+
+    const bool set = belosProblem->setProblem();
+    if (!set) {
+      if (comm->getRank() == 0) {
+        std::cerr << "ERROR: Belos::LinearProblem failed to set up correctly!" << std::endl;
+      }
       return EXIT_FAILURE;
     }
-    Teuchos::RCP<Teuchos::ParameterList> belosList = Teuchos::parameterList();
-    belosList->set("Maximum Iterations", 100);
-    belosList->set("Convergence Tolerance", 1e-6);
+
+    auto belosList = Teuchos::parameterList();
+    belosList->set("Maximum Iterations", opts.maxIterations);
+    belosList->set("Convergence Tolerance", opts.tolerance);
     belosList->set("Verbosity", Belos::Errors + Belos::Warnings + Belos::StatusTestDetails);
     belosList->set("Output Frequency", 1);
     belosList->set("Output Style", Belos::Brief);
     belosList->set("Implicit Residual Scaling", "None");
 
     Belos::SolverFactory<SC, MV, OP> solverFactory;
-    Teuchos::RCP<Belos::SolverManager<SC, MV, OP>> solver = solverFactory.create("gmres", belosList);
+    auto solver = solverFactory.create("gmres", belosList);
     solver->setProblem(belosProblem);
-    Belos::ReturnType retStatus = Belos::Unconverged;
-    retStatus                   = solver->solve();
 
-    int iters = solver->getNumIters();
-    success   = (iters < 50 && retStatus == Belos::Converged);
+    const auto retStatus = solver->solve();
+    const int iters      = solver->getNumIters();
+
+    success = (iters <= opts.expectedIters && retStatus == Belos::Converged);
+
     if (comm->getRank() == 0) {
-      if (success)
+      if (success) {
         std::cout << "SUCCESS! Belos converged in " << iters << " iterations." << std::endl;
-      else
-        std::cout << "FAILURE! Belos did not converge fast enough." << std::endl;
+      } else if (retStatus == Belos::Converged) {
+        std::cout << "FAILURE! Belos converged, but required "
+                  << iters << " iterations which exceeds the allowed "
+                  << opts.expectedIters << "." << std::endl;
+      } else {
+        std::cout << "FAILURE! Belos did not converge." << std::endl;
+      }
     }
+#else
+    if (comm->getRank() == 0) {
+      std::cout << "Belos not enabled; preconditioner was constructed, but no solve was performed." << std::endl;
+    }
+#endif
 
-    // Timer final summaries
-    globalTimeMonitor = Teuchos::null;  // stop this timer before summary
+    globalTimeMonitor = Teuchos::null;
     Teuchos::TimeMonitor::summarize();
   }
   TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
 
-  return (success ? EXIT_SUCCESS : EXIT_FAILURE);
+  return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
-//- -- --------------------------------------------------------
 #define MUELU_AUTOMATIC_TEST_ETI_NAME main_
 #include "MueLu_Test_ETI.hpp"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
   return Automatic_Test_ETI(argc, argv);
 }

--- a/packages/muelu/test/scaling/ComboPDriver.cpp
+++ b/packages/muelu/test/scaling/ComboPDriver.cpp
@@ -55,32 +55,14 @@
 #include <BelosXpetraAdapter.hpp>
 #endif
 
-#define FOURBYFOUR
-
 namespace {
 
-std::string defaultSuffix() {
-#ifdef BIGVERSION
-  return "big";
-#else
-  return "";
-#endif
-}
-
 int defaultBlockCount() {
-#ifdef FOURBYFOUR
   return 4;
-#else
-  return 2;
-#endif
 }
 
-std::string defaultMultiPhysFile(const std::string& suffix) {
-#ifdef FOURBYFOUR
-  return "multiPhys4x4" + suffix + ".mat";
-#else
-  return "multiPhys2x2" + suffix + ".mat";
-#endif
+std::string defaultMultiPhysFile() {
+  return "multiPhys4x4.mat";
 }
 
 std::string trim(std::string s) {
@@ -166,9 +148,8 @@ struct BlockSpec {
 };
 
 struct DriverOptions {
-  std::string suffix        = defaultSuffix();
   std::string xmlFile       = "comboP.xml";
-  std::string multiPhysFile = defaultMultiPhysFile(defaultSuffix());
+  std::string multiPhysFile = defaultMultiPhysFile();
   int nBlks                 = defaultBlockCount();
   int expectedIters         = 50;
   std::vector<BlockSpec> blocks;
@@ -178,19 +159,12 @@ struct DriverOptions {
 
 DriverOptions makeDefaultOptions() {
   DriverOptions opts;
-  const auto s = opts.suffix;
 
-#ifdef FOURBYFOUR
   opts.blocks = {
-      {"aux1" + s + ".mat", "coords1" + s + ".mat", "null1" + s + ".mat", ""},
-      {"aux2" + s + ".mat", "coords2" + s + ".mat", "null2" + s + ".mat", ""},
-      {"aux1" + s + ".mat", "coords1" + s + ".mat", "null1" + s + ".mat", ""},
-      {"aux2" + s + ".mat", "coords2" + s + ".mat", "null2" + s + ".mat", ""}};
-#else
-  opts.blocks = {
-      {"aux1" + s + ".mat", "coords1" + s + ".mat", "null1" + s + ".mat", ""},
-      {"aux2" + s + ".mat", "coords2" + s + ".mat", "null2" + s + ".mat", ""}};
-#endif
+      {"aux1.mat", "coords1.mat", "null1.mat", ""},
+      {"aux2.mat", "coords2.mat", "null2.mat", ""},
+      {"aux1.mat", "coords1.mat", "null1.mat", ""},
+      {"aux2.mat", "coords2.mat", "null2.mat", ""}};
 
   return opts;
 }

--- a/packages/muelu/test/scaling/ComboPDriver.cpp
+++ b/packages/muelu/test/scaling/ComboPDriver.cpp
@@ -125,7 +125,8 @@ std::vector<std::string> splitCommaSeparated(const std::string& input) {
   return result;
 }
 
-int readDimensionFromMatFile(const std::string& filename) {
+template <typename GO>
+GO readDimensionFromMatFile(const std::string& filename) {
   std::ifstream in(filename);
   if (!in.is_open()) {
     throw std::runtime_error("File not found: " + filename);
@@ -144,15 +145,13 @@ int readDimensionFromMatFile(const std::string& filename) {
     }
 
     std::istringstream iss(line);
-    int nRows = 0;
-    int nCols = 0;
-    int nnz   = 0;
+    GO nRows = 0;
+    GO nCols = 0;
 
     if (!(iss >> nRows >> nCols)) {
       throw std::runtime_error("Failed to parse matrix dimension line from file: " + filename);
     }
 
-    (void)nnz;
     return nRows;
   }
 
@@ -317,14 +316,14 @@ int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib lib, int arg
 
     std::vector<GO> blockDims(opts.nBlks, 0);
     for (int i = 0; i < opts.nBlks; ++i) {
-      blockDims[i] = static_cast<GO>(readDimensionFromMatFile(opts.blocks[i].auxFile));
+      blockDims[i] = static_cast<GO>(readDimensionFromMatFile<GO>(opts.blocks[i].auxFile));
     }
 
     const GO expectedMultiPhysDim =
         std::accumulate(blockDims.begin(), blockDims.end(), static_cast<GO>(0));
 
     const GO actualMultiPhysDim =
-        static_cast<GO>(readDimensionFromMatFile(opts.multiPhysFile));
+        static_cast<GO>(readDimensionFromMatFile<GO>(opts.multiPhysFile));
 
     if (actualMultiPhysDim != expectedMultiPhysDim) {
       if (comm->getRank() == 0) {
@@ -350,12 +349,7 @@ int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib lib, int arg
       GO nodalCount = blockDim;
 
       if (!opts.blocks[i].coordsFile.empty()) {
-        const GO probeSize  = blockDim;
-        const auto probeMap = MapFactory::Build(lib, probeSize, 0, comm);
-        auto coordsProbe =
-            Xpetra::IO<Magnitude, LO, GO, NO>::ReadMultiVector(opts.blocks[i].coordsFile, probeMap);
-
-        nodalCount = static_cast<GO>(coordsProbe->getMap()->getGlobalNumElements());
+        nodalCount = static_cast<GO>(readDimensionFromMatFile<GO>(opts.blocks[i].coordsFile));
 
         if (nodalCount <= 0) {
           throw std::runtime_error("Invalid nodal count inferred from coordinates for block " +


### PR DESCRIPTION
@trilinos/muelu
@rstumin 

Refactor ComboPDriver to be usable more generally. For example, for experimenting with solvers for the coupled voltage transport equation from thermal battery applications:

```bash
TRILINOS_BUILD_DIR=${TRILINOS_BUILD_DIR:=/workspace/trilinos-build}
driverCombo=${TRILINOS_BUILD_DIR}/packages/muelu/test/scaling/MueLu_ComboPDriver.exe

matrix=coupled_voltage.mm
nblks=2
xml=settings.xml
liquidCoords=liquid_voltage.coords
liquidMaterial=liquid_voltage.material
liquidMatrix=liquid_voltage.mm
solidCoords=solid_voltage.coords
solidMaterial=solid_voltage.material
solidMatrix=solid_voltage.mm


${driverCombo} \
  --xml=${xml} \
  --nblks=${nblks} \
  --matrix=${matrix} \
  --auxFiles=${liquidMatrix},${solidMatrix} \
  --coordFiles=${liquidCoords},${solidCoords} \
  --materialFiles=${liquidMaterial},${solidMaterial} \
  --nullFiles=none,none \
  --tol=1e-8
```