### PR TITLE
Add more restrictive token permissions for several workflows

### DIFF
--- a/.github/workflows/cdash_urls.yml
+++ b/.github/workflows/cdash_urls.yml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   pre-checks:
         runs-on: ubuntu-latest

--- a/.github/workflows/master_merge.yml
+++ b/.github/workflows/master_merge.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: 0 2 * * 6
 
+permissions:
+  contents: read
+
 jobs:
 
   master-merge:

--- a/.github/workflows/muelu_tutorial.yml
+++ b/.github/workflows/muelu_tutorial.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   muelu_tutorial_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: 0 0 * * 0
 
+permissions:
+  contents: read
+
 jobs:
   kokkos-snapshot:
     permissions:


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Silence code scanning alerts.

I think that this should not cause any issues because the workflows reset permissions anyway within their jobs.
