### PR TITLE
Framework: Suppress leaks from PMIx and hwloc

### DIFF
--- a/cmake/SimpleTesting/cmake/ctest-stage-test.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-stage-test.cmake
@@ -16,12 +16,25 @@ set(STAGE_TEST_ERROR OFF)
 if(NOT SKIP_RUN_TESTS)
     if(ENABLE_ASAN)
         set(CTEST_MEMORYCHECK_TYPE "AddressSanitizer")
+
+        # Maximum detection settings
+        # 1. detect_leaks=1: Finds memory leaks (LSan)
+        # 2. halt_on_error=1: Crashes immediately on first bug
+        # 3. detect_stack_use_after_return=1: Finds pointers to local variables that escaped the function
+        # 4. check_initialization_order=1: Finds bugs where global variables in different files depend on each other
+        # 5. strict_string_checks=1: Enables more aggressive checks for libc functions (strcpy, memcpy, etc.)
+        # 6. detect_odr_violation=1: Finds "One Definition Rule" violations (same symbol in different libraries)
+        set(ENV{ASAN_OPTIONS} "detect_leaks=1:halt_on_error=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_string_checks=1:detect_odr_violation=1")
         set(ENV{LSAN_OPTIONS} "suppressions=${CTEST_SOURCE_DIRECTORY}/packages/framework/asan_assets/lsan.supp")
+
         set(ENV{LD_PRELOAD} ${CTEST_SOURCE_DIRECTORY}/packages/framework/asan_assets/dummy_dlclose.so)
+
         ctest_memcheck(PARALLEL_LEVEL ${TEST_PARALLEL_LEVEL}
                        CAPTURE_CMAKE_ERROR captured_cmake_error
                        RETURN_VALUE test_error)
+
         unset(ENV{LD_PRELOAD})
+
         submit_by_parts( "MemCheck" )
     else()
         ctest_test(PARALLEL_LEVEL ${TEST_PARALLEL_LEVEL}

--- a/packages/framework/asan_assets/lsan.supp
+++ b/packages/framework/asan_assets/lsan.supp
@@ -16,4 +16,11 @@ leak:mca_coll_tuned.so
 leak:mca_coll_libnbc.so
 leak:mca_coll_basic.so
 leak:python
-
+leak:avx_component_op_query
+leak:pmix_bfrop_tma_kval_new
+leak:fetch_nodeinfo
+leak:fetch_sessioninfo
+leak:hwloc_bitmap_alloc
+leak:get_data
+leak:pmix_bfrops_base_tma_value_xfer
+leak:pmix_bfrops_base_value_load


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Reduce AddressSanitizer leak reports from third-party code (e.g. PMIx).
