### PR TITLE
MueLu, Kokkos-Kernels: Revert and fix SPAI changes

### DIFF
--- a/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_Householder_Serial_Internal.hpp
+++ b/packages/kokkos-kernels/batched/dense/impl/KokkosBatched_Householder_Serial_Internal.hpp
@@ -35,7 +35,7 @@ struct SerialLeftHouseholderInternal {
     mag_type norm_x2_square = zero;
     for (int i = 0; i < m_x2; ++i) {
       const auto x2_at_i = x2[i * x2s];
-      norm_x2_square += KAT::real(KAT::conj(x2_at_i) * x2_at_i);
+      norm_x2_square += Kokkos::real(Kokkos::conj(x2_at_i) * x2_at_i);
     }
 
     /// if norm_x2 is zero, return with trivial values
@@ -68,7 +68,7 @@ struct SerialLeftHouseholderInternal {
     // multiple possible expressions for tau
     // we chose the same as LAPACK which
     // guarentees that R is real valued.
-    const mag_type chi1_minus_alpha_square = KAT::magnitude(chi1_minus_alpha) * KAT::magnitude(chi1_minus_alpha);
+    const mag_type chi1_minus_alpha_square = Kokkos::abs(chi1_minus_alpha) * Kokkos::abs(chi1_minus_alpha);
     if constexpr (KAT::is_complex) {
       *tau = alpha / (alpha - *chi1);
     } else {

--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
@@ -30,6 +30,12 @@
 #include "MueLu_Utilities.hpp"
 #include "MueLu_InverseApproximationFactory_decl.hpp"
 
+#if KOKKOSKERNELS_VERSION < 50102
+#include "Teuchos_SerialDenseVector.hpp"
+#include "Teuchos_SerialDenseMatrix.hpp"
+#include "Teuchos_SerialQRDenseSolver.hpp"
+#endif
+
 namespace MueLu {
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -106,6 +112,8 @@ void InverseApproximationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Bui
 
   Set(currentLevel, "Ainv", Ainv);
 }
+
+#if KOKKOSKERNELS_VERSION >= 50102
 
 template <class local_matrix_type>
 class LocalSPAIFunctor {
@@ -270,6 +278,75 @@ InverseApproximationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetSpars
 
   return Ainv;
 }
+
+#else
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
+InverseApproximationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetSparseInverse(const RCP<Matrix>& Aorg, const RCP<const CrsGraph>& sparsityPattern) const {
+  // construct the inverse matrix with the given sparsity pattern
+  RCP<Matrix> Ainv = MatrixFactory::Build(sparsityPattern);
+  Ainv->resumeFill();
+
+  // gather missing rows from other procs to generate an overlapping map
+  RCP<Import> rowImport = ImportFactory::Build(sparsityPattern->getRowMap(), sparsityPattern->getColMap());
+  RCP<Matrix> A         = MatrixFactory::Build(Aorg, *rowImport);
+
+  // loop over all rows of the inverse sparsity pattern (this can be done in parallel)
+  for (size_t k = 0; k < sparsityPattern->getLocalNumRows(); k++) {
+    // 1. get column indices Ik of local row k
+    ArrayView<const LO> Ik;
+    sparsityPattern->getLocalRowView(k, Ik);
+
+    // 2. get all local A(Ik,:) rows
+    Array<ArrayView<const LO>> J(Ik.size());
+    Array<ArrayView<const SC>> Ak(Ik.size());
+    Array<LO> Jk;
+    for (LO i = 0; i < Ik.size(); i++) {
+      A->getLocalRowView(Ik[i], J[i], Ak[i]);
+      for (LO j = 0; j < J[i].size(); j++)
+        Jk.append(J[i][j]);
+    }
+    // set of unique column indices Jk
+    std::sort(Jk.begin(), Jk.end());
+    Jk.erase(std::unique(Jk.begin(), Jk.end()), Jk.end());
+    // create map
+    std::map<LO, LO> G;
+    for (LO i = 0; i < Jk.size(); i++) G.insert(std::pair<LO, LO>(Jk[i], i));
+
+    // 3. merge rows together
+    Teuchos::SerialDenseMatrix<LO, SC> localA(Jk.size(), Ik.size(), true);
+    for (LO i = 0; i < Ik.size(); i++) {
+      for (LO j = 0; j < J[i].size(); j++) {
+        localA(G.at(J[i][j]), i) = Ak[i][j];
+      }
+    }
+
+    // 4. get direction-vector
+    // diagonal needs an entry!
+    Teuchos::SerialDenseVector<LO, SC> ek(Jk.size(), true);
+    ek[std::find(Jk.begin(), Jk.end(), k) - Jk.begin()] = Teuchos::ScalarTraits<Scalar>::one();
+    ;
+
+    // 5. solve linear system for x
+    Teuchos::SerialDenseVector<LO, SC> localX(Ik.size());
+    Teuchos::SerialQRDenseSolver<LO, SC> qrSolver;
+    qrSolver.setMatrix(Teuchos::rcp(&localA, false));
+    qrSolver.setVectors(Teuchos::rcp(&localX, false), Teuchos::rcp(&ek, false));
+    const int err = qrSolver.solve();
+    TEUCHOS_TEST_FOR_EXCEPTION(err != 0, Exceptions::RuntimeError,
+                               "MueLu::InverseApproximationFactory::GetSparseInverse: Error in serial QR solve.");
+
+    // 6. set calculated row into Ainv
+    ArrayView<const SC> Mk(localX.values(), localX.length());
+    Ainv->replaceLocalValues(k, Ik, Mk);
+  }
+  Ainv->fillComplete();
+
+  return Ainv;
+}
+
+#endif
 
 }  // namespace MueLu
 


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
In Kokkos-Kernels 5.1.1 batched QR does not work for Sacado types. The fix for this is on Kokkos-Kernels develop. I also merged it into Trilinos, but that's obviously a mistake as it breaks builds with external Kokkos-Kernels. I am reverting that commit. I resurrected the old non-Kokkos implementation for the current version of Kokkos-Kernels.