### PR TITLE
Intrepid2: implement parametric distance and support shell elements

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellData.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellData.hpp
@@ -139,7 +139,7 @@ private:
 
   //! static views containing the parametrization maps, allocated on DeviceType::memory_space
   using ViewType = Kokkos::DynRankView<double,DeviceType>;
-  static ViewType lineEdgesParam;  // edge maps for 2d non-standard cells; shell line and beam
+  static ViewType beamEdgeParam, shellLineEdgesParam;  // edge maps for 2d non-standard cells; shell line and beam
   static ViewType triEdgesParam, quadEdgesParam; // edge maps for 2d standard cells
   static ViewType shellTriEdgesParam, shellQuadEdgesParam; // edge maps for 3d non-standard cells; shell tri and quad
   static ViewType tetEdgesParam, hexEdgesParam, pyrEdgesParam, wedgeEdgesParam; // edge maps for 3d standard cells
@@ -318,99 +318,167 @@ private:
 
 //============================================================================================//
 //                                                                                            //
-//                                       PointInclusion                                       //
+//                                       ParametricDistance                                   //
 //                                                                                            //
 //============================================================================================//
 
 
+/** \class  Intrepid2::ParametricDistance
+    \brief  This class implements a <var>distance</var> function that computes the parametric distance of a point in a reference cell.
+     A parametric distance is a continuous piecewise linear function that it is
+    (a) 0 at the centroid of the reference cell
+    (b) less than 1 for points inside the cell
+    (c) 1 on the cell boundary
+    (d) greater than 1 for points outside the cell
+  
+    The parametric distance is defined as the maximum of the linear functions associated with each cell side, where each function evaluates to 0.0 at the centroid and 1.0 on its respective side.
+
+    The function distance can be used to determine whether a point is inside or outside an element.
+ */
+
+template<unsigned CellTopologyKey>
+struct ParametricDistance;
+
+
 /** \class  Intrepid2::PointInclusion
-    \brief  This class implements a <var>check</var> function that determines whether a given point is 
+    \brief  This [deprecated] class implements a <var>check</var> function that determines whether a given point is 
             inside or outside the reference cell for a specific topology.
             The class has a template argument for the key of the shards topology
  */
 
 template<unsigned CellTopologyKey>
-  struct PointInclusion;
+struct [[deprecated("Deprecated, use ParametricDistance.")]] PointInclusion {
   
-  /** 
-   \brief Line topology
-  */
-  template<>
-  struct PointInclusion<shards::Line<>::key> {
-    template<typename PointViewType, typename ScalarType>
-    KOKKOS_INLINE_FUNCTION
-    static bool
-    check(const PointViewType &point, const ScalarType threshold);   
-  };
+  template<typename PointViewType, typename ScalarType>
+  KOKKOS_INLINE_FUNCTION
+  static bool
+  check(const PointViewType &point, const ScalarType threshold){
+    return ParametricDistance<CellTopologyKey>::distance(point) <= 1.0 + threshold;
+  } 
+};
+
+/** 
+ \brief Line topology
+*/
+template<>
+struct ParametricDistance<shards::Line<>::key> {    
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  static typename ScalarTraits<typename PointViewType::value_type>::scalar_type
+  distance(const PointViewType &point); 
+};
+
+/** 
+ \brief Beam topology
+*/
+template<>
+struct ParametricDistance<shards::Beam<>::key> {    
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  static typename ScalarTraits<typename PointViewType::value_type>::scalar_type
+  distance(const PointViewType &point); 
+};
+
+/** 
+ \brief ShellLine topology
+*/
+template<>
+struct ParametricDistance<shards::ShellLine<>::key> {    
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  static typename ScalarTraits<typename PointViewType::value_type>::scalar_type
+  distance(const PointViewType &point); 
+};
+
+/** 
+ \brief Triangle topology
+*/
+template<>
+struct ParametricDistance<shards::Triangle<>::key> {
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  static typename ScalarTraits<typename PointViewType::value_type>::scalar_type
+  distance(const PointViewType &point); 
+};
+
+/** 
+ \brief ShellTriangle topology
+*/
+template<>
+struct ParametricDistance<shards::ShellTriangle<>::key> {    
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  static typename ScalarTraits<typename PointViewType::value_type>::scalar_type
+  distance(const PointViewType &point); 
+};
+
+/** 
+ \brief Quadrilateral topology
+*/
+template<>
+struct ParametricDistance<shards::Quadrilateral<>::key> {
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  static typename ScalarTraits<typename PointViewType::value_type>::scalar_type
+  distance(const PointViewType &point); 
+};
+
+/** 
+ \brief ShellQuadrilateral topology
+*/
+template<>
+struct ParametricDistance<shards::ShellQuadrilateral<>::key> {    
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  static typename ScalarTraits<typename PointViewType::value_type>::scalar_type
+  distance(const PointViewType &point); 
+};
   
-  /** 
-   \brief Triangle topology
-  */
-  template<>
-  struct PointInclusion<shards::Triangle<>::key> {
-    template<typename PointViewType, typename ScalarType>
-    KOKKOS_INLINE_FUNCTION
-    static bool
-    check(const PointViewType &point, const ScalarType threshold);
-  };
-  
-  /** 
-   \brief Quadrilateral topology
-  */
-  template<>
-  struct PointInclusion<shards::Quadrilateral<>::key> {
+/** 
+ \brief Tetrahedron topology
+*/
+template<>
+struct ParametricDistance<shards::Tetrahedron<>::key> {
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  static typename ScalarTraits<typename PointViewType::value_type>::scalar_type
+  distance(const PointViewType &point); 
+};
 
-    template<typename PointViewType, typename ScalarType>
-    KOKKOS_INLINE_FUNCTION
-    static bool
-    check(const PointViewType &point, const ScalarType threshold);
-  };
-    
-  /** 
-   \brief Tetrahedron topology
-  */
-  template<>
-  struct PointInclusion<shards::Tetrahedron<>::key> {
-    template<typename PointViewType, typename ScalarType>
-    KOKKOS_INLINE_FUNCTION
-    static bool
-    check(const PointViewType &point, const ScalarType threshold);
-  };
+/** 
+ \brief Hexahedron topology
+*/
+template<>
+struct ParametricDistance<shards::Hexahedron<>::key> {
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  static typename ScalarTraits<typename PointViewType::value_type>::scalar_type
+  distance(const PointViewType &point); 
+};
 
-  /** 
-   \brief Hexahedron topology
-  */
-  template<>
-  struct PointInclusion<shards::Hexahedron<>::key> {
-    template<typename PointViewType, typename ScalarType>
-    KOKKOS_INLINE_FUNCTION
-    static bool
-    check(const PointViewType &point, const ScalarType threshold);
-  };
-  
-  /** 
-   \brief Pyramid topology
-  */
-  template<>
-  struct PointInclusion<shards::Pyramid<>::key> {
-    template<typename PointViewType, typename ScalarType>
-    KOKKOS_INLINE_FUNCTION
-    static bool
-    check(const PointViewType &point, const ScalarType threshold);
-  };
+/** 
+ \brief Pyramid topology
+*/
+template<>
+struct ParametricDistance<shards::Pyramid<>::key> {
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  static typename ScalarTraits<typename PointViewType::value_type>::scalar_type
+  distance(const PointViewType &point); 
+};
 
-  /** 
-   \brief Wedge topology
-  */
-  template<>
-  struct PointInclusion<shards::Wedge<>::key> {
-    template<typename PointViewType, typename ScalarType>
-    KOKKOS_INLINE_FUNCTION
-    static bool
-    check(const PointViewType &point, const ScalarType threshold);
-  };
+/** 
+ \brief Wedge topology
+*/
+template<>
+struct ParametricDistance<shards::Wedge<>::key> {
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  static typename ScalarTraits<typename PointViewType::value_type>::scalar_type
+  distance(const PointViewType &point); 
+};
 
-  const CellTopologyData* getCellTopologyData(const unsigned& cellTopologyKey);
+const CellTopologyData* getCellTopologyData(const unsigned& cellTopologyKey);
   
 }
 

