### PR TITLE
Framework: Add Nightly coverage check

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,6 +45,6 @@ jobs:
       target-runner-labels: "['self-hosted', 'gcc-12.3.0-openmpi-4.1.6']"
       genconfig-string: "rhel8_gcc-openmpi_debug-coverage_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all"
       cdash-track: "Nightly"
-      dashboard-build-name: ${AT2_IMAGE}_coverage_check
+      dashboard-build-name: ${AT2_IMAGE}_debug_shared_coverage
       max-cores-allowed: 29
       num-concurrent-tests: 16

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,3 +38,13 @@ jobs:
       dashboard-build-name: ${AT2_IMAGE}_debug_shared_address-sanitizer
       max-cores-allowed: 29
       num-concurrent-tests: 16
+
+  coverage-check:
+    uses: ./.github/workflows/ci.yml
+    with:
+      target-runner-labels: "['self-hosted', 'gcc-12.3.0-openmpi-4.1.6']"
+      genconfig-string: "rhel8_gcc-openmpi_debug-coverage_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all"
+      cdash-track: "Nightly"
+      dashboard-build-name: ${AT2_IMAGE}_coverage_check
+      max-cores-allowed: 29
+      num-concurrent-tests: 16

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1168,6 +1168,10 @@ use PACKAGE-ENABLES|ALL
 opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats BOOL FORCE : OFF
 
+[rhel8_gcc-openmpi_debug-coverage_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
+use rhel8_gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all
+use COVERAGE
+
 [rhel8_gcc-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel8_gcc-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1170,7 +1170,7 @@ opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats BOOL FORCE : OFF
 
 [rhel8_gcc-openmpi_debug-coverage_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel8_gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_all
-use COVERAGE
+use BUILD-TYPE|DEBUG-COVERAGE-GNU
 
 [rhel8_gcc-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel8_gcc-serial_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables


### PR DESCRIPTION
Add coverage check to Nightly builds.  Uses gcc-12.3.0-openmpi-4.1.6.

@trilinos/framework 

https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-751
