### PR TITLE
Tacho: complex supports

### DIFF
--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Blas_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Blas_Serial.hpp
@@ -50,11 +50,19 @@ template <typename T> struct BlasSerial {
           y[i*incy] += (A[i + j*lda] * val);
         }
       }
-    } else {
+    } else if (trans == 'C' || trans == 'c') {
       for (int j = 0; j < n; j++) {
-        T val = 0.0;
+        T val = zero;
         for (int i = 0; i < m; i++) {
           val += (arith_traits::conj(A[i + j*lda]) * x[i*incx]);
+        }
+        y[j*incy] += alpha * val;
+      }
+    } else {
+      for (int j = 0; j < n; j++) {
+        T val = zero;
+        for (int i = 0; i < m; i++) {
+          val += (A[i + j*lda] * x[i*incx]);
         }
         y[j*incy] += alpha * val;
       }
@@ -125,7 +133,7 @@ template <typename T> struct BlasSerial {
           }
         }
       }
-    } else {
+    } else if (trans == 'C' || trans == 'c') {
       if (uplo == 'U' || uplo == 'u') {
         // upper
         for (int j = 0; j < n; j++) {
@@ -161,6 +169,42 @@ template <typename T> struct BlasSerial {
           y[j*incy] += alpha * val;
         }
       }
+    } else {
+      if (uplo == 'U' || uplo == 'u') {
+        // upper
+        for (int j = 0; j < n; j++) {
+          T val = zero;
+          if (j < mn) {
+            // diagonal A(j,j)
+            val = x[j*incx];
+            if (diag != 'U' && diag != 'u')
+              val *= (A[j + j*lda]);
+
+            // off-diagonals of A(:,j)
+            for (int i = 0; i < j; i++) {
+              val += (A[i + j*lda] * x[i*incx]);
+            }
+          } else {
+            for (int i = 0; i < m; i++) {
+              val += (A[i + j*lda] * x[i*incx]);
+            }
+          }
+          y[j*incy] += alpha * val;
+        }
+      } else {
+        for (int j = 0; j < mn; j++) {
+          // diagonal A(j,j)
+          T val = x[j*incx];
+          if (diag != 'U' && diag != 'u')
+            val *= (A[j + j*lda]);
+
+          // off-diagonals of A(:,j)
+          for (int i = j+1; i < m; i++) {
+            val += (A[i + j*lda] * x[i*incx]);
+          }
+          y[j*incy] += alpha * val;
+        }
+      }
     }
   }
 
@@ -187,8 +231,8 @@ template <typename T> struct BlasSerial {
                                          const T *B, int ldb,
                           const T beta,  /* */ T *C, int ldc) {
 
+    typedef ArithTraits<T> arith_traits;
     const T one(1), zero(0);
-
     if (alpha == zero) {
       if (beta == zero) {
         for (int j = 0; j < n; j++) {
@@ -223,6 +267,24 @@ template <typename T> struct BlasSerial {
         } else {
           Kokkos::abort("gemm: transb is not valid");
         }
+      } else if (transa == 'C' || transa == 'c') {
+        if (transb == 'N' || transb == 'n') {
+          for (int j = 0; j < n; j++) {
+            if (beta == zero) {
+              for (int i = 0; i < m; i++) C[i + j*ldc] = zero;
+            } else if (beta != one) {
+              for (int i = 0; i < m; i++) C[i + j*ldc] *= beta;
+            }
+            for (int l = 0; l < k; l++) {
+              T val = alpha * B[l + j*ldb] ;
+              for (int i = 0; i < m; i++) {
+                C[i + j*ldc] += arith_traits::conj(A[l + i*lda]) * val;
+              }
+            }
+          }
+        } else {
+          Kokkos::abort("gemm: transb is not valid");
+        }
       } else {
         if (transb == 'N' || transb == 'n') {
           for (int j = 0; j < n; j++) {
@@ -239,7 +301,7 @@ template <typename T> struct BlasSerial {
             }
           }
         } else {
-          Kokkos::abort("gemm: transa is not valid");
+          Kokkos::abort("gemm: transb is not valid");
         }
       }
     }
@@ -278,7 +340,7 @@ template <typename T> struct BlasSerial {
           }
         }
       } else if (trans == 'C' || trans == 'c') {
-        // C = alpha * (A^T * A) + beta * C
+        // C = alpha * (A^H * A) + beta * C
         for (int j = 0; j < n; j++) {
           for (int i = 0; i <= j; i++) {
             // update
@@ -350,7 +412,7 @@ template <typename T> struct BlasSerial {
                 B[i + j*ldb] -= arith_traits::conj(A[l + i*lda]) * B[l + j*ldb];
               }
               if (diag != 'U' && diag != 'u') {
-                B[i + j*ldb] /= A[i + i*lda];
+                B[i + j*ldb] /= arith_traits::conj(A[i + i*lda]);
               }
             }
           }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Blas_Team.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Blas_Team.hpp
@@ -145,13 +145,15 @@ template <typename T> struct BlasTeam {
     }
 
     template <typename MemberType>
-    static KOKKOS_INLINE_FUNCTION void trmv_upper(MemberType &member, const bool trans, const bool unit_diag,
+    static KOKKOS_INLINE_FUNCTION void trmv_upper(MemberType &member, const char trans_char, const bool unit_diag,
                                                   const int m, const int n,
                                                   const T alpha, const T *KOKKOS_RESTRICT A, const int inca, const int lda,
                                                                  const T *KOKKOS_RESTRICT x, const int incx,
                                                   const T beta,        T *KOKKOS_RESTRICT y, const int incy) {
       typedef ArithTraits<T> arith_traits;
       const T one(1), zero(0);
+      const bool trans = (trans_char != 'N' && trans_char != 'n');
+      const bool conjugate = (trans_char == 'C' || trans_char == 'c');
       {
         int mt = (trans ?  n : m);
         if (beta == zero)
@@ -165,9 +167,8 @@ template <typename T> struct BlasTeam {
         
         // TODO: need team-thread implementation
         member.team_barrier();
-        if (trans) {
-          // Trans
-          #if 1
+        if (conjugate) {
+          // Conj
           Kokkos::parallel_for(
             Kokkos::TeamVectorRange(member, n),
             [&](const ordinal_type &j) { // Value capture is a workaround for cuda + gcc-7.2 compiler bug w/c++14
@@ -180,28 +181,22 @@ template <typename T> struct BlasTeam {
               }
               y[j*incy] += alpha * val;
             });
-          #else
-          if (inca == 1 || inca < lda) {
-            Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, n), [&](const int &j) {
-              T t = (unit_diag ? x[j * incx] : arith_traits::conj(A[j * inca + j * lda]) * x[j * incx]);
-              Kokkos::parallel_for(Kokkos::TeamThreadRange(member, j),
-                                   [&](const int &i) { t += arith_traits::conj(A[i * inca + j * lda]) * x[i * incx]; });
-              Kokkos::atomic_add(&y[j * incy], alpha * t); // TODO: can different blocks write to same y?
-              //y[j * incy] += alpha * t;
+        } else if (trans) {
+          // transpose
+          Kokkos::parallel_for(
+            Kokkos::TeamVectorRange(member, n),
+            [&](const ordinal_type &j) { // Value capture is a workaround for cuda + gcc-7.2 compiler bug w/c++14
+              T val = zero;
+              if (j < m) {
+                val = (unit_diag ? x[j*incx] : x[j*incx] * A[j + j*lda]);
+                for (int i = 0; i < j; i++) val += A[i*inca + j*lda] * x[i*incx];
+              } else {
+                for (int i = 0; i < m; i++) val += A[i*inca + j*lda] * x[i*incx];
+              }
+              y[j*incy] += alpha * val;
             });
-          } else {
-            Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &j) {
-              T t = (unit_diag ? x[j * incx] : arith_traits::conj(A[j * inca + j * lda]) * x[j * incx]);
-              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, j), 
-                                   [&](const int &i) { t += arith_traits::conj(A[i * inca + j * lda]) * x[i * incx]; });
-              Kokkos::atomic_add(&y[j * incy], alpha * t); // TODO: can different blocks write to same y?
-              //y[j * incy] += alpha * t;
-            });
-          }
-          #endif
         } else {
           // no-transpose
-          #if 1
           Kokkos::parallel_for(
             Kokkos::TeamVectorRange(member, m),
             [&](const ordinal_type &i) { // Value capture is a workaround for cuda + gcc-7.2 compiler bug w/c++14
@@ -209,25 +204,6 @@ template <typename T> struct BlasTeam {
               for (int j = i+1; j < n; j++) val += A[i*inca + j*lda] * x[j*incx];
               y[i*incy] += alpha * val;
             });
-          #else
-          if (inca == 1 || inca < lda) {
-            Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, m), [&](const int &i) {
-              T t = (unit_diag ? x[i * incx] : A[i * inca + i * lda] * x[i * incx]);
-              Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n-i-1),
-                                   [&](const int &j) { t += (A[i * inca + (i+1+j) * lda]) * x[(i+1+j) * incx]; });
-              Kokkos::atomic_add(&y[i * incy], alpha * t); // TODO: can different blocks write to same y?
-              //y[i * incy] += alpha * t;
-            });
-          } else {
-            Kokkos::parallel_for(Kokkos::TeamThreadRange(member, m), [&](const int &i) {
-              T t = (unit_diag ? x[i * incx] : A[i * inca + i * lda] * x[i * incx]);
-              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, n-i-1),
-                                   [&](const int &j) { t += (A[i * inca + (i+1+j) * lda]) * x[(i+1+j) * incx]; });
-              Kokkos::atomic_add(&y[i * incy], alpha * t); // TODO: can different blocks write to same y?
-              //y[i * incy] += alpha * t;
-            });
-          }
-          #endif
         }
       }
     }
@@ -377,10 +353,11 @@ template <typename T> struct BlasTeam {
 
         member.team_barrier();
         {
+          // C := beta*C + alpha cjA(A) * cjB(A)
           Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &j) {
-            const T *KOKKOS_RESTRICT pA = A + j * as0;
+            const T *KOKKOS_RESTRICT pB = A + j * as0;
             Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, j + 1), [&](const int &i) {
-              const T *KOKKOS_RESTRICT pB = A + i * as0;
+              const T *KOKKOS_RESTRICT pA = A + i * as0;
               T c(0);
               for (int p = 0; p < k; ++p)
                 c += cjA(pA[p * as1]) * cjB(pB[p * as1]);
@@ -409,10 +386,11 @@ template <typename T> struct BlasTeam {
 
         member.team_barrier();
         {
+          // C := beta*C + alpha cjA(A) * cjB(A)
           Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const int &j) {
             Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, n - j), [&](const int &i) {
               const int ii = i + j;
-              const T *KOKKOS_RESTRICT pA = A + j * as0, *KOKKOS_RESTRICT pB = A + ii * as0;
+              const T *KOKKOS_RESTRICT pB = A + j * as0, *KOKKOS_RESTRICT pA = A + ii * as0;
               T c(0);
               for (int p = 0; p < k; ++p)
                 c += cjA(pA[p * as1]) * cjB(pB[p * as1]);
@@ -537,12 +515,12 @@ template <typename T> struct BlasTeam {
                                                          const T *KOKKOS_RESTRICT x, const int xs,
                                           const T beta,        T *KOKKOS_RESTRICT y, const int ys) {
     if (uplo == 'U' || uplo == 'u') {
-        Impl::trmv_upper(member, (trans != 'N' && trans != 'n'),
-                                 (diag == 'U' || diag == 'u'),
-                                  m, n,
-                                  alpha, a, 1, lda,
-                                         x, xs,
-                                  beta,  y, ys);
+      Impl::trmv_upper(member, trans,
+                       (diag == 'U' || diag == 'u'),
+                       m, n,
+                       alpha, a, 1, lda,
+                              x, xs,
+                       beta,  y, ys);
     } else {
       Kokkos::abort("Trmv with lower-tridiagonal");
     }
@@ -562,7 +540,7 @@ template <typename T> struct BlasTeam {
       }
       case 'T':
       case 't': {
-        NoConjugate cjA;
+        NoConjugate cjA; // transpose is same as no-conjugate
         Impl::trsv_lower(member, cjA, diag, m, a, lda, 1, b, bs);
         break;
       }
@@ -573,7 +551,7 @@ template <typename T> struct BlasTeam {
         break;
       }
       default:
-        Kokkos::abort("trans is not valid");
+        Kokkos::abort("trans is not valid (trsv(U))");
       }
     } else if (uplo == 'L' || uplo == 'l') {
       switch (trans) {
@@ -585,7 +563,7 @@ template <typename T> struct BlasTeam {
       }
       case 'T':
       case 't': {
-        NoConjugate cjA;
+        NoConjugate cjA; // transpose is same as no-conjugate
         Impl::trsv_upper(member, cjA, diag, m, a, lda, 1, b, bs);
         break;
       }
@@ -596,7 +574,7 @@ template <typename T> struct BlasTeam {
         break;
       }
       default:
-        Kokkos::abort("trans is not valid");
+        Kokkos::abort("trans is not valid (trsv(L))");
       }
     }
   }
@@ -783,13 +761,20 @@ template <typename T> struct BlasTeam {
       }
       case 'C':
       case 'c': {
+        const Conjugate cjA;
+        const NoConjugate cjB;
+        Impl::herk_upper(member, cjA, cjB, n, k, alpha, a, lda, 1, beta, c, 1, ldc);
+        break;
+      }
+      case 'T':
+      case 't': {
         const NoConjugate cjA;
-        const Conjugate cjB;
+        const NoConjugate cjB;
         Impl::herk_upper(member, cjA, cjB, n, k, alpha, a, lda, 1, beta, c, 1, ldc);
         break;
       }
       default:
-        Kokkos::abort("trans is not valid");
+        Kokkos::abort("trans is not valid (herk(U))");
       }
     else if (uplo == 'L' || uplo == 'l')
       switch (trans) {
@@ -802,13 +787,20 @@ template <typename T> struct BlasTeam {
       }
       case 'C':
       case 'c': {
+        const Conjugate cjA;
+        const NoConjugate cjB;
+        Impl::herk_lower(member, cjA, cjB, n, k, alpha, a, lda, 1, beta, c, 1, ldc);
+        break;
+      }
+      case 'T':
+      case 't': {
         const NoConjugate cjA;
-        const Conjugate cjB;
+        const NoConjugate cjB;
         Impl::herk_lower(member, cjA, cjB, n, k, alpha, a, lda, 1, beta, c, 1, ldc);
         break;
       }
       default:
-        Kokkos::abort("trans is not valid");
+        Kokkos::abort("trans is not valid (herk(L))");
       }
     else
       Kokkos::abort("uplo is not valid");
@@ -844,7 +836,7 @@ template <typename T> struct BlasTeam {
           break;
         }
         default:
-          Kokkos::abort("trans is not valid");
+          Kokkos::abort("trans is not valid (trsm(Left,Upp))");
         }
       } else if (uplo == 'L' || uplo == 'l') {
         switch (trans) {
@@ -867,7 +859,7 @@ template <typename T> struct BlasTeam {
           break;
         }
         default:
-          Kokkos::abort("trans is not valid");
+          Kokkos::abort("trans is not valid (trsm(Left,Low))");
         }
       }
     }
@@ -899,7 +891,7 @@ template <typename T> struct BlasTeam {
           break;
         }
         default:
-          Kokkos::abort("trans is not valid");
+          Kokkos::abort("trans is not valid (trsm(Right,Upp))");
         }
       } else if (uplo == 'L' || uplo == 'l') {
         switch (trans) {
@@ -924,7 +916,7 @@ template <typename T> struct BlasTeam {
           break;
         }
         default:
-          Kokkos::abort("trans is not valid");
+          Kokkos::abort("trans is not valid (trsm(Right,Low))");
         }
       }
     }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_External.hpp
