### PR TITLE
Teuchos: Fix undefined behavior in unit tests

### DIFF
--- a/packages/teuchos/comm/test/Time/cxx_main.cpp
+++ b/packages/teuchos/comm/test/Time/cxx_main.cpp
@@ -234,7 +234,10 @@ double yetAnotherFunc()
 
   for (int i=0; i<10000; i++)
   {
-    sum += i*i*i;
+    // Use a wider type so i*i*i stays defined for i >= 1290 under UBSan.
+    const long long iCubed =
+      static_cast<long long>(i) * static_cast<long long>(i) * static_cast<long long>(i);
+    sum += static_cast<double>(iCubed);
   }
 
   return sum;

--- a/packages/teuchos/core/test/MemoryManagement/RCP_ForwardDeclUnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/RCP_ForwardDeclUnitTests.cpp
@@ -26,10 +26,9 @@ TEUCHOS_TYPE_NAME_TRAITS_BUILTIN_TYPE_SPECIALIZATION(DummyNS::UndefinedType);
 namespace {
 
 
-using Teuchos::rcp;
-using Teuchos::rcpFromRef;
-using Teuchos::rcpFromUndefRef;
 using Teuchos::RCP;
+using Teuchos::RCP_UNDEFINED_WEAK_NO_DEALLOC;
+using Teuchos::RCP_WEAK_NO_DEALLOC;
 
 using DummyNS::UndefinedType;
 
@@ -48,18 +47,14 @@ TEUCHOS_UNIT_TEST( RCP, ForwardDeclaredUndefined_rcp )
   // trouble.  Note that this has to be a non-owning RCP otherwise there will
   // be issues with the destructor call.
   UndefinedType *ut_ptr = 0;
+  // Construct a null non-owning RCP directly from the pointer.  Do not
+  // dereference ut_ptr to call rcpFromUndefRef()/rcpFromRef() since binding a
+  // reference to a null pointer is undefined behavior.
   RCP<UndefinedType> ut_rcp =
 #if defined(HAS_TEUCHOS_GET_BASE_OBJ_VOID_PTR)
-    rcpFromUndefRef(*ut_ptr)
-  // In this case, you have to use rcpFromUndefRef(...) in this case instead
-  // of rcpFromRef() because the latter requires the object to be defined in
-  // order to call dynamic_cast<const void*>(...) in order to get the base
-  // object address needed for RCPNode tracing.
+    RCP<UndefinedType>(ut_ptr, RCP_UNDEFINED_WEAK_NO_DEALLOC)
 #else
-    rcpFromRef(*ut_ptr)
-    // In this case, you can use rcpFromRef(...) because the object's baseq
-    // address will not be looked up using dynamic_cast and no deallocator
-    // needing to know the object's will be compiled.
+    RCP<UndefinedType>(ut_ptr, RCP_WEAK_NO_DEALLOC)
 #endif
     ;
 }

--- a/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp
+++ b/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp
@@ -523,12 +523,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( asSafe, realToUnsignedIntTypeOverflow, RealTy
   // body of TEST_NOTHROW below actually did the assignment.
   UnsignedIntType val = 42;
   // Make sure that val starts off with a different value than what
-  // its final value should be.
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    val == static_cast<UnsignedIntType> (maxVal),
-    std::logic_error,
-    "Dear test author, please pick a different marker value.  "
-    "Please report this bug to the Teuchos developers.");
+  // its final value should be.  Only compare via static_cast when
+  // maxVal is representable as UnsignedIntType (otherwise UB).
+  if (static_cast<RealType>(maxUnsignedIntVal) >= maxVal) {
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      val == static_cast<UnsignedIntType> (maxVal),
+      std::logic_error,
+      "Dear test author, please pick a different marker value.  "
+      "Please report this bug to the Teuchos developers.");
+  }
 
   // Conversion from any negative value should throw.
   TEST_THROW(val = asSafe<UnsignedIntType> (minVal), std::range_error);


### PR DESCRIPTION
@trilinos/teuchos

## Motivation

Fix undefined behavior in Teuchos unit tests (out-of-range `static_cast`, null reference binding, signed int overflow) so UBSan/ASan builds pass cleanly. No production code changes.

