### PR TITLE
Teuchos: Fix portable assertion for NonPrintableTypeException in ParameterList unit test

### DIFF
--- a/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
+++ b/packages/teuchos/parameterlist/test/ParameterList/ParameterList_UnitTests.cpp
@@ -12,6 +12,7 @@
 #include "Teuchos_as.hpp"
 #include "Teuchos_StandardParameterEntryValidators.hpp"
 #include "Teuchos_ParameterListModifier.hpp"
+#include "Teuchos_TypeNameTraits.hpp"
 #include "Teuchos_UnitTestHarness.hpp"
 
 
@@ -1253,9 +1254,10 @@ TEUCHOS_UNIT_TEST( ParameterList, NonPrintableParameterEntries){
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "If you get here then the test failed!");
     }
     catch (const NonprintableTypeException &except) {
-      std::string actualMessage = except.what();
-      std::string expectedMessage = "Trying to print type std::vector<int, std::allocator<int> > "
-                                    "which is not printable (i.e. does not have operator<<() defined)!";
+      const std::string actualMessage = except.what();
+      const std::string typeName = Teuchos::demangleName(typeid(std::vector<int>).name());
+      const std::string expectedMessage = "Trying to print type " + typeName +
+        " which is not printable (i.e. does not have operator<<() defined)!";
       TEST_ASSERT(actualMessage.find(expectedMessage) != std::string::npos);
     }
   }
@@ -1270,10 +1272,10 @@ TEUCHOS_UNIT_TEST( ParameterList, NonPrintableParameterEntries){
       TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "If you get here then the test failed!" );
     }
     catch (const NonprintableTypeException &except) {
-      std::string actualMessage = except.what();
-      std::string expectedMessage =
-              "Trying to print type Teuchos::(anonymous namespace)::Shape which is not printable "
-              "(i.e. does not have operator<<() defined)!";
+      const std::string actualMessage = except.what();
+      const std::string typeName = Teuchos::demangleName(typeid(Shape).name());
+      const std::string expectedMessage = "Trying to print type " + typeName +
+        " which is not printable (i.e. does not have operator<<() defined)!";
       TEST_ASSERT(actualMessage.find(expectedMessage) != std::string::npos);
     }
   }


### PR DESCRIPTION
@trilinos/teuchos

## Motivation

`typeid(T).name()` / `Teuchos::demangleName` are implementation-defined across compilers. The test compared against strings shaped like one toolchain’s output, so MSVC produced a different exception text for the same failure and the assertions failed even though behavior was correct.

Align expectations with the same name pipeline used when throwing `NonprintableTypeException`, so the test validates intent (non-printable type reported) without encoding a single compiler’s spelling of the type.

## Related Issues

- the problem that started it all: #14816 (there is no core issue in [Trilinos issues](https://github.com/trilinos/Trilinos/issues), but the main aim is to completely build and test all the Trilinos without any problems)
- failed test from: #15249

## Environment

| Item       | Value                                   |
| ---------- | --------------------------------------- |
| OS         | Windows 11 Pro x64, Build 26100             |
| CPU        | Intel Core i9-12900H (20 logical cores) |
| CMake      | 3.31.2                                  |
| MSVC  | 19.44.35211 (VS 2022 Community)          |
|clang-cl|21.1.5;x86_64-pc-windows-msvc;thread-model:posix|
| Ninja      | 1.12.1                                  |
| Build type | Release, shared libs, C++20             |

**This build**: MSVC+Ninja+Serial backend

## Testing

- help compilation script: [build.ps1.txt](https://github.com/user-attachments/files/27775737/build.ps1.txt)
- commands to reproduce:

```cmd
powershell -ExecutionPolicy ByPass -File .\build.ps1
set "PATH=D:\Develop\Trilinos\btserial\lib;%PATH%"
cmd /c "cd .\btserial && ctest -V --output-on-failure"
```

### Before

```log
96% tests passed, 4 tests failed out of 114

Subproject Time Summary:
Teuchos    =   7.95 sec*proc (114 tests)

Total Test time (real) =   8.45 sec

The following tests FAILED:
	 54 - TeuchosParameterList_ParameterList_UnitTests (Failed) Teuchos
	 79 - TeuchosParameterList_YamlParser_test (Failed)     Teuchos
	 91 - TeuchosComm_ParameterList_UnitTest_Parallel (Failed) Teuchos
	 92 - TeuchosComm_ParameterList_UnitTest_Parallel_one (Failed) Teuchos
```

### After

```log
97% tests passed, 3 tests failed out of 114

Subproject Time Summary:
Teuchos    =   8.83 sec*proc (114 tests)

Total Test time (real) =   9.46 sec

The following tests FAILED:
         79 - TeuchosParameterList_YamlParser_test (Failed)     Teuchos
         91 - TeuchosComm_ParameterList_UnitTest_Parallel (Failed) Teuchos
         92 - TeuchosComm_ParameterList_UnitTest_Parallel_one (Failed) Teuchos
Errors while running CTest
```

### Details

Full log of ctest: [ctest-output-msvc2022-ninja-serial.broken.full.log](https://github.com/user-attachments/files/27775577/ctest-output-msvc2022-ninja-serial.broken.full.log)
Details about failing `TeuchosParameterList_ParameterList_UnitTests`: [ctest-output-msvc2022-ninja-serial.broken-TeuchosParameterList_ParameterList_UnitTests.fixed.log](https://github.com/user-attachments/files/27775669/ctest-output-msvc2022-ninja-serial.broken-TeuchosParameterList_ParameterList_UnitTests.fixed.log)
Full ctest fixed `TeuchosParameterList_ParameterList_UnitTests` log: [ctest-output-msvc2022-ninja-serial.broken-TeuchosParameterList_ParameterList_UnitTests.fixed.log](https://github.com/user-attachments/files/27775704/ctest-output-msvc2022-ninja-serial.broken-TeuchosParameterList_ParameterList_UnitTests.fixed.log)