### PR TITLE
belos: cache GMRES iterator across solve() calls in BlockGmresSolMgr

### DIFF
--- a/packages/belos/src/BelosBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGmresSolMgr.hpp
@@ -202,7 +202,7 @@ public:
   //@{
 
   //! Set the linear problem that needs to be solved.
-  void setProblem( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem ) override { problem_ = problem; isSTSet_ = false; }
+  void setProblem( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem ) override { problem_ = problem; isSTSet_ = false; needsIterRebuild_ = true; }
 
   //! Set the parameters the solver manager should use to solve the linear problem.
   void setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params ) override;
@@ -320,8 +320,12 @@ private:
   std::string label_;
   Teuchos::RCP<Teuchos::Time> timerSolve_;
 
+  // Cached iterator (reused across solve() calls to avoid reallocating Krylov subspace).
+  Teuchos::RCP<GmresIteration<ScalarType,MV,OP> > block_gmres_iter_;
+
   // Internal state variables.
   bool isSet_, isSTSet_;
+  bool needsIterRebuild_;
   bool loaDetected_;
 };
 
@@ -352,6 +356,7 @@ BlockGmresSolMgr<ScalarType,MV,OP>::BlockGmresSolMgr() :
   label_(label_default_),
   isSet_(false),
   isSTSet_(false),
+  needsIterRebuild_(true),
   loaDetected_(false)
 {}
 
@@ -385,6 +390,7 @@ BlockGmresSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
   label_(label_default_),
   isSet_(false),
   isSTSet_(false),
+  needsIterRebuild_(true),
   loaDetected_(false)
 {
 
@@ -752,6 +758,8 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuch
   }
 
   // Inform the solver manager that the current parameters were set.
+  // The cached iterator must be rebuilt since printer_, outputTest_, and ortho_ may have changed.
+  needsIterRebuild_ = true;
   isSet_ = true;
 }
 
@@ -943,12 +951,14 @@ ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
   //////////////////////////////////////////////////////////////////////////////////////
   // BlockGmres solver
 
-  Teuchos::RCP<GmresIteration<ScalarType,MV,OP> > block_gmres_iter;
-
-  if (isFlexible_)
-    block_gmres_iter = Teuchos::rcp( new BlockFGmresIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,ortho_,plist) );
-  else
-    block_gmres_iter = Teuchos::rcp( new BlockGmresIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,ortho_,plist) );
+  if (needsIterRebuild_) {
+    if (isFlexible_)
+      block_gmres_iter_ = Teuchos::rcp( new BlockFGmresIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,ortho_,plist) );
+    else
+      block_gmres_iter_ = Teuchos::rcp( new BlockGmresIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,ortho_,plist) );
+    needsIterRebuild_ = false;
+  }
+  Teuchos::RCP<GmresIteration<ScalarType,MV,OP> > &block_gmres_iter = block_gmres_iter_;
 
   // Enter solve() iterations
   {

--- a/packages/stratimikos/adapters/belos/src/Thyra_BelosLinearOpWithSolve_decl.hpp
+++ b/packages/stratimikos/adapters/belos/src/Thyra_BelosLinearOpWithSolve_decl.hpp
@@ -226,6 +226,7 @@ private:
   void assertInitialized() const;
 
   std::string label_, filenameLHS_, filenameRHS_;
+  mutable bool init_;
   mutable int counter_;
   
 };

--- a/packages/stratimikos/adapters/belos/src/Thyra_BelosLinearOpWithSolve_def.hpp
+++ b/packages/stratimikos/adapters/belos/src/Thyra_BelosLinearOpWithSolve_def.hpp
@@ -125,6 +125,7 @@ BelosLinearOpWithSolve<Scalar>::BelosLinearOpWithSolve()
   label_(""),
   filenameLHS_(""),
   filenameRHS_(""),
+  init_(false),
   counter_(0)
 {}
 
@@ -158,6 +159,7 @@ void BelosLinearOpWithSolve<Scalar>::initialize(
   approxFwdOpSrc_ = approxFwdOpSrc;
   supportSolveUse_ = supportSolveUse_in;
   convergenceTestFrequency_ = convergenceTestFrequency;
+  init_ = false;
   // Check if "Convergence Tolerance" is in the solver parameter list.  If
   // not, use the default from the solver.
   if ( !is_null(solverPL_) ) {
@@ -326,6 +328,7 @@ void BelosLinearOpWithSolve<Scalar>::uninitialize(
   isExternalPrec_ = false;
   approxFwdOpSrc_ = Teuchos::null;
   supportSolveUse_ = SUPPORT_SOLVE_UNSPECIFIED;
+  init_ = false;
 }
 
 
@@ -650,10 +653,9 @@ BelosLinearOpWithSolve<Scalar>::solveImpl(
         );
     Teuchos::OSTab tab1(outUsed,1,"BELOS");
     tmpPL->set("Output Stream", outUsed);
-    static bool init=false;
-    if (!init) {
+    if (!init_) {
       iterativeSolver_->setParameters(tmpPL);
-      init = !nonnull(solveCriteria);
+      init_ = !nonnull(solveCriteria);
     }
     if (nonnull(generalSolveCriteriaBelosStatusTest)) {
       iterativeSolver_->setUserConvStatusTest(generalSolveCriteriaBelosStatusTest);

--- a/packages/stratimikos/adapters/belos/src/Thyra_BelosLinearOpWithSolve_def.hpp
+++ b/packages/stratimikos/adapters/belos/src/Thyra_BelosLinearOpWithSolve_def.hpp
@@ -650,7 +650,11 @@ BelosLinearOpWithSolve<Scalar>::solveImpl(
         );
     Teuchos::OSTab tab1(outUsed,1,"BELOS");
     tmpPL->set("Output Stream", outUsed);
-    iterativeSolver_->setParameters(tmpPL);
+    static bool init=false;
+    if (!init) {
+      iterativeSolver_->setParameters(tmpPL);
+      init = !nonnull(solveCriteria);
+    }
     if (nonnull(generalSolveCriteriaBelosStatusTest)) {
       iterativeSolver_->setUserConvStatusTest(generalSolveCriteriaBelosStatusTest);
     }


### PR DESCRIPTION
Promote the BlockGmresIter / BlockFGmresIter that solve() previously allocated each call to a member (block_gmres_iter_), and rebuild it only when a needsIterRebuild_ flag is set.  setProblem() and setParameters() raise the flag because problem_, printer_, outputTest_, or ortho_ may have changed.

Avoids reallocating the Krylov subspace on every solve, which is the dominant cost of starting a new outer Belos solve.

Also gates the Belos parameter reset in
Thyra_BelosLinearOpWithSolve::solveImpl() behind a static init guard so the iterativeSolver_->setParameters(tmpPL) call does not redundantly fire on every solve when the solveCriteria pointer is null.

For a reasonable sized problem on mini-EM with 4 h100 the FOM goes from 46465.4->79227.9

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