## Environment

| Item       | Value                                   |
| ---------- | --------------------------------------- |
| OS         | Linux Ubuntu 24.04 x86_64, 6.17.0-29-generic             |
| CPU        | Intel Core i9-12900H (20 logical cores) |
| CMake      | 4.2.1                                  |
|clang|18.1.3;x86_64-pc-linux-gnu;thread-model:posix|
| Ninja      | 1.11.1                                  |
| Build type | Debug, shared libs, C++20             |
| OpenMP | 202011 (aka 5.1) |
|MPI|(OpenRTE) 4.1.6|
|CUDA|12.8; Driver: 570.211.01|

### How I checked OpenMP, MPI, CUDA versions

```bash
echo | clang -fopenmp -dM -E - | grep _OPENMP
mpiexec --version
nvidia-smi
```

## Related Issues

- Root issue - #14816
- Detected in [LLVM Issue-199115](https://github.com/llvm/llvm-project/issues/199115) by @efriedma-quic and confirmed by ASan&UBSan build
- Investigative PR - #15283

## Testing

### Before (from https://github.com/llvm/llvm-project/issues/199115#issuecomment-4522142775)

```log
47: Teuchos::GlobalMPISession::GlobalMPISession(): started serial run
47: /home/loveit0/Documents/Prog/Trilinos/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp:527:3: runtime error: 1.79769e+308 is outside the range of representable values of type 'unsigned int'
47: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/loveit0/Documents/Prog/Trilinos/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp:527:3 
...
47: 9. asSafe_double_unsigned_int_type_realToUnsignedIntTypeOverflow_UnitTest ... 
47: *** RealType = double, UnsignedIntType = unsigned int, maxVal = 1.79769e+308, maxUnsignedIntVal = 4294967295, asSafe (maxVal) = (asSafe threw an exception)
47: /home/loveit0/Documents/Prog/Trilinos/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp:527:3: runtime error: 1.79769e+308 is outside the range of representable values of type 'unsigned long long'
47: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/loveit0/Documents/Prog/Trilinos/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp:527:3 
47: [Passed] (0.000328 sec)
47: 10. asSafe_double_unsigned_long_long_type_realToUnsignedIntTypeOverflow_UnitTest ... 
47: *** RealType = double, UnsignedIntType = unsigned long long, maxVal = 1.79769e+308, maxUnsignedIntVal = 18446744073709551615, asSafe (maxVal) = (asSafe threw an exception)
47: /home/loveit0/Documents/Prog/Trilinos/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp:527:3: runtime error: 1.79769e+308 is outside the range of representable values of type 'unsigned long'
47: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/loveit0/Documents/Prog/Trilinos/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp:527:3 
47: [Passed] (0.000301 sec)
47: 11. asSafe_double_unsigned_long_type_realToUnsignedIntTypeOverflow_UnitTest ... 
47: *** RealType = double, UnsignedIntType = unsigned long int, maxVal = 1.79769e+308, maxUnsignedIntVal = 18446744073709551615, asSafe (maxVal) = (asSafe threw an exception)
47: /home/loveit0/Documents/Prog/Trilinos/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp:527:3: runtime error: 3.40282e+38 is outside the range of representable values of type 'unsigned int'
47: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/loveit0/Documents/Prog/Trilinos/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp:527:3 
47: [Passed] (0.000292 sec)
...
47: 17. asSafe_float_unsigned_int_type_realToUnsignedIntTypeOverflow_UnitTest ... 
47: *** RealType = float, UnsignedIntType = unsigned int, maxVal = 3.40282e+38, maxUnsignedIntVal = 4294967295, asSafe (maxVal) = (asSafe threw an exception)
47: /home/loveit0/Documents/Prog/Trilinos/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp:527:3: runtime error: 3.40282e+38 is outside the range of representable values of type 'unsigned long long'
47: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/loveit0/Documents/Prog/Trilinos/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp:527:3 
47: [Passed] (0.000293 sec)
47: 18. asSafe_float_unsigned_long_long_type_realToUnsignedIntTypeOverflow_UnitTest ... 
47: *** RealType = float, UnsignedIntType = unsigned long long, maxVal = 3.40282e+38, maxUnsignedIntVal = 18446744073709551615, asSafe (maxVal) = (asSafe threw an exception)
47: /home/loveit0/Documents/Prog/Trilinos/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp:527:3: runtime error: 3.40282e+38 is outside the range of representable values of type 'unsigned long'
47: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/loveit0/Documents/Prog/Trilinos/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp:527:3 
47: [Passed] (0.000297 sec)
47: 19. asSafe_float_unsigned_long_type_realToUnsignedIntTypeOverflow_UnitTest ... 
47: *** RealType = float, UnsignedIntType = unsigned long int, maxVal = 3.40282e+38, maxUnsignedIntVal = 18446744073709551615, asSafe (maxVal) = (asSafe threw an exception)
```

### After (from https://github.com/llvm/llvm-project/issues/199115#issuecomment-4525285230)

```bash
(cd /home/loveit0/Documents/Prog/Trilinos/build_teuchos_asan_ubsan && ASAN_OPTIONS='halt_on_error=1:abort_on_error=1:detect_leaks=0:leak_check_at_exit=0:print_legend=1:print_summary=1:print_cmdline=1:print_full_thread_history=1:strict_string_checks=1:fast_unwind_on_malloc=0:fast_unwind_on_fatal=0:malloc_context_size=30:symbolize=1:symbolize_inline_frames=1:verbosity=1:detect_stack_use_after_return=1:alloc_dealloc_mismatch=1:dump_instruction_bytes=1' UBSAN_OPTIONS='print_stacktrace=1:halt_on_error=1:abort_on_error=1:print_summary=1:symbolize=1:symbolize_inline_frames=1:verbosity=1:log_exe_name=1' LSAN_OPTIONS='exitcode=0:print_suppressions=0' ctest -V --output-on-failure -R TypeConversions)
```

<details>
<summary>Details below👇</summary>

```log
(cd /home/loveit0/Documents/Prog/Trilinos/build_teuchos_asan_ubsan && ASAN_OPTIONS='halt_on_error=1:abort_on_error=1:detect_leaks=0:leak_check_at_exit=0:print_legend=1:print_summary=1:print_cmdline=1:print_full_thread_history=1:strict_string_checks=1:fast_unwind_on_malloc=0:fast_unwind_on_fatal=0:malloc_context_size=30:symbolize=1:symbolize_inline_frames=1:verbosity=1:detect_stack_use_after_return=1:alloc_dealloc_mismatch=1:dump_instruction_bytes=1' UBSAN_OPTIONS='print_stacktrace=1:halt_on_error=1:abort_on_error=1:print_summary=1:symbolize=1:symbolize_inline_frames=1:verbosity=1:log_exe_name=1' LSAN_OPTIONS='exitcode=0:print_suppressions=0' ctest -V --output-on-failure -R TypeConversions)
UpdateCTestConfiguration  from :/home/loveit0/Documents/Prog/Trilinos/build_teuchos_asan_ubsan/DartConfiguration.tcl
Parse Config file:/home/loveit0/Documents/Prog/Trilinos/build_teuchos_asan_ubsan/DartConfiguration.tcl
Test project /home/loveit0/Documents/Prog/Trilinos/build_teuchos_asan_ubsan
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 47
    Start 47: TeuchosCore_TypeConversions_UnitTest

47: Test command: /home/loveit0/Documents/Prog/Trilinos/build_teuchos_asan_ubsan/packages/teuchos/core/test/TypeConversions/TeuchosCore_TypeConversions_UnitTest.exe
47: Working Directory: /home/loveit0/Documents/Prog/Trilinos/build_teuchos_asan_ubsan/packages/teuchos/core/test/TypeConversions
47: Test timeout computed to be: 1500
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept '__isoc99_printf'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept '__isoc99_sprintf'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept '__isoc99_snprintf'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept '__isoc99_fprintf'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept '__isoc99_vprintf'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept '__isoc99_vsprintf'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept '__isoc99_vsnprintf'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept '__isoc99_vfprintf'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634a03190 of size 208
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634a03190 of size 208
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'pthread_mutexattr_getrobust_np'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdrmem_create'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdrstdio_create'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_short'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_u_short'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_int'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_u_int'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_long'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_u_long'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_hyper'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_u_hyper'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_longlong_t'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_u_longlong_t'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_int8_t'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_uint8_t'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_int16_t'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_uint16_t'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_int32_t'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_uint32_t'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_int64_t'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_uint64_t'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_quad_t'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_u_quad_t'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_bool'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_enum'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_char'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_u_char'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_float'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_double'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_bytes'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x7116348029f0 of size 176
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_string'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdrrec_create'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711635002dc0 of size 192
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept 'xdr_destroy'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634a03190 of size 208
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Registered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634a03190 of size 208
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Unregistered root region at 0x711634c007a0 of size 32
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: failed to intercept '__cxa_rethrow_primary_exception'
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer: libc interceptors initialized
47: || `[0x10007fff8000, 0x7fffffffffff]` || HighMem    ||
47: || `[0x02008fff7000, 0x10007fff7fff]` || HighShadow ||
47: || `[0x00008fff7000, 0x02008fff6fff]` || ShadowGap  ||
47: || `[0x00007fff8000, 0x00008fff6fff]` || LowShadow  ||
47: || `[0x000000000000, 0x00007fff7fff]` || LowMem     ||
47: MemToShadow(shadow): 0x00008fff7000 0x000091ff6dff 0x004091ff6e00 0x02008fff6fff
47: redzone=16
47: max_redzone=2048
47: quarantine_size_mb=256M
47: thread_local_quarantine_size_kb=1024K
47: malloc_context_size=30
47: SHADOW_SCALE: 3
47: SHADOW_GRANULARITY: 8
47: SHADOW_OFFSET: 0x7fff8000
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Installed the sigaction for signal 11
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Installed the sigaction for signal 7
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==Installed the sigaction for signal 8
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==T0: FakeStack created: 0x7116334f7000 -- 0x711634000000 stack_size_log: 20; mmapped 11300K, noreserve=0 
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==T0: stack [0x7ffec996f000,0x7ffeca16f000) size 0x800000; local=0x7ffeca16b894
47: ==TeuchosCore_TypeConversions_UnitTest.exe==20610==AddressSanitizer Init done
47: Teuchos::GlobalMPISession::GlobalMPISession(): started serial run
47: 
47: ***
47: *** Unit test suite ...
47: ***
47: 
47: 
47: Sorting tests by group name then by the order they were added ... (time = 0.000541)
47: 
47: Running unit tests ...
47: 
47: 0. asSafe_realToReal_UnitTest ... [Passed] (0.000829 sec)
47: 1. asSafe_stringToReal_UnitTest ... [Passed] (0.00148 sec)
47: 2. asSafe_stringToIntPositiveOverflow_UnitTest ... [Passed] (0.000102 sec)
47: 3. asSafe_stringToIntNegativeOverflow_UnitTest ... [Passed] (8.9e-05 sec)
47: 4. asSafe_complexToComplex_UnitTest ... [Passed] (0.000805 sec)
47: 5. asSafe_double_int_realToSignedIntTypeOverflow_UnitTest ... [Passed] (0.000188 sec)
47: 6. asSafe_double_long_realToSignedIntTypeOverflow_UnitTest ... [Passed] (1e-05 sec)
47: 7. asSafe_double_long_long_type_realToSignedIntTypeOverflow_UnitTest ... [Passed] (1e-05 sec)
47: 8. asSafe_double_short_realToSignedIntTypeOverflow_UnitTest ... [Passed] (0.000161 sec)
47: 9. asSafe_double_unsigned_int_type_realToUnsignedIntTypeOverflow_UnitTest ... 
47: *** RealType = double, UnsignedIntType = unsigned int, maxVal = 1.79769e+308, maxUnsignedIntVal = 4294967295, asSafe (maxVal) = (asSafe threw an exception)
47: [Passed] (0.00031 sec)
47: 10. asSafe_double_unsigned_long_long_type_realToUnsignedIntTypeOverflow_UnitTest ... 
47: *** RealType = double, UnsignedIntType = unsigned long long, maxVal = 1.79769e+308, maxUnsignedIntVal = 18446744073709551615, asSafe (maxVal) = (asSafe threw an exception)
47: [Passed] (0.000315 sec)
47: 11. asSafe_double_unsigned_long_type_realToUnsignedIntTypeOverflow_UnitTest ... 
47: *** RealType = double, UnsignedIntType = unsigned long int, maxVal = 1.79769e+308, maxUnsignedIntVal = 18446744073709551615, asSafe (maxVal) = (asSafe threw an exception)
47: [Passed] (0.000278 sec)
47: 12. asSafe_double_unsigned_short_type_realToSignedIntTypeOverflow_UnitTest ... [Passed] (0.000142 sec)
47: 13. asSafe_float_int_realToSignedIntTypeOverflow_UnitTest ... [Passed] (8e-06 sec)
47: 14. asSafe_float_long_realToSignedIntTypeOverflow_UnitTest ... [Passed] (6e-06 sec)
47: 15. asSafe_float_long_long_type_realToSignedIntTypeOverflow_UnitTest ... [Passed] (6e-06 sec)
47: 16. asSafe_float_short_realToSignedIntTypeOverflow_UnitTest ... [Passed] (0.000152 sec)
47: 17. asSafe_float_unsigned_int_type_realToUnsignedIntTypeOverflow_UnitTest ... 
47: *** RealType = float, UnsignedIntType = unsigned int, maxVal = 3.40282e+38, maxUnsignedIntVal = 4294967295, asSafe (maxVal) = (asSafe threw an exception)
47: [Passed] (0.000277 sec)
47: 18. asSafe_float_unsigned_long_long_type_realToUnsignedIntTypeOverflow_UnitTest ... 
47: *** RealType = float, UnsignedIntType = unsigned long long, maxVal = 3.40282e+38, maxUnsignedIntVal = 18446744073709551615, asSafe (maxVal) = (asSafe threw an exception)
47: [Passed] (0.000292 sec)
47: 19. asSafe_float_unsigned_long_type_realToUnsignedIntTypeOverflow_UnitTest ... 
47: *** RealType = float, UnsignedIntType = unsigned long int, maxVal = 3.40282e+38, maxUnsignedIntVal = 18446744073709551615, asSafe (maxVal) = (asSafe threw an exception)
47: [Passed] (0.000276 sec)
47: 20. asSafe_float_unsigned_short_type_realToSignedIntTypeOverflow_UnitTest ... [Passed] (0.000155 sec)
47: 21. asSafe_int_stringToIntegerPositive_UnitTest ... [Passed] (3.5e-05 sec)
47: 22. asSafe_int_stringToIntegerShouldThrow_UnitTest ... [Passed] (0.000187 sec)
47: 23. asSafe_int_stringToIntegerNegative_UnitTest ... [Passed] (2.4e-05 sec)
47: 24. asSafe_int_unsigned_int_type_negativeSignedIntToUnsignedInt_UnitTest ... [Passed] (0.000168 sec)
47: 25. asSafe_long_stringToIntegerPositive_UnitTest ... [Passed] (2.7e-05 sec)
47: 26. asSafe_long_stringToIntegerShouldThrow_UnitTest ... [Passed] (9.2e-05 sec)
47: 27. asSafe_long_stringToIntegerNegative_UnitTest ... [Passed] (2.6e-05 sec)
47: 28. asSafe_long_long_type_stringToIntegerPositive_UnitTest ... [Passed] (2.4e-05 sec)
47: 29. asSafe_long_long_type_stringToIntegerShouldThrow_UnitTest ... [Passed] (9.4e-05 sec)
47: 30. asSafe_long_long_type_stringToIntegerNegative_UnitTest ... [Passed] (2.1e-05 sec)
47: 31. asSafe_long_long_type_unsigned_long_long_type_negativeSignedIntToUnsignedInt_UnitTest ... [Passed] (0.000224 sec)
47: 32. asSafe_long_unsigned_long_type_negativeSignedIntToUnsignedInt_UnitTest ... [Passed] (0.000184 sec)
47: 33. asSafe_short_stringToIntegerPositive_UnitTest ... [Passed] (2.3e-05 sec)
47: 34. asSafe_short_stringToIntegerShouldThrow_UnitTest ... [Passed] (0.000162 sec)
47: 35. asSafe_short_stringToIntegerNegative_UnitTest ... [Passed] (1.9e-05 sec)
47: 36. asSafe_short_unsigned_short_type_negativeSignedIntToUnsignedInt_UnitTest ... [Passed] (0.000175 sec)
47: 37. asSafe_unsigned_int_type_stringToIntegerPositive_UnitTest ... [Passed] (2.6e-05 sec)
47: 38. asSafe_unsigned_int_type_stringToIntegerShouldThrow_UnitTest ... [Passed] (0.00016 sec)
47: 39. asSafe_unsigned_long_long_type_stringToIntegerPositive_UnitTest ... [Passed] (2.2e-05 sec)
47: 40. asSafe_unsigned_long_long_type_stringToIntegerShouldThrow_UnitTest ... [Passed] (0.000102 sec)
47: 41. asSafe_unsigned_long_type_stringToIntegerPositive_UnitTest ... [Passed] (2.3e-05 sec)
47: 42. asSafe_unsigned_long_type_stringToIntegerShouldThrow_UnitTest ... [Passed] (0.0001 sec)
47: 43. asSafe_unsigned_short_type_stringToIntegerPositive_UnitTest ... [Passed] (2e-05 sec)
47: 44. asSafe_unsigned_short_type_stringToIntegerShouldThrow_UnitTest ... [Passed] (0.000163 sec)
47: 45. as_int_int_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6e-05 sec)
47: 46. as_int_int_negativeSignedIntToSignedInt_UnitTest ... [Passed] (9.6e-05 sec)
47: 47. as_int_long_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.5e-05 sec)
47: 48. as_int_long_negativeSignedIntToSignedInt_UnitTest ... [Passed] (7.2e-05 sec)
47: 49. as_int_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.5e-05 sec)
47: 50. as_int_long_long_type_negativeSignedIntToSignedInt_UnitTest ... [Passed] (6.8e-05 sec)
47: 51. as_int_short_negativeSignedIntToSignedInt_UnitTest ... [Passed] (6.7e-05 sec)
47: 52. as_int_unsigned_int_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.2e-05 sec)
47: 53. as_int_unsigned_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.4e-05 sec)
47: 54. as_int_unsigned_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (8.2e-05 sec)
47: 55. as_int_unsigned_short_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.5e-05 sec)
47: 56. as_long_int_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.2e-05 sec)
47: 57. as_long_int_negativeSignedIntToSignedInt_UnitTest ... [Passed] (7.2e-05 sec)
47: 58. as_long_long_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.6e-05 sec)
47: 59. as_long_long_negativeSignedIntToSignedInt_UnitTest ... [Passed] (6.8e-05 sec)
47: 60. as_long_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.6e-05 sec)
47: 61. as_long_long_long_type_negativeSignedIntToSignedInt_UnitTest ... [Passed] (6.3e-05 sec)
47: 62. as_long_long_type_int_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6e-05 sec)
47: 63. as_long_long_type_int_negativeSignedIntToSignedInt_UnitTest ... [Passed] (6.3e-05 sec)
47: 64. as_long_long_type_long_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.7e-05 sec)
47: 65. as_long_long_type_long_negativeSignedIntToSignedInt_UnitTest ... [Passed] (6.2e-05 sec)
47: 66. as_long_long_type_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.7e-05 sec)
47: 67. as_long_long_type_long_long_type_negativeSignedIntToSignedInt_UnitTest ... [Passed] (6.6e-05 sec)
47: 68. as_long_long_type_short_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.5e-05 sec)
47: 69. as_long_long_type_short_negativeSignedIntToSignedInt_UnitTest ... [Passed] (6.7e-05 sec)
47: 70. as_long_long_type_unsigned_int_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.3e-05 sec)
47: 71. as_long_long_type_unsigned_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.5e-05 sec)
47: 72. as_long_long_type_unsigned_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.7e-05 sec)
47: 73. as_long_long_type_unsigned_short_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.4e-05 sec)
47: 74. as_long_short_negativeSignedIntToSignedInt_UnitTest ... [Passed] (5.9e-05 sec)
47: 75. as_long_unsigned_int_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.3e-05 sec)
47: 76. as_long_unsigned_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.5e-05 sec)
47: 77. as_long_unsigned_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.5e-05 sec)
47: 78. as_long_unsigned_short_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.2e-05 sec)
47: 79. as_short_int_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.9e-05 sec)
47: 80. as_short_int_negativeSignedIntToSignedInt_UnitTest ... [Passed] (6.5e-05 sec)
47: 81. as_short_long_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.7e-05 sec)
47: 82. as_short_long_negativeSignedIntToSignedInt_UnitTest ... [Passed] (6.6e-05 sec)
47: 83. as_short_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.7e-05 sec)
47: 84. as_short_long_long_type_negativeSignedIntToSignedInt_UnitTest ... [Passed] (6.4e-05 sec)
47: 85. as_short_short_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.8e-05 sec)
47: 86. as_short_short_negativeSignedIntToSignedInt_UnitTest ... [Passed] (6.1e-05 sec)
47: 87. as_short_unsigned_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.9e-05 sec)
47: 88. as_short_unsigned_short_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.2e-05 sec)
47: 89. as_unsigned_int_type_int_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.1e-05 sec)
47: 90. as_unsigned_int_type_long_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.7e-05 sec)
47: 91. as_unsigned_int_type_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.5e-05 sec)
47: 92. as_unsigned_int_type_short_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.9e-05 sec)
47: 93. as_unsigned_int_type_unsigned_int_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.9e-05 sec)
47: 94. as_unsigned_int_type_unsigned_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6e-05 sec)
47: 95. as_unsigned_int_type_unsigned_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.1e-05 sec)
47: 96. as_unsigned_long_long_type_int_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.3e-05 sec)
47: 97. as_unsigned_long_long_type_long_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6e-05 sec)
47: 98. as_unsigned_long_long_type_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.2e-05 sec)
47: 99. as_unsigned_long_long_type_short_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.6e-05 sec)
47: 100. as_unsigned_long_long_type_unsigned_int_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.8e-05 sec)
47: 101. as_unsigned_long_long_type_unsigned_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.3e-05 sec)
47: 102. as_unsigned_long_long_type_unsigned_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.4e-05 sec)
47: 103. as_unsigned_long_long_type_unsigned_short_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.9e-05 sec)
47: 104. as_unsigned_long_type_int_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.1e-05 sec)
47: 105. as_unsigned_long_type_long_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.5e-05 sec)
47: 106. as_unsigned_long_type_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.3e-05 sec)
47: 107. as_unsigned_long_type_short_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.8e-05 sec)
47: 108. as_unsigned_long_type_unsigned_int_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.6e-05 sec)
47: 109. as_unsigned_long_type_unsigned_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.2e-05 sec)
47: 110. as_unsigned_long_type_unsigned_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6e-05 sec)
47: 111. as_unsigned_short_type_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.3e-05 sec)
47: 112. as_unsigned_short_type_short_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.2e-05 sec)
47: 113. as_unsigned_short_type_unsigned_int_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.3e-05 sec)
47: 114. as_unsigned_short_type_unsigned_long_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.9e-05 sec)
47: 115. as_unsigned_short_type_unsigned_long_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (6.3e-05 sec)
47: 116. as_unsigned_short_type_unsigned_short_type_positiveFirstIntToSecondInt_UnitTest ... [Passed] (5.3e-05 sec)
47: 
47: Total Time: 0.0213 sec
47: 
47: Summary: total = 117, run = 117, passed = 117, failed = 0
47: 
47: End Result: TEST PASSED
1/1 Test #47: TeuchosCore_TypeConversions_UnitTest ...   Passed    0.06 sec

The following tests passed:
	TeuchosCore_TypeConversions_UnitTest

100% tests passed, 0 tests failed out of 1

Subproject Time Summary:
Teuchos    =   0.06 sec*proc (1 test)

Total Test time (real) =   0.07 sec
```

</details>

