### PR TITLE
Tpetra: Fix several UBs

### DIFF
--- a/packages/kokkos/algorithms/src/Kokkos_Random.hpp
+++ b/packages/kokkos/algorithms/src/Kokkos_Random.hpp
@@ -680,7 +680,7 @@ struct Random_UniqueIndex<Kokkos::Device<Kokkos::SYCL, MemorySpace>> {
     KOKKOS_COMPILER_INTEL_LLVM >= 20250000
     auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
 #else
-    auto item = sycl::ext::oneapi::experimental::this_nd_item<3>();
+    auto item           = sycl::ext::oneapi::experimental::this_nd_item<3>();
 #endif
     std::size_t threadIdx[3] = {item.get_local_id(2), item.get_local_id(1),
                                 item.get_local_id(0)};
@@ -823,12 +823,7 @@ class Random_XorShift64 {
 
   KOKKOS_INLINE_FUNCTION
   int rand(const int& start, const int& end) {
-    // Unsigned subtraction avoids signed-overflow UB when end-start > INT_MAX.
-    const uint32_t urange =
-        static_cast<uint32_t>(end) - static_cast<uint32_t>(start);
-    if (urange <= static_cast<uint32_t>(MAX_RAND))
-      return rand(static_cast<int>(urange)) + start;
-    return static_cast<int>(urand(urange) + static_cast<uint32_t>(start));
+    return rand(end - start) + start;
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -844,14 +839,7 @@ class Random_XorShift64 {
 
   KOKKOS_INLINE_FUNCTION
   int64_t rand64(const int64_t& start, const int64_t& end) {
-    // Unsigned subtraction avoids signed-overflow UB when end-start >
-    // INT64_MAX. The signed path is preserved when the range fits, keeping PRNG
-    // streams identical for previously-valid inputs.
-    const uint64_t urange =
-        static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
-    if (urange <= static_cast<uint64_t>(MAX_RAND64))
-      return rand64(static_cast<int64_t>(urange)) + start;
-    return static_cast<int64_t>(urand64(urange) + static_cast<uint64_t>(start));
+    return rand64(end - start) + start;
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -920,7 +908,7 @@ class Random_XorShift64_Pool {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_DEFAULTED_FUNCTION Random_XorShift64_Pool() = default;
 #else
-  Random_XorShift64_Pool() = default;
+  Random_XorShift64_Pool()   = default;
 #endif
 
   Random_XorShift64_Pool(uint64_t seed) {
@@ -1106,12 +1094,7 @@ class Random_XorShift1024 {
 
   KOKKOS_INLINE_FUNCTION
   int rand(const int& start, const int& end) {
-    // Unsigned subtraction avoids signed-overflow UB when end-start > INT_MAX.
-    const uint32_t urange =
-        static_cast<uint32_t>(end) - static_cast<uint32_t>(start);
-    if (urange <= static_cast<uint32_t>(MAX_RAND))
-      return rand(static_cast<int>(urange)) + start;
-    return static_cast<int>(urand(urange) + static_cast<uint32_t>(start));
+    return rand(end - start) + start;
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -1127,14 +1110,7 @@ class Random_XorShift1024 {
 
   KOKKOS_INLINE_FUNCTION
   int64_t rand64(const int64_t& start, const int64_t& end) {
-    // Unsigned subtraction avoids signed-overflow UB when end-start >
-    // INT64_MAX. The signed path is preserved when the range fits, keeping PRNG
-    // streams identical for previously-valid inputs.
-    const uint64_t urange =
-        static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
-    if (urange <= static_cast<uint64_t>(MAX_RAND64))
-      return rand64(static_cast<int64_t>(urange)) + start;
-    return static_cast<int64_t>(urand64(urange) + static_cast<uint64_t>(start));
+    return rand64(end - start) + start;
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/packages/kokkos/algorithms/src/Kokkos_Random.hpp
+++ b/packages/kokkos/algorithms/src/Kokkos_Random.hpp
@@ -680,7 +680,7 @@ struct Random_UniqueIndex<Kokkos::Device<Kokkos::SYCL, MemorySpace>> {
     KOKKOS_COMPILER_INTEL_LLVM >= 20250000
     auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
 #else
-    auto item           = sycl::ext::oneapi::experimental::this_nd_item<3>();
+    auto item = sycl::ext::oneapi::experimental::this_nd_item<3>();
 #endif
     std::size_t threadIdx[3] = {item.get_local_id(2), item.get_local_id(1),
                                 item.get_local_id(0)};
@@ -823,7 +823,12 @@ class Random_XorShift64 {
 
   KOKKOS_INLINE_FUNCTION
   int rand(const int& start, const int& end) {
-    return rand(end - start) + start;
+    // Unsigned subtraction avoids signed-overflow UB when end-start > INT_MAX.
+    const uint32_t urange =
+        static_cast<uint32_t>(end) - static_cast<uint32_t>(start);
+    if (urange <= static_cast<uint32_t>(MAX_RAND))
+      return rand(static_cast<int>(urange)) + start;
+    return static_cast<int>(urand(urange) + static_cast<uint32_t>(start));
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -839,7 +844,14 @@ class Random_XorShift64 {
 
   KOKKOS_INLINE_FUNCTION
   int64_t rand64(const int64_t& start, const int64_t& end) {
-    return rand64(end - start) + start;
+    // Unsigned subtraction avoids signed-overflow UB when end-start >
+    // INT64_MAX. The signed path is preserved when the range fits, keeping PRNG
+    // streams identical for previously-valid inputs.
+    const uint64_t urange =
+        static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
+    if (urange <= static_cast<uint64_t>(MAX_RAND64))
+      return rand64(static_cast<int64_t>(urange)) + start;
+    return static_cast<int64_t>(urand64(urange) + static_cast<uint64_t>(start));
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -908,7 +920,7 @@ class Random_XorShift64_Pool {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_DEFAULTED_FUNCTION Random_XorShift64_Pool() = default;
 #else
-  Random_XorShift64_Pool()   = default;
+  Random_XorShift64_Pool() = default;
 #endif
 
   Random_XorShift64_Pool(uint64_t seed) {
@@ -1094,7 +1106,12 @@ class Random_XorShift1024 {
 
   KOKKOS_INLINE_FUNCTION
   int rand(const int& start, const int& end) {
-    return rand(end - start) + start;
+    // Unsigned subtraction avoids signed-overflow UB when end-start > INT_MAX.
+    const uint32_t urange =
+        static_cast<uint32_t>(end) - static_cast<uint32_t>(start);
+    if (urange <= static_cast<uint32_t>(MAX_RAND))
+      return rand(static_cast<int>(urange)) + start;
+    return static_cast<int>(urand(urange) + static_cast<uint32_t>(start));
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -1110,7 +1127,14 @@ class Random_XorShift1024 {
 
   KOKKOS_INLINE_FUNCTION
   int64_t rand64(const int64_t& start, const int64_t& end) {
-    return rand64(end - start) + start;
+    // Unsigned subtraction avoids signed-overflow UB when end-start >
+    // INT64_MAX. The signed path is preserved when the range fits, keeping PRNG
+    // streams identical for previously-valid inputs.
+    const uint64_t urange =
+        static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
+    if (urange <= static_cast<uint64_t>(MAX_RAND64))
+      return rand64(static_cast<int64_t>(urange)) + start;
+    return static_cast<int64_t>(urand64(urange) + static_cast<uint64_t>(start));
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/packages/tpetra/core/example/BlockCrs/Tpetra_TestBlockCrsMeshDatabase.hpp
+++ b/packages/tpetra/core/example/BlockCrs/Tpetra_TestBlockCrsMeshDatabase.hpp
@@ -559,9 +559,9 @@ struct LocalGraphFill {
     const auto num_remote_elements = _remote_gids.extent(0);
 
     const auto owned_first  = _owned_gids.data();
-    const auto owned_last   = owned_first + (num_owned_elements - 1);
+    const auto owned_last   = owned_first + num_owned_elements;
     const auto remote_first = _remote_gids.data();
-    const auto remote_last  = remote_first + (num_remote_elements - 1);
+    const auto remote_last  = remote_first + num_remote_elements;
 
     // sides on i
     {

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -2148,10 +2148,15 @@ void CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(err, std::runtime_error, "getGlobalElements error");
     } else if (isGloballyIndexed()) {
       auto gblInds = getGlobalIndsViewHost(rowinfo);
-      std::memcpy(
-          (void*)indices.data(),
-          (const void*)gblInds.data(),
-          theNumEntries * sizeof(*indices.data()));
+      // Kokkos zero-extent views return null from .data(); glibc declares memcpy's
+      // dst/src params __attribute__((nonnull(1,2))), so UBSan nonnull-arg fires
+      // on a null pointer even when the byte count is zero.
+      if (theNumEntries > 0) {
+        std::memcpy(
+            (void*)indices.data(),
+            (const void*)gblInds.data(),
+            theNumEntries * sizeof(*indices.data()));
+      }
     }
   }
 }

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -3149,7 +3149,12 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
       bool err               = colMap.getGlobalElements(curLclInds.data(), numEntries, indices.data());
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(err, std::runtime_error, "getGlobalElements error");
       // FIXME - this should/could be a kokkos deep copy?
-      std::memcpy((void*)values.data(), (const void*)curVals.data(), numEntries * sizeof(*values.data()));
+      // Kokkos zero-extent views return null from .data(); glibc declares memcpy's
+      // dst/src params __attribute__((nonnull(1,2))), so UBSan nonnull-arg fires
+      // on a null pointer even when the byte count is zero.
+      if (numEntries > 0) {
+        std::memcpy((void*)values.data(), (const void*)curVals.data(), numEntries * sizeof(*values.data()));
+      }
     } else if (staticGraph_->isGloballyIndexed()) {
       auto curGblInds = staticGraph_->getGlobalIndsViewHost(rowinfo);
       auto curVals    = getValuesViewHost(rowinfo);

--- a/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
@@ -777,9 +777,11 @@ void lowCommunicationMakeColMapAndReindexSerial(const Teuchos::ArrayView<const s
       StartNext++;
     }
   }
-  Tpetra::sort2(ColIndices.begin() + NumLocalColGIDs + StartCurrent,
-                ColIndices.begin() + NumLocalColGIDs + StartNext,
-                RemotePermuteIDs.begin() + StartCurrent);
+  if (NumRemoteColGIDs > 0 && StartNext > StartCurrent) {
+    Tpetra::sort2(ColIndices.begin() + NumLocalColGIDs + StartCurrent,
+                  ColIndices.begin() + NumLocalColGIDs + StartNext,
+                  RemotePermuteIDs.begin() + StartCurrent);
+  }
 
   // Reverse the permutation to get the information we actually care about
   Teuchos::Array<LO> ReverseRemotePermuteIDs(NumRemoteColGIDs);

--- a/packages/tpetra/core/test/Blas/gemm.cpp
+++ b/packages/tpetra/core/test/Blas/gemm.cpp
@@ -312,7 +312,7 @@ void testGemmVsTeuchosBlasForOneTransComb(Teuchos::FancyOStream& out,
         return;
       }
     }  // beta
-  }  // alpha
+  }    // alpha
 }
 
 template <class EntryType, class CoeffType, class DeviceType>

--- a/packages/tpetra/core/test/Blas/gemm.cpp
+++ b/packages/tpetra/core/test/Blas/gemm.cpp
@@ -129,9 +129,15 @@ void testGemmVsTeuchosBlasForOneTransComb(Teuchos::FancyOStream& out,
 
   {
     typedef KokkosKernels::ArithTraits<entry_type> KATE;
-    // Integer arithmetic uses no wider accumulator, so large values cause
-    // signed-overflow UB.  256 keeps the worst-case product
-    // 2*k*maxVal^2 + 2*maxVal well below INT32_MAX for any k<=13.
+    // For integer types, the operation C = alpha*A*B + beta*C computes elements in the same type
+    // without a wider accumulator, so large values can cause signed-overflow UB. The worst-case magnitude is:
+    //
+    // |alpha| * K * maxVal^2 + |beta| * maxVal
+    //
+    // where K is the shared inner dimension. In this test |alpha|,|beta| ≤ 2, and K ≤ 13
+    // (see the loop in the unit test). Choosing maxVal = 256 gives the upper bound 2*13*256^2 + 2*256 = 1704448,
+    // which is far below the minimum of INT32_MAX (2^31-1) and INT64_MAX (2^63-1),
+    // guaranteeing no overflow for any integer entry_type used.
     const entry_type maxVal = std::is_integral<entry_type>::value
                                   ? entry_type(256)
                                   : Kokkos::rand<generator_type, entry_type>::max();
@@ -304,7 +310,7 @@ void testGemmVsTeuchosBlasForOneTransComb(Teuchos::FancyOStream& out,
         return;
       }
     }  // beta
-  }    // alpha
+  }  // alpha
 }
 
 template <class EntryType, class CoeffType, class DeviceType>

--- a/packages/tpetra/core/test/Blas/gemm.cpp
+++ b/packages/tpetra/core/test/Blas/gemm.cpp
@@ -310,7 +310,7 @@ void testGemmVsTeuchosBlasForOneTransComb(Teuchos::FancyOStream& out,
         return;
       }
     }  // beta
-  }  // alpha
+  }    // alpha
 }
 
 template <class EntryType, class CoeffType, class DeviceType>

--- a/packages/tpetra/core/test/Blas/gemm.cpp
+++ b/packages/tpetra/core/test/Blas/gemm.cpp
@@ -129,8 +129,20 @@ void testGemmVsTeuchosBlasForOneTransComb(Teuchos::FancyOStream& out,
 
   {
     typedef KokkosKernels::ArithTraits<entry_type> KATE;
-    const entry_type maxVal =
-        Kokkos::rand<generator_type, entry_type>::max();
+    // For integer types, A_ij * B_jk is computed in the same type with no
+    // wider accumulator, so large values cause signed-overflow UB.
+    // Worst case: |alpha|=2, k=M=13 (default), |beta|=2.
+    // Need: 2*13*maxVal^2 + 2*maxVal <= max(entry_type), i.e.
+    // 26*maxVal^2 + 2*maxVal <= max(entry_type).
+    // Using the exact positive root:
+    // maxVal <= floor((-2 + sqrt(4 + 104*max(entry_type))) / 52).
+    // - 64-bit: floor((-2 + sqrt(4 + 104*INT64_MAX)) / 52) = 595604800
+    // - 32-bit: floor((-2 + sqrt(4 + 104*INT32_MAX)) / 52) = 9088
+    const entry_type maxVal = std::is_integral<entry_type>::value
+                                  ? (sizeof(entry_type) >= 8
+                                         ? entry_type(595604800)
+                                         : entry_type(9088))
+                                  : Kokkos::rand<generator_type, entry_type>::max();
     const entry_type minVal =
         KATE::is_signed ? entry_type(-maxVal) : KATE::zero();
     Kokkos::fill_random(A_orig, randPool, minVal, maxVal);
@@ -209,9 +221,13 @@ void testGemmVsTeuchosBlasForOneTransComb(Teuchos::FancyOStream& out,
   // enough for complex.
   const mag_type fudgeFactor = KokkosKernels::ArithTraits<entry_type>::is_complex ? static_cast<mag_type>(8) : static_cast<mag_type>(4);
 
-  const mag_type boundOrig =
-      eps * fudgeFactor * (A_norm * B_norm * static_cast<mag_type>(k));
-  const mag_type bound = boundOrig < (fudgeFactor * eps) ? (fudgeFactor * eps) : boundOrig;
+  // Skip the floating-point roundoff bound for exact-integer types: eps == 0
+  // makes the whole product zero anyway, and computing A_norm * B_norm for
+  // full-range integer entries overflows mag_type (signed-overflow UB).
+  const mag_type boundOrig = (eps == static_cast<mag_type>(0))
+                                 ? static_cast<mag_type>(0)
+                                 : eps * fudgeFactor * (A_norm * B_norm * static_cast<mag_type>(k));
+  const mag_type bound     = boundOrig < (fudgeFactor * eps) ? (fudgeFactor * eps) : boundOrig;
   out << "bound: " << bound << endl;
 
   // This needs to be EntryType and not
@@ -296,7 +312,7 @@ void testGemmVsTeuchosBlasForOneTransComb(Teuchos::FancyOStream& out,
         return;
       }
     }  // beta
-  }    // alpha
+  }  // alpha
 }
 
 template <class EntryType, class CoeffType, class DeviceType>

--- a/packages/tpetra/core/test/Blas/gemm.cpp
+++ b/packages/tpetra/core/test/Blas/gemm.cpp
@@ -129,19 +129,11 @@ void testGemmVsTeuchosBlasForOneTransComb(Teuchos::FancyOStream& out,
 
   {
     typedef KokkosKernels::ArithTraits<entry_type> KATE;
-    // For integer types, A_ij * B_jk is computed in the same type with no
-    // wider accumulator, so large values cause signed-overflow UB.
-    // Worst case: |alpha|=2, k=M=13 (default), |beta|=2.
-    // Need: 2*13*maxVal^2 + 2*maxVal <= max(entry_type), i.e.
-    // 26*maxVal^2 + 2*maxVal <= max(entry_type).
-    // Using the exact positive root:
-    // maxVal <= floor((-2 + sqrt(4 + 104*max(entry_type))) / 52).
-    // - 64-bit: floor((-2 + sqrt(4 + 104*INT64_MAX)) / 52) = 595604800
-    // - 32-bit: floor((-2 + sqrt(4 + 104*INT32_MAX)) / 52) = 9088
+    // Integer arithmetic uses no wider accumulator, so large values cause
+    // signed-overflow UB.  256 keeps the worst-case product
+    // 2*k*maxVal^2 + 2*maxVal well below INT32_MAX for any k<=13.
     const entry_type maxVal = std::is_integral<entry_type>::value
-                                  ? (sizeof(entry_type) >= 8
-                                         ? entry_type(595604800)
-                                         : entry_type(9088))
+                                  ? entry_type(256)
                                   : Kokkos::rand<generator_type, entry_type>::max();
     const entry_type minVal =
         KATE::is_signed ? entry_type(-maxVal) : KATE::zero();

--- a/packages/tpetra/core/test/Blas/gemv.cpp
+++ b/packages/tpetra/core/test/Blas/gemv.cpp
@@ -109,19 +109,11 @@ void testGemvVsTeuchosBlas(Teuchos::FancyOStream& out,
 
   {
     typedef KokkosKernels::ArithTraits<entry_type> KATE;
-    // For integer types the dot product A_row·x is computed in the same type
-    // with no wider accumulator, so large values cause signed-overflow UB.
-    // Worst case: |alpha|=2, numCols=13 (max tested), |beta|=2.
-    // Need: 2*13*maxVal^2 + 2*maxVal <= max(entry_type), i.e.
-    // 26*maxVal^2 + 2*maxVal <= max(entry_type).
-    // Using the exact positive root:
-    // maxVal <= floor((-2 + sqrt(4 + 104*max(entry_type))) / 52).
-    // - 64-bit: floor((-2 + sqrt(4 + 104*INT64_MAX)) / 52) = 595604800
-    // - 32-bit: floor((-2 + sqrt(4 + 104*INT32_MAX)) / 52) = 9088
+    // Integer arithmetic uses no wider accumulator, so large values cause
+    // signed-overflow UB.  256 keeps the worst-case product
+    // 2*numCols*maxVal^2 + 2*maxVal well below INT32_MAX for any numCols<=13.
     const entry_type maxVal = std::is_integral<entry_type>::value
-                                  ? (sizeof(entry_type) >= 8
-                                         ? entry_type(595604800)
-                                         : entry_type(9088))
+                                  ? entry_type(256)
                                   : Kokkos::rand<generator_type, entry_type>::max();
     const entry_type minVal =
         KATE::is_signed ? entry_type(-maxVal) : KATE::zero();

--- a/packages/tpetra/core/test/Blas/gemv.cpp
+++ b/packages/tpetra/core/test/Blas/gemv.cpp
@@ -109,9 +109,15 @@ void testGemvVsTeuchosBlas(Teuchos::FancyOStream& out,
 
   {
     typedef KokkosKernels::ArithTraits<entry_type> KATE;
-    // Integer arithmetic uses no wider accumulator, so large values cause
-    // signed-overflow UB.  256 keeps the worst-case product
-    // 2*numCols*maxVal^2 + 2*maxVal well below INT32_MAX for any numCols<=13.
+    // For integer types, the operation C = alpha*A*B + beta*C computes elements in the same type
+    // without a wider accumulator, so large values can cause signed-overflow UB. The worst-case magnitude is:
+    //
+    // |alpha| * K * maxVal^2 + |beta| * maxVal
+    //
+    // where K is the shared inner dimension. In this test |alpha|,|beta| ≤ 2, and K ≤ 13
+    // (see the loop in the unit test). Choosing maxVal = 256 gives the upper bound 2*13*256^2 + 2*256 = 1704448,
+    // which is far below the minimum of INT32_MAX (2^31-1) and INT64_MAX (2^63-1),
+    // guaranteeing no overflow for any integer entry_type used.
     const entry_type maxVal = std::is_integral<entry_type>::value
                                   ? entry_type(256)
                                   : Kokkos::rand<generator_type, entry_type>::max();

--- a/packages/tpetra/core/test/Blas/gemv.cpp
+++ b/packages/tpetra/core/test/Blas/gemv.cpp
@@ -109,8 +109,20 @@ void testGemvVsTeuchosBlas(Teuchos::FancyOStream& out,
 
   {
     typedef KokkosKernels::ArithTraits<entry_type> KATE;
-    const entry_type maxVal =
-        Kokkos::rand<generator_type, entry_type>::max();
+    // For integer types the dot product A_row·x is computed in the same type
+    // with no wider accumulator, so large values cause signed-overflow UB.
+    // Worst case: |alpha|=2, numCols=13 (max tested), |beta|=2.
+    // Need: 2*13*maxVal^2 + 2*maxVal <= max(entry_type), i.e.
+    // 26*maxVal^2 + 2*maxVal <= max(entry_type).
+    // Using the exact positive root:
+    // maxVal <= floor((-2 + sqrt(4 + 104*max(entry_type))) / 52).
+    // - 64-bit: floor((-2 + sqrt(4 + 104*INT64_MAX)) / 52) = 595604800
+    // - 32-bit: floor((-2 + sqrt(4 + 104*INT32_MAX)) / 52) = 9088
+    const entry_type maxVal = std::is_integral<entry_type>::value
+                                  ? (sizeof(entry_type) >= 8
+                                         ? entry_type(595604800)
+                                         : entry_type(9088))
+                                  : Kokkos::rand<generator_type, entry_type>::max();
     const entry_type minVal =
         KATE::is_signed ? entry_type(-maxVal) : KATE::zero();
     Kokkos::fill_random(A_orig, randPool, minVal, maxVal);
@@ -189,11 +201,19 @@ void testGemvVsTeuchosBlas(Teuchos::FancyOStream& out,
       << "y_norm: " << y_norm << endl;
   // Add a little "fudge factor."  2 is enough for real, and 4 is
   // enough for complex.
-  const mag_type fudgeFactor    = KokkosKernels::ArithTraits<entry_type>::is_complex ? static_cast<mag_type>(4) : static_cast<mag_type>(2);
-  const mag_type nonTransFactor = A_norm * x_norm > fudgeFactor ? A_norm * x_norm : fudgeFactor;
+  const mag_type fudgeFactor = KokkosKernels::ArithTraits<entry_type>::is_complex ? static_cast<mag_type>(4) : static_cast<mag_type>(2);
+  // For exact-integer types eps == 0, so the bound is 0 and we must skip
+  // A_norm * x_norm / A_norm * y_norm, which would overflow mag_type for
+  // full-range integer entries (signed-overflow UB).
+  const bool exactInteger       = (eps == static_cast<mag_type>(0));
+  const mag_type nonTransFactor = exactInteger
+                                      ? fudgeFactor
+                                      : (A_norm * x_norm > fudgeFactor ? A_norm * x_norm : fudgeFactor);
   const mag_type nonTransBound  = nonTransFactor *
                                  static_cast<mag_type>(numCols) * eps;
-  const mag_type transFactor = A_norm * y_norm > fudgeFactor ? A_norm * y_norm : fudgeFactor;
+  const mag_type transFactor = exactInteger
+                                   ? fudgeFactor
+                                   : (A_norm * y_norm > fudgeFactor ? A_norm * y_norm : fudgeFactor);
   const mag_type transBound  = transFactor *
                               static_cast<mag_type>(numRows) * eps;
   out << "nonTransBound: " << nonTransBound << endl

--- a/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
@@ -2215,19 +2215,19 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(MultiVector, OffsetView, LO, GO, Scalar, Node)
     Array<Mag> a1(numSubVecs), a2(numSubVecs), a3(numSubVecs), aw(numVectors);  // after putScalar(): ...
     Array<Mag> changed(numSubVecs), zeros(numSubVecs, M0);
     for (int i = 0; i < 4; ++i) {
-      ArrayView<RCP<MV> > allMVs;  // (changed,three unchanged)
+      std::vector<RCP<MV> > allMVs;  // (changed,three unchanged)
       switch (i) {
         case 0:
-          allMVs = tuple<RCP<MV> >(A1e, A2e, A1o, A2o);
+          allMVs = {A1e, A2e, A1o, A2o};
           break;
         case 1:
-          allMVs = tuple<RCP<MV> >(A2e, A1o, A2o, A1e);
+          allMVs = {A2e, A1o, A2o, A1e};
           break;
         case 2:
-          allMVs = tuple<RCP<MV> >(A1o, A2o, A1e, A2e);
+          allMVs = {A1o, A2o, A1e, A2e};
           break;
         case 3:
-          allMVs = tuple<RCP<MV> >(A2o, A1e, A2e, A1o);
+          allMVs = {A2o, A1e, A2e, A1o};
           break;
       }
       allMVs[1]->norm2(b1());


### PR DESCRIPTION
@trilinos/tpetra

## Motivation

This patch fixes several UBs in source, test and example code:

- applying non-zero offset 8 to null pointer -> `TpetraCore_ImportExport2_UnitTests.exe`
- null pointer passed as argument 1, which is declared to never be null -> `TpetraCore_AsyncTransfer_UnitTests.exe`
- null pointer passed as argument 2, which is declared to never be null -> `TpetraCore_MatrixMarket_Tpetra_Issue11704.exe`|`TpetraCore_MatrixMatrix_UnitTests.exe`
- stack-use-after-scope -> `TpetraCore_MultiVector_UnitTests.exe`
- addition of unsigned offset to 0x5250000020c0 overflowed to 0x5250000020b8 -> `TpetraCore_BlockCrsPerfTest.exe`

---

- signed integer overflow: `9223372036854775807` - `-9223372036854775807` cannot be represented in type `int64_t` (aka `long`) fix moved to https://github.com/kokkos/kokkos/pull/9216

## Environment

| Item       | Value                                   |
| ---------- | --------------------------------------- |
| OS         | Linux Ubuntu 24.04 x86_64, 6.17.0-29-generic             |
| CPU        | Intel Core i9-12900H (20 logical cores) |
| CMake      | 4.2.1                                  |
|clang|18.1.3;x86_64-pc-linux-gnu;thread-model:posix|
| Ninja      | 1.11.1                                  |
| OpenMP | 202011 (aka 5.1) |
| Build type | Debug, shared libs, C++20             |

## Proofs

I made changes step-by-step, and finally 5th was success:

- [ctest-TpetraCore_CrsMatrix-crashes.log](https://github.com/user-attachments/files/28428975/ctest-TpetraCore_CrsMatrix-crashes.log)
- [ctest-TpetraCore_gem-crashes.log](https://github.com/user-attachments/files/28428977/ctest-TpetraCore_gem-crashes.log)
- [ctest-TpetraCore_gem-crashes-attempt2-part.log](https://github.com/user-attachments/files/28428978/ctest-TpetraCore_gem-crashes-attempt2-part.log)
- [ctest-TpetraCore_gem-crashes-attempt3.log](https://github.com/user-attachments/files/28428980/ctest-TpetraCore_gem-crashes-attempt3.log)
- [ctest-TpetraCore_gem-crashes-attempt4.log](https://github.com/user-attachments/files/28428981/ctest-TpetraCore_gem-crashes-attempt4.log)
- [ctest-TpetraCore_gem-crashes-attempt5.log](https://github.com/user-attachments/files/28428982/ctest-TpetraCore_gem-crashes-attempt5.log)

## Testing

### Serial

#### Before

[ctest-tpetra-asan-ubsan-serial-before.log](https://github.com/user-attachments/files/28429499/ctest-tpetra-asan-ubsan-serial-before.log)

```log
90% tests passed, 18 tests failed out of 174

Subproject Time Summary:
Tpetra    = 697.91 sec*proc (174 tests)

Total Test time (real) = 697.99 sec

The following tests FAILED:
	 12 - TpetraCore_gemv (Subprocess aborted)              Tpetra
	 13 - TpetraCore_gemm_m_eq_1 (Subprocess aborted)       Tpetra
	 14 - TpetraCore_gemm_m_eq_2 (Subprocess aborted)       Tpetra
	 15 - TpetraCore_gemm_m_eq_5 (Subprocess aborted)       Tpetra
	 16 - TpetraCore_gemm_m_eq_13 (Subprocess aborted)      Tpetra
	 44 - TpetraCore_CrsMatrix_UnitTests (Subprocess aborted) Tpetra
	 45 - TpetraCore_CrsMatrix_UnitTests2 (Subprocess aborted) Tpetra
	 46 - TpetraCore_CrsMatrix_UnitTests3 (Subprocess aborted) Tpetra
	 47 - TpetraCore_CrsMatrix_UnitTests4 (Subprocess aborted) Tpetra
	 48 - TpetraCore_CrsMatrix_NewCopyAndPermute (Subprocess aborted) Tpetra
	 83 - TpetraCore_ImportExport2_UnitTests_Send (Subprocess aborted) Tpetra
	 84 - TpetraCore_ImportExport2_UnitTests_ISend (Subprocess aborted) Tpetra
	 85 - TpetraCore_ImportExport2_UnitTests_Alltoall (Subprocess aborted) Tpetra
	 86 - TpetraCore_AsyncTransfer_UnitTests (Subprocess aborted) Tpetra
	 88 - TpetraCore_MatrixMarket_Tpetra_Issue11704 (Subprocess aborted) Tpetra
	105 - TpetraCore_MatrixMatrix_UnitTests (Subprocess aborted) Tpetra
	108 - TpetraCore_MultiVector_UnitTests (Subprocess aborted) Tpetra
	162 - TpetraCore_BlockCrsPerfTest (Subprocess aborted)  Tpetra
```

#### After

[ctest-tpetra-asan-ubsan-serial-after.log](https://github.com/user-attachments/files/28429211/ctest-tpetra-asan-ubsan-serial-after.log)

```log
95% tests passed, 9 tests failed out of 174

Subproject Time Summary:
Tpetra    = 1011.63 sec*proc (174 tests)

Total Test time (real) = 1011.73 sec

The following tests FAILED:
	 47 - TpetraCore_CrsMatrix_UnitTests4 (Subprocess aborted) Tpetra
	 83 - TpetraCore_ImportExport2_UnitTests_Send (Subprocess aborted) Tpetra
	 84 - TpetraCore_ImportExport2_UnitTests_ISend (Subprocess aborted) Tpetra
	 85 - TpetraCore_ImportExport2_UnitTests_Alltoall (Subprocess aborted) Tpetra
	 86 - TpetraCore_AsyncTransfer_UnitTests (Subprocess aborted) Tpetra
	 88 - TpetraCore_MatrixMarket_Tpetra_Issue11704 (Subprocess aborted) Tpetra
	105 - TpetraCore_MatrixMatrix_UnitTests (Subprocess aborted) Tpetra
	108 - TpetraCore_MultiVector_UnitTests (Subprocess aborted) Tpetra
	162 - TpetraCore_BlockCrsPerfTest (Subprocess aborted)  Tpetra
```

### OpenMP

#### Before

[ctest-tpetra-asan-ubsan-openmp-before.log](https://github.com/user-attachments/files/28434277/ctest-tpetra-asan-ubsan-openmp-before.log)

```log
89% tests passed, 19 tests failed out of 174

Subproject Time Summary:
Tpetra    = 347.48 sec*proc (174 tests)

Total Test time (real) = 347.59 sec

The following tests FAILED:
	 12 - TpetraCore_gemv (Subprocess aborted)              Tpetra
	 13 - TpetraCore_gemm_m_eq_1 (Subprocess aborted)       Tpetra
	 14 - TpetraCore_gemm_m_eq_2 (Subprocess aborted)       Tpetra
	 15 - TpetraCore_gemm_m_eq_5 (Subprocess aborted)       Tpetra
	 16 - TpetraCore_gemm_m_eq_13 (Subprocess aborted)      Tpetra
	 19 - TpetraCore_BlockCrsMatrix (Failed)                Tpetra
	 44 - TpetraCore_CrsMatrix_UnitTests (Subprocess aborted) Tpetra
	 45 - TpetraCore_CrsMatrix_UnitTests2 (Subprocess aborted) Tpetra
	 46 - TpetraCore_CrsMatrix_UnitTests3 (Subprocess aborted) Tpetra
	 47 - TpetraCore_CrsMatrix_UnitTests4 (Subprocess aborted) Tpetra
	 48 - TpetraCore_CrsMatrix_NewCopyAndPermute (Subprocess aborted) Tpetra
	 83 - TpetraCore_ImportExport2_UnitTests_Send (Subprocess aborted) Tpetra
	 84 - TpetraCore_ImportExport2_UnitTests_ISend (Subprocess aborted) Tpetra
	 85 - TpetraCore_ImportExport2_UnitTests_Alltoall (Subprocess aborted) Tpetra
	 86 - TpetraCore_AsyncTransfer_UnitTests (Subprocess aborted) Tpetra
	 88 - TpetraCore_MatrixMarket_Tpetra_Issue11704 (Subprocess aborted) Tpetra
	105 - TpetraCore_MatrixMatrix_UnitTests (Subprocess aborted) Tpetra
	108 - TpetraCore_MultiVector_UnitTests (Subprocess aborted) Tpetra
	162 - TpetraCore_BlockCrsPerfTest (Subprocess aborted)  Tpetra
```

#### After

[ctest-tpetra-asan-ubsan-openmp-after.log](https://github.com/user-attachments/files/28429827/ctest-tpetra-asan-ubsan-openmp-after.log)

```log
94% tests passed, 10 tests failed out of 174

Subproject Time Summary:
Tpetra    = 1526.56 sec*proc (174 tests)

Total Test time (real) = 574.18 sec

The following tests FAILED:
	 19 - TpetraCore_BlockCrsMatrix (Failed)                Tpetra
	 47 - TpetraCore_CrsMatrix_UnitTests4 (Subprocess aborted) Tpetra
	 83 - TpetraCore_ImportExport2_UnitTests_Send (Subprocess aborted) Tpetra
	 84 - TpetraCore_ImportExport2_UnitTests_ISend (Subprocess aborted) Tpetra
	 85 - TpetraCore_ImportExport2_UnitTests_Alltoall (Subprocess aborted) Tpetra
	 86 - TpetraCore_AsyncTransfer_UnitTests (Subprocess aborted) Tpetra
	 88 - TpetraCore_MatrixMarket_Tpetra_Issue11704 (Subprocess aborted) Tpetra
	105 - TpetraCore_MatrixMatrix_UnitTests (Subprocess aborted) Tpetra
	108 - TpetraCore_MultiVector_UnitTests (Subprocess aborted) Tpetra
	162 - TpetraCore_BlockCrsPerfTest (Subprocess aborted)  Tpetra
```

### MPI

#### Before

```log
88% tests passed, 35 tests failed out of 290

Subproject Time Summary:
Tpetra    = 3540.46 sec*proc (290 tests)

Total Test time (real) = 1335.20 sec

The following tests FAILED:
	 18 - TpetraCore_gemv_MPI_1 (Failed)                    Tpetra
	 19 - TpetraCore_gemm_m_eq_1_MPI_1 (Failed)             Tpetra
	 20 - TpetraCore_gemm_m_eq_2_MPI_1 (Failed)             Tpetra
	 21 - TpetraCore_gemm_m_eq_5_MPI_1 (Failed)             Tpetra
	 22 - TpetraCore_gemm_m_eq_13_MPI_1 (Failed)            Tpetra
	 25 - TpetraCore_BlockCrsMatrix_MPI_4 (Failed)          Tpetra
	 33 - TpetraCore_BlankRowBugTest_MPI_2 (Failed)         Tpetra
	 55 - TpetraCore_CrsGraph_UnitTests0_MPI_4 (Failed)     Tpetra
	 59 - TpetraCore_Issue601_MPI_4 (Failed)                Tpetra
	 66 - TpetraCore_CrsGraph_UnpackMerge_MPI_2 (Failed)    Tpetra
	 68 - TpetraCore_CrsGraphTransposer_UnitTests_MPI_4 (Failed) Tpetra
	 70 - TpetraCore_CrsMatrix_UnitTests_MPI_4 (Failed)     Tpetra
	 71 - TpetraCore_CrsMatrix_UnitTests2_MPI_4 (Failed)    Tpetra
	 72 - TpetraCore_CrsMatrix_UnitTests3_MPI_4 (Failed)    Tpetra
	 73 - TpetraCore_CrsMatrix_UnitTests4_MPI_4 (Failed)    Tpetra
	 74 - TpetraCore_CrsMatrix_NewCopyAndPermute_MPI_4 (Failed) Tpetra
	 82 - TpetraCore_CrsMatrix_ReplaceDomainMapAndImporter_MPI_4 (Failed) Tpetra
	 83 - TpetraCore_CrsMatrix_ReplaceRangeMapAndExporter_MPI_4 (Failed) Tpetra
	103 - TpetraCore_CrsMatrix_UnpackMerge_MPI_2 (Failed)   Tpetra
	105 - TpetraCore_CrsMatrix_Bug8447_MPI_2 (Failed)       Tpetra
	117 - TpetraCore_Issue1752_MPI_2 (Failed)               Tpetra
	128 - TpetraCore_GDSWStyle_BaselineTpetra_MPI_4 (Failed) Tpetra
	142 - TpetraCore_ImportExport2_UnitTests_Send_MPI_4 (Failed) Tpetra
	143 - TpetraCore_ImportExport2_UnitTests_ISend_MPI_4 (Failed) Tpetra
	144 - TpetraCore_ImportExport2_UnitTests_Alltoall_MPI_4 (Failed) Tpetra
	145 - TpetraCore_ImportExport2_UnitTests_Ialltofewv_MPI_4 (Failed) Tpetra
	146 - TpetraCore_AsyncTransfer_UnitTests_MPI_4 (Failed) Tpetra
	148 - TpetraCore_MatrixMarket_Tpetra_Issue11704_MPI_1 (Failed) Tpetra
	149 - TpetraCore_MatrixMarket_Tpetra_CrsMatrix_InOutTest_MPI_4 (Failed) Tpetra
	171 - TpetraCore_MatrixMarket_Tpetra_CrsGraph_InOutTest_MPI_4 (Failed) Tpetra
	204 - TpetraCore_NegativeBaseIndexTest_MPI_2 (Failed)   Tpetra
	205 - TpetraCore_MatrixMatrix_UnitTests_MPI_4 (Failed)  Tpetra
	208 - TpetraCore_MultiVector_UnitTests_MPI_4 (Failed)   Tpetra
	253 - TpetraCore_CrsMatrix_transpose_sortedRows_MPI_4 (Failed) Tpetra
	275 - TpetraCore_BlockCrsPerfTest_MPI_4 (Failed)        Tpetra
```

#### After

```log
90% tests passed, 28 tests failed out of 290

Subproject Time Summary:
Tpetra    = 3616.38 sec*proc (290 tests)

Total Test time (real) = 1480.28 sec

The following tests FAILED:
	 25 - TpetraCore_BlockCrsMatrix_MPI_4 (Failed)          Tpetra
	 33 - TpetraCore_BlankRowBugTest_MPI_2 (Failed)         Tpetra
	 55 - TpetraCore_CrsGraph_UnitTests0_MPI_4 (Failed)     Tpetra
	 59 - TpetraCore_Issue601_MPI_4 (Failed)                Tpetra
	 66 - TpetraCore_CrsGraph_UnpackMerge_MPI_2 (Failed)    Tpetra
	 68 - TpetraCore_CrsGraphTransposer_UnitTests_MPI_4 (Failed) Tpetra
	 71 - TpetraCore_CrsMatrix_UnitTests2_MPI_4 (Failed)    Tpetra
	 73 - TpetraCore_CrsMatrix_UnitTests4_MPI_4 (Failed)    Tpetra
	 74 - TpetraCore_CrsMatrix_NewCopyAndPermute_MPI_4 (Failed) Tpetra
	 82 - TpetraCore_CrsMatrix_ReplaceDomainMapAndImporter_MPI_4 (Failed) Tpetra
	 83 - TpetraCore_CrsMatrix_ReplaceRangeMapAndExporter_MPI_4 (Failed) Tpetra
	103 - TpetraCore_CrsMatrix_UnpackMerge_MPI_2 (Failed)   Tpetra
	105 - TpetraCore_CrsMatrix_Bug8447_MPI_2 (Failed)       Tpetra
	117 - TpetraCore_Issue1752_MPI_2 (Failed)               Tpetra
	128 - TpetraCore_GDSWStyle_BaselineTpetra_MPI_4 (Failed) Tpetra
	142 - TpetraCore_ImportExport2_UnitTests_Send_MPI_4 (Failed) Tpetra
	143 - TpetraCore_ImportExport2_UnitTests_ISend_MPI_4 (Failed) Tpetra
	144 - TpetraCore_ImportExport2_UnitTests_Alltoall_MPI_4 (Failed) Tpetra
	145 - TpetraCore_ImportExport2_UnitTests_Ialltofewv_MPI_4 (Failed) Tpetra
	146 - TpetraCore_AsyncTransfer_UnitTests_MPI_4 (Failed) Tpetra
	148 - TpetraCore_MatrixMarket_Tpetra_Issue11704_MPI_1 (Failed) Tpetra
	149 - TpetraCore_MatrixMarket_Tpetra_CrsMatrix_InOutTest_MPI_4 (Failed) Tpetra
	171 - TpetraCore_MatrixMarket_Tpetra_CrsGraph_InOutTest_MPI_4 (Failed) Tpetra
	204 - TpetraCore_NegativeBaseIndexTest_MPI_2 (Failed)   Tpetra
	205 - TpetraCore_MatrixMatrix_UnitTests_MPI_4 (Failed)  Tpetra
	208 - TpetraCore_MultiVector_UnitTests_MPI_4 (Failed)   Tpetra
	253 - TpetraCore_CrsMatrix_transpose_sortedRows_MPI_4 (Failed) Tpetra
	275 - TpetraCore_BlockCrsPerfTest_MPI_4 (Failed)        Tpetra
```

### CUDA

Can't check because of OOM described in https://github.com/trilinos/Trilinos/pull/15286#issuecomment-4525413685. It's worth taking note of this.

## Build and Test Commands

<details>
<summary>Build command:</summary>

```bash
TRILINOS_SRC_DIR="$(pwd)" && \
\
TARGET_BUILD_TYPE="Debug"          && \
TARGET_PACKAGE="tpetra"           && \
TARGET_PACKAGE_OFFICIAL="Tpetra"  && \
\
PATH="/usr/local/cuda-12.8/bin:$PATH"   && \
CUDA_ROOT="/usr/local/cuda-12.8"        && \
\
BUILD_DIR="$TRILINOS_SRC_DIR/build_${TARGET_PACKAGE}_tpetra_serial"   && \
mkdir -pv $BUILD_DIR                                    && \
\
ENABLE_ASAN="ON"         && \
ENABLE_UBSAN="ON"        && \
ENABLE_LSAN="OFF"         && \
ENABLE_TSAN="OFF"         && \
ENABLE_MSAN="OFF"          && \
ENABLE_CFI="OFF"          && \
\
if [ "$ENABLE_MSAN" == "ON" ] && [ "$ENABLE_CFI" == "ON" ]; then                            \
  echo "ERROR: ENABLE_MSAN and ENABLE_CFI are incompatible; use separate build dirs" >&2 && \
  exit 1                                                                                  ; \
fi                                                                                       && \
\
TARGET_C_COMPILER="$(which clang)"                                   && \
TARGET_CXX_COMPILER="$(which clang++)"                               && \
if [ "$ENABLE_MSAN" == "ON" ]; then                                     \
  LLVM_MSAN_PROJECT_ROOT="/home/loveit0/Documents/Prog/llvm-project" && \
  MSAN_LIBCXX_ROOT="${LLVM_MSAN_PROJECT_ROOT}/build-msan"            && \
  TARGET_C_COMPILER="${LLVM_MSAN_PROJECT_ROOT}/build/bin/clang"      && \
  TARGET_CXX_COMPILER="${LLVM_MSAN_PROJECT_ROOT}/build/bin/clang++"  && \
  PATH="${LLVM_MSAN_PROJECT_ROOT}/build/bin:$PATH"                    ; \
elif [ "$ENABLE_MSAN" != "ON" ] &&                                      \
     { [ "$ENABLE_ASAN" == "ON" ] || [ "$ENABLE_UBSAN" == "ON" ] ||     \
       [ "$ENABLE_LSAN" == "ON" ] || [ "$ENABLE_TSAN" == "ON" ] ||      \
       [ "$ENABLE_CFI" == "ON" ]; } &&                                  \
     [ -x /usr/bin/clang ] && [ -x /usr/bin/clang++ ]; then             \
  TARGET_C_COMPILER="/usr/bin/clang"                                 && \
  TARGET_CXX_COMPILER="/usr/bin/clang++"                              ; \
fi                                                                   && \
\
SAN_LIST=""                                                                          && \
if [ "$ENABLE_ASAN"  == "ON" ]; then SAN_LIST="${SAN_LIST:+$SAN_LIST,}address";   fi && \
if [ "$ENABLE_UBSAN" == "ON" ]; then SAN_LIST="${SAN_LIST:+$SAN_LIST,}undefined"; fi && \
if [ "$ENABLE_LSAN"  == "ON" ]; then SAN_LIST="${SAN_LIST:+$SAN_LIST,}leak";      fi && \
if [ "$ENABLE_TSAN"  == "ON" ]; then SAN_LIST="${SAN_LIST:+$SAN_LIST,}thread";    fi && \
if [ "$ENABLE_MSAN"  == "ON" ]; then SAN_LIST="${SAN_LIST:+$SAN_LIST,}memory";    fi && \
if [ "$ENABLE_CFI"   == "ON" ]; then SAN_LIST="${SAN_LIST:+$SAN_LIST,}cfi";       fi && \
\
SAN=""                                                                               && \
SAN_CXX=""                                                                           && \
SAN_LINK=""                                                                          && \
CFI_LTO=""                                                                           && \
CFI_PIE=""                                                                           && \
CMAKE_IPO="OFF"                                                                      && \
CMAKE_PIC="ON"                                                                       && \
if [ -n "$SAN_LIST" ]; then                                                             \
  SAN="-fsanitize=$SAN_LIST -fno-omit-frame-pointer -g";                                \
fi                                                                                   && \
if [ "$ENABLE_CFI" == "ON" ]; then                                                      \
  CFI_LTO="-flto=thin -fvisibility=hidden";                                             \
  CFI_PIE="-fno-pie";                                                                   \
  CMAKE_IPO="ON";                                                                       \
  CMAKE_PIC="OFF";                                                                      \
  SAN="${SAN} ${CFI_LTO} ${CFI_PIE}";                                                   \
fi                                                                                   && \
if [ "$ENABLE_MSAN" == "ON" ]; then                                                     \
  SAN="${SAN} -fsanitize-memory-track-origins=0 -O1";                                   \
  OPENBLAS_MSAN_ROOT="/home/loveit0/Documents/Prog/openblas-msan/install"            && \
  OPENBLAS_MSAN_LIB="${OPENBLAS_MSAN_ROOT}/lib/libopenblas.a"                        && \
  SAN_CXX="${SAN} -nostdinc++ -isystem ${MSAN_LIBCXX_ROOT}/include/c++/v1               \
    -DTEUCHOS_NO_ZERO_ITERATOR_CONVERSION";                                             \
  SAN_LINK="${SAN} -nostdlib++ -L${MSAN_LIBCXX_ROOT}/lib -unwindlib=libgcc";            \
  MSAN_LIBCXX_LIBS="-Wl,--start-group ${MSAN_LIBCXX_ROOT}/lib/libc++.a                  \
    ${MSAN_LIBCXX_ROOT}/lib/libc++abi.a -Wl,--end-group ${OPENBLAS_MSAN_LIB}            \
    -lgfortran -lgcc_s -lpthread -lc -lm -ldl";                                         \
elif [ "$ENABLE_CFI" == "ON" ]; then                                                    \
  SAN_CXX="$SAN";                                                                       \
  SAN_LINK="-fsanitize=$SAN_LIST -fno-omit-frame-pointer -g -flto=thin -no-pie";        \
else                                                                                    \
  SAN_CXX="$SAN";                                                                       \
  SAN_LINK="$SAN";                                                                      \
fi                                                                                   && \
\
ASAN_RUNTIME_OPTS='halt_on_error=1:abort_on_error=1:detect_leaks=0:leak_check_at_exit=0:print_legend=1:print_summary=1:print_cmdline=1:print_full_thread_history=1:strict_string_checks=1:fast_unwind_on_malloc=0:fast_unwind_on_fatal=0:malloc_context_size=30:symbolize=1:symbolize_inline_frames=1:verbosity=1:detect_stack_use_after_return=1:alloc_dealloc_mismatch=1:dump_instruction_bytes=1' && \
UBSAN_RUNTIME_OPTS='print_stacktrace=1:halt_on_error=1:abort_on_error=1:print_summary=1:symbolize=1:symbolize_inline_frames=1:verbosity=1:log_exe_name=1' && \
LSAN_RUNTIME_OPTS='exitcode=0:print_suppressions=0'                                                                                               && \
MSAN_RUNTIME_OPTS='halt_on_error=1:abort_on_error=1:print_stats=1:verbosity=1:symbolize=1:malloc_context_size=30:log_exe_name=1' && \
TSAN_RUNTIME_OPTS='halt_on_error=1:abort_on_error=1:report_thread_leaks=0:history_size=7:report_destroy_locked=1:report_signal_unsafe=1:verbosity=1:symbolize=1:log_exe_name=1' && \
\
ENABLE_OMP="OFF"          && \
ENABLE_MPI="OFF"          && \
ENABLE_CUDA="OFF"         && \
ENABLE_COMPLEX="ON"       && \
ENABLE_FORTRAN="ON"       && \
BUILD_SHARED="ON"         && \
if [ "$ENABLE_MSAN" == "ON" ]; then ENABLE_FORTRAN="OFF"; fi && \
if [ "$ENABLE_CFI"  == "ON" ]; then ENABLE_FORTRAN="OFF"; fi && \
if [ "$ENABLE_MSAN" == "ON" ]; then ENABLE_OMP="OFF";     fi && \
if [ "$ENABLE_MSAN" == "ON" ]; then ENABLE_MPI="OFF";     fi && \
if [ "$ENABLE_MSAN" == "ON" ]; then BUILD_SHARED="OFF";   fi && \
if [ "$ENABLE_CFI"  == "ON" ]; then BUILD_SHARED="OFF";   fi && \
if [ "$ENABLE_CFI"  == "ON" ] && [ "$ENABLE_UBSAN" != "ON" ]; then                          \
  echo "WARN: CFI builds usually pair with ENABLE_UBSAN=ON for clearer diagnostics" >&2   ; \
fi                                                                                       && \
if [ "$ENABLE_TSAN" == "ON" ] && { [ "$ENABLE_OMP" == "ON" ] || [ "$ENABLE_MPI" == "ON" ]; }; then \
  TSAN_RUNTIME_OPTS="${TSAN_RUNTIME_OPTS}:ignore_noninstrumented_modules=1"                                   ; \
fi                                                                                                           && \
MPI_CTEST_ENV=""                                                                                             && \
if [ "$ENABLE_TSAN" == "ON" ] && [ "$ENABLE_MPI" == "ON" ]; then                                                \
  MPI_CTEST_ENV="PMIX_MCA_gds=hash"                                                                           ; \
fi                                                                                                           && \
\
if [ "$ENABLE_MPI" == "ON" ] && [ "$ENABLE_MSAN" != "ON" ]; then                          \
  export OMPI_CC="$TARGET_C_COMPILER"                                                  && \
  export OMPI_CXX="$TARGET_CXX_COMPILER"                                               && \
  CMAKE_C_COMPILER="$(which mpicc)"                                                    && \
  CMAKE_CXX_COMPILER="$(which mpicxx)"                                                  ; \
else                                                                                      \
  CMAKE_C_COMPILER="$TARGET_C_COMPILER"                                                && \
  CMAKE_CXX_COMPILER="$TARGET_CXX_COMPILER"                                             ; \
fi                                                                                     && \
\
CMAKE_EXTRA_ARGS=()                                                           && \
if [ "$ENABLE_MSAN" == "ON" ]; then                                              \
  CMAKE_EXTRA_ARGS=(                                                             \
    -DCMAKE_LINKER="${LLVM_MSAN_PROJECT_ROOT}/build/bin/ld.lld"                  \
    -DCMAKE_C_FLAGS="${SAN}"                                                     \
    -DCMAKE_CXX_STANDARD_LIBRARIES="${MSAN_LIBCXX_LIBS}"                         \
    -DTPL_BLAS_LIBRARIES="${OPENBLAS_MSAN_LIB}"                                  \
    -DTPL_LAPACK_LIBRARIES="${OPENBLAS_MSAN_LIB}"                                \
  );                                                                             \
fi                                                                            && \
\
cmake -G Ninja \
  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON                \
  -DBUILD_SHARED_LIBS=${BUILD_SHARED}               \
  -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}            \
  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}        \
  -DCMAKE_BUILD_TYPE=${TARGET_BUILD_TYPE}           \
  -DCMAKE_CXX_STANDARD=20                           \
  -DCMAKE_C_FLAGS="${SAN_CXX}"                      \
  -DCMAKE_CXX_FLAGS="${SAN_CXX}"                    \
  -DCMAKE_EXE_LINKER_FLAGS="${SAN_LINK}"            \
  -DCMAKE_SHARED_LINKER_FLAGS="${SAN_LINK}"         \
  -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=${CMAKE_IPO} \
  -DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_PIC}    \
  "${CMAKE_EXTRA_ARGS[@]}"                          \
  -DCMAKE_PREFIX_PATH="${CUDA_ROOT}"                \
  -DCMAKE_CUDA_COMPILER="${CUDA_ROOT}/bin/nvcc"     \
  \
  -DTrilinos_ENABLE_COMPLEX=${ENABLE_COMPLEX} \
  -DTrilinos_ENABLE_Fortran=${ENABLE_FORTRAN} \
  \
  -DCUDAToolkit_ROOT="${CUDA_ROOT}"           \
  -DKokkos_ENABLE_CUDA=${ENABLE_CUDA}         \
  -DKokkos_ENABLE_CUDA_LAMBDA=${ENABLE_CUDA}  \
  -DKokkos_ARCH_NATIVE=${ENABLE_CUDA}         \
  -DKokkos_ARCH_ADA89=ON                      \
  -DTPL_ENABLE_CUDA=${ENABLE_CUDA}            \
  -DTPL_ENABLE_CUSPARSE=${ENABLE_CUDA}        \
  \
  -DTPL_ENABLE_MPI=${ENABLE_MPI}  \
  \
  -DTrilinos_ENABLE_OpenMP=${ENABLE_OMP}            \
  -DKokkos_ENABLE_OPENMP=${ENABLE_OMP}              \
  -DTrilinos_ENABLE_${TARGET_PACKAGE_OFFICIAL}=ON   \
  -D${TARGET_PACKAGE_OFFICIAL}_ENABLE_TESTS=ON      \
  \
  -S $TRILINOS_SRC_DIR      \
  -B $BUILD_DIR          && \
(cd $BUILD_DIR && ninja) && \
echo ""                                                                                         && \
echo "Run tests (copy-paste; leaks OFF for MPI/OpenMP):"                                        && \
if [ "$ENABLE_MSAN" == "ON" ]; then                                                                \
  echo "(cd $BUILD_DIR && MSAN_OPTIONS='${MSAN_RUNTIME_OPTS}' ctest -V --output-on-failure)" ;     \
elif [ "$ENABLE_TSAN" == "ON" ]; then                                                              \
  echo "(cd $BUILD_DIR && ${MPI_CTEST_ENV} TSAN_OPTIONS='${TSAN_RUNTIME_OPTS}' ctest -V --output-on-failure)" ;     \
elif [ "$ENABLE_ASAN" == "ON" ] || [ "$ENABLE_UBSAN" == "ON" ] || [ "$ENABLE_LSAN" == "ON" ]; then \
  echo "(cd $BUILD_DIR && ASAN_OPTIONS='${ASAN_RUNTIME_OPTS}' UBSAN_OPTIONS='${UBSAN_RUNTIME_OPTS}' LSAN_OPTIONS='${LSAN_RUNTIME_OPTS}' ctest -V --output-on-failure)" ; \
elif [ "$ENABLE_CFI" == "ON" ]; then                                                               \
  echo "(cd $BUILD_DIR && UBSAN_OPTIONS='${UBSAN_RUNTIME_OPTS}' ctest -V --output-on-failure)"   ; \
else                                                                                               \
  echo "(cd $BUILD_DIR && ctest -V --output-on-failure)"                                         ; \
fi
```

</details>

Test command:

```bash
(cd /home/loveit0/Develop/Trilinos/build_tpetra_tpetra_serial && ASAN_OPTIONS='halt_on_error=1:abort_on_error=1:detect_leaks=0:leak_check_at_exit=0:print_legend=1:print_summary=1:print_cmdline=1:print_full_thread_history=1:strict_string_checks=1:fast_unwind_on_malloc=0:fast_unwind_on_fatal=0:malloc_context_size=30:symbolize=1:symbolize_inline_frames=1:verbosity=1:detect_stack_use_after_return=1:alloc_dealloc_mismatch=1:dump_instruction_bytes=1' UBSAN_OPTIONS='print_stacktrace=1:halt_on_error=1:abort_on_error=1:print_summary=1:symbolize=1:symbolize_inline_frames=1:verbosity=1:log_exe_name=1' LSAN_OPTIONS='exitcode=0:print_suppressions=0' ctest -V --output-on-failure)
```

## Additional Information

About the fix in `Kokkos_Random.hpp`, I ran the tests with ASan and UBSan separately in the `upstream/develop' kokkos repo, but there are other errors, i.e. this particular chain is not manifested by kokkos tests, but is manifested by tests inside Tpetra.
Here is the full log: [ctest-kokkos-asan-ubsan-serial.log](https://github.com/user-attachments/files/28429085/ctest-kokkos-asan-ubsan-serial.log)

Summary from this log:

```log
22% tests passed, 35 tests failed out of 45

Label Time Summary:
Kokkos    =  21.01 sec*proc (44 tests)

Total Test time (real) =  21.18 sec

The following tests FAILED:
	  1 - Kokkos_CoreUnitTest_Serial_ViewSupport (Subprocess aborted) Kokkos
	  2 - Kokkos_CoreUnitTest_Serial_SmokeTest (Subprocess aborted) Kokkos
	  3 - Kokkos_CoreUnitTest_DefaultInstanceFencesOnFinalize (Subprocess aborted) Kokkos
	  4 - Kokkos_CoreUnitTest_Serial1 (Subprocess aborted)  Kokkos
	  5 - Kokkos_CoreUnitTest_Serial2 (Subprocess aborted)  Kokkos
	  6 - Kokkos_CoreUnitTest_Default (Subprocess aborted)  Kokkos
	  7 - Kokkos_CoreUnitTest_InitializeFinalize (Subprocess aborted) Kokkos
	  8 - Kokkos_CoreUnitTest_Develop (Subprocess aborted)  Kokkos
	  9 - Kokkos_CoreUnitTest_KokkosP (Subprocess aborted)  Kokkos
	 14 - Kokkos_ProfilingTestLibraryLoad (Subprocess aborted) Kokkos
	 15 - Kokkos_ProfilingTestLibraryCmdLine (Subprocess aborted) Kokkos
	 17 - Kokkos_IncrementalTest_SERIAL (Subprocess aborted) Kokkos
	 18 - Kokkos_CoreUnitTest_CTestDevice (Subprocess aborted) Kokkos
	 24 - Kokkos_ContainersUnitTest_Serial (Subprocess aborted) Kokkos
	 25 - Kokkos_UnitTest_Sort (Subprocess aborted)         Kokkos
	 26 - Kokkos_UnitTest_Random (Subprocess aborted)       Kokkos
	 27 - Kokkos_AlgorithmsUnitTest_StdSet_A (Subprocess aborted) Kokkos
	 28 - Kokkos_AlgorithmsUnitTest_StdSet_B (Subprocess aborted) Kokkos
	 29 - Kokkos_AlgorithmsUnitTest_StdSet_C (Subprocess aborted) Kokkos
	 30 - Kokkos_AlgorithmsUnitTest_StdSet_D (Subprocess aborted) Kokkos
	 31 - Kokkos_AlgorithmsUnitTest_StdSet_E (Subprocess aborted) Kokkos
	 32 - Kokkos_AlgorithmsUnitTest_StdSet_Team_A (Subprocess aborted) Kokkos
	 33 - Kokkos_AlgorithmsUnitTest_StdSet_Team_B (Subprocess aborted) Kokkos
	 34 - Kokkos_AlgorithmsUnitTest_StdSet_Team_C (Subprocess aborted) Kokkos
	 35 - Kokkos_AlgorithmsUnitTest_StdSet_Team_D (Subprocess aborted) Kokkos
	 36 - Kokkos_AlgorithmsUnitTest_StdSet_Team_E (Subprocess aborted) Kokkos
	 37 - Kokkos_AlgorithmsUnitTest_StdSet_Team_F (Subprocess aborted) Kokkos
	 38 - Kokkos_AlgorithmsUnitTest_StdSet_Team_G (Subprocess aborted) Kokkos
	 39 - Kokkos_AlgorithmsUnitTest_StdSet_Team_H (Subprocess aborted) Kokkos
	 40 - Kokkos_AlgorithmsUnitTest_StdSet_Team_I (Subprocess aborted) Kokkos
	 41 - Kokkos_AlgorithmsUnitTest_StdSet_Team_L (Subprocess aborted) Kokkos
	 42 - Kokkos_AlgorithmsUnitTest_StdSet_Team_M (Subprocess aborted) Kokkos
	 43 - Kokkos_AlgorithmsUnitTest_StdSet_Team_P (Subprocess aborted) Kokkos
	 44 - Kokkos_AlgorithmsUnitTest_StdSet_Team_Q (Subprocess aborted) Kokkos
	 45 - Kokkos_UnitTest_SIMD (Subprocess aborted)         Kokkos
```
