### PR TITLE
Master merge fixes

### DIFF
--- a/.github/workflows/master_merge.yml
+++ b/.github/workflows/master_merge.yml
@@ -11,17 +11,19 @@ jobs:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'trilinos/Trilinos' }}
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.SNAPSHOT_APP_ID }}
+          client-id: ${{ secrets.SNAPSHOT_APP_ID }}
           private-key: ${{ secrets.SNAPSHOT_APP_PRIVATE_KEY }}
 
       - name: Clone Trilinos
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: develop
+          fetch-depth: 0
 
       - name: Create PR
         env:
@@ -46,7 +48,7 @@ jobs:
           --body "Automatic PR from develop to master."
 
           # delete previously merged branches
-          merged_branches=`git branch --remote --merged ${REMOTE}/master | grep "master_merge_"`
+          merged_branches=`git branch --remote --merged ${REMOTE}/master | grep -E "master_merge_[0-9]{8}_[0-9]{4}"`
           for merged_branch in ${merged_branches} ; do
               # extract branch name
               merged_branch_name=`echo ${merged_branch} | cut -d "/" -f 2`

--- a/.github/workflows/muelu_tutorial.yml
+++ b/.github/workflows/muelu_tutorial.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out webpage repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -28,7 +28,7 @@ jobs:
         
       - name: Dispatch repository_dispatch event
         if: steps.changes.outputs.tutorial == 'true'
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.MUELU_REPO_ACCESS_TOKEN }} # A PAT with 'repo' scope
           script: |

--- a/.github/workflows/pre_commit_comment.yml
+++ b/.github/workflows/pre_commit_comment.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: 'Download artifact'
-      uses: actions/github-script@v9.0.0
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/pre_commit_run.yml
+++ b/.github/workflows/pre_commit_run.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       continue-on-error: true
 
     - run: git diff HEAD > format_patch.txt

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ secrets.SNAPSHOT_APP_ID }}
@@ -74,7 +74,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           app-id: ${{ secrets.SNAPSHOT_APP_ID }}


### PR DESCRIPTION
@trilinos/framework 

## Motivation

https://github.com/trilinos/Trilinos/actions/runs/25953914800/job/76296862238

- Only run in this repo, not in forks.
- `app-id` is deprecated. Use `client-id` instead.
- Fix detection of previous master merge branches. Branch deletion is still disabled.
- Pin a couple of GitHub action dependencies by SHA.