### PR TITLE
Framework: Fix argument quoting in actions

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -944,5 +944,5 @@ jobs:
       num-concurrent-tests: 16
       slots-per-gpu: 8
       skip-create-packageenables: true
-      extra-pr-driver-args: "--extra-configure-args=-C ${GITHUB_WORKSPACE}/packages/framework/cmake-fragments/ramses/gcc-mpi-openmp.cmake"
+      extra-pr-driver-args: --extra-configure-args=-C;${GITHUB_WORKSPACE}/packages/framework/cmake-fragments/ramses/gcc-mpi-openmp.cmake
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
             ${max_cores_allowed} \
             ${slots_per_gpu} \
             ${skip_create_packageenables} \
-            "${extra_pr_driver_args}"
+            ${extra_pr_driver_args}
       - name: Filtered build error logs
         if: success() || failure()
         shell: bash -l {0}


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Getting an error where '' was passed as an explicit argument.  I remembered that when I originally set this up I accounted for the "spaces have to be quoted" everywhere annoyance that comes when passing things through multiple layers, and it works with semicolons instead.  Change to that approach.

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-696

## Testing
Manually ran the nightly pipeline until it worked correctly.  May still fail CI (RAMSES job specifically).