@@ -19,7 +19,8 @@
 
 namespace Tacho {
 
-template <> struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Upper, Algo::External> {
+template <> 
+struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Upper, Algo::External> {
   template <typename ScalarType, typename ViewTypeA, typename ViewTypeB, typename ViewTypeC>
   inline static int invoke(const ScalarType alpha, const ViewTypeA &A, const ViewTypeB &B, const ScalarType beta,
                            const ViewTypeC &C) {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_Internal.hpp
@@ -19,7 +19,8 @@
 
 namespace Tacho {
 
-template <> struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Upper, Algo::Internal> {
+template <>
+struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Upper, Algo::Internal> {
   template <typename MemberType, typename ScalarType, typename ViewTypeA, typename ViewTypeB, typename ViewTypeC>
   KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ScalarType alpha, const ViewTypeA &A,
                                            const ViewTypeB &B, const ScalarType beta, const ViewTypeC &C) {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_GemmTriangular_OnDevice.hpp
@@ -19,7 +19,8 @@
 
 namespace Tacho {
 
-template <> struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Upper, Algo::OnDevice> {
+template <>
+struct GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Upper, Algo::OnDevice> {
   template <typename ScalarType, typename ViewTypeA, typename ViewTypeB, typename ViewTypeC>
   inline static int blas_invoke(const ScalarType alpha, const ViewTypeA &A, const ViewTypeB &B, const ScalarType beta,
                                 const ViewTypeC &C) {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_External.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_External.hpp
@@ -170,8 +170,8 @@ template <> struct LDL<Uplo::Lower, Algo::External> {
 template <typename ArgUplo> struct LDL_nopiv<ArgUplo, Algo::External> {
   // just call serial for now
   template <typename MemberType, typename ViewTypeA>
-  KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A) {
-    return LDL_nopiv<ArgUplo, Algo::Serial>::invoke(member, A);
+  KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A, const bool conjugate) {
+    return LDL_nopiv<ArgUplo, Algo::Serial>::invoke(member, A, conjugate);
   }
 };
 } // namespace Tacho

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_Internal.hpp
@@ -155,7 +155,7 @@ template <> struct LDL<Uplo::Lower, Algo::Internal> {
 
 template <typename ArgUplo> struct LDL_nopiv<ArgUplo, Algo::Internal> {
   template <typename MemberType, typename ViewTypeA>
-  KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A) {
+  KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A, const bool conjugate) {
 
     typedef typename ViewTypeA::non_const_value_type value_type;
     static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
@@ -163,7 +163,7 @@ template <typename ArgUplo> struct LDL_nopiv<ArgUplo, Algo::Internal> {
     int r_val = 0;
     const ordinal_type m = A.extent(0);
     if (m > 0)
-      LapackTeam<value_type>::sytrf_nopiv(member, ArgUplo::param, m, A.data(), A.stride(1), &r_val);
+      LapackTeam<value_type>::sytrf_nopiv(member, ArgUplo::param, conjugate, m, A.data(), A.stride(1), &r_val);
     return r_val;
   }
 };

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_OnDevice.hpp
@@ -127,11 +127,12 @@ template <> struct LDL<Uplo::Lower, Algo::OnDevice> {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   template <typename ExecSpaceType, typename ViewTypeA, typename ViewTypeP, typename ViewTypeD>
   inline static int device_modify(ExecSpaceType &exec_instance, const ViewTypeA &A, const ViewTypeP &P,
-                                  const ViewTypeD &D) {
+                                  const ViewTypeD &D, const bool conjugate) {
     using exec_space = ExecSpaceType;
     typedef typename ViewTypeA::non_const_value_type value_type;
-    const ordinal_type m = A.extent(0);
+    typedef ArithTraits<value_type> arith_traits;
 
+    const ordinal_type m = A.extent(0);
     int r_val(0);
     if (m > 0) {
       value_type *KOKKOS_RESTRICT Aptr = A.data();
@@ -157,7 +158,7 @@ template <> struct LDL<Uplo::Lower, Algo::OnDevice> {
                     fpiv[i] = 0;
 
                     D(i, 0) = A(i, i);
-                    D(i, 1) = A(i + 1, i); /// symmetric
+                    D(i, 1) = (conjugate ? arith_traits::conj(A(i + 1, i)) : A(i + 1, i)); /// symmetric
                     A(i, i) = one;
                   }
                 }
@@ -221,7 +222,7 @@ template <> struct LDL<Uplo::Lower, Algo::OnDevice> {
   }
 #endif
   template <typename MemberType, typename ViewTypeA, typename ViewTypeP, typename ViewTypeD>
-  inline static int modify(MemberType &member, const ViewTypeA &A, const ViewTypeP &P, const ViewTypeD &D) {
+  inline static int modify(MemberType &member, const ViewTypeA &A, const ViewTypeP &P, const ViewTypeD &D, bool conjugate) {
     typedef typename ViewTypeA::non_const_value_type value_type;
     typedef typename ViewTypeD::non_const_value_type value_type_d;
 
@@ -247,12 +248,12 @@ template <> struct LDL<Uplo::Lower, Algo::OnDevice> {
 #if defined(KOKKOS_ENABLE_CUDA)
     if (std::is_same<memory_space, Kokkos::CudaSpace>::value ||
         std::is_same<memory_space, Kokkos::CudaUVMSpace>::value) {
-      r_val = device_modify(member, A, P, D);
+      r_val = device_modify(member, A, P, D, conjugate);
     }
 #endif
 #if defined(KOKKOS_ENABLE_HIP)
     if (std::is_same<memory_space, Kokkos::HIPSpace>::value) {
-      r_val = device_modify(member, A, P, D);
+      r_val = device_modify(member, A, P, D, conjugate);
     }
 #endif
     return r_val;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_Serial.hpp
@@ -72,6 +72,7 @@ template <> struct LDL<Uplo::Lower, Algo::Serial> {
 
     if constexpr(runOnHost) {
       typedef typename ViewTypeA::non_const_value_type value_type;
+      typedef ArithTraits<value_type> arith_traits;
 
       static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
       static_assert(ViewTypeP::rank == 1, "P is not rank 1 view.");
@@ -98,7 +99,7 @@ template <> struct LDL<Uplo::Lower, Algo::Serial> {
               fpiv[i] = 0;
 
               D(i, 0) = A(i, i);
-              D(i, 1) = A(i + 1, i); /// symmetric
+              D(i, 1) = arith_traits::conj(A(i + 1, i)); /// symmetric
               A(i, i) = one;
             }
             {
@@ -168,7 +169,7 @@ template <> struct LDL<Uplo::Lower, Algo::Serial> {
 };
 
 template <typename ArgUplo> struct LDL_nopiv<ArgUplo, Algo::Serial> {
-  template <typename ViewTypeA> inline static int invoke(const ViewTypeA &A) {
+  template <typename ViewTypeA> inline static int invoke(const ViewTypeA &A, const bool conjugate) {
 
     static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
@@ -179,7 +180,7 @@ template <typename ArgUplo> struct LDL_nopiv<ArgUplo, Algo::Serial> {
       int r_val = 0;
       const ordinal_type m = A.extent(0);
       if (m > 0) {
-        LapackSerial<value_type>::sytrf_nopiv(ArgUplo::param, m, A.data(), A.stride(1), &r_val);
+        LapackSerial<value_type>::sytrf_nopiv(ArgUplo::param, conjugate, m, A.data(), A.stride(1), &r_val);
         TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LapackSerial (ldl-nopiv) returns non-zero error code.");
       }
       return r_val;
@@ -190,13 +191,13 @@ template <typename ArgUplo> struct LDL_nopiv<ArgUplo, Algo::Serial> {
   }
 
   template <typename MemberType, typename ViewTypeA>
-  KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A) {
+  KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A, const bool conjugate) {
 
     static constexpr bool runOnHost = run_tacho_on_host_v<typename ViewTypeA::execution_space>;
 
     if constexpr(runOnHost) {
       int r_val = 0;
-      r_val = invoke(A);
+      r_val = invoke(A, conjugate);
       //TACHO_TEST_FOR_EXCEPTION(r_val, std::runtime_error, "LapackSerial (ldl-nopiv) returns non-zero error code.");
       return r_val;
     } else {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_Supernodes_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_LDL_Supernodes_Serial.hpp
@@ -70,7 +70,7 @@ template <> struct LDL_Supernodes<Algo::Workflow::Serial> {
       UnmanagedViewType<value_type_matrix> ATL(ptr, m, m);
       ptr += m * m;
 
-      Symmetrize<Uplo::Upper, Algo::Internal>::invoke(member, ATL);
+      Symmetrize<Uplo::Upper, Algo::Internal>::invoke(member, ATL, false);
 
       LDL<Uplo::Lower, LDL_AlgoType>::invoke(member, ATL, P, W);
       LDL<Uplo::Lower, LDL_AlgoType>::modify(member, ATL, P, D);

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Lapack_Serial.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Lapack_Serial.hpp
@@ -231,7 +231,7 @@ template <typename T> struct LapackSerial {
   }
 
   // uplo = upper
-  inline static int sytrf_nopiv(const char uplo, const int m, T *A, const int lda, int *info) {
+  inline static int sytrf_nopiv(const char uplo, const bool conjugate, const int m, T *A, const int lda, int *info) {
       
     *info = 0; 
     if (m <= 0) 
@@ -252,7 +252,7 @@ template <typename T> struct LapackSerial {
       for (int j = i+1; j < m; j++) {
         const T aa = alpha * A[i + j*lda];
         for (int l = i+1; l <= j; l++) {
-          const T bb = arith_traits::conj(A[i + l*lda]);
+          const T bb = (conjugate ? arith_traits::conj(A[i + l*lda]) : A[i + l*lda]);
           A[l + j*lda] -= aa * bb;
         }
       }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Lapack_Team.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Lapack_Team.hpp
@@ -48,9 +48,9 @@ template <typename T> struct LapackTeam {
         Kokkos::parallel_for(Kokkos::TeamVectorRange(member, jend), [&](const int &j) { a12t[j * as1] /= alpha; });
         member.team_barrier();
         Kokkos::parallel_for(Kokkos::TeamThreadRange(member, jend), [&](const int &j) {
-          const T aa = arith_traits::conj(a12t[j * as1]);
+          const T aa = a12t[j * as1];
           Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, j + 1), [&](const int &i) {
-            const T bb = a12t[i * as1];
+            const T bb = arith_traits::conj(a12t[i * as1]);
             A22[i * as0 + j * as1] -= aa * bb;
           });
         });
@@ -420,7 +420,7 @@ template <typename T> struct LapackTeam {
   }
 
     template <typename MemberType>
-    static KOKKOS_INLINE_FUNCTION void sytrf_nopiv(const MemberType &member, const char uplo, const int m,
+    static KOKKOS_INLINE_FUNCTION void sytrf_nopiv(const MemberType &member, const char uplo, const bool conjugate, const int m,
                                                    T *KOKKOS_RESTRICT A, const int lda, int *info) {
       *info = 0;
       if (m <= 0)
@@ -441,9 +441,9 @@ template <typename T> struct LapackTeam {
         Kokkos::parallel_for(Kokkos::TeamVectorRange(member, jend), [&](const int &j) { a12t[j * lda] /= alpha; });
         member.team_barrier();
         Kokkos::parallel_for(Kokkos::TeamThreadRange(member, jend), [&](const int &j) {
-          const T aa = alpha * arith_traits::conj(a12t[j * lda]);
+          const T aa = alpha * a12t[j * lda];
           Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, j + 1), [&](const int &i) {
-            const T bb = a12t[i * lda];
+            const T bb = (conjugate ? arith_traits::conj(a12t[i * lda]) : a12t[i * lda]);
             A22[i + j * lda] -= aa * bb;
           });
         });

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NonPivLDL_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NonPivLDL_OnDevice.hpp
@@ -35,6 +35,7 @@ template <typename ArgUplo> struct LDL_nopiv<ArgUplo, Algo::OnDevice> {
     using arith_traits = ArithTraits<value_type>;
 
     const auto &exec_instance = member;
+    const bool conjugate = false;
     const ordinal_type m = A.extent(0);
 
     int r_val(0);
@@ -53,7 +54,7 @@ template <typename ArgUplo> struct LDL_nopiv<ArgUplo, Algo::OnDevice> {
        Kokkos::parallel_for(policy_update, KOKKOS_LAMBDA(const ordinal_type &id) {
          ordinal_type k = (i+1) + id / mn;
          ordinal_type j = (i+1) + id % mn;
-         A(k, j) -= arith_traits::conj(A(i, k)) * A(i, i) * A(i, j);
+         A(k, j) -= (conjugate ? arith_traits::conj(A(i, k)) : A(i, k)) * A(i, i) * A(i, j);
        });
       #else
        policy_type policy_update(exec_instance, i+1, m);
@@ -90,9 +91,9 @@ template <typename ArgUplo> struct LDL_nopiv<ArgUplo, Algo::OnDevice> {
 
       ordinal_type m2 = m - i2;
       if (m2 > 0) {
-        // Compute off-diagonal blocks
+        // Compute off-diagonal blocks (no conjugate)
         auto A12 = Kokkos::subview(A, range_type(i1, i2), range_type(i2, m));
-        Trsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, Algo::OnDevice>::invoke(
+        Trsm<Side::Left, Uplo::Upper, Trans::Transpose, Algo::OnDevice>::invoke(
                   handle, Diag::Unit(), one, A11, A12);
 
         // Save A12 in workspace

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -948,7 +948,7 @@ public:
               UnmanagedViewType<value_type_matrix> ATR(aptr, m, n_m); // aptr += m*n_m;
 
               // Apply L^{-1} on off-diagonal
-              _status = Trsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, Algo::OnDevice>::invoke(
+              _status = Trsm<Side::Left, Uplo::Upper, Trans::Transpose, Algo::OnDevice>::invoke(
                   handle_blas, Diag::Unit(), one, ATL, ATR);
               checkDeviceBlasStatus("trsm");
 
@@ -1033,7 +1033,7 @@ public:
               UnmanagedViewType<value_type_matrix> ABR(bptr, n_m, n_m); // shared with T
               UnmanagedViewType<value_type_matrix> K(bptr+(n_m * n_m), m, n_m);
 
-              _status = Trsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, Algo::OnDevice>::invoke(
+              _status = Trsm<Side::Left, Uplo::Upper, Trans::Transpose, Algo::OnDevice>::invoke(
                   handle_blas, Diag::Unit(), one, ATL, ATR);
               checkDeviceBlasStatus("trsm");
 
@@ -1108,7 +1108,7 @@ public:
               bptr += ABR.span();
               UnmanagedViewType<value_type_matrix> ATR(aptr, m, n_m); // aptr += m*n_m;
               {
-                _status = Trsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, Algo::OnDevice>::invoke(
+                _status = Trsm<Side::Left, Uplo::Upper, Trans::Transpose, Algo::OnDevice>::invoke(
                     handle_blas, Diag::Unit(), one, ATL, ATR);
                 checkDeviceBlasStatus("trsm");
 
@@ -1548,11 +1548,12 @@ public:
         {
           const ordinal_type offs = s.row_begin, m = s.m, n = s.n, n_m = n - m;
           if (m > 0) {
+            bool conjugate = false;
             value_type *aptr = s.u_buf;
             UnmanagedViewType<value_type_matrix> ATL(aptr, m, m);
             aptr += m * m;
 
-            _status = Symmetrize<Uplo::Upper, Algo::OnDevice>::invoke(exec_instance, ATL);
+            _status = Symmetrize<Uplo::Upper, Algo::OnDevice>::invoke(exec_instance, ATL, conjugate);
 
             ordinal_type *pivptr = _piv.data() + 4 * offs;
             UnmanagedViewType<ordinal_type_array> P(pivptr, 4 * m);
@@ -1561,7 +1562,7 @@ public:
 
             value_type *dptr = _diag.data() + 2 * offs;
             UnmanagedViewType<value_type_matrix> D(dptr, m, 2);
-            _status = LDL<Uplo::Lower, Algo::OnDevice>::modify(exec_instance, ATL, P, D);
+            _status = LDL<Uplo::Lower, Algo::OnDevice>::modify(exec_instance, ATL, P, D, conjugate);
             checkDeviceLapackStatus("ldl::modify");
 
             if (n_m > 0) {
@@ -1622,11 +1623,12 @@ public:
         {
           const ordinal_type offs = s.row_begin, m = s.m, n = s.n, n_m = n - m;
           if (m > 0) {
+            bool conjugate = false;
             value_type *aptr = s.u_buf;
             UnmanagedViewType<value_type_matrix> ATL(aptr, m, m);
             aptr += m * m;
 
-            _status = Symmetrize<Uplo::Upper, Algo::OnDevice>::invoke(exec_instance, ATL);
+            _status = Symmetrize<Uplo::Upper, Algo::OnDevice>::invoke(exec_instance, ATL, conjugate);
 
             ordinal_type *pivptr = _piv.data() + 4 * offs;
             UnmanagedViewType<ordinal_type_array> P(pivptr, 4 * m);
@@ -1635,7 +1637,7 @@ public:
 
             value_type *dptr = _diag.data() + 2 * offs;
             UnmanagedViewType<value_type_matrix> D(dptr, m, 2);
-            _status = LDL<Uplo::Lower, Algo::OnDevice>::modify(exec_instance, ATL, P, D);
+            _status = LDL<Uplo::Lower, Algo::OnDevice>::modify(exec_instance, ATL, P, D, conjugate);
             checkDeviceLapackStatus("ldl::modify");
 
             value_type *bptr = _buf.data() + h_buf_factor_ptr(p - pbeg);
@@ -1711,11 +1713,12 @@ public:
         {
           const ordinal_type offs = s.row_begin, m = s.m, n = s.n, n_m = n - m;
           if (m > 0) {
+            bool conjugate = false;
             value_type *aptr = s.u_buf;
             UnmanagedViewType<value_type_matrix> ATL(aptr, m, m);
             aptr += m * m;
 
-            _status = Symmetrize<Uplo::Upper, Algo::OnDevice>::invoke(exec_instance, ATL);
+            _status = Symmetrize<Uplo::Upper, Algo::OnDevice>::invoke(exec_instance, ATL, conjugate);
 
             ordinal_type *pivptr = _piv.data() + 4 * offs;
             UnmanagedViewType<ordinal_type_array> P(pivptr, 4 * m);
@@ -1724,7 +1727,7 @@ public:
 
             value_type *dptr = _diag.data() + 2 * offs;
             UnmanagedViewType<value_type_matrix> D(dptr, m, 2);
-            _status = LDL<Uplo::Lower, Algo::OnDevice>::modify(exec_instance, ATL, P, D);
+            _status = LDL<Uplo::Lower, Algo::OnDevice>::modify(exec_instance, ATL, P, D, conjugate);
             checkDeviceLapackStatus("ldl::modify");
 
             value_type *bptr = _buf.data() + h_buf_factor_ptr(p - pbeg);
@@ -1758,7 +1761,7 @@ public:
               // AT = ATL^{-1} [I, ATR] (= L^{-1} where A = LTL^T and A^{-1} = L^{-T} T^{-1} L^{-1} = (TL^{-T})^{-1) * L^{-1})
               //                                                             = (solveLDL_Upper_varian2 with Scale2x2_BlockInverseDiagonals) * (solveLDL_Lower_variant2)
               _status = Copy<Algo::OnDevice>::invoke(exec_instance, T, ATL);
-              _status = Symmetrize<Uplo::Lower, Algo::OnDevice>::invoke(exec_instance, T);
+              _status = Symmetrize<Uplo::Lower, Algo::OnDevice>::invoke(exec_instance, T, conjugate);
               _status = SetIdentity<Algo::OnDevice>::invoke(exec_instance, ATL, minus_one);
 
               UnmanagedViewType<value_type_matrix> AT(ATL.data(), m, n);
@@ -2181,7 +2184,7 @@ public:
             auto tT = Kokkos::subview(t, range_type(offm, offm + m), Kokkos::ALL());
 
             _status =
-                Trsv<Uplo::Upper, Trans::ConjTranspose, Algo::OnDevice>::invoke(handle_blas, Diag::Unit(), ATL, tT);
+                Trsv<Uplo::Upper, Trans::Transpose, Algo::OnDevice>::invoke(handle_blas, Diag::Unit(), ATL, tT);
             checkDeviceBlasStatus("trsv");
 
             if (n_m > 0) {
@@ -2190,7 +2193,7 @@ public:
               UnmanagedViewType<value_type_matrix> ATR(aptr, m, n_m); // aptr += m*n_m;
               UnmanagedViewType<value_type_matrix> bB(bptr, n_m, nrhs);
 
-              _status = Gemv<Trans::ConjTranspose, Algo::OnDevice>::invoke(handle_blas, minus_one, ATR, tT, zero, bB);
+              _status = Gemv<Trans::Transpose, Algo::OnDevice>::invoke(handle_blas, minus_one, ATR, tT, zero, bB);
               checkDeviceBlasStatus("gemv");
             }
 
@@ -2249,7 +2252,7 @@ public:
             checkDeviceBlasStatus("copy");
 
             // Solve diag (ATL is square)
-            _status = Trmv<Uplo::Upper, Trans::ConjTranspose, Algo::OnDevice>::invoke(handle_blas, Diag::Unit(), ATL, tT, bT);
+            _status = Trmv<Uplo::Upper, Trans::Transpose, Algo::OnDevice>::invoke(handle_blas, Diag::Unit(), ATL, tT, bT);
             checkDeviceBlasStatus("gemv");
 
             if (n_m > 0) {
@@ -2257,7 +2260,7 @@ public:
               UnmanagedViewType<value_type_matrix> ATR(aptr, m, n_m);
               UnmanagedViewType<value_type_matrix> bB(bptr, n_m, nrhs);
 
-              _status = Gemv<Trans::ConjTranspose, Algo::OnDevice>::invoke(handle_blas, minus_one, ATR, bT, zero, bB);
+              _status = Gemv<Trans::Transpose, Algo::OnDevice>::invoke(handle_blas, minus_one, ATR, bT, zero, bB);
               checkDeviceBlasStatus("gemv");
             }
 
@@ -2315,7 +2318,7 @@ public:
             checkDeviceBlasStatus("copy");
 
             // AT is short-wide: b := AT'\t : compute current block, and then use it to update off-diagonal
-            _status = Trmv<Uplo::Upper, Trans::ConjTranspose, Algo::OnDevice>::invoke(handle_blas, Diag::Unit(), AT, tT, b);
+            _status = Trmv<Uplo::Upper, Trans::Transpose, Algo::OnDevice>::invoke(handle_blas, Diag::Unit(), AT, tT, b);
             checkDeviceBlasStatus("trmv");
 
             // Apply D^{-1} on diagonal (already updated using this block, also n >= m so diagonal block is stored first in aptr)
@@ -2343,8 +2346,9 @@ public:
       return solveNoPivotLDLLowerOnDeviceVar2(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 3) {
       // apply L^{-1}
+      const bool conjugate = false;
       auto &s0 = _h_supernodes(_h_level_sids(pbeg));
-      _spmv->ApplyL_OnDevice(lvl, s0, t, _w_vec);
+      _spmv->ApplyL_OnDevice(lvl, s0, t, _w_vec, conjugate);
       {
         // apply D^{-1}
         const ordinal_type nrhs = t.extent(1);
@@ -3089,8 +3093,9 @@ public:
     else if (variant == 2)
       solveLDL_LowerOnDeviceVar2(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 3) {
+      bool conjugate = false;
       auto &s0 = _h_supernodes(_h_level_sids(pbeg));
-      _spmv->ApplyL_OnDevice(lvl, s0, t, _w_vec);
+      _spmv->ApplyL_OnDevice(lvl, s0, t, _w_vec, conjugate);
     } else {
       std::string msg = "Error: LevelSetTools::solveLDL_LowerOnDevice, algorithm variant ("
                         + std::to_string(variant) + ") is not supported.\n";
@@ -3737,8 +3742,6 @@ public:
     {
       // this should be considered with average problem sizes in levels
       const ordinal_type half_level = _nlevel / 2;
-      // const ordinal_type team_size_factor[2] = { 64, 16 }, vector_size_factor[2] = { 8, 8};
-      // const ordinal_type team_size_factor[2] = { 16, 16 }, vector_size_factor[2] = { 32, 32};
       const ordinal_type team_size_factor[2] = {64, 64}, vector_size_factor[2] = {8, 4};
       const ordinal_type team_size_update[2] = {16, 8}, vector_size_update[2] = {32, 32};
       // returned value from team Chol

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -37,6 +37,8 @@
 #include "Tacho_Scale2x2_BlockInverseDiagonals.hpp"
 #include "Tacho_Scale2x2_BlockInverseDiagonals_OnDevice.hpp"
 
+#include "Tacho_Spmv_OnDevice.hpp"
+
 #include "Tacho_Chol_OnDevice.hpp"
 #include "Tacho_NonPivLDL_OnDevice.hpp"
 #include "Tacho_LDL_OnDevice.hpp"
@@ -67,29 +69,6 @@
 
 //#define TACHO_TEST_LEVELSET_TOOLS_KERNEL_OVERHEAD
 //#define TACHO_ENABLE_LEVELSET_TOOLS_USE_LIGHT_KERNEL
-
-#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE))
-  // SpMV flag
-  #if (CUSPARSE_VERSION >= 11400)
-    #define TACHO_CUSPARSE_SPMV_ALG CUSPARSE_SPMV_ALG_DEFAULT
-  #else
-    #define TACHO_CUSPARSE_SPMV_ALG CUSPARSE_MV_ALG_DEFAULT
-  #endif
-  // SpMM flag
-  #if (CUSPARSE_VERSION >= 11000)
-    #define TACHO_CUSPARSE_SPMM_ALG CUSPARSE_SPMM_ALG_DEFAULT
-  #else
-    #define TACHO_CUSPARSE_SPMM_ALG CUSPARSE_MM_ALG_DEFAULT
-  #endif
-#elif defined(KOKKOS_ENABLE_HIP)
-  #if (ROCM_VERSION >= 60000)
-    #define tacho_rocsparse_spmv rocsparse_spmv
-  #elif (ROCM_VERSION >= 50400)
-    #define tacho_rocsparse_spmv rocsparse_spmv_ex
-  #else
-    #define tacho_rocsparse_spmv rocsparse_spmv
-  #endif
-#endif
 
 
 namespace Tacho {
@@ -190,16 +169,9 @@ private:
   value_type_array _work;
 
   // for using SpMV
+  using SpMV_type = SpMV<supernode_info_type>;
+  SpMV_type *_spmv;
   bool _keep_zeros;
-  rowptr_view rowptrU;
-  colind_view colindU;
-  nzvals_view nzvalsU;
-
-  rowptr_view rowptrL;
-  colind_view colindL;
-  nzvals_view nzvalsL;
-
-  nzvals_view nzvalsD;
 
   // common for host and cuda
   int _status;
@@ -209,22 +181,11 @@ private:
   bool _team_on_user_stream;
 
   // workspace for SpMV
-  bool _is_spmv_extracted;
   value_type_matrix _w_vec;
-  value_type_array  buffer_U;
-  value_type_array  buffer_L;
 #if defined(KOKKOS_ENABLE_CUDA)
   bool _is_cublas_created, _is_cusolver_dn_created;
   cublasHandle_t _handle_blas;
   cusolverDnHandle_t _handle_lapack;
-  #if defined(TACHO_HAVE_CUSPARSE)
-  // workspace for SpMV
-  // (separte for U and L, so that we can "destroy" without waiting for the other)
-  cusparseDnMatDescr_t matL, matU, matW;
-  cusparseDnVecDescr_t vecL, vecU, vecW;
-  cusparseHandle_t cusparseHandle;
-  #endif
-
   using blas_handle_type = cublasHandle_t;
   using lapack_handle_type = cusolverDnHandle_t;
   using stream_array_host = std::vector<cudaStream_t>;
@@ -234,11 +195,6 @@ private:
   bool _is_rocblas_created;
   rocblas_handle _handle_lapack; // just used for workspace size query
   std::vector<rocblas_handle> _handles;
-  // workspace for SpMV
-  rocsparse_dnmat_descr matL, matU, matW;
-  rocsparse_dnvec_descr vecL, vecU, vecW;
-  rocsparse_handle rocsparseHandle;
-
   using blas_handle_type = rocblas_handle;
   using lapack_handle_type = rocblas_handle;
   using stream_array_host = std::vector<hipStream_t>;
@@ -248,13 +204,12 @@ private:
   int _handle_blas, _handle_lapack; // dummy handle for convenience
   using blas_handle_type = int;
   using lapack_handle_type = int;
+  using stream_array_host = std::vector<int>;
   #define getBlasHandle()   _handle_blas
   #define getLapackHandle() _handle_lapack
 #endif
-
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
   stream_array_host _streams;
-#endif
+
   using exec_instance_array_host = std::vector<exec_space>;
   exec_instance_array_host _exec_instances;
 
@@ -778,6 +733,7 @@ public:
     _bufsize_solve = 0;
     _nstreams = 0;
     _team_on_user_stream = false;
+    _spmv = nullptr;
     _keep_zeros = false;
     stat_level = stat_level();
   }
@@ -800,7 +756,6 @@ public:
     _keep_zeros = false;
     _nstreams = 0;
     _team_on_user_stream = false;
-    _is_spmv_extracted = 0;
 #if defined(KOKKOS_ENABLE_CUDA)
     _is_cublas_created = 0;
     _is_cusolver_dn_created = 0;
@@ -808,6 +763,10 @@ public:
 #if defined(KOKKOS_ENABLE_HIP)
     _is_rocblas_created = 0;
 #endif
+    if (variant == 3)
+      _spmv = new SpMV_type(_keep_zeros);
+    else
+      _spmv = nullptr;
   }
 
   virtual ~NumericToolsLevelSet() {
@@ -830,7 +789,6 @@ public:
       _status = cudaStreamDestroy(_streams[i]);
       checkDeviceStatus("cudaStreamDestroy");
     }
-    _streams.clear();
 #endif
 #if defined(KOKKOS_ENABLE_HIP)
     if (_is_rocblas_created) {
@@ -847,8 +805,12 @@ public:
       _status = hipStreamDestroy(_streams[i]);
       checkDeviceStatus("cudaStreamDestroy");
     }
-    _streams.clear();
 #endif
+    _streams.clear();
+    if (_spmv != nullptr) {
+      delete _spmv;
+      _spmv = nullptr;
+    }
   }
 
   inline void createStream(const ordinal_type nstreams, const ordinal_type verbose = 0) {
@@ -902,7 +864,11 @@ public:
       ExecSpaceFactory<exec_space>::createInstance(_streams[i], _exec_instances[i]);
     }
 #else
-    // just one default execution space..
+    // just one dummy stream
+    _streams.clear();
+    _streams.resize(1);
+    _streams[0] = 0;
+    // just one default execution space.
     _exec_instances.clear();
     _exec_instances.resize(1);
     _exec_instances[0] = exec_space();
@@ -2113,549 +2079,18 @@ public:
   /// Extract CRS for SpMV
   ///
   inline void setupCRS(bool store_transpose, bool verbose) {
-    if (verbose) {
-      printf("LevelSetTools:setupCRS(method=%d)\n",this->getSolutionMethod());
-      printf("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n");
-    }
-    const bool lu = (this->getSolutionMethod() == 3);
-    const bool ldl = (this->getSolutionMethod() == 2);
-    const bool ldl_nopiv = (this->getSolutionMethod() == 0);
-
-    // ========================
-    // free CRS, 
-    // if it has been extracted
-    this->releaseCRS(true, verbose);
-
-    // ========================
-    // workspace
-    const ordinal_type m = _m;
-    const ordinal_type nrhs = 1;
-    Kokkos::resize(_w_vec, m, nrhs);
-
-#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE)) || \
-     defined(KOKKOS_ENABLE_HIP)
-    const value_type zero(0);
-
-    int ldw = _w_vec.stride(1);
-#if defined(KOKKOS_ENABLE_CUDA)
-    cudaDataType computeType;
-    if (std::is_same<value_type, double>::value) {
-      computeType = CUDA_R_64F;
-    } else if (std::is_same<value_type, float>::value) {
-      computeType = CUDA_R_32F;
-    } else {
-      TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
-                               "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
-    }
-    // create cusparse handle
-    cusparseCreate(&cusparseHandle);
-    // attach handle to stream-0
-    cusparseSetStream(cusparseHandle, _streams[0]);
-    // attach to Cusparse data struct
-    cusparseCreateDnMat(&matW, m, nrhs, ldw, (void*)(_w_vec.data()), computeType, CUSPARSE_ORDER_COL);
-    cusparseCreateDnVec(&vecW, m, (void*)(_w_vec.data()), computeType);
-    // also to T, to be destroyed before each SpMV call
-    cusparseCreateDnMat(&matL, m, nrhs, ldw, (void*)(_w_vec.data()), computeType, CUSPARSE_ORDER_COL);
-    cusparseCreateDnVec(&vecL, m, (void*)(_w_vec.data()), computeType);
-    cusparseCreateDnMat(&matU, m, nrhs, ldw, (void*)(_w_vec.data()), computeType, CUSPARSE_ORDER_COL);
-    cusparseCreateDnVec(&vecU, m, (void*)(_w_vec.data()), computeType);
-#elif defined(KOKKOS_ENABLE_HIP)
-    rocsparse_datatype rocsparse_compute_type = rocsparse_datatype_f64_r;
-    if (std::is_same<value_type, float>::value) {
-      rocsparse_compute_type = rocsparse_datatype_f32_r;
-    }
-    // create rocsparse handle
-    _status = rocsparse_create_handle(&rocsparseHandle);
-    checkDeviceBlasStatus("rocsparse_create_handle");
-    // attach handle to stream-0
-    rocsparse_set_stream(rocsparseHandle, _streams[0]);
-    checkDeviceBlasStatus("rocsparse_create_handle");
-    // attach to Rocsparse data struct
-    _status = rocsparse_create_dnmat_descr(&matW, m, nrhs, ldw, (void*)(_w_vec.data()), rocsparse_compute_type, rocsparse_order_column);
-    checkDeviceBlasStatus("rocsparse_dnmat_descr");
-    _status = rocsparse_create_dnvec_descr(&vecW, m, (void*)(_w_vec.data()), rocsparse_compute_type);
-    checkDeviceBlasStatus("rocsparse_dnmat_descr");
-    // also to T, to be destroyed before each SpMV call
-    _status = rocsparse_create_dnmat_descr(&matL, m, nrhs, ldw, (void*)(_w_vec.data()), rocsparse_compute_type, rocsparse_order_column);
-    checkDeviceBlasStatus("rocsparse_dnmat_descr");
-    _status = rocsparse_create_dnvec_descr(&vecL, m, (void*)(_w_vec.data()), rocsparse_compute_type);
-    checkDeviceBlasStatus("rocsparse_dnvec_descr");
-    _status = rocsparse_create_dnmat_descr(&matU, m, nrhs, ldw, (void*)(_w_vec.data()), rocsparse_compute_type, rocsparse_order_column);
-    checkDeviceBlasStatus("rocsparse_dnmat_descr");
-    _status = rocsparse_create_dnvec_descr(&vecU, m, (void*)(_w_vec.data()), rocsparse_compute_type);
-    checkDeviceBlasStatus("rocsparse_dnvec_descr");
-#endif
-#endif
-
-    // allocate rowptrs
-    Kokkos::resize(rowptrU, _team_serial_level_cut*(1+m));
-    Kokkos::resize(rowptrL, _team_serial_level_cut*(1+m));
-    Kokkos::deep_copy(rowptrL, 0);
-    // counting nnz, first, so that we can allocate in NumericalTool
-    size_t ptr = 0;
-    size_t nnzU = 0;
-    size_t nnzL = 0;
-    typedef TeamFunctor_ExtractCrs<supernode_info_type> functor_type;
-    for (ordinal_type lvl = 0; lvl < _team_serial_level_cut; ++lvl) {
-      const ordinal_type pbeg = _h_level_ptr(lvl), pend = _h_level_ptr(lvl + 1);
-
-      // the first supernode in this lvl (where the CRS matrix is stored)
-      auto &s0 = _h_supernodes(_h_level_sids(pbeg));
-      s0.spmv_explicit_transpose = store_transpose;
-
-      #define TACHO_INSERT_DIAGONALS
-      // NOTE: this needs extra vector-entry copy for the non-active rows at each level for solve (copy t to w, and w back to t)
-      //       but it seems faster on AMD 250X GPU, and not much performance impact on V100
-      #define TACHO_INSERT_DIAGONALS
-      // ========================
-      // count nnz / row
-      auto d_rowptrU = Kokkos::subview(rowptrU, range_type(ptr, ptr+m+1));
-      s0.rowptrU = d_rowptrU.data();
-
-      functor_type extractor_crs(_keep_zeros, _info, _solve_mode, _level_sids);
-      extractor_crs.setGlobalSize(m);
-      extractor_crs.setRange(pbeg, pend);
-      extractor_crs.setRowPtr(s0.rowptrU);
-      if (ldl) {
-        // integrate pivoting into U
-        extractor_crs.integratePivots(true, _piv);
-      }
-      {
-        using team_policy_type = Kokkos::TeamPolicy<Kokkos::Schedule<Kokkos::Static>, exec_space,
-                                                    typename functor_type::ExtractPtrTag>;
-        team_policy_type team_policy((pend-pbeg)+1, Kokkos::AUTO());
-
-        Kokkos::parallel_for("extract rowptr", team_policy, extractor_crs);
-        exec_space().fence();
-      }
-
-      // ========================
-      // shift to generate rowptr
-      {
-        using range_policy_type = Kokkos::RangePolicy<exec_space>;
-        Kokkos::parallel_scan("shiftRowptr", range_policy_type(0, m+1), rowptr_sum(s0.rowptrU));
-        exec_space().fence();
-        // get nnz
-        auto d_nnz = Kokkos::subview(d_rowptrU, range_type(m, m+1));
-        auto h_nnz = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_nnz);
-        s0.nnzU = h_nnz(0);
-        nnzU += s0.nnzU;
-      }
-
-      if (lu) {
-        // get nnz per row (L is stored by column)
-        auto d_rowptrL = Kokkos::subview(rowptrL, range_type(ptr, ptr+m+1));
-        s0.rowptrL = d_rowptrL.data();
-        {
-          using team_policy_type = Kokkos::TeamPolicy<Kokkos::Schedule<Kokkos::Static>, exec_space,
-                                                      typename functor_type::ExtractPtrColTag>;
-          team_policy_type team_policy((pend-pbeg)+1, Kokkos::AUTO());
-
-          extractor_crs.setRowPtr(s0.rowptrL);
-          Kokkos::parallel_for("extract rowptr L", team_policy, extractor_crs);
-          exec_space().fence();
-        }
-        {
-          // convert to offset
-          using range_policy_type = Kokkos::RangePolicy<exec_space>;
-          Kokkos::parallel_scan("shiftRowptr L", range_policy_type(0, m+1), rowptr_sum(s0.rowptrL));
-          exec_space().fence();
-          // get nnz (on CPU for now)
-          auto d_nnz = Kokkos::subview(d_rowptrL, range_type(m, m+1));
-          auto h_nnz = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_nnz);
-          s0.nnzL = h_nnz(0);
-          nnzL += s0.nnzL;
-        }
-        s0.spmv_explicit_transpose = true;
-      } else if (s0.spmv_explicit_transpose) {
-        // ========================
-        // explicitly form transpose
-        s0.nnzL = s0.nnzU;
-        auto d_rowptrL = Kokkos::subview(rowptrL, range_type(ptr, ptr+m+1));
-        s0.rowptrL = d_rowptrL.data();
-        nnzL += s0.nnzL;
-      }
-      ptr += (1+m);
-    }
-
-    // allocate (TODO: move to symbolic)
-    Kokkos::resize(colindU, nnzU);
-    Kokkos::resize(nzvalsU, nnzU);
-    Kokkos::resize(colindL, nnzL);
-    Kokkos::resize(nzvalsL, nnzL);
-    if (ldl_nopiv) {
-      // Initialized to be I, then updated with diagonal values during numeric
-      //  The location of the updated values should be the same / symbolic
-      const value_type one(1);
-      Kokkos::resize(nzvalsD, _team_serial_level_cut*m);
-      Kokkos::deep_copy(nzvalsD, one);
-    }
-
-    _is_spmv_extracted = 1;
+    const int method = this->getSolutionMethod();
+    _spmv->Setup(store_transpose, verbose, method, _m, _team_serial_level_cut,
+                _h_level_ptr, _level_sids, _h_level_sids, _h_solve_mode, _info, _h_supernodes, _solve_mode, _piv,
+                _streams[0],
+                _w_vec);
   }
 
   inline void loadCRS(bool store_transpose, bool verbose) {
-    // store both L & U?
-    const bool lu = (this->getSolutionMethod() == 3);
-    const bool ldl = (this->getSolutionMethod() == 2);
-    const bool ldl_nopiv = (this->getSolutionMethod() == 0);
-
-    // ========================
-    // workspace
-    const ordinal_type m = _m;
-#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE)) || \
-     defined(KOKKOS_ENABLE_HIP)
-#if defined(KOKKOS_ENABLE_CUDA)
-    // vectors used for preprocessing
-    cudaDataType computeType;
-    if (std::is_same<value_type, double>::value) {
-      computeType = CUDA_R_64F;
-    } else if (std::is_same<value_type, float>::value) {
-      computeType = CUDA_R_32F;
-    } else {
-      TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
-                               "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
-    }
-#ifdef USE_SPMM_FOR_WORKSPACE_SIZE
-    cusparseDnMatDescr_t vecX, vecY;
-    const ordinal_type ldx = _w_vec.stride(1);
-    cusparseCreateDnMat(&vecX, m, nrhs, ldx, _w_vec.data(), computeType, CUSPARSE_ORDER_COL);
-    cusparseCreateDnMat(&vecY, m, nrhs, ldx, _w_vec.data(), computeType, CUSPARSE_ORDER_COL);
-#else
-    cusparseDnVecDescr_t vecX, vecY;
-    cusparseCreateDnVec(&vecX, m, _w_vec.data(), computeType);
-    cusparseCreateDnVec(&vecY, m, _w_vec.data(), computeType);
-#endif
-#elif defined(KOKKOS_ENABLE_HIP)
-    rocsparse_datatype rocsparse_compute_type = rocsparse_datatype_f64_r;
-    if (std::is_same<value_type, float>::value) {
-      rocsparse_compute_type = rocsparse_datatype_f32_r;
-    }
-    // vectors used for preprocessing
-    rocsparse_dnvec_descr vecX, vecY;
-    rocsparse_create_dnvec_descr(&vecX, m, (void*)_w_vec.data(), rocsparse_compute_type);
-    rocsparse_create_dnvec_descr(&vecY, m, (void*)_w_vec.data(), rocsparse_compute_type);
-#endif
-#endif
-
-    size_t ptr = 0;
-    size_t nnzU = 0;
-    size_t nnzL = 0;
-    typedef TeamFunctor_ExtractCrs<supernode_info_type> functor_type;
-
-    // load nonzero val/ind
-    for (ordinal_type lvl = 0; lvl < _team_serial_level_cut; ++lvl) {
-      const ordinal_type pbeg = _h_level_ptr(lvl), pend = _h_level_ptr(lvl + 1);
-
-      // the first supernode in this lvl (where the CRS matrix is stored)
-      auto &s0 = _h_supernodes(_h_level_sids(pbeg));
-
-      // ========================
-      // assign memory
-      auto d_rowptrU = Kokkos::subview(rowptrU, range_type(ptr, ptr+m+1));
-      auto d_colindU = Kokkos::subview(colindU, range_type(nnzU, nnzU+s0.nnzU));
-      auto d_nzvalsU = Kokkos::subview(nzvalsU, range_type(nnzU, nnzU+s0.nnzU));
-      s0.colindU = d_colindU.data();
-      s0.nzvalsU = d_nzvalsU.data();
-      nnzU += s0.nnzU;
-
-      // ========================
-      // extract nonzero element
-      functor_type extractor_crs(_keep_zeros, _info, _solve_mode, _level_sids);
-      extractor_crs.setGlobalSize(m);
-      extractor_crs.setRange(pbeg, pend);
-      extractor_crs.setRowPtr(s0.rowptrU);
-      extractor_crs.setCrsView(s0.colindU, s0.nzvalsU);
-      if (ldl) {
-        // integrate pivoting into U
-        extractor_crs.integratePivots(true, _piv);
-      } else if (ldl_nopiv) {
-        auto d_nzvalsD = Kokkos::subview(nzvalsD, range_type(lvl*m, (lvl+1)*m));
-        s0.nzvalsD = d_nzvalsD.data();
-        extractor_crs.withUnitDiag(s0.nzvalsD);
-      }
-      {
-        using team_policy_type = Kokkos::TeamPolicy<Kokkos::Schedule<Kokkos::Static>, exec_space,
-                                                    typename functor_type::ExtractValTag>;
-        team_policy_type team_policy((pend-pbeg)+1, Kokkos::AUTO());
-
-        // >> launch functor to extract nonzero entries
-        Kokkos::parallel_for("extract nzvals", team_policy, extractor_crs);
-        exec_space().fence();
-      }
-
-      // ========================
-      // shift back (TODO: shift first to avoid this)
-      {
-        //  copy to CPU, for now
-        auto h_rowptr = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_rowptrU);
-        for (ordinal_type i = m; i > 0 ; i--) h_rowptr(i) = h_rowptr(i-1);
-        h_rowptr(0) = 0;
-        Kokkos::deep_copy(d_rowptrU, h_rowptr);
-      }
-
-      if (lu) {
-        auto d_rowptrL = Kokkos::subview(rowptrL, range_type(ptr, ptr+m+1));
-        auto d_colindL = Kokkos::subview(colindL, range_type(nnzL, nnzL+s0.nnzL));
-        auto d_nzvalsL = Kokkos::subview(nzvalsL, range_type(nnzL, nnzL+s0.nnzL));
-        s0.colindL = d_colindL.data();
-        s0.nzvalsL = d_nzvalsL.data();
-        nnzL += s0.nnzL;
-
-        // ========================
-        // insert nonzeros
-        extractor_crs.setRowPtr(s0.rowptrL);
-        extractor_crs.setCrsView(s0.colindL, s0.nzvalsL);
-        extractor_crs.setPivPtr(_piv);
-        {
-          using team_policy_type = Kokkos::TeamPolicy<Kokkos::Schedule<Kokkos::Static>, exec_space,
-                                                      typename functor_type::ExtractValColTag>;
-          team_policy_type team_policy((pend-pbeg)+1, Kokkos::AUTO());
-
-          // >> launch functor to extract nonzero entries
-          Kokkos::parallel_for("extract nzvals L", team_policy, extractor_crs);
-          exec_space().fence();
-        }
-        // ========================
-        // shift back
-        // (TODO: shift first to avoid this)
-        {
-          //  copy to CPU, for now
-          auto h_rowptr = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_rowptrL);
-          for (ordinal_type i = m; i > 0 ; i--) h_rowptr(i) = h_rowptr(i-1);
-          h_rowptr(0) = 0;
-          Kokkos::deep_copy(d_rowptrL, h_rowptr);
-        }
-      } else if (s0.spmv_explicit_transpose) {
-        // ========================
-        // transpose
-        // >> generate rowptr
-        extractor_crs.setRowPtrT(s0.rowptrL);
-        {
-          // >> count nnz / row (transpose)
-          using team_policy_type = Kokkos::RangePolicy<typename functor_type::TransPtrTag, exec_space>;
-          team_policy_type team_policy(0, m);
-          Kokkos::parallel_for("transpose pointer", team_policy, extractor_crs);
-        }
-        {
-          // >> accumulate to generate rowptr (transpose)
-          using range_policy_type = Kokkos::RangePolicy<exec_space>;
-          Kokkos::parallel_scan("shiftRowptrT", range_policy_type(0, m+1), rowptr_sum(s0.rowptrL));
-          exec_space().fence();
-        }
-
-        s0.nnzL = s0.nnzU;
-        auto d_colindL = Kokkos::subview(colindL, range_type(nnzL, nnzL+s0.nnzL));
-        auto d_nzvalsL = Kokkos::subview(nzvalsL, range_type(nnzL, nnzL+s0.nnzL));
-        s0.colindL = d_colindL.data();
-        s0.nzvalsL = d_nzvalsL.data();
-        nnzL += s0.nnzL;
- 
-        // ========================
-        // >> copy into transpose-matrix
-        extractor_crs.setRowPtrT(s0.rowptrL);
-        extractor_crs.setCrsViewT(s0.colindL, s0.nzvalsL);
-        {
-          using team_policy_type = Kokkos::RangePolicy<typename functor_type::TransMatTag, exec_space>;
-          team_policy_type team_policy(0, m);
-          Kokkos::parallel_for("transpose pointer", team_policy, extractor_crs);
-          exec_space().fence();
-        }
-        // ========================
-        // shift back
-        // (TODO: shift first to avoid this)
-        {
-          // copy to CPU, for now
-          auto d_rowptrL = Kokkos::subview(rowptrL, range_type(ptr, ptr+m+1));
-          auto h_rowptr = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_rowptrL);
-          for (ordinal_type i = m; i > 0 ; i--) h_rowptr(i) = h_rowptr(i-1);
-          h_rowptr(0) = 0;
-          Kokkos::deep_copy(d_rowptrL, h_rowptr);
-        }
-      }
-      ptr += (1+m);
-
-#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE)) || \
-     defined(KOKKOS_ENABLE_HIP)
-      const value_type one(1);
-      const value_type zero(0);
-      // ========================
-      // create NVIDIA/AMD data structures for SpMV
-      size_t buffer_size_L = 0;
-      size_t buffer_size_U = 0;
-      value_type alpha = one;
-      #ifdef TACHO_INSERT_DIAGONALS
-      value_type beta = zero;
-      #else
-      value_type beta = one;
-      #endif
-#if defined(KOKKOS_ENABLE_CUDA)
-      // create matrix
-      cusparseCreateCsr(&s0.U_cusparse, m, m, s0.nnzU,
-                        s0.rowptrU, s0.colindU, s0.nzvalsU,
-                        CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
-                        CUSPARSE_INDEX_BASE_ZERO, computeType);
-
-#ifdef USE_SPMM_FOR_WORKSPACE_SIZE
-      cusparseSpMM_bufferSize(cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                              &alpha, s0.U_cusparse, vecX, &beta, vecY,
-                              computeType, TACHO_CUSPARSE_SPMM_ALG, &buffer_size_U);
-#else
-      cusparseSpMV_bufferSize(cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, s0.U_cusparse, vecX, &beta, vecY,
-                              computeType, TACHO_CUSPARSE_SPMV_ALG, &buffer_size_U);
-#endif
-      if (s0.spmv_explicit_transpose) {
-        // create matrix (transpose(U) or L)
-        cusparseCreateCsr(&s0.L_cusparse, m, m, s0.nnzL,
-                          s0.rowptrL, s0.colindL, s0.nzvalsL,
-                          CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
-                          CUSPARSE_INDEX_BASE_ZERO, computeType);
-        // workspace size
-#ifdef USE_SPMM_FOR_WORKSPACE_SIZE
-        cusparseSpMM_bufferSize(cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                &alpha, s0.L_cusparse, vecX, &beta, vecY,
-                                computeType, TACHO_CUSPARSE_SPMM_ALG, &buffer_size_L);
-#else
-        cusparseSpMV_bufferSize(cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, s0.L_cusparse, vecX, &beta, vecY,
-                                computeType, TACHO_CUSPARSE_SPMV_ALG, &buffer_size_L);
-#endif
-      } else {
-        // create matrix (L_cusparse stores the same ptrs as descrU, but optimized for trans)
-        s0.nnzL = s0.nnzU;
-        cusparseCreateCsr(&s0.L_cusparse, m, m, s0.nnzU,
-                          s0.rowptrU, s0.colindU, s0.nzvalsU,
-                          CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
-                          CUSPARSE_INDEX_BASE_ZERO, computeType);
-        // workspace size for transpose SpMV
-#ifdef USE_SPMM_FOR_WORKSPACE_SIZE
-        cusparseSpMM_bufferSize(cusparseHandle, CUSPARSE_OPERATION_TRANSPOSE, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                                &alpha, s0.L_cusparse, vecX, &beta, vecY,
-                                computeType, TACHO_CUSPARSE_SPMM_ALG, &buffer_size_L);
-#else
-        cusparseSpMV_bufferSize(cusparseHandle, CUSPARSE_OPERATION_TRANSPOSE, &alpha, s0.L_cusparse, vecX, &beta, vecY,
-                                computeType, TACHO_CUSPARSE_SPMV_ALG, &buffer_size_L);
-#endif
-      }
-      // allocate workspace
-      if (buffer_size_U > buffer_U.extent(0)) {
-        Kokkos::resize(buffer_U, buffer_size_U);
-      }
-      if (buffer_size_L > buffer_L.extent(0)) {
-        Kokkos::resize(buffer_L, buffer_size_L);
-      }
-#elif defined(KOKKOS_ENABLE_HIP)
-      // create matrix
-      rocsparse_create_csr_descr(&(s0.descrU), m, m, s0.nnzU,
-                                 s0.rowptrU, s0.colindU, s0.nzvalsU,
-                                 rocsparse_indextype_i32, rocsparse_indextype_i32, rocsparse_index_base_zero, rocsparse_compute_type);
-      // workspace
-      tacho_rocsparse_spmv
-          (rocsparseHandle, rocsparse_operation_none,
-           &alpha, s0.descrU, vecX, &beta, vecY,
-           rocsparse_compute_type, rocsparse_spmv_alg_default,
-           #if ROCM_VERSION >= 50400
-           rocsparse_spmv_stage_buffer_size,
-           #endif
-           &buffer_size_U, nullptr);
-      // allocate workspace
-      if (buffer_size_U > buffer_U.extent(0)) {
-        Kokkos::resize(buffer_U, buffer_size_U);
-      }
-      #if ROCM_VERSION >= 50400
-      // preprocess
-      buffer_size_U = buffer_U.extent(0);
-      tacho_rocsparse_spmv
-          (rocsparseHandle, rocsparse_operation_none,
-           &alpha, s0.descrU, vecX, &beta, vecY,
-           rocsparse_compute_type, rocsparse_spmv_alg_default,
-           rocsparse_spmv_stage_preprocess,
-           &buffer_size_U, (void*)buffer_U.data());
-      #endif
-      if (s0.spmv_explicit_transpose) {
-        // create matrix (transpose)
-        _status = rocsparse_create_csr_descr(&(s0.descrL), m, m, s0.nnzL,
-                                             s0.rowptrL, s0.colindL, s0.nzvalsL,
-                                             rocsparse_indextype_i32, rocsparse_indextype_i32,
-                                             rocsparse_index_base_zero, rocsparse_compute_type);
-        checkDeviceBlasStatus("rocsparse_create_crs_descr");
-        // workspace
-        _status = tacho_rocsparse_spmv
-          (rocsparseHandle, rocsparse_operation_none,
-           &alpha, s0.descrL, vecX, &beta, vecY,
-           rocsparse_compute_type, rocsparse_spmv_alg_default,
-           #if ROCM_VERSION >= 50400
-           rocsparse_spmv_stage_buffer_size,
-           #endif
-           &buffer_size_L, nullptr);
-        checkDeviceBlasStatus("rocsparse_create_spmv");
-        // allocate workspace
-        if (buffer_size_L > buffer_L.extent(0)) {
-          Kokkos::resize(buffer_L, buffer_size_L);
-        }
-        #if ROCM_VERSION >= 50400
-        // preprocess
-        buffer_size_L = buffer_L.extent(0);
-        tacho_rocsparse_spmv
-          (rocsparseHandle, rocsparse_operation_none,
-           &alpha, s0.descrL, vecX, &beta, vecY,
-           rocsparse_compute_type, rocsparse_spmv_alg_default,
-            rocsparse_spmv_stage_preprocess,
-           &buffer_size_L, (void*)buffer_L.data());
-        #endif
-      } else {
-        // create matrix, transpose (L_cusparse stores the same ptrs as descrU, but optimized for trans)
-        _status = rocsparse_create_csr_descr(&(s0.descrL), m, m, s0.nnzU,
-                                             s0.rowptrU, s0.colindU, s0.nzvalsU,
-                                             rocsparse_indextype_i32, rocsparse_indextype_i32,
-                                             rocsparse_index_base_zero, rocsparse_compute_type);
-        checkDeviceBlasStatus("rocsparse_create_crs_descr");
-        // workspace (transpose)
-        _status = tacho_rocsparse_spmv
-          (rocsparseHandle, rocsparse_operation_transpose,
-           &alpha, s0.descrL, vecX, &beta, vecY,
-           rocsparse_compute_type, rocsparse_spmv_alg_default,
-           #if ROCM_VERSION >= 50400
-           rocsparse_spmv_stage_buffer_size,
-           #endif
-           &buffer_size_L, nullptr);
-        checkDeviceBlasStatus("rocsparse_create_spmv");
-        // allcate workspace
-        if (buffer_size_L > buffer_L.extent(0)) {
-          Kokkos::resize(buffer_L, buffer_size_L);
-        }
-        #if ROCM_VERSION >= 50400
-        // preprocess
-        buffer_size_L = buffer_L.extent(0);
-        tacho_rocsparse_spmv
-          (rocsparseHandle, rocsparse_operation_transpose,
-           &alpha, s0.descrL, vecX, &beta, vecY,
-           rocsparse_compute_type, rocsparse_spmv_alg_default,
-            rocsparse_spmv_stage_preprocess,
-           &buffer_size_L, (void*)buffer_L.data());
-        #endif
-      }
-#endif
-#endif
-    }
-#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE)) || \
-     defined(KOKKOS_ENABLE_HIP)
-#if defined(KOKKOS_ENABLE_CUDA)
-#ifdef USE_SPMM_FOR_WORKSPACE_SIZE
-    cusparseDestroyDnMat(vecX);
-    cusparseDestroyDnMat(vecY);
-#else
-    cusparseDestroyDnVec(vecX);
-    cusparseDestroyDnVec(vecY);
-#endif
-#elif defined(KOKKOS_ENABLE_HIP)
-    rocsparse_destroy_dnvec_descr(vecX);
-    rocsparse_destroy_dnvec_descr(vecY);
-#endif
-#endif
-    if (verbose) {
-      printf("LevelSetTools:loadCRS(method = %d)\n",this->getSolutionMethod());
-      printf("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n");
-    }
+    const int method = this->getSolutionMethod();
+    _spmv->Load(store_transpose, verbose, method, _m,
+                _h_level_ptr, _level_sids, _h_level_sids, _h_solve_mode, _info, _h_supernodes, _solve_mode, _piv,
+                _streams[0], _w_vec);
   }
 
   inline void extractCRS(bool store_transpose, bool verbose) {
@@ -2677,51 +2112,8 @@ public:
   /// Release CRS extracted for SpMV
   ///
   inline void releaseCRS(bool release_all, bool verbose) {
-    if (verbose) {
-      printf("LevelSetTools:releaseCRS\n");
-      printf("========================\n");
-      printf(" Have%s been extracted\n", (_is_spmv_extracted == 0 ?  " not" : ""));
-      if (release_all) printf(" Release all\n");
-      printf("\n"); fflush(stdout);
-    }
-    if(_is_spmv_extracted != 0) {
-      Kokkos::fence();
-      if (release_all) {
-        for (ordinal_type lvl = 0; lvl < _team_serial_level_cut; ++lvl) {
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
-          const ordinal_type pbeg = _h_level_ptr(lvl);
-#endif
-          // the first supernode in this lvl (where the CRS matrix is stored)
-#if defined(KOKKOS_ENABLE_CUDA)
-          auto &s0 = _h_supernodes(_h_level_sids(pbeg));
-          cusparseDestroySpMat(s0.U_cusparse);
-          cusparseDestroySpMat(s0.L_cusparse);
-#elif defined(KOKKOS_ENABLE_HIP)
-          auto &s0 = _h_supernodes(_h_level_sids(pbeg));
-          rocsparse_destroy_spmat_descr(s0.descrU);
-          rocsparse_destroy_spmat_descr(s0.descrL);
-#endif
-        }
-      }
-#if defined(TACHO_HAVE_CUSPARSE) && defined(KOKKOS_ENABLE_CUDA)
-      cusparseDestroy(cusparseHandle);
-      cusparseDestroyDnMat(matL);
-      cusparseDestroyDnVec(vecL);
-      cusparseDestroyDnMat(matU);
-      cusparseDestroyDnVec(vecU);
-      cusparseDestroyDnMat(matW);
-      cusparseDestroyDnVec(vecW); 
-#elif defined(KOKKOS_ENABLE_HIP)
-      rocsparse_destroy_handle(rocsparseHandle);
-      rocsparse_destroy_dnmat_descr(matL);
-      rocsparse_destroy_dnvec_descr(vecL);
-      rocsparse_destroy_dnmat_descr(matU);
-      rocsparse_destroy_dnvec_descr(vecU);
-      rocsparse_destroy_dnmat_descr(matW);
-      rocsparse_destroy_dnvec_descr(vecW); 
-#endif
-      _is_spmv_extracted = 0;
-    }
+    _spmv->Release(release_all, verbose,
+                  _h_level_ptr, _h_level_sids, _h_supernodes);
   }
 
 
@@ -2748,377 +2140,6 @@ public:
             policy, KOKKOS_LAMBDA(const ordinal_type &i) { buf_solve_nrhs_ptr(i) = nrhs * buf_solve_ptr(i); });
         Kokkos::deep_copy(_h_buf_solve_nrhs_ptr, _buf_solve_nrhs_ptr);
         _nrhs = nrhs;
-      }
-    }
-  }
-
-  inline void solveGenericLowerOnDeviceVar2_SpMV(const ordinal_type lvl, const ordinal_type nlvls,
-                                                 const ordinal_type sid, const value_type_matrix &t) {
-    const ordinal_type m = t.extent(0);
-    const ordinal_type nrhs = t.extent(1);
-    const ordinal_type old_nrhs = _w_vec.extent(1);
-
-    auto &s0 = _h_supernodes(_h_level_sids(sid));
-    if (old_nrhs != nrhs) {
-      // expand workspace
-      Kokkos::resize(_w_vec, m, nrhs);
-    }
-#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE)) || \
-     defined(KOKKOS_ENABLE_HIP)
-    const ordinal_type ldt = t.stride(1);
-
-#if defined(KOKKOS_ENABLE_CUDA)
-    cudaDataType computeType = CUDA_R_64F;
-    if (std::is_same<value_type, float>::value) {
-      computeType = CUDA_R_32F;
-    } else if (!std::is_same<value_type, double>::value) {
-      TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
-                               "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
-    }
-#elif defined(KOKKOS_ENABLE_HIP)
-    rocsparse_datatype rocsparse_compute_type = rocsparse_datatype_f64_r;
-    if (std::is_same<value_type, float>::value) {
-      rocsparse_compute_type = rocsparse_datatype_f32_r;
-    } else if (!std::is_same<value_type, double>::value) {
-      TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
-                               "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
-    }
-#endif
-    #ifdef TACHO_INSERT_DIAGONALS
-    // compute t = L^{-1}*w
-    const value_type alpha (1);
-    const value_type beta  (0);
-    if (old_nrhs != nrhs) {
-      // attach to Cusparse/Rocsparse data struct
-      int ldw = _w_vec.stride(1);
-#if defined(KOKKOS_ENABLE_CUDA)
-      // destroy previous
-      cusparseDestroyDnMat(matW);
-      cusparseDestroyDnVec(vecW);
-      // create new
-      cusparseCreateDnMat(&matW, m, nrhs, ldw, (void*)(_w_vec.data()), computeType, CUSPARSE_ORDER_COL);
-      cusparseCreateDnVec(&vecW, m, (void*)(_w_vec.data()), computeType);
-#elif defined(KOKKOS_ENABLE_HIP)
-      // destroy previous
-      rocsparse_destroy_dnmat_descr(matW);
-      rocsparse_destroy_dnvec_descr(vecW);
-      // create new
-      rocsparse_create_dnmat_descr(&matW, m, nrhs, ldw, (void*)(_w_vec.data()), rocsparse_compute_type, rocsparse_order_column);
-      rocsparse_create_dnvec_descr(&vecW, m, (void*)(_w_vec.data()), rocsparse_compute_type);
-#endif
-    }
-    #else
-    exit(0);
-    #endif
-#if defined(KOKKOS_ENABLE_CUDA)
-    // Desctory old CSR
-    cusparseDestroySpMat(s0.L_cusparse);
-    // Re-create CuSparse CSR
-    if (s0.spmv_explicit_transpose) {
-      cusparseCreateCsr(&s0.L_cusparse, m, m, s0.nnzL,
-                        s0.rowptrL, s0.colindL, s0.nzvalsL,
-                        CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
-                        CUSPARSE_INDEX_BASE_ZERO, computeType);
-    } else {
-      cusparseCreateCsr(&s0.L_cusparse, m, m, s0.nnzU,
-                        s0.rowptrU, s0.colindU, s0.nzvalsU,
-                        CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
-                        CUSPARSE_INDEX_BASE_ZERO, computeType);
-    }
-    // Call SpMV/SPMM
-    cusparseStatus_t status;
-    cusparseOperation_t opL = (s0.spmv_explicit_transpose ? CUSPARSE_OPERATION_NON_TRANSPOSE : CUSPARSE_OPERATION_TRANSPOSE);
-    if (nrhs > 1) {
-      if (lvl == nlvls-1) {
-        // start : destroy previous
-        cusparseDestroyDnMat(matL);
-        // start : create DnMat for T
-        cusparseCreateDnMat(&matL, m, nrhs, ldt, (void*)(t.data()), computeType, CUSPARSE_ORDER_COL);
-      }
-      // create vectors
-      auto matX = ((nlvls-1-lvl)%2 == 0 ? matL : matW);
-      auto matY = ((nlvls-1-lvl)%2 == 0 ? matW : matL);
-      // SpMM
-      status = cusparseSpMM(cusparseHandle, opL, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                            &alpha, s0.L_cusparse, 
-                                    matX,
-                            &beta,  matY,
-                            computeType, TACHO_CUSPARSE_SPMM_ALG, (void*)buffer_L.data());
-    } else {
-      if (lvl == nlvls-1) {
-        // start : destroy previous
-        cusparseDestroyDnVec(vecL);
-        // start : create DnMat for T
-        cusparseCreateDnVec(&vecL, m, (void*)(t.data()), computeType);
-      }
-      // create vectors
-      auto vecX = ((nlvls-1-lvl)%2 == 0 ? vecL : vecW);
-      auto vecY = ((nlvls-1-lvl)%2 == 0 ? vecW : vecL);
-      // SpMV
-      status = cusparseSpMV(cusparseHandle, opL,
-                            &alpha, s0.L_cusparse, 
-                                    vecX,
-                            &beta,  vecY,
-                            computeType, TACHO_CUSPARSE_SPMV_ALG, (void*)buffer_L.data());
-    }
-    if (CUSPARSE_STATUS_SUCCESS != status) {
-      printf( " Failed cusparseSpMV for SpMV (lower)\n" );
-    }
-#elif defined(KOKKOS_ENABLE_HIP)
-    rocsparse_status status;
-    if (nrhs > 1) {
-      if (lvl == nlvls-1) {
-        // start : destroy previous
-        rocsparse_destroy_dnmat_descr(matL);
-        // start : create DnMat for T
-        rocsparse_create_dnmat_descr(&matL, m, nrhs, ldt, (void*)(t.data()), rocsparse_compute_type, rocsparse_order_column);
-      }
-      // create vectors
-      auto vecX = ((nlvls-1-lvl)%2 == 0 ? matL : matW);
-      auto vecY = ((nlvls-1-lvl)%2 == 0 ? matW : matL);
-      if (s0.spmv_explicit_transpose) {
-        size_t buffer_size_L = buffer_L.extent(0);
-        status = rocsparse_spmm(rocsparseHandle, rocsparse_operation_none, rocsparse_operation_none,
-                                &alpha, s0.descrL, vecX, &beta, vecY,
-                                rocsparse_compute_type, rocsparse_spmm_alg_default,
-                                rocsparse_spmm_stage_compute,
-                                &buffer_size_L, (void*)buffer_L.data());
-      } else {
-        size_t buffer_size_L = buffer_L.extent(0);
-        status = rocsparse_spmm(rocsparseHandle, rocsparse_operation_transpose, rocsparse_operation_none,
-                                &alpha, s0.descrL, vecX, &beta, vecY, // dscrL stores the same ptrs as descrU, but optimized for trans
-                                rocsparse_compute_type, rocsparse_spmm_alg_default,
-                                rocsparse_spmm_stage_compute,
-                                &buffer_size_L, (void*)buffer_L.data());
-      }
-    } else {
-      if (lvl == nlvls-1) {
-        // start : destroy previous
-        rocsparse_destroy_dnvec_descr(vecL);
-        // start : create DnVec for T
-        rocsparse_create_dnvec_descr(&vecL, m, (void*)(t.data()), rocsparse_compute_type);
-      }
-      size_t buffer_size_L = buffer_L.extent(0);
-      auto vecX = ((nlvls-1-lvl)%2 == 0 ? vecL : vecW);
-      auto vecY = ((nlvls-1-lvl)%2 == 0 ? vecW : vecL);
-      if (s0.spmv_explicit_transpose) {
-        status = tacho_rocsparse_spmv
-          (rocsparseHandle, rocsparse_operation_none,
-           &alpha, s0.descrL, vecX, &beta, vecY,
-           rocsparse_compute_type, rocsparse_spmv_alg_default,
-           #if ROCM_VERSION >= 50400
-           rocsparse_spmv_stage_compute,
-           #endif
-           &buffer_size_L, (void*)buffer_L.data());
-      } else {
-        status = tacho_rocsparse_spmv
-          (rocsparseHandle, rocsparse_operation_transpose,
-           &alpha, s0.descrL, vecX, &beta, vecY, // dscrL stores the same ptrs as descrU, but optimized for trans
-           rocsparse_compute_type, rocsparse_spmv_alg_default,
-           #if ROCM_VERSION >= 50400
-           rocsparse_spmv_stage_compute,
-           #endif
-           &buffer_size_L, (void*)buffer_L.data());
-      }
-    }
-    if (rocsparse_status_success != status) {
-      printf( " Failed rocsparse_spmv for L\n" );
-    }
-#endif
-#else
-    const value_type zero(0);
-    auto h_w = Kokkos::create_mirror_view_and_copy(host_memory_space(), ((nlvls-1-lvl)%2 == 0 ? t : _w_vec));
-    auto h_t = Kokkos::create_mirror_view(host_memory_space(), ((nlvls-1-lvl)%2 == 0 ? _w_vec : t));
-    Kokkos::deep_copy(h_t, zero);
-
-    if (s0.spmv_explicit_transpose) {
-      UnmanagedViewType<int_type_array>    d_rowptrL(s0.rowptrL, m+1);
-      UnmanagedViewType<int_type_array>    d_colindL(s0.colindL, s0.nnzL);
-      UnmanagedViewType<value_type_array>  d_nzvalsL(s0.nzvalsL, s0.nnzL);
-      auto h_rowptr = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_rowptrL);
-      auto h_colind = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_colindL);
-      auto h_nzvals = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_nzvalsL);
-      for (ordinal_type i = 0; i < m ; i++) {
-        for (int k = h_rowptr(i); k < h_rowptr(i+1); k++) {
-          for (int j = 0; j < nrhs; j++) {
-            h_t(i, j) += h_nzvals(k) * h_w(h_colind(k), j);
-          }
-        }
-      }
-    } else {
-      UnmanagedViewType<int_type_array>    d_rowptrU(s0.rowptrU, m+1);
-      UnmanagedViewType<int_type_array>    d_colindU(s0.colindU, s0.nnzU);
-      UnmanagedViewType<value_type_array>  d_nzvalsU(s0.nzvalsU, s0.nnzU);
-      auto h_rowptr = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_rowptrU);
-      auto h_colind = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_colindU);
-      auto h_nzvals = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_nzvalsU);
-      for (ordinal_type i = 0; i < m ; i++) {
-        for (int k = h_rowptr(i); k < h_rowptr(i+1); k++) {
-          for (int j = 0; j < nrhs; j++) {
-            h_t(h_colind(k), j) += h_nzvals(k) * h_w(i, j);
-          }
-        }
-      }
-    }
-    if ((nlvls-1-lvl)%2 == 0) {
-      Kokkos::deep_copy(_w_vec, h_t);
-    } else {
-      Kokkos::deep_copy(t, h_t);
-    }
-#endif
-    if (lvl == 0) {
-      // end : copy to output
-      if ((nlvls-1)%2 == 0) {
-        Kokkos::deep_copy(t, _w_vec);
-      }
-    }
-  }
-
-  inline void solveGenericUpperOnDeviceVar2_SpMV(const ordinal_type lvl, const ordinal_type nlvls,
-                                                 const ordinal_type sid, const value_type_matrix &t) {
-    const ordinal_type m = t.extent(0);
-    const ordinal_type nrhs = t.extent(1);
-
-    auto &s0 = _h_supernodes(_h_level_sids(sid));
-
-#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE)) || \
-     defined(KOKKOS_ENABLE_HIP)
-    #ifdef TACHO_INSERT_DIAGONALS
-    // x = t & y = w (lvl = 0,2,4)
-    // compute t = L^{-1}*w
-    const value_type alpha (1);
-    const value_type beta  (0);
-    const ordinal_type ldt = t.stride(1);
-    #else
-    exit(0);
-    #endif
-#if defined(KOKKOS_ENABLE_CUDA)
-    cudaDataType computeType = CUDA_R_64F;
-    if (std::is_same<value_type, float>::value) {
-      computeType = CUDA_R_32F;
-    } else if (!std::is_same<value_type, double>::value) {
-      TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
-                               "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
-    }
-
-    cusparseStatus_t status;
-    // Desctory old CSR
-    cusparseDestroySpMat(s0.U_cusparse);
-    // Re-create CuSparse CSR
-    cusparseCreateCsr(&s0.U_cusparse, m, m, s0.nnzU,
-                      s0.rowptrU, s0.colindU, s0.nzvalsU,
-                      CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
-                      CUSPARSE_INDEX_BASE_ZERO, computeType);
-
-    // Call SpMV/SPMM
-    if (nrhs > 1) {
-      if (lvl == 0) {
-        // start : destroy previous
-        cusparseDestroyDnMat(matU);
-        // start : create DnMat for T
-        cusparseCreateDnMat(&matU, m, nrhs, ldt, (void*)(t.data()), computeType, CUSPARSE_ORDER_COL);
-      }
-      auto vecX = (lvl%2 == 0 ? matU : matW);
-      auto vecY = (lvl%2 == 0 ? matW : matU);
-      // SpMM
-      status = cusparseSpMM(cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                            &alpha, s0.U_cusparse, 
-                                    vecX,
-                            &beta,  vecY,
-                            computeType, TACHO_CUSPARSE_SPMM_ALG, (void*)buffer_U.data());
-    } else {
-      if (lvl == 0) {
-        // start : destroy previous
-        cusparseDestroyDnVec(vecU);
-        // start : create DnMat for T
-        cusparseCreateDnVec(&vecU, m, (void*)(t.data()), computeType);
-      }
-      auto vecX = (lvl%2 == 0 ? vecU : vecW);
-      auto vecY = (lvl%2 == 0 ? vecW : vecU);
-      // SpMV
-      status = cusparseSpMV(cusparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                            &alpha, s0.U_cusparse, 
-                                    vecX,
-                            &beta,  vecY,
-                            computeType, TACHO_CUSPARSE_SPMV_ALG, (void*)buffer_U.data());
-    }
-    if (CUSPARSE_STATUS_SUCCESS != status) {
-       printf( " Failed cusparseSpMV for SpMV (upper)\n" );
-    }
-#elif defined(KOKKOS_ENABLE_HIP)
-    rocsparse_datatype rocsparse_compute_type = rocsparse_datatype_f64_r;
-    if (std::is_same<value_type, float>::value) {
-      rocsparse_compute_type = rocsparse_datatype_f32_r;
-    } else if (!std::is_same<value_type, double>::value) {
-      TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
-                               "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
-    }
-    size_t buffer_size_U = buffer_U.extent(0);
-    rocsparse_status status;
-    if (nrhs > 1) {
-      if (lvl == 0) {
-        // start : create DnMat for T
-        rocsparse_destroy_dnmat_descr(matU);
-        rocsparse_create_dnmat_descr(&matU, m, nrhs, ldt, (void*)(t.data()), rocsparse_compute_type, rocsparse_order_column);
-      }
-      auto vecX = (lvl%2 == 0 ? matU : matW);
-      auto vecY = (lvl%2 == 0 ? matW : matU);
-      status = rocsparse_spmm(rocsparseHandle, rocsparse_operation_none, rocsparse_operation_none,
-                              &alpha, s0.descrU, vecX, &beta, vecY,
-                              rocsparse_compute_type, rocsparse_spmm_alg_default,
-                              rocsparse_spmm_stage_compute,
-                              &buffer_size_U, (void*)buffer_U.data());
-    } else {
-      if (lvl == 0) {
-        // start : create DnVec for T
-        rocsparse_destroy_dnvec_descr(vecU);
-        rocsparse_create_dnvec_descr(&vecU, m, (void*)(t.data()), rocsparse_compute_type);
-      }
-      auto vecX = (lvl%2 == 0 ? vecU : vecW);
-      auto vecY = (lvl%2 == 0 ? vecW : vecU);
-      status = tacho_rocsparse_spmv
-          (rocsparseHandle, rocsparse_operation_none,
-           &alpha, s0.descrU, vecX, &beta, vecY,
-           rocsparse_compute_type, rocsparse_spmv_alg_default,
-           #if ROCM_VERSION >= 50400
-           rocsparse_spmv_stage_compute,
-           #endif
-           &buffer_size_U, (void*)buffer_U.data());
-    }
-    if (rocsparse_status_success != status) {
-      printf( " Failed rocsparse_spmv for U\n" );
-    }
-#endif
-#else
-    const value_type zero(0);
-    auto h_w = Kokkos::create_mirror_view_and_copy(host_memory_space(), (lvl%2 == 0 ? t : _w_vec));
-    auto h_t = Kokkos::create_mirror_view(host_memory_space(), (lvl%2 == 0 ? _w_vec : t));
-    Kokkos::deep_copy(h_t, zero);
-
-    UnmanagedViewType<int_type_array>    d_rowptrU(s0.rowptrU, m+1);
-    UnmanagedViewType<int_type_array>    d_colindU(s0.colindU, s0.nnzU);
-    UnmanagedViewType<value_type_array>  d_nzvalsU(s0.nzvalsU, s0.nnzU);
-    auto h_rowptr = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_rowptrU);
-    auto h_colind = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_colindU);
-    auto h_nzvals = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_nzvalsU);
-
-    for (ordinal_type i = 0; i < m ; i++) {
-      for (int k = h_rowptr(i); k < h_rowptr(i+1); k++) {
-        for (int j = 0; j < nrhs; j++) {
-          h_t(i, j) += h_nzvals(k) * h_w(h_colind(k), j);
-        }
-      }
-    }
-    if (lvl%2 == 0) {
-      Kokkos::deep_copy(_w_vec, h_t);
-    } else {
-      Kokkos::deep_copy(t, h_t);
-    }
-#endif
-    if (lvl == nlvls-1) {
-      // end : copy to output
-      if (lvl%2 == 0) {
-        Kokkos::deep_copy(t, _w_vec);
       }
     }
   }
@@ -3322,7 +2343,8 @@ public:
       return solveNoPivotLDLLowerOnDeviceVar2(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 3) {
       // apply L^{-1}
-      solveGenericLowerOnDeviceVar2_SpMV(lvl, nlvls, pbeg, t);
+      auto &s0 = _h_supernodes(_h_level_sids(pbeg));
+      _spmv->ApplyL_OnDevice(lvl, s0, t, _w_vec);
       {
         // apply D^{-1}
         const ordinal_type nrhs = t.extent(1);
@@ -3523,7 +2545,8 @@ public:
     else if (variant == 2)
       return solveNoPivotLDLUpperOnDeviceVar2(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 3) {
-      solveGenericUpperOnDeviceVar2_SpMV(lvl, nlvls, pbeg, t);
+      auto &s0 = _h_supernodes(_h_level_sids(pbeg));
+      _spmv->ApplyU_OnDevice(lvl, s0, t, _w_vec);
     } else {
       std::string msg = "Error: LevelSetTools::solveNoPivotLDLUpperOnDevice, algorithm variant ("
                         + std::to_string(variant) + ") is not supported.\n";
@@ -3700,7 +2723,8 @@ public:
     else if (variant == 2)
       return solveCholeskyLowerOnDeviceVar2(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 3) {
-      solveGenericLowerOnDeviceVar2_SpMV(lvl, nlvls, pbeg, t);
+      auto &s0 = _h_supernodes(_h_level_sids(pbeg));
+      _spmv->ApplyL_OnDevice(lvl, s0, t, _w_vec);
     } else {
       std::string msg = "Error: LevelSetTools::solveCholeskyLowerOnDevice, algorithm variant ("
                         + std::to_string(variant) + ") is not supported.\n";
@@ -3879,7 +2903,8 @@ public:
     else if (variant == 2)
       return solveCholeskyUpperOnDeviceVar2(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 3) {
-      solveGenericUpperOnDeviceVar2_SpMV(lvl, nlvls, pbeg, t);
+      auto &s0 = _h_supernodes(_h_level_sids(pbeg));
+      _spmv->ApplyU_OnDevice(lvl, s0, t, _w_vec);
     } else {
       std::string msg = "Error: LevelSetTools::solveCholeskyUpperOnDevice, algorithm variant ("
                         + std::to_string(variant) + ") is not supported.\n";
@@ -4063,9 +3088,10 @@ public:
       solveLDL_LowerOnDeviceVar1(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 2)
       solveLDL_LowerOnDeviceVar2(pbeg, pend, h_buf_solve_ptr, t);
-    else if (variant == 3)
-      solveGenericLowerOnDeviceVar2_SpMV(lvl, nlvls, pbeg, t);
-    else {
+    else if (variant == 3) {
+      auto &s0 = _h_supernodes(_h_level_sids(pbeg));
+      _spmv->ApplyL_OnDevice(lvl, s0, t, _w_vec);
+    } else {
       std::string msg = "Error: LevelSetTools::solveLDL_LowerOnDevice, algorithm variant ("
                         + std::to_string(variant) + ") is not supported.\n";
       TACHO_TEST_FOR_EXCEPTION(true, std::logic_error, msg.c_str());
@@ -4295,7 +3321,8 @@ public:
       // NOTE: merge D into U, or convert D into Crs?
       solveLDL_DiagOnDevice(pbeg, pend, h_buf_solve_ptr, (lvl%2 == 0 ? t : _w_vec));
       Kokkos::fence();
-      solveGenericUpperOnDeviceVar2_SpMV(lvl, nlvls, pbeg, t);
+      auto &s0 = _h_supernodes(_h_level_sids(pbeg));
+      _spmv->ApplyU_OnDevice(lvl, s0, t, _w_vec);
     } else {
       std::string msg = "Error: LevelSetTools::solveLDL_UpperOnDevice, algorithm variant ("
                         + std::to_string(variant) + ") is not supported.\n";
@@ -4484,7 +3511,8 @@ public:
       return solveLU_LowerOnDeviceVar2(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 3) {
       // L (stored by cols) incorporate partial-pivoting
-      solveGenericLowerOnDeviceVar2_SpMV(lvl, nlvls, pbeg, t);
+      auto &s0 = _h_supernodes(_h_level_sids(pbeg));
+      _spmv->ApplyL_OnDevice(lvl, s0, t, _w_vec);
     } else {
       std::string msg = "Error: LevelSetTools::solveLU_LowerOnDevice, algorithm variant ("
                         + std::to_string(variant) + ") is not supported.\n";
@@ -4648,7 +3676,8 @@ public:
     else if (variant == 2)
       return solveLU_UpperOnDeviceVar2(pbeg, pend, h_buf_solve_ptr, t);
     else if (variant == 3) {
-      solveGenericUpperOnDeviceVar2_SpMV(lvl, nlvls, pbeg, t);
+      auto &s0 = _h_supernodes(_h_level_sids(pbeg));
+      _spmv->ApplyU_OnDevice(lvl, s0, t, _w_vec);
     } else {
       std::string msg = "Error: LevelSetTools::solveLU_UpperOnDevice, algorithm variant ("
                         + std::to_string(variant) + ") is not supported.\n";
@@ -4827,10 +3856,6 @@ public:
       printf("Summary: LevelSetTools-Variant-%d (CholeskyFactorize)\n", variant);
       printf("=====================================================\n");
       printf( "\n  ** Team = %f s, Device = %f s, Update = %f s **\n",time_parallel,time_device,time_update );
-      if (variant == 3) {
-        printf( "  extractCRS with total nnzL = %ld and nnzU = %ld\n",colindL.extent(0),colindU.extent(0) );
-        if (store_transpose) printf( "  > explicitly storing transpose\n" );
-      }
       printf( "\n" );
       print_stat_factor();
       fflush(stdout);
@@ -5589,11 +4614,7 @@ public:
       printf("Summary: LevelSetTools-Variant-%d (LU Factorize)\n", variant);
       printf("================================================\n");
       printf( "\n  ** Team = %f s, Device = %f s, Update = %f s (%d streams) **\n",time_parallel,time_device,time_update,_nstreams );
-      if (variant == 3) {
-        printf( " extractCRS with total nnzL = %ld and nnzU = %ld\n\n",colindL.extent(0),colindU.extent(0) );
-      } else {
-        printf( "\n" );
-      }
+      printf( "\n" );
       print_stat_factor();
       fflush(stdout);
     }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_LevelSet.hpp
@@ -2353,7 +2353,6 @@ public:
         // apply D^{-1}
         const ordinal_type nrhs = t.extent(1);
         auto matY = (lvl == 0 ? t : ((nlvls-1-lvl)%2 == 0 ? _w_vec : t));
-        auto &s0 = _h_supernodes(_h_level_sids(pbeg));
         const UnmanagedViewType<nzvals_view> matD(s0.nzvalsD, _m);
 
         using policy_type = Kokkos::RangePolicy<exec_space>;

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Scale2x2_BlockInverseDiagonals_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Scale2x2_BlockInverseDiagonals_Internal.hpp
@@ -37,7 +37,7 @@ template <> struct Scale2x2_BlockInverseDiagonals<Side::Left, Algo::Internal> {
               const value_type det = a00 * a11 - a10 * a01;
               const value_type x0 = A(i - 1, 0), x1 = A(i, 0);
 
-              A(i - 1, 0) = (a11 * x0 - a10 * x1) / det;
+              A(i - 1, 0) = (a11 * x0 - a01 * x1) / det;
               A(i, 0) = (-a10 * x0 + a00 * x1) / det;
             } else {
               const value_type a00 = D(i, 0);
@@ -56,7 +56,7 @@ template <> struct Scale2x2_BlockInverseDiagonals<Side::Left, Algo::Internal> {
               for (ordinal_type j = 0; j < n; ++j) {
                 const value_type x0 = A(i - 1, j), x1 = A(i, j);
 
-                A(i - 1, j) = (a11 * x0 - a10 * x1) / det;
+                A(i - 1, j) = (a11 * x0 - a01 * x1) / det;
                 A(i, j) = (-a10 * x0 + a00 * x1) / det;
               }
             } else {
@@ -111,7 +111,7 @@ template <> struct Scale2x2_BlockInverseDiagonals<Side::Left, Algo::Internal> {
               const value_type det = a00 * a11 - a10 * a01;
               Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const ordinal_type &j) {
                 const value_type x0 = A(i - 1, j), x1 = A(i, j);
-                A(i - 1, j) = (a11 * x0 - a10 * x1) / det;
+                A(i - 1, j) = (a11 * x0 - a01 * x1) / det;
                 A(i, j) = (-a10 * x0 + a00 * x1) / det;
               });
             } else {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Scale2x2_BlockInverseDiagonals_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Scale2x2_BlockInverseDiagonals_OnDevice.hpp
@@ -37,11 +37,12 @@ template <> struct Scale2x2_BlockInverseDiagonals<Side::Left, Algo::OnDevice> {
                   /// do nothing
                 } else if (pval < 0) {
                   /// take 2x2 block to D
-                  const value_type a00 = D(i - 1, 0), a01 = D(i - 1, 1), a10 = D(i, 0), a11 = D(i, 1);
+                  const value_type a00 = D(i - 1, 0), a01 = D(i - 1, 1),
+                                   a10 = D(i, 0), a11 = D(i, 1);
                   const value_type det = a00 * a11 - a10 * a01;
                   const value_type x0 = A(i - 1, 0), x1 = A(i, 0);
 
-                  A(i - 1, 0) = (a11 * x0 - a10 * x1) / det;
+                  A(i - 1, 0) = (a11 * x0 - a01 * x1) / det;
                   A(i, 0) = (-a10 * x0 + a00 * x1) / det;
                 } else {
                   const value_type a00 = D(i, 0);
@@ -59,11 +60,12 @@ template <> struct Scale2x2_BlockInverseDiagonals<Side::Left, Algo::OnDevice> {
                   /// do nothing
                 } else if (pval < 0) {
                   /// take 2x2 block to D
-                  const value_type a00 = D(i - 1, 0), a01 = D(i - 1, 1), a10 = D(i, 0), a11 = D(i, 1);
+                  const value_type a00 = D(i - 1, 0), a01 = D(i - 1, 1),
+                                   a10 = D(i, 0), a11 = D(i, 1);
                   const value_type det = a00 * a11 - a10 * a01;
                   Kokkos::parallel_for(Kokkos::TeamVectorRange(member, n), [=](const ordinal_type &j) {
                     const value_type x0 = A(i - 1, j), x1 = A(i, j);
-                    A(i - 1, j) = (a11 * x0 - a10 * x1) / det;
+                    A(i - 1, j) = (a11 * x0 - a01 * x1) / det;
                     A(i, j) = (-a10 * x0 + a00 * x1) / det;
                   });
                 } else {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Spmv_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Spmv_OnDevice.hpp
@@ -116,7 +116,8 @@ public:
   int ApplyL_OnDevice(const ordinal_type lvl,
                             supernode_type &s0,
                       const multi_vectors_type &t,
-                            multi_vectors_type &w) {
+                            multi_vectors_type &w,
+                            bool conjugate = true) {
     int r_val(0);
     const ordinal_type m = t.extent(0);
     const ordinal_type nrhs = t.extent(1);
@@ -131,17 +132,37 @@ public:
     const ordinal_type ldt = t.stride(1);
 
 #if defined(KOKKOS_ENABLE_CUDA)
-    cudaDataType computeType = CUDA_R_64F;
-    if (std::is_same<value_type, float>::value) {
+    cudaDataType computeType;
+    if (std::is_same<value_type, double>::value) {
+      computeType = CUDA_R_64F;
+      conjugate = false;
+    } else if (std::is_same<value_type, float>::value) {
       computeType = CUDA_R_32F;
+      conjugate = false;
+    } else if (std::is_same<value_type, Kokkos::complex<double>>::value ||
+               std::is_same<value_type,    std::complex<double>>::value) {
+      computeType = CUDA_C_64F;
+    } else if (std::is_same<value_type, Kokkos::complex<float>>::value ||
+               std::is_same<value_type,    std::complex<float>>::value) {
+      computeType = CUDA_C_32F;
     } else if (!std::is_same<value_type, double>::value) {
       TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
                                "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
     }
 #elif defined(KOKKOS_ENABLE_HIP)
-    rocsparse_datatype rocsparse_compute_type = rocsparse_datatype_f64_r;
-    if (std::is_same<value_type, float>::value) {
+    rocsparse_datatype rocsparse_compute_type;
+    if (std::is_same<value_type, double>::value) {
+      rocsparse_compute_type = rocsparse_datatype_f64_r;
+      conjugate = false;
+    } else if (std::is_same<value_type, float>::value) {
       rocsparse_compute_type = rocsparse_datatype_f32_r;
+      conjugate = false;
+    } else if (std::is_same<value_type, Kokkos::complex<double>>::value ||
+               std::is_same<value_type,    std::complex<double>>::value) {
+      rocsparse_compute_type = rocsparse_datatype_f64_c;
+    } else if (std::is_same<value_type, Kokkos::complex<float>>::value ||
+               std::is_same<value_type,    std::complex<float>>::value) {
+      rocsparse_compute_type = rocsparse_datatype_f32_c;
     } else if (!std::is_same<value_type, double>::value) {
       TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
                                "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
@@ -186,7 +207,8 @@ public:
     }
     // Call SpMV/SPMM
     cusparseStatus_t status;
-    cusparseOperation_t opL = (s0.spmv_explicit_transpose ? CUSPARSE_OPERATION_NON_TRANSPOSE : CUSPARSE_OPERATION_TRANSPOSE);
+    cusparseOperation_t opL = (s0.spmv_explicit_transpose ? CUSPARSE_OPERATION_NON_TRANSPOSE :
+                               (conjugate ? CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE : CUSPARSE_OPERATION_TRANSPOSE));
     if (nrhs > 1) {
       if (lvl == _nlvls-1) {
         // start : destroy previous
@@ -244,7 +266,8 @@ public:
                                 &buffer_size, (void*)buffer_L.data());
       } else {
         size_t buffer_size = buffer_L.extent(0);
-        status = rocsparse_spmm(sparseHandle, rocsparse_operation_transpose, rocsparse_operation_none,
+        status = rocsparse_spmm(sparseHandle,
+                                (conjugate ? rocsparse_operation_conjugate_transpose : rocsparse_operation_transpose), rocsparse_operation_none,
                                 &alpha, s0.descrL, vecX, &beta, vecY, // dscrL stores the same ptrs as descrU, but optimized for trans
                                 rocsparse_compute_type, rocsparse_spmm_alg_default,
                                 rocsparse_spmm_stage_compute,
@@ -271,7 +294,7 @@ public:
            &buffer_size, (void*)buffer_L.data());
       } else {
         status = tacho_rocsparse_spmv
-          (sparseHandle, rocsparse_operation_transpose,
+          (sparseHandle, (conjugate ? rocsparse_operation_conjugate_transpose : rocsparse_operation_transpose),
            &alpha, s0.descrL, vecX, &beta, vecY, // dscrL stores the same ptrs as descrU, but optimized for trans
            rocsparse_compute_type, rocsparse_spmv_alg_default,
            #if ROCM_VERSION >= 50400
@@ -281,7 +304,7 @@ public:
       }
     }
     if (rocsparse_status_success != status) {
-      printf( " Failed rocsparse_spmv for L\n" );
+      printf( " Failed rocsparse_spmv for L (%s explicit transpose%s)\n",(s0.spmv_explicit_transpose ? "with" : "without"),(conjugate ? ", conjugate" : "") );
     }
 #endif
 #else
@@ -311,10 +334,11 @@ public:
       auto h_rowptr = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_rowptrU);
       auto h_colind = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_colindU);
       auto h_nzvals = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_nzvalsU);
+      using ATS = Tacho::ArithTraits<value_type>;
       for (ordinal_type i = 0; i < m ; i++) {
         for (int k = h_rowptr(i); k < h_rowptr(i+1); k++) {
           for (int j = 0; j < nrhs; j++) {
-            h_t(h_colind(k), j) += h_nzvals(k) * h_w(i, j);
+            h_t(h_colind(k), j) += (conjugate ? ATS::conj(h_nzvals(k)) : h_nzvals(k)) * h_w(i, j);
           }
         }
       }
@@ -355,6 +379,12 @@ public:
     cudaDataType computeType = CUDA_R_64F;
     if (std::is_same<value_type, float>::value) {
       computeType = CUDA_R_32F;
+    } else if (std::is_same<value_type, Kokkos::complex<double>>::value ||
+               std::is_same<value_type,    std::complex<double>>::value) {
+      computeType = CUDA_C_64F;
+    } else if (std::is_same<value_type, Kokkos::complex<float>>::value ||
+               std::is_same<value_type,    std::complex<float>>::value) {
+      computeType = CUDA_C_32F;
     } else if (!std::is_same<value_type, double>::value) {
       TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
                                "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
@@ -408,6 +438,12 @@ public:
     rocsparse_datatype rocsparse_compute_type = rocsparse_datatype_f64_r;
     if (std::is_same<value_type, float>::value) {
       rocsparse_compute_type = rocsparse_datatype_f32_r;
+    } else if (std::is_same<value_type, Kokkos::complex<double>>::value ||
+               std::is_same<value_type,    std::complex<double>>::value) {
+      rocsparse_compute_type = rocsparse_datatype_f64_c;
+    } else if (std::is_same<value_type, Kokkos::complex<float>>::value ||
+               std::is_same<value_type,    std::complex<float>>::value) {
+      rocsparse_compute_type = rocsparse_datatype_f32_c;
     } else if (!std::is_same<value_type, double>::value) {
       TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
                                "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
@@ -588,6 +624,12 @@ public:
       computeType = CUDA_R_64F;
     } else if (std::is_same<value_type, float>::value) {
       computeType = CUDA_R_32F;
+    } else if (std::is_same<value_type, Kokkos::complex<double>>::value ||
+               std::is_same<value_type,    std::complex<double>>::value) {
+      computeType = CUDA_C_64F;
+    } else if (std::is_same<value_type, Kokkos::complex<float>>::value ||
+               std::is_same<value_type,    std::complex<float>>::value) {
+      computeType = CUDA_C_32F;
     } else {
       TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
                                "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
@@ -608,6 +650,12 @@ public:
     rocsparse_datatype rocsparse_compute_type = rocsparse_datatype_f64_r;
     if (std::is_same<value_type, float>::value) {
       rocsparse_compute_type = rocsparse_datatype_f32_r;
+    } else if (std::is_same<value_type, Kokkos::complex<double>>::value ||
+               std::is_same<value_type,    std::complex<double>>::value) {
+      rocsparse_compute_type = rocsparse_datatype_f64_c;
+    } else if (std::is_same<value_type, Kokkos::complex<float>>::value ||
+               std::is_same<value_type,    std::complex<float>>::value) {
+      rocsparse_compute_type = rocsparse_datatype_f32_c;
     }
     // create rocsparse handle
     _status = rocsparse_create_handle(&sparseHandle);
@@ -760,6 +808,7 @@ public:
     const bool lu = (method == 3);
     const bool ldl = (method == 2);
     const bool ldl_nopiv = (method == 0);
+    const bool conjugate = (!ldl && !ldl_nopiv); // conjugate if not-ldl
 
     int r_val(0);
     // ========================
@@ -773,6 +822,12 @@ public:
       computeType = CUDA_R_64F;
     } else if (std::is_same<value_type, float>::value) {
       computeType = CUDA_R_32F;
+    } else if (std::is_same<value_type, Kokkos::complex<double>>::value ||
+               std::is_same<value_type,    std::complex<double>>::value) {
+      computeType = CUDA_C_64F;
+    } else if (std::is_same<value_type, Kokkos::complex<float>>::value ||
+               std::is_same<value_type,    std::complex<float>>::value) {
+      computeType = CUDA_C_32F;
     } else {
       TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
                                "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
@@ -792,6 +847,12 @@ public:
     rocsparse_datatype rocsparse_compute_type = rocsparse_datatype_f64_r;
     if (std::is_same<value_type, float>::value) {
       rocsparse_compute_type = rocsparse_datatype_f32_r;
+    } else if (std::is_same<value_type, Kokkos::complex<double>>::value ||
+               std::is_same<value_type,    std::complex<double>>::value) {
+      rocsparse_compute_type = rocsparse_datatype_f64_c;
+    } else if (std::is_same<value_type, Kokkos::complex<float>>::value ||
+               std::is_same<value_type,    std::complex<float>>::value) {
+      rocsparse_compute_type = rocsparse_datatype_f32_c;
     }
     // vectors used for preprocessing
     rocsparse_dnvec_descr vecX, vecY;
@@ -916,6 +977,7 @@ public:
         // >> copy into transpose-matrix
         extractor_crs.setRowPtrT(s0.rowptrL);
         extractor_crs.setCrsViewT(s0.colindL, s0.nzvalsL);
+        extractor_crs.setConjugate(conjugate);
         {
           using team_policy_type = Kokkos::RangePolicy<typename functor_type::TransMatTag, exec_space>;
           team_policy_type team_policy(0, m);

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Spmv_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Spmv_OnDevice.hpp
@@ -589,10 +589,7 @@ public:
             ordinal_type_array &piv,
 	    const stream_type &stream_0,
             multi_vectors_type &_w_vec) {
-    using host_device_type = typename UseThisDevice<Kokkos::DefaultHostExecutionSpace>::type;
-    using host_memory_space = typename host_device_type::memory_space;
     using range_type = Kokkos::pair<ordinal_type, ordinal_type>;
-
     int r_val(0);
     if (verbose) {
       printf("LevelSetTools:setupCRS(method=%d)\n",method);
@@ -799,12 +796,7 @@ public:
            ordinal_type_array &piv,
 	   const stream_type &stream_0,
            multi_vectors_type &_w_vec) {
-
-    using exec_space = typename multi_vectors_type::execution_space;
-    using host_device_type = typename UseThisDevice<Kokkos::DefaultHostExecutionSpace>::type;
-    using host_memory_space = typename host_device_type::memory_space;
     using range_type = Kokkos::pair<ordinal_type, ordinal_type>;
-
     const bool lu = (method == 3);
     const bool ldl = (method == 2);
     const bool ldl_nopiv = (method == 0);

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Spmv_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Spmv_OnDevice.hpp
@@ -1,0 +1,1123 @@
+// clang-format off
+// @HEADER
+// *****************************************************************************
+//                            Tacho package
+//
+// Copyright 2022 NTESS and the Tacho contributors.
+// SPDX-License-Identifier: BSD-2-Clause
+// *****************************************************************************
+// @HEADER
+// clang-format on
+#ifndef __TACHO_SPMV_ON_DEVICE_HPP__
+#define __TACHO_SPMV_ON_DEVICE_HPP__
+
+/// \file  Tacho_Spmv_OnDevice.hpp
+/// \brief Sparse-matrix dense-vector multiplication
+/// \author Kyungjoo Kim (kyukim@sandia.gov)
+
+#include "Tacho_SupernodeInfo.hpp"
+#include "Tacho_TeamFunctor_ExtractCRS.hpp"
+
+#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE))
+  // SpMV flag
+  #if (CUSPARSE_VERSION >= 11400)
+    #define TACHO_CUSPARSE_SPMV_ALG CUSPARSE_SPMV_ALG_DEFAULT
+  #else
+    #define TACHO_CUSPARSE_SPMV_ALG CUSPARSE_MV_ALG_DEFAULT
+  #endif
+  // SpMM flag
+  #if (CUSPARSE_VERSION >= 11000)
+    #define TACHO_CUSPARSE_SPMM_ALG CUSPARSE_SPMM_ALG_DEFAULT
+  #else
+    #define TACHO_CUSPARSE_SPMM_ALG CUSPARSE_MM_ALG_DEFAULT
+  #endif
+#elif defined(KOKKOS_ENABLE_HIP)
+  #if (ROCM_VERSION >= 60000)
+    #define tacho_rocsparse_spmv rocsparse_spmv
+  #elif (ROCM_VERSION >= 50400)
+    #define tacho_rocsparse_spmv rocsparse_spmv_ex
+  #else
+    #define tacho_rocsparse_spmv rocsparse_spmv
+  #endif
+#endif
+
+namespace Tacho {
+
+template<typename supernode_info_type>
+struct SpMV {
+
+private:
+  using device_type = typename supernode_info_type::device_type;
+  using exec_space  = typename device_type::execution_space;
+
+  using host_device_type = typename UseThisDevice<Kokkos::DefaultHostExecutionSpace>::type;
+  using host_memory_space = typename host_device_type::memory_space;
+
+  using value_type       = typename supernode_info_type::value_type;
+  using value_type_array = typename supernode_info_type::value_type_array;
+  using int_type_array   = typename supernode_info_type::int_type_array;
+
+  using rowptr_view = Kokkos::View<int *, device_type>;
+  using colind_view = Kokkos::View<int *, device_type>;
+  using nzvals_view = Kokkos::View<value_type *, device_type>;
+
+  bool _keep_zeros;
+  bool _is_spmv_extracted;
+  ordinal_type _nlvls;
+
+  rowptr_view rowptrU;
+  colind_view colindU;
+  nzvals_view nzvalsU;
+
+  rowptr_view rowptrL;
+  colind_view colindL;
+  nzvals_view nzvalsL;
+
+  nzvals_view nzvalsD;
+  value_type_array  buffer_L;
+  value_type_array  buffer_U;
+#if defined(KOKKOS_ENABLE_CUDA)
+  #if defined(TACHO_HAVE_CUSPARSE)
+  // workspace for SpMV
+  // (separte for U and L, so that we can "destroy" without waiting for the other)
+  cusparseDnMatDescr_t matL, matU, matW;
+  cusparseDnVecDescr_t vecL, vecU, vecW;
+  cusparseHandle_t sparseHandle;
+  #endif
+#elif defined(KOKKOS_ENABLE_HIP)
+  // workspace for SpMV
+  rocsparse_dnmat_descr matL, matU, matW;
+  rocsparse_dnvec_descr vecL, vecU, vecW;
+  rocsparse_handle sparseHandle;
+#endif
+
+  int _status;
+  inline void check_OnDeviceSPMV_Status(const char *func, const char *lib) {
+    if (_status != 0) {
+      printf("Error: %s, %s returns non-zero status %d\n", lib, func, _status);
+      std::runtime_error("checkStatus failed");
+    }
+  }
+
+public:
+  SpMV() {
+    _keep_zeros = false;
+    _is_spmv_extracted = false;
+    _nlvls = 0;
+  }
+
+  SpMV(bool keep_zeros) {
+    _keep_zeros = keep_zeros;
+    _is_spmv_extracted = false;
+    _nlvls = 0;
+  }
+
+  template <typename supernode_type, typename multi_vectors_type>
+  int ApplyL_OnDevice(const ordinal_type lvl,
+                            supernode_type &s0,
+                      const multi_vectors_type &t,
+                            multi_vectors_type &w) {
+    int r_val(0);
+    const ordinal_type m = t.extent(0);
+    const ordinal_type nrhs = t.extent(1);
+    const ordinal_type old_nrhs = w.extent(1);
+
+    if (old_nrhs != nrhs) {
+      // expand workspace
+      Kokkos::resize(w, m, nrhs);
+    }
+#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE)) || \
+     defined(KOKKOS_ENABLE_HIP)
+    const ordinal_type ldt = t.stride(1);
+
+#if defined(KOKKOS_ENABLE_CUDA)
+    cudaDataType computeType = CUDA_R_64F;
+    if (std::is_same<value_type, float>::value) {
+      computeType = CUDA_R_32F;
+    } else if (!std::is_same<value_type, double>::value) {
+      TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
+                               "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
+    }
+#elif defined(KOKKOS_ENABLE_HIP)
+    rocsparse_datatype rocsparse_compute_type = rocsparse_datatype_f64_r;
+    if (std::is_same<value_type, float>::value) {
+      rocsparse_compute_type = rocsparse_datatype_f32_r;
+    } else if (!std::is_same<value_type, double>::value) {
+      TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
+                               "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
+    }
+#endif
+    // compute t = L^{-1}*w
+    const value_type alpha (1);
+    const value_type beta  (0);
+    if (old_nrhs != nrhs) {
+      // attach to Cusparse/Rocsparse data struct
+      int ldw = w.stride(1);
+#if defined(KOKKOS_ENABLE_CUDA)
+      // destroy previous
+      cusparseDestroyDnMat(matW);
+      cusparseDestroyDnVec(vecW);
+      // create new
+      cusparseCreateDnMat(&matW, m, nrhs, ldw, (void*)(w.data()), computeType, CUSPARSE_ORDER_COL);
+      cusparseCreateDnVec(&vecW, m, (void*)(w.data()), computeType);
+#elif defined(KOKKOS_ENABLE_HIP)
+      // destroy previous
+      rocsparse_destroy_dnmat_descr(matW);
+      rocsparse_destroy_dnvec_descr(vecW);
+      // create new
+      rocsparse_create_dnmat_descr(&matW, m, nrhs, ldw, (void*)(w.data()), rocsparse_compute_type, rocsparse_order_column);
+      rocsparse_create_dnvec_descr(&vecW, m, (void*)(w.data()), rocsparse_compute_type);
+#endif
+    }
+#if defined(KOKKOS_ENABLE_CUDA)
+    // Desctory old CSR
+    cusparseDestroySpMat(s0.L_cusparse);
+    // Re-create CuSparse CSR
+    if (s0.spmv_explicit_transpose) {
+      cusparseCreateCsr(&s0.L_cusparse, m, m, s0.nnzL,
+                        s0.rowptrL, s0.colindL, s0.nzvalsL,
+                        CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
+                        CUSPARSE_INDEX_BASE_ZERO, computeType);
+    } else {
+      cusparseCreateCsr(&s0.L_cusparse, m, m, s0.nnzU,
+                        s0.rowptrU, s0.colindU, s0.nzvalsU,
+                        CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
+                        CUSPARSE_INDEX_BASE_ZERO, computeType);
+    }
+    // Call SpMV/SPMM
+    cusparseStatus_t status;
+    cusparseOperation_t opL = (s0.spmv_explicit_transpose ? CUSPARSE_OPERATION_NON_TRANSPOSE : CUSPARSE_OPERATION_TRANSPOSE);
+    if (nrhs > 1) {
+      if (lvl == _nlvls-1) {
+        // start : destroy previous
+        cusparseDestroyDnMat(matL);
+        // start : create DnMat for T
+        cusparseCreateDnMat(&matL, m, nrhs, ldt, (void*)(t.data()), computeType, CUSPARSE_ORDER_COL);
+      }
+      // create vectors
+      auto matX = ((_nlvls-1-lvl)%2 == 0 ? matL : matW);
+      auto matY = ((_nlvls-1-lvl)%2 == 0 ? matW : matL);
+      // SpMM
+      status = cusparseSpMM(sparseHandle, opL, CUSPARSE_OPERATION_NON_TRANSPOSE,
+                            &alpha, s0.L_cusparse,
+                                    matX,
+                            &beta,  matY,
+                            computeType, TACHO_CUSPARSE_SPMM_ALG, (void*)buffer_L.data());
+    } else {
+      if (lvl == _nlvls-1) {
+        // start : destroy previous
+        cusparseDestroyDnVec(vecL);
+        // start : create DnMat for T
+        cusparseCreateDnVec(&vecL, m, (void*)(t.data()), computeType);
+      }
+      // create vectors
+      auto vecX = ((_nlvls-1-lvl)%2 == 0 ? vecL : vecW);
+      auto vecY = ((_nlvls-1-lvl)%2 == 0 ? vecW : vecL);
+      // SpMV
+      status = cusparseSpMV(sparseHandle, opL,
+                            &alpha, s0.L_cusparse,
+                                    vecX,
+                            &beta,  vecY,
+                            computeType, TACHO_CUSPARSE_SPMV_ALG, (void*)buffer_L.data());
+    }
+    if (CUSPARSE_STATUS_SUCCESS != status) {
+      printf( " Failed cusparseSpMV for SpMV (lower)\n" );
+    }
+#elif defined(KOKKOS_ENABLE_HIP)
+    rocsparse_status status;
+    if (nrhs > 1) {
+      if (lvl == _nlvls-1) {
+        // start : destroy previous
+        rocsparse_destroy_dnmat_descr(matL);
+        // start : create DnMat for T
+        rocsparse_create_dnmat_descr(&matL, m, nrhs, ldt, (void*)(t.data()), rocsparse_compute_type, rocsparse_order_column);
+      }
+      // create vectors
+      auto vecX = ((_nlvls-1-lvl)%2 == 0 ? matL : matW);
+      auto vecY = ((_nlvls-1-lvl)%2 == 0 ? matW : matL);
+      if (s0.spmv_explicit_transpose) {
+        size_t buffer_size = buffer_L.extent(0);
+        status = rocsparse_spmm(sparseHandle, rocsparse_operation_none, rocsparse_operation_none,
+                                &alpha, s0.descrL, vecX, &beta, vecY,
+                                rocsparse_compute_type, rocsparse_spmm_alg_default,
+                                rocsparse_spmm_stage_compute,
+                                &buffer_size, (void*)buffer_L.data());
+      } else {
+        size_t buffer_size = buffer_L.extent(0);
+        status = rocsparse_spmm(sparseHandle, rocsparse_operation_transpose, rocsparse_operation_none,
+                                &alpha, s0.descrL, vecX, &beta, vecY, // dscrL stores the same ptrs as descrU, but optimized for trans
+                                rocsparse_compute_type, rocsparse_spmm_alg_default,
+                                rocsparse_spmm_stage_compute,
+                                &buffer_size, (void*)buffer_L.data());
+      }
+    } else {
+      if (lvl == _nlvls-1) {
+        // start : destroy previous
+        rocsparse_destroy_dnvec_descr(vecL);
+        // start : create DnVec for T
+        rocsparse_create_dnvec_descr(&vecL, m, (void*)(t.data()), rocsparse_compute_type);
+      }
+      size_t buffer_size = buffer_L.extent(0);
+      auto vecX = ((_nlvls-1-lvl)%2 == 0 ? vecL : vecW);
+      auto vecY = ((_nlvls-1-lvl)%2 == 0 ? vecW : vecL);
+      if (s0.spmv_explicit_transpose) {
+        status = tacho_rocsparse_spmv
+          (sparseHandle, rocsparse_operation_none,
+           &alpha, s0.descrL, vecX, &beta, vecY,
+           rocsparse_compute_type, rocsparse_spmv_alg_default,
+           #if ROCM_VERSION >= 50400
+           rocsparse_spmv_stage_compute,
+           #endif
+           &buffer_size, (void*)buffer_L.data());
+      } else {
+        status = tacho_rocsparse_spmv
+          (sparseHandle, rocsparse_operation_transpose,
+           &alpha, s0.descrL, vecX, &beta, vecY, // dscrL stores the same ptrs as descrU, but optimized for trans
+           rocsparse_compute_type, rocsparse_spmv_alg_default,
+           #if ROCM_VERSION >= 50400
+           rocsparse_spmv_stage_compute,
+           #endif
+           &buffer_size, (void*)buffer_L.data());
+      }
+    }
+    if (rocsparse_status_success != status) {
+      printf( " Failed rocsparse_spmv for L\n" );
+    }
+#endif
+#else
+    const value_type zero(0);
+    auto h_w = Kokkos::create_mirror_view_and_copy(host_memory_space(), ((_nlvls-1-lvl)%2 == 0 ? t : w));
+    auto h_t = Kokkos::create_mirror_view(host_memory_space(), ((_nlvls-1-lvl)%2 == 0 ? w : t));
+    Kokkos::deep_copy(h_t, zero);
+
+    if (s0.spmv_explicit_transpose) {
+      UnmanagedViewType<int_type_array>    d_rowptrL(s0.rowptrL, m+1);
+      UnmanagedViewType<int_type_array>    d_colindL(s0.colindL, s0.nnzL);
+      UnmanagedViewType<value_type_array>  d_nzvalsL(s0.nzvalsL, s0.nnzL);
+      auto h_rowptr = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_rowptrL);
+      auto h_colind = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_colindL);
+      auto h_nzvals = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_nzvalsL);
+      for (ordinal_type i = 0; i < m ; i++) {
+        for (int k = h_rowptr(i); k < h_rowptr(i+1); k++) {
+          for (int j = 0; j < nrhs; j++) {
+            h_t(i, j) += h_nzvals(k) * h_w(h_colind(k), j);
+          }
+        }
+      }
+    } else {
+      UnmanagedViewType<int_type_array>    d_rowptrU(s0.rowptrU, m+1);
+      UnmanagedViewType<int_type_array>    d_colindU(s0.colindU, s0.nnzU);
+      UnmanagedViewType<value_type_array>  d_nzvalsU(s0.nzvalsU, s0.nnzU);
+      auto h_rowptr = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_rowptrU);
+      auto h_colind = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_colindU);
+      auto h_nzvals = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_nzvalsU);
+      for (ordinal_type i = 0; i < m ; i++) {
+        for (int k = h_rowptr(i); k < h_rowptr(i+1); k++) {
+          for (int j = 0; j < nrhs; j++) {
+            h_t(h_colind(k), j) += h_nzvals(k) * h_w(i, j);
+          }
+        }
+      }
+    }
+    if ((_nlvls-1-lvl)%2 == 0) {
+      Kokkos::deep_copy(w, h_t);
+    } else {
+      Kokkos::deep_copy(t, h_t);
+    }
+#endif
+    if (lvl == 0) {
+      // end : copy to output
+      if ((_nlvls-1)%2 == 0) {
+        Kokkos::deep_copy(t, w);
+      }
+    }
+    return r_val;
+  }
+
+  template <typename supernode_type,
+            typename multi_vectors_type>
+  int ApplyU_OnDevice(const ordinal_type lvl,
+                            supernode_type &s0,
+                      const multi_vectors_type &t,
+                            multi_vectors_type &w) {
+    int r_val(0);
+    const ordinal_type m = t.extent(0);
+    const ordinal_type nrhs = t.extent(1);
+
+#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE)) || \
+     defined(KOKKOS_ENABLE_HIP)
+    // x = t & y = w (lvl = 0,2,4)
+    // compute t = L^{-1}*w
+    const value_type alpha (1);
+    const value_type beta  (0);
+    const ordinal_type ldt = t.stride(1);
+#if defined(KOKKOS_ENABLE_CUDA)
+    cudaDataType computeType = CUDA_R_64F;
+    if (std::is_same<value_type, float>::value) {
+      computeType = CUDA_R_32F;
+    } else if (!std::is_same<value_type, double>::value) {
+      TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
+                               "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
+    }
+
+    cusparseStatus_t status;
+    // Desctory old CSR
+    cusparseDestroySpMat(s0.U_cusparse);
+    // Re-create CuSparse CSR
+    cusparseCreateCsr(&s0.U_cusparse, m, m, s0.nnzU,
+                      s0.rowptrU, s0.colindU, s0.nzvalsU,
+                      CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
+                      CUSPARSE_INDEX_BASE_ZERO, computeType);
+
+    // Call SpMV/SPMM
+    if (nrhs > 1) {
+      if (lvl == 0) {
+        // start : destroy previous
+        cusparseDestroyDnMat(matU);
+        // start : create DnMat for T
+        cusparseCreateDnMat(&matU, m, nrhs, ldt, (void*)(t.data()), computeType, CUSPARSE_ORDER_COL);
+      }
+      auto vecX = (lvl%2 == 0 ? matU : matW);
+      auto vecY = (lvl%2 == 0 ? matW : matU);
+      // SpMM
+      status = cusparseSpMM(sparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, CUSPARSE_OPERATION_NON_TRANSPOSE,
+                            &alpha, s0.U_cusparse,
+                                    vecX,
+                            &beta,  vecY,
+                            computeType, TACHO_CUSPARSE_SPMM_ALG, (void*)buffer_U.data());
+    } else {
+      if (lvl == 0) {
+        // start : destroy previous
+        cusparseDestroyDnVec(vecU);
+        // start : create DnMat for T
+        cusparseCreateDnVec(&vecU, m, (void*)(t.data()), computeType);
+      }
+      auto vecX = (lvl%2 == 0 ? vecU : vecW);
+      auto vecY = (lvl%2 == 0 ? vecW : vecU);
+      // SpMV
+      status = cusparseSpMV(sparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+                            &alpha, s0.U_cusparse,
+                                    vecX,
+                            &beta,  vecY,
+                            computeType, TACHO_CUSPARSE_SPMV_ALG, (void*)buffer_U.data());
+    }
+    if (CUSPARSE_STATUS_SUCCESS != status) {
+       printf( " Failed cusparseSpMV for SpMV (upper)\n" );
+    }
+#elif defined(KOKKOS_ENABLE_HIP)
+    rocsparse_datatype rocsparse_compute_type = rocsparse_datatype_f64_r;
+    if (std::is_same<value_type, float>::value) {
+      rocsparse_compute_type = rocsparse_datatype_f32_r;
+    } else if (!std::is_same<value_type, double>::value) {
+      TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
+                               "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
+    }
+    size_t buffer_size = buffer_U.extent(0);
+    rocsparse_status status;
+    if (nrhs > 1) {
+      if (lvl == 0) {
+        // start : create DnMat for T
+        rocsparse_destroy_dnmat_descr(matU);
+        rocsparse_create_dnmat_descr(&matU, m, nrhs, ldt, (void*)(t.data()), rocsparse_compute_type, rocsparse_order_column);
+      }
+      auto vecX = (lvl%2 == 0 ? matU : matW);
+      auto vecY = (lvl%2 == 0 ? matW : matU);
+      status = rocsparse_spmm(sparseHandle, rocsparse_operation_none, rocsparse_operation_none,
+                              &alpha, s0.descrU, vecX, &beta, vecY,
+                              rocsparse_compute_type, rocsparse_spmm_alg_default,
+                              rocsparse_spmm_stage_compute,
+                              &buffer_size, (void*)buffer_U.data());
+    } else {
+      if (lvl == 0) {
+        // start : create DnVec for T
+        rocsparse_destroy_dnvec_descr(vecU);
+        rocsparse_create_dnvec_descr(&vecU, m, (void*)(t.data()), rocsparse_compute_type);
+      }
+      auto vecX = (lvl%2 == 0 ? vecU : vecW);
+      auto vecY = (lvl%2 == 0 ? vecW : vecU);
+      status = tacho_rocsparse_spmv
+          (sparseHandle, rocsparse_operation_none,
+           &alpha, s0.descrU, vecX, &beta, vecY,
+           rocsparse_compute_type, rocsparse_spmv_alg_default,
+           #if ROCM_VERSION >= 50400
+           rocsparse_spmv_stage_compute,
+           #endif
+           &buffer_size, (void*)buffer_U.data());
+    }
+    if (rocsparse_status_success != status) {
+      printf( " Failed rocsparse_spmv for U\n" );
+    }
+#endif
+#else
+    const value_type zero(0);
+    auto h_w = Kokkos::create_mirror_view_and_copy(host_memory_space(), (lvl%2 == 0 ? t : w));
+    auto h_t = Kokkos::create_mirror_view(host_memory_space(), (lvl%2 == 0 ? w : t));
+    Kokkos::deep_copy(h_t, zero);
+
+    UnmanagedViewType<int_type_array>    d_rowptrU(s0.rowptrU, m+1);
+    UnmanagedViewType<int_type_array>    d_colindU(s0.colindU, s0.nnzU);
+    UnmanagedViewType<value_type_array>  d_nzvalsU(s0.nzvalsU, s0.nnzU);
+    auto h_rowptr = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_rowptrU);
+    auto h_colind = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_colindU);
+    auto h_nzvals = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_nzvalsU);
+
+    for (ordinal_type i = 0; i < m ; i++) {
+      for (int k = h_rowptr(i); k < h_rowptr(i+1); k++) {
+        for (int j = 0; j < nrhs; j++) {
+          h_t(i, j) += h_nzvals(k) * h_w(h_colind(k), j);
+        }
+      }
+    }
+    if (lvl%2 == 0) {
+      Kokkos::deep_copy(w, h_t);
+    } else {
+      Kokkos::deep_copy(t, h_t);
+    }
+#endif
+    if (lvl == _nlvls-1) {
+      // end : copy to output
+      if (lvl%2 == 0) {
+        Kokkos::deep_copy(t, w);
+      }
+    }
+    return r_val;
+  }
+
+  template <typename size_type_array_host, typename ordinal_type_array_host, typename supernode_type_array_host>
+  int Release(const bool release_all, const bool verbose,
+              const size_type_array_host &h_level_ptr,
+              const ordinal_type_array_host &h_level_sids,
+              const supernode_type_array_host &h_supernodes) {
+    int r_val(0);
+    if (verbose) {
+      printf("LevelSetTools:releaseCRS\n");
+      printf("========================\n");
+      printf(" Have%s been extracted\n", (_is_spmv_extracted == 0 ?  " not" : ""));
+      if (release_all) printf(" Release all\n");
+      printf("\n"); fflush(stdout);
+    }
+    if(_is_spmv_extracted != 0) {
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+      Kokkos::fence();
+      if (release_all) {
+        for (ordinal_type lvl = 0; lvl < _nlvls; ++lvl) {
+          const ordinal_type pbeg = h_level_ptr(lvl);
+          // the first supernode in this lvl (where the CRS matrix is stored)
+          auto &s0 = h_supernodes(h_level_sids(pbeg));
+#if defined(KOKKOS_ENABLE_CUDA)
+          cusparseDestroySpMat(s0.U_cusparse);
+          cusparseDestroySpMat(s0.L_cusparse);
+#elif defined(KOKKOS_ENABLE_HIP)
+          rocsparse_destroy_spmat_descr(s0.descrU);
+          rocsparse_destroy_spmat_descr(s0.descrL);
+#endif
+        }
+      }
+#if defined(TACHO_HAVE_CUSPARSE) && defined(KOKKOS_ENABLE_CUDA)
+      cusparseDestroy(sparseHandle);
+      cusparseDestroyDnMat(matL);
+      cusparseDestroyDnVec(vecL);
+      cusparseDestroyDnMat(matU);
+      cusparseDestroyDnVec(vecU);
+      cusparseDestroyDnMat(matW);
+      cusparseDestroyDnVec(vecW);
+#elif defined(KOKKOS_ENABLE_HIP)
+      rocsparse_destroy_handle(sparseHandle);
+      rocsparse_destroy_dnmat_descr(matL);
+      rocsparse_destroy_dnvec_descr(vecL);
+      rocsparse_destroy_dnmat_descr(matU);
+      rocsparse_destroy_dnvec_descr(vecU);
+      rocsparse_destroy_dnmat_descr(matW);
+      rocsparse_destroy_dnvec_descr(vecW);
+#endif
+#endif
+      _is_spmv_extracted = 0;
+    }
+    return r_val;
+  }
+
+
+  template <typename size_type_array_host, typename ordinal_type_array_host, typename ordinal_type_array, 
+            typename supernode_type_array_host,
+            typename stream_type,
+            typename multi_vectors_type>
+  int Setup(const bool store_transpose, const bool verbose,
+            const int method, const ordinal_type m, const ordinal_type nlvls,
+            const size_type_array_host &h_level_ptr,
+            const ordinal_type_array &level_sids,
+            const ordinal_type_array_host &h_level_sids,
+            const ordinal_type_array_host &h_solve_mode,
+            const supernode_info_type &supernode_info,
+            const supernode_type_array_host &h_supernodes,
+            const ordinal_type_array &solve_mode,
+            ordinal_type_array &piv,
+	    const stream_type &stream_0,
+            multi_vectors_type &_w_vec) {
+    using host_device_type = typename UseThisDevice<Kokkos::DefaultHostExecutionSpace>::type;
+    using host_memory_space = typename host_device_type::memory_space;
+    using range_type = Kokkos::pair<ordinal_type, ordinal_type>;
+
+    int r_val(0);
+    if (verbose) {
+      printf("LevelSetTools:setupCRS(method=%d)\n",method);
+      printf("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n");
+    }
+    const bool lu = (method == 3);
+    const bool ldl = (method == 2);
+    const bool ldl_nopiv = (method == 0);
+    const ordinal_type nrhs = 1;
+
+    // ========================
+    // free CRS,
+    // if it has been extracted
+    _nlvls = nlvls; // store # of levels
+    Release(true, verbose,
+            h_level_ptr, h_level_sids, h_supernodes);
+
+    // ========================
+    // workspace
+    Kokkos::resize(_w_vec, m, nrhs);
+#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE)) || \
+     defined(KOKKOS_ENABLE_HIP)
+    const value_type zero(0);
+
+    int ldw = _w_vec.stride(1);
+#if defined(KOKKOS_ENABLE_CUDA)
+    cudaDataType computeType;
+    if (std::is_same<value_type, double>::value) {
+      computeType = CUDA_R_64F;
+    } else if (std::is_same<value_type, float>::value) {
+      computeType = CUDA_R_32F;
+    } else {
+      TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
+                               "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
+    }
+    // create cusparse handle
+    cusparseCreate(&sparseHandle);
+    // attach handle to stream-0
+    cusparseSetStream(sparseHandle, stream_0);
+    // attach to Cusparse data struct
+    cusparseCreateDnMat(&matW, m, nrhs, ldw, (void*)(_w_vec.data()), computeType, CUSPARSE_ORDER_COL);
+    cusparseCreateDnVec(&vecW, m, (void*)(_w_vec.data()), computeType);
+    // also to T, to be destroyed before each SpMV call
+    cusparseCreateDnMat(&matL, m, nrhs, ldw, (void*)(_w_vec.data()), computeType, CUSPARSE_ORDER_COL);
+    cusparseCreateDnVec(&vecL, m, (void*)(_w_vec.data()), computeType);
+    cusparseCreateDnMat(&matU, m, nrhs, ldw, (void*)(_w_vec.data()), computeType, CUSPARSE_ORDER_COL);
+    cusparseCreateDnVec(&vecU, m, (void*)(_w_vec.data()), computeType);
+#elif defined(KOKKOS_ENABLE_HIP)
+    rocsparse_datatype rocsparse_compute_type = rocsparse_datatype_f64_r;
+    if (std::is_same<value_type, float>::value) {
+      rocsparse_compute_type = rocsparse_datatype_f32_r;
+    }
+    // create rocsparse handle
+    _status = rocsparse_create_handle(&sparseHandle);
+    check_OnDeviceSPMV_Status("rocsparse_create_handle", "rocsparse");
+    // attach handle to stream-0
+    rocsparse_set_stream(sparseHandle, stream_0);
+    check_OnDeviceSPMV_Status("rocsparse_create_handle", "rocsparse");
+    // attach to Rocsparse data struct
+    _status = rocsparse_create_dnmat_descr(&matW, m, nrhs, ldw, (void*)(_w_vec.data()), rocsparse_compute_type, rocsparse_order_column);
+    check_OnDeviceSPMV_Status("rocsparse_dnmat_descr", "rocsparse");
+    _status = rocsparse_create_dnvec_descr(&vecW, m, (void*)(_w_vec.data()), rocsparse_compute_type);
+    check_OnDeviceSPMV_Status("rocsparse_dnmat_descr", "rocsparse");
+    // also to T, to be destroyed before each SpMV call
+    _status = rocsparse_create_dnmat_descr(&matL, m, nrhs, ldw, (void*)(_w_vec.data()), rocsparse_compute_type, rocsparse_order_column);
+    check_OnDeviceSPMV_Status("rocsparse_dnmat_descr", "rocsparse");
+    _status = rocsparse_create_dnvec_descr(&vecL, m, (void*)(_w_vec.data()), rocsparse_compute_type);
+    check_OnDeviceSPMV_Status("rocsparse_dnvec_descr", "rocsparse");
+    _status = rocsparse_create_dnmat_descr(&matU, m, nrhs, ldw, (void*)(_w_vec.data()), rocsparse_compute_type, rocsparse_order_column);
+    check_OnDeviceSPMV_Status("rocsparse_dnmat_descr", "rocsparse");
+    _status = rocsparse_create_dnvec_descr(&vecU, m, (void*)(_w_vec.data()), rocsparse_compute_type);
+    check_OnDeviceSPMV_Status("rocsparse_dnvec_descr", "rocsparse");
+#endif
+#endif
+
+    // allocate rowptrs
+    Kokkos::resize(rowptrU, nlvls*(1+m));
+    Kokkos::resize(rowptrL, nlvls*(1+m));
+    Kokkos::deep_copy(rowptrL, 0);
+    // counting nnz, first, so that we can allocate in NumericalTool
+    size_t ptr = 0;
+    size_t nnzU = 0;
+    size_t nnzL = 0;
+    typedef TeamFunctor_ExtractCrs<supernode_info_type> functor_type;
+    for (ordinal_type lvl = 0; lvl < nlvls; ++lvl) {
+      const ordinal_type pbeg = h_level_ptr(lvl), pend = h_level_ptr(lvl + 1);
+
+      // the first supernode in this lvl (where the CRS matrix is stored)
+      auto &s0 = h_supernodes(h_level_sids(pbeg));
+      s0.spmv_explicit_transpose = store_transpose;
+
+      // ========================
+      // count nnz / row
+      auto d_rowptrU = Kokkos::subview(rowptrU, range_type(ptr, ptr+m+1));
+      s0.rowptrU = d_rowptrU.data();
+
+      functor_type extractor_crs(_keep_zeros, supernode_info, solve_mode, level_sids);
+      extractor_crs.setGlobalSize(m);
+      extractor_crs.setRange(pbeg, pend);
+      extractor_crs.setRowPtr(s0.rowptrU);
+      if (ldl) {
+        // integrate pivoting into U
+        extractor_crs.integratePivots(true, piv);
+      }
+      {
+        using team_policy_type = Kokkos::TeamPolicy<Kokkos::Schedule<Kokkos::Static>, exec_space,
+                                                    typename functor_type::ExtractPtrTag>;
+        team_policy_type team_policy((pend-pbeg)+1, Kokkos::AUTO());
+
+        Kokkos::parallel_for("extract rowptr", team_policy, extractor_crs);
+        exec_space().fence();
+      }
+
+      // ========================
+      // shift to generate rowptr
+      {
+        using range_policy_type = Kokkos::RangePolicy<exec_space>;
+        Kokkos::parallel_scan("shiftRowptr", range_policy_type(0, m+1), rowptr_sum(s0.rowptrU));
+        exec_space().fence();
+        // get nnz
+        auto d_nnz = Kokkos::subview(d_rowptrU, range_type(m, m+1));
+        auto h_nnz = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_nnz);
+        s0.nnzU = h_nnz(0);
+        nnzU += s0.nnzU;
+      }
+
+      if (lu) {
+        // get nnz per row (L is stored by column)
+        auto d_rowptrL = Kokkos::subview(rowptrL, range_type(ptr, ptr+m+1));
+        s0.rowptrL = d_rowptrL.data();
+        {
+          using team_policy_type = Kokkos::TeamPolicy<Kokkos::Schedule<Kokkos::Static>, exec_space,
+                                                      typename functor_type::ExtractPtrColTag>;
+          team_policy_type team_policy((pend-pbeg)+1, Kokkos::AUTO());
+
+          extractor_crs.setRowPtr(s0.rowptrL);
+          Kokkos::parallel_for("extract rowptr L", team_policy, extractor_crs);
+          exec_space().fence();
+        }
+        {
+          // convert to offset
+          using range_policy_type = Kokkos::RangePolicy<exec_space>;
+          Kokkos::parallel_scan("shiftRowptr L", range_policy_type(0, m+1), rowptr_sum(s0.rowptrL));
+          exec_space().fence();
+          // get nnz (on CPU for now)
+          auto d_nnz = Kokkos::subview(d_rowptrL, range_type(m, m+1));
+          auto h_nnz = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_nnz);
+          s0.nnzL = h_nnz(0);
+          nnzL += s0.nnzL;
+        }
+        s0.spmv_explicit_transpose = true;
+      } else if (s0.spmv_explicit_transpose) {
+        // ========================
+        // explicitly form transpose
+        s0.nnzL = s0.nnzU;
+        auto d_rowptrL = Kokkos::subview(rowptrL, range_type(ptr, ptr+m+1));
+        s0.rowptrL = d_rowptrL.data();
+        nnzL += s0.nnzL;
+      }
+      ptr += (1+m);
+    }
+    // allocate (TODO: move to symbolic)
+    Kokkos::resize(colindU, nnzU);
+    Kokkos::resize(nzvalsU, nnzU);
+    Kokkos::resize(colindL, nnzL);
+    Kokkos::resize(nzvalsL, nnzL);
+    if (ldl_nopiv) {
+      // Initialized to be I, then updated with diagonal values during numeric
+      //  The location of the updated values should be the same / symbolic
+      const value_type one(1);
+      Kokkos::resize(nzvalsD, nlvls*m);
+      Kokkos::deep_copy(nzvalsD, one);
+    }
+    _is_spmv_extracted = true;
+
+    return r_val;
+  }
+
+  template <typename size_type_array_host, typename ordinal_type_array_host, typename ordinal_type_array,
+            typename supernode_type_array_host,
+            typename stream_type,
+            typename multi_vectors_type>
+  int Load(const bool store_transpose, const bool verbose,
+           const int method, const ordinal_type m,
+           const size_type_array_host &h_level_ptr,
+           const ordinal_type_array &level_sids,
+           const ordinal_type_array_host &h_level_sids,
+           const ordinal_type_array_host &h_solve_mode,
+           const supernode_info_type &supernode_info,
+           const supernode_type_array_host &h_supernodes,
+           const ordinal_type_array &solve_mode,
+           ordinal_type_array &piv,
+	   const stream_type &stream_0,
+           multi_vectors_type &_w_vec) {
+
+    using exec_space = typename multi_vectors_type::execution_space;
+    using host_device_type = typename UseThisDevice<Kokkos::DefaultHostExecutionSpace>::type;
+    using host_memory_space = typename host_device_type::memory_space;
+    using range_type = Kokkos::pair<ordinal_type, ordinal_type>;
+
+    const bool lu = (method == 3);
+    const bool ldl = (method == 2);
+    const bool ldl_nopiv = (method == 0);
+
+    int r_val(0);
+    // ========================
+    // workspace
+#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE)) || \
+     defined(KOKKOS_ENABLE_HIP)
+#if defined(KOKKOS_ENABLE_CUDA)
+    // vectors used for preprocessing
+    cudaDataType computeType;
+    if (std::is_same<value_type, double>::value) {
+      computeType = CUDA_R_64F;
+    } else if (std::is_same<value_type, float>::value) {
+      computeType = CUDA_R_32F;
+    } else {
+      TACHO_TEST_FOR_EXCEPTION(true, std::logic_error,
+                               "LevelSetTools::solveCholeskyLowerOnDevice: ComputeSPMV only supported double or float");
+    }
+#ifdef USE_SPMM_FOR_WORKSPACE_SIZE
+    const ordinal_type nrhs = 1;
+    cusparseDnMatDescr_t vecX, vecY;
+    const ordinal_type ldx = _w_vec.stride(1);
+    cusparseCreateDnMat(&vecX, m, nrhs, ldx, _w_vec.data(), computeType, CUSPARSE_ORDER_COL);
+    cusparseCreateDnMat(&vecY, m, nrhs, ldx, _w_vec.data(), computeType, CUSPARSE_ORDER_COL);
+#else
+    cusparseDnVecDescr_t vecX, vecY;
+    cusparseCreateDnVec(&vecX, m, _w_vec.data(), computeType);
+    cusparseCreateDnVec(&vecY, m, _w_vec.data(), computeType);
+#endif
+#elif defined(KOKKOS_ENABLE_HIP)
+    rocsparse_datatype rocsparse_compute_type = rocsparse_datatype_f64_r;
+    if (std::is_same<value_type, float>::value) {
+      rocsparse_compute_type = rocsparse_datatype_f32_r;
+    }
+    // vectors used for preprocessing
+    rocsparse_dnvec_descr vecX, vecY;
+    rocsparse_create_dnvec_descr(&vecX, m, (void*)_w_vec.data(), rocsparse_compute_type);
+    rocsparse_create_dnvec_descr(&vecY, m, (void*)_w_vec.data(), rocsparse_compute_type);
+#endif
+#endif
+    size_t ptr = 0;
+    size_t nnzU = 0;
+    size_t nnzL = 0;
+    typedef TeamFunctor_ExtractCrs<supernode_info_type> functor_type;
+
+    // load nonzero val/ind
+    for (ordinal_type lvl = 0; lvl < _nlvls; ++lvl) {
+      const ordinal_type pbeg = h_level_ptr(lvl), pend = h_level_ptr(lvl + 1);
+
+      // the first supernode in this lvl (where the CRS matrix is stored)
+      auto &s0 = h_supernodes(h_level_sids(pbeg));
+
+      // ========================
+      // assign memory
+      auto d_rowptrU = Kokkos::subview(rowptrU, range_type(ptr, ptr+m+1));
+      auto d_colindU = Kokkos::subview(colindU, range_type(nnzU, nnzU+s0.nnzU));
+      auto d_nzvalsU = Kokkos::subview(nzvalsU, range_type(nnzU, nnzU+s0.nnzU));
+      s0.colindU = d_colindU.data();
+      s0.nzvalsU = d_nzvalsU.data();
+      nnzU += s0.nnzU;
+
+      // ========================
+      // extract nonzero element
+      functor_type extractor_crs(_keep_zeros, supernode_info, solve_mode, level_sids);
+      extractor_crs.setGlobalSize(m);
+      extractor_crs.setRange(pbeg, pend);
+      extractor_crs.setRowPtr(s0.rowptrU);
+      extractor_crs.setCrsView(s0.colindU, s0.nzvalsU);
+      if (ldl) {
+        // integrate pivoting into U
+        extractor_crs.integratePivots(true, piv);
+      } else if (ldl_nopiv) {
+        auto d_nzvalsD = Kokkos::subview(nzvalsD, range_type(lvl*m, (lvl+1)*m));
+        s0.nzvalsD = d_nzvalsD.data();
+        extractor_crs.withUnitDiag(s0.nzvalsD);
+      }
+      {
+        using team_policy_type = Kokkos::TeamPolicy<Kokkos::Schedule<Kokkos::Static>, exec_space,
+                                                    typename functor_type::ExtractValTag>;
+        team_policy_type team_policy((pend-pbeg)+1, Kokkos::AUTO());
+
+        // >> launch functor to extract nonzero entries
+        Kokkos::parallel_for("extract nzvals", team_policy, extractor_crs);
+        exec_space().fence();
+      }
+
+      // ========================
+      // shift back (TODO: shift first to avoid this)
+      {
+        //  copy to CPU, for now
+        auto h_rowptr = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_rowptrU);
+        for (ordinal_type i = m; i > 0 ; i--) h_rowptr(i) = h_rowptr(i-1);
+        h_rowptr(0) = 0;
+        Kokkos::deep_copy(d_rowptrU, h_rowptr);
+      }
+
+      if (lu) {
+        auto d_rowptrL = Kokkos::subview(rowptrL, range_type(ptr, ptr+m+1));
+        auto d_colindL = Kokkos::subview(colindL, range_type(nnzL, nnzL+s0.nnzL));
+        auto d_nzvalsL = Kokkos::subview(nzvalsL, range_type(nnzL, nnzL+s0.nnzL));
+        s0.colindL = d_colindL.data();
+        s0.nzvalsL = d_nzvalsL.data();
+        nnzL += s0.nnzL;
+
+        // ========================
+        // insert nonzeros
+        extractor_crs.setRowPtr(s0.rowptrL);
+        extractor_crs.setCrsView(s0.colindL, s0.nzvalsL);
+        extractor_crs.setPivPtr(piv);
+        {
+          using team_policy_type = Kokkos::TeamPolicy<Kokkos::Schedule<Kokkos::Static>, exec_space,
+                                                      typename functor_type::ExtractValColTag>;
+          team_policy_type team_policy((pend-pbeg)+1, Kokkos::AUTO());
+
+          // >> launch functor to extract nonzero entries
+          Kokkos::parallel_for("extract nzvals L", team_policy, extractor_crs);
+          exec_space().fence();
+        }
+        // ========================
+        // shift back
+        // (TODO: shift first to avoid this)
+        {
+          //  copy to CPU, for now
+          auto h_rowptr = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_rowptrL);
+          for (ordinal_type i = m; i > 0 ; i--) h_rowptr(i) = h_rowptr(i-1);
+          h_rowptr(0) = 0;
+          Kokkos::deep_copy(d_rowptrL, h_rowptr);
+        }
+      } else if (s0.spmv_explicit_transpose) {
+        // ========================
+        // transpose
+        // >> generate rowptr
+        extractor_crs.setRowPtrT(s0.rowptrL);
+        {
+          // >> count nnz / row (transpose)
+          using team_policy_type = Kokkos::RangePolicy<typename functor_type::TransPtrTag, exec_space>;
+          team_policy_type team_policy(0, m);
+          Kokkos::parallel_for("transpose pointer", team_policy, extractor_crs);
+        }
+        {
+          // >> accumulate to generate rowptr (transpose)
+          using range_policy_type = Kokkos::RangePolicy<exec_space>;
+          Kokkos::parallel_scan("shiftRowptrT", range_policy_type(0, m+1), rowptr_sum(s0.rowptrL));
+          exec_space().fence();
+        }
+
+        s0.nnzL = s0.nnzU;
+        auto d_colindL = Kokkos::subview(colindL, range_type(nnzL, nnzL+s0.nnzL));
+        auto d_nzvalsL = Kokkos::subview(nzvalsL, range_type(nnzL, nnzL+s0.nnzL));
+        s0.colindL = d_colindL.data();
+        s0.nzvalsL = d_nzvalsL.data();
+        nnzL += s0.nnzL;
+
+        // ========================
+        // >> copy into transpose-matrix
+        extractor_crs.setRowPtrT(s0.rowptrL);
+        extractor_crs.setCrsViewT(s0.colindL, s0.nzvalsL);
+        {
+          using team_policy_type = Kokkos::RangePolicy<typename functor_type::TransMatTag, exec_space>;
+          team_policy_type team_policy(0, m);
+          Kokkos::parallel_for("transpose pointer", team_policy, extractor_crs);
+          exec_space().fence();
+        }
+        // ========================
+        // shift back
+        // (TODO: shift first to avoid this)
+        {
+          // copy to CPU, for now
+          auto d_rowptrL = Kokkos::subview(rowptrL, range_type(ptr, ptr+m+1));
+          auto h_rowptr = Kokkos::create_mirror_view_and_copy(host_memory_space(), d_rowptrL);
+          for (ordinal_type i = m; i > 0 ; i--) h_rowptr(i) = h_rowptr(i-1);
+          h_rowptr(0) = 0;
+          Kokkos::deep_copy(d_rowptrL, h_rowptr);
+        }
+      }
+      ptr += (1+m);
+#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE)) || \
+     defined(KOKKOS_ENABLE_HIP)
+      const value_type one(1);
+      const value_type zero(0);
+      // ========================
+      // create NVIDIA/AMD data structures for SpMV
+      size_t buffer_size_L = 0;
+      size_t buffer_size_U = 0;
+      value_type alpha = one;
+      value_type beta = zero;
+#if defined(KOKKOS_ENABLE_CUDA)
+      // create matrix
+      cusparseCreateCsr(&s0.U_cusparse, m, m, s0.nnzU,
+                        s0.rowptrU, s0.colindU, s0.nzvalsU,
+                        CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
+                        CUSPARSE_INDEX_BASE_ZERO, computeType);
+
+#ifdef USE_SPMM_FOR_WORKSPACE_SIZE
+      cusparseSpMM_bufferSize(sparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, CUSPARSE_OPERATION_NON_TRANSPOSE,
+                              &alpha, s0.U_cusparse, vecX, &beta, vecY,
+                              computeType, TACHO_CUSPARSE_SPMM_ALG, &buffer_size_U);
+#else
+      cusparseSpMV_bufferSize(sparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, s0.U_cusparse, vecX, &beta, vecY,
+                              computeType, TACHO_CUSPARSE_SPMV_ALG, &buffer_size_U);
+#endif
+      if (s0.spmv_explicit_transpose) {
+        // create matrix (transpose(U) or L)
+        cusparseCreateCsr(&s0.L_cusparse, m, m, s0.nnzL,
+                          s0.rowptrL, s0.colindL, s0.nzvalsL,
+                          CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
+                          CUSPARSE_INDEX_BASE_ZERO, computeType);
+        // workspace size
+#ifdef USE_SPMM_FOR_WORKSPACE_SIZE
+        cusparseSpMM_bufferSize(sparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, CUSPARSE_OPERATION_NON_TRANSPOSE,
+                                &alpha, s0.L_cusparse, vecX, &beta, vecY,
+                                computeType, TACHO_CUSPARSE_SPMM_ALG, &buffer_size_L);
+#else
+        cusparseSpMV_bufferSize(sparseHandle, CUSPARSE_OPERATION_NON_TRANSPOSE, &alpha, s0.L_cusparse, vecX, &beta, vecY,
+                                computeType, TACHO_CUSPARSE_SPMV_ALG, &buffer_size_L);
+#endif
+      } else {
+        // create matrix (L_cusparse stores the same ptrs as descrU, but optimized for trans)
+        s0.nnzL = s0.nnzU;
+        cusparseCreateCsr(&s0.L_cusparse, m, m, s0.nnzU,
+                          s0.rowptrU, s0.colindU, s0.nzvalsU,
+                          CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I,
+                          CUSPARSE_INDEX_BASE_ZERO, computeType);
+        // workspace size for transpose SpMV
+#ifdef USE_SPMM_FOR_WORKSPACE_SIZE
+        cusparseSpMM_bufferSize(sparseHandle, CUSPARSE_OPERATION_TRANSPOSE, CUSPARSE_OPERATION_NON_TRANSPOSE,
+                                &alpha, s0.L_cusparse, vecX, &beta, vecY,
+                                computeType, TACHO_CUSPARSE_SPMM_ALG, &buffer_size_L);
+#else
+        cusparseSpMV_bufferSize(sparseHandle, CUSPARSE_OPERATION_TRANSPOSE, &alpha, s0.L_cusparse, vecX, &beta, vecY,
+                                computeType, TACHO_CUSPARSE_SPMV_ALG, &buffer_size_L);
+#endif
+      }
+      // allocate workspace
+      // allocate workspace
+      if (buffer_size_U > buffer_U.extent(0)) {
+        Kokkos::resize(buffer_U, buffer_size_U);
+      }
+      if (buffer_size_L > buffer_L.extent(0)) {
+        Kokkos::resize(buffer_L, buffer_size_L);
+      }
+#elif defined(KOKKOS_ENABLE_HIP)
+      // create matrix
+      rocsparse_create_csr_descr(&(s0.descrU), m, m, s0.nnzU,
+                                 s0.rowptrU, s0.colindU, s0.nzvalsU,
+                                 rocsparse_indextype_i32, rocsparse_indextype_i32, rocsparse_index_base_zero, rocsparse_compute_type);
+      // workspace
+      tacho_rocsparse_spmv
+          (sparseHandle, rocsparse_operation_none,
+           &alpha, s0.descrU, vecX, &beta, vecY,
+           rocsparse_compute_type, rocsparse_spmv_alg_default,
+           #if ROCM_VERSION >= 50400
+           rocsparse_spmv_stage_buffer_size,
+           #endif
+           &buffer_size_U, nullptr);
+      // allocate workspace
+      if (buffer_size_U > buffer_U.extent(0)) {
+        Kokkos::resize(buffer_U, buffer_size_U);
+      }
+      #if ROCM_VERSION >= 50400
+      // preprocess
+      buffer_size_U = buffer_U.extent(0);
+      tacho_rocsparse_spmv
+          (sparseHandle, rocsparse_operation_none,
+           &alpha, s0.descrU, vecX, &beta, vecY,
+           rocsparse_compute_type, rocsparse_spmv_alg_default,
+           rocsparse_spmv_stage_preprocess,
+           &buffer_size_U, (void*)buffer_U.data());
+      #endif
+      if (s0.spmv_explicit_transpose) {
+        // create matrix (transpose)
+        _status = rocsparse_create_csr_descr(&(s0.descrL), m, m, s0.nnzL,
+                                             s0.rowptrL, s0.colindL, s0.nzvalsL,
+                                             rocsparse_indextype_i32, rocsparse_indextype_i32,
+                                             rocsparse_index_base_zero, rocsparse_compute_type);
+        check_OnDeviceSPMV_Status("rocsparse_create_crs_descr", "rocsparse");
+        // workspace
+        _status = tacho_rocsparse_spmv
+          (sparseHandle, rocsparse_operation_none,
+           &alpha, s0.descrL, vecX, &beta, vecY,
+           rocsparse_compute_type, rocsparse_spmv_alg_default,
+           #if ROCM_VERSION >= 50400
+           rocsparse_spmv_stage_buffer_size,
+           #endif
+           &buffer_size_L, nullptr);
+        check_OnDeviceSPMV_Status("rocsparse_create_spmv", "rocsparse");
+        // allocate workspace
+        if (buffer_size_L > buffer_L.extent(0)) {
+          Kokkos::resize(buffer_L, buffer_size_L);
+        }
+        #if ROCM_VERSION >= 50400
+        // preprocess
+        buffer_size_L = buffer_L.extent(0);
+        tacho_rocsparse_spmv
+          (sparseHandle, rocsparse_operation_none,
+           &alpha, s0.descrL, vecX, &beta, vecY,
+           rocsparse_compute_type, rocsparse_spmv_alg_default,
+            rocsparse_spmv_stage_preprocess,
+           &buffer_size_L, (void*)buffer_L.data());
+        #endif
+      } else {
+        // create matrix, transpose (L_cusparse stores the same ptrs as descrU, but optimized for trans)
+        _status = rocsparse_create_csr_descr(&(s0.descrL), m, m, s0.nnzU,
+                                             s0.rowptrU, s0.colindU, s0.nzvalsU,
+                                             rocsparse_indextype_i32, rocsparse_indextype_i32,
+                                             rocsparse_index_base_zero, rocsparse_compute_type);
+        check_OnDeviceSPMV_Status("rocsparse_create_crs_descr", "rocsparse");
+        // workspace (transpose)
+        _status = tacho_rocsparse_spmv
+          (sparseHandle, rocsparse_operation_transpose,
+           &alpha, s0.descrL, vecX, &beta, vecY,
+           rocsparse_compute_type, rocsparse_spmv_alg_default,
+           #if ROCM_VERSION >= 50400
+           rocsparse_spmv_stage_buffer_size,
+           #endif
+           &buffer_size_L, nullptr);
+        check_OnDeviceSPMV_Status("rocsparse_create_spmv", "rocsparse");
+        // allcate workspace
+        if (buffer_size_L > buffer_L.extent(0)) {
+          Kokkos::resize(buffer_L, buffer_size_L);
+        }
+        #if ROCM_VERSION >= 50400
+        // preprocess
+        buffer_size_L = buffer_L.extent(0);
+        tacho_rocsparse_spmv
+          (sparseHandle, rocsparse_operation_transpose,
+           &alpha, s0.descrL, vecX, &beta, vecY,
+           rocsparse_compute_type, rocsparse_spmv_alg_default,
+            rocsparse_spmv_stage_preprocess,
+           &buffer_size_L, (void*)buffer_L.data());
+        #endif
+      }
+#endif
+#endif
+    }
+#if (defined(KOKKOS_ENABLE_CUDA) && defined(TACHO_HAVE_CUSPARSE)) || \
+     defined(KOKKOS_ENABLE_HIP)
+#if defined(KOKKOS_ENABLE_CUDA)
+#ifdef USE_SPMM_FOR_WORKSPACE_SIZE
+    cusparseDestroyDnMat(vecX);
+    cusparseDestroyDnMat(vecY);
+#else
+    cusparseDestroyDnVec(vecX);
+    cusparseDestroyDnVec(vecY);
+#endif
+#elif defined(KOKKOS_ENABLE_HIP)
+    rocsparse_destroy_dnvec_descr(vecX);
+    rocsparse_destroy_dnvec_descr(vecY);
+#endif
+#endif
+    if (verbose) {
+      printf("LevelSetTools:loadCRS(method = %d)\n",method);
+      printf("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n");
+      printf( " CRS with total nnzL = %ld and nnzU = %ld\n",colindL.extent(0),colindU.extent(0) );
+      if (store_transpose) printf( "  > explicitly storing transpose\n" );
+    }
+    return r_val;
+  }
+
+ };
+} // namespace Tacho
+#endif

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Symmetrize_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Symmetrize_Internal.hpp
@@ -19,9 +19,11 @@ namespace Tacho {
 
 template <> struct Symmetrize<Uplo::Upper, Algo::Internal> {
   template <typename MemberType, typename ViewTypeA>
-  KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A) {
-    const ordinal_type m = A.extent(0), n = A.extent(1);
+  KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A, const bool conjugate) {
+    using value_type = typename ViewTypeA::non_const_value_type;
+    using arith_traits = ArithTraits<value_type>;
 
+    const ordinal_type m = A.extent(0), n = A.extent(1);
     if (m == n) {
       if (A.span() > 0) {
         KOKKOS_IF_ON_DEVICE((
@@ -31,7 +33,7 @@ template <> struct Symmetrize<Uplo::Upper, Algo::Internal> {
         KOKKOS_IF_ON_HOST((
         for (ordinal_type j = 0; j < n; ++j)
           for (ordinal_type i = 0; i < j; ++i)
-            A(j, i) = A(i, j);))
+            A(j, i) = (conjugate ? arith_traits::conj(A(i, j)) : A(i, j));))
       }
     } else {
       Kokkos::printf("Error: Symmetrize<Algo::Internal> A is not square\n");
@@ -42,19 +44,22 @@ template <> struct Symmetrize<Uplo::Upper, Algo::Internal> {
 
 template <> struct Symmetrize<Uplo::Lower, Algo::Internal> {
   template <typename MemberType, typename ViewTypeA>
-  KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A) {
-    const ordinal_type m = A.extent(0), n = A.extent(1);
+  KOKKOS_INLINE_FUNCTION static int invoke(MemberType &member, const ViewTypeA &A, const bool conjugate) {
+    using value_type = typename ViewTypeA::non_const_value_type;
+    using arith_traits = ArithTraits<value_type>;
 
+    const ordinal_type m = A.extent(0), n = A.extent(1);
     if (m == n) {
       if (A.span() > 0) {
         KOKKOS_IF_ON_DEVICE((
         Kokkos::parallel_for(Kokkos::TeamThreadRange(member, n), [&](const ordinal_type &j) {
-          Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, j), [&](const ordinal_type &i) { A(i, j) = A(j, i); });
+          Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, j), [&](const ordinal_type &i) {
+            A(i, j) = (conjugate ? arith_traits::conj(A(j, i)) : A(j, i)); });
         });))
         KOKKOS_IF_ON_HOST((
         for (ordinal_type j = 0; j < n; ++j)
           for (ordinal_type i = 0; i < j; ++i)
-            A(i, j) = A(j, i);))
+            A(i, j) = (conjugate ? arith_traits::conj(A(j, i)) : A(j, i));))
       }
     } else {
       Kokkos::printf("Error: Symmetrize<Algo::Internal> A is not square\n");

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Symmetrize_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Symmetrize_OnDevice.hpp
@@ -18,18 +18,21 @@
 namespace Tacho {
 
 template <> struct Symmetrize<Uplo::Upper, Algo::OnDevice> {
-  template <typename ViewTypeA> inline static int invoke(const ViewTypeA &A) {
+
+  template <typename ViewTypeA> inline static int invoke(const ViewTypeA &A, const bool conjugate = false) {
     static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
     static_assert(std::is_same<typename ViewTypeA::memory_space, Kokkos::HostSpace>::value,
                   "A is not accessible from host");
 
+    using value_type = typename ViewTypeA::non_const_value_type;
+    using arith_traits = ArithTraits<value_type>;
     const ordinal_type m = A.extent(0), n = A.extent(1);
 
     if (m == n) {
       if (A.span() > 0) {
         for (ordinal_type j = 0; j < n; ++j)
           for (ordinal_type i = 0; i < j; ++i)
-            A(j, i) = A(i, j);
+            A(j, i) = (conjugate ? arith_traits::conj(A(i, j)) : A(i, j));
       }
     } else {
       TACHO_TEST_FOR_EXCEPTION(true, std::logic_error, "A is not a square matrix");
@@ -38,8 +41,11 @@ template <> struct Symmetrize<Uplo::Upper, Algo::OnDevice> {
   }
 
   template <typename ExecSpaceType, typename ViewTypeA>
-  inline static int invoke(ExecSpaceType &exec_instance, const ViewTypeA &A) {
+  inline static int invoke(ExecSpaceType &exec_instance, const ViewTypeA &A, const bool conjugate) {
     static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
+
+    using value_type = typename ViewTypeA::non_const_value_type;
+    using arith_traits = ArithTraits<value_type>;
     const ordinal_type m = A.extent(0), n = A.extent(1);
 
     if (m == n) {
@@ -51,7 +57,7 @@ template <> struct Symmetrize<Uplo::Upper, Algo::OnDevice> {
               const ordinal_type i = ij % m;
               const ordinal_type j = ij / m;
               if (i < j)
-                A(j, i) = A(i, j);
+                A(j, i) = (conjugate ? arith_traits::conj(A(i, j)) : A(i, j));
             });
       }
     } else {
@@ -62,18 +68,20 @@ template <> struct Symmetrize<Uplo::Upper, Algo::OnDevice> {
 };
 
 template <> struct Symmetrize<Uplo::Lower, Algo::OnDevice> {
-  template <typename ViewTypeA> inline static int invoke(const ViewTypeA &A) {
+  template <typename ViewTypeA> inline static int invoke(const ViewTypeA &A, const bool conjugate = false) {
     static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
     static_assert(std::is_same<typename ViewTypeA::memory_space, Kokkos::HostSpace>::value,
                   "A is not accessible from host");
 
+    using value_type = typename ViewTypeA::non_const_value_type;
+    using arith_traits = ArithTraits<value_type>;
     const ordinal_type m = A.extent(0), n = A.extent(1);
 
     if (m == n) {
       if (A.span() > 0) {
         for (ordinal_type j = 0; j < n; ++j)
           for (ordinal_type i = 0; i < j; ++i)
-            A(i, j) = A(j, i);
+            A(i, j) = (conjugate ? arith_traits::conj(A(j, i)) : A(j, i));
       }
     } else {
       TACHO_TEST_FOR_EXCEPTION(true, std::logic_error, "A is not a square matrix");
@@ -82,8 +90,11 @@ template <> struct Symmetrize<Uplo::Lower, Algo::OnDevice> {
   }
 
   template <typename ExecSpaceType, typename ViewTypeA>
-  inline static int invoke(ExecSpaceType &exec_instance, const ViewTypeA &A) {
+  inline static int invoke(ExecSpaceType &exec_instance, const ViewTypeA &A, const bool conjugate) {
     static_assert(ViewTypeA::rank == 2, "A is not rank 2 view.");
+
+    using value_type = typename ViewTypeA::non_const_value_type;
+    using arith_traits = ArithTraits<value_type>;
     const ordinal_type m = A.extent(0), n = A.extent(1);
 
     if (m == n) {
@@ -95,7 +106,7 @@ template <> struct Symmetrize<Uplo::Lower, Algo::OnDevice> {
               const ordinal_type i = ij % m;
               const ordinal_type j = ij / m;
               if (i < j)
-                A(i, j) = A(j, i);
+                A(i, j) = (conjugate ? arith_traits::conj(A(j, i)) : A(j, i));
             });
       }
     } else {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_ExtractCRS.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_ExtractCRS.hpp
@@ -48,6 +48,7 @@ public:
   typedef typename supernode_info_type::value_type value_type;
   typedef typename supernode_info_type::value_type_matrix value_type_matrix;
   typedef typename supernode_info_type::ordinal_type_array ordinal_type_array;
+  using ATS = Tacho::ArithTraits<value_type>;
 
 private:
   bool _keep_zeros;
@@ -71,6 +72,8 @@ private:
   value_type* _d;
   // to apply pivoting on U? (always applied to L of LU)
   bool _no_perm;
+  // conjugate explicit-transpose
+  bool _conjugate;
 
 public:
   KOKKOS_INLINE_FUNCTION
@@ -109,6 +112,8 @@ public:
     _no_perm = !with_pivot;
     _piv = piv;
   }
+  inline void setConjugate(bool conjugate) { _conjugate = conjugate; }
+
   struct ExtractPtrTag {};
   struct ExtractValTag {};
   struct ExtractPtrColTag {};
@@ -390,7 +395,7 @@ public:
     for (ordinal_type k = _rowptr[i]; k < _rowptr[i+1]; k++) {
       int nnz = Kokkos::atomic_fetch_add(&(_rowptrT[_colind[k]]), 1);
       _colindT[nnz] = i;
-      _nzvalsT[nnz] = _nzvals[k];
+      _nzvalsT[nnz] = (_conjugate ? ATS::conj(_nzvals[k]) : _nzvals[k]);
     }
   }
 };

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeChol.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeChol.hpp
@@ -87,15 +87,16 @@ public:
       value_type *aptr = s.u_buf;
       UnmanagedViewType<value_type_matrix> ATL(aptr, m, m);
       aptr += m * m;
-      LDL_nopiv<Uplo::Upper, CholAlgoType>::invoke(member, ATL);
+      bool conjugate = false;
+      LDL_nopiv<Uplo::Upper, CholAlgoType>::invoke(member, ATL, conjugate);
       member.team_barrier();
 
       if (n_m > 0) {
         const value_type one(1), minus_one(-1), zero(0);
         // Apply L^{-1} on off-diagonal
         UnmanagedViewType<value_type_matrix> ATR(aptr, m, n_m);
-        Trsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, TrsmAlgoType>::invoke(member, Diag::Unit(), one, ATL,
-                                                                                  ATR);
+        Trsm<Side::Left, Uplo::Upper, Trans::Transpose, TrsmAlgoType>::invoke(member, Diag::Unit(), one, ATL,
+                                                                           ATR);
         member.team_barrier(); // TODO: check when we need barrier
 
         // Save in workspace
@@ -109,7 +110,7 @@ public:
 
         // ABR = -ATR*W
         GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Upper, GemmAlgoType>::invoke(member, minus_one, ATR,
-                                                                                                W, zero, ABR);
+                                                                                             W, zero, ABR);
       }
     }
   }
@@ -129,15 +130,16 @@ public:
       aptr += m * m;
 
       // Factor diagonal block
-      LDL_nopiv<Uplo::Upper, CholAlgoType>::invoke(member, ATL);
+      bool conjugate = false;
+      LDL_nopiv<Uplo::Upper, CholAlgoType>::invoke(member, ATL, conjugate);
       member.team_barrier();
 
       if (n_m > 0) {
         // * Update off-diagonal block
         // Apply L^{-T} on off-diagonal (TODO: should we gemm after inversion?)
         UnmanagedViewType<value_type_matrix> ATR(aptr, m, n_m);
-        Trsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, TrsmAlgoType>::invoke(member, Diag::Unit(), one, ATL,
-                                                                                  ATR);
+        Trsm<Side::Left, Uplo::Upper, Trans::Transpose, TrsmAlgoType>::invoke(member, Diag::Unit(), one, ATL,
+                                                                           ATR);
         member.team_barrier();
 
         // compute Inverse of diagobal block (NOTE: T and ABR point to the same address = need to compute inverse before gemm)
@@ -167,7 +169,7 @@ public:
         // * Update remaining block
         // ABR = -ATR*W
         GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Upper, GemmAlgoType>::invoke(member, minus_one, ATR,
-                                                                                                W, zero, ABR);
+                                                                                             W, zero, ABR);
       } else {
         // compute Inverse of diagobal block
         Copy<Algo::Internal>::invoke(member, T, ATL);
@@ -201,14 +203,15 @@ public:
       UnmanagedViewType<value_type_matrix> ATL(aptr, m, m);
       aptr += m * m;
       // Factor diagonal block
-      LDL_nopiv<Uplo::Upper, CholAlgoType>::invoke(member, ATL);
+      bool conjugate = false;
+      LDL_nopiv<Uplo::Upper, CholAlgoType>::invoke(member, ATL, conjugate);
       member.team_barrier();
 
       if (n_m > 0) {
         // * Update off-diagonal block
         UnmanagedViewType<value_type_matrix> ATR(aptr, m, n_m);
-        Trsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, TrsmAlgoType>::invoke(member, Diag::Unit(), one, ATL,
-                                                                                  ATR);
+        Trsm<Side::Left, Uplo::Upper, Trans::Transpose, TrsmAlgoType>::invoke(member, Diag::Unit(), one, ATL,
+                                                                           ATR);
         member.team_barrier();
 
         // Save ATR in workspace
@@ -223,7 +226,7 @@ public:
         // * Update remaining block
         // ABR = -ATR*W
         GemmTriangular<Trans::Transpose, Trans::NoTranspose, Uplo::Upper, HerkAlgoType>::invoke(member, minus_one, ATR,
-                                                                                                W, zero, ABR);
+                                                                                             W, zero, ABR);
         member.team_barrier();
       }
       // * Invert the whole block row
@@ -280,7 +283,6 @@ public:
         // chol
         Trsm<Side::Left, Uplo::Upper, Trans::ConjTranspose, TrsmAlgoType>::invoke(member, Diag::NonUnit(), one, ATL,
                                                                                   ATR);
-
         member.team_barrier();
         Herk<Uplo::Upper, Trans::ConjTranspose, HerkAlgoType>::invoke(member, minus_one, ATR, zero, ABR);
       }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeLDL.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_FactorizeLDL.hpp
@@ -76,11 +76,13 @@ public:
     using GemmAlgoType = typename GemmAlgorithm_Team::type;
     using TrsmAlgoType = typename TrsmAlgorithm_Team::type;
 
-    int err = 0;
+    const bool conjugate = false;
     const ordinal_type m = s.m, n = s.n, n_m = n - m;
+
+    int err = 0;
     if (m > 0) {
       UnmanagedViewType<value_type_matrix> ATL(s.u_buf, m, m);
-      Symmetrize<Uplo::Upper, Algo::Internal>::invoke(member, ATL);
+      Symmetrize<Uplo::Upper, Algo::Internal>::invoke(member, ATL, conjugate);
       member.team_barrier();
       err = LDL<Uplo::Lower, LDL_AlgoType>::invoke(member, ATL, P, W);
       member.team_barrier();
@@ -122,13 +124,15 @@ public:
     using TrsmAlgoType = typename TrsmAlgorithm::type;
     using GemmAlgoType = typename GemmAlgorithm::type;
 
-    int err = 0;
+    const bool conjugate = false;
     const value_type one(1), minus_one(-1), zero(0);
+
+    int err = 0;
     const ordinal_type m = s.m, n = s.n, n_m = n - m;
     if (m > 0) {
       UnmanagedViewType<value_type_matrix> ATL(s.u_buf, m, m);
 
-      Symmetrize<Uplo::Upper, Algo::Internal>::invoke(member, ATL);
+      Symmetrize<Uplo::Upper, Algo::Internal>::invoke(member, ATL, conjugate);
       member.team_barrier();
 
       err = LDL<Uplo::Lower, LDL_AlgoType>::invoke(member, ATL, P, W);
@@ -183,13 +187,15 @@ public:
     using TrsmAlgoType = typename TrsmAlgorithm::type;
     using GemmAlgoType = typename GemmAlgorithm::type;
 
-    int err = 0;
+    const bool conjugate = false;
     const value_type one(1), minus_one(-1), zero(0);
     const ordinal_type m = s.m, n = s.n, n_m = n - m;
+
+    int err = 0;
     if (m > 0) {
       UnmanagedViewType<value_type_matrix> ATL(s.u_buf, m, m);
 
-      Symmetrize<Uplo::Upper, Algo::Internal>::invoke(member, ATL);
+      Symmetrize<Uplo::Upper, Algo::Internal>::invoke(member, ATL, conjugate);
       member.team_barrier();
 
       err = LDL<Uplo::Lower, LDL_AlgoType>::invoke(member, ATL, P, W);
@@ -218,7 +224,7 @@ public:
         Copy<Algo::Internal>::invoke(member, ATR, STR);
         member.team_barrier();
 
-        Symmetrize<Uplo::Lower, Algo::Internal>::invoke(member, T);
+        Symmetrize<Uplo::Lower, Algo::Internal>::invoke(member, T, conjugate);
         SetIdentity<Algo::Internal>::invoke(member, ATL, minus_one);
         Scale2x2_BlockInverseDiagonals<Side::Left, Algo::Internal> /// row scaling
             ::invoke(member, P, D, ATR);

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_SolveLowerChol.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_SolveLowerChol.hpp
@@ -119,14 +119,14 @@ public:
 
         const ordinal_type offm = s.row_begin;
         auto tT = Kokkos::subview(_t, range_type(offm, offm + m), Kokkos::ALL());
-        Trsv<Uplo::Upper, Trans::ConjTranspose, TrsvAlgoType>::invoke(member, Diag::Unit(), ATL, tT);
+        Trsv<Uplo::Upper, Trans::Transpose, TrsvAlgoType>::invoke(member, Diag::Unit(), ATL, tT);
 
         if (n_m > 0) {
           // update remaining
           member.team_barrier();
           UnmanagedViewType<value_type_matrix> ATR(aptr, m, n_m); // aptr += m*n;
           UnmanagedViewType<value_type_matrix> bB(bptr, n_m, _nrhs);
-          Gemv<Trans::ConjTranspose, GemvAlgoType>::invoke(member, minus_one, ATR, tT, zero, bB);
+          Gemv<Trans::Transpose, GemvAlgoType>::invoke(member, minus_one, ATR, tT, zero, bB);
         }
 
         // Apply D^{-1} to current block of vectors, tT (note: solving with L, and then D)
@@ -221,7 +221,7 @@ public:
         auto tT = Kokkos::subview(_t, range_type(offm, offm + m), Kokkos::ALL());
 
         // solve with diag L (ATL is square)
-        Trmv<Uplo::Upper, Trans::ConjTranspose, GemvAlgoType>::invoke(member, Diag::Unit(), one, ATL, tT, zero, bT);
+        Trmv<Uplo::Upper, Trans::Transpose, GemvAlgoType>::invoke(member, Diag::Unit(), one, ATL, tT, zero, bT);
 
         if (n_m > 0) {
           // update offdiag
@@ -229,7 +229,7 @@ public:
           UnmanagedViewType<value_type_matrix> bB(bptr, n_m, _nrhs);
 
           member.team_barrier();
-          Gemv<Trans::ConjTranspose, GemvAlgoType>::invoke(member, minus_one, ATR, bT, zero, bB);
+          Gemv<Trans::Transpose, GemvAlgoType>::invoke(member, minus_one, ATR, bT, zero, bB);
         }
 
         // Apply D^{-1} to current block of vectors, tT (note: solving with L, and then D)
@@ -327,7 +327,7 @@ public:
         auto tT = Kokkos::subview(_t, range_type(offm, offm + m), Kokkos::ALL());
 
         // AT is not square
-        Trmv<Uplo::Upper, Trans::ConjTranspose, GemvAlgoType>::invoke(member, Diag::Unit(), one, AT, tT, zero, b);
+        Trmv<Uplo::Upper, Trans::Transpose, GemvAlgoType>::invoke(member, Diag::Unit(), one, AT, tT, zero, b);
 
         // Apply D^{-1} to current block of vectors, tT (note: solving with L, and then D, also n>=m, so diag is stored first in aptr)
         UnmanagedViewType<value_type_matrix> ATL(aptr, m, m);

--- a/packages/shylu/shylu_node/tacho/unit-test/Tacho_TestSolver.cpp
+++ b/packages/shylu/shylu_node/tacho/unit-test/Tacho_TestSolver.cpp
@@ -19,15 +19,25 @@
 
 /// matrix generator
 template <typename CrsMatrixBaseTypeHost>
-int generate2dLaplace(const int nx, CrsMatrixBaseTypeHost &A) {
+int generate2dLaplace(const int nx, CrsMatrixBaseTypeHost &A, bool conj) {
   // generate Laplace matrix on 5pt stencil
   int n = nx*nx;
   int nnz = n + 4*nx*(nx-1);
 
   using value_type = typename CrsMatrixBaseTypeHost::value_type;
+  using ATS = Tacho::ArithTraits<value_type>;
   typename CrsMatrixBaseTypeHost::size_type_array    ap("ap", n+1);
   typename CrsMatrixBaseTypeHost::ordinal_type_array aj("aj", nnz);
   typename CrsMatrixBaseTypeHost::value_type_array   ax("ax", nnz);
+
+  value_type FIVE(5.0); 
+  value_type mONE; 
+  if (std::is_same<value_type, double>::value)
+    ATS::set_real(mONE, -1.0);
+  if (std::is_same<value_type, Kokkos::complex<double>>::value) {
+    ATS::set_real(mONE,  0.0);
+    ATS::set_imag(mONE, -1.0);
+  }
 
   nnz = 0;
   ap(0) = 0;
@@ -36,25 +46,25 @@ int generate2dLaplace(const int nx, CrsMatrixBaseTypeHost &A) {
       int k = i*nx + j;
       if (i > 0) {
         aj(nnz) = k-nx;
-        ax(nnz) = value_type(1.0);
+        ax(nnz) = mONE;
         nnz ++;
       }
       if (j > 0) {
         aj(nnz) = k-1;
-        ax(nnz) = value_type(1.0);
+        ax(nnz) = mONE;
         nnz ++;
       }
       aj(nnz) = k;
-      ax(nnz) = value_type(4.0);
+      ax(nnz) = FIVE;
       nnz++;
       if (j < nx-1) {
         aj(nnz) = k+1;
-        ax(nnz) = value_type(1.0);
+        ax(nnz) = (conj ? ATS::conj(mONE) : mONE);
         nnz ++;
       }
       if (i < nx-1) {
         aj(nnz) = k+nx;
-        ax(nnz) = value_type(1.0);
+        ax(nnz) = (conj ? ATS::conj(mONE) : mONE);
         nnz ++;
       }
       ap(k+1) = nnz;
@@ -68,7 +78,7 @@ int generate2dLaplace(const int nx, CrsMatrixBaseTypeHost &A) {
 
 // main test driver
 template <typename value_type>
-int driver(const std::string file, const std::string method_name, const int variant, const int nrhs,
+int driver(const std::string file, const std::string method_name, const int variant, const int nrhs, const bool conj = true,
            const bool store_transpose = false, const bool single_solve = true, const bool single_setup = true,
            const bool team_on_user_stream = false) {
   int nx = 100;
@@ -94,6 +104,10 @@ int driver(const std::string file, const std::string method_name, const int vari
   Tacho::printExecSpaceConfiguration<typename device_type::execution_space>("DeviceSpace", detail);
   Tacho::printExecSpaceConfiguration<typename host_device_type::execution_space>("HostSpace", detail);
   std::cout << std::endl << "    --------------------- " << std::endl;
+  if (std::is_same<value_type, double>::value)
+    std::cout << "     Scalar Type:: double " << std::endl;
+  if (std::is_same<value_type, Kokkos::complex<double>>::value)
+    std::cout << "     Scalar Type:: complex<double> " << std::endl;
   std::cout << "     Method Name:: " << method_name << std::endl;
   std::cout << "     Solver Type:: " << variant << std::endl;
   std::cout << "          # RHSs:: " << nrhs << std::endl;
@@ -122,7 +136,7 @@ int driver(const std::string file, const std::string method_name, const int vari
       Tacho::MatrixMarket<value_type>::read(file, A, sanitize, verbose);
     } else {
       std::cout << " Generate 2D Laplace matrix(nx = " << nx << ")" << std::endl;
-      generate2dLaplace(nx, A);
+      generate2dLaplace(nx, A, conj);
     }
 
     /// create tacho solver
@@ -161,7 +175,7 @@ int driver(const std::string file, const std::string method_name, const int vari
       if(r_val == 0) {
         r_val = solver.initialize();
       }
-      int num_solves = 5; // number of numeric + solve calls
+      int num_solves = 3; // number of numeric + solve calls
       for (int step = 0; step < num_solves && r_val == 0; step++) {
         if (step > 0) {
           // perturb the first element (diagonal if Laplace), on host
@@ -170,6 +184,10 @@ int driver(const std::string file, const std::string method_name, const int vari
         // copy A to device
         Kokkos::deep_copy(values_on_device, A.Values());
         if (step%2 == 0) {
+          /// > default
+          solver.shiftDiagonal(0);
+          solver.useDefaultPivotTolerance(0);
+        } else if (step%2 == 1) {
           /// > test "shift diag" code path
           solver.shiftDiagonal(1);
           solver.useDefaultPivotTolerance(0);
@@ -208,8 +226,9 @@ int driver(const std::string file, const std::string method_name, const int vari
           } else {
             Kokkos::deep_copy (x, one);
             solver.computeSpMV(values_on_device, x, b);
-            Kokkos::deep_copy (x, zero);
           }
+          Kokkos::deep_copy (x, zero);
+          Kokkos::deep_copy (t, zero);
           r_val = solver.solve(x, b, t);
         }
         if(r_val == 0) {
@@ -233,122 +252,189 @@ int driver(const std::string file, const std::string method_name, const int vari
   return r_val;
 }
 
-
 // tests
+//  Cholesky
+#define TACHO_CHOL_TEST( SCALAR ) \
+  /* Chol */                                                        \
+  /* > single RHS */                                                \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", 0, 1, conj), 0);           \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", 1, 1, conj), 0);           \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", 2, 1, conj), 0);           \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", 3, 1, conj), 0);           \
+  /* > explicit transpose */                                        \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", 3, 1, conj, true), 0);     \
+  /* > multiple RHSs */                                             \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", 0, 5, conj), 0);           \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", 1, 5, conj), 0);           \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", 2, 5, conj), 0);           \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", 3, 5, conj), 0);           \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", 3, 5, conj, true), 0);     \
+  /* > one-stream */                                                \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", 0, 1, conj, false, true, true, true), 0); \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", 1, 1, conj, false, true, true, true), 0); \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", 2, 1, conj, false, true, true, true), 0);
+
+#define TACHO_CHOL_SEQ_TEST( SCALAR ) \
+  /* > sequential path */                                   \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", -1, 1, conj), 0);  \
+  EXPECT_EQ(driver<SCALAR>(file, "chol", -1, 5, conj), 0);
+
 TEST( Solver, Chol ) {
-  // Chol
-  std::string file = "";
-  // > single RHS
-  EXPECT_EQ(driver<double>(file, "chol", 0, 1), 0);
-  EXPECT_EQ(driver<double>(file, "chol", 1, 1), 0);
-  EXPECT_EQ(driver<double>(file, "chol", 2, 1), 0);
-  EXPECT_EQ(driver<double>(file, "chol", 3, 1), 0);
-  EXPECT_EQ(driver<double>(file, "chol", 3, 1, true), 0);
-  // > multiple RHSs
-  EXPECT_EQ(driver<double>(file, "chol", 0, 5), 0);
-  EXPECT_EQ(driver<double>(file, "chol", 1, 5), 0);
-  EXPECT_EQ(driver<double>(file, "chol", 2, 5), 0);
-  EXPECT_EQ(driver<double>(file, "chol", 3, 5), 0);
-  EXPECT_EQ(driver<double>(file, "chol", 3, 5, true), 0);
-  // > one-stream
-  EXPECT_EQ(driver<double>(file, "chol", 0, 1, false, true, true, true), 0);
-  EXPECT_EQ(driver<double>(file, "chol", 1, 1, false, true, true, true), 0);
-  EXPECT_EQ(driver<double>(file, "chol", 2, 1, false, true, true, true), 0);
+  std::string file = ""; 
+  const bool conj = true;
+  TACHO_CHOL_TEST( double )
+  TACHO_CHOL_TEST( Kokkos::complex<double> )
   #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
-  // > sequential path
-  EXPECT_EQ(driver<double>(file, "chol", -1, 1), 0);
-  EXPECT_EQ(driver<double>(file, "chol", -1, 5), 0);
+  TACHO_CHOL_SEQ_TEST( double )
+  TACHO_CHOL_SEQ_TEST( Kokkos::complex<double> )
   #endif
 }
+
+//  LU
+#define TACHO_LU_TEST( SCALAR ) \
+  /* > single RHS */                                                              \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 0, 1, conj), 0);                           \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 1, 1, conj), 0);                           \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 2, 1, conj), 0);                           \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 3, 1, conj), 0);                           \
+  /* > multiple RHSs */                                                           \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 0, 5, conj), 0);                           \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 1, 5, conj), 0);                           \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 2, 5, conj), 0);                           \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 3, 5, conj), 0);                           \
+  /* > one-stream */                                                              \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 0, 1, conj, false, true, true, true), 0);  \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 1, 1, conj, false, true, true, true), 0);  \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 2, 1, conj, false, true, true, true), 0);
+
+#define TACHO_LU_CHOL_TEST( SCALAR ) \
+  /* multiple symbolic calls */                                                   \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 3, 5, conj, false, false, false), 0);      \
+  /* with mixed LU or Chol */                                                     \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 0, 1, conj, false, false), 0);             \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 1, 1, conj, false, false), 0);             \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 2, 1, conj, false, false), 0);             \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 3, 1, conj, false, false), 0);             \
+  /* multiple RHSs */                                                             \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 0, 5, conj, false, false), 0);             \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 1, 5, conj, false, false), 0);             \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 2, 5, conj, false, false), 0);             \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", 3, 5, conj, false, false), 0);
+
+#define TACHO_LU_SEQ_TEST( SCALAR ) \
+  /* > sequential path */                           \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", -1, 1, conj), 0);  \
+  EXPECT_EQ(driver<SCALAR>(file, "lu", -1, 5, conj), 0);  \
 
 TEST( Solver, LU ) {
   // LU
   std::string file = "";
-  // > single RHS
-  EXPECT_EQ(driver<double>(file, "lu", 0, 1), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 1, 1), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 2, 1), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 3, 1), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 0, 1, false, false), 0); // with mixed LU or Chol
-  EXPECT_EQ(driver<double>(file, "lu", 1, 1, false, false), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 2, 1, false, false), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 3, 1, false, false), 0);
-  // > multiple RHSs
-  EXPECT_EQ(driver<double>(file, "lu", 0, 5), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 1, 5), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 2, 5), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 3, 5), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 0, 5, false, false), 0); // with mixed LU or Chol
-  EXPECT_EQ(driver<double>(file, "lu", 1, 5, false, false), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 2, 5, false, false), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 3, 5, false, false), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 3, 5, false, false, false), 0); // multiple symbolic calls
-  // > one-stream
-  EXPECT_EQ(driver<double>(file, "lu", 0, 1, false, true, true, true), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 1, 1, false, true, true, true), 0);
-  EXPECT_EQ(driver<double>(file, "lu", 2, 1, false, true, true, true), 0);
+  // > conjugate
+  bool conj = true;
+  TACHO_LU_TEST( double )
+  TACHO_LU_TEST( Kokkos::complex<double> )
+  TACHO_LU_CHOL_TEST( double )
+  TACHO_LU_CHOL_TEST( Kokkos::complex<double> )
   #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
