### PR TITLE
Teuchos: ParameterList XMLParser support CRLF {Serial}

### DIFF
--- a/packages/teuchos/parameterlist/src/Teuchos_XMLParser.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_XMLParser.cpp
@@ -377,6 +377,12 @@ void XMLParser::getSTag(unsigned char lookahead, std::string &tag, Teuchos::map<
           getReference(refstr);
           attval += refstr;
         }
+        else if ( c == '\r' ) {
+          // \link https://www.w3.org/TR/xml/#sec-line-ends
+          // XML spec p2.11: normalize \r\n and standalone \r to \n.
+          // Skip \r here; the \n that follows (in \r\n) will be appended normally,
+          // and a standalone \r at end-of-line is not encountered in well-formed XML.
+        }
         else if ( c!='<' ) {
           // valid character for attval
           attval.push_back(c);


### PR DESCRIPTION
@trilinos/teuchos

## Motivation

This patch fixes failing in `TeuchosParameterList_YamlParser_test`, `TeuchosComm_ParameterList_UnitTest_Parallel` and `TeuchosComm_ParameterList_UnitTest_Parallel_one` for Windows x64.

`FileInputStream` opens XML files with `fopen(..., "rb")` (binary mode), preserving `\r\n` in multiline attribute values on Windows CRLF checkouts. `YAML::Reader::read_file` uses `std::ifstream` (text mode), normalizing `\r\n` to `\n`. This caused `haveSameValues()` to return `false` for `meshInput` in `YAML_XmlEquivalence_UnitTest` (Match4.xml).

## Related Issues

- the problem that started it all: #14816 (there is no core issue in [Trilinos issues](https://github.com/trilinos/Trilinos/issues), but the main aim is to completely build and test all the Trilinos without any problems)

> **NOTE**: Changes in this PR includes changes from [[PR-3071](https://github.com/kokkos/kokkos-kernels/pull/3071); [PR-3072](https://github.com/kokkos/kokkos-kernels/pull/3072) #15245, #15248; #15249; #15267] - it is the reason why there is no failed tests.

```ps1
git status
  On branch windows/teuchos-parameterlist-xmlparser-support-crlf
  Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   packages/kokkos-kernels/blas/impl/KokkosBlas1_iamax_spec.hpp
	modified:   packages/kokkos-kernels/sparse/unit_test/Test_Sparse_gauss_seidel.hpp
	modified:   packages/teuchos/core/src/Teuchos_any.hpp
	modified:   packages/teuchos/core/test/MemoryManagement/RCP_test.cpp
	modified:   packages/teuchos/core/test/UnitTest/CMakeLists.txt
	modified:   packages/teuchos/parameterlist/src/Teuchos_XMLParser.cpp
	modified:   packages/teuchos/parser/src/Teuchos_FiniteAutomaton.cpp
	modified:   packages/teuchos/parser/src/Teuchos_FiniteAutomaton.hpp

no changes added to commit (use "git add" and/or "git commit -a")
```

## Environment

| Item       | Value                                   |
| ---------- | --------------------------------------- |
| OS         | Windows 11 Pro x64, Build 26100             |
| CPU        | Intel Core i9-12900H (20 logical cores) |
| CMake      | 3.31.2                                  |
| MSVC  | 19.44.35211 (VS 2022 Community)          |
|clang-cl|21.1.5;x86_64-pc-windows-msvc;thread-model:posix|
| Ninja      | 1.12.1                                  |
| Build type | RelWithDebInfo, shared libs, C++20             |

**This build**: MSVC+Ninja

## Testing

- help compilation script: [build.ps1.txt](https://github.com/user-attachments/files/27775737/build.ps1.txt)
- commands to reproduce:

Open `x64 Native Tools Command Prompt for VS 2022` and type:

```cmd
powershell -ExecutionPolicy ByPass -File .\build.ps1
... <configuring>
... <compiling  >
```

Open any convenient Powershell, and enter the following commands:

```ps1
$savedPath = $env:PATH
$env:PATH   = "D:\Develop\Trilinos\btserial\lib;$env:PATH"

try {
    Push-Location "D:\Develop\Trilinos\btserial"
    & ctest -V --output-on-failure
}
finally {
    Pop-Location
    $env:PATH = $savedPath
}
```

If we need to re-compile and update libs, do this in `x64 Native Tools Command Prompt for VS 2022`:

```cmd
powershell -ExecutionPolicy ByPass -File .\build.ps1 --update-libs
```

OR in powershell:

```ps1
.\build.ps1 -UpdateLibs
```

### Before

```log
96% tests passed, 4 tests failed out of 114

Subproject Time Summary:
Teuchos    =   7.25 sec*proc (114 tests)

Total Test time (real) =   7.65 sec

The following tests FAILED:
	 54 - TeuchosParameterList_ParameterList_UnitTests (Failed) Teuchos
	 79 - TeuchosParameterList_YamlParser_test (Failed)     Teuchos
	 91 - TeuchosComm_ParameterList_UnitTest_Parallel (Failed) Teuchos
	 92 - TeuchosComm_ParameterList_UnitTest_Parallel_one (Failed) Teuchos
```

### After

```log
100% tests passed, 0 tests failed out of 114

Subproject Time Summary:
Teuchos    =   5.55 sec*proc (114 tests)
```

### Details

- full log with failings: [ctest-output-msvc2022-ninja-serial.full.log](https://github.com/user-attachments/files/27812616/ctest-output-msvc2022-ninja-serial.full.log)
- full log with fixed code: [ctest-output-msvc2022-ninja-serial.full.fixed.log](https://github.com/user-attachments/files/27812734/ctest-output-msvc2022-ninja-serial.full.fixed.log)
- details about failing `TeuchosParameterList_YamlParser_test`: [ctest-output-TeuchosParameterList_YamlParser_test.broken.log](https://github.com/user-attachments/files/27812708/ctest-output-TeuchosParameterList_YamlParser_test.broken.log)
- details about fixed `TeuchosParameterList_YamlParser_test`: [ctest-output-TeuchosParameterList_YamlParser_test.fixed.log](https://github.com/user-attachments/files/27812699/ctest-output-TeuchosParameterList_YamlParser_test.fixed.log)

## Question

- Is it possible to mention source links in comments?
