### PR TITLE
Teuchos: don't use a deleted std::string ctor.

### DIFF
--- a/packages/teuchos/core/src/Teuchos_ScalarTraitsDecl.hpp
+++ b/packages/teuchos/core/src/Teuchos_ScalarTraitsDecl.hpp
@@ -117,7 +117,7 @@ struct ScalarTraits
   //! Returns a random number (between -one() and +one()) of this scalar type.
   static inline T random()                   { return UndefinedScalarTraits<T>::notDefined(); }
   //! Returns the name of this scalar type.
-  static inline std::string name()           { (void)UndefinedScalarTraits<T>::notDefined(); return 0; }
+  static inline std::string name()           { (void)UndefinedScalarTraits<T>::notDefined(); return std::string(); }
   //! Returns a number of magnitudeType that is the square root of this scalar type \c x.
   static inline T squareroot(T x) { return UndefinedScalarTraits<T>::notDefined(); }
   //! Returns the result of raising one scalar \c x to the power \c y.


### PR DESCRIPTION
@trilinos/teuchos

## Motivation
 * `std::string(std::nullptr_t)` is deleted in C++23. I can't compile an app which uses Sacado with clang 22 without this patch.

## Related Issues
* N/A