-  // > sequential path
-  EXPECT_EQ(driver<double>(file, "lu", -1, 1), 0);
-  EXPECT_EQ(driver<double>(file, "lu", -1, 5), 0);
+  TACHO_LU_SEQ_TEST( double )
+  TACHO_LU_SEQ_TEST( Kokkos::complex<double> )
+  #endif
+  // > complex symmetric
+  //   no LU_CHOL (chol is only for Hermitian)
+  conj = false;
+  TACHO_LU_TEST( Kokkos::complex<double> )
+  #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
+  TACHO_LU_SEQ_TEST( Kokkos::complex<double> )
   #endif
 }
+
+//  LDL
+#define TACHO_LDL_TEST( SCALAR ) \
+  /* > single RHS */                                                               \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 0, 1, conj), 0);                           \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 1, 1, conj), 0);                           \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 2, 1, conj), 0);                           \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 3, 1, conj), 0);                           \
+  /* > explicit transpose */                                                       \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 3, 1, conj, true), 0);                     \
+  /* > multiple RHSs */                                                            \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 0, 5, conj), 0);                           \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 1, 5, conj), 0);                           \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 2, 5, conj), 0);                           \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 3, 5, conj), 0);                           \
+  /* > one-stream */                                                               \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 0, 1, conj, false, true, true, true), 0);  \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 1, 1, conj, false, true, true, true), 0);  \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 2, 1, conj, false, true, true, true), 0); 
+
+#define TACHO_LDL_CHOL_TEST( SCALAR ) \
+  /* with mixed LDL or Chol, only for double or float */                           \
+  /* Chol is for Hermitian, LDL for Symmetrix */                                   \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 0, 1, conj, false, false), 0);             \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 1, 1, conj, false, false), 0);             \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 2, 1, conj, false, false), 0);             \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 3, 1, conj, false, false), 0);             \
+  /* with multiple RHSs */                                                         \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 0, 5, conj, false, false), 0);             \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 1, 5, conj, false, false), 0);             \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 2, 5, conj, false, false), 0);             \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", 3, 5, conj, false, false), 0);             \
+
+#define TACHO_LDL_SEQ_TEST( SCALAR ) \
+  /* > sequential path */                                 \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", -1, 1, conj), 0); \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl", -1, 5, conj), 0); \
 
 TEST( Solver, LDL ) {
   // LDL
   std::string file = "";
-  // > single RHS
-  EXPECT_EQ(driver<double>(file, "ldl", 0, 1), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", 1, 1), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", 2, 1), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", 3, 1), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", 0, 1, false, false), 0); // with mixed LDL or Chol
-  EXPECT_EQ(driver<double>(file, "ldl", 1, 1, false, false), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", 2, 1, false, false), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", 3, 1, false, false), 0);
-  // > multiple RHSs
-  EXPECT_EQ(driver<double>(file, "ldl", 0, 5), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", 1, 5), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", 2, 5), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", 3, 5), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", 0, 5, false, false), 0); // with mixed LDL or Chol
-  EXPECT_EQ(driver<double>(file, "ldl", 1, 5, false, false), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", 2, 5, false, false), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", 3, 5, false, false), 0);
-  // > one-stream
-  EXPECT_EQ(driver<double>(file, "ldl", 0, 1, false, true, true, true), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", 1, 1, false, true, true, true), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", 2, 1, false, true, true, true), 0);
+  const bool conj = false;
+  TACHO_LDL_TEST( double )
+  TACHO_LDL_TEST( Kokkos::complex<double> )
+  // LDL + Chol (not for complex because Chol is for Hermitian, LDL is for complex symmetric)
+  TACHO_LDL_CHOL_TEST( double )
   #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
