### PR TITLE
Teuchos: Implemented crossplatform `getenv`|`setenv`|`unsetenv` via Win32 API + POSIX API

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -751,10 +751,10 @@ StackedTimer::reportXML(std::ostream &os, const std::string& datestamp, const st
 
 std::string
 StackedTimer::reportWatchrXML(const std::string& name, Teuchos::RCP<const Teuchos::Comm<int> > comm) {
-  const char* rawWatchrDir = getenv("WATCHR_PERF_DIR");
-  const char* rawBuildName = getenv("WATCHR_BUILD_NAME");
+  const char* rawWatchrDir = Teuchos::getEnvironmentVariableValue("WATCHR_PERF_DIR");
+  const char* rawBuildName = Teuchos::getEnvironmentVariableValue("WATCHR_BUILD_NAME");
   std::string gitSHA(Trilinos::TRILINOS_GIT_SHA);
-  const char* rawBuildDateOverride = getenv("WATCHR_BUILD_DATE");
+  const char* rawBuildDateOverride = Teuchos::getEnvironmentVariableValue("WATCHR_BUILD_DATE");
   //WATCHR_PERF_DIR is required (will also check nonempty below)
   if(!rawWatchrDir)
     return "";

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -16,6 +16,7 @@
 #include "Teuchos_CommHelpers.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_Array.hpp"
+#include "Teuchos_EnvVariables.hpp"
 #include "Teuchos_PerformanceMonitorBase.hpp"
 #include "Teuchos_Behavior.hpp"
 #include "TeuchosComm_config.h" // for HAVE_TEUCHOSCOMM_MAGISTRATE
@@ -31,8 +32,8 @@
 #include <cassert>
 #include <chrono>
 #include <climits>
-#include <cstdlib> // for std::getenv and atoi
-#include <ctime> // for timestamp support
+#include <cstdlib> // for atoi
+#include <ctime>   // for timestamp support
 #include <iostream>
 
 #if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOS)
@@ -548,11 +549,11 @@ public:
     if (start_base_timer)
       this->startBaseTimer();
 
-    auto check_verbose = std::getenv("TEUCHOS_ENABLE_VERBOSE_TIMERS");
+    auto check_verbose = Teuchos::getEnvironmentVariableValue("TEUCHOS_ENABLE_VERBOSE_TIMERS");
     if (check_verbose != nullptr)
       enable_verbose_ = true;
 
-    auto check_timestamp = std::getenv("TEUCHOS_ENABLE_VERBOSE_TIMESTAMP_LEVELS");
+    auto check_timestamp = Teuchos::getEnvironmentVariableValue("TEUCHOS_ENABLE_VERBOSE_TIMESTAMP_LEVELS");
     if (check_timestamp != nullptr) {
       verbose_timestamp_levels_ = std::atoi(check_timestamp);
     }

--- a/packages/teuchos/core/src/Teuchos_EnvVariables.cpp
+++ b/packages/teuchos/core/src/Teuchos_EnvVariables.cpp
@@ -12,9 +12,15 @@
 #include <stddef.h>
 #include <string>
 
-#include <cstdlib> // std::getenv
-#include <map>
+#if !defined(_MSC_VER)
+#include <cerrno>  // errno
+#endif
+
+#include <cstdlib> // std::free
+#include <cstring> // std::strchr, std::strerror
+#include <memory>  // std::addressof
 #include <sstream>
+#include <map>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -23,6 +29,151 @@
 #include "Teuchos_TestForException.hpp"
 
 namespace Teuchos {
+
+namespace {
+
+bool environmentVariableNameIsValid(const char name[]) {
+  return name != nullptr && std::strchr(name, '=') == nullptr;
+}
+
+void throwEnvironmentVariablePlatformError(const char operation[],
+                                         const char name[],
+                                         const std::string& detail) {
+  std::ostringstream oss;
+  oss << "Teuchos environment variable " << operation << " failed";
+  if(name != nullptr) {
+    oss << " for \"" << name << "\"";
+  }
+  oss << ": " << detail;
+  TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, oss.str());
+}
+
+// setenv/unsetenv are POSIX; MSVC CRT provides _putenv_s instead.
+// See setenv(3), unsetenv, _putenv_s, and _dupenv_s documentation linked from
+// Teuchos_EnvVariables.hpp.
+// Other Windows toolchains (e.g. MinGW) may still expose setenv/unsetenv.
+#if defined(_MSC_VER)
+void setEnvironmentVariableImpl(const char* name, const char* value, int overwrite) {
+  if(!environmentVariableNameIsValid(name) || value == nullptr) {
+    return;
+  }
+  if(overwrite == 0) {
+    char* buf{};
+    size_t bufSize{};
+    const errno_t dupStatus = _dupenv_s(std::addressof(buf), std::addressof(bufSize), name);
+    if(dupStatus != 0) {
+      std::ostringstream oss;
+      oss << "_dupenv_s returned " << dupStatus;
+      throwEnvironmentVariablePlatformError("set", name, oss.str());
+    }
+    if(buf != nullptr) {
+      std::free(buf);
+      return;
+    }
+  }
+  const errno_t putStatus = _putenv_s(name, value);
+  if(putStatus != 0) {
+    std::ostringstream oss;
+    oss << "_putenv_s returned " << putStatus;
+    throwEnvironmentVariablePlatformError("set", name, oss.str());
+  }
+}
+
+void unsetEnvironmentVariableImpl(const char* name) {
+  if(!environmentVariableNameIsValid(name)) {
+    return;
+  }
+  const errno_t putStatus = _putenv_s(name, "");
+  if(putStatus != 0) {
+    std::ostringstream oss;
+    oss << "_putenv_s returned " << putStatus;
+    throwEnvironmentVariablePlatformError("unset", name, oss.str());
+  }
+}
+#else  // !defined(_MSC_VER)
+void setEnvironmentVariableImpl(const char* name, const char* value, int overwrite) {
+  if(!environmentVariableNameIsValid(name) || value == nullptr) {
+    return;
+  }
+  if(setenv(name, value, overwrite) != 0) {
+    const int err = errno;
+    std::ostringstream oss;
+    oss << "setenv returned -1, errno=" << err;
+    if(err != 0) {
+      oss << " (" << std::strerror(err) << ")";
+    }
+    throwEnvironmentVariablePlatformError("set", name, oss.str());
+  }
+}
+
+void unsetEnvironmentVariableImpl(const char* name) {
+  if(!environmentVariableNameIsValid(name)) {
+    return;
+  }
+  if(unsetenv(name) != 0) {
+    const int err = errno;
+    std::ostringstream oss;
+    oss << "unsetenv returned -1, errno=" << err;
+    if(err != 0) {
+      oss << " (" << std::strerror(err) << ")";
+    }
+    throwEnvironmentVariablePlatformError("unset", name, oss.str());
+  }
+}
+#endif
+
+#if defined(_MSC_VER)
+const char* getEnvironmentVariableValueImpl(const char* name) {
+  char* buf{};
+  size_t bufSize{};
+  const errno_t dupStatus = _dupenv_s(std::addressof(buf), std::addressof(bufSize), name);
+  if(dupStatus != 0) {
+    std::ostringstream oss;
+    oss << "_dupenv_s returned " << dupStatus;
+    throwEnvironmentVariablePlatformError("get", name, oss.str());
+  }
+  if(buf == nullptr) {
+    return nullptr;
+  }
+  thread_local std::string valueStorage;
+  valueStorage.assign(buf);
+  std::free(buf);
+  return valueStorage.c_str();
+}
+#else  // !defined(_MSC_VER)
+const char* getEnvironmentVariableValueImpl(const char* name) {
+  // C++11 and later: concurrent std::getenv calls do not data-race only while
+  // the process environment is unchanged. setenv/unsetenv/putenv (including
+  // Teuchos set/unset helpers) require external synchronization with reads.
+  // The returned pointer is owned by the C runtime; copy to std::string if the
+  // value must outlive this call or any later environment access.
+  return std::getenv(name);
+}
+#endif
+
+} // namespace
+
+const char* getEnvironmentVariableValue(const char name[]) {
+  if(!environmentVariableNameIsValid(name)) {
+    return nullptr;
+  }
+  return getEnvironmentVariableValueImpl(name);
+}
+
+namespace {
+
+const char* getEnvironmentVariableValueFromView(std::string_view environmentVariableName) {
+  const std::string nameString(environmentVariableName);
+  return getEnvironmentVariableValue(nameString.c_str());
+}
+
+} // namespace
+
+void setEnvironmentVariable(const char name[], const char value[], int overwrite) {
+  setEnvironmentVariableImpl(name, value, overwrite);
+}
+
+void unsetEnvironmentVariable(const char name[]) { unsetEnvironmentVariableImpl(name); }
 
 namespace {
 
@@ -50,7 +201,6 @@ void setEnvironmentVariableMap(
     const char environmentVariableName[],
     std::map<std::string, std::map<std::string, bool>> &valsMap,
     const bool defaultValue) {
-  using std::getenv;
   using std::map;
   using std::string;
   using std::vector;
@@ -59,7 +209,7 @@ void setEnvironmentVariableMap(
   valsMap[environmentVariableName] =
       map<string, bool>{{"DEFAULT", defaultValue}};
 
-  const char *varVal = getenv(environmentVariableName);
+  const char *varVal = getEnvironmentVariableValue(environmentVariableName);
   if (varVal == nullptr) {
     // Environment variable is not set, use the default value for any named
     // variants
@@ -92,9 +242,9 @@ void setEnvironmentVariableMap(
 } // namespace
 
 template <typename T>
-T getEnvironmentVariable(const std::string_view environmentVariableName,
+T getEnvironmentVariable(std::string_view environmentVariableName,
                          const T defaultValue) {
-  const char *varVal = std::getenv(environmentVariableName.data());
+  const char* varVal = getEnvironmentVariableValueFromView(environmentVariableName);
   if (varVal == nullptr) {
     return defaultValue;
   } else {
@@ -115,8 +265,8 @@ T getEnvironmentVariable(const std::string_view environmentVariableName,
 // full specialization of bool to preserve historical parsing behavior
 template <>
 bool getEnvironmentVariable<bool>(
-    const std::string_view environmentVariableName, const bool defaultValue) {
-  const char *varVal = std::getenv(environmentVariableName.data());
+    std::string_view environmentVariableName, const bool defaultValue) {
+  const char* varVal = getEnvironmentVariableValueFromView(environmentVariableName);
   bool retVal = defaultValue;
   if (varVal != nullptr) {
     auto state = environmentVariableState(std::string(varVal));
@@ -135,9 +285,9 @@ Else, return cast to size_t
 */
 template <>
 size_t
-getEnvironmentVariable<size_t>(const std::string_view environmentVariableName,
+getEnvironmentVariable<size_t>(std::string_view environmentVariableName,
                                const size_t defaultValue) {
-  const char *varVal = std::getenv(environmentVariableName.data());
+  const char* varVal = getEnvironmentVariableValueFromView(environmentVariableName);
   if (varVal == nullptr) {
     return defaultValue;
   } else {
@@ -180,7 +330,7 @@ bool idempotentlyGetNamedEnvironmentVariableAsBool(
 
 template <typename T>
 T idempotentlyGetEnvironmentVariable(
-    T &value, bool &initialized, const std::string_view environmentVariableName,
+    T &value, bool &initialized, std::string_view environmentVariableName,
     const T defaultValue) {
   if (!initialized) {
     value = getEnvironmentVariable<T>(environmentVariableName, defaultValue);
@@ -192,10 +342,10 @@ T idempotentlyGetEnvironmentVariable(
 
 template std::string getEnvironmentVariable<std::string>(std::string_view, const std::string);
 
-template std::string idempotentlyGetEnvironmentVariable<std::string>(std::string&, bool&, const std::string_view, const std::string);
-template int idempotentlyGetEnvironmentVariable<int>(int&, bool&, const std::string_view, const int);
-template unsigned long idempotentlyGetEnvironmentVariable<unsigned long>(unsigned long&, bool&, const std::string_view, const unsigned long);
-template bool idempotentlyGetEnvironmentVariable<bool>(bool&, bool&, const std::string_view, const bool);
-template unsigned long long idempotentlyGetEnvironmentVariable<unsigned long long>(unsigned long long&, bool&, const std::string_view, const unsigned long long);
+template std::string idempotentlyGetEnvironmentVariable<std::string>(std::string&, bool&, std::string_view, const std::string);
+template int idempotentlyGetEnvironmentVariable<int>(int&, bool&, std::string_view, const int);
+template unsigned long idempotentlyGetEnvironmentVariable<unsigned long>(unsigned long&, bool&, std::string_view, const unsigned long);
+template bool idempotentlyGetEnvironmentVariable<bool>(bool&, bool&, std::string_view, const bool);
+template unsigned long long idempotentlyGetEnvironmentVariable<unsigned long long>(unsigned long long&, bool&, std::string_view, const unsigned long long);
 
 } // namespace Teuchos

--- a/packages/teuchos/core/src/Teuchos_EnvVariables.hpp
+++ b/packages/teuchos/core/src/Teuchos_EnvVariables.hpp
@@ -10,12 +10,97 @@
 #ifndef TEUCHOS_ENVVARIABLES_HPP
 #define TEUCHOS_ENVVARIABLES_HPP
 
+#include <string>
 #include <string_view>
 
 namespace Teuchos {
 
+/** \brief Read a process environment variable by name.
+ *
+ * \param[in] name Variable name (must not contain '=').
+ * \return Pointer to the value, or nullptr if \c name is invalid or the variable
+ *         is unset. On MSVC the value is held in per-thread storage inside this
+ *         function; on other platforms the pointer refers to the C runtime
+ *         environment table (see \c std::getenv).
+ *
+ * \warning <b>Lifetime.</b> Do not retain the returned pointer across later calls
+ *          to \c getEnvironmentVariableValue, \c setEnvironmentVariable,
+ *          \c unsetEnvironmentVariable, or other APIs that modify the process
+ *          environment. Earlier pointers may be invalidated (see
+ *          <a href="https://stackoverflow.com/questions/48568707/getenv-function-may-be-unsafe-really">discussion of getenv safety</a>).
+ *          Copy into an owning \c std::string if the value must outlive the call.
+ *
+ * \warning <b>Concurrency.</b> Since C++11, \c std::getenv is thread-safe only while
+ *          the environment is not modified. Concurrent \c setenv, \c unsetenv, or
+ *          \c putenv (and the Teuchos wrappers that call them) introduce data races
+ *          with reads unless you provide external synchronization.
+ *
+ * \throws std::runtime_error if the underlying platform read fails (for example
+ *         \c ENOMEM from \c _dupenv_s on MSVC).
+ *
+ * \sa <a href="https://en.cppreference.com/w/cpp/utility/program/getenv">std::getenv</a>,
+ *     <a href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/dupenv-s-wdupenv-s?view=msvc-170">_dupenv_s</a>
+ */
+const char* getEnvironmentVariableValue(const char name[]);
+
+/** \brief Overload for \c std::string - avoids requiring <tt>.c_str()</tt> at call sites. */
+inline const char* getEnvironmentVariableValue(const std::string& name) {
+  return getEnvironmentVariableValue(name.c_str());
+}
+
+/** \brief Set a process environment variable.
+ *
+ * \param[in] name Variable name (must not contain '=').
+ * \param[in] value Value to assign.
+ * \param[in] overwrite If zero and the variable already exists, the call is a
+ *            no-op; otherwise the value is replaced (POSIX \c setenv semantics).
+ *
+ * \note No-op if \c name or \c value is nullptr or \c name contains '=' (no
+ *       exception; POSIX would report \c EINVAL for an invalid name).
+ *
+ * \warning Modifies the process environment. Not safe to call concurrently with
+ *          \c getEnvironmentVariableValue, \c std::getenv, or other readers without
+ *          synchronization. May invalidate pointers returned by prior \c std::getenv
+ *          calls on platforms that use the C environment table directly.
+ *
+ * \throws std::runtime_error if the underlying platform call fails (for example
+ *         \c ENOMEM on POSIX or a non-zero return from MSVC \c _putenv_s).
+ *
+ * \sa <a href="https://man7.org/linux/man-pages/man3/setenv.3.html">setenv(3)</a>,
+ *     <a href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/putenv-s-wputenv-s?view=msvc-170">_putenv_s</a>,
+ *     <a href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/dupenv-s-wdupenv-s?view=msvc-170">_dupenv_s</a>
+ */
+void setEnvironmentVariable(const char name[], const char value[], int overwrite);
+
+/** \brief Overload for \c std::string - avoids requiring <tt>.c_str()</tt> at call sites. */
+inline void setEnvironmentVariable(const std::string& name, const std::string& value, int overwrite) {
+  setEnvironmentVariable(name.c_str(), value.c_str(), overwrite);
+}
+
+/** \brief Remove a process environment variable.
+ *
+ * \param[in] name Variable name (must not contain '=').
+ *
+ * \note No-op if \c name is nullptr or contains '=' (no exception).
+ *
+ * \warning Same concurrency and pointer-invalidation considerations as
+ *          \c setEnvironmentVariable.
+ *
+ * \throws std::runtime_error if the underlying platform call fails.
+ *
+ * \sa <a href="https://pubs.opengroup.org/onlinepubs/9690949399/functions/unsetenv.html">unsetenv</a>,
+ *     <a href="https://man7.org/linux/man-pages/man3/setenv.3.html">unsetenv(3)</a>,
+ *     <a href="https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/putenv-s-wputenv-s?view=msvc-170">_putenv_s</a> (empty value removes the variable)
+ */
+void unsetEnvironmentVariable(const char name[]);
+
+/** \brief Overload for \c std::string - avoids requiring <tt>.c_str()</tt> at call sites. */
+inline void unsetEnvironmentVariable(const std::string& name) {
+  unsetEnvironmentVariable(name.c_str());
+}
+
 template <typename T>
-T getEnvironmentVariable(const std::string_view environmentVariableName,
+T getEnvironmentVariable(std::string_view environmentVariableName,
                          const T defaultValue);
 
 bool idempotentlyGetNamedEnvironmentVariableAsBool(
@@ -35,7 +120,7 @@ bool idempotentlyGetNamedEnvironmentVariableAsBool(
  */
 template <typename T>
 T idempotentlyGetEnvironmentVariable(
-    T &value, bool &initialized, const std::string_view environmentVariableName,
+    T &value, bool &initialized, std::string_view environmentVariableName,
     const T defaultValue);
 
 } // namespace Teuchos

--- a/packages/teuchos/core/src/Teuchos_SystemInformation.cpp
+++ b/packages/teuchos/core/src/Teuchos_SystemInformation.cpp
@@ -288,12 +288,12 @@ std::map<std::string, std::string> collectSystemInformation() {
 
   auto &environmentVariables = getEnvironmentVariablesSet();
   for (auto &envVariable : environmentVariables) {
-    const char *varVal = std::getenv(envVariable.c_str());
-    if (varVal == nullptr)
+    const char* varVal = Teuchos::getEnvironmentVariableValue(envVariable);
+    if(varVal == nullptr) {
       data[envVariable] = "NOT SET";
+    }
     else {
-      data[envVariable] =
-          Teuchos::getEnvironmentVariable<std::string>(envVariable, "");
+      data[envVariable] = varVal;
     }
   }
 

--- a/packages/teuchos/core/test/UnitTest/SystemInformation_UnitTests.cpp
+++ b/packages/teuchos/core/test/UnitTest/SystemInformation_UnitTests.cpp
@@ -8,58 +8,11 @@
 // @HEADER
 
 
+#include "Teuchos_EnvVariables.hpp"
 #include "Teuchos_UnitTestHarness.hpp"
 #include "Teuchos_SystemInformation.hpp"
-#include <cstdlib>
-#include <cstring>
-#include <utility>
 
 namespace {
-
-// setenv/unsetenv are POSIX; MSVC CRT provides _putenv_s instead.
-// Other Windows toolchains (e.g. MinGW) may still expose setenv/unsetenv.
-#if defined(_MSC_VER)
-void teuchosTestSetEnv(const char* name, const char* value, int overwrite)
-{
-  if(name == nullptr || value == nullptr || std::strchr(name, '=') != nullptr) {
-    return;
-  }
-  if(overwrite == 0) {
-    char* buf{};
-    size_t bufSize{};
-    if(_dupenv_s(std::addressof(buf), std::addressof(bufSize), name) == 0 && buf != nullptr) {
-      std::free(buf);
-      return;
-    }
-  }
-  (void)_putenv_s(name, value);
-}
-
-void teuchosTestUnsetEnv(const char* name)
-{
-  if(name == nullptr || std::strchr(name, '=') != nullptr) {
-    return;
-  }
-  (void)_putenv_s(name, "");
-}
-#else  // !defined(_MSC_VER)
-void teuchosTestSetEnv(const char* name, const char* value, int overwrite)
-{
-  if(name == nullptr || value == nullptr || std::strchr(name, '=') != nullptr) {
-    return;
-  }
-  (void)setenv(name, value, overwrite);
-}
-
-void teuchosTestUnsetEnv(const char* name)
-{
-  if(name == nullptr || std::strchr(name, '=') != nullptr) {
-    return;
-  }
-  (void)unsetenv(name);
-}
-#endif
-
 
 TEUCHOS_UNIT_TEST( SystemInformation, Commands )
 {
@@ -79,13 +32,13 @@ TEUCHOS_UNIT_TEST( SystemInformation, EnvVariables ) {
     TEST_EQUALITY_CONST(values["BLAH_BLAH"], "NOT SET");
   }
 
-  teuchosTestSetEnv("BLAH_BLAH", "test", 1);
+  Teuchos::setEnvironmentVariable("BLAH_BLAH", "test", 1);
   {
     auto values = Teuchos::SystemInformation::collectSystemInformation();
     TEST_ASSERT(values.find("BLAH_BLAH") != values.end());
     TEST_EQUALITY_CONST(values["BLAH_BLAH"], "test");
   }
-  teuchosTestUnsetEnv("BLAH_BLAH");
+  Teuchos::unsetEnvironmentVariable("BLAH_BLAH");
 }
 
 


### PR DESCRIPTION
@trilinos/teuchos

## Motivation

This patch implements crossplatform functionality to get and set environment variables. Earlier used `getenv` and `setenv` 
POSIX functions. Replaced all the occurences `getenv` on `getEnvironmentVariableValue`, `setenv` on `setEnvironmentVariable` and `unsetenv` with `unsetEnvironmentVariable`.

Also, I replaced all the `const std::string_view` with `std::string_view` in `Teuchos_EnvVariables.hpp|.cpp` because this type is non-owning and `const`ness is no need, doesn't make sense. `const` on top-level value parameters is redundant in declarations - it is an implementation detail and not part of the function interface. I mean that these two are identical from caller side:

```cpp
void foo(std::string_view sv);
void foo(const std::string_view sv);
```

Here is the confirmation: https://godbolt.org/z/n7zEYrs74

## Environment

| Item       | Value                                            |
| ---------- | ------------------------------------------------ |
| OS         | Windows 11 Pro (Build 26100)                  |
| CPU        | 12th Gen Intel(R) Core(TM) i9-12900H  (20 logical cores)          |
| CMake      | 4.3.2                                           |
| MSVC       | 19.51.36244 for x64 (VS 2026 Community)                  |
| clang-cl   | 21.1.5;x86_64-pc-windows-msvc;thread-model:posix |
| Ninja      | 1.12.1                                           |
|OpenMP|202011 (aka 5.1)|
|MS-MPI|10.0.12498.5|
|CUDA|12.9; driver: 576.28|
| Build type | RelWithDebInfo, shared libs, C++20               |

## Related Issues

- Root issue - #14816
- Firstly implemented in #15245 in anonymous namespace like helpers, for now separated in centralized place

## Stakeholder Feedback

- @cgcgcg (Trilinos contributor, primary reviewer) - confirmed that adding cross-platform wrappers for `getenv`/`setenv` in Teuchos is a reasonable approach (see discussion in #14816).

> I never used this section, am I doing correct? Or this is it optional?

## Testing

### Serial

- [configuration-output-clangcl-21.1.5-ninja-serial.log](https://github.com/user-attachments/files/28410692/configuration-output-clangcl-21.1.5-ninja-serial.log)
- [compilation-output-clangcl-21.1.5-ninja-serial.log](https://github.com/user-attachments/files/28410695/compilation-output-clangcl-21.1.5-ninja-serial.log)
- [compilation-output-clangcl-21.1.5-ninja-serial.log.warn.log](https://github.com/user-attachments/files/28410696/compilation-output-clangcl-21.1.5-ninja-serial.log.warn.log)

```ps1
$savedPath = $env:PATH
$buildDir  = "D:\Develop\Trilinos\bteuchosserial\"
$env:PATH  = "$buildDir\lib;$env:PATH"
try {
    Push-Location "$buildDir"
    & ctest -V --output-on-failure
}
finally {
    Pop-Location
    $env:PATH = $savedPath
}
```

```log
100% tests passed, 0 tests failed out of 114

Subproject Time Summary:
Teuchos    =  10.97 sec*proc (114 tests)

Total Test time (real) =  16.22 sec
```

### OpenMP

- [configuration-output-clangcl-21.1.5-ninja-openmp.log](https://github.com/user-attachments/files/28410738/configuration-output-clangcl-21.1.5-ninja-openmp.log)
- [compilation-output-clangcl-21.1.5-ninja-openmp.log](https://github.com/user-attachments/files/28410743/compilation-output-clangcl-21.1.5-ninja-openmp.log)
- [compilation-output-clangcl-21.1.5-ninja-openmp.log.warn.log](https://github.com/user-attachments/files/28410744/compilation-output-clangcl-21.1.5-ninja-openmp.log.warn.log)

```ps1
$savedPath = $env:PATH
$buildDir  = "D:\Develop\Trilinos\bteuchosomp\"
$env:PATH  = "$buildDir\lib;$env:PATH"
try {
    Push-Location "$buildDir"
    & ctest -V --output-on-failure
}
finally {
    Pop-Location
    $env:PATH = $savedPath
}
```

```log
100% tests passed, 0 tests failed out of 114

Subproject Time Summary:
Teuchos    =  10.62 sec*proc (114 tests)

Total Test time (real) =  15.61 sec
```

## MS-MPI

- [configuration-output-clangcl-21.1.5-ninja-mpi.log](https://github.com/user-attachments/files/28410770/configuration-output-clangcl-21.1.5-ninja-mpi.log)
- [compilation-output-clangcl-ninja-mpi.log](https://github.com/user-attachments/files/28410777/compilation-output-clangcl-ninja-mpi.log)
- [compilation-output-clangcl-ninja-mpi.log.warn.log](https://github.com/user-attachments/files/28410780/compilation-output-clangcl-ninja-mpi.log.warn.log)

```ps1
$savedPath = $env:PATH
$buildDir  = "D:\Develop\Trilinos\bteuchosmsmpi\"
$env:PATH  = "$buildDir\lib;$env:PATH"
try {
    Push-Location "$buildDir"
    & ctest -V --output-on-failure
}
finally {
    Pop-Location
    $env:PATH = $savedPath
}
```

```log
97% tests passed, 4 tests failed out of 143

Subproject Time Summary:
Teuchos    =  77.49 sec*proc (143 tests)

Total Test time (real) =  41.10 sec

The following tests FAILED:
	 24 - TeuchosCore_testTeuchosTestForTermination_0_MPI_4 (Failed) Teuchos
	 25 - TeuchosCore_testTeuchosTestForTermination_1_MPI_4 (Failed) Teuchos
	 26 - TeuchosCore_testTeuchosTestForTermination_2_MPI_4 (Failed) Teuchos
	 27 - TeuchosCore_testTeuchosTestForTermination_3_MPI_4 (Failed) Teuchos
Errors while running CTest
```

#### Details about failed MS-MPI tests

[ctest-output-clangcl-ninja-mpi.log](https://github.com/user-attachments/files/28410834/ctest-output-clangcl-ninja-mpi.log)

## Additional Information

- Configuration and compilation were done with using [build.ps1.txt](https://github.com/user-attachments/files/28409880/build.ps1.txt);
- I did not check for CUDA because there is a main blocker - #15289 and everything mentioned within it.