### PR TITLE
Tpetra matrix generator: check MV entry is owned

### DIFF
--- a/packages/tpetra/core/test/TpetraUtils_MatrixGenerator.hpp
+++ b/packages/tpetra/core/test/TpetraUtils_MatrixGenerator.hpp
@@ -651,16 +651,18 @@ class MatrixGenerator {
  private:
   template <class Vec, class S>
   static void miniFE_vector_generate_block(Vec& vec, int nx, S a, S b, int& count, int start, int end) {
-    if ((count >= start) && (count < end))
-      vec.replaceGlobalValue(count++ - start, 0.0);
+    auto map       = vec.getMap();
+    auto insertVal = [&](int i, S val) {
+      if ((i >= start) && (i < end) && map->isNodeGlobalElement(i)) {
+        vec.replaceGlobalValue(i, val);
+      }
+    };
+    insertVal(count++ - start, 0.0);
     for (int i = 0; i < nx - 2; i++) {
-      if ((count >= start) && (count < end))
-        vec.replaceGlobalValue(count++ - start, a / nx / nx / nx);
+      insertVal(count++ - start, a / nx / nx / nx);
     }
-    if ((count >= start) && (count < end))
-      vec.replaceGlobalValue(count++ - start, a / nx / nx / nx + b / nx);
-    if ((count >= start) && (count < end))
-      vec.replaceGlobalValue(count++ - start, 1.0);
+    insertVal(count++ - start, a / nx / nx / nx + b / nx);
+    insertVal(count++ - start, 1.0);
   }
 
   template <class Vec, class S>


### PR DESCRIPTION
@trilinos/tpetra 
Fixes #13811.

All ranks participate in inserting all entries into the FE example multivector, so just make sure each GID is owned before inserting. This actually was trying to write out of bounds (index ``OrdinalTraits<LO>::invalid()``, aka -1) to the local MV view according to Kokkos bounds checking.