-  // > sequential path
-  EXPECT_EQ(driver<double>(file, "ldl", -1, 1), 0);
-  EXPECT_EQ(driver<double>(file, "ldl", -1, 5), 0);
+  TACHO_LDL_SEQ_TEST( double )
+  TACHO_LDL_SEQ_TEST( Kokkos::complex<double> )
   #endif
 }
+
+//  Non-piv LDL
+#define TACHO_NOPIV_TEST( SCALAR ) \
+  /* > single RHS */                                                          \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 0, 1, conj), 0);                \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 1, 1, conj), 0);                \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 2, 1, conj), 0);                \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 3, 1, conj), 0);                \
+  /* > multiple RHSs */                                                       \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 0, 5, conj), 0);                \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 1, 5, conj), 0);                \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 2, 5, conj), 0);                \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 3, 5, conj), 0);
+// Mix Non-piv LDL & Chol (cannot do for complex)
+#define TACHO_NOPIV_CHOL_TEST( SCALAR ) \
+  /* with mixed nopiv-LDL or Chol, only for double or float */                \
+  /* Chol for Hermitian and LDL for symmetrix */                              \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 0, 1, conj, false, false), 0);  \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 1, 1, conj, false, false), 0);  \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 2, 1, conj, false, false), 0);  \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 3, 1, conj, false, false), 0);  \
+  /*EXPECT_EQ(driver<double>(file, "ldl-nopiv", 3, 1, conj, true), 0);*/      \
+  /* with mixed nopiv-LDL or Chol */                                          \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 0, 5, conj, false, false), 0);  \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 1, 5, conj, false, false), 0);  \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 2, 5, conj, false, false), 0);  \
+  EXPECT_EQ(driver<SCALAR>(file, "ldl-nopiv", 3, 5, conj, false, false), 0);  \
+  /*EXPECT_EQ(driver<double>(file, "ldl-nopiv", 3, 5, conj, true), 0);*/      \
 
 TEST( Solver, NonPivLDL ) {
   // Non-piv LDL
   std::string file = "";
-  // > single RHS
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 0, 1), 0);
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 1, 1), 0);
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 2, 1), 0);
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 3, 1), 0);
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 0, 1, false, false), 0); // with mixed nopiv-LDL or Chol
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 1, 1, false, false), 0);
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 2, 1, false, false), 0);
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 3, 1, false, false), 0);
-  //EXPECT_EQ(driver<double>(file, "ldl-nopiv", 3, 1, true), 0);
-  // > multiple RHSs
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 0, 5), 0);
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 1, 5), 0);
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 2, 5), 0);
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 3, 5), 0);
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 0, 5, false, false), 0); // with mixed nopiv-LDL or Chol
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 1, 5, false, false), 0);
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 2, 5, false, false), 0);
-  EXPECT_EQ(driver<double>(file, "ldl-nopiv", 3, 5, false, false), 0);
-  //EXPECT_EQ(driver<double>(file, "ldl-nopiv", 3, 5, true), 0);
+  const bool conj = false;
+  TACHO_NOPIV_TEST( double )
+  TACHO_NOPIV_TEST( Kokkos::complex<double> )
+  // Non-piv LDL + Chol (not for complex because Chol is for Hermitian, LDL is for complex symmetric)
+  TACHO_NOPIV_CHOL_TEST( double ) 
   //#if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && !defined(KOKKOS_ENABLE_SYCL)
   //// > sequential path
   //EXPECT_EQ(driver<double>(file, "ldl-nopiv", -1, 1), 0);


### PR DESCRIPTION

@trilinos/shylu

## Motivation
cleanup support for complex support
- `chol` supports complex Hermitian
- `lu` supports both complex symmetric and Hermitian
- `ldl` supports only complex symmetric

## Testing
- added complex<double> to unit-test

## Additional Information
- added complex support to variant 3