### PR TITLE
CMake: Enable exception handling mechanism for Windows MSVC-ABI C++ compilers

### DIFF
--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -35,6 +35,42 @@ IF (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
   ENDIF()
 ENDIF()
 
+# Windows toolchains with the MSVC C++ ABI need /EHsc so throw/catch work in all
+# packages and tests.  Covers Visual Studio and Ninja generators, cl.exe, clang-cl,
+# Intel (classic icpc), and IntelLLVM on Windows - not MinGW/Cygwin (different models).
+IF(WIN32 AND NOT CYGWIN AND ${PROJECT_NAME}_ENABLE_CXX)
+  SET(_TRILINOS_WINDOWS_MSVC_ABI_CXX FALSE)
+  IF(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    SET(_TRILINOS_WINDOWS_MSVC_ABI_CXX TRUE)
+  ELSEIF(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND "x${CMAKE_CXX_SIMULATE_ID}" STREQUAL "xMSVC")
+    SET(_TRILINOS_WINDOWS_MSVC_ABI_CXX TRUE)
+  ELSEIF(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+    SET(_TRILINOS_WINDOWS_MSVC_ABI_CXX TRUE)
+  ELSEIF(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+    SET(_TRILINOS_WINDOWS_MSVC_ABI_CXX TRUE)
+  ENDIF()
+  IF(_TRILINOS_WINDOWS_MSVC_ABI_CXX)
+    IF(CMAKE_CXX_FLAGS MATCHES "(^| )/EHa( |$)")
+      MESSAGE(WARNING
+        "CMAKE_CXX_FLAGS contains /EHa; Trilinos will not add /EHsc (exception model left to user).")
+    ELSEIF(CMAKE_CXX_FLAGS MATCHES "(^| )/EHsc-( |$)")
+      MESSAGE(WARNING
+        "CMAKE_CXX_FLAGS contains /EHsc-; Trilinos will not add /EHsc (exceptions explicitly disabled).")
+    ELSEIF(NOT CMAKE_CXX_FLAGS MATCHES "(^| )/EHsc( |$)")
+      MESSAGE("-- "
+        "Adding '/EHsc' for C++ exception handling on Windows (${CMAKE_CXX_COMPILER_ID})")
+      SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
+      ADD_COMPILE_OPTIONS($<$<COMPILE_LANGUAGE:CXX>:/EHsc>)
+    ELSE()
+      # CMAKE_CXX_FLAGS already has /EHsc (e.g. CMake MSVC defaults); still set
+      # directory compile options so a later -DCMAKE_CXX_FLAGS= override cannot
+      # drop exceptions for targets in this project.
+      ADD_COMPILE_OPTIONS($<$<COMPILE_LANGUAGE:CXX>:/EHsc>)
+    ENDIF()
+  ENDIF()
+  UNSET(_TRILINOS_WINDOWS_MSVC_ABI_CXX)
+ENDIF()
+
 IF (KokkosEnable)
   MESSAGE("-- " "Skip adding flags for OpenMP because Kokkos flags does that ...")
   SET(OpenMP_CXX_FLAGS_OVERRIDE " ")


### PR DESCRIPTION
@trilinos/Trilinos

## Motivation

On Windows with MSVC-like compilers there is a problem with exception model, that we need to turn on for correct stack unwinding. This patch do the same thing as in recent [Kokkos PR-9181](https://github.com/kokkos/kokkos/pull/9181). But in that PR I didn't mention the minimal example which will reinforce these changes. Here is the minimal repro and output:

https://godbolt.org/z/qE9bssdWs

<img width="1580" height="612" alt="изображение" src="https://github.com/user-attachments/assets/af8bdf61-bac2-433a-a029-72a050f7fee7" />

> As we can see, clang-cl restricts to compile code with exceptions but withou `/EHsc` while MSVC only warns about it, but allows to compile this code. I agree with clang-cl policy in this case - no need to compile unsafe code, error better then just warn

## Environment

| Item       | Value                                            |
| ---------- | ------------------------------------------------ |
| OS         | Windows 10 Pro x64, Build 19044                  |
| CPU        | 12th Gen Intel(R) Core(TM) i7-12700K  (20 logical cores)          |
| CMake      | 4.2.1                                           |
| MSVC       | 19.51.36243 (VS 2026 Community)                  |
| clang-cl   | 21.1.7;x86_64-pc-windows-msvc;thread-model:posix |
| Ninja      | 1.13.2                                           |
| Build type | RelWithDebInfo, shared libs, C++20               |

## Related Issues

- [Kokkos PR-9181](github.com/kokkos/kokkos/pull/9181)
- #14816

## Related Links

- [Exception Handling Model](https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170)
- [Fail Fast Exceptions 0xc0000409](https://learn.microsoft.com/en-us/shows/inside/c0000409)

## Testing

### Before (Techos example)

Most of tests will fail because of fail fast way `0xc0000409`

```log
18% tests passed, 93 tests failed out of 114

Subproject Time Summary:
Teuchos    =  54.08 sec*proc (114 tests)

Total Test time (real) =  55.43 sec

The following tests FAILED:
	  1 - TeuchosCore_Allocator_UnitTest (Exit code 0xc0000409) Teuchos
	  3 - TeuchosCore_CommandLineProcessor_test (Exit code 0xc0000409) Teuchos
	  4 - TeuchosCore_CLP_Remove_Quotes (Exit code 0xc0000409) Teuchos
...
	 92 - TeuchosComm_ParameterList_UnitTest_Parallel_one (Exit code 0xc0000409) Teuchos
	 93 - TeuchosComm_Time_test (Exit code 0xc0000409)     Teuchos
	 94 - TeuchosComm_UnitTest_TimeMonitor_UnitTests (Failed) Teuchos
	 99 - TeuchosNumerics_BLAS_ROTG_test (Exit code 0xc0000409) Teuchos
	105 - TeuchosNumerics_Polynomial_test (Exit code 0xc0000409) Teuchos
	106 - TeuchosNumerics_MatrixMarket_Raw_InOutTest (Exit code 0xc0000409) Teuchos
	110 - TeuchosNumerics_hilbert (Exit code 0xc0000409)   Teuchos
	112 - TeuchosRemainder_SolverFactory (Exit code 0xc0000409) Teuchos
	113 - TeuchosRemainder_LinearSolverSetupFailure (Exit code 0xc0000409) Teuchos
	114 - TeuchosKokkosCompat_linkTest (Exit code 0xc0000409) Teuchos
```

### After (Teuchos example)

```log
98% tests passed, 2 tests failed out of 114

Subproject Time Summary:
Teuchos    =   2.92 sec*proc (114 tests)

Total Test time (real) =   3.04 sec

The following tests FAILED:
	 46 - TeuchosCore_TypeConversions_UnitTest (Failed)     Teuchos
	 54 - TeuchosParameterList_ParameterList_UnitTests (Failed) Teuchos
Errors while running CTest
```

## Additional Information

For my previous PRs: [#15245, #15248, #15249, #15267, #15268] I manually added flag `/EHsc` in `CMAKE_CXX_FLAGS`, so there weren't problems.
Failing `TeuchosParameterList_ParameterList_UnitTests` is from #15267, and I know the fix for failing `TeuchosCore_TypeConversions_UnitTest`, but I need more time to complete it (thoughts that there is a bug in clang-cl codegen, will make issue in LLVM and ask about it).
