### PR TITLE
Tpetra: Using OpenCode to document sync semantics of Tpetra MultiVector .

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -696,6 +696,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   /// corresponding to values in \c indices, then the redundant
   /// indices will be eliminated.  This may happen either at
   /// insertion or during the next call to fillComplete().
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host if device data is more recent
   void
   insertGlobalIndices(const global_ordinal_type globalRow,
                       const Teuchos::ArrayView<const global_ordinal_type>& indices);
@@ -706,6 +709,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// Arguments are the same and in the same order as
   /// Epetra_CrsGraph::InsertGlobalIndices.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host if device data is more recent
   void
   insertGlobalIndices(const global_ordinal_type globalRow,
                       const local_ordinal_type numEnt,
@@ -721,11 +727,13 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
      \post <tt>indicesAreAllocated() == true</tt>
      \post <tt>isLocallyIndexed() == true</tt>
 
-     \note If the graph row already contains entries at the indices
-       corresponding to values in \c indices, then the redundant
-       indices will be eliminated; this may happen at insertion or
-       during the next call to fillComplete().
-  */
+      \note If the graph row already contains entries at the indices
+        corresponding to values in \c indices, then the redundant
+        indices will be eliminated; this may happen at insertion or
+        during the next call to fillComplete().
+   */
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host if device data is more recent
   void
   insertLocalIndices(const local_ordinal_type localRow,
                      const Teuchos::ArrayView<const local_ordinal_type>& indices);
@@ -736,6 +744,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// Arguments are the same and in the same order as
   /// Epetra_CrsGraph::InsertMyIndices.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host if device data is more recent
   void
   insertLocalIndices(const local_ordinal_type localRow,
                      const local_ordinal_type numEnt,
@@ -747,10 +758,12 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
      \pre <tt>isGloballyIndexed() == false</tt>
      \pre <tt>isStorageOptimized() == false</tt>
 
-     \post <tt>getNumEntriesInLocalRow(localRow) == 0</tt>
-     \post <tt>indicesAreAllocated() == true</tt>
-     \post <tt>isLocallyIndexed() == true</tt>
-  */
+      \post <tt>getNumEntriesInLocalRow(localRow) == 0</tt>
+      \post <tt>indicesAreAllocated() == true</tt>
+      \post <tt>isLocallyIndexed() == true</tt>
+   */
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host if device data is more recent
   void removeLocalIndices(local_ordinal_type localRow);
 
   //@}
@@ -764,6 +777,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// This method must be called collectively (that is, like any MPI
   /// collective) over all processes in the graph's communicator.
+  ///
+  /// MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// Kokkos synchronization: sometimes - may synchronize device to host for communication buffers
   void globalAssemble();
 
   /// \brief Resume fill operations.
@@ -784,6 +800,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// This method must be called collectively (that is, like any MPI
   /// collective) over all processes in the graph's communicator.
+  ///
+  /// MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// Kokkos synchronization: never
   void
   resumeFill(const Teuchos::RCP<Teuchos::ParameterList>& params =
                  Teuchos::null);
@@ -800,6 +819,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// This method must be called collectively (that is, like any MPI
   /// collective) over all processes in the graph's communicator.
+  ///
+  /// MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// Kokkos synchronization: sometimes - may synchronize device to host for communication and sorting operations
   ///
   /// \warning The domain Map and row Map arguments to this method
   ///   MUST be one to one!  If you have Maps that are not one to
@@ -844,6 +866,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   /// This method must be called collectively (that is, like any MPI
   /// collective) over all processes in the graph's communicator.
   ///
+  /// MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// Kokkos synchronization: sometimes - may synchronize device to host for communication and sorting operations
+  ///
   /// \warning It is only valid to call this overload of
   ///   fillComplete if the row Map is one to one!  If the row Map
   ///   is NOT one to one, you must call the above three-argument
@@ -870,6 +895,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// This method must be called collectively (that is, like any MPI
   /// collective) over all processes in the graph's communicator.
+  ///
+  /// MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// Kokkos synchronization: sometimes - may synchronize device to host for communication operations
   ///
   /// \warning This method is intended for expert developer use
   ///   only, and should never be called by user code.
@@ -1098,6 +1126,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   /// \param gblRow [in] Global index of the row.
   /// \param gblColInds [out] On output: Global column indices.
   /// \param numColInds [out] Number of indices returned.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access row data
   void
   getGlobalRowCopy(global_ordinal_type gblRow,
                    nonconst_global_inds_host_view_type& gblColInds,
@@ -1110,6 +1141,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   /// \param numColInds [out] Number of indices returned.
   ///
   /// \pre <tt>hasColMap()</tt>
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access row data
   void
   getLocalRowCopy(local_ordinal_type lclRow,
                   nonconst_local_inds_host_view_type& lclColInds,
@@ -1125,6 +1159,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// \pre <tt>! isLocallyIndexed()</tt>
   /// \post <tt>gblColInds.size() == getNumEntriesInGlobalRow(gblRow)</tt>
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access row data
   void
   getGlobalRowView(
       const global_ordinal_type gblRow,
@@ -1144,6 +1181,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// \pre <tt>! isGloballyIndexed()</tt>
   /// \post <tt>lclColInds.size() == getNumEntriesInLocalRow(lclRow)</tt>
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access row data
   void
   getLocalRowView(
       const LocalOrdinal lclRow,
@@ -1190,6 +1230,8 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
                  const Kokkos::DualView<const local_ordinal_type*,
                                         buffer_device_type>& permuteFromLIDs,
                  const CombineMode CM) override;
+  /// MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// Kokkos synchronization: sometimes - may synchronize device to host for permutation operations
 
   void copyAndPermuteNew(
       const row_graph_type& source,
@@ -1198,6 +1240,8 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
       const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteToLIDs,
       const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteFromLIDs,
       const CombineMode CM);
+  /// MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// Kokkos synchronization: sometimes - may synchronize device to host for permutation operations
 
   void insertGlobalIndicesDevice(
       const CrsGraph<LocalOrdinal, GlobalOrdinal, Node>& srcCrsGraph,
@@ -1205,6 +1249,8 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
       const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteToLIDs,
       const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteFromLIDs,
       LocalOrdinal loopEnd);
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host for insertion operations
 
   using padding_type = Details::CrsPadding<
       local_ordinal_type, global_ordinal_type>;
@@ -1265,6 +1311,8 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
       Kokkos::DualView<packet_type*, buffer_device_type>& exports,
       Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
       size_t& constantNumPackets) override;
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host for packing operations
 
   using dist_object_type::packAndPrepare;  ///< DistObject overloads
                                            ///< packAndPrepare. Explicitly use
@@ -1276,12 +1324,16 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
        Teuchos::Array<global_ordinal_type>& exports,
        const Teuchos::ArrayView<size_t>& numPacketsPerLID,
        size_t& constantNumPackets) const override;
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host for packing operations
 
   void
   packFillActive(const Teuchos::ArrayView<const local_ordinal_type>& exportLIDs,
                  Teuchos::Array<global_ordinal_type>& exports,
                  const Teuchos::ArrayView<size_t>& numPacketsPerLID,
                  size_t& constantNumPackets) const;
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host for packing operations
 
   void
   packFillActiveNew(const Kokkos::DualView<const local_ordinal_type*,
@@ -1292,6 +1344,8 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
                                      buffer_device_type>
                         numPacketsPerLID,
                     size_t& constantNumPackets) const;
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host for packing operations
 
   using dist_object_type::unpackAndCombine;  ///< DistObject has overloaded
                                              ///< unpackAndCombine, use the
@@ -1309,6 +1363,8 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
                        numPacketsPerLID,
                    const size_t constantNumPackets,
                    const CombineMode combineMode) override;
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host for unpacking and combining operations
 
   //@}
   //! \name Advanced methods, at increased risk of deprecation.
@@ -1356,10 +1412,16 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///   does NOT allocate the array; the caller must allocate.  Must
   ///   have getLocalNumRows() entries on the calling process.  (This
   ///   may be different on different processes.)
+  ///
+  /// MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// Kokkos synchronization: sometimes - may synchronize device to host for offset computation
   void
   getLocalDiagOffsets(const Kokkos::View<size_t*, device_type, Kokkos::MemoryUnmanaged>& offsets) const;
 
   /// \brief Get offsets of the off-rank entries in the graph.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host for offset computation
   void
   getLocalOffRankOffsets(offset_device_view_type& offsets) const;
 
@@ -1372,6 +1434,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   /// \param offsets [out] Output array of offsets.  This method
   ///   reallocates the array if it is not long enough.  This is why
   ///   the method takes the array by reference.
+  ///
+  /// MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// Kokkos synchronization: sometimes - may synchronize device to host for offset computation
   void
   getLocalDiagOffsets(Teuchos::ArrayRCP<size_t>& offsets) const;
 
@@ -1384,6 +1449,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// \warning This method is intended for expert developer use
   ///   only, and should never be called by user code.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host if setting data from host
   void
   setAllIndices(const typename local_graph_device_type::row_map_type& rowPointers,
                 const typename local_graph_device_type::entries_type::non_const_type& columnIndices);
@@ -1397,22 +1465,35 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// \warning This method is intended for expert developer use
   ///   only, and should never be called by user code.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host if setting data from host
   void
   setAllIndices(const Teuchos::ArrayRCP<size_t>& rowPointers,
                 const Teuchos::ArrayRCP<local_ordinal_type>& columnIndices);
 
   /// \brief Get a host view of the packed row offsets.
   ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access row pointers
   row_ptrs_host_view_type getLocalRowPtrsHost() const;
 
   /// \brief Get a device view of the packed row offsets.
   ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: never - returns device view directly
   row_ptrs_device_view_type getLocalRowPtrsDevice() const;
 
   /// \brief Get a host view of the packed column indicies
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access column indices
   local_inds_host_view_type getLocalIndicesHost() const;
 
   /// \brief Get a device view of the packed column indicies
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: never - returns device view directly
   local_inds_device_view_type getLocalIndicesDevice() const;
 
   /// \brief Replace the graph's current column Map with the given Map.
@@ -1433,6 +1514,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///
   ///   It is strongly recommended to use \c Tpetra::Details::makeColMap()
   ///   to create the column map. makeColMap() follows Aztec ordering by default.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: never
   void replaceColMap(const Teuchos::RCP<const map_type>& newColMap);
 
   /// \brief Reindex the column indices in place, and replace the
@@ -1454,6 +1538,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// \param sortIndicesInEachRow [in] If true, sort the indices in
   ///   each row after reindexing.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host for reindexing operations
   void
   reindexColumns(const Teuchos::RCP<const map_type>& newColMap,
                  const Teuchos::RCP<const import_type>& newImport = Teuchos::null,
@@ -1465,6 +1552,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// \pre <tt>isFillComplete() == true</tt>
   /// \pre <tt>isFillActive() == false</tt>
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: never
   void
   replaceDomainMap(const Teuchos::RCP<const map_type>& newDomainMap);
 
@@ -1481,6 +1571,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///   of the given Import is the same as this graph's column Map.
   /// \pre Either the given Import object is null, or the source Map
   ///    of the given Import is the same as this graph's domain Map.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: never
   void
   replaceDomainMapAndImporter(const Teuchos::RCP<const map_type>& newDomainMap,
                               const Teuchos::RCP<const import_type>& newImporter);
@@ -1491,6 +1584,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// \pre <tt>isFillComplete() == true</tt>
   /// \pre <tt>isFillActive() == false</tt>
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: never
   void
   replaceRangeMap(const Teuchos::RCP<const map_type>& newRangeMap);
 
@@ -1507,6 +1603,9 @@ class CrsGraph : public RowGraph<LocalOrdinal, GlobalOrdinal, Node>,
   ///   of the given Export is the same as this graph's Range Map.
   /// \pre Either the given Export object is null, or the source Map
   ///    of the given Export is the same as this graph's Row Map.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: never
   void
   replaceRangeMapAndExporter(const Teuchos::RCP<const map_type>& newRangeMap,
                              const Teuchos::RCP<const export_type>& newExporter);

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -948,6 +948,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   may not use insertGlobalValues() or
   ///   insertLocalValues().</li>
   /// </ol>
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   void
   insertGlobalValues(const GlobalOrdinal globalRow,
                      const Teuchos::ArrayView<const GlobalOrdinal>& cols,
@@ -967,6 +970,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   /// \param vals [in] Values to insert.
   /// \param inds [in] Global indices of the columns into which
   ///   to insert the entries.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   void
   insertGlobalValues(const GlobalOrdinal globalRow,
                      const LocalOrdinal numEnt,
@@ -1015,6 +1021,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   may not use insertGlobalValues() or
   ///   insertLocalValues().</li>
   /// </ol>
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   void
   insertLocalValues(const LocalOrdinal localRow,
                     const Teuchos::ArrayView<const LocalOrdinal>& cols,
@@ -1040,6 +1049,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   matrix graph, and sums values that are already present. INSERT
   ///   inserts values that are not yet in the matrix graph, and
   ///   replaces values that are already present.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   void
   insertLocalValues(const LocalOrdinal localRow,
                     const LocalOrdinal numEnt,
@@ -1104,6 +1116,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   /// <li> <tt>! isFillActive ()</tt> </li>
   /// <li> <tt> inputInds.extent (0) != inputVals.extent (0)</tt> </li>
   /// </ul>
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   local_ordinal_type
   replaceGlobalValues(
       const global_ordinal_type globalRow,
@@ -1112,6 +1127,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
 
   /// \brief Overload of replaceGlobalValues (see above), that takes
   ///   Teuchos::ArrayView (host pointers) instead of Kokkos::View.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   LocalOrdinal
   replaceGlobalValues(const GlobalOrdinal globalRow,
                       const Teuchos::ArrayView<const GlobalOrdinal>& cols,
@@ -1131,6 +1149,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   /// \param vals [in] Values to use for replacing the entries.
   /// \param cols [in] Global indices of the columns in which to
   ///   replace the entries.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   LocalOrdinal
   replaceGlobalValues(const GlobalOrdinal globalRow,
                       const LocalOrdinal numEnt,
@@ -1193,6 +1214,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   <li> <tt>! hasColMap ()</tt> </li>
   ///   <li> <tt> cols.extent (0) != vals.extent (0)</tt> </li>
   ///   </ul>
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   local_ordinal_type
   replaceLocalValues(
       const local_ordinal_type localRow,
@@ -1202,6 +1226,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   /// \brief Backwards compatibility version of replaceLocalValues
   ///   (see above), that takes Teuchos::ArrayView (host pointers)
   ///   instead of Kokkos::View.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   LocalOrdinal
   replaceLocalValues(const LocalOrdinal localRow,
                      const Teuchos::ArrayView<const LocalOrdinal>& cols,
@@ -1224,6 +1251,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// \return The number of indices for which values were actually
   ///   replaced; the number of "correct" indices.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   LocalOrdinal
   replaceLocalValues(const LocalOrdinal localRow,
                      const LocalOrdinal numEnt,
@@ -1314,6 +1344,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// This method has the same preconditions and return value
   /// meaning as replaceGlobalValues() (which see).
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   LocalOrdinal
   sumIntoGlobalValues(const GlobalOrdinal globalRow,
                       const Teuchos::ArrayView<const GlobalOrdinal>& cols,
@@ -1342,6 +1375,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// \return The number of indices for which values were actually
   ///   modified; the number of "correct" indices.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   LocalOrdinal
   sumIntoGlobalValues(const GlobalOrdinal globalRow,
                       const LocalOrdinal numEnt,
@@ -1409,6 +1445,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// This method has the same preconditions and return value
   /// meaning as replaceLocalValues() (which see).
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   local_ordinal_type
   sumIntoLocalValues(
       const local_ordinal_type localRow,
@@ -1445,6 +1484,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// This method has the same preconditions and return value
   /// meaning as replaceLocalValues() (which see).
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   LocalOrdinal
   sumIntoLocalValues(const LocalOrdinal localRow,
                      const Teuchos::ArrayView<const LocalOrdinal>& cols,
@@ -1788,9 +1830,15 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   }
 
   //! Set all matrix entries equal to \c alpha.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   void setAllToScalar(const Scalar& alpha);
 
   //! Scale the matrix's values: <tt>this := alpha*this</tt>.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
   void scale(const Scalar& alpha);
 
   /// \brief Set the local matrix using three (compressed sparse row) arrays.
@@ -1918,6 +1966,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   /// an exception, or it may silently drop the entries inserted
   /// into invalid rows.  Behavior may vary, depending on whether
   /// Tpetra was built with debug checking enabled.
+  ///
+  /// MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// Kokkos synchronization: sometimes - may synchronize device to host for communication buffers, inherits sync behavior from CrsGraph::globalAssemble
   void globalAssemble();
 
   /// \brief Resume operations that may change the values or
@@ -1933,6 +1984,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   /// resumeFill calls as many times as you wish.
   ///
   /// \post <tt>isFillActive() && ! isFillComplete()</tt>
+  ///
+  /// MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// Kokkos synchronization: never
   void resumeFill(const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
   /// \brief Tell the matrix that you are done changing its
@@ -1992,6 +2046,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///      or disappear at any time.
   /// </li>
   /// </ul>
+  ///
+  /// MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// Kokkos synchronization: sometimes - may synchronize device to host for communication and sorting operations, inherits sync behavior from CrsGraph::fillComplete
   void
   fillComplete(const Teuchos::RCP<const map_type>& domainMap,
                const Teuchos::RCP<const map_type>& rangeMap,
@@ -2023,6 +2080,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   /// \param params [in/out] List of parameters controlling this
   ///   method's behavior.  See documentation of the three-argument
   ///   version of fillComplete (above) for valid parameters.
+  ///
+  /// MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// Kokkos synchronization: sometimes - may synchronize device to host for communication and sorting operations, inherits sync behavior from CrsGraph::fillComplete
   void
   fillComplete(const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
@@ -2052,6 +2112,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   Tpetra::Map::isSameAs), then this may be Teuchos::null.
   /// \param params [in/out] List of parameters controlling this
   ///   method's behavior.
+  ///
+  /// MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// Kokkos synchronization: sometimes - may synchronize device to host for communication operations, inherits sync behavior from CrsGraph::expertStaticFillComplete
   void
   expertStaticFillComplete(const Teuchos::RCP<const map_type>& domainMap,
                            const Teuchos::RCP<const map_type>& rangeMap,
@@ -2076,6 +2139,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///
   /// \pre The matrix must not have been created with a constant
   ///   (a.k.a. "static") CrsGraph.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: never - inherits sync behavior from CrsGraph::replaceColMap
   void
   replaceColMap(const Teuchos::RCP<const map_type>& newColMap);
 
@@ -2295,6 +2361,9 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   least once.  This method will do no error checking, so you
   ///   are responsible for knowing when it is safe to call this
   ///   method.
+  ///
+  /// MPI synchronization: never
+  /// Kokkos synchronization: sometimes for getLocalMatrixHost (may synchronize device to host), never for getLocalMatrixDevice
   TPETRA_DETAILS_ALWAYS_INLINE local_matrix_device_type
   getLocalMatrixDevice() const;
   local_matrix_host_type getLocalMatrixHost() const;

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -950,7 +950,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   /// </ol>
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   void
   insertGlobalValues(const GlobalOrdinal globalRow,
                      const Teuchos::ArrayView<const GlobalOrdinal>& cols,
@@ -972,7 +972,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   to insert the entries.
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   void
   insertGlobalValues(const GlobalOrdinal globalRow,
                      const LocalOrdinal numEnt,
@@ -1023,7 +1023,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   /// </ol>
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   void
   insertLocalValues(const LocalOrdinal localRow,
                     const Teuchos::ArrayView<const LocalOrdinal>& cols,
@@ -1051,7 +1051,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   replaces values that are already present.
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   void
   insertLocalValues(const LocalOrdinal localRow,
                     const LocalOrdinal numEnt,
@@ -1118,7 +1118,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   /// </ul>
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   local_ordinal_type
   replaceGlobalValues(
       const global_ordinal_type globalRow,
@@ -1129,7 +1129,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   Teuchos::ArrayView (host pointers) instead of Kokkos::View.
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   LocalOrdinal
   replaceGlobalValues(const GlobalOrdinal globalRow,
                       const Teuchos::ArrayView<const GlobalOrdinal>& cols,
@@ -1151,7 +1151,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   replace the entries.
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   LocalOrdinal
   replaceGlobalValues(const GlobalOrdinal globalRow,
                       const LocalOrdinal numEnt,
@@ -1216,7 +1216,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   </ul>
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   local_ordinal_type
   replaceLocalValues(
       const local_ordinal_type localRow,
@@ -1228,7 +1228,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   instead of Kokkos::View.
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   LocalOrdinal
   replaceLocalValues(const LocalOrdinal localRow,
                      const Teuchos::ArrayView<const LocalOrdinal>& cols,
@@ -1253,7 +1253,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   replaced; the number of "correct" indices.
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   LocalOrdinal
   replaceLocalValues(const LocalOrdinal localRow,
                      const LocalOrdinal numEnt,
@@ -1346,7 +1346,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   /// meaning as replaceGlobalValues() (which see).
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   LocalOrdinal
   sumIntoGlobalValues(const GlobalOrdinal globalRow,
                       const Teuchos::ArrayView<const GlobalOrdinal>& cols,
@@ -1377,7 +1377,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   modified; the number of "correct" indices.
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   LocalOrdinal
   sumIntoGlobalValues(const GlobalOrdinal globalRow,
                       const LocalOrdinal numEnt,
@@ -1447,7 +1447,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   /// meaning as replaceLocalValues() (which see).
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   local_ordinal_type
   sumIntoLocalValues(
       const local_ordinal_type localRow,
@@ -1486,7 +1486,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   /// meaning as replaceLocalValues() (which see).
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   LocalOrdinal
   sumIntoLocalValues(const LocalOrdinal localRow,
                      const Teuchos::ArrayView<const LocalOrdinal>& cols,
@@ -1832,13 +1832,13 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   //! Set all matrix entries equal to \c alpha.
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   void setAllToScalar(const Scalar& alpha);
 
   //! Scale the matrix's values: <tt>this := alpha*this</tt>.
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes - may synchronize device to host to access matrix data
+  /// Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   void scale(const Scalar& alpha);
 
   /// \brief Set the local matrix using three (compressed sparse row) arrays.
@@ -2363,7 +2363,7 @@ class CrsMatrix : public RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
   ///   method.
   ///
   /// MPI synchronization: never
-  /// Kokkos synchronization: sometimes for getLocalMatrixHost (may synchronize device to host), never for getLocalMatrixDevice
+  /// Kokkos synchronization: never for getLocalMatrixDevice, sometimes for getLocalMatrixHost - calls sync_host() to ensure host data is up-to-date
   TPETRA_DETAILS_ALWAYS_INLINE local_matrix_device_type
   getLocalMatrixDevice() const;
   local_matrix_host_type getLocalMatrixHost() const;

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -65,6 +65,9 @@ namespace Tpetra {
 /// is because the method reserves the right to check for
 /// compatibility of the two Maps, at least in debug mode, and throw
 /// if they are not compatible.
+///
+/// \brief MPI synchronization: sometimes - may perform Map compatibility checks in debug mode which require collective operations
+/// \brief Kokkos synchronization: sometimes - may synchronize device data when copying between different memory spaces
 template <class DS, class DL, class DG, class DN,
           class SS, class SL, class SG, class SN>
 void deep_copy(MultiVector<DS, DL, DG, DN>& dst,
@@ -112,6 +115,9 @@ createCopy(const MultiVector<ST, LO, GO, NT>& src);
 ///   resulting MultiVector.
 /// \param numVectors [in] Number of columns of the resulting
 ///   MultiVector.
+///
+/// \brief MPI synchronization: sometimes - may require collective operations if Map has distributed communicator
+/// \brief Kokkos synchronization: never
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
 createMultiVector(const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node>>& map,
@@ -794,6 +800,8 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   virtual ~MultiVector() = default;
 
   //! Swap contents of \c mv with contents of \c *this.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: never
   void swap(MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& mv);
 
   //@}
@@ -842,6 +850,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///   process with respect to the MultiVector's Map.
   /// \param col [in] Column index of the entry to modify.
   /// \param value [in] Incoming value to add to the entry.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   void
   replaceGlobalValue(const GlobalOrdinal gblRow,
                      const size_t col,
@@ -911,6 +922,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// \param atomic [in] Whether to use an atomic update.  If this
   ///   class' execution space is not Kokkos::Serial, then this is
   ///   true by default, else it is false by default.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   void
   sumIntoGlobalValue(const GlobalOrdinal gblRow,
                      const size_t col,
@@ -983,6 +997,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///   calling process.
   /// \param col [in] Column index of the entry to modify.
   /// \param value [in] Incoming value to add to the entry.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   void
   replaceLocalValue(const LocalOrdinal lclRow,
                     const size_t col,
@@ -1053,6 +1070,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// \param atomic [in] Whether to use an atomic update.  If this
   ///   class' execution space is not Kokkos::Serial, then this is
   ///   true by default, else it is false by default.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   void
   sumIntoLocalValue(const LocalOrdinal lclRow,
                     const size_t col,
@@ -1095,6 +1115,12 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   }
 
   //! Set all values in the multivector with the given value.
+  ///
+  /// \brief MPI synchronization: never, Kokkos synchronization: sometimes
+  ///
+  /// Synchronization details:
+  /// - MPI synchronization: This method never requires MPI synchronization
+  /// - Kokkos synchronization: Performs operation in the most recently updated memory space (device or host) to avoid unnecessary synchronization; uses Access::OverwriteAll to bypass sync when appropriate
   void putScalar(const Scalar& value);
 
   /// \brief Set all values in the multivector with the given value.
@@ -1123,6 +1149,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///   Corresponding values on different processes might be
   ///   correlated.  It also does not promise to use a high-quality
   ///   pseudorandom number generator within each process.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host if device data is more recent, then generate random values on host and sync back to device
   void randomize();
 
   /// \brief Set all values in the multivector to pseudorandom
@@ -1138,6 +1167,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///   Corresponding values on different processes might be
   ///   correlated.  It also does not promise to use a high-quality
   ///   pseudorandom number generator within each process.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host if device data is more recent, then generate random values on host and sync back to device
   void randomize(const Scalar& minVal, const Scalar& maxVal);
 
   /// \brief Replace the underlying Map in place.
@@ -1205,6 +1237,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///
   /// \note This method does <i>not</i> do data redistribution.  If
   ///   you need to move data around, use Import or Export.
+  ///
+  /// \brief MPI synchronization: always - must be called collectively on all processes in the communicator
+  /// \brief Kokkos synchronization: never
   void replaceMap(const Teuchos::RCP<const map_type>& map);
 
   /// \brief Sum values of a locally replicated multivector across all processes.
@@ -1213,6 +1248,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///   MultiVectors.
   ///
   /// \pre isDistributed() == false
+  ///
+  /// \brief MPI synchronization: always - uses MPI_Allreduce to sum values across all processes
+  /// \brief Kokkos synchronization: always - uses Kokkos::fence() for UVM synchronization before MPI operations
   void reduce();
 
   //@}
@@ -1245,26 +1283,38 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   //@{
 
   //! Return a MultiVector with copies of selected columns.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
   subCopy(const Teuchos::Range1D& colRng) const;
 
   //! Return a MultiVector with copies of selected columns.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
   subCopy(const Teuchos::ArrayView<const size_t>& cols) const;
 
   //! Return a const MultiVector with const views of selected columns.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   Teuchos::RCP<const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
   subView(const Teuchos::Range1D& colRng) const;
 
   //! Return a const MultiVector with const views of selected columns.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   Teuchos::RCP<const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
   subView(const Teuchos::ArrayView<const size_t>& cols) const;
 
   //! Return a MultiVector with views of selected columns.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
   subViewNonConst(const Teuchos::Range1D& colRng);
 
   //! Return a MultiVector with views of selected columns.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
   subViewNonConst(const Teuchos::ArrayView<const size_t>& cols);
 
@@ -1330,43 +1380,42 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// number of entries in \c subMap (in this case, zero) and the \c
   /// offset may equal the number of local entries in
   /// <tt>*this</tt>.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   Teuchos::RCP<const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
   offsetView(const Teuchos::RCP<const map_type>& subMap,
              const size_t offset) const;
 
   /// \brief Return a nonconst view of a subset of rows.
   ///
-  /// Return a nonconst (modifiable) view of this MultiVector
-  /// consisting of a subset of the rows, as specified by an offset
-  /// and a subset Map of this MultiVector's current row Map.  If
-  /// you want X1 or X2 to be const (nonmodifiable) views, use
-  /// offsetView() with the same arguments.  "View" means "alias":
-  /// if the original (this) MultiVector's data change, the view
-  /// will see the changed data, and if the view's data change, the
-  /// original MultiVector will see the changed data.
-  ///
-  /// \param subMap [in] The row Map for the new MultiVector.  This
-  ///   must be a subset Map of this MultiVector's row Map.
-  /// \param offset [in] The local row offset at which to start the view.
-  ///
   /// See the documentation of offsetView() for a code example and
   /// an explanation of edge cases.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
   offsetViewNonConst(const Teuchos::RCP<const map_type>& subMap,
                      const size_t offset);
 
   //! Return a Vector which is a const view of column j.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   Teuchos::RCP<const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
   getVector(const size_t j) const;
 
   //! Return a Vector which is a nonconst view of column j.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   Teuchos::RCP<Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
   getVectorNonConst(const size_t j);
 
   //! Const view of the local values in a particular vector of this multivector.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes device to host if device data is more recent (checked via need_sync_host())
   Teuchos::ArrayRCP<const Scalar> getData(size_t j) const;
 
   //! View of the local values in a particular vector of this multivector.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes device to host if device data is more recent (checked via need_sync_host())
   Teuchos::ArrayRCP<Scalar> getDataNonConst(size_t j);
 
   /// \brief Fill the given array with a copy of this multivector's
@@ -1376,6 +1425,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///   matrix with column-major storage.
   ///
   /// \param LDA [in] Leading dimension of the matrix A.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes device to host if device data is more recent (checked via need_sync_host())
   void
   get1dCopy(const Teuchos::ArrayView<Scalar>& A,
             const size_t LDA) const;
@@ -1386,6 +1438,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// \param ArrayOfPtrs [out] Array of arrays, one for each column
   ///   of the multivector.  On output, we fill ArrayOfPtrs[j] with
   ///   the data for column j of this multivector.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes device to host if device data is more recent (checked via need_sync_host())
   void
   get2dCopy(const Teuchos::ArrayView<const Teuchos::ArrayView<Scalar>>& ArrayOfPtrs) const;
 
@@ -1394,9 +1449,13 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// This method assumes that the columns of the multivector are
   /// stored contiguously.  If not, this method throws
   /// std::runtime_error.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes device to host if device data is more recent (checked via need_sync_host())
   Teuchos::ArrayRCP<const Scalar> get1dView() const;
 
   //! Return const persisting pointers to values.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes device to host if device data is more recent (checked via need_sync_host())
   Teuchos::ArrayRCP<Teuchos::ArrayRCP<const Scalar>> get2dView() const;
 
   /// \brief Nonconst persisting (1-D) view of this multivector's local values.
@@ -1404,51 +1463,82 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// This method assumes that the columns of the multivector are
   /// stored contiguously.  If not, this method throws
   /// std::runtime_error.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes device to host if device data is more recent (checked via need_sync_host())
   Teuchos::ArrayRCP<Scalar> get1dViewNonConst();
 
   //! Return non-const persisting pointers to values.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes device to host if device data is more recent (checked via need_sync_host())
   Teuchos::ArrayRCP<Teuchos::ArrayRCP<Scalar>> get2dViewNonConst();
 
   /// \brief Return a read-only, up-to-date view of this MultiVector's local data on host.
   /// This requires that there are no live device-space views.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes device to host if device data is more recent (checked via need_sync_host())
   typename dual_view_type::t_host::const_type getLocalViewHost(Access::ReadOnlyStruct) const;
 
   /// \brief Return a mutable, up-to-date view of this MultiVector's local data on host.
   /// This requires that there are no live device-space views.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes device to host if device data is more recent (checked via need_sync_host())
   typename dual_view_type::t_host getLocalViewHost(Access::ReadWriteStruct);
 
   /// \brief Return a mutable view of this MultiVector's local data on host, assuming all existing data will be overwritten.
   /// This requires that there are no live device-space views.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes device to host if device data is more recent (checked via need_sync_host())
   typename dual_view_type::t_host getLocalViewHost(Access::OverwriteAllStruct);
 
   /// \brief Return a read-only, up-to-date view of this MultiVector's local data on device.
   /// This requires that there are no live host-space views.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes host to device if host data is more recent (checked via need_sync_device())
   typename dual_view_type::t_dev::const_type getLocalViewDevice(Access::ReadOnlyStruct) const;
 
   /// \brief Return a mutable, up-to-date view of this MultiVector's local data on device.
   /// This requires that there are no live host-space views.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes host to device if host data is more recent (checked via need_sync_device())
   typename dual_view_type::t_dev getLocalViewDevice(Access::ReadWriteStruct);
 
   /// \brief Return a mutable view of this MultiVector's local data on device, assuming all existing data will be overwritten.
   /// This requires that there are no live host-space views.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes host to device if host data is more recent (checked via need_sync_device())
   typename dual_view_type::t_dev getLocalViewDevice(Access::OverwriteAllStruct);
 
   /// \brief Return the wrapped dual view holding this MultiVector's local data.
   ///
   /// \warning This method is ONLY for use by experts. We highly recommend accessing the local data
   /// by using the member functions getLocalViewHost and getLocalViewDevice.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   wrapped_dual_view_type getWrappedDualView() const;
 
   //! Whether this MultiVector needs synchronization to the given space.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: never
   template <class TargetDeviceType>
   bool need_sync() const {
     return view_.getDualView().template need_sync<TargetDeviceType>();
   }
 
   //! Whether this MultiVector needs synchronization to the host.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: never
   bool need_sync_host() const;
 
   //! Whether this MultiVector needs synchronization to the device.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: never
   bool need_sync_device() const;
 
   /// \brief Return a view of the local data on a specific device, with the given access mode.
@@ -1479,18 +1569,24 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// typedef typename dual_view_type::t_host host_view_type;
   /// host_view_type hostView = DV.getLocalView<host_execution_space> (Access::ReadWrite);
   /// \endcode
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   template <class TargetDeviceType>
   typename std::remove_reference<decltype(std::declval<dual_view_type>().template view<TargetDeviceType>())>::type::const_type
   getLocalView(Access::ReadOnlyStruct s) const {
     return view_.template getView<TargetDeviceType>(s);
   }
 
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   template <class TargetDeviceType>
   typename std::remove_reference<decltype(std::declval<dual_view_type>().template view<TargetDeviceType>())>::type
   getLocalView(Access::ReadWriteStruct s) {
     return view_.template getView<TargetDeviceType>(s);
   }
 
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   template <class TargetDeviceType>
   typename std::remove_reference<decltype(std::declval<dual_view_type>().template view<TargetDeviceType>())>::type
   getLocalView(Access::OverwriteAllStruct s) {
@@ -1514,6 +1610,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// \pre \c dots has at least as many entries as the number of columns in A.
   ///
   /// \post <tt>dots[j] == (this->getVector[j])->dot (* (A.getVector[j]))</tt>
+  ///
+  /// \brief MPI synchronization: always - uses MPI_Allreduce for global dot product computation
+  /// \brief Kokkos synchronization: sometimes - may use Kokkos::fence() when device data needs synchronization
   void
   dot(const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A,
       const Teuchos::ArrayView<dot_type>& dots) const;
@@ -1621,9 +1720,13 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   }
 
   //! Put element-wise absolute values of input Multi-vector in target: A = abs(this)
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   void abs(const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A);
 
   //! Put element-wise reciprocal values of input Multi-vector in target, this(i,j) = 1/A(i,j).
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   void reciprocal(const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A);
 
   /// \brief Scale in place: <tt>this = alpha*this</tt>.
@@ -1633,6 +1736,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// means, for example, that if \c *this contains NaN entries
   /// before calling this method, the NaN entries will remain after
   /// this method finishes.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   void scale(const Scalar& alpha);
 
   /// \brief Scale each column in place: <tt>this[j] = alpha[j]*this[j]</tt>.
@@ -1643,6 +1749,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// the entries of alpha are zero.  That means, for example, that
   /// if \c *this contains NaN entries before calling this method,
   /// the NaN entries will remain after this method finishes.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   void scale(const Teuchos::ArrayView<const Scalar>& alpha);
 
   /// \brief Scale each column in place: <tt>this[j] = alpha[j]*this[j]</tt>.
@@ -1653,6 +1762,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// the entries of alpha are zero.  That means, for example, that
   /// if \c *this contains NaN entries before calling this method,
   /// the NaN entries will remain after this method finishes.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   void scale(const Kokkos::View<const impl_scalar_type*, device_type>& alpha);
 
   /// \brief Scale in place: <tt>this = alpha * A</tt>.
@@ -1663,6 +1775,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// this method, the NaN entries will remain after this method
   /// finishes.  It is legal for the input A to alias this
   /// MultiVector.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   void
   scale(const Scalar& alpha,
         const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A);
@@ -1673,6 +1788,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// zero, overwrite \c *this unconditionally, even if it contains
   /// NaN entries.  It is legal for the input A to alias this
   /// MultiVector.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   void
   update(const Scalar& alpha,
          const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A,
@@ -1684,6 +1802,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// gamma is zero, overwrite \c *this unconditionally, even if it
   /// contains NaN entries.  It is legal for the inputs A or B to
   /// alias this MultiVector.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   void
   update(const Scalar& alpha,
          const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A,
@@ -1702,6 +1823,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// The one-norm of a vector is the sum of the magnitudes of the
   /// vector's entries.  On exit, norms(j) is the one-norm of column
   /// j of this MultiVector.
+  ///
+  /// \brief MPI synchronization: always - uses MPI_Allreduce for global norm computation
+  /// \brief Kokkos synchronization: sometimes - may use Kokkos::fence() when device data needs synchronization
   void
   norm1(const Kokkos::View<mag_type*, Kokkos::HostSpace>& norms) const;
 
@@ -1753,6 +1877,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// \brief Compute the one-norm of each vector (column).
   ///
   /// See the uppermost norm1() method above for documentation.
+  ///
+  /// \brief MPI synchronization: always - uses MPI_Allreduce for global norm computation
+  /// \brief Kokkos synchronization: sometimes - may use Kokkos::fence() when device data needs synchronization
   void norm1(const Teuchos::ArrayView<mag_type>& norms) const;
 
   /// \brief Compute the one-norm of each vector (column).
@@ -1794,6 +1921,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// square root of the sum of squares of the magnitudes of the
   /// vector's entries.  On exit, norms(k) is the two-norm of column
   /// k of this MultiVector.
+  ///
+  /// \brief MPI synchronization: always - uses MPI_Allreduce for global norm computation
+  /// \brief Kokkos synchronization: sometimes - may use Kokkos::fence() when device data needs synchronization
   void
   norm2(const Kokkos::View<mag_type*, Kokkos::HostSpace>& norms) const;
 
@@ -1878,6 +2008,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// The infinity-norm of a vector is the maximum of the magnitudes
   /// of the vector's entries.  On exit, norms(j) is the
   /// infinity-norm of column j of this MultiVector.
+  ///
+  /// \brief MPI synchronization: always - uses MPI_Allreduce for global norm computation
+  /// \brief Kokkos synchronization: sometimes - may use Kokkos::fence() when device data needs synchronization
   void normInf(const Kokkos::View<mag_type*, Kokkos::HostSpace>& norms) const;
 
   template <class ViewType>
@@ -1927,6 +2060,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///   storing the result in a Teuchos::ArrayView.
   ///
   /// See the uppermost normInf() method above for documentation.
+  ///
+  /// \brief MPI synchronization: always - uses MPI_Allreduce for global norm computation
+  /// \brief Kokkos synchronization: sometimes - may use Kokkos::fence() when device data needs synchronization
   void normInf(const Teuchos::ArrayView<mag_type>& norms) const;
 
   /// \brief Compute the infinity-norm of each vector (column),
@@ -1961,6 +2097,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///
   /// The outcome of this routine is undefined for non-floating
   /// point scalar types (e.g., int).
+  ///
+  /// \brief MPI synchronization: always - uses MPI reduce operations for global mean computation
+  /// \brief Kokkos synchronization: sometimes - may use Kokkos::fence() when device data needs synchronization
   void meanValue(const Teuchos::ArrayView<impl_scalar_type>& means) const;
 
   template <typename T>
@@ -1981,6 +2120,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// If beta is zero, overwrite \c *this unconditionally, even if
   /// it contains NaN entries.  This imitates the semantics of
   /// analogous BLAS routines like DGEMM.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   void
   multiply(Teuchos::ETransp transA,
            Teuchos::ETransp transB,
@@ -2009,6 +2151,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// or a Map with a local communicator (<tt>MPI_COMM_SELF</tt>).
   /// This case may occur in block relaxation algorithms when
   /// applying a diagonal scaling.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   void
   elementWiseMultiply(Scalar scalarAB,
                       const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A,
@@ -2019,12 +2164,18 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   //@{
 
   //! Number of columns in the multivector.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: never
   size_t getNumVectors() const;
 
   //! Local number of rows on the calling process.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: never
   size_t getLocalLength() const;
 
   //! Global number of rows in the multivector.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: never
   global_size_t getGlobalLength() const;
 
   /// \brief Stride between columns in the multivector.
@@ -2032,16 +2183,22 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   /// This is only meaningful if \c isConstantStride() returns true.
   ///
   /// \warning This may be different on different processes.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: never
   size_t getStride() const;
 
   /// \brief Whether this multivector has constant stride between columns.
   ///
   /// \warning This may be different on different processes.
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: never
   bool isConstantStride() const;
 
   /// \brief Whether this multivector's memory might alias other. This is conservative: if either this or other
   ///     is not constant stride, then it simply checks whether the contiguous memory allocations overlap. It
   ///     doesn't check whether the sets of columns overlap. This is a symmetric relation: X.aliases(Y) == Y.aliases(X).
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: never
   bool aliases(const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& other) const;
 
   //@}
@@ -2050,6 +2207,8 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   //@{
 
   //! A simple one-line description of this object.
+  /// \brief MPI synchronization: sometimes - may require collective operations at higher verbosity levels
+  /// \brief Kokkos synchronization: never
   virtual std::string description() const override;
 
   /// \brief Print the object with the given verbosity level to a FancyOStream.
@@ -2080,6 +2239,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///   part of the multivector.  This will print out as many rows
   ///   of data as the global number of rows in the multivector, so
   ///   beware.
+  ///
+  /// \brief MPI synchronization: sometimes - may require collective operations at higher verbosity levels
+  /// \brief Kokkos synchronization: never
   virtual void
   describe(Teuchos::FancyOStream& out,
            const Teuchos::EVerbosityLevel verbLevel =
@@ -2099,6 +2261,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///   the removeEmptyProcesses() method on the row Map.  If it
   ///   is not, this method's behavior is undefined.  This pointer
   ///   will be null on excluded processes.
+  ///
+  /// \brief MPI synchronization: always - collective operation that changes the communicator
+  /// \brief Kokkos synchronization: never
   virtual void
   removeEmptyProcessesInPlace(const Teuchos::RCP<const map_type>& newMap) override;
 
@@ -2112,6 +2277,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///
   /// \warning This method is only for expert use.  It may change or
   ///   disappear at any time.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: never
   void setCopyOrView(const Teuchos::DataAccess copyOrView) {
     TEUCHOS_TEST_FOR_EXCEPTION(
         copyOrView == Teuchos::Copy, std::invalid_argument,
@@ -2129,6 +2297,9 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///
   /// \warning This method is only for expert use.  It may change or
   ///   disappear at any time.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: never
   Teuchos::DataAccess getCopyOrView() const {
     return Teuchos::View;
   }
@@ -2147,11 +2318,17 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///   or otherwise change its dimensions.  This is <i>not</i> an
   ///   assignment operator; it does not change anything in \c *this
   ///   other than the contents of storage.
+  ///
+  /// \brief MPI synchronization: sometimes - may perform Map compatibility checks in debug mode which require collective operations
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   void
   assign(const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& src);
 
   /// \brief Return another MultiVector with the same entries, but
   ///   converted to a different Scalar type \c T.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - may synchronize device to host or host to device depending on which memory space contains the most recent data
   template <class T>
   Teuchos::RCP<MultiVector<T, LocalOrdinal, GlobalOrdinal, Node>>
   convert() const;
@@ -2164,6 +2341,8 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   ///
   /// \post Any outstanding views of \c src or \c *this remain valid.
   ///
+  /// \brief MPI synchronization: sometimes - may perform Map compatibility checks in debug mode which require collective operations
+  /// \brief Kokkos synchronization: never
   bool isSameSize(const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& vec) const;
 
  private:
@@ -2386,6 +2565,8 @@ class MultiVector : public DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node>
                          const CombineMode CM               = INSERT) override;
 
  public:
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: never
   bool importsAreAliased();
 
  protected:

--- a/packages/tpetra/core/src/Tpetra_Vector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Vector_decl.hpp
@@ -239,6 +239,8 @@ class Vector : public MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> {
   //! Replace current value at the specified location with specified value.
   /** \pre \c globalRow must be a valid global element on this node, according to the row map.
    */
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   void replaceGlobalValue(const GlobalOrdinal globalRow, const Scalar& value);
 
   /// \brief Add value to existing value, using global (row) index.
@@ -260,6 +262,9 @@ class Vector : public MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> {
   /// \param atomic [in] Whether to use an atomic update.  If this
   ///   class' execution space is not Kokkos::Serial, then this is
   ///   true by default, else it is false by default.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   void
   sumIntoGlobalValue(const GlobalOrdinal globalRow,
                      const Scalar& value,
@@ -268,6 +273,8 @@ class Vector : public MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> {
   //! Replace current value at the specified location with specified values.
   /** \pre \c localRow must be a valid local element on this node, according to the row map.
    */
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   void replaceLocalValue(const LocalOrdinal myRow, const Scalar& value);
 
   /// \brief Add \c value to existing value, using local (row) index.
@@ -287,6 +294,9 @@ class Vector : public MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> {
   /// \param atomic [in] Whether to use an atomic update.  If this
   ///   class' execution space is not Kokkos::Serial, then this is
   ///   true by default, else it is false by default.
+  ///
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - calls sync_host() to ensure host data is up-to-date before modification, then modify_host() to mark host data as modified
   void
   sumIntoLocalValue(const LocalOrdinal myRow,
                     const Scalar& value,
@@ -299,6 +309,8 @@ class Vector : public MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> {
 
   using MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get1dCopy;  // overloading, not hiding
   //! Return multi-vector values in user-provided two-dimensional array (using Teuchos memory management classes).
+  /// \brief MPI synchronization: never
+  /// \brief Kokkos synchronization: sometimes - synchronizes device to host if device data is more recent (checked via need_sync_host())
   void get1dCopy(const Teuchos::ArrayView<Scalar>& A) const;
 
   using MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getDataNonConst;  // overloading, not hiding


### PR DESCRIPTION
Issue: n/a
Tests: docs only
Stakeholder feedback: @cgcgcg