### PR TITLE
Teuchos: Add explicit virtual/override to templated unit test helper macros to fix clang-cl vtable bug

### DIFF
--- a/packages/teuchos/core/src/Teuchos_UnitTestHelpers.hpp
+++ b/packages/teuchos/core/src/Teuchos_UnitTestHelpers.hpp
@@ -133,13 +133,15 @@ see Teuchos_LocalTestingHelpers.hpp and Teuchos_TestingHelpers.hpp.
     TEST_GROUP##_##TEST_NAME##_UnitTest(const std::string& typeName) \
       : Teuchos::UnitTestBase( std::string(#TEST_GROUP)+"_"+typeName, #TEST_NAME ) \
     {} \
-    void runUnitTestImpl( Teuchos::FancyOStream &out, bool &success ) const; \
+    virtual void runUnitTestImpl( Teuchos::FancyOStream &out, bool &success ) const override \
+    { runUnitTestImplBody(out, success); } \
+    void runUnitTestImplBody( Teuchos::FancyOStream &out, bool &success ) const; \
     virtual std::string unitTestFile() const { return __FILE__; } \
     virtual long int unitTestFileLineNumber() const { return __LINE__; } \
   }; \
   \
   template<class TYPE> \
-        void TEST_GROUP##_##TEST_NAME##_UnitTest<TYPE>::runUnitTestImpl( \
+        void TEST_GROUP##_##TEST_NAME##_UnitTest<TYPE>::runUnitTestImplBody( \
     Teuchos::FancyOStream &out, bool &success ) const \
 
 /** \brief Instantiate a templated unit test with one template parameter.
@@ -279,13 +281,15 @@ see Teuchos_LocalTestingHelpers.hpp and Teuchos_TestingHelpers.hpp.
       :Teuchos::UnitTestBase( \
          std::string(#TEST_GROUP)+"_"+type1Name+"_"+type2Name, #TEST_NAME ) \
     {} \
-    void runUnitTestImpl( Teuchos::FancyOStream &out, bool &success ) const; \
+    virtual void runUnitTestImpl( Teuchos::FancyOStream &out, bool &success ) const override \
+    { runUnitTestImplBody(out, success); } \
+    void runUnitTestImplBody( Teuchos::FancyOStream &out, bool &success ) const; \
     virtual std::string unitTestFile() const { return __FILE__; } \
     virtual long int unitTestFileLineNumber() const { return __LINE__; } \
   }; \
   \
   template<class TYPE1, class TYPE2> \
-        void TEST_GROUP##_##TEST_NAME##_UnitTest<TYPE1,TYPE2>::runUnitTestImpl( \
+        void TEST_GROUP##_##TEST_NAME##_UnitTest<TYPE1,TYPE2>::runUnitTestImplBody( \
     Teuchos::FancyOStream &out, bool &success ) const \
 
 /** \brief Instantiate a templated unit test with two template parameters.
@@ -322,13 +326,15 @@ see Teuchos_LocalTestingHelpers.hpp and Teuchos_TestingHelpers.hpp.
       :Teuchos::UnitTestBase( \
          std::string(#TEST_GROUP)+"_"+type1Name+"_"+type2Name+"_"+type3Name, #TEST_NAME ) \
     {} \
-    void runUnitTestImpl( Teuchos::FancyOStream &out, bool &success ) const; \
+    virtual void runUnitTestImpl( Teuchos::FancyOStream &out, bool &success ) const override \
+    { runUnitTestImplBody(out, success); } \
+    void runUnitTestImplBody( Teuchos::FancyOStream &out, bool &success ) const; \
     virtual std::string unitTestFile() const { return __FILE__; } \
     virtual long int unitTestFileLineNumber() const { return __LINE__; } \
   }; \
   \
   template<class TYPE1, class TYPE2, class TYPE3> \
-        void TEST_GROUP##_##TEST_NAME##_UnitTest<TYPE1,TYPE2,TYPE3>::runUnitTestImpl( \
+        void TEST_GROUP##_##TEST_NAME##_UnitTest<TYPE1,TYPE2,TYPE3>::runUnitTestImplBody( \
     Teuchos::FancyOStream &out, bool &success ) const \
 
 
@@ -361,13 +367,15 @@ see Teuchos_LocalTestingHelpers.hpp and Teuchos_TestingHelpers.hpp.
       :Teuchos::UnitTestBase( \
          std::string(#TEST_GROUP)+"_"+type1Name+"_"+type2Name+"_"+type3Name+"_"+type4Name, #TEST_NAME ) \
     {} \
-    void runUnitTestImpl( Teuchos::FancyOStream &out, bool &success ) const; \
+    virtual void runUnitTestImpl( Teuchos::FancyOStream &out, bool &success ) const override \
+    { runUnitTestImplBody(out, success); } \
+    void runUnitTestImplBody( Teuchos::FancyOStream &out, bool &success ) const; \
     virtual std::string unitTestFile() const { return __FILE__; } \
     virtual long int unitTestFileLineNumber() const { return __LINE__; } \
   }; \
   \
   template<class TYPE1, class TYPE2, class TYPE3, class TYPE4> \
-        void TEST_GROUP##_##TEST_NAME##_UnitTest<TYPE1,TYPE2,TYPE3,TYPE4>::runUnitTestImpl( \
+        void TEST_GROUP##_##TEST_NAME##_UnitTest<TYPE1,TYPE2,TYPE3,TYPE4>::runUnitTestImplBody( \
     Teuchos::FancyOStream &out, bool &success ) const \
 
 


### PR DESCRIPTION
@trilinos/teuchos

## Motivation

> This PR was completed as I mentioned in _Additional Information_ from #15279.

On Windows with clang-cl (MSVC ABI), `TEUCHOS_UNIT_TEST_TEMPLATE_{1,2,3,4}_DECL` previously declared `runUnitTestImpl` without `virtual`/`override` and defined it out-of-class; when the derived test class lives in an EXE and `Teuchos::UnitTestBase` is `dllimport`, clang-cl 21.1.5 and 22.1.6 (latest release on 21.05.2026) fail to treat the member as an override, emit a 1-byte NOP stub for `runUnitTestImpl`, and fill vtable slot 4 with that address `UnitTestBase::runUnitTest()` dispatches into padding and crashes with `STATUS_BREAKPOINT`. This patch declares an in-class `virtual void runUnitTestImpl(...) const override` that forwards to `runUnitTestImplBody`, and moves the existing out-of-class macro tail to define `runUnitTestImplBody` instead, preserving the user-facing macro syntax while giving the compiler an explicit override for correct vtable emission; no ABI change on other platforms.

Thus, this patch will cover all the tests on Teuchos with OpenMP backend.

## Environment

| Item       | Value                                   |
| ---------- | --------------------------------------- |
| OS         | Windows 11 Pro x64, Build 26100             |
| CPU        | Intel Core i9-12900H (20 logical cores) |
| CMake      | 3.31.2                                  |
|clang-cl|21.1.5;x86_64-pc-windows-msvc;thread-model:posix|
|clang-cl|22.1.6;x86_64-pc-windows-msvc;thread-model:posix|
| Ninja      | 1.12.1                                  |
| Build type | Release, shared libs, C++20             |

**NOTE**: Checked with clang-cl 21.1.5 and clang-cl 22.1.6.

## Related Issues

- #14816
- [LLVM-project issue](https://github.com/llvm/llvm-project/issues/199115)

## Proofs

[crash_main_90f8_2026-05-21_23-16-36-792.log](https://github.com/user-attachments/files/28121578/crash_main_90f8_2026-05-21_23-16-36-792.log)
[crash_main_vtable_diag_90f8_2026-05-21_23-16-36-963.log](https://github.com/user-attachments/files/28121592/crash_main_vtable_diag_90f8_2026-05-21_23-16-36-963.log)
[crash_main_slots_diag_90f8_2026-05-21_23-16-37-015.log](https://github.com/user-attachments/files/28121593/crash_main_slots_diag_90f8_2026-05-21_23-16-37-015.log)

Process exits with `0x80000003` (`STATUS_BREAKPOINT`) when running test 9: `asSafe_realToUnsignedIntTypeOverflow_UnitTest<double, unsigned int>`.

**Call stack at crash**:

```log
TeuchosCore_TypeConversions_UnitTest!
  `anonymous namespace'::asSafe_realToUnsignedIntTypeOverflow_UnitTest<double,unsigned int>
  ::unitTestFileLineNumber+0x12          ← lands on int3 after NOP
teuchoscore!Teuchos::UnitTestBase::runUnitTest+0x38
teuchoscore!Teuchos::UnitTestRepository::runUnitTestImpl+0x25
teuchoscore!Teuchos::UnitTestRepository::runUnitTests+0xd6b
teuchoscore!Teuchos::UnitTestRepository::runUnitTestsFromMain+0x79
TeuchosCore_TypeConversions_UnitTest!main+0x40
```

The crash address is `unitTestFileLineNumber + 0x12`, not a symbol named `runUnitTestImpl`. That is expected: the vtable slot incorrectly points into the padding/NOP region immediately after `unitTestFileLineNumber`, not into a real function.

**Memory layout at the crash site (ub rip)**

```log
; unitTestFileLineNumber ends; compiler-inserted padding:
00007ff6`15d24b9a  cc    int 3
00007ff6`15d24b9b  cc    int 3
00007ff6`15d24b9c  cc    int 3
00007ff6`15d24b9d  cc    int 3
00007ff6`15d24b9e  cc    int 3
00007ff6`15d24b9f  cc    int 3

; "body" of runUnitTestImpl - entire function is ONE byte:
00007ff6`15d24ba0  90    nop          <- vtable slot 4 points HERE (unitTestFileLineNumber+0x10)

00007ff6`15d24ba1  cc    int 3        <- rip at crash (unitTestFileLineNumber+0x12)
00007ff6`15d24ba2  cc    int 3
...

; Next real function - destructor - starts at +0x20 from unitTestFileLineNumber start:
00007ff6`15d24bb0  56    push rsi     <- ~asSafe_realToUnsignedIntTypeOverflow_UnitTest::~...
```

**Execution flow:**

1. `call qword ptr [rax+20h]` enters at `0x15d24ba0`.
2. the single `nop` executes (no-op).
3. Fall-through reaches `int 3` at `0x15d24ba1`.
4. Windows raises `STATUS_BREAKPOINT` (`0x80000003`).

**COFF object file evidence (pre-link)**

```log
Section 28: RawDataSize=1, content=0x90, CRC=0xF00F9344
  Symbol: ?runUnitTestImpl@?$asSafe_realToUnsignedIntTypeOverflow_UnitTest@NI...
Section 27: RawDataSize=6   (unitTestFileLineNumber - normal)
Section 29: RawDataSize=59  (destructor - normal)
```

For comparison, the first template class in the same TU (`realToSignedIntTypeOverflow_UnitTest`) gets a normal ~2213-byte runUnitTestImpl with ~137 relocations. The second class gets 1 byte.
All instantiations of the unsigned-overflow group share section CRC `0xF00F9344` (= CRC of single byte `0x90`), suggesting incorrect COMDAT deduplication of empty bodies across template specializations.

## Testing

### Clang-cl 21.1.5

Configuration output: [configuration-output-clangcl-21.1.5-ninja-openmp.log](https://github.com/user-attachments/files/28121646/configuration-output-clangcl-21.1.5-ninja-openmp.log)
Compilation output: [compilation-output-clangcl-21.1.5-ninja-openmp.log](https://github.com/user-attachments/files/28121637/compilation-output-clangcl-21.1.5-ninja-openmp.log)
Ctest output: [ctest-output-clangcl-21.1.5-ninja-openmp.log](https://github.com/user-attachments/files/28121690/ctest-output-clangcl-21.1.5-ninja-openmp.log)

### Clang-cl 22.1.6

[configuration-output-clangcl-22.1.6-ninja-openmp.log](https://github.com/user-attachments/files/28121701/configuration-output-clangcl-22.1.6-ninja-openmp.log)
[compilation-output-clangcl-22.1.6-ninja-openmp.log](https://github.com/user-attachments/files/28121702/compilation-output-clangcl-22.1.6-ninja-openmp.log)
[ctest-output-clangcl-22.1.6-ninja-openmp.log](https://github.com/user-attachments/files/28121706/ctest-output-clangcl-22.1.6-ninja-openmp.log)

### Example of test command

```ps1
$savedPath = $env:PATH
$buildDir  = "D:\Develop\Trilinos\btomp"
$env:PATH  = "$buildDir\lib;$env:PATH"
try {
    Push-Location "$buildDir"
    & ctest -V --output-on-failure
}
finally {
    Pop-Location
    $env:PATH = $savedPath
}
```

### Before

```log
99% tests passed, 1 tests failed out of 114

Subproject Time Summary:
Teuchos    =  12.40 sec*proc (114 tests)

Total Test time (real) =  14.06 sec

The following tests FAILED:
	 46 - TeuchosCore_TypeConversions_UnitTest (Failed)     Teuchos
Errors while running CTest
```

### After

```log
100% tests passed, 0 tests failed out of 114

Subproject Time Summary:
Teuchos    =  12.31 sec*proc (114 tests)

Total Test time (real) =  12.65 sec
```

## Additional Information

Updated build script: [build.ps1.txt](https://github.com/user-attachments/files/28121874/build.ps1.txt)
In this complex analysis I used Claude Sonnet 4.6 web version, so, if smth is wrong, sorry for that, I will be appreciate for any corrections and literature suggestions!
