### PR TITLE
SEACAS: fix -Wsign-compare in parallel SideBlock get_field_internal

### DIFF
--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_ParallelDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_ParallelDatabaseIO.C
@@ -1595,7 +1595,7 @@ namespace Iocgns {
     int         id   = sb->get_property("id").get_int();
     const auto &sset = decomp->m_sideSets[id];
 
-    auto num_to_get = field.verify(data_size);
+    int64_t num_to_get = field.verify(data_size);
     if (num_to_get > 0) {
       int64_t entity_count = sb->entity_count();
       if (num_to_get != entity_count) {


### PR DESCRIPTION
@trilinos/seacas 

## Motivation
This was failing in the non-blocking RAMSES PR build being added in #15210 and can be seen in this CDash report https://sems-cdash-son.sandia.gov/cdash/builds/1273605.

Unsure if this is the best way to go about the fix since it seems to be technically an error-prone integer conversion, but I found precedence in the serial SideBlock `get_field_internal`.