--- a/packages/intrepid2/src/Cell/Intrepid2_CellDataDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellDataDef.hpp
@@ -33,7 +33,7 @@ isSupported( const unsigned cellTopoKey ) {
   case shards::Beam<2>::key:
   case shards::Beam<3>::key:
   case shards::Triangle<3>::key:
-  case shards::Triangle<4>::key:
+  //case shards::Triangle<4>::key:
   case shards::Triangle<6>::key:
   case shards::ShellTriangle<3>::key:
   case shards::ShellTriangle<6>::key:
@@ -44,7 +44,7 @@ isSupported( const unsigned cellTopoKey ) {
   case shards::ShellQuadrilateral<8>::key:
   case shards::ShellQuadrilateral<9>::key:
   case shards::Tetrahedron<4>::key:
-  case shards::Tetrahedron<8>::key:
+  //case shards::Tetrahedron<8>::key:
   case shards::Tetrahedron<10>::key:
   case shards::Tetrahedron<11>::key:
   case shards::Hexahedron<8>::key:
@@ -52,7 +52,7 @@ isSupported( const unsigned cellTopoKey ) {
   case shards::Hexahedron<27>::key:
   case shards::Pyramid<5>::key:
   case shards::Pyramid<13>::key:
-  case shards::Pyramid<14>::key:
+  //case shards::Pyramid<14>::key:
   case shards::Wedge<6>::key:
   case shards::Wedge<15>::key:
   case shards::Wedge<18>::key:

--- a/packages/intrepid2/src/Cell/Intrepid2_CellDataDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellDataDef.hpp
@@ -35,14 +35,14 @@ isSupported( const unsigned cellTopoKey ) {
   case shards::Triangle<3>::key:
   case shards::Triangle<4>::key:
   case shards::Triangle<6>::key:
-  // case shards::ShellTriangle<3>::key:
-  // case shards::ShellTriangle<6>::key:
+  case shards::ShellTriangle<3>::key:
+  case shards::ShellTriangle<6>::key:
   case shards::Quadrilateral<4>::key:
   case shards::Quadrilateral<8>::key:
   case shards::Quadrilateral<9>::key:
-  // case shards::ShellQuadrilateral<4>::key:
-  // case shards::ShellQuadrilateral<8>::key:
-  // case shards::ShellQuadrilateral<9>::key:
+  case shards::ShellQuadrilateral<4>::key:
+  case shards::ShellQuadrilateral<8>::key:
+  case shards::ShellQuadrilateral<9>::key:
   case shards::Tetrahedron<4>::key:
   case shards::Tetrahedron<8>::key:
   case shards::Tetrahedron<10>::key:
@@ -100,17 +100,17 @@ get( const ordinal_type          subcellDim,
   case shards::Quadrilateral<8>::key:
   case shards::Quadrilateral<9>::key:      subcellParam = quadEdgesParam; break;
 
-  // case shards::ShellTriangle<3>::key:
-  // case shards::ShellTriangle<6>::key:      subcellParam = ( subcellDim == 2 ? shellTriFacesParam : shellTriEdgesParam ); break;
+  case shards::ShellTriangle<3>::key:
+  case shards::ShellTriangle<6>::key:      subcellParam = ( subcellDim == 2 ? shellTriFacesParam : shellTriEdgesParam ); break;
 
-  // case shards::ShellQuadrilateral<4>::key:
-  // case shards::ShellQuadrilateral<8>::key:
-  // case shards::ShellQuadrilateral<9>::key: subcellParam = ( subcellDim == 2 ? shellQuadFacesParam : shellQuadEdgesParam ); break;
+  case shards::ShellQuadrilateral<4>::key:
+  case shards::ShellQuadrilateral<8>::key:
+  case shards::ShellQuadrilateral<9>::key: subcellParam = ( subcellDim == 2 ? shellQuadFacesParam : shellQuadEdgesParam ); break;
 
   case shards::ShellLine<2>::key:
-  case shards::ShellLine<3>::key:
+  case shards::ShellLine<3>::key:          subcellParam = shellLineEdgesParam; break;
   case shards::Beam<2>::key:
-  case shards::Beam<3>::key:               subcellParam = lineEdgesParam; break;
+  case shards::Beam<3>::key:               subcellParam = beamEdgeParam; break;
   default: {
     INTREPID2_TEST_FOR_EXCEPTION( true, std::invalid_argument,
         ">>> ERROR (Intrepid2::RefSubcellParametrization::get): invalid cell topology.");
@@ -189,12 +189,27 @@ RefSubcellParametrization<DeviceType>::set() {
   }
   {
     const auto tri = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<3> >());
-
     subcellDim = 1;
     triEdgesParam = ViewType("CellTools::SubcellParametrization::triEdges", tri.getSubcellCount(subcellDim), tri.getDimension(), subcellDim+1);
     auto subcellParamHost = Kokkos::create_mirror_view(triEdgesParam);
     set( subcellParamHost, subcellDim, tri );
     deep_copy(triEdgesParam,subcellParamHost);
+  }
+  {
+    const auto shellTri = shards::CellTopology(shards::getCellTopologyData<shards::ShellTriangle<3> >());
+
+    subcellDim = 2;
+    shellTriFacesParam = ViewType("CellTools::SubcellParametrization::shellTriFaces", shellTri.getSubcellCount(subcellDim), shellTri.getDimension(), subcellDim+1);
+    auto subcell2dParamHost = Kokkos::create_mirror_view(shellTriFacesParam);
+    set( subcell2dParamHost, subcellDim, shellTri );
+    deep_copy(shellTriFacesParam,subcell2dParamHost);
+
+
+    subcellDim = 1;
+    shellTriEdgesParam = ViewType("CellTools::SubcellParametrization::shellTriEdges", shellTri.getSubcellCount(subcellDim), shellTri.getDimension(), subcellDim+1);
+    auto subcellParamHost = Kokkos::create_mirror_view(shellTriEdgesParam);
+    set( subcellParamHost, subcellDim, shellTri );
+    deep_copy(shellTriEdgesParam,subcellParamHost);
   }
   {
     const auto quad = shards::CellTopology(shards::getCellTopologyData<shards::Quadrilateral<4> >());
@@ -207,17 +222,42 @@ RefSubcellParametrization<DeviceType>::set() {
 
   }
   {
-    const auto line = shards::CellTopology(shards::getCellTopologyData<shards::ShellLine<2> >());
+    const auto shellQuad = shards::CellTopology(shards::getCellTopologyData<shards::ShellQuadrilateral<4> >());
+
+    subcellDim = 2;
+    shellQuadFacesParam = ViewType("CellTools::SubcellParametrization::shellQuadFaces", shellQuad.getSubcellCount(subcellDim), shellQuad.getDimension(), subcellDim+1);
+    auto subcell2dParamHost = Kokkos::create_mirror_view(shellQuadFacesParam);
+    set( subcell2dParamHost, subcellDim, shellQuad );
+    deep_copy(shellQuadFacesParam,subcell2dParamHost);
 
     subcellDim = 1;
-    lineEdgesParam = ViewType("CellTools::SubcellParametrization::lineEdges", line.getSubcellCount(subcellDim), line.getDimension(), subcellDim+1);
-    auto subcellParamHost = Kokkos::create_mirror_view(lineEdgesParam);
-    set( subcellParamHost, subcellDim, line );
-    deep_copy(lineEdgesParam,subcellParamHost);
+    shellQuadEdgesParam = ViewType("CellTools::SubcellParametrization::shellQuadEdges", shellQuad.getSubcellCount(subcellDim), shellQuad.getDimension(), subcellDim+1);
+    auto subcellParamHost = Kokkos::create_mirror_view(shellQuadEdgesParam);
+    set( subcellParamHost, subcellDim, shellQuad );
+    deep_copy(shellQuadEdgesParam,subcellParamHost);
+  }
+  {
+    const auto beam = shards::CellTopology(shards::getCellTopologyData<shards::Beam<2> >());
+
+    subcellDim = 1;
+    beamEdgeParam = ViewType("CellTools::SubcellParametrization::beamEdge", beam.getSubcellCount(subcellDim), beam.getDimension(), subcellDim+1);
+    auto subcellParamHost = Kokkos::create_mirror_view(beamEdgeParam);
+    set( subcellParamHost, subcellDim, beam );
+    deep_copy(beamEdgeParam,subcellParamHost);
+  }
+  {
+    const auto shellLine = shards::CellTopology(shards::getCellTopologyData<shards::ShellLine<2> >());
+
+    subcellDim = 1;
+    shellLineEdgesParam = ViewType("CellTools::SubcellParametrization::shellLineEdges", shellLine.getSubcellCount(subcellDim), shellLine.getDimension(), subcellDim+1);
+    auto subcellParamHost = Kokkos::create_mirror_view(shellLineEdgesParam);
+    set( subcellParamHost, subcellDim, shellLine );
+    deep_copy(shellLineEdgesParam,subcellParamHost);
   }
 
   Kokkos::push_finalize_hook( [=] {
-    lineEdgesParam = ViewType();
+    beamEdgeParam = ViewType();
+    shellLineEdgesParam = ViewType();
     triEdgesParam = ViewType();
     quadEdgesParam = ViewType();
     shellTriEdgesParam = ViewType();
@@ -381,7 +421,8 @@ isSubcellParametrizationSet_ = false;
     RefSubcellParametrization<DeviceType>:: \
     obj = typename RefSubcellParametrization<DeviceType>::ViewType();
 
-DefineStaticRefParametrization(lineEdgesParam)
+DefineStaticRefParametrization(beamEdgeParam)
+DefineStaticRefParametrization(shellLineEdgesParam)
 DefineStaticRefParametrization(triEdgesParam)
 DefineStaticRefParametrization(quadEdgesParam)
 DefineStaticRefParametrization(shellTriEdgesParam)
@@ -823,93 +864,122 @@ refCenterDataStatic_ = {
 };
 
 
-// Point Inclusion 
+// ParametricDistance
 
-
-  template<typename PointViewType, typename ScalarType>
+  template<typename PointViewType>
   KOKKOS_INLINE_FUNCTION
-  bool
-  PointInclusion<shards::Line<>::key>::
-  check(const PointViewType &point, const ScalarType threshold) {
-    //this implementation should work when PointType is a Sacado Fad<ScalarType>
-    const ScalarType minus_one = -1.0 - threshold, plus_one = 1.0 + threshold;
-    return (minus_one <= point(0) && point(0) <= plus_one);
-  }  
+  typename ScalarTraits<typename PointViewType::value_type>::scalar_type 
+  ParametricDistance<shards::Line<>::key>::
+  distance(const PointViewType &point) {
+    using scalar_type = typename ScalarTraits<typename PointViewType::value_type>::scalar_type;
+    const scalar_type p0 = get_scalar_value(point(0));
+    return Util<scalar_type>::max(-p0, p0); 
+  }
 
-  template<typename PointViewType, typename ScalarType>
+  template<typename PointViewType>
   KOKKOS_INLINE_FUNCTION
-  bool
-  PointInclusion<shards::Triangle<>::key>::
-  check(const PointViewType &point, const ScalarType threshold) {
-    //this implementation should work when PointType is a Sacado Fad<ScalarType>
-    using PointType = typename PointViewType::value_type; 
-    const PointType one = 1.0;
-    const PointType distance = max( max( -point(0), -point(1) ), point(0) + point(1) - one );
-    return distance < threshold;
+  typename ScalarTraits<typename PointViewType::value_type>::scalar_type 
+  ParametricDistance<shards::Beam<>::key>::
+  distance(const PointViewType &point) {
+    return ParametricDistance<shards::Quadrilateral<>::key>::distance(point);
+  }
+
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  typename ScalarTraits<typename PointViewType::value_type>::scalar_type 
+  ParametricDistance<shards::ShellLine<>::key>::
+  distance(const PointViewType &point) {
+    return ParametricDistance<shards::Quadrilateral<>::key>::distance(point);
+  }
+
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  typename ScalarTraits<typename PointViewType::value_type>::scalar_type 
+  ParametricDistance<shards::Triangle<>::key>::
+  distance(const PointViewType &point) {
+    using scalar_type = typename ScalarTraits<typename PointViewType::value_type>::scalar_type;
+    constexpr scalar_type one(1), two(2), three(3);
+    const scalar_type& p0 = get_scalar_value(point(0));
+    const scalar_type& p1 = get_scalar_value(point(1));
+    return Util<scalar_type>::max(one-three*p0, three*(p0+p1)-two, one-three*p1); 
+  }
+
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  typename ScalarTraits<typename PointViewType::value_type>::scalar_type 
+  ParametricDistance<shards::ShellTriangle<>::key>::
+  distance(const PointViewType &point) {
+    return ParametricDistance<shards::Wedge<>::key>::distance(point);
+  }
+
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  typename ScalarTraits<typename PointViewType::value_type>::scalar_type 
+  ParametricDistance<shards::Quadrilateral<>::key>::
+  distance(const PointViewType &point) {
+    using scalar_type = typename ScalarTraits<typename PointViewType::value_type>::scalar_type;
+    const scalar_type& p0 = get_scalar_value(point(0));
+    const scalar_type& p1 = get_scalar_value(point(1));
+    return Util<scalar_type>::max(-p1, p0, p1, -p0); 
+  }
+
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  typename ScalarTraits<typename PointViewType::value_type>::scalar_type 
+  ParametricDistance<shards::ShellQuadrilateral<>::key>::
+  distance(const PointViewType &point) {
+    return ParametricDistance<shards::Hexahedron<>::key>::distance(point);
+  }
+
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  typename ScalarTraits<typename PointViewType::value_type>::scalar_type 
+  ParametricDistance<shards::Tetrahedron<>::key>::
+  distance(const PointViewType &point) {
+    using scalar_type = typename ScalarTraits<typename PointViewType::value_type>::scalar_type;
+    constexpr scalar_type one(1), three(3), four(4);
+    const scalar_type& p0 = get_scalar_value(point(0));
+    const scalar_type& p1 = get_scalar_value(point(1));
+    const scalar_type& p2 = get_scalar_value(point(2));
+    return Util<scalar_type>::max(one-four*p1, four*(p0+p1+p2)-three, one-four*p0, one-four*p2);
+  }
+
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  typename ScalarTraits<typename PointViewType::value_type>::scalar_type 
+  ParametricDistance<shards::Hexahedron<>::key>::
+  distance(const PointViewType &point) {
+    using scalar_type = typename ScalarTraits<typename PointViewType::value_type>::scalar_type;
+    const scalar_type& p0 = get_scalar_value(point(0));
+    const scalar_type& p1 = get_scalar_value(point(1));
+    const scalar_type& p2 = get_scalar_value(point(2));
+    return Util<scalar_type>::max(-p1, p0, p1, -p0, -p2, p2); 
+  }
+
+  template<typename PointViewType>
+  KOKKOS_INLINE_FUNCTION
+  typename ScalarTraits<typename PointViewType::value_type>::scalar_type 
+  ParametricDistance<shards::Pyramid<>::key>::
+  distance(const PointViewType &point) {
+    using scalar_type = typename ScalarTraits<typename PointViewType::value_type>::scalar_type;
+    constexpr scalar_type one(1), four(4), onethird(1.0/3.0), fourthirds(4.0/3.0);
+    const scalar_type& p0 = get_scalar_value(point(0));
+    const scalar_type& p1 = get_scalar_value(point(1));
+    const scalar_type& p2 = get_scalar_value(point(2));
+    return Util<scalar_type>::max(fourthirds*(p2-p1)-onethird,  fourthirds*(p2+p0)-onethird, fourthirds*(p2+p1)-onethird, fourthirds*(p2-p0)-onethird, one-four*p2);
   }
   
-  template<typename PointViewType, typename ScalarType>
+  template<typename PointViewType>
   KOKKOS_INLINE_FUNCTION
-  bool
-  PointInclusion<shards::Quadrilateral<>::key>::
-  check(const PointViewType &point, const ScalarType threshold) {
-    //this implementation should work when PointType is a Sacado Fad<ScalarType>
-    const ScalarType minus_one = -1.0 - threshold, plus_one = 1.0 + threshold;
-    return ((minus_one <= point(0) && point(0) <= plus_one) &&
-            (minus_one <= point(1) && point(1) <= plus_one));
-  }  
-
-  template<typename PointViewType, typename ScalarType>
-  KOKKOS_INLINE_FUNCTION
-  bool
-  PointInclusion<shards::Tetrahedron<>::key>::
-  check(const PointViewType &point, const ScalarType threshold) {
-    //this implementation should work when PointType is a Sacado Fad<ScalarType>
-    using PointType = typename PointViewType::value_type; 
-    const PointType one = 1.0;
-    const PointType distance = max( max(-point(0),-point(1)),
-                                  max(-point(2), point(0) + point(1) + point(2) - one) );
-    return distance < threshold;
-  }
-
-  template<typename PointViewType, typename ScalarType>
-  KOKKOS_INLINE_FUNCTION
-  bool
-  PointInclusion<shards::Hexahedron<>::key>::
-  check(const PointViewType &point, const ScalarType threshold) {
-    //this implementation should work when PointType is a Sacado Fad<ScalarType>
-    const ScalarType minus_one = -1.0 - threshold, plus_one = 1.0 + threshold;
-    return ((minus_one <= point(0) && point(0) <= plus_one) &&
-            (minus_one <= point(1) && point(1) <= plus_one) &&
-            (minus_one <= point(2) && point(2) <= plus_one));
-  }
-  
-  template<typename PointViewType, typename ScalarType>
-  KOKKOS_INLINE_FUNCTION
-  bool
-  PointInclusion<shards::Pyramid<>::key>::
-  check(const PointViewType &point, const ScalarType threshold) {
-    //this implementation should work when PointType is a Sacado Fad<ScalarType>
-    using PointType = typename PointViewType::value_type; 
-    const PointType minus_one = -1.0 - threshold, plus_one = 1.0 + threshold, minus_zero = -threshold;
-    const PointType left = minus_one + point(2);
-    const PointType right =  plus_one - point(2);
-    return ((left       <= point(0) && point(0) <= right) &&
-            (left       <= point(1) && point(1) <= right) &&
-            (minus_zero <= point(2) && point(2) <= plus_one));
-  }
-
-  template<typename PointViewType, typename ScalarType>
-  KOKKOS_INLINE_FUNCTION
-  bool
-  PointInclusion<shards::Wedge<>::key>::
-  check(const PointViewType &point, const ScalarType threshold) {
-    //this implementation should work when PointType is a Sacado Fad<ScalarType>
-    using PointType = typename PointViewType::value_type; 
-    const ScalarType minus_one = -1.0 - threshold, plus_one = 1.0 + threshold;
-    const PointType one = 1.0;
-    const PointType distance = max( max( -point(0), -point(1) ), point(0) + point(1) - one );
-    return (distance < threshold && (minus_one <= point(2) && point(2) <= plus_one));
+  typename ScalarTraits<typename PointViewType::value_type>::scalar_type 
+  ParametricDistance<shards::Wedge<>::key>::
+  distance(const PointViewType &point) {
+    using scalar_type = typename ScalarTraits<typename PointViewType::value_type>::scalar_type;
+    constexpr scalar_type one(1), two(2), three(3);
+    const scalar_type& p0 = get_scalar_value(point(0));
+    const scalar_type& p1 = get_scalar_value(point(1));
+    const scalar_type& p2 = get_scalar_value(point(2));
+    return Util<scalar_type>::max(one-three*p0, three*(p0+p1)-two, one-three*p1, -p2, p2);
   }
 
 }  // Intrepid2 namespace

--- a/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
@@ -72,6 +72,41 @@ namespace Intrepid2 {
       \li     inclusion tests for point sets in reference and physical cells.
   */
 
+  namespace FunctorCellTools {
+
+    /** \brief Computes the values or gradients of basis functions at input points
+    */
+    template<typename OutputViewType,
+             typename InputViewType,
+             typename ImplBasis,
+             EOperator Operator>
+    struct F_getValues {
+      OutputViewType output_;
+      const InputViewType input_;
+
+      KOKKOS_INLINE_FUNCTION
+      F_getValues(OutputViewType output,
+                  const InputViewType input) 
+        : output_(output), 
+          input_(input) {}
+
+      KOKKOS_INLINE_FUNCTION
+      void
+      operator()(const ordinal_type cl, const ordinal_type pt) const {
+        auto in  = Kokkos::subview(input_,  cl, pt, Kokkos::ALL()); // D
+        if constexpr(Operator == OPERATOR_VALUE) {
+          auto out = Kokkos::subview(output_, cl, Kokkos::ALL(), pt); // N
+          ImplBasis::template Serial<OPERATOR_VALUE>::getValues(out, in);
+        }
+        else if constexpr (Operator == OPERATOR_GRAD) {
+          auto out = Kokkos::subview(output_, cl, Kokkos::ALL(), pt, Kokkos::ALL()); // N, D
+          ImplBasis::template Serial<OPERATOR_GRAD>::getValues(out, in);
+        } else {
+          static_assert((Operator != OPERATOR_VALUE) && (Operator != OPERATOR_GRAD), "Invalid template parameter. Only OPERATOR_VALUE and OPERATOR_GRAD are supported.");
+        } 
+      }
+    };
+  }
 
   template<typename DeviceType>
   class CellTools {
@@ -89,8 +124,6 @@ namespace Intrepid2 {
       return RefSubcellParametrization<DeviceType>::isSupported(cellTopo.getKey());
     }
 
-  private:
-
     /** \brief Generates default HGrad basis based on cell topology
         \param cellTopo            [in] - cell topology
      */
@@ -101,41 +134,177 @@ namespace Intrepid2 {
       Teuchos::RCP<Basis<DeviceType,outputValueType,pointValueType> > r_val;
 
       switch (cellTopo.getKey()) {
-      case shards::Line<2>::key:          r_val = Teuchos::rcp(new Basis_HGRAD_LINE_C1_FEM   <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Line<3>::key:          r_val = Teuchos::rcp(new Basis_HGRAD_LINE_C2_FEM   <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Triangle<3>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_TRI_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Quadrilateral<4>::key: r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_C1_FEM   <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Tetrahedron<4>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_TET_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Hexahedron<8>::key:    r_val = Teuchos::rcp(new Basis_HGRAD_HEX_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Wedge<6>::key:         r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_C1_FEM  <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Pyramid<5>::key:       r_val = Teuchos::rcp(new Basis_HGRAD_PYR_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Line<2>::key:                r_val = Teuchos::rcp(new Basis_HGRAD_LINE_C1_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Triangle<3>::key:            r_val = Teuchos::rcp(new Basis_HGRAD_TRI_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Quadrilateral<4>::key:       r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_C1_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Tetrahedron<4>::key:         r_val = Teuchos::rcp(new Basis_HGRAD_TET_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Hexahedron<8>::key:          r_val = Teuchos::rcp(new Basis_HGRAD_HEX_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Wedge<6>::key:               r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_C1_FEM  <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Pyramid<5>::key:             r_val = Teuchos::rcp(new Basis_HGRAD_PYR_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
 
-      case shards::Triangle<6>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_TRI_C2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Quadrilateral<8>::key: r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_I2_FEM   <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Quadrilateral<9>::key: r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_C2_FEM   <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Tetrahedron<10>::key:  r_val = Teuchos::rcp(new Basis_HGRAD_TET_C2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Tetrahedron<11>::key:  r_val = Teuchos::rcp(new Basis_HGRAD_TET_COMP12_FEM<DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Hexahedron<20>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_HEX_I2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Hexahedron<27>::key:   r_val = Teuchos::rcp(new Basis_HGRAD_HEX_C2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Wedge<15>::key:        r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_I2_FEM  <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Wedge<18>::key:        r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_C2_FEM  <DeviceType,outputValueType,pointValueType>()); break;
-      case shards::Pyramid<13>::key:      r_val = Teuchos::rcp(new Basis_HGRAD_PYR_I2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Line<3>::key:                r_val = Teuchos::rcp(new Basis_HGRAD_LINE_C2_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Triangle<6>::key:            r_val = Teuchos::rcp(new Basis_HGRAD_TRI_C2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Quadrilateral<8>::key:       r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_I2_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Quadrilateral<9>::key:       r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_C2_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Tetrahedron<10>::key:        r_val = Teuchos::rcp(new Basis_HGRAD_TET_C2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Tetrahedron<11>::key:        r_val = Teuchos::rcp(new Basis_HGRAD_TET_COMP12_FEM<DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Hexahedron<20>::key:         r_val = Teuchos::rcp(new Basis_HGRAD_HEX_I2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Hexahedron<27>::key:         r_val = Teuchos::rcp(new Basis_HGRAD_HEX_C2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Wedge<15>::key:              r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_I2_FEM  <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Wedge<18>::key:              r_val = Teuchos::rcp(new Basis_HGRAD_WEDGE_C2_FEM  <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Pyramid<13>::key:            r_val = Teuchos::rcp(new Basis_HGRAD_PYR_I2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
 
-      case shards::Beam<2>::key:
-      case shards::Beam<3>::key:
-      case shards::ShellLine<2>::key:
-      case shards::ShellLine<3>::key:
-      case shards::ShellTriangle<3>::key:
-      case shards::ShellTriangle<6>::key:
-      case shards::ShellQuadrilateral<4>::key:
-      case shards::ShellQuadrilateral<8>::key:
-      case shards::ShellQuadrilateral<9>::key:
+      case shards::Beam<2>::key:                r_val = Teuchos::rcp(new Basis_HGRAD_LINE_C1_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::Beam<3>::key:                r_val = Teuchos::rcp(new Basis_HGRAD_LINE_C2_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::ShellLine<2>::key:           r_val = Teuchos::rcp(new Basis_HGRAD_LINE_C1_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::ShellLine<3>::key:           r_val = Teuchos::rcp(new Basis_HGRAD_LINE_C2_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::ShellTriangle<3>::key:       r_val = Teuchos::rcp(new Basis_HGRAD_TRI_C1_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::ShellTriangle<6>::key:       r_val = Teuchos::rcp(new Basis_HGRAD_TRI_C2_FEM    <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::ShellQuadrilateral<4>::key:  r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_C1_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::ShellQuadrilateral<8>::key:  r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_I2_FEM   <DeviceType,outputValueType,pointValueType>()); break;
+      case shards::ShellQuadrilateral<9>::key:  r_val = Teuchos::rcp(new Basis_HGRAD_QUAD_C2_FEM   <DeviceType,outputValueType,pointValueType>()); break;
       default: {
         INTREPID2_TEST_FOR_EXCEPTION( true, std::invalid_argument,
                                       ">>> ERROR (Intrepid2::CellTools::createHGradBasis): Cell topology not supported.");
       }
       }
       return r_val;
+    }
+
+
+
+    /** \brief Computes the value or gradient of HGRAD basis functions at input points
+        \param output     [out] - view of dimensions [C,N,P] or [C,N,P,D] containing the basis value or their gradients at input points
+        \param input      [in]  - view of dimension [C,P,D], containing the points at which the basis values or gradients are evaluated
+        \param basis      [in]  - basis pointer
+
+        the template parameter Operator can either be OPERATOR_VALUE or OPERATOR_GRAD.
+     */
+    template<EOperator Operator,
+             typename OutputViewType,
+             typename InputViewType
+             >
+    static void
+    getHGradValues(      OutputViewType output,
+                   const InputViewType input,
+                   const Basis<DeviceType,typename OutputViewType::value_type,typename InputViewType::value_type>* basis) {
+
+      using outputValueType = typename OutputViewType::value_type;
+      using pointValueType = typename InputViewType::value_type;
+      using range_policy_type = Kokkos::MDRangePolicy<typename DeviceType::execution_space, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
+      range_policy_type policy( { 0, 0 }, { input.extent(0), input.extent(1) } );
+
+      #define KOKKOS_BASIS_PARALLEL_FOR(BasisName)      \
+        do {                                                                                                                      \
+          using FunctorType = FunctorCellTools::F_getValues<OutputViewType, InputViewType, Intrepid2::Impl::BasisName, Operator>; \
+          Kokkos::parallel_for(policy, FunctorType(output, input));                                                               \
+        } while (0)
+
+      if(dynamic_cast<const Basis_HGRAD_LINE_C1_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_LINE_C1_FEM);
+      else if(dynamic_cast<const Basis_HGRAD_TRI_C1_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_TRI_C1_FEM);
+      else if(dynamic_cast<const Basis_HGRAD_QUAD_C1_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_QUAD_C1_FEM);
+      else if(dynamic_cast<const Basis_HGRAD_TET_C1_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_TET_C1_FEM);
+      else if(dynamic_cast<const Basis_HGRAD_HEX_C1_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_HEX_C1_FEM);
+      else if(dynamic_cast<const Basis_HGRAD_WEDGE_C1_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_WEDGE_C1_FEM);
+      else if(dynamic_cast<const Basis_HGRAD_PYR_C1_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_PYR_C1_FEM);
+
+      else if(dynamic_cast<const Basis_HGRAD_LINE_C2_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_LINE_C2_FEM);
+      else if(dynamic_cast<const Basis_HGRAD_TRI_C2_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_TRI_C2_FEM);
+      else if(dynamic_cast<const Basis_HGRAD_QUAD_I2_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_QUAD_DEG2_FEM<true>);
+      else if(dynamic_cast<const Basis_HGRAD_QUAD_C2_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_QUAD_DEG2_FEM<false>);
+      else if(dynamic_cast<const Basis_HGRAD_TET_C2_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_TET_C2_FEM);
+      else if(dynamic_cast<const Basis_HGRAD_TET_COMP12_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_TET_COMP12_FEM);
+      else if(dynamic_cast<const Basis_HGRAD_HEX_I2_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_HEX_DEG2_FEM<true>);
+      else if(dynamic_cast<const Basis_HGRAD_HEX_C2_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_HEX_DEG2_FEM<false>);
+      else if(dynamic_cast<const Basis_HGRAD_WEDGE_I2_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_WEDGE_DEG2_FEM<true>);
+      else if(dynamic_cast<const Basis_HGRAD_WEDGE_C2_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_WEDGE_DEG2_FEM<false>);
+      else if(dynamic_cast<const Basis_HGRAD_PYR_I2_FEM<DeviceType,outputValueType,pointValueType>*>(basis))
+        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_PYR_I2_FEM);
+      else {
+        INTREPID2_TEST_FOR_EXCEPTION( true, std::invalid_argument,
+                                      ">>> ERROR (Intrepid2::CellTools::getHGradValues): Basis type not supported.");
+      }
+  }
+      
+    
+  /** \brief Computes the value or gradient of HGRAD basis functions at input points
+      \param output     [out] - view of dimensions [C,N,P] or [C,N,P,D] containing the basis value or their gradients at input points
+      \param input      [in]  - view of dimension [C,P,D], containing the points at which the basis values or gradients are evaluated
+      \param cellTopo   [in]  - cell topology
+
+      the template parameter Operator can either be OPERATOR_VALUE or OPERATOR_GRAD.
+  */
+  template<EOperator Operator,
+           typename OutputViewType,
+           typename InputViewType
+          >
+    static void
+    getHGradValues(      OutputViewType output,
+                   const InputViewType input,
+                   const shards::CellTopology cellTopo) {
+
+      using range_policy_type = Kokkos::MDRangePolicy<typename DeviceType::execution_space, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
+      range_policy_type policy( { 0, 0 }, { input.extent(0), input.extent(1) } );
+
+      #define KOKKOS_BASIS_PARALLEL_FOR(BasisName)      \
+        do {                                                                                                                      \
+          using FunctorType = FunctorCellTools::F_getValues<OutputViewType, InputViewType, Intrepid2::Impl::BasisName, Operator>; \
+          Kokkos::parallel_for(policy, FunctorType(output, input));                                                               \
+        } while (0)
+
+      switch (cellTopo.getKey()) {
+      case shards::Line<2>::key:                KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_LINE_C1_FEM); break; 
+      case shards::Triangle<3>::key:            KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_TRI_C1_FEM); break;
+      case shards::Quadrilateral<4>::key:       KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_QUAD_C1_FEM); break;
+      case shards::Tetrahedron<4>::key:         KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_TET_C1_FEM); break;
+      case shards::Hexahedron<8>::key:          KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_HEX_C1_FEM); break;
+      case shards::Wedge<6>::key:               KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_WEDGE_C1_FEM); break;
+      case shards::Pyramid<5>::key:             KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_PYR_C1_FEM); break;
+
+      case shards::Line<3>::key:                KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_LINE_C2_FEM); break;   
+      case shards::Triangle<6>::key:            KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_TRI_C2_FEM); break;
+      case shards::Quadrilateral<8>::key:       KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_QUAD_DEG2_FEM<true>); break;
+      case shards::Quadrilateral<9>::key:       KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_QUAD_DEG2_FEM<false>); break;
+      case shards::Tetrahedron<10>::key:        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_TET_C2_FEM); break;
+      case shards::Tetrahedron<11>::key:        KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_TET_COMP12_FEM); break;
+      case shards::Hexahedron<20>::key:         KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_HEX_DEG2_FEM<true>); break;
+      case shards::Hexahedron<27>::key:         KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_HEX_DEG2_FEM<false>); break;
+      case shards::Wedge<15>::key:              KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_WEDGE_DEG2_FEM<true>); break;
+      case shards::Wedge<18>::key:              KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_WEDGE_DEG2_FEM<false>); break;
+      case shards::Pyramid<13>::key:            KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_PYR_I2_FEM); break;
+
+      case shards::Beam<2>::key:                KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_LINE_C1_FEM); break;
+      case shards::Beam<3>::key:                KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_LINE_C2_FEM); break;
+      case shards::ShellLine<2>::key:           KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_LINE_C1_FEM); break;
+      case shards::ShellLine<3>::key:           KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_LINE_C2_FEM); break;
+      case shards::ShellTriangle<3>::key:       KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_TRI_C1_FEM); break;
+      case shards::ShellTriangle<6>::key:       KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_TRI_C2_FEM); break;
+      case shards::ShellQuadrilateral<4>::key:  KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_QUAD_C1_FEM); break;
+      case shards::ShellQuadrilateral<8>::key:  KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_QUAD_DEG2_FEM<true>); break;
+      case shards::ShellQuadrilateral<9>::key:  KOKKOS_BASIS_PARALLEL_FOR(Basis_HGRAD_QUAD_DEG2_FEM<false>); break;
+      
+      default: {
+        INTREPID2_TEST_FOR_EXCEPTION( true, std::invalid_argument,
+                                      ">>> ERROR (Intrepid2::CellTools::getHGradValues): Cell topology not supported.");
+      }
+      }
     }
 
 public:
@@ -291,7 +460,38 @@ public:
                 points,
                 worksetCell,
                 basis);
-   }
+    }
+
+
+
+    /** \brief  Computes the scaled normal component of a d-dimensional resudial vecor with respect to a (d-1) dimensional manifold, given the manifold tangents.
+
+      The dimension d can be either 2 or 3.
+      Typically, the input residual is the difference between points in d space and their projections onto the manifold.
+      This function compute the normal n to the manifold as the outer product of the manifold tangents.
+      It then computes the normal component as
+      \f[
+      (n \cdot \mbox{residual}) / |n|^2
+      \f]
+      and multiplies it by the input scaling term. 
+
+      \param  result      [out] - rank-2 array with dimensions (C,P) containing the normal component of the residual scaled by scaling
+      \param  tangents    [in]  - rank-4 container with logical dimensions (C,P,D,D-1) containing the tangents of a (D-1) dimensional manifold at points
+      \param  residual    [in]  - rank-3 array with dimensions (C,P,D), containing a vector in D dimensional space, typically the difference between points in 3D space and their projection on the manifold
+      \param  scaling     [in]  - a scalar quantity to scale the normal component.
+    */
+    
+    template<typename OutViewType, 
+             typename TanViewType,
+             typename InViewType>
+    static void
+    scaledResidualNormalComponent(
+               OutViewType result,
+               const TanViewType tangents,
+               const InViewType residual,
+               const typename InViewType::value_type scaling);
+
+
 
     /** \brief  Computes the inverse of the Jacobian matrix \e DF of the reference-to-physical frame map \e F.
 
@@ -962,20 +1162,22 @@ public:
 
         There are 2 use cases:
         \li     Applies \f$ F_{c} \f$ for \b all cells in a cell workset to a \b single point set stored
-        in a rank-2 (P,D) array;
+        in a rank-2 (P,D2) array;
         \li     Applies \f$ F_{c} \f$ for \b all cells in a cell workset to \b multiple point sets having
-        the same number of points, indexed by cell ordinal, and stored in a rank-3 (C,P,D) array;
+        the same number of points, indexed by cell ordinal, and stored in a rank-3 (C,P,D2) array;
 
-        For a single point set in a rank-2 array (P,D) returns a rank-3 (C,P,D) array such that
+        For a single point set in a rank-2 array (P,D1) returns a rank-3 (C,P,D2) array such that
         \f[
         \mbox{physPoints}(c,p,d) = \Big(F_c(\mbox{refPoint}(p,*)) \Big)_d \quad c=0,\ldots, C
         \f]
-        For multiple point sets in a rank-3 (C,P,D) array returns a rank-3 (C,P,D) array such that
+        For multiple point sets in a rank-3 (C,P,D1) array returns a rank-3 (C,P,D2) array such that
         \f[
         \mbox{physPoints}(c,p,d) = \Big(F_c(\mbox{refPoint}(c,p,*)) \Big)_d \quad c=0,\ldots, C
         \f]
         This corresponds to mapping multiple sets of reference points to a matching number of
         physical cells.
+
+        The reference (D1) and physics D2 dimensions don't have to be the same, as long as D1 is not greater than D2.
 
         Requires pointer to HGrad basis that defines reference to physical cell mapping.
         See Section \ref sec_cell_topology_ref_map for definition of the mapping function.
@@ -988,10 +1190,10 @@ public:
         is the image of the reference cell under that map. CellTools provides several
         inclusion tests methods to check whether or not the points are inside a reference cell.
 
-        \param  physPoints        [out] - rank-3 array with dimensions (C,P,D) with the images of the ref. points
-        \param  refPoints          [in]  - rank-3/2 array with dimensions (C,P,D)/(P,D) with points in reference frame
-        \param  cellWorkset      [in]  - rank-3 container with logical dimensions (C,N,D) with the nodes of the cell workset
-        \param  basis                   [in]  - pointer to HGrad basis used in reference-to-physical cell mapping
+        \param  physPoints        [out] - rank-3 array with dimensions (C,P,D2) with the images of the ref. points
+        \param  refPoints         [in]  - rank-3/2 array with dimensions (C,P,D1)/(P,D1) with points in reference frame
+        \param  cellWorkset       [in]  - rank-3 container with logical dimensions (C,N,D2) with the nodes of the cell workset
+        \param  basis             [in]  - pointer to HGrad basis used in reference-to-physical cell mapping
 
     */
     template<typename PhysPointValueType,
@@ -1008,20 +1210,22 @@ public:
 
         There are 2 use cases:
         \li     Applies \f$ F_{c} \f$ for \b all cells in a cell workset to a \b single point set stored
-        in a rank-2 (P,D) array;
+        in a rank-2 (P,D2) array;
         \li     Applies \f$ F_{c} \f$ for \b all cells in a cell workset to \b multiple point sets having
-        the same number of points, indexed by cell ordinal, and stored in a rank-3 (C,P,D) array;
+        the same number of points, indexed by cell ordinal, and stored in a rank-3 (C,P,D2) array;
 
-        For a single point set in a rank-2 array (P,D) returns a rank-3 (C,P,D) array such that
+        For a single point set in a rank-2 array (P,D1) returns a rank-3 (C,P,D2) array such that
         \f[
         \mbox{physPoints}(c,p,d) = \Big(F_c(\mbox{refPoint}(p,*)) \Big)_d \quad c=0,\ldots, C
         \f]
-        For multiple point sets in a rank-3 (C,P,D) array returns a rank-3 (C,P,D) array such that
+        For multiple point sets in a rank-3 (C,P,D1) array returns a rank-3 (C,P,D2) array such that
         \f[
         \mbox{physPoints}(c,p,d) = \Big(F_c(\mbox{refPoint}(c,p,*)) \Big)_d \quad c=0,\ldots, C
         \f]
         This corresponds to mapping multiple sets of reference points to a matching number of
         physical cells.
+
+        The reference (D1) and physics D2 dimensions don't have to be the same, as long as D1 is not greater than D2.
 
         Requires cell topology with a reference cell. See Section \ref sec_cell_topology_ref_map
         for definition of the mapping function. Presently supported cell topologies are
@@ -1038,9 +1242,9 @@ public:
         is the image of the reference cell under that map. CellTools provides several
         inclusion tests methods to check whether or not the points are inside a reference cell.
 
-        \param  physPoints        [out] - rank-3 array with dimensions (C,P,D) with the images of the ref. points
-        \param  refPoints         [in]  - rank-3/2 array with dimensions (C,P,D)/(P,D) with points in reference frame
-        \param  cellWorkset       [in]  - rank-3 array with dimensions (C,N,D) with the nodes of the cell workset
+        \param  physPoints        [out] - rank-3 array with dimensions (C,P,D2) with the images of the ref. points
+        \param  refPoints         [in]  - rank-3/2 array with dimensions (C,P,D1)/(P,D1) with points in reference frame
+        \param  cellWorkset       [in]  - rank-3 array with dimensions (C,N,D2) with the nodes of the cell workset
         \param  cellTopo          [in]  - cell topology of the cells stored in \c cellWorkset
 
     */
@@ -1051,14 +1255,7 @@ public:
     mapToPhysicalFrame(       PhysPointViewType    physPoints,
                         const RefPointViewType     refPoints,
                         const WorksetCellViewType  worksetCell,
-                        const shards::CellTopology cellTopo ) {
-      using nonConstRefPointValueType = typename RefPointViewType::non_const_value_type;
-      auto basis = createHGradBasis<nonConstRefPointValueType,nonConstRefPointValueType>(cellTopo);
-      mapToPhysicalFrame(physPoints,
-                         refPoints,
-                         worksetCell,
-                         basis);
-    }
+                        const shards::CellTopology cellTopo );
 
 
     /** \brief  Computes parameterization maps of 1- and 2-subcells of reference cells.
@@ -1191,6 +1388,8 @@ public:
         are not necessarily contained in the reference cell corresponding to the specified
         cell topology.
 
+        returns true if it converged to a solution, false otherwise
+
         \param  refPoints         [out] - rank-3 array with dimensions (C,P,D) with the images of the physical points
         \param  physPoints        [in]  - rank-3 array with dimensions (C,P,D) with points in physical frame
         \param  worksetCell       [in]  - rank-3 array with dimensions (C,N,D) with the nodes of the cell workset
@@ -1200,13 +1399,54 @@ public:
     template<typename refPointValueType,    class ...refPointProperties,
              typename physPointValueType,   class ...physPointProperties,
              typename worksetCellValueType, class ...worksetCellProperties>
-    static void
+    static bool
     mapToReferenceFrame(       Kokkos::DynRankView<refPointValueType,refPointProperties...>    refPoints,
                          const Kokkos::DynRankView<physPointValueType,physPointProperties...>  physPoints,
                          const Kokkos::DynRankView<worksetCellValueType,worksetCellProperties...>   worksetCell,
-                         const shards::CellTopology cellTopo );
+                         const shards::CellTopology cellTopo,
+                         const physPointValueType shellThickness = -1.0 );
+
+
 
     /** \brief  Computation of \f$ F^{-1}_{c} \f$, the inverse of the reference-to-physical frame map
+        where refPoints is also used as initial guess.
+
+        Applies \f$ F^{-1}_{c} \f$ for \b all cells in a cell workset to \b multiple point sets
+        having the same number of points, indexed by cell ordinal, and stored in a rank-3
+        (C,P,D) array. Returns a rank-3 (C,P,D) array such that
+        \f[
+        \mbox{refPoints}(c,p,d) = \Big(F^{-1}_c(physPoint(c,p,*)) \Big)_d
+        \f]
+
+        Requires pointer to HGrad basis that defines reference to physical cell mapping.
+        See Section \ref sec_cell_topology_ref_map for definition of the mapping function.
+
+        Note, refPoints is used as initial guess.
+
+        \warning
+        The array \c physPoints represents an arbitrary set (or sets) of points in the physical
+        frame that are not required to belong in the physical cell (cells) that define(s) the reference
+        to physical mapping. As a result, the images of these points in the reference frame
+        are not necessarily contained in the reference cell corresponding to the specified
+        cell topology.
+
+        \param  refPoints         [out] - rank-3 array with dimensions (C,P,D) with the images of the physical points
+        \param  physPoints        [in]  - rank-3 array with dimensions (C,P,D) with points in physical frame
+        \param  worksetCell       [in]  - rank-3 array with dimensions (C,N,D) with the nodes of the cell workset
+        \param  basis             [in]  - pointer to HGrad basis used for reference to physical cell mapping
+    */
+    template<typename refPointValueType,    class ...refPointProperties,
+             typename physPointValueType,   class ...physPointProperties,
+             typename worksetCellValueType, class ...worksetCellProperties>
+             
+    static bool
+    mapToReferenceFrame(       Kokkos::DynRankView<refPointValueType,refPointProperties...>       refPoints,
+                         const Kokkos::DynRankView<physPointValueType,physPointProperties...>     physPoints,
+                         const Kokkos::DynRankView<worksetCellValueType,worksetCellProperties...> worksetCell,
+                         const BasisPtr<DeviceType, refPointValueType, refPointValueType>         basis,
+                         const physPointValueType                                                 shellThickness = -1.0 );
+
+    /** \brief  [Deprecated] Computation of \f$ F^{-1}_{c} \f$, the inverse of the reference-to-physical frame map
         using user-supplied initial guess.
 
         Applies \f$ F^{-1}_{c} \f$ for \b all cells in a cell workset to \b multiple point sets
@@ -1226,9 +1466,9 @@ public:
         are not necessarily contained in the reference cell corresponding to the specified
         cell topology.
 
-        \param  refPoints         [out] - rank-3/2 array with dimensions (C,P,D)/(P,D) with the images of the physical points
-        \param  initGuess         [in]  - rank-3/2 array with dimensions (C,P,D)/(P,D) with the initial guesses for each point
-        \param  physPoints        [in]  - rank-3/2 array with dimensions (C,P,D)/(P,D) with points in physical frame
+        \param  refPoints         [out] - rank-3 array with dimensions (C,P,D) with the images of the physical points
+        \param  initGuess         [in]  - rank-3 array with dimensions (C,P,D) with the initial guesses for each point
+        \param  physPoints        [in]  - rank-3 array with dimensions (C,P,D) with points in physical frame
         \param  worksetCell       [in]  - rank-3 array with dimensions (C,N,D) with the nodes of the cell workset
         \param  basis             [in]  - pointer to HGrad basis used for reference to physical cell mapping
     */
@@ -1237,12 +1477,17 @@ public:
              typename physPointValueType,   class ...physPointProperties,
              typename worksetCellValueType, class ...worksetCellProperties,
              typename HGradBasisPtrType>
-    static void
+    [[deprecated("Deprecated, use mapToReferenceFrame instead with refPoints initialized with initGuess.")]]
+    static bool
     mapToReferenceFrameInitGuess(       Kokkos::DynRankView<refPointValueType,refPointProperties...>       refPoints,
                                   const Kokkos::DynRankView<initGuessValueType,initGuessProperties...>     initGuess,
                                   const Kokkos::DynRankView<physPointValueType,physPointProperties...>     physPoints,
                                   const Kokkos::DynRankView<worksetCellValueType,worksetCellProperties...> worksetCell,
-                                  const HGradBasisPtrType basis );
+                                  const HGradBasisPtrType basis,
+                                  const physPointValueType shellThickness = -1.0 ){
+                                    Kokkos::deep_copy(refPoints,initGuess);
+                                    return mapToReferenceFrame(refPoints,physPoints,worksetCell,basis,initGuess);
+                                  }
 
 
     /** \brief  Computation of \f$ F^{-1}_{c} \f$, the inverse of the reference-to-physical frame map
@@ -1269,9 +1514,9 @@ public:
         are not necessarily contained in the reference cell corresponding to the specified
         cell topology.
 
-        \param  refPoints         [out] - rank-3/2 array with dimensions (C,P,D)/(P,D) with the images of the physical points
-        \param  initGuess         [in]  - rank-3/2 array with dimensions (C,P,D)/(P,D) with the initial guesses for each point
-        \param  physPoints        [in]  - rank-3/2 array with dimensions (C,P,D)/(P,D) with points in physical frame
+        \param  refPoints         [out] - rank-3 array with dimensions (C,P,D) with the images of the physical points
+        \param  initGuess         [in]  - rank-3 array with dimensions (C,P,D) with the initial guesses for each point
+        \param  physPoints        [in]  - rank-3 array with dimensions (C,P,D) with points in physical frame
         \param  worksetCell       [in]  - rank-3 array with dimensions (C,N,D) with the nodes of the cell workset
         \param  cellTopo          [in]  - cell topology of the cells stored in \c cellWorkset
     */
@@ -1279,19 +1524,13 @@ public:
              typename initGuessValueType,   class ...initGuessProperties,
              typename physPointValueType,   class ...physPointProperties,
              typename worksetCellValueType, class ...worksetCellProperties>
-    static void
+    static bool
     mapToReferenceFrameInitGuess(       Kokkos::DynRankView<refPointValueType,refPointProperties...>       refPoints,
                                   const Kokkos::DynRankView<initGuessValueType,initGuessProperties...>     initGuess,
                                   const Kokkos::DynRankView<physPointValueType,physPointProperties...>     physPoints,
                                   const Kokkos::DynRankView<worksetCellValueType,worksetCellProperties...> worksetCell,
-                                  const shards::CellTopology cellTopo ) {
-      auto basis = createHGradBasis<refPointValueType,refPointValueType>(cellTopo);
-      mapToReferenceFrameInitGuess(refPoints,
-                                   initGuess,
-                                   physPoints,
-                                   worksetCell,
-                                   basis);
-    }
+                                  const shards::CellTopology cellTopo,
+                                  const physPointValueType shellThickness = -1.0 ); 
 
 
     //============================================================================================//
@@ -1396,27 +1635,27 @@ public:
 
         Requires cell topology with a reference cell.
 
-        \param  point             [in]  - rank-1 view (D) of the point tested for inclusion
+        \param  refPoint          [in]  - rank-1 view (D) of the reference point tested for inclusion
         \param  cellTopo          [in]  - cell topology
         \return the parametric distance of the point in the specified reference cell.
     */
     template<typename PointViewType>
     static bool
-    parametricDistance( const PointViewType        point,
+    parametricDistance( const PointViewType         refPoint,
                          const shards::CellTopology cellTopo);
 
     /** \brief  Checks if a point belongs to a reference cell.
 
         Requires cell topology with a reference cell.
 
-        \param  point             [in]  - rank-1 view (D) of the point tested for inclusion
+        \param  refPoint          [in]  - rank-1 view (D) of the reference point tested for inclusion
         \param  cellTopo          [in]  - cell topology
         \param  threshold         [in]  - "tightness" of the inclusion test
         \return true if the point is in the closure of the specified reference cell and false otherwise.
     */
     template<typename PointViewType>
     static bool
-    checkPointInclusion( const PointViewType        point,
+    checkPointInclusion( const PointViewType        refPoint,
                          const shards::CellTopology cellTopo,
                          const typename ScalarTraits<typename PointViewType::value_type>::scalar_type thres =
                                threshold<typename ScalarTraits<typename PointViewType::value_type>::scalar_type>() );
@@ -1429,14 +1668,14 @@ public:
         The cell topology key is a template argument.
         Requires cell topology with a reference cell.
         \param  inCell            [out] - rank-1 view (P) or rank-2 view (C,P). On return, its entries will be set to 1 or 0 depending on whether points are included in cells
-        \param  point             [in]  - rank-2 view (P,D) or rank-3 view (C,P,D) with reference coordinates of the points tested for inclusion
+        \param  refPoints         [in]  - rank-2 view (P,D) or rank-3 view (C,P,D) with coordinates of the reference points tested for inclusion
         \param  threshold         [in]  - "tightness" of the inclusion test
     */
     template<unsigned cellTopologyKey,
              typename OutputViewType,
              typename InputViewType>
     static void checkPointwiseInclusion(       OutputViewType inCell,
-                                         const InputViewType points,
+                                         const InputViewType refPoints,
                                          const typename ScalarTraits<typename InputViewType::value_type>::scalar_type thresh =
                                                threshold<typename ScalarTraits<typename InputViewType::value_type>::scalar_type>());
 
@@ -1453,7 +1692,7 @@ public:
     template<typename InCellViewType,
              typename PointViewType>
     static void checkPointwiseInclusion(       InCellViewType inCell,
-                                         const PointViewType points,
+                                         const PointViewType refPoints,
                                          const shards::CellTopology cellTopo,
                                          const typename ScalarTraits<typename PointViewType::value_type>::scalar_type thres =
                                                threshold<typename ScalarTraits<typename PointViewType::value_type>::scalar_type>() );
@@ -1462,6 +1701,8 @@ public:
                 The points can belong to a global set and stored in a rank-2 (P,D) view,
                 or to multiple sets indexed by a cell ordinal and stored in a rank-3 (C,P,D) view
                 cells in a cell workset.
+
+                returns true if the computation is valid (map to reference cell converged), false otherwise
 
         \param  inCell            [out] - rank-2 view (P,D)  with results from the pointwise inclusion test
         \param  points            [in]  - rank-2 view (P,D) or rank-3 view (C,P,D) with the physical points
@@ -1472,12 +1713,13 @@ public:
     template<typename inCellValueType, class ...inCellProperties,
              typename pointValueType, class ...pointProperties,
              typename cellWorksetValueType, class ...cellWorksetProperties>
-    static void checkPointwiseInclusion(       Kokkos::DynRankView<inCellValueType,inCellProperties...> inCell,
+    static bool checkPointwiseInclusion(       Kokkos::DynRankView<inCellValueType,inCellProperties...> inCell,
                                          const Kokkos::DynRankView<pointValueType,pointProperties...> points,
                                          const Kokkos::DynRankView<cellWorksetValueType,cellWorksetProperties...> cellWorkset,
                                          const shards::CellTopology cellTopo,
                                          const typename ScalarTraits<pointValueType>::scalar_type thres =
-                                               threshold<typename ScalarTraits<pointValueType>::scalar_type>() );
+                                               threshold<typename ScalarTraits<pointValueType>::scalar_type>(),
+                                         const typename ScalarTraits<pointValueType>::scalar_type shellThickness = -1.0 );
 
 
     // //============================================================================================//

--- a/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
@@ -471,7 +471,7 @@ public:
       This function compute the normal n to the manifold as the outer product of the manifold tangents.
       It then computes the normal component as
       \f[
-      (n \cdot \mbox{residual}) / |n|^2
+      (n \cdot \mbox{residual}) / |n|
       \f]
       and multiplies it by the input scaling term. 
 
@@ -1225,7 +1225,10 @@ public:
         This corresponds to mapping multiple sets of reference points to a matching number of
         physical cells.
 
-        The reference (D1) and physics D2 dimensions don't have to be the same, as long as D1 is not greater than D2.
+        The reference (D1) and physics D2 dimensions do not have to be the same, as long as D1 is not greater than D2.
+        For beam and shell cells, D1 = D2; however, the reference-to-physical frame map,
+        sends the in-plane (D1-1) reference coordinats into the D2 physiscal space.
+        As a result, for beam and shell cells, the orthogonal reference coordinates are ignored.
 
         Requires cell topology with a reference cell. See Section \ref sec_cell_topology_ref_map
         for definition of the mapping function. Presently supported cell topologies are
@@ -1486,7 +1489,7 @@ public:
                                   const HGradBasisPtrType basis,
                                   const physPointValueType shellThickness = -1.0 ){
                                     Kokkos::deep_copy(refPoints,initGuess);
-                                    return mapToReferenceFrame(refPoints,physPoints,worksetCell,basis,initGuess);
+                                    return mapToReferenceFrame(refPoints,physPoints,worksetCell,basis,shellThickness);
                                   }
 
 
@@ -1640,9 +1643,10 @@ public:
         \return the parametric distance of the point in the specified reference cell.
     */
     template<typename PointViewType>
-    static bool
+    [[deprecated("Deprecated, use the templated ParametricDistance struct directly.")]]
+    static typename ScalarTraits<typename PointViewType::value_type>::scalar_type
     parametricDistance( const PointViewType         refPoint,
-                         const shards::CellTopology cellTopo);
+                        const shards::CellTopology  cellTopo);
 
     /** \brief  Checks if a point belongs to a reference cell.
 
@@ -1654,6 +1658,7 @@ public:
         \return true if the point is in the closure of the specified reference cell and false otherwise.
     */
     template<typename PointViewType>
+    [[deprecated("Deprecated, use checkPointwiseInclusion, or the templated ParametricDistance struct directly.")]]
     static bool
     checkPointInclusion( const PointViewType        refPoint,
                          const shards::CellTopology cellTopo,

--- a/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
@@ -1386,6 +1386,25 @@ public:
     //                                                                                            //
     //============================================================================================//
 
+
+    /** \brief  Compute the parametric distance of the point in the specified reference cell.
+        The parametric distance is a continuous piecewise linear function that it is
+        (a) 0 at the centroid of the reference cell,
+        (b) less than 1 for points inside the cell
+        (c) 1 on the cell boundary
+        (d) greater than 1 for points outside the cell
+
+        Requires cell topology with a reference cell.
+
+        \param  point             [in]  - rank-1 view (D) of the point tested for inclusion
+        \param  cellTopo          [in]  - cell topology
+        \return the parametric distance of the point in the specified reference cell.
+    */
+    template<typename PointViewType>
+    static bool
+    parametricDistance( const PointViewType        point,
+                         const shards::CellTopology cellTopo);
+
     /** \brief  Checks if a point belongs to a reference cell.
 
         Requires cell topology with a reference cell.

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefInclusion.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefInclusion.hpp
@@ -38,9 +38,9 @@ namespace Intrepid2 {
                        const shards::CellTopology   cellTopo) {
 #ifdef HAVE_INTREPID2_DEBUG
     INTREPID2_TEST_FOR_EXCEPTION( point.rank() != 1, std::invalid_argument,
-                                  ">>> ERROR (Intrepid2::CellTools::checkPointInclusion): Point must have rank 1. ");
+                                  ">>> ERROR (Intrepid2::CellTools::parametricDistance): Point must have rank 1. ");
     INTREPID2_TEST_FOR_EXCEPTION( point.extent(0) != cellTopo.getDimension(), std::invalid_argument,
-                                  ">>> ERROR (Intrepid2::CellTools::checkPointInclusion): Point and cell dimensions do not match. ");
+                                  ">>> ERROR (Intrepid2::CellTools::parametricDistance): Point and cell dimensions do not match. ");
 #endif
     // A cell with extended topology has the same reference cell as a cell with base topology. 
     // => testing for inclusion in a reference Triangle<> and a reference Triangle<6> relies on 
@@ -187,12 +187,28 @@ namespace Intrepid2 {
       checkPointwiseInclusion<shards::Line<>::key,decltype(inCell),decltype(points)>(inCell, points, threshold);
       break;
 
+    case shards::Beam<>::key :
+      checkPointwiseInclusion<shards::Beam<>::key,decltype(inCell),decltype(points)>(inCell, points, threshold);
+      break;
+
+    case shards::ShellLine<>::key :
+      checkPointwiseInclusion<shards::ShellLine<>::key,decltype(inCell),decltype(points)>(inCell, points, threshold);
+      break;
+
     case shards::Triangle<>::key :
       checkPointwiseInclusion<shards::Triangle<>::key,decltype(inCell),decltype(points)>(inCell, points, threshold);
+      break;
+    
+    case shards::ShellTriangle<>::key :
+      checkPointwiseInclusion<shards::ShellTriangle<>::key,decltype(inCell),decltype(points)>(inCell, points, threshold);
       break;
 
     case shards::Quadrilateral<>::key :
       checkPointwiseInclusion<shards::Quadrilateral<>::key,decltype(inCell),decltype(points)>(inCell, points, threshold);
+      break;
+
+    case shards::ShellQuadrilateral<>::key :
+      checkPointwiseInclusion<shards::ShellQuadrilateral<>::key,decltype(inCell),decltype(points)>(inCell, points, threshold);
       break;
 
     case shards::Tetrahedron<>::key :
@@ -212,7 +228,7 @@ namespace Intrepid2 {
       break;
       
     default:
-      INTREPID2_TEST_FOR_EXCEPTION( false,
+      INTREPID2_TEST_FOR_EXCEPTION( true,
                                     std::invalid_argument,
                                     ">>> ERROR (Intrepid2::CellTools::checkPointInclusion): Invalid cell topology. ");
     }
@@ -222,33 +238,36 @@ namespace Intrepid2 {
   template<typename inCellValueType, class ...inCellProperties,
            typename pointValueType, class ...pointProperties,
            typename cellWorksetValueType, class ...cellWorksetProperties>
-  void
+  bool
   CellTools<DeviceType>::
   checkPointwiseInclusion(       Kokkos::DynRankView<inCellValueType,inCellProperties...> inCell,
                            const Kokkos::DynRankView<pointValueType,pointProperties...> points,
                            const Kokkos::DynRankView<cellWorksetValueType,cellWorksetProperties...> cellWorkset,
                            const shards::CellTopology cellTopo,
-                           const typename ScalarTraits<pointValueType>::scalar_type threshold ) {
+                           const typename ScalarTraits<pointValueType>::scalar_type threshold,
+                           const typename ScalarTraits<pointValueType>::scalar_type shellThickness ) {
 #ifdef HAVE_INTREPID2_DEBUG
     {
       const auto key = cellTopo.getBaseKey();
+      const bool isShellorBeam = (key == shards::Beam<>::key) || (key == shards::ShellLine<>::key) || (key == shards::ShellTriangle<>::key) || (key == shards::ShellQuadrilateral<>::key);      
       INTREPID2_TEST_FOR_EXCEPTION( key != shards::Line<>::key &&
                                     key != shards::Triangle<>::key &&
                                     key != shards::Quadrilateral<>::key &&
                                     key != shards::Tetrahedron<>::key &&                                                                                                                                               
                                     key != shards::Hexahedron<>::key &&                                                                                                                                                
                                     key != shards::Wedge<>::key &&                                                                                                                                                     
-                                    key != shards::Pyramid<>::key, 
+                                    key != shards::Pyramid<>::key &&
+                                    !isShellorBeam,
                                     std::invalid_argument, 
                                     ">>> ERROR (Intrepid2::CellTools::checkPointwiseInclusion): cell topology not supported");
       INTREPID2_TEST_FOR_EXCEPTION( inCell.rank() != 2, std::invalid_argument,
                                     ">>> ERROR (Intrepid2::CellTools::checkPointwiseInclusion): InCell must have rank 2. ");
       INTREPID2_TEST_FOR_EXCEPTION( cellWorkset.rank() != 3, std::invalid_argument,
                                     ">>> ERROR (Intrepid2::CellTools::checkPointwiseInclusion): cellWorkset must have rank 3. ");
-      INTREPID2_TEST_FOR_EXCEPTION( cellWorkset.extent(2) != cellTopo.getDimension(), std::invalid_argument,
-                                    ">>> ERROR (Intrepid2::CellTools::checkPointInclusion): cellWorkset and points have incompatible dimensions. ");
       INTREPID2_TEST_FOR_EXCEPTION( (points.rank() == 3) && (points.extent(0) != cellWorkset.extent(0)) , std::invalid_argument,
                                     ">>> ERROR (Intrepid2::CellTools::checkPointInclusion): cellWorkset and points have incompatible dimensions. ");
+      INTREPID2_TEST_FOR_EXCEPTION( isShellorBeam && (shellThickness < 0.0) , std::invalid_argument,
+                                    ">>> ERROR (Intrepid2::CellTools::checkPointInclusion): beam and shell topologies require cell thickness information. ");
     }
 #endif    
     const ordinal_type 
@@ -257,16 +276,19 @@ namespace Intrepid2 {
       spaceDim = cellTopo.getDimension();
 
     auto refPoints = Impl::createMatchingDynRankView(points, "CellTools::checkPointwiseInclusion::refPoints", numCells, numPoints, spaceDim);
+
+    bool isValid(false);
     
     // expect refPoints(CPD), points (CPD or PD), cellWorkset(CND) 
     if(points.rank() == 3)  
-      mapToReferenceFrame(refPoints, points, cellWorkset, cellTopo);
+      isValid = mapToReferenceFrame(refPoints, points, cellWorkset, cellTopo, shellThickness);
     else { //points.rank() == 2
-      auto cellPoints = Impl::createMatchingDynRankView(points, "CellTools::checkPointwiseInclusion::physCellPoints", numCells, numPoints, spaceDim);
+      auto cellPoints = Impl::createMatchingDynRankView(points, "CellTools::checkPointwiseInclusion::physCellPoints", numCells, numPoints, points.extent_int(1));
       RealSpaceTools<DeviceType>::clone(cellPoints,points);
-      mapToReferenceFrame(refPoints, cellPoints, cellWorkset, cellTopo);
+      isValid = mapToReferenceFrame(refPoints, cellPoints, cellWorkset, cellTopo, shellThickness);
     }    
     checkPointwiseInclusion(inCell, refPoints, cellTopo, threshold);
+    return isValid;
   }
 
 }

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefInclusion.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefInclusion.hpp
@@ -32,10 +32,10 @@ namespace Intrepid2 {
 
   template<typename DeviceType>
   template<typename PointViewType>
-  bool 
+  typename ScalarTraits<typename PointViewType::value_type>::scalar_type 
   CellTools<DeviceType>::
   parametricDistance( const PointViewType      point,
-                       const shards::CellTopology   cellTopo) {
+                      const shards::CellTopology   cellTopo) {
 #ifdef HAVE_INTREPID2_DEBUG
     INTREPID2_TEST_FOR_EXCEPTION( point.rank() != 1, std::invalid_argument,
                                   ">>> ERROR (Intrepid2::CellTools::parametricDistance): Point must have rank 1. ");

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefInclusion.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefInclusion.hpp
@@ -29,7 +29,64 @@ namespace Intrepid2 {
   //                                                                                            //
   //============================================================================================//
 
-  
+
+  template<typename DeviceType>
+  template<typename PointViewType>
+  bool 
+  CellTools<DeviceType>::
+  parametricDistance( const PointViewType      point,
+                       const shards::CellTopology   cellTopo) {
+#ifdef HAVE_INTREPID2_DEBUG
+    INTREPID2_TEST_FOR_EXCEPTION( point.rank() != 1, std::invalid_argument,
+                                  ">>> ERROR (Intrepid2::CellTools::checkPointInclusion): Point must have rank 1. ");
+    INTREPID2_TEST_FOR_EXCEPTION( point.extent(0) != cellTopo.getDimension(), std::invalid_argument,
+                                  ">>> ERROR (Intrepid2::CellTools::checkPointInclusion): Point and cell dimensions do not match. ");
+#endif
+    // A cell with extended topology has the same reference cell as a cell with base topology. 
+    // => testing for inclusion in a reference Triangle<> and a reference Triangle<6> relies on 
+    // on the same set of inequalities. To eliminate unnecessary cases we switch on the base topology
+    const auto key = cellTopo.getBaseKey();
+    using scalar_type = typename ScalarTraits<typename PointViewType::value_type>::scalar_type;
+    scalar_type distance(0);
+    switch (key) {    
+    case shards::Line<>::key :
+      distance = ParametricDistance<shards::Line<>::key>::distance(point);
+      break;
+    case shards::ShellLine<>::key :
+      distance = ParametricDistance<shards::ShellLine<>::key>::distance(point);
+      break;
+    case shards::Triangle<>::key :
+      distance = ParametricDistance<shards::Triangle<>::key>::distance(point);
+      break;      
+    case shards::ShellTriangle<>::key :
+      distance = ParametricDistance<shards::ShellTriangle<>::key>::distance(point);
+      break;
+    case shards::ShellQuadrilateral<>::key :
+      distance = ParametricDistance<shards::ShellQuadrilateral<>::key>::distance(point);
+      break;
+    case shards::Quadrilateral<>::key :
+      distance = ParametricDistance<shards::Quadrilateral<>::key>::distance(point);
+      break;      
+    case shards::Tetrahedron<>::key :
+      distance = ParametricDistance<shards::Tetrahedron<>::key>::distance(point);
+      break;
+    case shards::Hexahedron<>::key :
+      distance = ParametricDistance<shards::Hexahedron<>::key>::distance(point);
+      break;
+    case shards::Wedge<>::key :
+      distance = ParametricDistance<shards::Wedge<>::key>::distance(point);
+      break;
+    case shards::Pyramid<>::key : 
+      distance = ParametricDistance<shards::Pyramid<>::key>::distance(point);
+      break;      
+    default:
+      INTREPID2_TEST_FOR_EXCEPTION( true, std::invalid_argument,
+                                    ">>> ERROR (Intrepid2::CellTools::parametricDistance): Invalid cell topology. ");
+    }
+    return distance;
+  }
+
+
   template<typename DeviceType>
   template<typename PointViewType>
   bool 
@@ -37,53 +94,7 @@ namespace Intrepid2 {
   checkPointInclusion( const PointViewType          point,
                        const shards::CellTopology   cellTopo,
                        const typename ScalarTraits<typename PointViewType::value_type>::scalar_type threshold) {
-#ifdef HAVE_INTREPID2_DEBUG
-    INTREPID2_TEST_FOR_EXCEPTION( point.rank() != 1, std::invalid_argument,
-                                  ">>> ERROR (Intrepid2::CellTools::checkPointInclusion): Point must have rank 1. ");
-    INTREPID2_TEST_FOR_EXCEPTION( point.extent(0) != cellTopo.getDimension(), std::invalid_argument,
-                                  ">>> ERROR (Intrepid2::CellTools::checkPointInclusion): Point and cell dimensions do not match. ");
-#endif
-    bool testResult = true;
-
-    // A cell with extended topology has the same reference cell as a cell with base topology. 
-    // => testing for inclusion in a reference Triangle<> and a reference Triangle<6> relies on 
-    // on the same set of inequalities. To eliminate unnecessary cases we switch on the base topology
-    const auto key = cellTopo.getBaseKey();
-    switch (key) {
-    
-    case shards::Line<>::key :
-      testResult = PointInclusion<shards::Line<>::key>::check(point, threshold);
-      break;
-    case shards::Triangle<>::key :
-      testResult = PointInclusion<shards::Triangle<>::key>::check(point, threshold);
-      break;      
-    case shards::Quadrilateral<>::key :
-      testResult = PointInclusion<shards::Quadrilateral<>::key>::check(point, threshold);
-      break;      
-    case shards::Tetrahedron<>::key :
-      testResult = PointInclusion<shards::Tetrahedron<>::key>::check(point, threshold);
-      break;
-    case shards::Hexahedron<>::key :
-      testResult = PointInclusion<shards::Hexahedron<>::key>::check(point, threshold);
-      break;
-    case shards::Wedge<>::key :
-      testResult = PointInclusion<shards::Wedge<>::key>::check(point, threshold);
-      break;
-    case shards::Pyramid<>::key : 
-      testResult = PointInclusion<shards::Pyramid<>::key>::check(point, threshold);
-      break;      
-    default:
-      INTREPID2_TEST_FOR_EXCEPTION( !( (key == shards::Line<>::key ) ||
-                                       (key == shards::Triangle<>::key)  ||
-                                       (key == shards::Quadrilateral<>::key) ||
-                                       (key == shards::Tetrahedron<>::key)  ||
-                                       (key == shards::Hexahedron<>::key)  ||
-                                       (key == shards::Wedge<>::key)  ||
-                                       (key == shards::Pyramid<>::key) ),
-                                    std::invalid_argument,
-                                    ">>> ERROR (Intrepid2::CellTools::checkPointInclusion): Invalid cell topology. ");
-    }
-    return testResult;
+    return parametricDistance(point, cellTopo) <= 1.0 + threshold;
   }
 
 
@@ -109,7 +120,7 @@ namespace Intrepid2 {
     void
     operator()(const ordinal_type i) const {
       const auto in = Kokkos::subview(input_,i,Kokkos::ALL());
-      const auto check = PointInclusion<cellTopologyKey>::check(in, threshold_);
+      const bool check = ParametricDistance<cellTopologyKey>::distance(in) <= 1.0 + threshold_;
       output_(i) = check;        
     }
     
@@ -117,7 +128,7 @@ namespace Intrepid2 {
     void
     operator()(const ordinal_type i, const ordinal_type j) const {
       const auto in = Kokkos::subview(input_,i,j,Kokkos::ALL());
-      const auto check = PointInclusion<cellTopologyKey>::check(in, threshold_);
+      const bool check = ParametricDistance<cellTopologyKey>::distance(in) <= 1.0 + threshold_;
       output_(i,j) = check;        
     }
   };

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
@@ -45,29 +45,29 @@ namespace Intrepid2 {
       const worksetCellType  _worksetCells;
       const basisGradType    _basisGrads;
       const int              _startCell;
-      const int              _endCell;
 
       KOKKOS_INLINE_FUNCTION
       F_setJacobian( jacobianViewType jacobian_,
                      worksetCellType  worksetCells_,
                      basisGradType    basisGrads_,
-                     const int        startCell_,
-                     const int        endCell_)
+                     const int        startCell_)
         : _jacobian(jacobian_), _worksetCells(worksetCells_), _basisGrads(basisGrads_),
-          _startCell(startCell_), _endCell(endCell_) {}
+          _startCell(startCell_) {}
 
       KOKKOS_INLINE_FUNCTION
       void operator()(const ordinal_type cell,
                       const ordinal_type point) const {
         
-        const ordinal_type dim = _jacobian.extent(2); // dim2 and dim3 should match
+        const ordinal_type phys_dim = _jacobian.extent(2); // dim2 and dim3 should match
         
         const ordinal_type gradRank = rank(_basisGrads);
+        const ordinal_type ref_dim = _basisGrads.extent_int(gradRank-1);
+
         if ( gradRank == 3)
         {
           const ordinal_type cardinality = _basisGrads.extent(0);
-          for (ordinal_type i=0;i<dim;++i)
-            for (ordinal_type j=0;j<dim;++j) {
+          for (ordinal_type i=0;i<phys_dim;++i)
+            for (ordinal_type j=0;j<ref_dim;++j) {
               _jacobian(cell, point, i, j) = 0;
               for (ordinal_type bf=0;bf<cardinality;++bf)
                 _jacobian(cell, point, i, j) += _worksetCells(cell+_startCell, bf, i) * _basisGrads(bf, point, j);
@@ -76,8 +76,8 @@ namespace Intrepid2 {
         else
         {
           const ordinal_type cardinality = _basisGrads.extent(1);
-          for (ordinal_type i=0;i<dim;++i)
-          for (ordinal_type j=0;j<dim;++j) {
+          for (ordinal_type i=0;i<phys_dim;++i)
+          for (ordinal_type j=0;j<ref_dim;++j) {
             _jacobian(cell, point, i, j) = 0;
             for (ordinal_type bf=0;bf<cardinality;++bf)
               _jacobian(cell, point, i, j) += _worksetCells(cell+_startCell, bf, i) * _basisGrads(cell, bf, point, j);
@@ -85,7 +85,10 @@ namespace Intrepid2 {
         }
       }
     };
+
   }
+
+
 
   template<typename DeviceType>
   template<class PointScalar>
@@ -780,14 +783,15 @@ namespace Intrepid2 {
     using FunctorType      = FunctorCellTools::F_setJacobian<JacobianViewType,WorksetType,BasisGradientsType> ;
     
     // resolve the -1 default argument for endCell into the true end cell index
-    int endCellResolved = (endCell == -1) ? worksetCell.extent_int(0) : endCell;
+    ordinal_type endCellResolved = (endCell == -1) ? worksetCell.extent_int(0) : endCell;
     
     using range_policy_type = Kokkos::MDRangePolicy
       < ExecSpaceType, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
     range_policy_type policy( { 0, 0 },
-                              { jacobian.extent(0), jacobian.extent(1) } );
-    Kokkos::parallel_for( policy, FunctorType(jacobian, worksetCell, gradients, startCell, endCellResolved) );
+                              { std::max(jacobian.extent_int(0), endCellResolved-startCell), jacobian.extent_int(1) } );
+    Kokkos::parallel_for( policy, FunctorType(jacobian, worksetCell, gradients, startCell) );
   }
+
 
   template<typename DeviceType>
   template<typename JacobianViewType,
@@ -812,8 +816,6 @@ namespace Intrepid2 {
     CellTools_setJacobianArgs(jacobian, points, worksetCell, basis->getBaseCellTopology(), startCell, endCell);
     //static_assert(std::is_same( pointValueType, decltype(basis->getDummyOutputValue()) ));
 #endif
-    const auto cellTopo = basis->getBaseCellTopology();
-    const ordinal_type spaceDim = cellTopo.getDimension();
     const ordinal_type numCells = jacobian.extent(0);
     
     //points can be rank-2 (P,D), or rank-3 (C,P,D)
@@ -828,19 +830,16 @@ namespace Intrepid2 {
     switch (pointRank) {
     case 2: {
       // For most FEMs
-      grads = Impl::createMatchingView<GradViewType>(points, "CellTools::setJacobian::grads", basisCardinality, numPoints, spaceDim);
+      grads = Impl::createMatchingView<GradViewType>(points, "CellTools::setJacobian::grads", basisCardinality, numPoints, basis->getDomainDimension());
       basis->getValues(grads, 
                        points, 
                        OPERATOR_GRAD);
       break;
     }
     case 3: { 
-      // For CVFEM
-      grads = Impl::createMatchingView<GradViewType>(points, "CellTools::setJacobian::grads", numCells, basisCardinality, numPoints, spaceDim);
-      for (ordinal_type cell=0;cell<numCells;++cell) 
-        basis->getValues(Kokkos::subview( grads,  cell, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL() ),  
-                         Kokkos::subview( points, cell, Kokkos::ALL(), Kokkos::ALL() ),  
-                         OPERATOR_GRAD);
+      // For CVFEM or map to reference frames for point inclusion
+      grads = Impl::createMatchingView<GradViewType>(points, "CellTools::setJacobian::grads", numCells, basisCardinality, numPoints, basis->getDomainDimension());
+      getHGradValues<OPERATOR_GRAD>(grads,points,basis.get());
       break;
     }
     }

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
@@ -783,12 +783,15 @@ namespace Intrepid2 {
     using FunctorType      = FunctorCellTools::F_setJacobian<JacobianViewType,WorksetType,BasisGradientsType> ;
     
     // resolve the -1 default argument for endCell into the true end cell index
+    // In some cases, endCell may be smaller than worksetCell.extent(0).
+    // This can occur when cells are split across worksets and the final
+    // workset is not completely filled with valid cells.
     ordinal_type endCellResolved = (endCell == -1) ? worksetCell.extent_int(0) : endCell;
     
     using range_policy_type = Kokkos::MDRangePolicy
       < ExecSpaceType, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
     range_policy_type policy( { 0, 0 },
-                              { std::max(jacobian.extent_int(0), endCellResolved-startCell), jacobian.extent_int(1) } );
+                              { std::min(jacobian.extent_int(0), endCellResolved-startCell), jacobian.extent_int(1) } );
     Kokkos::parallel_for( policy, FunctorType(jacobian, worksetCell, gradients, startCell) );
   }
 

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefPhysToRef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefPhysToRef.hpp
@@ -175,12 +175,7 @@ namespace Intrepid2 {
       cellCenter("CellTools::mapToReferenceFrame::cellCenter", spaceDim);
     getReferenceCellCenter(cellCenter, cellTopo);
 
-    // Default: map (C,P,D) array of physical pt. sets to (C,P,D) array. Requires (C,P,D) initial guess.
-    const auto numCells = worksetCell.extent(0);
-    const auto numPoints = physPoints.extent(1);
-    
-    // init guess is created locally and non fad whatever refpoints type is 
-    auto initGuess = Impl::createMatchingDynRankView(refPoints, "CellTools::mapToReferenceFrame::initGuess", numCells, numPoints, spaceDim );
+    // initialize refPoints with the cell center
     rst::clone(refPoints, cellCenter);
     
     auto basis = createHGradBasis<refPointValueType,refPointValueType>(cellTopo);
@@ -249,7 +244,7 @@ namespace Intrepid2 {
     using errorViewType = Kokkos::DynRankView<typename ScalarTraits<refPointValueType>::scalar_type, DeviceType>;
     using errorType = typename errorViewType::value_type;
     errorViewType
-      xScalarTmp    ("CellTools::mapToReferenceFrameInitGuess::xScalarTmp",     numCells, numPoints, refDim),
+      xScalarTmp    ("CellTools::mapToReferenceFrameInitGuess::xScalarTmp",     numCells, numPoints, physDim),
       errorPointwise("CellTools::mapToReferenceFrameInitGuess::errorPointwise", numCells, numPoints);
 
     
@@ -258,7 +253,7 @@ namespace Intrepid2 {
     errorType error(0), physInfNorm(0);
 
     rst::extractScalarValues(xScalarTmp, physPoints);
-    rst::vectorNorm(errorPointwise, Kokkos::subview(xScalarTmp, Kokkos::ALL(), Kokkos::ALL(), refDimRange), NORM_TWO);
+    rst::vectorNorm(errorPointwise, xScalarTmp, NORM_TWO);
     using range_policy_type = Kokkos::MDRangePolicy<typename DeviceType::execution_space, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
     range_policy_type policy( { 0, 0 }, { numCells, numPoints } );
     using FunctorType = FunctorCellTools::F_maxNorm<errorViewType>;
@@ -279,9 +274,9 @@ namespace Intrepid2 {
       mapToPhysicalFrame(physTmp, xOld, worksetCell, basis); // physTmp <- F(xOld)
       rst::subtract(physTmp, physPoints, physTmp);           // physTmp <- physPoints - F(xOld)
 
-      // l2 error (Euclidean distance) between old and new iterates: |physPoints - F(xOld)|
+      // l2 error (Euclidean distance) of the residual |physPoints - F(xOld)|
       rst::extractScalarValues(xScalarTmp, physTmp);
-      rst::vectorNorm(errorPointwise, Kokkos::subview(xScalarTmp, Kokkos::ALL(), Kokkos::ALL(), refDimRange), NORM_TWO);
+      rst::vectorNorm(errorPointwise, xScalarTmp, NORM_TWO);
 
       error = 0;
       Kokkos::parallel_reduce("MaxReduction", policy, FunctorType(errorPointwise), Kokkos::Max<errorType>(error));
@@ -304,7 +299,7 @@ namespace Intrepid2 {
       }
   
       // extract values
-      rst::extractScalarValues(xScalarTmp, refPts);
+      rst::extractScalarValues(Kokkos::subview(xScalarTmp, Kokkos::ALL(), Kokkos::ALL(), refDimRange), refPts);
 
       rst::add(refPts, xOld);                                 // refPoints <- refPoints + xOld
 
@@ -317,6 +312,11 @@ namespace Intrepid2 {
       // Stopping criterion:
       if (error < tol) {
         converged = true;
+        if(isShell) { //update Jacobian and residual so that they are consistent with refPts
+          setJacobian(jacobian, refPts, worksetCell, basis);
+          mapToPhysicalFrame(physTmp, refPts, worksetCell, basis); // physTmp <- F(refPts)
+          rst::subtract(physTmp, physPoints, physTmp);             // physTmp <- physPoints - F(refPts)
+        }
         break;
       }
 
@@ -330,7 +330,6 @@ namespace Intrepid2 {
       //and dividing it by the shell half thickness. We do so by solving
       //(physPoints - F(xOld)) * n /|n|^2 / (H/2)
       //where H is the shell thickness and  n is the normal to the manifold defined by the map to physical frame (n is orthogonal to the tangents defined by the Jacobian)
-      setJacobian(jacobian, refPts, worksetCell, basis);
       scaledResidualNormalComponent(
                Kokkos::subview(refPoints,Kokkos::ALL(), Kokkos::ALL(), refDim),
                jacobian,

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefPhysToRef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefPhysToRef.hpp
@@ -253,7 +253,7 @@ namespace Intrepid2 {
       errorPointwise("CellTools::mapToReferenceFrameInitGuess::errorPointwise", numCells, numPoints);
 
     
-    const auto tol = tolerence<errorType>();
+    const auto tol = tolerance<errorType>();
 
     errorType error(0), physInfNorm(0);
 

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefPhysToRef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefPhysToRef.hpp
@@ -28,18 +28,130 @@ namespace Intrepid2 {
   //                                                                                            //          
   //                      Reference-to-physical frame mapping and its inverse                   //          
   //                                                                                            //          
-  //============================================================================================//   
+  //============================================================================================//  
+
+  namespace FunctorCellTools {
+
+    /**
+     \brief Functor for computing the scaled normal component of the residual, 3d version
+     
+    */
+
+    template<typename OutViewType, typename TanViewType, typename InViewType>
+    struct F_scaledResidualNormalComponent3d {
+            OutViewType result_;
+            TanViewType workview_;
+            const TanViewType tangents_;
+            const InViewType residual_;
+            const typename OutViewType::value_type scaling_;
+
+      KOKKOS_INLINE_FUNCTION
+      F_scaledResidualNormalComponent3d( OutViewType result,
+                           TanViewType workview,
+                     const TanViewType tangents,
+                     const InViewType residual,
+                     const typename OutViewType::value_type scaling)
+        : result_(result), workview_(workview), tangents_(tangents), residual_(residual), scaling_(scaling) {}
+
+      KOKKOS_INLINE_FUNCTION
+      void operator()(const ordinal_type cell,
+                      const ordinal_type point) const {
+        
+        auto t1 = Kokkos::subview( tangents_,  cell, point, Kokkos::ALL(), 0);
+        auto t2 = Kokkos::subview( tangents_,  cell, point, Kokkos::ALL(), 1);
+        auto n = Kokkos::subview( workview_,  cell, point, Kokkos::ALL());
+        Kernels::Serial::vector_product_d3(n, t1, t2);
+        result_(cell,point) = (n(0)*residual_(cell,point,0) + n(1)*residual_(cell,point,1) + n(2)*residual_(cell,point,2))*scaling_/Kernels::Serial::norm(n, NORM_TWO);
+      }
+    };
+
+    /**
+     \brief Functor for computing the scaled normal component of the residual, 2d version
+    */
+    template<typename OutViewType, typename TanViewType, typename InViewType>
+    struct F_scaledResidualNormalComponent2d {
+            OutViewType result_;
+            const TanViewType tangents_;
+            const InViewType residual_;
+            const typename InViewType::value_type scaling_;
+
+      KOKKOS_INLINE_FUNCTION
+      F_scaledResidualNormalComponent2d( OutViewType result,
+                     const TanViewType tangents,
+                     const InViewType residual,
+                     const typename InViewType::value_type scaling)
+        : result_(result), tangents_(tangents), residual_(residual), scaling_(scaling) {}
+
+      KOKKOS_INLINE_FUNCTION
+      void operator()(const ordinal_type cell,
+                      const ordinal_type point) const {        
+        auto t = Kokkos::subview( tangents_,  cell, point, Kokkos::ALL(), 0); // n = [-t_1, t_0]
+        result_(cell,point) = (-t(1)*residual_(cell,point,0) + t(0)*residual_(cell,point,1))*scaling_/Kernels::Serial::norm(t, NORM_TWO);
+      }
+    };
+
+    /**
+     \brief Functor for computing the max norm of a view
+    */
+    template<typename ViewType>
+    struct F_maxNorm {
+      const ViewType view_;
+      KOKKOS_INLINE_FUNCTION
+      F_maxNorm( const ViewType view) 
+        : view_(view) {}
+
+      KOKKOS_INLINE_FUNCTION
+      void operator()(const ordinal_type cl,
+                      const ordinal_type pt,
+                      typename ViewType::value_type& lmax) const {
+        if (view_(cl,pt) > lmax) lmax = view_(cl,pt);
+      }
+    };
+
+  }
+
+  template<typename DeviceType>
+  template<typename OutViewType, typename TanViewType, typename InViewType>
+  void
+  CellTools<DeviceType>::
+  scaledResidualNormalComponent(
+               OutViewType result,
+               const TanViewType tangents,
+               const InViewType residual,
+               const typename InViewType::value_type scaling)
+  {
+    constexpr bool is_accessible =
+        Kokkos::SpaceAccessibility<MemSpaceType,
+        typename decltype(tangents)::memory_space>::accessible;
+    static_assert(is_accessible, "CellTools<DeviceType>::setJacobian(..): output view's memory space is not compatible with DeviceType");
+
+    using range_policy_type = Kokkos::MDRangePolicy
+      < ExecSpaceType, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
+    range_policy_type policy( { 0, 0 },
+                              { tangents.extent(0), tangents.extent(1) } );
+    if (tangents.extent_int(2) == 2) {
+      using FunctorType      = FunctorCellTools::F_scaledResidualNormalComponent2d<OutViewType, TanViewType, InViewType> ;
+      Kokkos::parallel_for( policy, FunctorType(result, tangents, residual, scaling) );
+    } else {
+      using FunctorType      = FunctorCellTools::F_scaledResidualNormalComponent3d<OutViewType, TanViewType, InViewType> ;
+      TanViewType work = Impl::createMatchingDynRankView(tangents, "work_view", tangents.extent_int(0), tangents.extent_int(1), tangents.extent_int(2));
+      Kokkos::parallel_for( policy, FunctorType(result, work, tangents, residual, scaling) );
+    }
+  }
+
+
 
   template<typename DeviceType>
   template<typename refPointValueType,    class ...refPointProperties,
            typename physPointValueType,   class ...physPointProperties,
            typename worksetCellValueType, class ...worksetCellProperties>
-  void
+  bool
   CellTools<DeviceType>::
   mapToReferenceFrame(       Kokkos::DynRankView<refPointValueType,refPointProperties...>       refPoints,
                        const Kokkos::DynRankView<physPointValueType,physPointProperties...>     physPoints,
                        const Kokkos::DynRankView<worksetCellValueType,worksetCellProperties...> worksetCell,
-                       const shards::CellTopology cellTopo ) {
+                       const shards::CellTopology cellTopo, 
+                       const physPointValueType shellThickness ) {
     constexpr bool are_accessible =
         Kokkos::SpaceAccessibility<MemSpaceType,
         typename decltype(refPoints)::memory_space>::accessible &&
@@ -69,36 +181,27 @@ namespace Intrepid2 {
     
     // init guess is created locally and non fad whatever refpoints type is 
     auto initGuess = Impl::createMatchingDynRankView(refPoints, "CellTools::mapToReferenceFrame::initGuess", numCells, numPoints, spaceDim );
-    rst::clone(initGuess, cellCenter);
+    rst::clone(refPoints, cellCenter);
     
-    mapToReferenceFrameInitGuess(refPoints, initGuess, physPoints, worksetCell, cellTopo);  
+    auto basis = createHGradBasis<refPointValueType,refPointValueType>(cellTopo);
+    return mapToReferenceFrame(refPoints, physPoints, worksetCell, basis, shellThickness);  
   }
   
 
   template<typename DeviceType>
   template<typename refPointValueType,    class ...refPointProperties,
-           typename initGuessValueType,   class ...initGuessProperties,
            typename physPointValueType,   class ...physPointProperties,
-           typename worksetCellValueType, class ...worksetCellProperties,
-           typename HGradBasisPtrType>
-  void
+           typename worksetCellValueType, class ...worksetCellProperties>
+  bool
   CellTools<DeviceType>::
-  mapToReferenceFrameInitGuess(       Kokkos::DynRankView<refPointValueType,refPointProperties...>       refPoints,
-                                const Kokkos::DynRankView<initGuessValueType,initGuessProperties...>     initGuess,
-                                const Kokkos::DynRankView<physPointValueType,physPointProperties...>     physPoints,
-                                const Kokkos::DynRankView<worksetCellValueType,worksetCellProperties...> worksetCell,
-                                const HGradBasisPtrType basis ) {
-#ifdef HAVE_INTREPID2_DEBUG
-    CellTools_mapToReferenceFrameInitGuessArgs(refPoints, initGuess, physPoints, worksetCell, 
-                                               basis->getBaseCellTopology());
-
-#endif
-
+  mapToReferenceFrame(       Kokkos::DynRankView<refPointValueType,refPointProperties...>       refPoints,
+                       const Kokkos::DynRankView<physPointValueType,physPointProperties...>     physPoints,
+                       const Kokkos::DynRankView<worksetCellValueType,worksetCellProperties...> worksetCell,
+                       const BasisPtr<DeviceType, refPointValueType, refPointValueType>         basis,
+                       const physPointValueType shellThickness) {
     constexpr bool are_accessible =
         Kokkos::SpaceAccessibility<MemSpaceType,
         typename decltype(refPoints)::memory_space>::accessible &&
-        Kokkos::SpaceAccessibility<MemSpaceType,
-        typename decltype(initGuess)::memory_space>::accessible &&
         Kokkos::SpaceAccessibility<MemSpaceType,
         typename decltype(physPoints)::memory_space>::accessible &&
         Kokkos::SpaceAccessibility<MemSpaceType,
@@ -106,9 +209,11 @@ namespace Intrepid2 {
 
     static_assert(are_accessible, "CellTools<DeviceType>::mapToReferenceFrameInitGuess(..): input/output views' memory spaces are not compatible with DeviceType");
 
+    const bool isShell = (shellThickness>0);
 
-    const auto cellTopo = basis->getBaseCellTopology();
-    const auto spaceDim = cellTopo.getDimension();
+    //note, for Beam and Shell elements, refPoints have refDim+1 dimension 
+    const ordinal_type refDim = basis->getDomainDimension();
+    const ordinal_type physDim = physPoints.extent_int(2);
 
     // Default: map (C,P,D) array of physical pt. sets to (C,P,D) array. 
     // Requires (C,P,D) temp arrays and (C,P,D,D) Jacobians.
@@ -116,64 +221,152 @@ namespace Intrepid2 {
     const auto numPoints = physPoints.extent(1);
 
     using rst = RealSpaceTools<DeviceType>;
-    const auto tol = tolerence();
+    auto refDimRange = Kokkos::pair<ordinal_type,ordinal_type>(0,refDim);
 
     using result_layout = typename DeduceLayout< decltype(refPoints) >::result_layout;
     // Temp arrays for Newton iterates and Jacobians. Resize according to rank of ref. point array
-    auto xOld = Impl::createMatchingDynRankView(refPoints, "CellTools::mapToReferenceFrameInitGuess::xOld", numCells, numPoints, spaceDim);
-    auto xTmp = Impl::createMatchingDynRankView(refPoints, "CellTools::mapToReferenceFrameInitGuess::xTmp", numCells, numPoints, spaceDim);
+    auto xOld = Impl::createMatchingDynRankView(refPoints, "CellTools::mapToReferenceFrameInitGuess::xOld", numCells, numPoints, refDim);
+    auto xTmp = Impl::createMatchingDynRankView(refPoints, "CellTools::mapToReferenceFrameInitGuess::xTmp", numCells, numPoints, refDim);
+    auto physTmp = Impl::createMatchingDynRankView(refPoints, "CellTools::mapToReferenceFrameInitGuess::physTmp", numCells, numPoints, physDim);
 
     // deep copy may not work with FAD but this is right thing to do as it can move data between devices
-    Kokkos::deep_copy(xOld, initGuess);
+    Kokkos::deep_copy(xOld, Kokkos::subview(refPoints, Kokkos::ALL(), Kokkos::ALL(), refDimRange));
 
     // jacobian should select fad dimension between xOld and worksetCell as they are input; no front interface yet
     using valueTypeJ = std::common_type_t<typename decltype(refPoints)::value_type, typename decltype(worksetCell)::value_type>;    
     using viewTypeJ = Kokkos::DynRankView<valueTypeJ, result_layout, DeviceType >;
     using view_factory = Impl::CreateViewFactory<decltype(refPoints), decltype(worksetCell)>;
-    viewTypeJ jacobian = view_factory::template create_view<viewTypeJ>(refPoints, worksetCell, "CellTools::mapToReferenceFrameInitGuess::jacobian", numCells, numPoints, spaceDim, spaceDim);
-    viewTypeJ jacobianInv = view_factory::template create_view<viewTypeJ>(refPoints, worksetCell, "CellTools::mapToReferenceFrameInitGuess::jacobianInv", numCells, numPoints, spaceDim, spaceDim);
+
+    viewTypeJ metric;
+    if(refDim < physDim)
+      metric = view_factory::template create_view<viewTypeJ>(refPoints, worksetCell, "CellTools::mapToReferenceFrameInitGuess::metric", numCells, numPoints, refDim, refDim);
+    viewTypeJ jacobian = view_factory::template create_view<viewTypeJ>(refPoints, worksetCell, "CellTools::mapToReferenceFrameInitGuess::jacobian", numCells, numPoints, physDim, refDim);
+    
+    //  when refDim < physDim, this will contain the inverse of the metric
+    viewTypeJ jacobianInv = view_factory::template create_view<viewTypeJ>(refPoints, worksetCell, "CellTools::mapToReferenceFrameInitGuess::jacobianInv", numCells, numPoints, refDim, refDim);
+
     
     using errorViewType = Kokkos::DynRankView<typename ScalarTraits<refPointValueType>::scalar_type, DeviceType>;
+    using errorType = typename errorViewType::value_type;
     errorViewType
-      xScalarTmp    ("CellTools::mapToReferenceFrameInitGuess::xScalarTmp",     numCells, numPoints, spaceDim),
-      errorPointwise("CellTools::mapToReferenceFrameInitGuess::errorPointwise", numCells, numPoints),
-      errorCellwise ("CellTools::mapToReferenceFrameInitGuess::errorCellwise",  numCells);
+      xScalarTmp    ("CellTools::mapToReferenceFrameInitGuess::xScalarTmp",     numCells, numPoints, refDim),
+      errorPointwise("CellTools::mapToReferenceFrameInitGuess::errorPointwise", numCells, numPoints);
+
+    
+    const auto tol = tolerence<errorType>();
+
+    errorType error(0), physInfNorm(0);
+
+    rst::extractScalarValues(xScalarTmp, physPoints);
+    rst::vectorNorm(errorPointwise, Kokkos::subview(xScalarTmp, Kokkos::ALL(), Kokkos::ALL(), refDimRange), NORM_TWO);
+    using range_policy_type = Kokkos::MDRangePolicy<typename DeviceType::execution_space, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
+    range_policy_type policy( { 0, 0 }, { numCells, numPoints } );
+    using FunctorType = FunctorCellTools::F_maxNorm<errorViewType>;
+    Kokkos::parallel_reduce("MaxReduction", policy, FunctorType(errorPointwise), Kokkos::Max<errorType>(physInfNorm));
+    
+    auto refPts = Kokkos::subview(refPoints,Kokkos::ALL(), Kokkos::ALL(), refDimRange);
+      
 
     // Newton method to solve the equation F(refPoints) - physPoints = 0:
     // refPoints = xOld - DF^{-1}(xOld)*(F(xOld) - physPoints) = xOld + DF^{-1}(xOld)*(physPoints - F(xOld))
+    bool converged(false);
     for (ordinal_type iter=0;iter<Parameters::MaxNewton;++iter) {
       
       // Jacobians at the old iterates and their inverses. 
       setJacobian(jacobian, xOld, worksetCell, basis);
-      setJacobianInv(jacobianInv, jacobian);
       
       // The Newton step.
-      mapToPhysicalFrame(xTmp, xOld, worksetCell, basis); // xTmp <- F(xOld)
-      rst::subtract(xTmp, physPoints, xTmp);              // xTmp <- physPoints - F(xOld)
-      rst::matvec(refPoints, jacobianInv, xTmp);          // refPoints <- DF^{-1}( physPoints - F(xOld) )
-      rst::add(refPoints, xOld);                          // refPoints <- DF^{-1}( physPoints - F(xOld) ) + xOld
+      mapToPhysicalFrame(physTmp, xOld, worksetCell, basis); // physTmp <- F(xOld)
+      rst::subtract(physTmp, physPoints, physTmp);           // physTmp <- physPoints - F(xOld)
 
-      // l2 error (Euclidean distance) between old and new iterates: |xOld - xNew|
-      rst::subtract(xTmp, xOld, refPoints);
+      // l2 error (Euclidean distance) between old and new iterates: |physPoints - F(xOld)|
+      rst::extractScalarValues(xScalarTmp, physTmp);
+      rst::vectorNorm(errorPointwise, Kokkos::subview(xScalarTmp, Kokkos::ALL(), Kokkos::ALL(), refDimRange), NORM_TWO);
 
+      error = 0;
+      Kokkos::parallel_reduce("MaxReduction", policy, FunctorType(errorPointwise), Kokkos::Max<errorType>(error));
+
+      if (error < tol*physInfNorm) {
+        converged = true;
+        break;
+      }
+
+
+      if(refDim < physDim) {
+        rst::matvec(xTmp, jacobian, physTmp, true);          // xTmp <- DF^{T}( physPoints - F(xOld) ))
+        rst::AtA(metric,jacobian);
+        setJacobianInv(jacobianInv, metric);             
+        rst::matvec(refPts, jacobianInv, xTmp);              // refPoints <- (DF^{T} DF)^{-1} DF^{T}( physPoints - F(xOld) )
+      }
+      else { 
+        setJacobianInv(jacobianInv, jacobian);
+        rst::matvec(refPts, jacobianInv, physTmp);           // refPoints <- DF^{-1}( physPoints - F(xOld) )
+      }
+  
       // extract values
-      rst::extractScalarValues(xScalarTmp, xTmp);
-      rst::vectorNorm(errorPointwise, xScalarTmp, NORM_TWO);
+      rst::extractScalarValues(xScalarTmp, refPts);
 
-      // Average L2 error for a multiple sets of physical points: error is rank-2 (C,P) array 
-      rst::vectorNorm(errorCellwise, errorPointwise, NORM_ONE);
+      rst::add(refPts, xOld);                                 // refPoints <- refPoints + xOld
 
-      auto errorCellwise_h = Kokkos::create_mirror_view(errorCellwise);
-      Kokkos::deep_copy(errorCellwise_h, errorCellwise);
-      const auto errorTotal = rst::Serial::vectorNorm(errorCellwise_h, NORM_ONE);
+      
+      error = 0;
+      // l2 error (Euclidean distance) between old and new iterates: |xOld - xNew|
+      rst::vectorNorm(errorPointwise, Kokkos::subview(xScalarTmp, Kokkos::ALL(), Kokkos::ALL(), refDimRange), NORM_TWO);
+      Kokkos::parallel_reduce("MaxReduction", policy, FunctorType(errorPointwise), Kokkos::Max<errorType>(error));    
     
       // Stopping criterion:
-      if (errorTotal < tol) 
+      if (error < tol) {
+        converged = true;
         break;
+      }
 
       // initialize next Newton step ( this is not device friendly )
-      Kokkos::deep_copy(xOld, refPoints);
+      Kokkos::deep_copy(xOld, refPts);
     }
+
+    if(isShell) {
+      //for shell elements, we can reconstruct the orthogonal reference component by approximating the 
+      //signed distance between the physical point and the map to physical space of the reference line (in 2d) or triangle,quad (in 3d),
+      //and dividing it by the shell half thickness. We do so by solving
+      //(physPoints - F(xOld)) * n /|n|^2 / (H/2)
+      //where H is the shell thickness and  n is the normal to the manifold defined by the map to physical frame (n is orthogonal to the tangents defined by the Jacobian)
+      setJacobian(jacobian, refPts, worksetCell, basis);
+      scaledResidualNormalComponent(
+               Kokkos::subview(refPoints,Kokkos::ALL(), Kokkos::ALL(), refDim),
+               jacobian,
+               physTmp,
+               2.0/shellThickness);
+    } 
+
+    return converged;
+  }
+
+
+  template<typename DeviceType>
+  template<typename refPointValueType,    class ...refPointProperties,
+           typename initGuessValueType,   class ...initGuessProperties,
+           typename physPointValueType,   class ...physPointProperties,
+           typename worksetCellValueType, class ...worksetCellProperties>
+  bool
+  CellTools<DeviceType>::
+  mapToReferenceFrameInitGuess(       Kokkos::DynRankView<refPointValueType,refPointProperties...>       refPoints,
+                                const Kokkos::DynRankView<initGuessValueType,initGuessProperties...>     initGuess,
+                                const Kokkos::DynRankView<physPointValueType,physPointProperties...>     physPoints,
+                                const Kokkos::DynRankView<worksetCellValueType,worksetCellProperties...> worksetCell,
+                                const shards::CellTopology cellTopo,
+                                const physPointValueType shellThickness) {
+    
+  #ifdef HAVE_INTREPID2_DEBUG
+    CellTools_mapToReferenceFrameInitGuessArgs(refPoints, initGuess, physPoints, worksetCell, cellTopo);
+  #endif
+    
+    Kokkos::deep_copy(refPoints,initGuess);
+    auto basis = createHGradBasis<refPointValueType,refPointValueType>(cellTopo);
+    return mapToReferenceFrame(refPoints,
+                                 physPoints,
+                                 worksetCell,
+                                 basis,
+                                 shellThickness);
   }
 
 }

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefRefToPhys.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefRefToPhys.hpp
@@ -139,9 +139,6 @@ namespace Intrepid2 {
                      const RefPointViewType  refPoints,
                      const WorksetType       worksetCell,
                      const HGradBasisPtrType basis ) {
-#ifdef HAVE_INTREPID2_DEBUG
-    CellTools_mapToPhysicalFrameArgs( physPoints, refPoints, worksetCell, basis->getBaseCellTopology() );
-#endif
     constexpr bool are_accessible =
         Kokkos::SpaceAccessibility<MemSpaceType,
         typename decltype(physPoints)::memory_space>::accessible &&
@@ -157,6 +154,7 @@ namespace Intrepid2 {
     const auto refPointRank = refPoints.rank();
     const auto numPoints = (refPointRank == 2 ? refPoints.extent(0) : refPoints.extent(1));
     const auto basisCardinality = basis->getCardinality();
+    const auto basisDimRange = Kokkos::pair<ordinal_type,ordinal_type>(0, basis->getDomainDimension());
 
     using valViewType = Kokkos::DynRankView<decltype(basis->getDummyOutputValue()),DeviceType>;
 
@@ -166,18 +164,15 @@ namespace Intrepid2 {
     case 2: {
       // refPoints is (P,D): single set of ref. points is mapped to one or multiple physical cells
       vals = Impl::createMatchingView<valViewType>(physPoints, "CellTools::mapToPhysicalFrame::vals", basisCardinality, numPoints);
-      basis->getValues(vals,
-                       refPoints,
-                       OPERATOR_VALUE);
+      const auto refPts = Kokkos::subdynrankview(refPoints, Kokkos::ALL(), basisDimRange); //needed for shell topologies
+      basis->getValues(vals, refPts, OPERATOR_VALUE);
       break;
     }
     case 3: {
       // refPoints is (C,P,D): multiple sets of ref. points are mapped to matching number of physical cells.
       vals = Impl::createMatchingView<valViewType>(physPoints, "CellTools::mapToPhysicalFrame::vals", numCells, basisCardinality, numPoints);
-      for (size_type cell=0;cell<numCells;++cell)
-        basis->getValues(Kokkos::subdynrankview( vals,      cell, Kokkos::ALL(), Kokkos::ALL() ),
-                         Kokkos::subdynrankview( refPoints, cell, Kokkos::ALL(), Kokkos::ALL() ),
-                         OPERATOR_VALUE);
+      const auto refPts = Kokkos::subdynrankview(refPoints, Kokkos::ALL(), Kokkos::ALL(), basisDimRange);  //needed for shell topologies
+      getHGradValues<OPERATOR_VALUE>(vals, refPts, basis.get());
       break;
     }
     }
@@ -187,6 +182,28 @@ namespace Intrepid2 {
     const auto loopSize = physPoints.extent(0)*physPoints.extent(1);
     Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
     Kokkos::parallel_for( policy, FunctorType(physPoints, worksetCell, vals) );
+  }
+
+  template<typename DeviceType>
+  template<typename PhysPointViewType,
+             typename RefPointViewType,
+             typename WorksetCellViewType>
+    void
+    CellTools<DeviceType>::
+    mapToPhysicalFrame(       PhysPointViewType    physPoints,
+                        const RefPointViewType     refPoints,
+                        const WorksetCellViewType  worksetCell,
+                        const shards::CellTopology cellTopo ) {
+    
+    #ifdef HAVE_INTREPID2_DEBUG
+      CellTools_mapToPhysicalFrameArgs( physPoints, refPoints, worksetCell, cellTopo );
+    #endif
+      using nonConstRefPointValueType = typename RefPointViewType::non_const_value_type;
+      auto basis = createHGradBasis<nonConstRefPointValueType,nonConstRefPointValueType>(cellTopo);
+      mapToPhysicalFrame(physPoints,
+                         refPoints,
+                         worksetCell,
+                         basis);
   }
 
   template<typename DeviceType>

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefValidateArguments.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefValidateArguments.hpp
@@ -44,9 +44,7 @@ namespace Intrepid2 {
     //TODO: check this. not working for composite tet
     //INTREPID2_TEST_FOR_EXCEPTION( worksetCell.extent(1) != cellTopo.getSubcellCount(0), std::invalid_argument,
     //                              ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 1 (number of cell nodes) of worksetCell array does not match cell topology." );
-  
-    INTREPID2_TEST_FOR_EXCEPTION( worksetCell.extent(2) != cellTopo.getDimension(), std::invalid_argument,
-                                  ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 2 (spatial dimension) of worksetCell array  does not match cell dimension." );
+ 
     
     // Validate points array: can be rank-2 (P,D) or rank-3 (C,P,D)
     // If rank-2: admissible jacobians: rank-3 (P,D,D) or rank-4 (C,P,D,D); admissible whichCell: -1 (default) or cell ordinal.
@@ -64,8 +62,6 @@ namespace Intrepid2 {
     
     switch (pointRank) {
     case 2: {
-      INTREPID2_TEST_FOR_EXCEPTION( points.extent(1) != cellTopo.getDimension(), std::invalid_argument,
-                                    ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 1 (spatial dimension) of points array does not match cell dimension." );
       
       INTREPID2_TEST_FOR_EXCEPTION( jacobian.rank() != 4, std::invalid_argument, 
                                     ">>> ERROR (Intrepid2::CellTools::setJacobian): rank = 4 required for jacobian array." );
@@ -76,11 +72,11 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION( jacobian.extent(1) != points.extent(0), std::invalid_argument,
                                     ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 1 (number of points) of jacobian array must equal dim 0 of points array." );
       
-      INTREPID2_TEST_FOR_EXCEPTION( jacobian.extent(2) != points.extent(1), std::invalid_argument,
-                                    ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 2 (spatial dimension) of jacobian array must equal dim 1 of points array." );
+      INTREPID2_TEST_FOR_EXCEPTION( jacobian.extent(2) != worksetCell.extent(2), std::invalid_argument,
+                                    ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 2 (range dimension) of jacobian array must equal dim 2 of worksetCell (phys points) array");
       
-      INTREPID2_TEST_FOR_EXCEPTION( jacobian.extent(2) != jacobian.extent(3), std::invalid_argument,
-                                    ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 2 = dim 3 (same spatial dimensions) required for jacobian array." );
+      INTREPID2_TEST_FOR_EXCEPTION( jacobian.extent(3) != points.extent(1), std::invalid_argument,
+                                    ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 3 (domain dimension) of Jacobian array must equal dim 1 (spatial dimension) of points array. " );
       
       INTREPID2_TEST_FOR_EXCEPTION( jacobian.extent(3) < 1 || jacobian.extent(3) > 3, std::invalid_argument,
                                     ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 2 and dim 3 (spatial dimensions) must be between 1 and 3." );
@@ -90,8 +86,6 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION( points.extent_int(0) != numCells, std::invalid_argument,
                                     ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 0 (number of cells) of points array must equal number of cells requested from in the workset.");
 
-      INTREPID2_TEST_FOR_EXCEPTION( points.extent(2) != cellTopo.getDimension(), std::invalid_argument,
-                                    ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 2 (spatial dimension) of points array does not match cell dimension");
       
       // rank-4 (C,P,D,D) jacobian required for rank-3 (C,P,D) input points
       INTREPID2_TEST_FOR_EXCEPTION( jacobian.rank() != 4, std::invalid_argument,
@@ -103,11 +97,11 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION( jacobian.extent(1) != points.extent(1), std::invalid_argument,
                                     ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 1 (number of points) of jacobian array must equal dim 1 of points array");
       
-      INTREPID2_TEST_FOR_EXCEPTION( jacobian.extent(2) != points.extent(2), std::invalid_argument,
-                                    ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 2 (spatial dimension) of jacobian array must equal dim 2 of points array");
+      INTREPID2_TEST_FOR_EXCEPTION( jacobian.extent(2) != worksetCell.extent(2), std::invalid_argument,
+                                    ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 2 (range dimension) of jacobian array must equal dim 2 of worksetCell (phys points) array");
       
-      INTREPID2_TEST_FOR_EXCEPTION( jacobian.extent(2) != jacobian.extent(3), std::invalid_argument,
-                                    ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 2 = dim 3 (same spatial dimensions) required for jacobian array. ");
+      INTREPID2_TEST_FOR_EXCEPTION( jacobian.extent(3) != points.extent(2), std::invalid_argument,
+                                    ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 3 (domain dimension) of Jacobian array must equal dim 2 (spatial dimension) of points array. ");
 
       INTREPID2_TEST_FOR_EXCEPTION( jacobian.extent(3) < 1 || jacobian.extent(3) > 3, std::invalid_argument,
                                     ">>> ERROR (Intrepid2::CellTools::setJacobian): dim 2 and dim 3 (spatial dimensions) must be between 1 and 3." );
@@ -271,22 +265,18 @@ namespace Intrepid2 {
     // INTREPID2_TEST_FOR_EXCEPTION( worksetCell.extent(1) != cellTopo.getSubcellCount(0), std::invalid_argument,
     //                              ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): dim 1 (number of cell nodes) of worksetCell array does not match cell topology" );
   
-    INTREPID2_TEST_FOR_EXCEPTION( worksetCell.extent(2) != cellTopo.getDimension(), std::invalid_argument,
-                                  ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): dim 2 (spatial dimension) of worksetCell array  does not match cell dimension" );
-    
     // Admissible ranks and dimensions of refPoints and physPoints depend on whichCell value:
     // default is to map multiple sets of points to multiple sets of points. (C,P,D) arrays required
     
     const ordinal_type physPointRank = physPoints.rank();
     const ordinal_type refPointRank = refPoints.rank();
     
-    INTREPID2_TEST_FOR_EXCEPTION( refPointRank != 2 &&
-                                  refPointRank != 3, std::invalid_argument, 
-                                  ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): refPoint must have rank 2 or 3." );
+    INTREPID2_TEST_FOR_EXCEPTION( refPointRank != 3, std::invalid_argument, 
+                                  ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): refPoint must have rank 3." );
     
-    INTREPID2_TEST_FOR_EXCEPTION( physPointRank != refPointRank, std::invalid_argument, 
-                                  ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): physPoints rank does not match refPoints rank." );
-    for (ordinal_type i=0;i<refPointRank;++i) {
+    INTREPID2_TEST_FOR_EXCEPTION( physPointRank != 3, std::invalid_argument, 
+                                  ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): physPoints must have rank 3." );
+    for (ordinal_type i=0;i<refPointRank-1;++i) {
       INTREPID2_TEST_FOR_EXCEPTION( refPoints.extent(i) != physPoints.extent(i), std::invalid_argument, 
                                     ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): physPoints dimension (i) does not match refPoints dimension (i)." );
     }
@@ -304,14 +294,14 @@ namespace Intrepid2 {
     // Call the method that validates arguments with the default initial guess selection
     CellTools_mapToReferenceFrameArgs(refPoints, physPoints, worksetCell, cellTopo);
   
-    // Then check initGuess: its rank and dimensions must match those of physPoints.
-    INTREPID2_TEST_FOR_EXCEPTION( initGuess.rank() != physPoints.rank(), std::invalid_argument, 
-                                  ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): InitGuess must have the same rank as physPoints");         
+    // Then check initGuess: its rank and dimensions must match those of refPoints.
+    INTREPID2_TEST_FOR_EXCEPTION( initGuess.rank() != refPoints.rank(), std::invalid_argument, 
+                                  ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): InitGuess must have the same rank as refPoints");         
 
     const ordinal_type r = initGuess.rank();
     for (ordinal_type i=0;i<r;++i) {
-      INTREPID2_TEST_FOR_EXCEPTION( initGuess.extent(i) != physPoints.extent(i), std::invalid_argument, 
-                                    ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): InitGuess dimension (i) does not match ot physPoints dimension(i).");
+      INTREPID2_TEST_FOR_EXCEPTION( initGuess.extent(i) != refPoints.extent(i), std::invalid_argument, 
+                                    ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): InitGuess dimension (i) does not match ot refPoints dimension(i).");
     }         
   }
 

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefValidateArguments.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefValidateArguments.hpp
@@ -217,6 +217,9 @@ namespace Intrepid2 {
       
       INTREPID2_TEST_FOR_EXCEPTION( physPoints.rank() != 3, std::invalid_argument,
                                     ">>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): rank = 3 required for physPoints array for the default whichCell value." );
+
+      INTREPID2_TEST_FOR_EXCEPTION( cellTopo.getDimension() > worksetCell.extent(2), std::invalid_argument,
+                                    ">>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): reference dimension cannot exceed physical dimension." );
       
       INTREPID2_TEST_FOR_EXCEPTION( physPoints.extent(0) != worksetCell.extent(0), std::invalid_argument,
                                     ">>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): dim 0 (number of cells) of physPoints array must equal dim 0 of worksetCell array." );
@@ -235,6 +238,9 @@ namespace Intrepid2 {
       
       INTREPID2_TEST_FOR_EXCEPTION( refPoints.extent(2) != cellTopo.getDimension(), std::invalid_argument,
                                     ">>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): dim 2 (spatial dimension) of refPoints array does not match cell dimension." );
+
+      INTREPID2_TEST_FOR_EXCEPTION( cellTopo.getDimension() > worksetCell.extent(2), std::invalid_argument,
+                                    ">>> ERROR (Intrepid2::CellTools::mapToPhysicalFrame): reference dimension cannot exceed physical dimension." );
     
       // physPoints must match rank and dimensions of refPoints
       INTREPID2_TEST_FOR_EXCEPTION( refPointRank != physPointRank, std::invalid_argument, 
@@ -280,6 +286,17 @@ namespace Intrepid2 {
       INTREPID2_TEST_FOR_EXCEPTION( refPoints.extent(i) != physPoints.extent(i), std::invalid_argument, 
                                     ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): physPoints dimension (i) does not match refPoints dimension (i)." );
     }
+    
+    const ordinal_type physDim = worksetCell.extent_int(2);
+
+    INTREPID2_TEST_FOR_EXCEPTION( physPoints.extent_int(2) != physDim, std::invalid_argument,
+                                  ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): "
+                                  "physPoints.extent(2) must match worksetCell.extent(2)." );
+
+    INTREPID2_TEST_FOR_EXCEPTION( refPoints.extent(2) != cellTopo.getDimension(), std::invalid_argument,
+                                  ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): "
+                                  "refPoints.extent(2) must match the expected reference output dimension for cellTopo." );
+
   }
 
   template<typename refPointViewType, 
@@ -296,12 +313,12 @@ namespace Intrepid2 {
   
     // Then check initGuess: its rank and dimensions must match those of refPoints.
     INTREPID2_TEST_FOR_EXCEPTION( initGuess.rank() != refPoints.rank(), std::invalid_argument, 
-                                  ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): InitGuess must have the same rank as refPoints");         
+                                  ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrameInitGuess): InitGuess must have the same rank as refPoints");         
 
     const ordinal_type r = initGuess.rank();
     for (ordinal_type i=0;i<r;++i) {
       INTREPID2_TEST_FOR_EXCEPTION( initGuess.extent(i) != refPoints.extent(i), std::invalid_argument, 
-                                    ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): InitGuess dimension (i) does not match ot refPoints dimension(i).");
+                                    ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrameInitGuess): InitGuess dimension (i) does not match ot refPoints dimension(i).");
     }         
   }
 

--- a/packages/intrepid2/src/Cell/Intrepid2_CellTools_Serial.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellTools_Serial.hpp
@@ -121,7 +121,7 @@ public:
     mapToReferenceFrame(const refPointViewType &refPoint, // refDim
         const phyPointViewType &physPoint, // physDim
         const nodeViewType &nodes,
-        const double tol = tolerence(),
+        const double tol = tolerance(),
         const typename phyPointViewType::value_type shellThickness = -1.0) {  // numNodes,physDim
 
       bool isBeamOrShell = (shellThickness > 0); 

--- a/packages/intrepid2/src/Cell/Intrepid2_CellTools_Serial.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellTools_Serial.hpp
@@ -98,6 +98,8 @@ public:
         Note that the physical point can be in a space with larger dimension, e.g. if mapping a
         reference quadrilateral into a side in 3D space.
 
+        Note, it doesn't work with FAD Types
+
         \warning
         The array \c physPoints represents an arbitrary set (or sets) of points in the physical
         frame that are not required to belong in the physical cell (cells) that define(s) the reference
@@ -119,8 +121,13 @@ public:
     mapToReferenceFrame(const refPointViewType &refPoint, // refDim
         const phyPointViewType &physPoint, // physDim
         const nodeViewType &nodes,
-        const double tol = tolerence()) {  // numNodes,physDim
-      const ordinal_type refDim = refPoint.extent(0);
+        const double tol = tolerence(),
+        const typename phyPointViewType::value_type shellThickness = -1.0) {  // numNodes,physDim
+
+      bool isBeamOrShell = (shellThickness > 0); 
+
+      //for Beam or Shell elements, refPoint has dimension refDim+1  (e.g., shellQuadrilateral is a 3D topology, but maps according to the QUAD basis functions)
+      const ordinal_type refDim = refPoint.extent(0) - ordinal_type(isBeamOrShell);
       const ordinal_type physDim = physPoint.extent(0);
       const ordinal_type numNodes = nodes.extent(0);
 
@@ -165,18 +172,21 @@ public:
       Kokkos::AnonymousSpace,
       Kokkos::MemoryUnmanaged> oldRefPoint(ptr, refDim); ptr += refDim;
 
+      double xphyNorm = Kernels::Serial::norm(physPoint, NORM_TWO);
+
+      const auto refDimRange = Kokkos::pair<ordinal_type,ordinal_type>(0, refDim);
+      auto refPt = Kokkos::subview(refPoint,refDimRange); //needed for shell elements
+
       // set initial guess
-      for (ordinal_type j=0;j<refDim;++j) oldRefPoint(j) = 0;
+      Kernels::Serial::copy(oldRefPoint, refPt);
 
-      double xphyNorm = Kernels::Serial::norm(physPoint, NORM_ONE);
-
-      bool converged = false;
+      bool converged = false;      
       for (ordinal_type iter=0;iter<Parameters::MaxNewton;++iter) {
         // xtmp := F(oldRefPoint);
         implBasisType::template Serial<OPERATOR_VALUE>::getValues(vals, oldRefPoint);
         mapToPhysicalFrame(tmpPhysPoint, vals, nodes);
         Kernels::Serial::z_is_axby(tmpPhysPoint, 1.0, physPoint, -1.0, tmpPhysPoint);  //residual  xtmp := physPoint - F(oldRefPoint);
-        double residualNorm = Kernels::Serial::norm(tmpPhysPoint, NORM_ONE);
+        double residualNorm = Kernels::Serial::norm(tmpPhysPoint, NORM_TWO);
         if (residualNorm < tol*xphyNorm) {
           converged = true;
           break;
@@ -195,20 +205,35 @@ public:
         }
 
         // Newton
-        Kernels::Serial::gemv_notrans(1.0, invDf, tmpPhysPoint, 0.0, refPoint); // refPoint := DF^{-1}( physPoint - F(oldRefPoint))
-        Kernels::Serial::z_is_axby(refPoint, 1.0, oldRefPoint,  1.0, refPoint); // refPoint += oldRefPoint
+        Kernels::Serial::gemv_notrans(1.0, invDf, tmpPhysPoint, 0.0, refPt); // refPoint := DF^{-1}( physPoint - F(oldRefPoint))
 
-        // temporarily overwriting oldRefPoint with oldRefPoint-refPoint
-        Kernels::Serial::z_is_axby(oldRefPoint, 1.0, oldRefPoint, -1.0, refPoint);
+        double err = Kernels::Serial::norm(refPt, NORM_TWO); //error on increment
 
-        double err = Kernels::Serial::norm(oldRefPoint, NORM_ONE);
+        Kernels::Serial::z_is_axby(refPt, 1.0, oldRefPoint,  1.0, refPt); // refPoint += oldRefPoint
+
         if (err < tol) {
           converged = true;
           break;
         }
 
-        Kernels::Serial::copy(oldRefPoint, refPoint);
+        Kernels::Serial::copy(oldRefPoint, refPt);
       }
+
+      if(isBeamOrShell) {
+        implBasisType::template Serial<OPERATOR_GRAD>::getValues(grads, refPt);
+        CellTools::Serial::computeJacobian(jac, grads, nodes);
+        if (physDim==3) {
+          auto t1 = Kokkos::subview( jac, Kokkos::ALL(), 0);
+          auto t2 = Kokkos::subview( jac, Kokkos::ALL(), 1);
+          auto n = Kokkos::subview( invDf,  0,  Kokkos::ALL());  
+          Kernels::Serial::vector_product_d3(n, t1, t2);
+          refPoint(refDim) = (n(0)*tmpPhysPoint(0) + n(1)*tmpPhysPoint(1) + n(2)*tmpPhysPoint(2))*2.0/shellThickness/Kernels::Serial::norm(n, NORM_TWO);
+        } else { //physDim == 2
+          auto t1 = Kokkos::subview( jac, Kokkos::ALL(), 0);
+          refPoint(refDim) = (-t1(1)*tmpPhysPoint(0) + t1(0)*tmpPhysPoint(1))*2.0/shellThickness/Kernels::Serial::norm(t1, NORM_TWO);
+        }
+      }
+
       return converged;
     }
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEMDef.hpp
@@ -272,7 +272,7 @@ Basis_HCURL_TET_In_FEM( const ordinal_type order,
 #ifdef HAVE_INTREPID2_DEBUG
   ordinal_type num_nonzero_sv = 0;
   for (int i=0;i<cardVecPn;i++)
-    num_nonzero_sv += (S(i,0) > 10*tolerence());
+    num_nonzero_sv += (S(i,0) > 10*tolerance());
 
   INTREPID2_TEST_FOR_EXCEPTION( num_nonzero_sv != card, std::invalid_argument,
       ">>> ERROR: (Intrepid2::Basis_HCURL_TET_In_FEM( order, pointType), Matrix V1 should have rank equal to the cardinality of HCURL space");

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_DefaultCubatureFactoryDef.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_DefaultCubatureFactoryDef.hpp
@@ -31,7 +31,9 @@ namespace Intrepid2 {
     Teuchos::RCP<Cubature<DT,PT,WT> > r_val;
 
     switch (topologyKey) {
-    case shards::Line<>::key: {
+    case shards::Line<>::key:
+    case shards::Beam<>::key:
+    case shards::ShellLine<>::key: {
       INTREPID2_TEST_FOR_EXCEPTION( degree.size() < 1, std::invalid_argument,
                                     ">>> ERROR (DefaultCubatureFactory): Provided degree array is of insufficient length.");
       if (isValidPolyType(polytype))
@@ -40,7 +42,8 @@ namespace Intrepid2 {
         r_val = Teuchos::rcp(new CubatureDirectLineGauss<DT,PT,WT>(degree[0]));
       break;
     }
-    case shards::Triangle<>::key: {
+    case shards::Triangle<>::key: 
+    case shards::ShellTriangle<>::key: {
       INTREPID2_TEST_FOR_EXCEPTION( degree.size() < 1, std::invalid_argument,
                                     ">>> ERROR (DefaultCubatureFactory): Provided degree array is of insufficient length.");
       if(symmetric || (degree[0] > 20)) {
@@ -125,7 +128,10 @@ namespace Intrepid2 {
     }
     default: {
       INTREPID2_TEST_FOR_EXCEPTION( ( (topologyKey != shards::Line<>::key)               &&
+                                      (topologyKey != shards::Beam<>::key)               &&
+                                      (topologyKey != shards::ShellLine<>::key)          &&
                                       (topologyKey != shards::Triangle<>::key)           &&
+                                      (topologyKey != shards::ShellTriangle<>::key)      &&
                                       (topologyKey != shards::Quadrilateral<>::key)      &&
                                       (topologyKey != shards::ShellQuadrilateral<>::key) &&
                                       (topologyKey != shards::Tetrahedron<>::key)        &&

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HCURL.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HCURL.hpp
@@ -322,7 +322,7 @@ getCoeffMatrix_HCURL(OutputViewType &output,
     {
       //After solving the system w/ LAPACK, Phi contains A^T (or A^-T)
       // transpose and clean up numerical noise (for permutation matrices)
-      const double eps = tolerence();
+      const double eps = tolerance();
       for (ordinal_type i=0;i<ndofSubcell;++i) {
         auto intmatii = std::round(OrtMat(i,i));
         OrtMat(i,i) = (std::abs(OrtMat(i,i) - intmatii) < eps) ? intmatii : OrtMat(i,i);

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HDIV.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HDIV.hpp
@@ -262,7 +262,7 @@ getCoeffMatrix_HDIV(OutputViewType &output,
     //After solving the system w/ LAPACK, Phi contains A^T
 
     // transpose and clean up numerical noise (for permutation matrices)
-    const double eps = tolerence();
+    const double eps = tolerance();
     for (ordinal_type i=0;i<ndofSubcell;++i) {
       auto intmatii = std::round(OrtMat(i,i));
       OrtMat(i,i) = (std::abs(OrtMat(i,i) - intmatii) < eps) ? intmatii : OrtMat(i,i);

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HGRAD.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HGRAD.hpp
@@ -216,7 +216,7 @@ getCoeffMatrix_HGRAD(OutputViewType &output, /// this is device view
     //After solving the system w/ LAPACK, Phi contains A^T
     
     // transpose B and clean up numerical noise (for permutation matrices)
-    const double eps = tolerence();
+    const double eps = tolerance();
     for (ordinal_type i=0;i<ndofSubcell;++i) {
       auto intmatii = std::round(OrtMat(i,i));
       OrtMat(i,i) = (std::abs(OrtMat(i,i) - intmatii) < eps) ? intmatii : OrtMat(i,i);

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HVOL.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HVOL.hpp
@@ -191,7 +191,7 @@ getCoeffMatrix_HVOL(OutputViewType &output, /// this is device view
     //After solving the system w/ LAPACK, Phi contains A^T
     
     // transpose B and clean up numerical noise (for permutation matrices)
-    const double eps = tolerence();
+    const double eps = tolerance();
     for (ordinal_type i=0;i<cardinality;++i) {
       auto intmatii = std::round(OrtMat(i,i));
       OrtMat(i,i) = (std::abs(OrtMat(i,i) - intmatii) < eps) ? intmatii : OrtMat(i,i);

--- a/packages/intrepid2/src/Shared/Intrepid2_Kernels.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Kernels.hpp
@@ -233,11 +233,11 @@ namespace Intrepid2 {
 
       template<typename AViewType>
       KOKKOS_INLINE_FUNCTION
-      static double
+      static typename AViewType::non_const_value_type
       norm(const AViewType &A, const ENorm normType) {
         typedef typename AViewType::non_const_value_type value_type;
         const ordinal_type m = A.extent(0), n = A.extent(1);
-        double r_val = 0;
+        value_type r_val = 0;
         switch(normType) {
         case NORM_TWO:{
           for (ordinal_type i=0;i<m;++i)

--- a/packages/intrepid2/src/Shared/Intrepid2_PolylibDef.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_PolylibDef.hpp
@@ -402,7 +402,7 @@ namespace Intrepid2 {
            const ordinal_type np,
            const double alpha,
            const double beta) {
-    const double tol = tolerence();
+    const double tol = tolerance();
 
     typedef typename zViewType::value_type value_type;
     typedef typename zViewType::pointer_type pointer_type;
@@ -435,7 +435,7 @@ namespace Intrepid2 {
            const ordinal_type np,
            const double alpha,
            const double beta) {
-    const double tol = tolerence();
+    const double tol = tolerance();
 
     typedef typename zViewType::value_type value_type;
     typedef typename zViewType::pointer_type pointer_type;
@@ -473,7 +473,7 @@ namespace Intrepid2 {
            const ordinal_type np,
            const double alpha,
            const double beta) {
-    const double tol = tolerence();
+    const double tol = tolerance();
 
     typedef typename zViewType::value_type value_type;
     typedef typename zViewType::pointer_type pointer_type;
@@ -511,7 +511,7 @@ namespace Intrepid2 {
            const ordinal_type np,
            const double alpha,
            const double beta) {
-    const double one = 1.0, two = 2.0, tol = tolerence();
+    const double one = 1.0, two = 2.0, tol = tolerance();
 
     typedef typename zViewType::value_type value_type;
     typedef typename zViewType::pointer_type pointer_type;
@@ -699,7 +699,7 @@ namespace Intrepid2 {
 
     const double dth = M_PI/(2.0*n);
     const double one = 1.0, two = 2.0;
-    const double tol = tolerence();
+    const double tol = tolerance();
 
     typedef typename zViewType::value_type value_type;
     typedef typename zViewType::pointer_type pointer_type;

--- a/packages/intrepid2/src/Shared/Intrepid2_RealSpaceTools.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_RealSpaceTools.hpp
@@ -395,9 +395,10 @@ namespace Intrepid2 {
         array (rank 2, 3 or 4) of square matrices, indexed by (D, D),
         (i0, D, D) or (i0, i1, D, D).
         
-        \param matVec  [out]  - matrix-vector product indexed by (D), (i0, D) or (i0, i1, D)
-        \param inMat    [in]  - the matrix argument indexed by (D, D), (i0, D, D) or (i0, i1, D, D)
-        \param inVec    [in]  - the vector argument indexed by (D), (i0, D) or (i0, i1, D)
+        \param matVec   [out]  - matrix-vector product indexed by (D), (i0, D) or (i0, i1, D)
+        \param inMat     [in]  - the matrix argument indexed by (D, D), (i0, D, D) or (i0, i1, D, D)
+        \param inVec     [in]  - the vector argument indexed by (D), (i0, D) or (i0, i1, D)
+        \param transpose [in]  - whether the matrix should be transposed
 
         \note  Requirements (checked at runtime, in debug mode): \n
         \li rank(<b><var>matVec</var></b>) == rank(<b><var>inVec</var></b>) == rank(<b><var>inMat</var></b>) - 1
@@ -411,18 +412,19 @@ namespace Intrepid2 {
     static void
     matvec(       Kokkos::DynRankView<matVecValueType,matVecProperties...> matVecs,
             const Kokkos::DynRankView<inMatValueType, inMatProperties...>  inMats,
-            const Kokkos::DynRankView<inVecValueType, inVecProperties...>  inVecs );
+            const Kokkos::DynRankView<inVecValueType, inVecProperties...>  inVecs,
+            const bool transpose = false);
     
     /** \brief Computes the matrix-matrix product \f$A^T A\f$, for an input rectangular matrix \f$A\f$.
         
-        \param matVec  [out]  - matrix-matrix product \f$A^T A\f$ indexed by (D, D), (i0, D, D) or (i0, i1, D, D)
+        \param outMat  [out]  - matrix-matrix product \f$A^T A\f$ indexed by (D, D), (i0, D, D) or (i0, i1, D, D)
         \param inMat    [in]  - the matrix argument \f$A\f$ indexed by (D, D), (i0, D, D) or (i0, i1, D, D)
     */
     template<typename outMatValueType, class ...outMatProperties,
              typename inMatValueType,  class ...inMatProperties>
     static void
-    AtA(       Kokkos::DynRankView<outMatValueType,outMatProperties...> outMats,
-         const Kokkos::DynRankView<inMatValueType, inMatProperties...>  inMats);
+    AtA(       Kokkos::DynRankView<outMatValueType,outMatProperties...> outMat,
+         const Kokkos::DynRankView<inMatValueType, inMatProperties...>  inMat);
 
     /** \brief Vector product using multidimensional arrays:\n
         <b><var>vecProd</var></b> = <b><var>inVecLeft</var></b> x <b><var>inVecRight</var></b>

--- a/packages/intrepid2/src/Shared/Intrepid2_RealSpaceToolsDef.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_RealSpaceToolsDef.hpp
@@ -1300,7 +1300,8 @@ det( DeterminantArrayViewType detArray, const MatrixViewType inMats );
     */ 
     template<typename matVecViewType,
              typename inMatViewType,
-             typename inVecViewType>
+             typename inVecViewType,
+             bool transpose>
     struct F_matvec {
             matVecViewType _matVecs;
       const inMatViewType  _inMats;
@@ -1341,7 +1342,10 @@ det( DeterminantArrayViewType detArray, const MatrixViewType inMats );
         for (ordinal_type i=0;i<iend;++i) {
           result(i) = 0;
           for (ordinal_type j=0;j<jend;++j)
-            result(i) += mat(i, j)*vec(j);
+            if constexpr (transpose)
+              result(i) += mat(j, i)*vec(j);
+            else
+              result(i) += mat(i, j)*vec(j);
         }
       }
     };
@@ -1406,7 +1410,8 @@ det( DeterminantArrayViewType detArray, const MatrixViewType inMats );
   RealSpaceTools<DeviceType>::
   matvec(       Kokkos::DynRankView<matVecValueType,matVecProperties...> matVecs,
           const Kokkos::DynRankView<inMatValueType, inMatProperties...>  inMats,
-          const Kokkos::DynRankView<inVecValueType, inVecProperties...>  inVecs ) {
+          const Kokkos::DynRankView<inVecValueType, inVecProperties...>  inVecs, 
+          const bool transpose) {
 
 #ifdef HAVE_INTREPID2_DEBUG
     INTREPID2_TEST_FOR_EXCEPTION( inMats.rank() < 2 || inMats.rank() > 4, std::invalid_argument,
@@ -1424,10 +1429,6 @@ det( DeterminantArrayViewType detArray, const MatrixViewType inMats );
         INTREPID2_TEST_FOR_EXCEPTION( matVecs.extent(i) != inVecs.extent(i), std::invalid_argument,
                                       ">>> ERROR (RealSpaceTools::matvec): Dimensions of vector array arguments do not agree!");
       }
-      // matvec compatibility 
-      INTREPID2_TEST_FOR_EXCEPTION( inMats.extent(0) != matVecs.extent(matVecs.rank()-1) || 
-                                    inMats.extent(1) != inVecs.extent(inVecs.rank()-1), std::invalid_argument,
-                                    ">>> ERROR (RealSpaceTools::matvec): Matvec dimensions are not compatible each other.");
     } else if (inVecs.rank() < matVecs.rank()) {
       // multiple matrix, single input and multiple output
       INTREPID2_TEST_FOR_EXCEPTION( inMats.rank() != (matVecs.rank()+1), std::invalid_argument,
@@ -1436,10 +1437,6 @@ det( DeterminantArrayViewType detArray, const MatrixViewType inMats );
         INTREPID2_TEST_FOR_EXCEPTION( inMats.extent(i) != matVecs.extent(i), std::invalid_argument,
                                       ">>> ERROR (RealSpaceTools::matvec): Dimensions of vector and matrix array arguments do not agree!");
       }
-      // matvec compatibility 
-      INTREPID2_TEST_FOR_EXCEPTION( inMats.extent(inMats.rank()-2) != matVecs.extent(matVecs.rank()-1) || 
-                                    inMats.extent(inMats.rank()-1) != inVecs.extent(inVecs.rank()-1), std::invalid_argument,
-                                    ">>> ERROR (RealSpaceTools::matvec): Matvec dimensions are not compatible each other.");
     } else {
       // multiple matrix, multiple input and multiple output
       INTREPID2_TEST_FOR_EXCEPTION( inMats.rank() != (matVecs.rank()+1), std::invalid_argument,
@@ -1450,13 +1447,19 @@ det( DeterminantArrayViewType detArray, const MatrixViewType inMats );
         INTREPID2_TEST_FOR_EXCEPTION( inMats.extent(i) != matVecs.extent(i), std::invalid_argument,
                                         ">>> ERROR (RealSpaceTools::matvec): Dimensions of vector and matrix array arguments do not agree!");
       }
-      for (size_type i=0;i<inVecs.rank();++i) {
+      for (ordinal_type i=0;i<static_cast<ordinal_type>(inVecs.rank()-1);++i) {
         INTREPID2_TEST_FOR_EXCEPTION( matVecs.extent(i) != inVecs.extent(i), std::invalid_argument,
                                         ">>> ERROR (RealSpaceTools::matvec): Dimensions of vector array arguments do not agree!");
       }
-      INTREPID2_TEST_FOR_EXCEPTION( inMats.extent(inMats.rank()-1) != inVecs.extent(inVecs.rank()-1), std::invalid_argument,
-                                      ">>> ERROR (RealSpaceTools::matvec): Matrix column dimension does not match to the length of a vector!");
     }
+    // matvec compatibility 
+    INTREPID2_TEST_FOR_EXCEPTION( !transpose && (inMats.extent(inMats.rank()-2) != matVecs.extent(matVecs.rank()-1) || 
+                                  inMats.extent(inMats.rank()-1) != inVecs.extent(inVecs.rank()-1)), std::invalid_argument,
+                                  ">>> ERROR (RealSpaceTools::matvec): Matvec dimensions are not compatible each other.");
+    INTREPID2_TEST_FOR_EXCEPTION( transpose && (inMats.extent(inMats.rank()-1) != matVecs.extent(matVecs.rank()-1) || 
+                                  inMats.extent(inMats.rank()-2) != inVecs.extent(inVecs.rank()-1)), std::invalid_argument,
+                                  ">>> ERROR (RealSpaceTools::matvec): Matvec dimensions are not compatible each other.");
+
 #endif
     using MemSpaceType = typename DeviceType::memory_space;
     constexpr bool are_accessible =
@@ -1468,8 +1471,6 @@ det( DeterminantArrayViewType detArray, const MatrixViewType inMats );
         typename decltype(inVecs)::memory_space>::accessible;
     static_assert(are_accessible, "RealSpaceTools<DeviceType>::matvec(..): input/output views' memory spaces are not compatible with DeviceType");
 
-    using FunctorType = FunctorRealSpaceTools::F_matvec<decltype(matVecs),decltype(inMats),decltype(inVecs)>;
-
     size_type loopSize = 1;
     const ordinal_type r = matVecs.rank() - 1;
     for (ordinal_type i=0;i<r;++i) 
@@ -1477,7 +1478,13 @@ det( DeterminantArrayViewType detArray, const MatrixViewType inMats );
 
     using ExecSpaceType = typename DeviceType::execution_space;
     Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
-    Kokkos::parallel_for( policy, FunctorType(matVecs, inMats, inVecs) );
+    if(transpose) {
+      using FunctorType = FunctorRealSpaceTools::F_matvec<decltype(matVecs),decltype(inMats),decltype(inVecs),true>;
+      Kokkos::parallel_for( policy, FunctorType(matVecs, inMats, inVecs) );
+    } else {
+      using FunctorType = FunctorRealSpaceTools::F_matvec<decltype(matVecs),decltype(inMats),decltype(inVecs),false>;
+      Kokkos::parallel_for( policy, FunctorType(matVecs, inMats, inVecs) );
+    }
   }
 
 

--- a/packages/intrepid2/src/Shared/Intrepid2_Types.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Types.hpp
@@ -67,13 +67,13 @@ namespace Intrepid2 {
 
   template<typename ValueType>
   KOKKOS_FORCEINLINE_FUNCTION
-  ValueType tolerence() {
+  ValueType tolerance() {
     return 100.0*epsilon<ValueType>();
   }
 
   KOKKOS_FORCEINLINE_FUNCTION
-  double tolerence() {
-    return tolerence<double>();
+  double tolerance() {
+    return tolerance<double>();
   }
 
   template<typename ValueType>
@@ -123,7 +123,7 @@ namespace Intrepid2 {
     /// Maximum number of families that a VectorData object will store -- 3 corresponds to H(div) and H(curl) on a hexahedron.
     static constexpr ordinal_type MaxBasisFamilies = 3;
 
-    // we do not want to use hard-wired epsilon, threshold and tolerence. 
+    // we do not want to use hard-wired epsilon, threshold and tolerance. 
     // static constexpr double Epsilon   = 1.0e-16; 
     // static constexpr double Threshold = 1.0e-15;
     // static constexpr double Tolerence = 1.0e-14;

--- a/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
@@ -248,6 +248,15 @@ namespace Intrepid2 {
       return (a > b ? a : b);
     }
 
+    template <typename... Args>
+    requires (std::is_same_v<T, Args> && ...)
+    KOKKOS_FORCEINLINE_FUNCTION
+    static T max(const T a, const T b, Args... args) {
+        // Recursively find the max of everything after the first argument
+        T tmp_max = max(b, args...);
+        return (a > tmp_max) ? a : tmp_max;
+    }
+
     KOKKOS_FORCEINLINE_FUNCTION
     static T abs(const T a) {
       return (a > 0 ? a : T(-a));

--- a/packages/intrepid2/unit-test/Cell/test_01.hpp
+++ b/packages/intrepid2/unit-test/Cell/test_01.hpp
@@ -200,7 +200,7 @@ namespace Intrepid2 {
         typedef CellTools<DeviceType> ct;
         typedef Kokkos::DynRankView<value_type,DeviceType> DynRankView;
 
-        const value_type tol = tolerence<value_type>()*100.0;
+        const value_type tol = tolerance<value_type>()*100.0;
 
         int errorFlag = 0;
       

--- a/packages/intrepid2/unit-test/Cell/test_02.hpp
+++ b/packages/intrepid2/unit-test/Cell/test_02.hpp
@@ -81,7 +81,7 @@ namespace Intrepid2 {
       using ct = CellTools<DeviceType>;
       using DynRankView = Kokkos::DynRankView<ValueType,DeviceType>;
 
-      const ValueType tol = tolerence<ValueType>()*100.0;
+      const ValueType tol = tolerance<ValueType>()*100.0;
 
       int errorFlag = 0;
 

--- a/packages/intrepid2/unit-test/Cell/test_03.hpp
+++ b/packages/intrepid2/unit-test/Cell/test_03.hpp
@@ -85,7 +85,7 @@ namespace Intrepid2 {
       using DynRankView = Kokkos::DynRankView<ValueType,DeviceType>;
       using DynRankViewHost = Kokkos::DynRankView<ValueType,Kokkos::HostSpace>;
 
-      const ValueType tol = tolerence<ValueType>()*100.0;
+      const ValueType tol = tolerance<ValueType>()*100.0;
 
       int errorFlag = 0;
 

--- a/packages/intrepid2/unit-test/Cell/test_04.hpp
+++ b/packages/intrepid2/unit-test/Cell/test_04.hpp
@@ -22,6 +22,7 @@
 #include "Intrepid2_DefaultCubatureFactory.hpp"
 
 #include "Intrepid2_CellTools.hpp"
+#include "Intrepid2_CellTools_Serial.hpp"
 
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
@@ -31,6 +32,105 @@
 namespace Intrepid2 {
 
   namespace Test {
+
+    template<typename OutputViewType,
+             typename InputViewType,
+             typename WorksetViewType,
+             typename ImplBasis>      
+    struct F_mapToReferenceFrame {
+      OutputViewType output_;
+      const InputViewType input_;
+      const WorksetViewType workset_;
+      const typename InputViewType::value_type shellThickness_;
+
+
+      KOKKOS_INLINE_FUNCTION
+      F_mapToReferenceFrame(OutputViewType output,
+                            const InputViewType input,
+                            const WorksetViewType workset,
+                            const typename InputViewType::value_type shellThickness) 
+        : output_(output), 
+          input_(input), 
+          workset_(workset),
+          shellThickness_(shellThickness) {}
+      
+      KOKKOS_INLINE_FUNCTION
+      void
+      operator()(const ordinal_type cl, const ordinal_type pt) const {
+        auto nodes = Kokkos::subview(workset_, cl, Kokkos::ALL(), Kokkos::ALL()); // N,D
+        auto in  = Kokkos::subview(input_,  cl, pt, Kokkos::ALL()); // D
+        auto out = Kokkos::subview(output_, cl, pt, Kokkos::ALL()); // D
+
+        const auto tol = tolerence<typename OutputViewType::value_type>();        
+          
+        Impl::CellTools::Serial::mapToReferenceFrame<ImplBasis>(out, in, nodes, tol, shellThickness_);
+        }
+      };
+
+    template<typename DeviceType,
+             typename OutputViewType,
+             typename InputViewType,
+             typename WorksetViewType>
+      static void
+      mapToReferenceFrameSerialImpl(      OutputViewType output,
+                    const InputViewType input,
+                    const WorksetViewType workset,
+                    const shards::CellTopology cellTopo,
+                    typename InputViewType::value_type shellThickness) {
+
+        using range_policy_type = Kokkos::MDRangePolicy<typename DeviceType::execution_space, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
+        range_policy_type policy( { 0, 0 }, { input.extent(0), input.extent(1) } );
+
+        OutputViewType cellCenter("cellCenter", cellTopo.getDimension());
+        CellTools<DeviceType>::getReferenceCellCenter(cellCenter, cellTopo);
+        RealSpaceTools<DeviceType>::clone(output, cellCenter);
+
+        #define KOKKOS_MAP_TO_REF_PARALLEL_FOR(BasisName)      \
+          do {                                                                                                                      \
+            using FunctorType = F_mapToReferenceFrame<OutputViewType, InputViewType, WorksetViewType, Intrepid2::Impl::BasisName>; \
+            Kokkos::parallel_for(policy, FunctorType(output, input, workset, shellThickness));                                                               \
+          } while (0)
+
+        switch (cellTopo.getKey()) {
+        case shards::Line<2>::key:                KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_LINE_C1_FEM); break; 
+        case shards::Triangle<3>::key:            KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_TRI_C1_FEM); break;
+        case shards::Quadrilateral<4>::key:       KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_QUAD_C1_FEM); break;
+        case shards::Tetrahedron<4>::key:         KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_TET_C1_FEM); break;
+        case shards::Hexahedron<8>::key:          KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_HEX_C1_FEM); break;
+        case shards::Wedge<6>::key:               KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_WEDGE_C1_FEM); break;
+        case shards::Pyramid<5>::key:             KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_PYR_C1_FEM); break;
+
+        case shards::Line<3>::key:                KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_LINE_C2_FEM); break;   
+        case shards::Triangle<6>::key:            KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_TRI_C2_FEM); break;
+        case shards::Quadrilateral<8>::key:       KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_QUAD_DEG2_FEM<true>); break;
+        case shards::Quadrilateral<9>::key:       KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_QUAD_DEG2_FEM<false>); break;
+        case shards::Tetrahedron<10>::key:        KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_TET_C2_FEM); break;
+        case shards::Tetrahedron<11>::key:        KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_TET_COMP12_FEM); break;
+        case shards::Hexahedron<20>::key:         KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_HEX_DEG2_FEM<true>); break;
+        case shards::Hexahedron<27>::key:         KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_HEX_DEG2_FEM<false>); break;
+        case shards::Wedge<15>::key:              KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_WEDGE_DEG2_FEM<true>); break;
+        case shards::Wedge<18>::key:              KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_WEDGE_DEG2_FEM<false>); break;
+        case shards::Pyramid<13>::key:            KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_PYR_I2_FEM); break;
+
+        case shards::Beam<2>::key:                KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_LINE_C1_FEM); break;
+        case shards::Beam<3>::key:                KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_LINE_C2_FEM); break;
+        case shards::ShellLine<2>::key:           KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_LINE_C1_FEM); break;
+        case shards::ShellLine<3>::key:           KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_LINE_C2_FEM); break;
+        case shards::ShellTriangle<3>::key:       KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_TRI_C1_FEM); break;
+        case shards::ShellTriangle<6>::key:       KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_TRI_C2_FEM); break;
+        case shards::ShellQuadrilateral<4>::key:  KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_QUAD_C1_FEM); break;
+        case shards::ShellQuadrilateral<8>::key:  KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_QUAD_DEG2_FEM<true>); break;
+        case shards::ShellQuadrilateral<9>::key:  KOKKOS_MAP_TO_REF_PARALLEL_FOR(Basis_HGRAD_QUAD_DEG2_FEM<false>); break;
+        
+        default: {
+          INTREPID2_TEST_FOR_EXCEPTION( true, std::invalid_argument,
+                                        ">>> ERROR (Intrepid2::CellTools::createHGradBasis): Cell topology not supported.");
+        }
+        }
+      }
+
+
+
 #define INTREPID2_TEST_ERROR_EXPECTED( S )                              \
     try {                                                               \
       S ;                                                               \
@@ -85,10 +185,10 @@ namespace Intrepid2 {
 
       // Collect all supported cell topologies
       std::vector<shards::CellTopology> standardBaseTopologies;
-      shards::getTopologies(standardBaseTopologies, 4, shards::STANDARD_CELL, shards::BASE_TOPOLOGY);
+      shards::getTopologies(standardBaseTopologies, 4, shards::ALL_CELLS, shards::ALL_TOPOLOGIES);
       const auto topoSize = standardBaseTopologies.size();
 
-      for (auto testCase=0;testCase<2;++testCase) {
+      for (auto testCase=0;testCase<3;++testCase) {
         try {
           switch (testCase) {
           case 0: {
@@ -104,6 +204,14 @@ namespace Intrepid2 {
               << "\n"
               << "===============================================================================\n" 
               << "| Test 2: computing F(x) and F^{-1}(x) using user-defined initial guess.      |\n" 
+              << "===============================================================================\n\n";
+            break;
+          }
+          case 2: {
+            *outStream
+              << "\n"
+              << "===============================================================================\n" 
+              << "| Test 3: computing F(x) and F^{-1}(x) using serial implementation.            |\n" 
               << "===============================================================================\n\n";
             break;
           }
@@ -135,15 +243,16 @@ namespace Intrepid2 {
             const auto cellCubature = cubFactory.create<DeviceType,ValueType,ValueType>(cell, testAccuracy);
             const auto cubDim = cellCubature->getDimension();
             const auto cubNumPoints = cellCubature->getNumPoints();
+            const auto cellDim  = cell.getDimension();
             
-            DynRankView ConstructWithLabel(cubPoints,  cubNumPoints, cubDim );
+            DynRankView ConstructWithLabel(cubPoints,  cubNumPoints, cellDim );
+            auto cubDimRange = std::pair<int,int>(0,cubDim);
             DynRankView ConstructWithLabel(cubWeights, cubNumPoints );
-            cellCubature->getCubature(cubPoints, cubWeights);
+            cellCubature->getCubature(Kokkos::subview(cubPoints, Kokkos::ALL(), cubDimRange), cubWeights);
 
             // 2.   Define a cell workset by perturbing the worksetCell of the reference cell with the specified topology
             // 2.1  Resize dimensions of the rank-3 (C,N,D) cell workset array for the current topology
             const auto numNodes = cell.getNodeCount();
-            const auto cellDim  = cell.getDimension();
 
             DynRankView ConstructWithLabel(worksetCell, numCells, numNodes, cellDim);
             
@@ -159,10 +268,10 @@ namespace Intrepid2 {
 
             // 2.3  Create randomly perturbed version of the reference cell and save in the cell workset array
             for (auto cellOrd=0;cellOrd<numCells;++cellOrd) {
-              // Move vertices +/-0.125 along their axes. Gives nondegenerate cells for base and extended topologies 
+              // Move vertices +/-0.03125 along their axes. Gives nontrivial cells for base and extended topologies 
               for (size_type nodeOrd=0;nodeOrd<numNodes;++nodeOrd) 
                 for(size_type d=0;d<cellDim;++d) {
-                  const auto delta = Teuchos::ScalarTraits<double>::random()/16.0;
+                  const auto delta = Teuchos::ScalarTraits<double>::random()/32.0;
                   hWorksetCell(cellOrd, nodeOrd, d) = hRefCellNodes(nodeOrd, d) + delta;
                 } 
             }
@@ -173,8 +282,8 @@ namespace Intrepid2 {
              *      to a physical point set in rank-2 (P,D) array for a specified cell ordinal. Use the cub.
              *      points array for this test. Resize physPoints and controlPoints to rank-2 (P,D) arrays.
              */
-            DynRankView ConstructWithLabel(physPoints,    numCells, cubNumPoints, cubDim );
-            DynRankView ConstructWithLabel(controlPoints, numCells, cubNumPoints, cubDim );
+            DynRankView ConstructWithLabel(physPoints,    numCells, cubNumPoints, cellDim );
+            DynRankView ConstructWithLabel(controlPoints, numCells, cubNumPoints, cellDim );
             
             *outStream 
               << " Mapping a set of " << cubNumPoints << " points to one cell in a workset of " << numCells << " " 
@@ -182,18 +291,26 @@ namespace Intrepid2 {
 
             // Forward map:: requires cell ordinal; input (P,D) -> output (C,P,D)
             ct::mapToPhysicalFrame(physPoints, cubPoints, worksetCell, cell);
-
+            
+            const auto key = cell.getBaseKey();
+            const bool isShellorBeam = (key == shards::Beam<>::key) || (key == shards::ShellLine<>::key) || (key == shards::ShellTriangle<>::key) || (key == shards::ShellQuadrilateral<>::key);
+            ValueType shellThickness = (isShellorBeam) ? 0.01 : -1.0;
+            
             // Inverse map: requires cell ordinal; input (C,P,D) -> output (C,P,D)
             switch (testCase) {
             case 0: {
-              ct::mapToReferenceFrame(controlPoints, physPoints, worksetCell, cell);
+              ct::mapToReferenceFrame(controlPoints, physPoints, worksetCell, cell, shellThickness);
               break;
             }
             case 1: {
-              DynRankView ConstructWithLabel(initGuess, numCells, cubNumPoints, cubDim );
+              DynRankView ConstructWithLabel(initGuess, numCells, cubNumPoints, cellDim );
               // cubPoints become the initial guess
               RealSpaceTools<DeviceType>::clone(initGuess, cubPoints);
-              ct::mapToReferenceFrameInitGuess(controlPoints, initGuess, physPoints, worksetCell, cell);
+              ct::mapToReferenceFrameInitGuess(controlPoints, initGuess, physPoints, worksetCell, cell, shellThickness);
+              break;
+            }
+            case 2: {
+              mapToReferenceFrameSerialImpl<DeviceType>(controlPoints, physPoints, worksetCell, cell, shellThickness);
               break;
             }
             }

--- a/packages/intrepid2/unit-test/Cell/test_04.hpp
+++ b/packages/intrepid2/unit-test/Cell/test_04.hpp
@@ -61,7 +61,7 @@ namespace Intrepid2 {
         auto in  = Kokkos::subview(input_,  cl, pt, Kokkos::ALL()); // D
         auto out = Kokkos::subview(output_, cl, pt, Kokkos::ALL()); // D
 
-        const auto tol = tolerence<typename OutputViewType::value_type>();        
+        const auto tol = tolerance<typename OutputViewType::value_type>();        
           
         Impl::CellTools::Serial::mapToReferenceFrame<ImplBasis>(out, in, nodes, tol, shellThickness_);
         }
@@ -179,7 +179,7 @@ namespace Intrepid2 {
       using ct = CellTools<DeviceType>;
       using DynRankView = Kokkos::DynRankView<ValueType,DeviceType>;
 
-      const ValueType tol = tolerence<ValueType>()*100.0;
+      const ValueType tol = tolerance<ValueType>()*100.0;
 
       int errorFlag  = 0;
 

--- a/packages/intrepid2/unit-test/Cell/test_06.hpp
+++ b/packages/intrepid2/unit-test/Cell/test_06.hpp
@@ -97,7 +97,7 @@ namespace Intrepid2 {
         const ordinal_type P = _output.extent(1);
 
         auto nodes = Kokkos::subview(_workset, cl, Kokkos::ALL(), Kokkos::ALL()); // N,D
-        typename InputViewType::value_type tol = tolerence();
+        typename InputViewType::value_type tol = tolerance();
         for (ordinal_type i=0;i<P;++i) {
           auto in  = Kokkos::subview(_input,  cl, i, Kokkos::ALL()); // D
           auto out = Kokkos::subview(_output, cl, i, Kokkos::ALL()); // D
@@ -136,7 +136,7 @@ namespace Intrepid2 {
         << "|                                                                             |\n"
         << "===============================================================================\n";
   
-      const ValueType tol = tolerence<ValueType>()*100.0;
+      const ValueType tol = tolerance<ValueType>()*100.0;
 
       int errorFlag = 0;
       

--- a/packages/intrepid2/unit-test/Cell/test_06.hpp
+++ b/packages/intrepid2/unit-test/Cell/test_06.hpp
@@ -37,7 +37,8 @@ namespace Intrepid2 {
 
     template<typename OutputViewType,
              typename inputViewType,
-             typename worksetViewType>
+             typename worksetViewType,
+             typename ImplBasis>
     struct F_mapToPhysicalFrame {
       OutputViewType _output;
       inputViewType _input;
@@ -63,28 +64,32 @@ namespace Intrepid2 {
         for (ordinal_type i=0;i<P;++i) {
           auto in  = Kokkos::subview(_input,      i, Kokkos::ALL()); // D
           auto out = Kokkos::subview(_output, cl, i, Kokkos::ALL()); // D
-          Impl::Basis_HGRAD_QUAD_C1_FEM::Serial<OPERATOR_VALUE>::getValues(val, in);
+          ImplBasis::template Serial<OPERATOR_VALUE>::getValues(val, in);
           Impl::CellTools::Serial::mapToPhysicalFrame(out, val, nodes);
         }
       }
     };
 
     template<typename OutputViewType,
-             typename inputViewType,
-             typename worksetViewType>      
+             typename InputViewType,
+             typename WorksetViewType,
+             typename ImplBasis>      
     struct F_mapToReferenceFrame {
       OutputViewType _output;
-      inputViewType _input;
-      worksetViewType _workset;
+      InputViewType _input;
+      WorksetViewType _workset;
+      typename InputViewType::value_type _shellThickness;
 
 
       KOKKOS_INLINE_FUNCTION
       F_mapToReferenceFrame(OutputViewType output_,
-                            inputViewType input_,
-                            worksetViewType workset_) 
+                            InputViewType input_,
+                            WorksetViewType workset_,
+                            typename InputViewType::value_type shellThickness_ = -1.0) 
         : _output(output_), 
           _input(input_), 
-          _workset(workset_) {}
+          _workset(workset_),
+          _shellThickness(shellThickness_) {}
       
       KOKKOS_INLINE_FUNCTION
       void
@@ -92,12 +97,13 @@ namespace Intrepid2 {
         const ordinal_type P = _output.extent(1);
 
         auto nodes = Kokkos::subview(_workset, cl, Kokkos::ALL(), Kokkos::ALL()); // N,D
+        typename InputViewType::value_type tol = tolerence();
         for (ordinal_type i=0;i<P;++i) {
           auto in  = Kokkos::subview(_input,  cl, i, Kokkos::ALL()); // D
           auto out = Kokkos::subview(_output, cl, i, Kokkos::ALL()); // D
           
           Impl::CellTools::Serial
-            ::mapToReferenceFrame<Impl::Basis_HGRAD_QUAD_C1_FEM>(out, in, nodes);
+            ::mapToReferenceFrame<ImplBasis>(out, in, nodes, tol, _shellThickness);
         }
         
       }
@@ -213,7 +219,8 @@ namespace Intrepid2 {
           {
             typedef F_mapToPhysicalFrame<decltype(b_pts_on_phy),
                                          decltype(pts_on_ref),
-                                         decltype(workset)> FunctorType;
+                                         decltype(workset),
+                                         Impl::Basis_HGRAD_QUAD_C1_FEM> FunctorType;
             Kokkos::parallel_for(policy, FunctorType(b_pts_on_phy, pts_on_ref, workset));
           }
           // I love lambda...
@@ -281,7 +288,8 @@ namespace Intrepid2 {
           {
             typedef F_mapToReferenceFrame<decltype(b_pts_on_ref),
                                           decltype(pts_on_phy),
-                                          decltype(workset)> FunctorType;
+                                          decltype(workset),
+                                          Impl::Basis_HGRAD_QUAD_C1_FEM> FunctorType;
             Kokkos::parallel_for(policy, FunctorType(b_pts_on_ref, pts_on_phy, workset));
           }
           // Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const ordinal_type cl) {
@@ -294,8 +302,7 @@ namespace Intrepid2 {
           //         ::mapToReferenceFrame<Impl::Basis_HGRAD_QUAD_C1_FEM>(pt_on_ref, pt_on_phy, nodes);
           //     }
           //   });
-          auto b_pts_on_ref_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), b_pts_on_ref);
-          Kokkos::deep_copy(b_pts_on_ref_host, b_pts_on_ref);
+          auto b_pts_on_ref_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_pts_on_ref);
 
           // ** compare          
           {
@@ -358,7 +365,8 @@ namespace Intrepid2 {
           {
             typedef F_mapToPhysicalFrame<decltype(b_pts3d_on_phy),
                                          decltype(pts_on_ref),
-                                         decltype(workset3d)> FunctorType;
+                                         decltype(workset3d),
+                                         Impl::Basis_HGRAD_QUAD_C1_FEM> FunctorType;
             Kokkos::parallel_for(policy, FunctorType(b_pts3d_on_phy, pts_on_ref, workset3d));
           }
 
@@ -367,24 +375,24 @@ namespace Intrepid2 {
           ///
 
           // ** compute via impl interface
-          Kokkos::DynRankView<ValueType,DeviceArrayLayout,DeviceType> b_pts3d_on_ref("b_pts3d_on_ref", C, P, D);
-
+          
           {
-            typedef F_mapToReferenceFrame<decltype(b_pts3d_on_ref),
+            Kokkos::deep_copy(b_pts_on_ref, 0.0);
+            typedef F_mapToReferenceFrame<decltype(b_pts_on_ref),
                                           decltype(b_pts3d_on_phy),
-                                          decltype(workset3d)> FunctorType;
-            Kokkos::parallel_for(policy, FunctorType(b_pts3d_on_ref, b_pts3d_on_phy, workset3d));
+                                          decltype(workset3d),
+                                          Impl::Basis_HGRAD_QUAD_C1_FEM> FunctorType;
+            Kokkos::parallel_for(policy, FunctorType(b_pts_on_ref, b_pts3d_on_phy, workset3d));
           }
 
-          auto b_pts3d_on_ref_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), b_pts3d_on_ref);
-          Kokkos::deep_copy(b_pts3d_on_ref_host, b_pts3d_on_ref);
+          Kokkos::deep_copy(b_pts_on_ref_host, b_pts_on_ref);
 
           // ** compare
           {
             for (ordinal_type cl=0;cl<C;++cl)
               for (ordinal_type i=0;i<P;++i)
                 for (ordinal_type j=0;j<D;++j) {
-                  const double diff = std::abs(pts_on_ref_host(i, j) - b_pts3d_on_ref_host(cl, i, j));
+                  const double diff = std::abs(pts_on_ref_host(i, j) - b_pts_on_ref_host(cl, i, j));
                   if (diff > tol) {
                     *outStream << "Error (3d physical space) : mapToReferenceFrame (impl version) at ("
                                << cl << "," << i << "," << j
@@ -393,6 +401,67 @@ namespace Intrepid2 {
                   }
                 }
           }
+
+          *outStream
+            << "\n"
+            << "===============================================================================\n"
+            << "| Test 3: map to reference shell quad c1 element from 3D physical space:      |\n"
+            << "===============================================================================\n\n";
+
+          ValueType shellThickness = 1.0e-2;
+
+          // perturb phys points
+          auto b_pts3d_on_phy_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_pts3d_on_phy);
+          ValueType eps = 1e-3;
+          b_pts3d_on_phy_host(0,0,2) += -eps;
+          b_pts3d_on_phy_host(1,1,1) += eps;
+          b_pts3d_on_phy_host(2,3,0) += 2.0*eps;
+          Kokkos::deep_copy(b_pts3d_on_phy,b_pts3d_on_phy_host);
+
+
+          // ** compute via front interface
+          Kokkos::DynRankView<ValueType,DeviceArrayLayout,DeviceType> a_pts3d_on_ref("a_pts3d_on_ref", C, P, D+1);
+          {
+            CellTools<DeviceType>
+              ::mapToReferenceFrame(a_pts3d_on_ref, b_pts3d_on_phy, workset3d, 
+                                    shards::CellTopology(shards::getCellTopologyData<shards::ShellQuadrilateral<4> >()), shellThickness);
+          }
+          
+          // ** compute via Impl interface
+          Kokkos::DynRankView<ValueType,DeviceArrayLayout,DeviceType> b_pts3d_on_ref("b_pts3d_on_ref", C, P, D+1);
+          {            
+            typedef F_mapToReferenceFrame<decltype(b_pts3d_on_ref),
+                                          decltype(b_pts3d_on_phy),
+                                          decltype(workset3d),
+                                          Impl::Basis_HGRAD_QUAD_C1_FEM> FunctorType;
+              Kokkos::parallel_for(policy, FunctorType(b_pts3d_on_ref, b_pts3d_on_phy, workset3d,shellThickness));
+          }
+
+          
+
+          auto a_pts3d_on_ref_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), a_pts3d_on_ref);
+          auto b_pts3d_on_ref_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), b_pts3d_on_ref);
+
+
+          // ** compare          
+          {
+            for (ordinal_type cl=0;cl<C;++cl)
+              for (ordinal_type i=0;i<P;++i) 
+                for (ordinal_type j=0;j<D+1;++j) {
+                  const double diff = std::abs(a_pts3d_on_ref_host(cl, i, j) - b_pts3d_on_ref_host(cl, i, j));
+                  if (diff > tol) {
+                    *outStream << "Error : mapToReferenceFrame (impl version) at (" 
+                               << cl << "," << i << "," << j 
+                               << ") with diff = " << diff << "\n";
+                    errorFlag++;
+                  }
+                }
+          }
+
+
+
+
+
         }
       } catch (std::logic_error &err) {
         //============================================================================================//

--- a/packages/intrepid2/unit-test/Cell/test_07.hpp
+++ b/packages/intrepid2/unit-test/Cell/test_07.hpp
@@ -112,6 +112,22 @@ namespace Intrepid2 {
     };
 
     template <typename ValueType>
+    struct MapPoints<shards::ShellLine<2>::key, ValueType> {
+      ValueType operator()(const ValueType* coords, int comp) {
+        MapPoints<shards::Quadrilateral<4>::key, ValueType> quad4Map;
+        return quad4Map(coords, comp);
+      }
+    };
+
+    template <typename ValueType>
+    struct MapPoints<shards::ShellLine<3>::key, ValueType> {
+      ValueType operator()(const ValueType* coords, int comp) {
+        MapPoints<shards::Quadrilateral<9>::key, ValueType> quad9Map;
+        return quad9Map(coords, comp);
+      }
+    };
+
+    template <typename ValueType>
     struct MapPoints<shards::Triangle<3>::key, ValueType> {
       ValueType operator()(const ValueType* coords, int comp) {
         const auto& x = coords[0]; const auto& y = coords[1];
@@ -126,6 +142,22 @@ namespace Intrepid2 {
         MapPoints<shards::Triangle<3>::key, ValueType> linearMap;
         const auto& x = coords[0]; const auto& y = coords[1];
         return linearMap(coords, comp) -0.1*x*x+0.05*x*y+0.2*y*y;
+      }
+    };
+
+    template <typename ValueType>
+    struct MapPoints<shards::ShellTriangle<3>::key, ValueType> {
+      ValueType operator()(const ValueType* coords, int comp) {
+        MapPoints<shards::Wedge<6>::key, ValueType> wedge6Map;
+        return wedge6Map(coords, comp);
+      }
+    };
+
+    template <typename ValueType>
+    struct MapPoints<shards::ShellTriangle<6>::key, ValueType> {
+      ValueType operator()(const ValueType* coords, int comp) {
+        MapPoints<shards::Wedge<15>::key, ValueType> wedge15Map;
+        return wedge15Map(coords, comp);
       }
     };
 
@@ -153,6 +185,30 @@ namespace Intrepid2 {
         MapPoints<shards::Quadrilateral<4>::key, ValueType> bilinearMap;
         const auto& x = coords[0]; const auto& y = coords[1];
         return bilinearMap(coords, comp)-0.1*x*x -0.2*y*y +0.05*x*y*(x-y+x*y);
+      }
+    };
+
+    template <typename ValueType>
+    struct MapPoints<shards::ShellQuadrilateral<4>::key, ValueType> {
+      ValueType operator()(const ValueType* coords, int comp) {
+        MapPoints<shards::Hexahedron<8>::key, ValueType> trilineareMap;
+        return trilineareMap(coords, comp);
+      }
+    };
+
+    template <typename ValueType>
+    struct MapPoints<shards::ShellQuadrilateral<8>::key, ValueType> {
+      ValueType operator()(const ValueType* coords, int comp) {
+        MapPoints<shards::Hexahedron<20>::key, ValueType> hexa20Map;
+        return hexa20Map(coords, comp);
+      }
+    };
+
+    template <typename ValueType>
+    struct MapPoints<shards::ShellQuadrilateral<9>::key, ValueType> {
+      ValueType operator()(const ValueType* coords, int comp) {
+        MapPoints<shards::Hexahedron<27>::key, ValueType> hexa27Map;
+        return hexa27Map(coords, comp);
       }
     };
 
@@ -257,41 +313,20 @@ namespace Intrepid2 {
 #define INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, host_points, physPoints, physNodes, shtopo, cellTools)     \
     {                                                                                                                            \
         MapPoints<shtopo::key,ValueType> mapPoints;                                                                              \
-        Intrepid2::HostBasisPtr<ValueType, ValueType> basisPtr;                                                                  \
-        using HostDeviceType = Kokkos::HostSpace::device_type;                                                                   \
         shards::CellTopology topo( shards::getCellTopologyData<shtopo>());                                                       \
-        switch (topo.getKey()) {                                                                                                 \
-          case shards::Line<2>::key:          basisPtr = Teuchos::rcp(new Basis_HGRAD_LINE_C1_FEM   <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Line<3>::key:          basisPtr = Teuchos::rcp(new Basis_HGRAD_LINE_C2_FEM   <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Triangle<3>::key:      basisPtr = Teuchos::rcp(new Basis_HGRAD_TRI_C1_FEM    <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Quadrilateral<4>::key: basisPtr = Teuchos::rcp(new Basis_HGRAD_QUAD_C1_FEM   <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Tetrahedron<4>::key:   basisPtr = Teuchos::rcp(new Basis_HGRAD_TET_C1_FEM    <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Hexahedron<8>::key:    basisPtr = Teuchos::rcp(new Basis_HGRAD_HEX_C1_FEM    <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Wedge<6>::key:         basisPtr = Teuchos::rcp(new Basis_HGRAD_WEDGE_C1_FEM  <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Pyramid<5>::key:       basisPtr = Teuchos::rcp(new Basis_HGRAD_PYR_C1_FEM    <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Triangle<6>::key:      basisPtr = Teuchos::rcp(new Basis_HGRAD_TRI_C2_FEM    <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Quadrilateral<8>::key: basisPtr = Teuchos::rcp(new Basis_HGRAD_QUAD_I2_FEM   <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Quadrilateral<9>::key: basisPtr = Teuchos::rcp(new Basis_HGRAD_QUAD_C2_FEM   <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Tetrahedron<10>::key:  basisPtr = Teuchos::rcp(new Basis_HGRAD_TET_C2_FEM    <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Tetrahedron<11>::key:  basisPtr = Teuchos::rcp(new Basis_HGRAD_TET_COMP12_FEM<HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Hexahedron<20>::key:   basisPtr = Teuchos::rcp(new Basis_HGRAD_HEX_I2_FEM    <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Hexahedron<27>::key:   basisPtr = Teuchos::rcp(new Basis_HGRAD_HEX_C2_FEM    <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Wedge<15>::key:        basisPtr = Teuchos::rcp(new Basis_HGRAD_WEDGE_I2_FEM  <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Wedge<18>::key:        basisPtr = Teuchos::rcp(new Basis_HGRAD_WEDGE_C2_FEM  <HostDeviceType,ValueType,ValueType>()); break;  \
-          case shards::Pyramid<13>::key:      basisPtr = Teuchos::rcp(new Basis_HGRAD_PYR_I2_FEM    <HostDeviceType,ValueType,ValueType>()); break;  \
-          default:   {};                                                                                                         \
-        }                                                                                                                        \
+        const auto basisPtr = cellTools::template createHGradBasis<ValueType, ValueType>(topo);                                  \
                                                                                                                                  \
         auto dim = topo.getDimension();                                                                                          \
-        auto refNodes_h = Kokkos::DynRankView<ValueType,Kokkos::HostSpace>("refNodes",basisPtr->getCardinality(),dim);           \
-        basisPtr->getDofCoords(refNodes_h);                                                                                      \
+        auto refNodes = Kokkos::DynRankView<ValueType,DeviceType>("refNodes",basisPtr->getCardinality(),basisPtr->getDomainDimension());                    \
+        basisPtr->getDofCoords(refNodes);                                                                                        \
         physNodes = Kokkos::DynRankView<ValueType,DeviceType>("physNodes",1,basisPtr->getCardinality(),dim);                     \
         physPoints = Kokkos::DynRankView<ValueType,DeviceType>("physPoints", host_points.extent(0),dim);                         \
         auto physNodes_h = Kokkos::create_mirror_view(physNodes);                                                                \
         auto physPoints_h = Kokkos::create_mirror_view(physPoints);                                                              \
+        auto refNodes_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), refNodes);                                                   \
         ValueType coords[3]={};                                                                                                  \
         for(size_t i=0; i< refNodes_h.extent(0);++i) {                                                                           \
-          for (size_t d=0; d<dim; ++d)                                                                                           \
+          for (size_t d=0; d<refNodes_h.extent(1); ++d)                                                                                           \
             coords[d]= refNodes_h(i,d);                                                                                          \
           for (size_t d=0; d<dim; ++d)                                                                                           \
             physNodes_h(0,i,d) = mapPoints(coords,d);                                                                            \
@@ -308,7 +343,7 @@ namespace Intrepid2 {
         
 // This macro performs the inclusion test for four points and check that they are inside/outside the cell as expected.
 // We expect that the first and third points are inside the cell, whereas the second and fourth are outside.
-#define INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, points, physNodes, shtopo, cellTools)     \
+#define INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, points, physNodes, shtopo, shellThickness, cellTools)  \
     {                                                                                   \
         Kokkos::deep_copy(inCell, 0.0);                                                 \
         shards::CellTopology topo( shards::getCellTopologyData<shtopo>());              \
@@ -316,32 +351,31 @@ namespace Intrepid2 {
         std::string label = "reference";                                                \
         if(physNodes.extent(0)==0)                                                      \
           cellTools::checkPointwiseInclusion(Kokkos::subview(inCell,0,Kokkos::ALL()),   \
-            points, topo );                                                             \
+            points, topo);                                                              \
         else {                                                                          \
-          cellTools::checkPointwiseInclusion(inCell, points, physNodes, topo );         \
+          cellTools::checkPointwiseInclusion(inCell, points, physNodes, topo, 0.0, shellThickness  ); \
           label = "physical";                                                           \
         }                                                                               \
-        auto inCell_host = Kokkos::create_mirror_view(inCell);                          \
-        Kokkos::deep_copy(inCell_host, inCell);                                         \
+        auto inCell_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), inCell); \
         auto numPoints = points.extent(0);                                              \
         if (inCell_host(0,0)==0) {                                                      \
           *outStream << "Error : Point 0 is inside the " <<label <<" element " <<       \
-          topo.getName() << " but PointWiseInclusion says otherwise";                   \
+          topo.getName() << " but PointWiseInclusion says otherwise" << std::endl;      \
           errorFlag++;                                                                  \
         }                                                                               \
         if (inCell_host(0,1)==1)     {                                                  \
           *outStream << "Error : Point 1 is outside the " <<label <<" element " <<      \
-          topo.getName() << " but PointWiseInclusion says otherwise";                   \
+          topo.getName() << " but PointWiseInclusion says otherwise"<< std::endl;       \
           errorFlag++;                                                                  \
         }                                                                               \
         if (numPoints>2 && inCell_host(0,2)==0)     {                                   \
           *outStream << "Error : Point 2 is inside the " <<label <<" element " <<       \
-          topo.getName() << " but PointWiseInclusion says otherwise";                   \
+          topo.getName() << " but PointWiseInclusion says otherwise"<< std::endl;       \
           errorFlag++;                                                                  \
         }                                                                               \
         if (numPoints>3 && inCell_host(0,3)==1)     {                                   \
           *outStream << "Error : Point 3 is outside the " <<label <<" element " <<      \
-          topo.getName() << " but PointWiseInclusion says otherwise";                   \
+          topo.getName() << " but PointWiseInclusion says otherwise"<< std::endl;       \
           errorFlag++;                                                                  \
         }                                                                               \
       }                                                                                 \
@@ -447,6 +481,7 @@ namespace Intrepid2 {
         auto pts2d_h = Kokkos::create_mirror_view(pts2d); 
         auto pts3d_h = Kokkos::create_mirror_view(pts3d); 
         ValueType eps = 1e-4;
+        ValueType shellThickness = -1.0; //only used for beams or shells
         using ct = Intrepid2::CellTools<DeviceType>;
 
         // line topologies
@@ -455,14 +490,45 @@ namespace Intrepid2 {
         pts1d_h(2,0) = 1.0-eps;    //point near vertex (in)
         pts1d_h(3,0) = 1.0+eps;    //point near vertex (out)
         Kokkos::deep_copy(pts1d,pts1d_h);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts1d, emptyView, shards::Line<2>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts1d, emptyView, shards::Line<3>, ct);
 
+         *outStream << "\nLine" <<std::endl;
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts1d, emptyView, shards::Line<2>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts1d, emptyView, shards::Line<3>, shellThickness, ct);
+
+        
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts1d_h, physPoints, physNodes, shards::Line<2>, ct);    
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Line<2>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Line<2>, shellThickness, ct);
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts1d_h, physPoints, physNodes, shards::Line<3>, ct);  
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Line<3>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Line<3>, shellThickness, ct);
 
+        // Beam and shellLine topologies
+        pts2d_h(0,0) = -1.0+eps; pts2d_h(0,1) = 0.0+eps; //point near vertex (in)
+        pts2d_h(1,0) = -1.0-eps; pts2d_h(1,1) = 0.0;     //point near vertex (out)
+        pts2d_h(2,0) = 1.0-eps;  pts2d_h(2,1) = 0.0-eps; //point near vertex (in)
+        pts2d_h(3,0) = 1.0+eps;  pts2d_h(3,1) = 1.0+eps; //point near vertex (out in the orthogonal direction)
+        Kokkos::deep_copy(pts2d,pts2d_h);
+        *outStream << "\nBeam, ShellLine and Line cells in 2D physical space" <<std::endl;
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts2d, emptyView, shards::Beam<2>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts2d, emptyView, shards::ShellLine<2>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts2d, emptyView, shards::ShellLine<3>, shellThickness, ct);
+
+
+        //line in 2D physical space (physical points and nodes are in 2D space, but topology is 2d line)  
+        INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts2d_h, physPoints, physNodes, shards::ShellLine<2>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Line<2>, shellThickness, ct);
+
+        shellThickness = 0.002;
+        //for shell elements, we should not expect that the recovered orthogonal reference coordinate is the same as the original ref coordinate 
+        //here we pick the original reference coordinate to make sure the recovered one is outside the ref element.
+        //for beams and shellLine, the recovered orthogonal ref coordinate is approximately the distance between the 2d physical point and the 1d physical map of the reference line, divided by the beam/shell half-thickness.
+        pts2d_h(3,1) = 0.0-50.0*eps; //point near edge (out)
+
+        INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts2d_h, physPoints, physNodes, shards::ShellLine<2>, ct);  
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Beam<2>, shellThickness, ct);  
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::ShellLine<2>, shellThickness, ct);
+        INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts2d_h, physPoints, physNodes, shards::ShellLine<3>, ct);  
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::ShellLine<3>, shellThickness, ct);
+        shellThickness = -1.0;
 
         // triangle topologies
         pts2d_h(0,0) = 0.0+eps; pts2d_h(0,1) = 0.0+eps; //point near vertex (in)
@@ -471,13 +537,41 @@ namespace Intrepid2 {
         pts2d_h(3,0) = 0.5+eps; pts2d_h(3,1) = 0.5+eps; //point near edge (out)
         Kokkos::deep_copy(pts2d,pts2d_h);
 
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts2d, emptyView, shards::Triangle<3>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts2d, emptyView, shards::Triangle<4>, ct);
+        *outStream << "\nTriangle" <<std::endl;
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts2d, emptyView, shards::Triangle<3>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts2d, emptyView, shards::Triangle<6>, shellThickness, ct);
 
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts2d_h, physPoints, physNodes, shards::Triangle<3>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Triangle<3>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Triangle<3>, shellThickness, ct);
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts2d_h, physPoints, physNodes, shards::Triangle<6>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Triangle<6>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Triangle<6>, shellThickness, ct);
+
+
+        //triangle and shellTriangle topologies in 3D physical space 
+        pts3d_h(0,0) = 0.0+eps; pts3d_h(0,1) = 0.0+eps; pts3d_h(0,2) = 0.0+eps; //point near vertex (in)
+        pts3d_h(1,0) = 0.0-eps; pts3d_h(1,1) = 0.0-eps; pts3d_h(1,2) = 0.0;     //point near vertex (out)
+        pts3d_h(2,0) = 0.5-eps; pts3d_h(2,1) = 0.5-eps; pts3d_h(2,2) = 0.0-eps; //point near edge (in)
+        pts3d_h(3,0) = 0.5-eps; pts3d_h(3,1) = 0.5-eps; pts3d_h(3,2) = 1.0+eps; //point near edge (out in the orthogonal direction)
+        Kokkos::deep_copy(pts3d,pts3d_h);
+
+        *outStream << "\nShellTriangle and Triangle cells in 3D physical space" <<std::endl;
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::ShellTriangle<3>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::ShellTriangle<6>, shellThickness, ct);
+ 
+        //triangle in 3D physical space (physical points and nodes are in 3D space, but topology is 2d triangle)  
+        INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::ShellTriangle<3>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Triangle<3>, shellThickness, ct);
+
+        shellThickness = 0.0002;
+        //for shell elements, we should not expect that the recovered orthogonal reference coordinate is the same as the original ref coordinate 
+        //here we pick the original reference coordinate to make sure the recovered one is outside the ref element.
+        //for shellTriangle, the recovered orthogonal ref coordinate is the distance between the 3d physical point and the 2d physical map of the reference triangle, divided by the shell half-thickness.
+        pts3d_h(3,2) = 0.0+5.0*eps; //point near edge (out)
+        INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::ShellTriangle<3>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::ShellTriangle<3>, shellThickness, ct);
+        INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::ShellTriangle<6>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::ShellTriangle<6>, shellThickness, ct);
+        shellThickness = -1.0;
 
 
         // quadrilateral topologies
@@ -487,32 +581,64 @@ namespace Intrepid2 {
         pts2d_h(3,0) = 0.0; pts2d_h(3,1) = -1.0-eps;       //point near edge (out)
         Kokkos::deep_copy(pts2d,pts2d_h);
 
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts2d, emptyView, shards::Quadrilateral<4>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts2d, emptyView, shards::Quadrilateral<8>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts2d, emptyView, shards::Quadrilateral<9>, ct);
+        *outStream << "\nQuadrilateral" <<std::endl;
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts2d, emptyView, shards::Quadrilateral<4>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts2d, emptyView, shards::Quadrilateral<8>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts2d, emptyView, shards::Quadrilateral<9>, shellThickness, ct);
 
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts2d_h, physPoints, physNodes, shards::Quadrilateral<4>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Quadrilateral<4>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Quadrilateral<4>, shellThickness, ct);
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts2d_h, physPoints, physNodes, shards::Quadrilateral<8>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Quadrilateral<8>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Quadrilateral<8>, shellThickness, ct);
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts2d_h, physPoints, physNodes, shards::Quadrilateral<9>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Quadrilateral<9>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Quadrilateral<9>, shellThickness, ct);
 
+
+        // shell quadrilateral topologies
+        pts3d_h(0,0) = -1.0+eps; pts3d_h(0,1) = -1.0+eps; pts3d_h(0,2) = 0.0+eps;        //point near vertex (in)
+        pts3d_h(1,0) = -1.0-eps; pts3d_h(1,1) = -1.0-eps; pts3d_h(1,2) = 0.0-eps;        //point near vertex (out)
+        pts3d_h(2,0) = 0.0; pts3d_h(2,1) = -1.0+eps; pts3d_h(2,2) = 0.-eps;  //point near face (in)
+        pts3d_h(3,0) = 0.0; pts3d_h(3,1) = -1.0+eps; pts3d_h(3,2) = 1.0+eps;  //point near face (out in the orthogonal direction)
+        Kokkos::deep_copy(pts3d,pts3d_h);
+
+        *outStream << "\nShellQuadrilateral and Quadrilateral cells in 3D physical space" <<std::endl;
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::ShellQuadrilateral<4>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::ShellQuadrilateral<8>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::ShellQuadrilateral<9>, shellThickness, ct);
+
+        //quadrilateral in 3D physical space (physical points and nodes are in 3D space, but topology is 2d quadrilateral)  
+        INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::ShellQuadrilateral<4>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Quadrilateral<4>, shellThickness, ct);
+
+        shellThickness = 0.002;
+        //for shell elements, we should not expect that the recovered orthogonal reference coordinate is the same as the original ref coordinate 
+        //here we pick the original reference coordinate to make sure the recovered one is outside the ref element.
+        //for shellquadrilateral, the recovered orthogonal ref coordinate is approximately the distance between the 3d physical point and the 2d physical map of the reference quadrilateral, divided by the shell half-thickness.
+        pts3d_h(3,2) = 0.0-50.0*eps; //point near edge (out)
+        INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::ShellQuadrilateral<4>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::ShellQuadrilateral<4>, shellThickness, ct);
+        INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::ShellQuadrilateral<8>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::ShellQuadrilateral<8>, shellThickness, ct);
+        INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::ShellQuadrilateral<9>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::ShellQuadrilateral<9>, shellThickness, ct);
+        shellThickness = -1.0;
+
+
+        // tetrahedron topologies
         pts3d_h(0,0) = 0.0+eps; pts3d_h(0,1) = 0.0+eps; pts3d_h(0,2) = 0.0+eps;        //point near vertex (in)
         pts3d_h(1,0) = 0.0-eps; pts3d_h(1,1) = 0.0-eps; pts3d_h(1,2) = 0.0-eps;        //point near vertex (out)
         pts3d_h(2,0) = 1./3.-eps; pts3d_h(2,1) = 1./3.-eps; pts3d_h(2,2) = 1./3.-eps;  //point near face (in)
         pts3d_h(3,0) = 1./3.+eps; pts3d_h(3,1) = 1./3.+eps; pts3d_h(3,2) = 1./3.+eps;  //point near face (out)
         Kokkos::deep_copy(pts3d,pts3d_h);
 
-
-        // tetrahedron topologies
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Tetrahedron<4>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Tetrahedron<10>, ct);
+        *outStream << "\nTetrahedron" <<std::endl;
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Tetrahedron<4>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Tetrahedron<10>, shellThickness, ct);
 
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::Tetrahedron<4>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes  , shards::Tetrahedron<4>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes  , shards::Tetrahedron<4>, shellThickness, ct);
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::Tetrahedron<10>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Tetrahedron<10>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Tetrahedron<10>, shellThickness, ct);
 
 
         // pyramid topologies
@@ -522,14 +648,14 @@ namespace Intrepid2 {
         pts3d_h(3,0) = 0.0; pts3d_h(3,1) = 0.0; pts3d_h(3,2) = 0.0-eps;                //points near face (out)
         Kokkos::deep_copy(pts3d,pts3d_h);
 
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Pyramid<5>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Pyramid<13>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Pyramid<14>, ct);
+        *outStream << "\nPyramid" <<std::endl;
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Pyramid<5>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Pyramid<13>, shellThickness, ct);
         
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::Pyramid<5>, ct);
-	      INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Pyramid<5>, ct);
+	      INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Pyramid<5>, shellThickness, ct);
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::Pyramid<13>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Pyramid<13>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Pyramid<13>, shellThickness, ct);
         //missing basis functions for Pyramid<14>, need to implement them
 
 
@@ -540,16 +666,17 @@ namespace Intrepid2 {
         pts3d_h(3,0) = 0.5+eps; pts3d_h(3,1) = 0.5+eps; pts3d_h(3,2) = 0.0;       //point near face (out)
         Kokkos::deep_copy(pts3d,pts3d_h);
 
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Wedge<6>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Wedge<15>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Wedge<18>, ct);
+        *outStream << "\nWedge" <<std::endl;
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Wedge<6>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Wedge<15>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Wedge<18>, shellThickness, ct);
         
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::Wedge<6>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Wedge<6>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Wedge<6>, shellThickness, ct);
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::Wedge<15>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Wedge<15>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Wedge<15>, shellThickness, ct);
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::Wedge<18>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Wedge<18>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Wedge<18>, shellThickness, ct);
 
 
         // hexahedron topologies
@@ -559,16 +686,17 @@ namespace Intrepid2 {
         pts3d_h(3,0) = 0.0; pts3d_h(3,1) = 0.0; pts3d_h(3,2) = -1.0-eps;            //point near face (out)
         Kokkos::deep_copy(pts3d,pts3d_h);
 
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Hexahedron<8>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Hexahedron<20>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Hexahedron<27>, ct);
+        *outStream << "\nHexahedron" <<std::endl;
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Hexahedron<8>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Hexahedron<20>, shellThickness, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, pts3d, emptyView, shards::Hexahedron<27>, shellThickness, ct);
 
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::Hexahedron<8>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Hexahedron<8>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Hexahedron<8>, shellThickness, ct);
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::Hexahedron<20>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Hexahedron<20>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Hexahedron<20>, shellThickness, ct);
         INTREPID2_COMPUTE_POINTS_AND_CELL_NODES_IN_PHYS_SPACE(inCell, pts3d_h, physPoints, physNodes, shards::Hexahedron<27>, ct);
-        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Hexahedron<27>, ct);
+        INTREPID2_TEST_CHECK_POINTWISE_INCLUSION(inCell, physPoints, physNodes, shards::Hexahedron<27>, shellThickness, ct);
 
       } catch (std::logic_error &err) {
         //============================================================================================//

--- a/packages/intrepid2/unit-test/Cell/test_07.hpp
+++ b/packages/intrepid2/unit-test/Cell/test_07.hpp
@@ -406,7 +406,7 @@ namespace Intrepid2 {
         << "|                                                                             |\n"
         << "===============================================================================\n";
   
-      const ValueType tol = tolerence<ValueType>()*100.0;
+      const ValueType tol = tolerance<ValueType>()*100.0;
 
       int errorFlag = 0;
       

--- a/packages/intrepid2/unit-test/Cell/test_07.hpp
+++ b/packages/intrepid2/unit-test/Cell/test_07.hpp
@@ -90,7 +90,7 @@ namespace Intrepid2 {
       operator()(const ordinal_type i) const {
         const auto in = Kokkos::subview(_input,i,Kokkos::ALL());
         for (int k=0;k<3;++k) in(k)+=_offset;        
-        const auto check = PointInclusion<cellTopologyKey>::check(in, threshold<ValueType>());        
+        const bool check = ParametricDistance<cellTopologyKey>::distance(in) < 1.0 + threshold<ValueType>();        
         _output(i) = check;        
       }
     };

--- a/packages/intrepid2/unit-test/Discretization/Basis/DeRHAM_HEX_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/DeRHAM_HEX_FEM/test_01.hpp
@@ -74,7 +74,7 @@ int DeRHAM_HEX_FEM_Test01(const bool verbose) {
 
   typedef Kokkos::DynRankView<ValueType,DeviceSpaceType> DynRankView;
 
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
   int errorFlag = 0;
 
   // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/DeRHAM_QUAD_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/DeRHAM_QUAD_FEM/test_01.hpp
@@ -74,7 +74,7 @@ int DeRHAM_QUAD_FEM_Test01(const bool verbose) {
 
   typedef Kokkos::DynRankView<ValueType,DeviceSpaceType> DynRankView;
 
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
   int errorFlag = 0;
 
   // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/DeRHAM_TET_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/DeRHAM_TET_FEM/test_01.hpp
@@ -74,7 +74,7 @@ int DeRHAM_TET_FEM_Test01(const bool verbose) {
 
   typedef Kokkos::DynRankView<ValueType,DeviceSpaceType> DynRankView;
 
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
   int errorFlag = 0;
 
   // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/DeRHAM_TRI_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/DeRHAM_TRI_FEM/test_01.hpp
@@ -74,7 +74,7 @@ int DeRHAM_TRI_FEM_Test01(const bool verbose) {
 
   typedef Kokkos::DynRankView<ValueType,DeviceSpaceType> DynRankView;
 
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
   int errorFlag = 0;
 
   // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_HEX_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_HEX_I1_FEM/test_01.hpp
@@ -81,7 +81,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType> DynRankViewHost;
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       typedef ValueType outputValueType;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_HEX_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_HEX_In_FEM/test_01.hpp
@@ -74,7 +74,7 @@ int HCURL_HEX_In_FEM_Test01(const bool verbose) {
   typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
   typedef Kokkos::DynRankView<scalar_type, HostSpaceType> DynRankViewHostScalarValueType;
 
-  const scalar_type tol = tolerence();
+  const scalar_type tol = tolerance();
   int errorFlag = 0;
 
   typedef Basis_HCURL_HEX_In_FEM<DeviceType,OutValueType,PointValueType> HexBasisType;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_QUAD_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_QUAD_I1_FEM/test_01.hpp
@@ -71,7 +71,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType> DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
 
       int errorFlag = 0;
 

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_QUAD_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_QUAD_In_FEM/test_01.hpp
@@ -78,7 +78,7 @@ int HCURL_QUAD_In_FEM_Test01(const bool verbose) {
   typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
   typedef Kokkos::DynRankView<scalar_type, HostSpaceType> DynRankViewHostScalarValueType;
 
-  const scalar_type tol = tolerence();
+  const scalar_type tol = tolerance();
   int errorFlag = 0;
 
   typedef Basis_HCURL_QUAD_In_FEM<DeviceType,OutValueType,PointValueType> QuadBasisType;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TET_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TET_I1_FEM/test_01.hpp
@@ -52,7 +52,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType> DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
 
       int errorFlag = 0;
 

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TET_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TET_In_FEM/test_01.hpp
@@ -58,7 +58,7 @@ int HCURL_TET_In_FEM_Test01(const bool verbose) {
   typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
   typedef Kokkos::DynRankView<scalar_type, HostSpaceType> DynRankViewHostScalarValueType;
 
-  const scalar_type tol = tolerence();
+  const scalar_type tol = tolerance();
   int errorFlag = 0;
 
   // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TRI_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TRI_I1_FEM/test_01.hpp
@@ -53,7 +53,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType> DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
 
       int errorFlag = 0;
 

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TRI_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TRI_In_FEM/test_01.hpp
@@ -76,7 +76,7 @@ int HCURL_TRI_In_FEM_Test01(const bool verbose) {
   typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
   typedef Kokkos::DynRankView<scalar_type, HostSpaceType> DynRankViewHostScalarValueType;
 
-  const scalar_type tol = tolerence();
+  const scalar_type tol = tolerance();
   int errorFlag = 0;
   constexpr ordinal_type dim =2;
 

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_WEDGE_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_WEDGE_I1_FEM/test_01.hpp
@@ -72,7 +72,7 @@ namespace Test {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType> DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
 
       int errorFlag = 0;
 

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_HEX_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_HEX_I1_FEM/test_01.hpp
@@ -71,7 +71,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType> DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
 
       int errorFlag = 0;
 

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_HEX_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_HEX_In_FEM/test_01.hpp
@@ -74,7 +74,7 @@ int HDIV_HEX_In_FEM_Test01(const bool verbose) {
   typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
   typedef Kokkos::DynRankView<scalar_type, HostSpaceType> DynRankViewHostScalarValueType;
 
-  const scalar_type tol = tolerence();
+  const scalar_type tol = tolerance();
   int errorFlag = 0;
 
   typedef Basis_HDIV_HEX_In_FEM<DeviceType,OutValueType,PointValueType> HexBasisType;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_QUAD_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_QUAD_I1_FEM/test_01.hpp
@@ -69,7 +69,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType> DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       typedef ValueType outputValueType;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_QUAD_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_QUAD_In_FEM/test_01.hpp
@@ -78,7 +78,7 @@ int HDIV_QUAD_In_FEM_Test01(const bool verbose) {
   typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
   typedef Kokkos::DynRankView<scalar_type, HostSpaceType> DynRankViewHostScalarValueType;
 
-  const scalar_type tol = tolerence();
+  const scalar_type tol = tolerance();
   int errorFlag = 0;
 
   typedef Basis_HDIV_QUAD_In_FEM<DeviceType,OutValueType,PointValueType> QuadBasisType;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TET_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TET_I1_FEM/test_01.hpp
@@ -71,7 +71,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType> DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
       
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TET_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TET_In_FEM/test_01.hpp
@@ -76,7 +76,7 @@ int HDIV_TET_In_FEM_Test01(const bool verbose) {
   typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
   typedef Kokkos::DynRankView<scalar_type, HostSpaceType> DynRankViewHostScalarValueType;
 
-  const scalar_type tol = tolerence();
+  const scalar_type tol = tolerance();
   int errorFlag = 0;
 
   // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TRI_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TRI_I1_FEM/test_01.hpp
@@ -70,7 +70,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType> DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TRI_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TRI_In_FEM/test_01.hpp
@@ -75,7 +75,7 @@ int HDIV_TRI_In_FEM_Test01(const bool verbose) {
   typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
   typedef Kokkos::DynRankView<scalar_type, HostSpaceType> DynRankViewHostScalarValueType;
 
-  const scalar_type tol = tolerence();
+  const scalar_type tol = tolerance();
   int errorFlag = 0;
   constexpr ordinal_type dim =2;
 

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_WEDGE_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_WEDGE_I1_FEM/test_01.hpp
@@ -69,7 +69,7 @@ int HDIV_WEDGE_I1_FEM_Test01(const bool verbose) {
   typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
   typedef Kokkos::DynRankView<ValueType,HostSpaceType> DynRankViewHost;
 
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
   int errorFlag = 0;
 
   // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C1_FEM/test_01.hpp
@@ -50,7 +50,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C1_FEM/test_02.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C1_FEM/test_02.hpp
@@ -209,7 +209,7 @@ namespace Intrepid2 {
 
       typedef Kokkos::DynRankView<ValueType,DeviceSpaceType> DynRankView;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       typedef ValueType pointValueType;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C2_FEM/test_01.hpp
@@ -50,7 +50,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_Cn_FEM/test_01.hpp
@@ -58,7 +58,7 @@ int HGRAD_HEX_Cn_FEM_Test01(const bool verbose) {
   typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
   typedef Kokkos::DynRankView<scalar_type, HostSpaceType> DynRankViewHostScalarValueType;
 
-  const scalar_type tol = tolerence();
+  const scalar_type tol = tolerance();
   int errorFlag = 0;
 
   typedef Basis_HGRAD_HEX_Cn_FEM<DeviceType,OutValueType,PointValueType> HexBasisType;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_C1_FEM/test_01.hpp
@@ -49,7 +49,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_C2_FEM/test_01.hpp
@@ -48,7 +48,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_Cn_FEM/test_01.hpp
@@ -51,7 +51,7 @@ namespace Test {
       typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
 
       constexpr int spaceDim = 1;
-      const scalar_type tol = tolerence();
+      const scalar_type tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_Cn_FEM_JACOBI/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_Cn_FEM_JACOBI/test_01.hpp
@@ -52,7 +52,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,Kokkos::HostSpace>   DynRankViewHost;
       
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
       
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_PYR_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_PYR_C1_FEM/test_01.hpp
@@ -44,7 +44,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_PYR_I2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_PYR_I2_FEM/test_01.hpp
@@ -81,7 +81,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C1_FEM/test_01.hpp
@@ -46,7 +46,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C2_FEM/test_01.hpp
@@ -52,7 +52,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_Cn_FEM/test_01.hpp
@@ -59,7 +59,7 @@ int HGRAD_QUAD_Cn_FEM_Test01(const bool verbose) {
   typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;      
   typedef Kokkos::DynRankView<scalar_type, HostSpaceType> DynRankViewHostScalarValueType;      
 
-  const scalar_type tol = tolerence();
+  const scalar_type tol = tolerance();
   int errorFlag = 0;
 
   typedef Basis_HGRAD_QUAD_Cn_FEM<DeviceType,OutValueType,PointValueType> QuadBasisType;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_C1_FEM/test_01.hpp
@@ -51,7 +51,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
       
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_C2_FEM/test_01.hpp
@@ -52,7 +52,7 @@ namespace Test {
     typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
     typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 
-    const ValueType tol = tolerence();
+    const ValueType tol = tolerance();
     int errorFlag = 0;
       
     // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_COMP12_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_COMP12_FEM/test_01.hpp
@@ -52,7 +52,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_Cn_FEM/test_01.hpp
@@ -54,7 +54,7 @@ int HGRAD_TET_Cn_FEM_Test01(const bool verbose) {
   typedef typename ScalarTraits<OutValueType>::scalar_type scalar_type;
   typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
 
-  const scalar_type tol = tolerence();
+  const scalar_type tol = tolerance();
   int errorFlag = 0;
 
   // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_Cn_FEM_ORTH/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_Cn_FEM_ORTH/test_01.hpp
@@ -49,7 +49,7 @@ int HGRAD_TET_Cn_FEM_ORTH_Test01(const bool verbose) {
 
   typedef Kokkos::DynRankView<ValueType, DeviceType> DynRankView;
 
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
   int errorFlag = 0;
 
   // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C1_FEM/test_01.hpp
@@ -51,7 +51,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C2_FEM/test_01.hpp
@@ -51,7 +51,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_Cn_FEM/test_01.hpp
@@ -56,7 +56,7 @@ namespace Intrepid2 {
       typedef typename ScalarTraits<OutValueType>::scalar_type scalar_type;
       typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
 
-      const scalar_type tol = tolerence();
+      const scalar_type tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_Cn_FEM_ORTH/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_Cn_FEM_ORTH/test_01.hpp
@@ -49,7 +49,7 @@ int HGRAD_TRI_Cn_FEM_ORTH_Test01(const bool verbose) {
 
   typedef Kokkos::DynRankView<ValueType, DeviceType> DynRankView;
 
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
   int errorFlag = 0;
 
   // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_WEDGE_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_WEDGE_C1_FEM/test_01.hpp
@@ -70,7 +70,7 @@ namespace Intrepid2 {
         typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
         typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_WEDGE_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_WEDGE_C2_FEM/test_01.hpp
@@ -70,7 +70,7 @@ namespace Intrepid2 {
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
       typedef Kokkos::DynRankView<ValueType,HostSpaceType>   DynRankViewHost;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HVOL_C0_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HVOL_C0_FEM/test_01.hpp
@@ -58,7 +58,7 @@ namespace Intrepid2 {
 
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
 
-      const ValueType tol = tolerence();
+      const ValueType tol = tolerance();
       int errorFlag = 0;
 
       // for virtual function, value and point types are declared in the class

--- a/packages/intrepid2/unit-test/Discretization/Basis/HVOL_HEX_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HVOL_HEX_Cn_FEM/test_01.hpp
@@ -77,7 +77,7 @@ int HVOL_HEX_Cn_FEM_Test01(const bool verbose) {
   typedef typename ScalarTraits<OutValueType>::scalar_type scalar_type;
   typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;     
 
-  const scalar_type tol = tolerence();
+  const scalar_type tol = tolerance();
   int errorFlag = 0;
 
   typedef Basis_HVOL_HEX_Cn_FEM<DeviceType,OutValueType,PointValueType> HexBasisType;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HVOL_LINE_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HVOL_LINE_Cn_FEM/test_01.hpp
@@ -75,7 +75,7 @@ namespace Intrepid2 {
       typedef typename ScalarTraits<OutValueType>::scalar_type scalar_type;
       typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
 
-      const scalar_type tol = tolerence();
+      const scalar_type tol = tolerance();
       int errorFlag = 0;
 
       typedef Basis_HVOL_LINE_Cn_FEM<DeviceType,OutValueType,PointValueType> LineBasisType;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HVOL_QUAD_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HVOL_QUAD_Cn_FEM/test_01.hpp
@@ -78,7 +78,7 @@ namespace Intrepid2 {
       typedef typename ScalarTraits<OutValueType>::scalar_type scalar_type;
       typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
 
-      const scalar_type tol = tolerence();
+      const scalar_type tol = tolerance();
       int errorFlag = 0;
 
       typedef Basis_HVOL_QUAD_Cn_FEM<DeviceType,OutValueType,PointValueType> QuadBasisType;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HVOL_TET_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HVOL_TET_Cn_FEM/test_01.hpp
@@ -72,7 +72,7 @@ namespace Intrepid2 {
       typedef typename ScalarTraits<OutValueType>::scalar_type scalar_type;
       typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
 
-      const scalar_type tol = tolerence();
+      const scalar_type tol = tolerance();
       int errorFlag = 0;
 
       typedef Basis_HVOL_TET_Cn_FEM<DeviceType,OutValueType,PointValueType> TetBasisType;

--- a/packages/intrepid2/unit-test/Discretization/Basis/HVOL_TRI_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HVOL_TRI_Cn_FEM/test_01.hpp
@@ -72,7 +72,7 @@ namespace Intrepid2 {
       typedef typename ScalarTraits<OutValueType>::scalar_type scalar_type;
       typedef Kokkos::DynRankView<scalar_type, DeviceType> DynRankViewScalarValueType;
 
-      const scalar_type tol = tolerence();
+      const scalar_type tol = tolerance();
       int errorFlag = 0;
 
       typedef Basis_HVOL_TRI_Cn_FEM<DeviceType,OutValueType,PointValueType> TriBasisType;

--- a/packages/intrepid2/unit-test/Discretization/FunctionSpaceTools/test_04.hpp
+++ b/packages/intrepid2/unit-test/Discretization/FunctionSpaceTools/test_04.hpp
@@ -85,7 +85,7 @@ namespace Intrepid2 {
       typedef FunctionSpaceTools<DeviceType> fst;
       typedef Kokkos::DynRankView<ValueType,DeviceType> DynRankView;
 
-      const auto tol = tolerence();
+      const auto tol = tolerance();
 
       int errorFlag = 0;
 

--- a/packages/intrepid2/unit-test/Discretization/Integration/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Integration/test_01.hpp
@@ -102,7 +102,7 @@ namespace Intrepid2 {
       typedef CubatureTensor                 <DeviceType,pointValueType,weightValueType> CubatureTensorType;
       //typedef CubatureTensorPyr              <DeviceType,pointValueType,weightValueType> CubatureTensorPyrType;
 
-      const auto tol = 100.0 * tolerence();
+      const auto tol = 100.0 * tolerance();
 
       int errorFlag  = 0;
 

--- a/packages/intrepid2/unit-test/Discretization/Integration/test_02.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Integration/test_02.hpp
@@ -91,7 +91,7 @@ namespace Intrepid2 {
       typedef ValueType weightValueType;
       typedef CubatureDirectLineGauss<DeviceType,pointValueType,weightValueType> CubatureLineType;
 
-      const auto tol = 10.0 * tolerence();
+      const auto tol = 10.0 * tolerance();
 
       int errorFlag = 0;
 

--- a/packages/intrepid2/unit-test/Discretization/Integration/test_03.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Integration/test_03.hpp
@@ -94,7 +94,7 @@ namespace Intrepid2 {
       typedef CubatureDirectLineGauss<DeviceType,pointValueType,weightValueType> CubatureLineType;
       typedef CubatureTensor<DeviceType,pointValueType,weightValueType> CubatureTensorType;
 
-      const auto tol = 10.0 * tolerence();
+      const auto tol = 10.0 * tolerance();
 
       int errorFlag = 0;
       

--- a/packages/intrepid2/unit-test/Discretization/Integration/test_04.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Integration/test_04.hpp
@@ -93,7 +93,7 @@ namespace Intrepid2 {
       typedef CubatureDirectLineGauss<DeviceType,pointValueType,weightValueType> CubatureLineType;
       typedef CubatureTensor<DeviceType,pointValueType,weightValueType> CubatureTensorType;
       
-      const auto tol = 10.0 * tolerence();
+      const auto tol = 10.0 * tolerance();
 
       int errorFlag = 0;
 

--- a/packages/intrepid2/unit-test/Discretization/Integration/test_05.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Integration/test_05.hpp
@@ -93,7 +93,7 @@ namespace Intrepid2 {
       typedef CubatureDirectTriDefault<DeviceType,pointValueType,weightValueType> CubatureTriType;
       typedef CubatureDirectTriSymmetric<DeviceType,pointValueType,weightValueType> CubatureTriSymType;
 
-      const auto tol = 10.0 * tolerence();
+      const auto tol = 10.0 * tolerance();
 
       int errorFlag = 0;
 

--- a/packages/intrepid2/unit-test/Discretization/Integration/test_06.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Integration/test_06.hpp
@@ -92,9 +92,9 @@ namespace Intrepid2 {
       typedef CubatureDirectTetDefault<DeviceType,pointValueType,weightValueType> CubatureTetType;
       typedef CubatureDirectTetSymmetric<DeviceType,pointValueType,weightValueType> CubatureTetSymType;
       
-      // tolerence is too tight to test upto order 20
+      // tolerance is too tight to test upto order 20
       // tol factor increased by 1000 due to cubature order 20 test failure
-      const auto tol = 2000.0 * tolerence();
+      const auto tol = 2000.0 * tolerance();
 
       int errorFlag = 0;
 

--- a/packages/intrepid2/unit-test/Discretization/Integration/test_07.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Integration/test_07.hpp
@@ -95,8 +95,8 @@ namespace Intrepid2 {
       typedef CubatureDirectLineGaussJacobi20<DeviceType,pointValueType,weightValueType> CubatureLineJacobiType;
       typedef CubatureTensorPyr<DeviceType,pointValueType,weightValueType> CubatureTensorPyrType;
       
-      // tolerence is too tight to test upto order 20
-      const auto tol = 1000.0 * tolerence();
+      // tolerance is too tight to test upto order 20
+      const auto tol = 1000.0 * tolerance();
 
       int errorFlag = 0;
 

--- a/packages/intrepid2/unit-test/Discretization/Integration/test_10.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Integration/test_10.hpp
@@ -84,7 +84,7 @@ namespace Intrepid2 {
       typedef ValueType weightValueType;
       typedef CubaturePolylib<DeviceSpaceType,pointValueType,weightValueType> CubatureLineType;
 
-      const auto tol = 100.0 * tolerence(); // relaxing this as we support higher-order cubature
+      const auto tol = 100.0 * tolerance(); // relaxing this as we support higher-order cubature
 
       int errorFlag = 0;
 

--- a/packages/intrepid2/unit-test/Discretization/Integration/test_25.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Integration/test_25.hpp
@@ -61,7 +61,7 @@ namespace Intrepid2 {
 
       typedef Kokkos::DynRankView<ValueType,DeviceSpaceType> DynRankView;
       
-      const auto tol = tolerence();
+      const auto tol = tolerance();
 
       int errorFlag = 0;
       try {
@@ -167,7 +167,7 @@ namespace Intrepid2 {
       typedef ValueType weightValueType;
       typedef CubatureControlVolume<DeviceSpaceType,pointValueType,weightValueType> CubatureControlVolumeType;
       
-      const auto tol = tolerence();
+      const auto tol = tolerance();
 
       int errorFlag = 0;
       try {
@@ -759,7 +759,7 @@ namespace Intrepid2 {
         typedef CubatureControlVolume<DeviceSpaceType,pointValueType,weightValueType> CubatureControlVolumeType;
         typedef CubatureControlVolumeSide<DeviceSpaceType,pointValueType,weightValueType> CubatureControlVolumeSideType;
         
-        const auto tol = tolerence();
+        const auto tol = tolerance();
 
         *outStream << " - Quadrilateral cell testing \n";
         {

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_HEX.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_HEX.hpp
@@ -95,7 +95,7 @@ int OrientationHex(const bool verbose) {
   oldFormatState.copyfmt(std::cout);
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   struct Fun {
     ValueType

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_HEX_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_HEX_newBasis.hpp
@@ -84,7 +84,7 @@ int OrientationHexNewBasis(const bool verbose) {
   oldFormatState.copyfmt(std::cout);
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   struct Fun {
     ValueType

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_QuadFace_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_QuadFace_newBasis.hpp
@@ -90,7 +90,7 @@ int OrientationPyrQuadFaceNewBasis(const bool verbose) {
   oldFormatState.copyfmt(std::cout);
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   struct Fun {
     ValueType

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_TriFace_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_PYR_TriFace_newBasis.hpp
@@ -93,7 +93,7 @@ int OrientationPyrTriFaceNewBasis(const bool verbose) {
   oldFormatState.copyfmt(std::cout);
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   struct Fun {
     ValueType

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_QUAD.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_QUAD.hpp
@@ -90,7 +90,7 @@ int OrientationQuad(const bool verbose) {
   oldFormatState.copyfmt(std::cout);
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   struct Fun {
     ValueType

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_QUAD_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_QUAD_newBasis.hpp
@@ -90,7 +90,7 @@ int OrientationQuadNewBasis(const bool verbose) {
   oldFormatState.copyfmt(std::cout);
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   struct Fun {
     ValueType

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_TET.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_TET.hpp
@@ -95,7 +95,7 @@ int OrientationTet(const bool verbose) {
   oldFormatState.copyfmt(std::cout);
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   struct Fun {
     ValueType

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_TRI.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_TRI.hpp
@@ -90,7 +90,7 @@ int OrientationTri(const bool verbose) {
   oldFormatState.copyfmt(std::cout);
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   struct Fun {
     ValueType

--- a/packages/intrepid2/unit-test/Orientation/test_orientationtools_hex_coeff_matrix.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientationtools_hex_coeff_matrix.hpp
@@ -64,7 +64,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       int errorFlag = 0;
-      //const double tol = tolerence();
+      //const double tol = tolerance();
       constexpr ordinal_type maxOrder = Parameters::MaxOrder;
 
       typedef OrientationTools<DeviceType> ots;

--- a/packages/intrepid2/unit-test/Orientation/test_orientationtools_hex_mesh.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientationtools_hex_mesh.hpp
@@ -64,7 +64,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       int errorFlag = 0;
-      //const double tol = tolerence();
+      //const double tol = tolerance();
 
       typedef OrientationTools<DeviceType> ots;
       try {

--- a/packages/intrepid2/unit-test/Orientation/test_orientationtools_modify_basis_hex_hcurl.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientationtools_modify_basis_hex_hcurl.hpp
@@ -63,7 +63,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       int errorFlag = 0;
-      const double tol = 100*tolerence();
+      const double tol = 100*tolerance();
       constexpr ordinal_type maxOrder = Parameters::MaxOrder;
 
       typedef OrientationTools<DeviceType> ots;

--- a/packages/intrepid2/unit-test/Orientation/test_orientationtools_modify_basis_hex_hgrad.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientationtools_modify_basis_hex_hgrad.hpp
@@ -63,7 +63,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       int errorFlag = 0;
-      const double tol = 100*tolerence();
+      const double tol = 100*tolerance();
       constexpr ordinal_type maxOrder = Parameters::MaxOrder ;
 
       typedef OrientationTools<DeviceType> ots;

--- a/packages/intrepid2/unit-test/Orientation/test_orientationtools_modify_basis_quad_hcurl.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientationtools_modify_basis_quad_hcurl.hpp
@@ -63,7 +63,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       int errorFlag = 0;
-      //const double tol = tolerence();
+      //const double tol = tolerance();
       constexpr ordinal_type maxOrder = Parameters::MaxOrder ;
 
       typedef OrientationTools<DeviceType> ots;

--- a/packages/intrepid2/unit-test/Orientation/test_orientationtools_modify_basis_quad_hcurl_i1.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientationtools_modify_basis_quad_hcurl_i1.hpp
@@ -63,7 +63,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       int errorFlag = 0;
-      const double tol = tolerence();
+      const double tol = tolerance();
 
       typedef OrientationTools<DeviceType> ots;
       try {

--- a/packages/intrepid2/unit-test/Orientation/test_orientationtools_modify_basis_quad_hgrad.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientationtools_modify_basis_quad_hgrad.hpp
@@ -64,7 +64,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       int errorFlag = 0;
-      const double tol = tolerence();
+      const double tol = tolerance();
       constexpr ordinal_type maxOrder = Parameters::MaxOrder ;
 
       typedef OrientationTools<DeviceType> ots;

--- a/packages/intrepid2/unit-test/Orientation/test_orientationtools_modify_basis_tri_hcurl.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientationtools_modify_basis_tri_hcurl.hpp
@@ -64,7 +64,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       int errorFlag = 0;
-      const double tol = tolerence();
+      const double tol = tolerance();
       constexpr ordinal_type maxOrder = Parameters::MaxOrder ;
 
       typedef OrientationTools<DeviceType> ots;

--- a/packages/intrepid2/unit-test/Orientation/test_orientationtools_modify_basis_tri_hgrad.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientationtools_modify_basis_tri_hgrad.hpp
@@ -63,7 +63,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       int errorFlag = 0;
-      const double tol = tolerence();
+      const double tol = tolerance();
       constexpr ordinal_type maxOrder = Parameters::MaxOrder ;
 
       typedef OrientationTools<DeviceType> ots;

--- a/packages/intrepid2/unit-test/Orientation/test_orientationtools_quad_coeff_matrix.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientationtools_quad_coeff_matrix.hpp
@@ -63,7 +63,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       int errorFlag = 0;
-      const double tol = tolerence();
+      const double tol = tolerance();
       constexpr ordinal_type maxOrder = Parameters::MaxOrder ;
 
       typedef OrientationTools<DeviceType> ots;

--- a/packages/intrepid2/unit-test/Orientation/test_orientationtools_quad_mesh.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientationtools_quad_mesh.hpp
@@ -64,7 +64,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       int errorFlag = 0;
-      //const double tol = tolerence();
+      //const double tol = tolerance();
 
       typedef OrientationTools<DeviceType> ots;
       try {

--- a/packages/intrepid2/unit-test/Orientation/test_orientationtools_tet_coeff_matrix.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientationtools_tet_coeff_matrix.hpp
@@ -63,7 +63,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       int errorFlag = 0;
-      //const double tol = tolerence();
+      //const double tol = tolerance();
       constexpr ordinal_type maxOrder = Parameters::MaxOrder;
 
       typedef OrientationTools<DeviceType> ots;

--- a/packages/intrepid2/unit-test/Orientation/test_orientationtools_tri_coeff_matrix.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientationtools_tri_coeff_matrix.hpp
@@ -65,7 +65,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       int errorFlag = 0;
-      const double tol = tolerence();
+      const double tol = tolerance();
       constexpr ordinal_type maxOrder = Parameters::MaxOrder;
 
       typedef OrientationTools<DeviceType> ots;

--- a/packages/intrepid2/unit-test/Orientation/test_orientationtools_tri_mesh.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientationtools_tri_mesh.hpp
@@ -63,7 +63,7 @@ namespace Intrepid2 {
         << "===============================================================================\n";
 
       int errorFlag = 0;
-      //const double tol = tolerence();
+      //const double tol = tolerance();
 
       typedef OrientationTools<DeviceType> ots;
       try {

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_HEX.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_HEX.hpp
@@ -99,7 +99,7 @@ int DeRhamCommutativityHex(const bool verbose) {
   *outStream << "\n";
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   //target functions and their derivatives
 

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_QUAD.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_QUAD.hpp
@@ -102,7 +102,7 @@ int DeRhamCommutativityQuad(const bool verbose) {
   *outStream << "\n";
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   //target functions and their derivatives
 

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_TET.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_TET.hpp
@@ -99,7 +99,7 @@ int DeRhamCommutativityTet(const bool verbose) {
   *outStream << "\n";
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   //target functions and their derivatives
 

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_TRI.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_TRI.hpp
@@ -102,7 +102,7 @@ int DeRhamCommutativityTri(const bool verbose) {
   *outStream << "\n";
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   //target functions and their derivatives
 

--- a/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_WEDGE.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_DeRham_commutativity_WEDGE.hpp
@@ -95,7 +95,7 @@ int DeRhamCommutativityWedge(const bool verbose) {
   *outStream << "\n";
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   //target functions and their derivatives
 

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_HEX.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_HEX.hpp
@@ -107,7 +107,7 @@ int InterpolationProjectionHex(const bool verbose) {
   *outStream << "\n";
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   bool pickTest = false;
   int elemPermutation=0, sharedSidePermutation=0;

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_QUAD.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_QUAD.hpp
@@ -103,7 +103,7 @@ int InterpolationProjectionQuad(const bool verbose) {
   *outStream << "\n";
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   //target functions and their derivatives
 

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TET.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TET.hpp
@@ -101,7 +101,7 @@ int InterpolationProjectionTet(const bool verbose) {
   using DynRankViewIntHost = Kokkos::DynRankView<ordinal_type,Kokkos::HostSpace>;
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   bool pickTest = false;
   int elemPermutation=0, sharedSidePermutation=0;

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TRI.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TRI.hpp
@@ -97,7 +97,7 @@ int InterpolationProjectionTri(const bool verbose) {
   using DynRankViewIntHost = Kokkos::DynRankView<ordinal_type,Kokkos::HostSpace>;
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   //target functions and their derivatives
 

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_WEDGE.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_WEDGE.hpp
@@ -104,7 +104,7 @@ int InterpolationProjectionWedge(const bool verbose) {
   *outStream << "\n";
 
   int errorFlag = 0;
-  const ValueType tol = tolerence();
+  const ValueType tol = tolerance();
 
   bool pickTest = false;
   int elemPermutation=0, sharedSidePermutation=0;

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_01.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_01.hpp
@@ -89,7 +89,7 @@ namespace Intrepid2 {
 #else
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
 #endif 
-      const value_type tol = tolerence()*10000.0;
+      const value_type tol = tolerance()*10000.0;
       int errorFlag = 0;
       
       *outStream                                \

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_02.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_02.hpp
@@ -89,7 +89,7 @@ namespace Intrepid2 {
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
 #endif 
       
-      const value_type tol = tolerence()*10000.0;
+      const value_type tol = tolerance()*10000.0;
       int errorFlag = 0;
       
       *outStream                                \

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_03.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_03.hpp
@@ -90,7 +90,7 @@ namespace Intrepid2 {
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
 #endif 
 
-      const value_type tol = tolerence()*10000.0;
+      const value_type tol = tolerance()*10000.0;
       int errorFlag = 0;
 
       *outStream                                \

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_04.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_04.hpp
@@ -85,7 +85,7 @@ namespace Intrepid2 {
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
 #endif 
       
-      const value_type tol = tolerence()*10000.0;
+      const value_type tol = tolerance()*10000.0;
       int errorFlag = 0;
       
       

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_05.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_05.hpp
@@ -90,7 +90,7 @@ namespace Intrepid2 {
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
 #endif 
 
-      const value_type tol = tolerence()*100.0;
+      const value_type tol = tolerance()*100.0;
       int errorFlag = 0;
 
       *outStream                                \

--- a/packages/intrepid2/unit-test/Shared/Polylib/test_01.hpp
+++ b/packages/intrepid2/unit-test/Shared/Polylib/test_01.hpp
@@ -235,7 +235,7 @@ namespace Intrepid2 {
 
       const ordinal_type npLower = 5, npUpper = Polylib::MaxPolylibPoint;
       const ordinal_type npUpperStep1 = 21; // we cover all np values from npLower to npUpperStep1; we only cover every 5th one after that
-      const ValueType tol = 1000.0 * tolerence();
+      const ValueType tol = 1000.0 * tolerance();
       const double  lowOrderTol = tol;
       const double highOrderTol = tol * 100;
 

--- a/packages/intrepid2/unit-test/Shared/RealSpaceTools/test_01.hpp
+++ b/packages/intrepid2/unit-test/Shared/RealSpaceTools/test_01.hpp
@@ -259,7 +259,7 @@ namespace Intrepid2 {
       outStream->precision(20);
 
       try {
-        const value_type tol = tolerence()*100.0;
+        const value_type tol = tolerance()*100.0;
         
         // two-dimensional base containers
         for (auto dim=3; dim>0; dim--) {


### PR DESCRIPTION
@trilinos/intrepid2

This PR contain a redesign of `PointInclusion` tools to expose the parametric distance, and an extension of `cellTools` to support beam and shell elements. 

1. Redesign of the `PointInclusion` tools to expose the parametric distance, similarly to what is done in Sierra. The parametric distance of a point w.r.t. a reference cell is such that:
a) the distance is zero at the centroid
b) the distance is less than one if the point is in the interior of the cell
c) the distance is greater than one if the point is outside the cell
d) the distance is equal to one on the cell boundary 
It is now possible to compute the parametric distance for each cell using serial, device friendly, functions templated on the cell topology key. The parametric distance is used to determine whether a point is inside or outside a reference cell, replacing the current implementation of `PointInclusion` (which is now deprecated)

2. Extension of `cellTools` to support beam and shell elements, in particular
    a) changes to `mapToPhysicalFrame` to support shell elements. 
    b) changes to `mapToReferenceFrame` to support shell elements
         - support maps from (D+1) dimensional physical space to D dimensional reference space
         - support shell maps. After mapping to the reference D dimensional reference space, estimate the D+1 reference coordinate by computing the distance between the  physical points and the D dimensional manifold in physical space, and divide the distance by the shell half-thickness
    c) changes to `PointInclusion` to use the shell elements.
    d) changes to `Cell` tests to exercise these new capabilities.
    Also performed some changes to  `mapToReferenceFrame` and `mapToPhysicalFrame` and related routines to improve performance.



<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
