### PR TITLE
panzer: update test type for kokkos 5.1.99 compatibility

### DIFF
--- a/packages/panzer/dof-mgr/test/fe_assembly/test_fe_projection.hpp
+++ b/packages/panzer/dof-mgr/test/fe_assembly/test_fe_projection.hpp
@@ -124,7 +124,11 @@ template<typename ValueType, typename DeviceSpaceType>
 int feProjection(int argc, char *argv[]) {
 
   using HostSpaceType = typename
+#if KOKKOS_VERSION >= 50199
+      Kokkos::Impl::HostMirror<typename DeviceSpaceType::memory_space>::Space::execution_space;
+#else
       Kokkos::Impl::HostMirror<DeviceSpaceType>::Space::execution_space;
+#endif
   using DynRankView = Kokkos::DynRankView<ValueType,DeviceSpaceType>;
   using DynRankViewHost = Kokkos::DynRankView<ValueType,HostSpaceType>;
 


### PR DESCRIPTION
@trilinos/panzer 

compatibility update with kokkos@develop with use of HostMirror type in test_fe_projection.hpp see https://github.com/kokkos/kokkos/pull/8252

The `Impl::HostMirror` usage should be replaced altogether, but this will resolve nightly integration test failures for now

Confirmed this resolved compilation issues in local Hip build

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
