### PR TITLE
Attempt to fix linking of fp-exception check

### DIFF
--- a/packages/stk/cmake/stk_wrappers.cmake
+++ b/packages/stk/cmake/stk_wrappers.cmake
@@ -24,12 +24,25 @@ function(stk_check_fp_handling)
 # here: https://cmake.org/cmake/help/latest/command/try_run.html
 # As of Nov 8, 2024, trilinos and stk require cmake 3.23
 #
+  string(TOLOWER ${CMAKE_BUILD_TYPE} build_type)
+  if (build_type STREQUAL "debug")
+    set(TRYCOMPILE_CMAKE_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}")
+  else()
+    set(TRYCOMPILE_CMAKE_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}")
+  endif()
+
+  set(TRYCOMPILE_LINK_LIBS "${CMAKE_CXX_STD_LIBRARIES}")
+
   message("calling try_run with bindir=${CMAKE_CURRENT_BINARY_DIR}/fpexcept, srcfile=${${PACKAGE_NAME}_SOURCE_DIR}/cmake/fpexcept/fpexcept_test.cpp")
   try_run(RUN_RESULT COMPILE_RESULT
           ${CMAKE_CURRENT_BINARY_DIR}/fpexcept
           ${${PACKAGE_NAME}_SOURCE_DIR}/cmake/fpexcept/fpexcept_test.cpp
+          COMPILE_DEFINITIONS ${TRYCOMPILE_CMAKE_FLAGS}
+          LINK_LIBRARIES ${TRYCOMPILE_LINK_LIBS}
+          COMPILE_OUTPUT_VARIABLE FP_COMPILE_OUTPUT
           RUN_OUTPUT_VARIABLE FP_RESULT)
-  
+
+  message("FP_COMPILE_OUTPUT: ${FP_COMPILE_OUTPUT}")
   message("FP-EXCEPT-CHECK COMPILE_RESULT: ${COMPILE_RESULT}")
   message("FP-EXCEPT-CHECK RUN_RESULT: ${RUN_RESULT}")
   set(STK_HAVE_FP_EXCEPT ${FP_RESULT} CACHE BOOL "")
@@ -38,8 +51,10 @@ function(stk_check_fp_handling)
   try_run(RUN_RESULT COMPILE_RESULT
           ${CMAKE_CURRENT_BINARY_DIR}/fperrno
           ${${PACKAGE_NAME}_SOURCE_DIR}/cmake/fperrno/fperrno_test.cpp
+          COMPILE_DEFINITIONS ${TRYCOMPILE_CMAKE_FLAGS}
+          LINK_LIBRARIES ${TRYCOMPILE_LINK_LIBS}
           RUN_OUTPUT_VARIABLE FP_RESULT)
-  
+
   message("FP-ERRNO-CHECK COMPILE_RESULT: ${COMPILE_RESULT}")
   message("FP-ERRNO-CHECK RUN_RESULT: ${RUN_RESULT}")
   set(STK_HAVE_FP_ERRNO ${FP_RESULT} CACHE BOOL "")
@@ -180,7 +195,7 @@ function(stk_process_enables)
       set(STK_ENABLE_STKBalance ON CACHE BOOL "")
     endif()
   endif()
-  
+
   if(STK_ENABLE_TESTS)
     set(STK_ENABLE_STKUnit_tests ON CACHE BOOL "")
     set(STK_ENABLE_STKDoc_tests ON CACHE BOOL "")
@@ -231,7 +246,7 @@ macro(STK_SUBPACKAGES)
       add_subdirectory(stk_emend)
       message("STKEmend is enabled.")
     endif()
-    
+
     if(STK_ENABLE_STKSearch)
       add_subdirectory(stk_search)
       message("STKSearch is enabled.")
@@ -285,15 +300,15 @@ macro(STK_SUBPACKAGES)
     if(STK_ENABLE_STKUnit_Test_Utils)
       add_subdirectory(stk_unit_test_utils)
       message("STKUnit_test_utils is enabled.")
-    endif()  
+    endif()
 
     if(STK_ENABLE_TESTS)
       message("STK_ENABLE_TESTS is true")
- 
+
       if (NOT STK_ENABLE_STKUnit_Test_Utils)
         message("Adding STKUnit_Test_Utils because STK tests are enabled.")
         add_subdirectory(stk_unit_test_utils)
-      endif()  
+      endif()
 
       find_package(GTest REQUIRED)
 


### PR DESCRIPTION
Add link libraries to the try_run command that we
use in cmake to check for floating-point exception/error handling.

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes #15271 
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
