### PR TITLE
Galeri:MueLu:  Adding capabilities in Galeri to create a finite element mass and

### DIFF
--- a/packages/galeri/src/Galeri_StencilProblems_decl.hpp
+++ b/packages/galeri/src/Galeri_StencilProblems_decl.hpp
@@ -94,6 +94,39 @@ class Brick3DProblem : public ScalarProblem<Map, Matrix, MultiVector> {
   Teuchos::RCP<RealValuedMultiVector> BuildCoords();
 };
 
+// =============================================  Scalar3D_27Pt =============================================
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
+class Scalar3D_27PtProblem : public ScalarProblem<Map, Matrix, MultiVector> {
+ public:
+  using RealValuedMultiVector = typename Problem<Map, Matrix, MultiVector>::RealValuedMultiVector;
+
+  Scalar3D_27PtProblem(Teuchos::ParameterList& list, const Teuchos::RCP<const Map>& map);
+  Teuchos::RCP<Matrix> BuildMatrix();
+  Teuchos::RCP<RealValuedMultiVector> BuildCoords();
+};
+
+// =============================================  HexFEM_LapStiff =============================================
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
+class HexFEM_LapStiffProblem : public ScalarProblem<Map, Matrix, MultiVector> {
+ public:
+  using RealValuedMultiVector = typename Problem<Map, Matrix, MultiVector>::RealValuedMultiVector;
+
+  HexFEM_LapStiffProblem(Teuchos::ParameterList& list, const Teuchos::RCP<const Map>& map);
+  Teuchos::RCP<Matrix> BuildMatrix();
+  Teuchos::RCP<RealValuedMultiVector> BuildCoords();
+};
+
+// =============================================  HexFEM_Mass =============================================
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
+class HexFEM_MassProblem : public ScalarProblem<Map, Matrix, MultiVector> {
+ public:
+  using RealValuedMultiVector = typename Problem<Map, Matrix, MultiVector>::RealValuedMultiVector;
+
+  HexFEM_MassProblem(Teuchos::ParameterList& list, const Teuchos::RCP<const Map>& map);
+  Teuchos::RCP<Matrix> BuildMatrix();
+  Teuchos::RCP<RealValuedMultiVector> BuildCoords();
+};
+
 // =============================================  Identity  =============================================
 template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
 class IdentityProblem : public Problem<Map, Matrix, MultiVector> {

--- a/packages/galeri/src/Galeri_StencilProblems_def.hpp
+++ b/packages/galeri/src/Galeri_StencilProblems_def.hpp
@@ -454,6 +454,325 @@ Teuchos::RCP<typename Problem<Map, Matrix, MultiVector>::RealValuedMultiVector> 
   return this->Coords_;
 }
 
+// =============================================  Scalar3D_27Pt =============================================
+
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
+Scalar3D_27PtProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>::Scalar3D_27PtProblem(Teuchos::ParameterList& list, const Teuchos::RCP<const Map>& map)
+  : ScalarProblem<Map, Matrix, MultiVector>(list, map) {}
+
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
+Teuchos::RCP<Matrix> Scalar3D_27PtProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>::BuildMatrix() {
+  Teuchos::ParameterList list = this->list_;
+  GlobalOrdinal nx            = -1;
+  GlobalOrdinal ny            = -1;
+  GlobalOrdinal nz            = -1;
+
+  if (list.isParameter("nx")) {
+    if (list.isType<int>("nx"))
+      nx = Teuchos::as<GlobalOrdinal>(list.get<int>("nx"));
+    else
+      nx = list.get<GlobalOrdinal>("nx");
+  }
+  if (list.isParameter("ny")) {
+    if (list.isType<int>("ny"))
+      ny = Teuchos::as<GlobalOrdinal>(list.get<int>("ny"));
+    else
+      ny = list.get<GlobalOrdinal>("ny");
+  }
+  if (list.isParameter("nz")) {
+    if (list.isType<int>("nz"))
+      nz = Teuchos::as<GlobalOrdinal>(list.get<int>("nz"));
+    else
+      nz = list.get<GlobalOrdinal>("nz");
+  }
+
+  if (nx == -1 || ny == -1 || nz == -1) {
+    GlobalOrdinal n = this->Map_->getGlobalNumElements();
+    nx              = (GlobalOrdinal)Teuchos::ScalarTraits<double>::pow(n, 0.33334);
+    ny              = nx;
+    nz              = nx;
+    TEUCHOS_TEST_FOR_EXCEPTION(nx * ny * nz != n, std::logic_error, "You need to specify nx, ny, and nz");
+  }
+  Scalar S111 = -1.0, S211 = -1.0, S311 = -1.0;
+  Scalar S121 = -1.0, S221 = -1.0, S321 = -1.0;
+  Scalar S131 = -1.0, S231 = -1.0, S331 = -1.0;
+  Scalar S112 = -1.0, S212 = -1.0, S312 = -1.0;
+  Scalar S122 = -1.0, S222 = 26.0, S322 = -1.0;
+  Scalar S132 = -1.0, S232 = -1.0, S332 = -1.0;
+  Scalar S113 = -1.0, S213 = -1.0, S313 = -1.0;
+  Scalar S123 = -1.0, S223 = -1.0, S323 = -1.0;
+  Scalar S133 = -1.0, S233 = -1.0, S333 = -1.0;
+
+  // 27-pt stencil given by
+  //
+  //            ^    S131  S231 S331
+  //     z=-1   |y   S121  S221 S321
+  //            |    S111  S211 S311
+  //                 ----- x ------>
+  //
+  //            ^    S132  S232 S332
+  //     z= 0   |y   S122  S222 S322
+  //            |    S112  S212 S312
+  //                 ----- x ------>
+  //
+  //            ^    S133  S233 S333
+  //     z=+1   |y   S123  S223 S323
+  //            |    S113  S213 S313
+  //                 ----- x ------>
+  //
+  if ((list.isParameter("S111")) && (list.isType<Scalar>("S111"))) S111 = list.get("S111", -1);
+  if ((list.isParameter("S112")) && (list.isType<Scalar>("S112"))) S112 = list.get("S112", -1);
+  if ((list.isParameter("S113")) && (list.isType<Scalar>("S113"))) S113 = list.get("S113", -1);
+  if ((list.isParameter("S121")) && (list.isType<Scalar>("S121"))) S121 = list.get("S121", -1);
+  if ((list.isParameter("S122")) && (list.isType<Scalar>("S122"))) S122 = list.get("S122", -1);
+  if ((list.isParameter("S123")) && (list.isType<Scalar>("S123"))) S123 = list.get("S123", -1);
+  if ((list.isParameter("S131")) && (list.isType<Scalar>("S131"))) S131 = list.get("S131", -1);
+  if ((list.isParameter("S132")) && (list.isType<Scalar>("S132"))) S132 = list.get("S132", -1);
+  if ((list.isParameter("S133")) && (list.isType<Scalar>("S133"))) S133 = list.get("S133", -1);
+
+  if ((list.isParameter("S211")) && (list.isType<Scalar>("S211"))) S211 = list.get("S211", -1);
+  if ((list.isParameter("S212")) && (list.isType<Scalar>("S212"))) S212 = list.get("S212", -1);
+  if ((list.isParameter("S213")) && (list.isType<Scalar>("S213"))) S213 = list.get("S213", -1);
+  if ((list.isParameter("S221")) && (list.isType<Scalar>("S221"))) S221 = list.get("S221", -1);
+  if ((list.isParameter("S222")) && (list.isType<Scalar>("S222"))) S222 = list.get("S222", 26.0);
+  if ((list.isParameter("S223")) && (list.isType<Scalar>("S223"))) S223 = list.get("S223", -1);
+  if ((list.isParameter("S231")) && (list.isType<Scalar>("S231"))) S231 = list.get("S231", -1);
+  if ((list.isParameter("S232")) && (list.isType<Scalar>("S232"))) S232 = list.get("S232", -1);
+  if ((list.isParameter("S233")) && (list.isType<Scalar>("S233"))) S233 = list.get("S233", -1);
+
+  if ((list.isParameter("S311")) && (list.isType<Scalar>("S311"))) S311 = list.get("S311", -1);
+  if ((list.isParameter("S312")) && (list.isType<Scalar>("S312"))) S312 = list.get("S312", -1);
+  if ((list.isParameter("S313")) && (list.isType<Scalar>("S313"))) S313 = list.get("S313", -1);
+  if ((list.isParameter("S321")) && (list.isType<Scalar>("S321"))) S321 = list.get("S321", -1);
+  if ((list.isParameter("S322")) && (list.isType<Scalar>("S322"))) S322 = list.get("S322", -1);
+  if ((list.isParameter("S323")) && (list.isType<Scalar>("S323"))) S323 = list.get("S323", -1);
+  if ((list.isParameter("S331")) && (list.isType<Scalar>("S331"))) S331 = list.get("S331", -1);
+  if ((list.isParameter("S332")) && (list.isType<Scalar>("S332"))) S332 = list.get("S332", -1);
+  if ((list.isParameter("S333")) && (list.isType<Scalar>("S333"))) S333 = list.get("S333", -1);
+
+  bool keepBCs = this->list_.get("keepBCs", false);
+
+  this->A_ = Scalar3D_27Pt<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix>(this->Map_, nx, ny, nz,
+                                                                             S111, S211, S311, S121, S221, S321, S131, S231, S331,
+                                                                             S112, S212, S312, S122, S222, S322, S132, S232, S332,
+                                                                             S113, S213, S313, S123, S223, S323, S133, S233, S333,
+                                                                             this->DirichletBC_, keepBCs, "3D 27 point stencil", false);
+  this->A_->setObjectLabel(this->getObjectLabel());
+  return this->A_;
+}
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
+Teuchos::RCP<typename Problem<Map, Matrix, MultiVector>::RealValuedMultiVector> Scalar3D_27PtProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>::BuildCoords() {
+  Teuchos::ParameterList list = this->list_;
+  this->Coords_               = Utils::CreateCartesianCoordinates<typename RealValuedMultiVector::scalar_type, LocalOrdinal, GlobalOrdinal, Map, RealValuedMultiVector>("3D", this->Map_, this->list_);
+
+  return this->Coords_;
+}
+
+// =============================================  HexFEM_LapStiff =============================================
+
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
+HexFEM_LapStiffProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>::HexFEM_LapStiffProblem(Teuchos::ParameterList& list, const Teuchos::RCP<const Map>& map)
+  : ScalarProblem<Map, Matrix, MultiVector>(list, map) {}
+
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
+Teuchos::RCP<Matrix> HexFEM_LapStiffProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>::BuildMatrix() {
+  Teuchos::ParameterList list = this->list_;
+  GlobalOrdinal nx            = -1;
+  GlobalOrdinal ny            = -1;
+  GlobalOrdinal nz            = -1;
+
+  if (list.isParameter("nx")) {
+    if (list.isType<int>("nx"))
+      nx = Teuchos::as<GlobalOrdinal>(list.get<int>("nx"));
+    else
+      nx = list.get<GlobalOrdinal>("nx");
+  }
+  if (list.isParameter("ny")) {
+    if (list.isType<int>("ny"))
+      ny = Teuchos::as<GlobalOrdinal>(list.get<int>("ny"));
+    else
+      ny = list.get<GlobalOrdinal>("ny");
+  }
+  if (list.isParameter("nz")) {
+    if (list.isType<int>("nz"))
+      nz = Teuchos::as<GlobalOrdinal>(list.get<int>("nz"));
+    else
+      nz = list.get<GlobalOrdinal>("nz");
+  }
+
+  if (nx == -1 || ny == -1 || nz == -1) {
+    GlobalOrdinal n = this->Map_->getGlobalNumElements();
+    nx              = (GlobalOrdinal)Teuchos::ScalarTraits<double>::pow(n, 0.33334);
+    ny              = nx;
+    nz              = nx;
+    TEUCHOS_TEST_FOR_EXCEPTION(nx * ny * nz != n, std::logic_error, "You need to specify nx, ny, and nz");
+  }
+  Scalar one      = Teuchos::ScalarTraits<Scalar>::one();
+  Scalar stretchx = (Scalar)this->list_.get("stretchx", one);
+  Scalar stretchy = (Scalar)this->list_.get("stretchy", one);
+  Scalar stretchz = (Scalar)this->list_.get("stretchz", one);
+  Scalar lx       = (Scalar)this->list_.get("lx", one);
+  Scalar ly       = (Scalar)this->list_.get("ly", one);
+  Scalar lz       = (Scalar)this->list_.get("lz", one);
+  Scalar hx, hy, hz;
+
+  // not sure why in other galeri spots nx+1,ny+1,nz+1 are used. When
+  // coordinates printed, nx-1,ny-1,nz-1 must be used to match coordinates
+  hx = stretchx * lx / (nx - 1);
+  hy = stretchy * ly / (ny - 1);
+  hz = stretchz * lz / (nz - 1);
+
+  // Unassembled stiffness matrix coefficients
+
+  Scalar Sdiag     = (hy * hz) / (9. * hx) + (hx * (hy * hy + hz * hz)) / (9. * hy * hz);  // good
+  Scalar Sxneigh   = (-1. / 9.) * (hy * hz) / hx + (hx * (hy * hy + hz * hz)) / (18. * hy * hz);
+  Scalar Syneigh   = (hx * hy) / (18. * hz) - (hx * hz) / (9. * hy) + (hy * hz) / (18. * hx);  // good
+  Scalar Szneigh   = (-1 / 9.) * (hx * hy) / hz + (hx * hz) / (18. * hy) + (hy * hz) / (18. * hx);
+  Scalar Sxyneigh  = (hx * hy) / (36. * hz) - (hx * hz) / (18. * hy) - (hy * hz) / (18. * hx);  // good
+  Scalar Sxzneigh  = (-1 / 18.) * (hx * hy) / hz + (hx * hz) / (36. * hy) - (hy * hz) / (18. * hx);
+  Scalar Syzneigh  = (hy * hz) / (36. * hx) - (hx * (hy * hy + hz * hz)) / (18. * hy * hz);  // good
+  Scalar Sxyzneigh = (-1 / 36.) * (hy * hz) / hx - (hx * (hy * hy + hz * hz)) / (36. * hy * hz);
+
+  // We assume an interior stencil. So the diagonal entry has 8
+  // contributions, while off-diagonals have either 1, 2, or 4
+  // contributions
+  Scalar S111 = Sxyzneigh, S211 = Syzneigh * 2., S311 = Sxyzneigh;
+  Scalar S121 = Sxzneigh * 2.0, S221 = Szneigh * 4., S321 = Sxzneigh * 2.0;
+  Scalar S131 = Sxyzneigh, S231 = Syzneigh * 2., S331 = Sxyzneigh;
+
+  Scalar S112 = Sxyneigh * 2., S212 = Syneigh * 4., S312 = Sxyneigh * 2.;
+  Scalar S122 = Sxneigh * 4., S222 = Sdiag * 8., S322 = Sxneigh * 4.;
+  Scalar S132 = Sxyneigh * 2., S232 = Syneigh * 4, S332 = Sxyneigh * 2;
+
+  Scalar S113 = Sxyzneigh, S213 = Syzneigh * 2., S313 = Sxyzneigh;
+  Scalar S123 = Sxzneigh * 2.0, S223 = Szneigh * 4., S323 = Sxzneigh * 2.0;
+  Scalar S133 = Sxyzneigh, S233 = Syzneigh * 2., S333 = Sxyzneigh;
+
+  // 27-pt stencil given by
+  //
+  //            ^    S131  S231 S331
+  //     z=-1   |y   S121  S221 S321
+  //            |    S111  S211 S311
+  //                 ----- x ------>
+  //
+  //            ^    S132  S232 S332
+  //     z= 0   |y   S122  S222 S322
+  //            |    S112  S212 S312
+  //                 ----- x ------>
+  //
+  //            ^    S133  S233 S333
+  //     z=+1   |y   S123  S223 S323
+  //            |    S113  S213 S313
+  //                 ----- x ------>
+  //
+
+  bool keepBCs = this->list_.get("keepBCs", false);
+
+  this->A_ = Scalar3D_27Pt<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix>(this->Map_, nx, ny, nz,
+                                                                             S111, S211, S311, S121, S221, S321, S131, S231, S331,
+                                                                             S112, S212, S312, S122, S222, S322, S132, S232, S332,
+                                                                             S113, S213, S313, S123, S223, S323, S133, S233, S333,
+                                                                             this->DirichletBC_, keepBCs, "HexFEM_LapStiff", true);
+  this->A_->setObjectLabel(this->getObjectLabel());
+  return this->A_;
+}
+
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
+Teuchos::RCP<typename Problem<Map, Matrix, MultiVector>::RealValuedMultiVector> HexFEM_LapStiffProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>::BuildCoords() {
+  Teuchos::ParameterList list = this->list_;
+  this->Coords_               = Utils::CreateCartesianCoordinates<typename RealValuedMultiVector::scalar_type, LocalOrdinal, GlobalOrdinal, Map, RealValuedMultiVector>("3D", this->Map_, this->list_);
+
+  return this->Coords_;
+}
+
+// =============================================  HexFEM_Mass =============================================
+
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
+HexFEM_MassProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>::HexFEM_MassProblem(Teuchos::ParameterList& list, const Teuchos::RCP<const Map>& map)
+  : ScalarProblem<Map, Matrix, MultiVector>(list, map) {}
+
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
+Teuchos::RCP<Matrix> HexFEM_MassProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>::BuildMatrix() {
+  Teuchos::ParameterList list = this->list_;
+  GlobalOrdinal nx            = -1;
+  GlobalOrdinal ny            = -1;
+  GlobalOrdinal nz            = -1;
+
+  if (list.isParameter("nx")) {
+    if (list.isType<int>("nx"))
+      nx = Teuchos::as<GlobalOrdinal>(list.get<int>("nx"));
+    else
+      nx = list.get<GlobalOrdinal>("nx");
+  }
+  if (list.isParameter("ny")) {
+    if (list.isType<int>("ny"))
+      ny = Teuchos::as<GlobalOrdinal>(list.get<int>("ny"));
+    else
+      ny = list.get<GlobalOrdinal>("ny");
+  }
+  if (list.isParameter("nz")) {
+    if (list.isType<int>("nz"))
+      nz = Teuchos::as<GlobalOrdinal>(list.get<int>("nz"));
+    else
+      nz = list.get<GlobalOrdinal>("nz");
+  }
+
+  if (nx == -1 || ny == -1 || nz == -1) {
+    GlobalOrdinal n = this->Map_->getGlobalNumElements();
+    nx              = (GlobalOrdinal)Teuchos::ScalarTraits<double>::pow(n, 0.33334);
+    ny              = nx;
+    nz              = nx;
+    TEUCHOS_TEST_FOR_EXCEPTION(nx * ny * nz != n, std::logic_error, "You need to specify nx, ny, and nz");
+  }
+  Scalar M111 = 1.0, M211 = 4.0, M311 = 1.0;
+  Scalar M121 = 4.0, M221 = 16.0, M321 = 4.0;
+  Scalar M131 = 1.0, M231 = 4.0, M331 = 1.0;
+
+  Scalar M112 = 4.0, M212 = 16.0, M312 = 4.0;
+  Scalar M122 = 16.0, M222 = 64.0, M322 = 16.0;
+  Scalar M132 = 4.0, M232 = 16.0, M332 = 4.0;
+
+  Scalar M113 = 1.0, M213 = 4.0, M313 = 1.0;
+  Scalar M123 = 4.0, M223 = 16.0, M323 = 4.0;
+  Scalar M133 = 1.0, M233 = 4.0, M333 = 1.0;
+
+  // 27-pt stencil given by
+  //
+  //            ^    M131  M231 M331
+  //     z=-1   |y   M121  M221 M321
+  //            |    M111  M211 M311
+  //                 ----- x ------>
+  //
+  //            ^    M132  M232 M332
+  //     z= 0   |y   M122  M222 M322
+  //            |    M112  M212 M312
+  //                 ----- x ------>
+  //
+  //            ^    M133  M233 M333
+  //     z=+1   |y   M123  M223 M323
+  //            |    M113  M213 M313
+  //                 ----- x ------>
+  //
+
+  bool keepBCs = this->list_.get("keepBCs", false);
+
+  this->A_ = Scalar3D_27Pt<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix>(this->Map_, nx, ny, nz,
+                                                                             M111, M211, M311, M121, M221, M321, M131, M231, M331,
+                                                                             M112, M212, M312, M122, M222, M322, M132, M232, M332,
+                                                                             M113, M213, M313, M123, M223, M323, M133, M233, M333,
+                                                                             this->DirichletBC_, keepBCs, "HexFEM_Mass", true);
+  this->A_->setObjectLabel(this->getObjectLabel());
+  return this->A_;
+}
+
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
+Teuchos::RCP<typename Problem<Map, Matrix, MultiVector>::RealValuedMultiVector> HexFEM_MassProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>::BuildCoords() {
+  Teuchos::ParameterList list = this->list_;
+  this->Coords_               = Utils::CreateCartesianCoordinates<typename RealValuedMultiVector::scalar_type, LocalOrdinal, GlobalOrdinal, Map, RealValuedMultiVector>("3D", this->Map_, this->list_);
+
+  return this->Coords_;
+}
+
 // =============================================  Identity  =============================================
 
 template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
@@ -626,6 +945,9 @@ Teuchos::RCP<Matrix> Recirc2DProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, M
   template class Galeri::Xpetra::Star2DProblem<S, LO, GO, Tpetra::Map<LO, GO, N>, Tpetra::CrsMatrix<S, LO, GO, N>, Tpetra::MultiVector<S, LO, GO, N>>;                 \
   template class Galeri::Xpetra::BigStar2DProblem<S, LO, GO, Tpetra::Map<LO, GO, N>, Tpetra::CrsMatrix<S, LO, GO, N>, Tpetra::MultiVector<S, LO, GO, N>>;              \
   template class Galeri::Xpetra::Brick3DProblem<S, LO, GO, Tpetra::Map<LO, GO, N>, Tpetra::CrsMatrix<S, LO, GO, N>, Tpetra::MultiVector<S, LO, GO, N>>;                \
+  template class Galeri::Xpetra::Scalar3D_27PtProblem<S, LO, GO, Tpetra::Map<LO, GO, N>, Tpetra::CrsMatrix<S, LO, GO, N>, Tpetra::MultiVector<S, LO, GO, N>>;          \
+  template class Galeri::Xpetra::HexFEM_LapStiffProblem<S, LO, GO, Tpetra::Map<LO, GO, N>, Tpetra::CrsMatrix<S, LO, GO, N>, Tpetra::MultiVector<S, LO, GO, N>>;        \
+  template class Galeri::Xpetra::HexFEM_MassProblem<S, LO, GO, Tpetra::Map<LO, GO, N>, Tpetra::CrsMatrix<S, LO, GO, N>, Tpetra::MultiVector<S, LO, GO, N>>;            \
   template class Galeri::Xpetra::IdentityProblem<S, LO, GO, Tpetra::Map<LO, GO, N>, Tpetra::CrsMatrix<S, LO, GO, N>, Tpetra::MultiVector<S, LO, GO, N>>;               \
   template class Galeri::Xpetra::Recirc2DProblem<S, LO, GO, Tpetra::Map<LO, GO, N>, Tpetra::CrsMatrix<S, LO, GO, N>, Tpetra::MultiVector<S, LO, GO, N>>;
 
@@ -638,6 +960,9 @@ Teuchos::RCP<Matrix> Recirc2DProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, M
   template class Galeri::Xpetra::Star2DProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::CrsMatrixWrap<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;                   \
   template class Galeri::Xpetra::BigStar2DProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::CrsMatrixWrap<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;                \
   template class Galeri::Xpetra::Brick3DProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::CrsMatrixWrap<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;                  \
+  template class Galeri::Xpetra::Scalar3D_27PtProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::CrsMatrixWrap<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;            \
+  template class Galeri::Xpetra::HexFEM_LapStiffProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::CrsMatrixWrap<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;          \
+  template class Galeri::Xpetra::HexFEM_MassProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::CrsMatrixWrap<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;              \
   template class Galeri::Xpetra::IdentityProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::CrsMatrixWrap<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;                 \
   template class Galeri::Xpetra::Recirc2DProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::CrsMatrixWrap<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;                 \
                                                                                                                                                                              \
@@ -649,6 +974,9 @@ Teuchos::RCP<Matrix> Recirc2DProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, M
   template class Galeri::Xpetra::Star2DProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::TpetraCrsMatrix<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;                 \
   template class Galeri::Xpetra::BigStar2DProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::TpetraCrsMatrix<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;              \
   template class Galeri::Xpetra::Brick3DProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::TpetraCrsMatrix<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;                \
+  template class Galeri::Xpetra::Scalar3D_27PtProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::TpetraCrsMatrix<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;          \
+  template class Galeri::Xpetra::HexFEM_LapStiffProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::TpetraCrsMatrix<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;        \
+  template class Galeri::Xpetra::HexFEM_MassProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::TpetraCrsMatrix<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;            \
   template class Galeri::Xpetra::IdentityProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::TpetraCrsMatrix<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;               \
   template class Galeri::Xpetra::Recirc2DProblem<S, LO, GO, Xpetra::Map<LO, GO, N>, Xpetra::TpetraCrsMatrix<S, LO, GO, N>, Xpetra::MultiVector<S, LO, GO, N>>;
 

--- a/packages/galeri/src/Galeri_StencilProblems_def.hpp
+++ b/packages/galeri/src/Galeri_StencilProblems_def.hpp
@@ -724,17 +724,37 @@ Teuchos::RCP<Matrix> HexFEM_MassProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map
     nz              = nx;
     TEUCHOS_TEST_FOR_EXCEPTION(nx * ny * nz != n, std::logic_error, "You need to specify nx, ny, and nz");
   }
-  Scalar M111 = 1.0, M211 = 4.0, M311 = 1.0;
-  Scalar M121 = 4.0, M221 = 16.0, M321 = 4.0;
-  Scalar M131 = 1.0, M231 = 4.0, M331 = 1.0;
+  // compute mesh spacing
+  Scalar one      = Teuchos::ScalarTraits<Scalar>::one();
+  Scalar stretchx = (Scalar)this->list_.get("stretchx", one);
+  Scalar stretchy = (Scalar)this->list_.get("stretchy", one);
+  Scalar stretchz = (Scalar)this->list_.get("stretchz", one);
+  Scalar lx       = (Scalar)this->list_.get("lx", one);
+  Scalar ly       = (Scalar)this->list_.get("ly", one);
+  Scalar lz       = (Scalar)this->list_.get("lz", one);
+  Scalar hx, hy, hz;
 
-  Scalar M112 = 4.0, M212 = 16.0, M312 = 4.0;
-  Scalar M122 = 16.0, M222 = 64.0, M322 = 16.0;
-  Scalar M132 = 4.0, M232 = 16.0, M332 = 4.0;
+  // not sure why in other galeri spots nx+1,ny+1,nz+1 are used. When
+  // coordinates printed, nx-1,ny-1,nz-1 must be used to match coordinates
+  hx = stretchx * lx / ((Scalar)(nx - 1));
+  hy = stretchy * ly / ((Scalar)(ny - 1));
+  hz = stretchz * lz / ((Scalar)(nz - 1));
 
-  Scalar M113 = 1.0, M213 = 4.0, M313 = 1.0;
-  Scalar M123 = 4.0, M223 = 16.0, M323 = 4.0;
-  Scalar M133 = 1.0, M233 = 4.0, M333 = 1.0;
+  std::cout << "mesh spacing is " << hx << "   " << hy << "   " << hz << std::endl;
+
+  Scalar alpha = hx * hy * hz / 216.;
+
+  Scalar M111 = alpha * 1.0, M211 = alpha * 4.0, M311 = alpha * 1.0;
+  Scalar M121 = alpha * 4.0, M221 = alpha * 16.0, M321 = alpha * 4.0;
+  Scalar M131 = alpha * 1.0, M231 = alpha * 4.0, M331 = alpha * 1.0;
+
+  Scalar M112 = alpha * 4.0, M212 = alpha * 16.0, M312 = alpha * 4.0;
+  Scalar M122 = alpha * 16.0, M222 = alpha * 64.0, M322 = alpha * 16.0;
+  Scalar M132 = alpha * 4.0, M232 = alpha * 16.0, M332 = alpha * 4.0;
+
+  Scalar M113 = alpha * 1.0, M213 = alpha * 4.0, M313 = alpha * 1.0;
+  Scalar M123 = alpha * 4.0, M223 = alpha * 16.0, M323 = alpha * 4.0;
+  Scalar M133 = alpha * 1.0, M233 = alpha * 4.0, M333 = alpha * 1.0;
 
   // 27-pt stencil given by
   //

--- a/packages/galeri/src/Galeri_StencilProblems_def.hpp
+++ b/packages/galeri/src/Galeri_StencilProblems_def.hpp
@@ -618,19 +618,19 @@ Teuchos::RCP<Matrix> HexFEM_LapStiffProblem<Scalar, LocalOrdinal, GlobalOrdinal,
 
   // not sure why in other galeri spots nx+1,ny+1,nz+1 are used. When
   // coordinates printed, nx-1,ny-1,nz-1 must be used to match coordinates
-  hx = stretchx * lx / (nx - 1);
-  hy = stretchy * ly / (ny - 1);
-  hz = stretchz * lz / (nz - 1);
+  hx = stretchx * lx / ((Scalar)(nx - 1));
+  hy = stretchy * ly / ( (Scalar) (ny - 1);
+  hz = stretchz * lz / ( (Scalar) (nz - 1);
 
   // Unassembled stiffness matrix coefficients
 
-  Scalar Sdiag     = (hy * hz) / (9. * hx) + (hx * (hy * hy + hz * hz)) / (9. * hy * hz);  // good
+  Scalar Sdiag     = (hy * hz) / (9. * hx) + (hx * (hy * hy + hz * hz)) / (9. * hy * hz);
   Scalar Sxneigh   = (-1. / 9.) * (hy * hz) / hx + (hx * (hy * hy + hz * hz)) / (18. * hy * hz);
-  Scalar Syneigh   = (hx * hy) / (18. * hz) - (hx * hz) / (9. * hy) + (hy * hz) / (18. * hx);  // good
+  Scalar Syneigh   = (hx * hy) / (18. * hz) - (hx * hz) / (9. * hy) + (hy * hz) / (18. * hx);
   Scalar Szneigh   = (-1 / 9.) * (hx * hy) / hz + (hx * hz) / (18. * hy) + (hy * hz) / (18. * hx);
-  Scalar Sxyneigh  = (hx * hy) / (36. * hz) - (hx * hz) / (18. * hy) - (hy * hz) / (18. * hx);  // good
+  Scalar Sxyneigh  = (hx * hy) / (36. * hz) - (hx * hz) / (18. * hy) - (hy * hz) / (18. * hx);
   Scalar Sxzneigh  = (-1 / 18.) * (hx * hy) / hz + (hx * hz) / (36. * hy) - (hy * hz) / (18. * hx);
-  Scalar Syzneigh  = (hy * hz) / (36. * hx) - (hx * (hy * hy + hz * hz)) / (18. * hy * hz);  // good
+  Scalar Syzneigh  = (hy * hz) / (36. * hx) - (hx * (hy * hy + hz * hz)) / (18. * hy * hz);
   Scalar Sxyzneigh = (-1 / 36.) * (hy * hz) / hx - (hx * (hy * hy + hz * hz)) / (36. * hy * hz);
 
   // We assume an interior stencil. So the diagonal entry has 8
@@ -642,7 +642,7 @@ Teuchos::RCP<Matrix> HexFEM_LapStiffProblem<Scalar, LocalOrdinal, GlobalOrdinal,
 
   Scalar S112 = Sxyneigh * 2., S212 = Syneigh * 4., S312 = Sxyneigh * 2.;
   Scalar S122 = Sxneigh * 4., S222 = Sdiag * 8., S322 = Sxneigh * 4.;
-  Scalar S132 = Sxyneigh * 2., S232 = Syneigh * 4, S332 = Sxyneigh * 2;
+  Scalar S132 = Sxyneigh * 2., S232 = Syneigh * 4., S332 = Sxyneigh * 2.;
 
   Scalar S113 = Sxyzneigh, S213 = Syzneigh * 2., S313 = Sxyzneigh;
   Scalar S123 = Sxzneigh * 2.0, S223 = Szneigh * 4., S323 = Sxzneigh * 2.0;

--- a/packages/galeri/src/Galeri_StencilProblems_def.hpp
+++ b/packages/galeri/src/Galeri_StencilProblems_def.hpp
@@ -619,8 +619,8 @@ Teuchos::RCP<Matrix> HexFEM_LapStiffProblem<Scalar, LocalOrdinal, GlobalOrdinal,
   // not sure why in other galeri spots nx+1,ny+1,nz+1 are used. When
   // coordinates printed, nx-1,ny-1,nz-1 must be used to match coordinates
   hx = stretchx * lx / ((Scalar)(nx - 1));
-  hy = stretchy * ly / ( (Scalar) (ny - 1);
-  hz = stretchz * lz / ( (Scalar) (nz - 1);
+  hy = stretchy * ly / ((Scalar)(ny - 1));
+  hz = stretchz * lz / ((Scalar)(nz - 1));
 
   // Unassembled stiffness matrix coefficients
 

--- a/packages/galeri/src/Galeri_StencilProblems_def.hpp
+++ b/packages/galeri/src/Galeri_StencilProblems_def.hpp
@@ -740,8 +740,6 @@ Teuchos::RCP<Matrix> HexFEM_MassProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map
   hy = stretchy * ly / ((Scalar)(ny - 1));
   hz = stretchz * lz / ((Scalar)(nz - 1));
 
-  std::cout << "mesh spacing is " << hx << "   " << hy << "   " << hz << std::endl;
-
   Scalar alpha = hx * hy * hz / 216.;
 
   Scalar M111 = alpha * 1.0, M211 = alpha * 4.0, M311 = alpha * 1.0;

--- a/packages/galeri/src/Galeri_XpetraMatrixTypes.hpp
+++ b/packages/galeri/src/Galeri_XpetraMatrixTypes.hpp
@@ -781,6 +781,331 @@ class Brick3DStencil {
   }
 };
 
+template <class Scalar, class Map, bool keepBCs, bool scaleNeumBCstencil>
+class Scalar3D_27PtStencil {
+  //  low z plane      mid z plane      high z plane
+  // S111 S211 S311   S112 S212 S312   S113 S213 S313   low y
+  // S121 S221 S321   S122 S222 S322   S123 S223 S323
+  // S131 S231 S331   S132 S232 S332   S133 S233 S333   high y
+  // x-->             x-->             x-->
+
+  using ATS               = KokkosKernels::ArithTraits<Scalar>;
+  using impl_scalar_type  = typename ATS::val_type;
+  using LocalOrdinal      = typename Map::local_ordinal_type;
+  using GlobalOrdinal     = typename Map::global_ordinal_type;
+  using Node              = typename Map::node_type;
+  using local_map_type    = typename Map::local_map_type;
+  using local_matrix_type = typename ::Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::local_matrix_type;
+  using rowptr_type       = typename local_matrix_type::row_map_type::non_const_type;
+  using colidx_type       = typename local_matrix_type::index_type::non_const_type;
+  using values_type       = typename local_matrix_type::values_type::non_const_type;
+  using exec_space        = typename Node::execution_space;
+  using memory_space      = typename Node::memory_space;
+  using hashmap_type      = typename Kokkos::UnorderedMap<GlobalOrdinal, void, exec_space>;
+  using StencilIndices    = GlobalOrdinal[3][3][3];
+
+  GlobalOrdinal nx = -1, ny = -1, nz = -1;
+  impl_scalar_type S111, S211, S311, S121, S221, S321, S131, S231, S331,
+      S112, S212, S312, S122, S222, S322, S132, S232, S332,
+      S113, S213, S313, S123, S223, S323, S133, S233, S333;
+  DirBC DirichletBC;
+  local_map_type lclMap;
+
+  const impl_scalar_type one  = KokkosKernels::ArithTraits<impl_scalar_type>::one();
+  const impl_scalar_type zero = KokkosKernels::ArithTraits<impl_scalar_type>::zero();
+  GlobalOrdinal INVALID;
+
+  Kokkos::View<impl_scalar_type[3][3][3], memory_space> stencil_entries;
+
+  const size_t LOW  = 0;
+  const size_t MID  = 1;
+  const size_t HIGH = 2;
+
+ public:
+  hashmap_type off_rank_indices;
+  local_map_type lclColMap;
+  colidx_type colidx;
+  values_type values;
+
+  Scalar3D_27PtStencil(const Map& map, GlobalOrdinal nx_, GlobalOrdinal ny_, GlobalOrdinal nz_,
+                       Scalar S111_, Scalar S211_, Scalar S311_,
+                       Scalar S121_, Scalar S221_, Scalar S321_,
+                       Scalar S131_, Scalar S231_, Scalar S331_,
+                       Scalar S112_, Scalar S212_, Scalar S312_,
+                       Scalar S122_, Scalar S222_, Scalar S322_,
+                       Scalar S132_, Scalar S232_, Scalar S332_,
+                       Scalar S113_, Scalar S213_, Scalar S313_,
+                       Scalar S123_, Scalar S223_, Scalar S323_,
+                       Scalar S133_, Scalar S233_, Scalar S333_, DirBC DirichletBC_)
+    : nx(nx_)
+    , ny(ny_)
+    , nz(nz_)
+    , S111(S111_)
+    , S211(S211_)
+    , S311(S311_)
+    , S121(S121_)
+    , S221(S221_)
+    , S321(S321_)
+    , S131(S131_)
+    , S231(S231_)
+    , S331(S331_)
+    , S112(S112_)
+    , S212(S212_)
+    , S312(S312_)
+    , S122(S122_)
+    , S222(S222_)
+    , S322(S322_)
+    , S132(S132_)
+    , S232(S232_)
+    , S332(S332_)
+    , S113(S113_)
+    , S213(S213_)
+    , S313(S313_)
+    , S123(S123_)
+    , S223(S223_)
+    , S323(S323_)
+    , S133(S133_)
+    , S233(S233_)
+    , S333(S333_)
+    , DirichletBC(DirichletBC_) {
+    lclMap  = map.getLocalMap();
+    INVALID = Teuchos::OrdinalTraits<GlobalOrdinal>::invalid();
+
+    stencil_entries        = Kokkos::View<impl_scalar_type[3][3][3], memory_space>("stencil_entries");
+    auto stencil_entries_h = Kokkos::create_mirror_view(stencil_entries);
+
+    // left plane
+    stencil_entries_h(LOW, LOW, LOW)   = S111;
+    stencil_entries_h(LOW, LOW, MID)   = S112;
+    stencil_entries_h(LOW, LOW, HIGH)  = S113;
+    stencil_entries_h(LOW, MID, LOW)   = S121;
+    stencil_entries_h(LOW, MID, MID)   = S122;
+    stencil_entries_h(LOW, MID, HIGH)  = S123;
+    stencil_entries_h(LOW, HIGH, LOW)  = S131;
+    stencil_entries_h(LOW, HIGH, MID)  = S132;
+    stencil_entries_h(LOW, HIGH, HIGH) = S133;
+
+    // middle plane
+    stencil_entries_h(MID, LOW, LOW)   = S211;
+    stencil_entries_h(MID, LOW, MID)   = S212;
+    stencil_entries_h(MID, LOW, HIGH)  = S213;
+    stencil_entries_h(MID, MID, LOW)   = S221;
+    stencil_entries_h(MID, MID, MID)   = S222;
+    stencil_entries_h(MID, MID, HIGH)  = S223;
+    stencil_entries_h(MID, HIGH, LOW)  = S231;
+    stencil_entries_h(MID, HIGH, MID)  = S232;
+    stencil_entries_h(MID, HIGH, HIGH) = S233;
+
+    // right plane
+    stencil_entries_h(HIGH, LOW, LOW)   = S311;
+    stencil_entries_h(HIGH, LOW, MID)   = S312;
+    stencil_entries_h(HIGH, LOW, HIGH)  = S313;
+    stencil_entries_h(HIGH, MID, LOW)   = S321;
+    stencil_entries_h(HIGH, MID, MID)   = S322;
+    stencil_entries_h(HIGH, MID, HIGH)  = S323;
+    stencil_entries_h(HIGH, HIGH, LOW)  = S331;
+    stencil_entries_h(HIGH, HIGH, MID)  = S332;
+    stencil_entries_h(HIGH, HIGH, HIGH) = S333;
+
+    Kokkos::deep_copy(stencil_entries, stencil_entries_h);
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  void GetNeighbours(const GlobalOrdinal i,
+                     StencilIndices stencil_indices,
+                     bool& isDirichlet) const {
+    GlobalOrdinal low_x, low_y, low_z, high_x, high_y, high_z;
+
+    // still using this function as opposed to just computing this directly
+    GetNeighboursCartesian3dKokkos(i, nx, ny, nz, low_x, high_x, low_y, high_y, low_z, high_z, INVALID);
+
+    stencil_indices[0][0][0] = low_z - nx - 1;
+    stencil_indices[1][0][0] = low_z - nx;
+    stencil_indices[2][0][0] = low_z - nx + 1;
+    stencil_indices[0][1][0] = low_z - 1;
+    stencil_indices[1][1][0] = low_z;
+    stencil_indices[2][1][0] = low_z + 1;
+    stencil_indices[0][2][0] = low_z + nx - 1;
+    stencil_indices[1][2][0] = low_z + nx;
+    stencil_indices[2][2][0] = low_z + nx + 1;
+
+    stencil_indices[0][0][1] = i - nx - 1;
+    stencil_indices[1][0][1] = i - nx;
+    stencil_indices[2][0][1] = i - nx + 1;
+    stencil_indices[0][1][1] = i - 1;
+    stencil_indices[1][1][1] = i;
+    stencil_indices[2][1][1] = i + 1;
+    stencil_indices[0][2][1] = i + nx - 1;
+    stencil_indices[1][2][1] = i + nx;
+    stencil_indices[2][2][1] = i + nx + 1;
+
+    stencil_indices[0][0][2] = high_z - nx - 1;
+    stencil_indices[1][0][2] = high_z - nx;
+    stencil_indices[2][0][2] = high_z - nx + 1;
+    stencil_indices[0][1][2] = high_z - 1;
+    stencil_indices[1][1][2] = high_z;
+    stencil_indices[2][1][2] = high_z + 1;
+    stencil_indices[0][2][2] = high_z + nx - 1;
+    stencil_indices[1][2][2] = high_z + nx;
+    stencil_indices[2][2][2] = high_z + nx + 1;
+
+    // remove stencil entries that cross over boundary
+
+    if (low_z == INVALID) {
+      for (size_t k0 = 0; k0 < 3; ++k0)
+        for (size_t k1 = 0; k1 < 3; ++k1)
+          stencil_indices[k0][k1][0] = INVALID;
+    }
+    if (high_z == INVALID) {
+      for (size_t k0 = 0; k0 < 3; ++k0)
+        for (size_t k1 = 0; k1 < 3; ++k1)
+          stencil_indices[k0][k1][2] = INVALID;
+    }
+    if (low_y == INVALID) {
+      for (size_t k0 = 0; k0 < 3; ++k0)
+        for (size_t k2 = 0; k2 < 3; ++k2)
+          stencil_indices[k0][0][k2] = INVALID;
+    }
+    if (high_y == INVALID) {
+      for (size_t k0 = 0; k0 < 3; ++k0)
+        for (size_t k2 = 0; k2 < 3; ++k2)
+          stencil_indices[k0][2][k2] = INVALID;
+    }
+    if (low_x == INVALID) {
+      for (size_t k1 = 0; k1 < 3; ++k1)
+        for (size_t k2 = 0; k2 < 3; ++k2)
+          stencil_indices[0][k1][k2] = INVALID;
+    }
+    if (high_x == INVALID) {
+      for (size_t k1 = 0; k1 < 3; ++k1)
+        for (size_t k2 = 0; k2 < 3; ++k2)
+          stencil_indices[2][k1][k2] = INVALID;
+    }
+
+    // keeping the original LEFT,RIGHT,BOTTOM ... notation
+    isDirichlet = (low_x == INVALID && (DirichletBC & DIR_LEFT)) ||
+                  (high_x == INVALID && (DirichletBC & DIR_RIGHT)) ||
+                  (low_z == INVALID && (DirichletBC & DIR_BOTTOM)) ||
+                  (high_z == INVALID && (DirichletBC & DIR_TOP)) ||
+                  (low_y == INVALID && (DirichletBC & DIR_FRONT)) ||
+                  (high_y == INVALID && (DirichletBC & DIR_BACK));
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  bool IsBoundary(const GlobalOrdinal i) const {
+    GlobalOrdinal ix  = i % nx;
+    GlobalOrdinal ixy = i % (nx * ny);
+    GlobalOrdinal iy  = (ixy - ix) / nx;
+    GlobalOrdinal iz  = (i - ixy) / (nx * ny);
+    return (ix == 0 || ix == nx - 1 || iy == 0 || iy == ny - 1 || iz == 0 || iz == nz - 1);
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  void CountRowNNZ(const GlobalOrdinal i, LocalOrdinal& partial_nnz, const bool is_final) const {
+    GlobalOrdinal center;
+    StencilIndices stencil_indices;
+    bool isDirichlet;
+
+    center = lclMap.getGlobalElement(i);
+    GetNeighbours(center, stencil_indices, isDirichlet);
+
+    if (isDirichlet && keepBCs) {
+      // Dirichlet unknown we want to keep
+      Galeri_processEntry(center);
+    } else {
+      for (size_t k0 = 0; k0 < 3; ++k0)
+        for (size_t k1 = 0; k1 < 3; ++k1)
+          for (size_t k2 = 0; k2 < 3; ++k2)
+            Galeri_processEntry(stencil_indices[k0][k1][k2]);
+    }
+  }
+
+  // This version adjust stencil near Neumman boundaries to match a standard FE code
+  // For interior stencil points, scale factor will be 1. On a Neumann boundary
+  // the scale factor migth be 1, 1/2, 1/4, 1/8 depending on the location of the
+  // off diagonal.
+  KOKKOS_FORCEINLINE_FUNCTION
+  void EnterValues(const LocalOrdinal i, typename rowptr_type::value_type& entryPtr) const {
+    GlobalOrdinal center;
+    StencilIndices stencil_indices;
+    bool isDirichlet;
+    typename rowptr_type::value_type rowStart = entryPtr;
+
+    center = lclMap.getGlobalElement(i);
+    GetNeighbours(center, stencil_indices, isDirichlet);
+    impl_scalar_type offDiagonalSum = zero;
+    if (isDirichlet && keepBCs) {  // just a Dirichlet point
+      // Dirichlet unknown we want to keep
+      Galeri_enterValue(rowStart, center, one);
+    } else if (!isDirichlet && scaleNeumBCstencil) {  // interior or Neum. BC
+      GlobalOrdinal ii, jj, kk, remainder;
+      // compute grid location (ii,jj,kk) corresponding to center
+      ii        = (center % nx);
+      remainder = (center - ii) / nx;
+      jj        = (remainder % ny);
+      kk        = (remainder - jj) / ny;
+
+      for (size_t k0 = 0; k0 < 3; ++k0) {
+        for (size_t k1 = 0; k1 < 3; ++k1) {
+          for (size_t k2 = 0; k2 < 3; ++k2) {
+            // To handle Neum. BCs, we must scale certain stencil
+            // coefficients near the boundary.  The basic idea is to
+            // divide scaleFactor by 2 for each coord direction on boundary
+            impl_scalar_type scaleFactor = one;
+            if (ii == 0) {
+              if (k0 == 0)
+                scaleFactor = zero;
+              else if (k0 == 1)
+                scaleFactor /= 2.;
+            }
+            if (ii == nx - 1) {
+              if (k0 == 2)
+                scaleFactor = zero;
+              else if (k0 == 1)
+                scaleFactor /= 2.;
+            }
+            if (jj == 0) {
+              if (k1 == 0)
+                scaleFactor = zero;
+              else if (k1 == 1)
+                scaleFactor /= 2.;
+            }
+            if (jj == ny - 1) {
+              if (k1 == 2)
+                scaleFactor = zero;
+              else if (k1 == 1)
+                scaleFactor /= 2.;
+            }
+            if (kk == 0) {
+              if (k2 == 0)
+                scaleFactor = zero;
+              else if (k2 == 1)
+                scaleFactor /= 2.;
+            }
+            if (kk == nz - 1) {
+              if (k2 == 2)
+                scaleFactor = zero;
+              else if (k2 == 1)
+                scaleFactor /= 2.;
+            }
+            Galeri_enterValue(rowStart, stencil_indices[k0][k1][k2], (scaleFactor * stencil_entries(k0, k1, k2)));
+          }
+        }
+      }
+    } else {  // Implicitly handled Dirichlet bcs. Truncate stencil for entries that fall over the boundary
+      for (size_t k0 = 0; k0 < 3; ++k0) {
+        for (size_t k1 = 0; k1 < 3; ++k1) {
+          for (size_t k2 = 0; k2 < 3; ++k2) {
+            if ((k0 != MID) || (k1 != MID) || (k2 != MID))
+              Galeri_enterValue(rowStart, stencil_indices[k0][k1][k2], (stencil_entries(k0, k1, k2)));
+          }
+        }
+      }
+      Galeri_enterValue(rowStart, center, (IsBoundary(center) && !isDirichlet) ? -offDiagonalSum : stencil_entries(MID, MID, MID));
+    }
+  }
+};
+
 #undef Galeri_processEntry
 #undef Galeri_enterValue
 
@@ -1427,6 +1752,51 @@ Brick3D(const Teuchos::RCP<const Map>& map,
                                                nx, ny, nz,
                                                a, b, c, d, e, f, g,
                                                DirichletBC);
+    return StencilMatrix<Matrix>(map, stencil, label);
+  }
+}
+
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix>
+Teuchos::RCP<Matrix>
+Scalar3D_27Pt(const Teuchos::RCP<const Map>& map,
+              const GlobalOrdinal nx, const GlobalOrdinal ny, const GlobalOrdinal nz,
+              const Scalar S111, const Scalar S211, const Scalar S311,
+              const Scalar S121, const Scalar S221, const Scalar S321,
+              const Scalar S131, const Scalar S231, const Scalar S331,
+              const Scalar S112, const Scalar S212, const Scalar S312,
+              const Scalar S122, const Scalar S222, const Scalar S322,
+              const Scalar S132, const Scalar S232, const Scalar S332,
+              const Scalar S113, const Scalar S213, const Scalar S313,
+              const Scalar S123, const Scalar S223, const Scalar S323,
+              const Scalar S133, const Scalar S233, const Scalar S333,
+              const DirBC DirichletBC = 0, const bool keepBCs = false, const std::string& label = "Scalar3D_27Pt", bool scaleNeumBCstencil = false) {
+  if ((keepBCs) && (scaleNeumBCstencil)) {
+    Scalar3D_27PtStencil<Scalar, Map, true, true> stencil(*map, nx, ny, nz,
+                                                          S111, S211, S311, S121, S221, S321, S131, S231, S331,
+                                                          S112, S212, S312, S122, S222, S322, S132, S232, S332,
+                                                          S113, S213, S313, S123, S223, S323, S133, S233, S333,
+                                                          DirichletBC);
+    return StencilMatrix<Matrix>(map, stencil, label);
+  } else if ((!keepBCs) && (scaleNeumBCstencil)) {
+    Scalar3D_27PtStencil<Scalar, Map, false, true> stencil(*map, nx, ny, nz,
+                                                           S111, S211, S311, S121, S221, S321, S131, S231, S331,
+                                                           S112, S212, S312, S122, S222, S322, S132, S232, S332,
+                                                           S113, S213, S313, S123, S223, S323, S133, S233, S333,
+                                                           DirichletBC);
+    return StencilMatrix<Matrix>(map, stencil, label);
+  } else if ((keepBCs) && (!scaleNeumBCstencil)) {
+    Scalar3D_27PtStencil<Scalar, Map, true, false> stencil(*map, nx, ny, nz,
+                                                           S111, S211, S311, S121, S221, S321, S131, S231, S331,
+                                                           S112, S212, S312, S122, S222, S322, S132, S232, S332,
+                                                           S113, S213, S313, S123, S223, S323, S133, S233, S333,
+                                                           DirichletBC);
+    return StencilMatrix<Matrix>(map, stencil, label);
+  } else {
+    Scalar3D_27PtStencil<Scalar, Map, false, false> stencil(*map, nx, ny, nz,
+                                                            S111, S211, S311, S121, S221, S321, S131, S231, S331,
+                                                            S112, S212, S312, S122, S222, S322, S132, S232, S332,
+                                                            S113, S213, S313, S123, S223, S323, S133, S233, S333,
+                                                            DirichletBC);
     return StencilMatrix<Matrix>(map, stencil, label);
   }
 }

--- a/packages/galeri/src/Galeri_XpetraMatrixTypes.hpp
+++ b/packages/galeri/src/Galeri_XpetraMatrixTypes.hpp
@@ -1033,8 +1033,8 @@ class Scalar3D_27PtStencil {
 
     center = lclMap.getGlobalElement(i);
     GetNeighbours(center, stencil_indices, isDirichlet);
-    impl_scalar_type offDiagonalSum = zero;
-    if (isDirichlet && keepBCs) {  // just a Dirichlet point
+    impl_scalar_type offDiagonalSum = zero;  // sum accumulated in Galeri_enterValue() macro
+    if (isDirichlet && keepBCs) {            // just a Dirichlet point
       // Dirichlet unknown we want to keep
       Galeri_enterValue(rowStart, center, one);
     } else if (!isDirichlet && scaleNeumBCstencil) {  // interior or Neum. BC

--- a/packages/galeri/src/Galeri_XpetraParameters_decl.hpp
+++ b/packages/galeri/src/Galeri_XpetraParameters_decl.hpp
@@ -34,7 +34,7 @@ class Parameters : public Teuchos::VerboseObject<Parameters<GO> >, public Teucho
              double h = 1.0, double delta = 0.0,
              int PMLXL = 0, int PMLXR = 0, int PMLYL = 0, int PMLYR = 0, int PMLZL = 0, int PMLZR = 0,
              double omega = 2.0 * M_PI, double shift = 0.5, GO mx = -1, GO my = -1, GO mz = -1, int model = 0,
-             double lx = 1., double ly = 1., double conv = 1., double diff = 1.);
+             double lx = 1., double ly = 1., double lz = 1., double conv = 1., double diff = 1.);
 
   GO GetNumGlobalElements() const;
 
@@ -79,6 +79,7 @@ class Parameters : public Teuchos::VerboseObject<Parameters<GO> >, public Teucho
 
   mutable double lx_;
   mutable double ly_;
+  mutable double lz_;
   mutable double conv_;
   mutable double diff_;
 

--- a/packages/galeri/src/Galeri_XpetraParameters_def.hpp
+++ b/packages/galeri/src/Galeri_XpetraParameters_def.hpp
@@ -22,7 +22,7 @@ Parameters<GO>::Parameters(Teuchos::CommandLineProcessor& clp, GO nx, GO ny, GO 
                            double h, double delta,
                            int PMLXL, int PMLXR, int PMLYL, int PMLYR, int PMLZL, int PMLZR,
                            double omega, double shift, GO mx, GO my, GO mz, int model,
-                           double lx, double ly, double conv, double diff)
+                           double lx, double ly, double lz, double conv, double diff)
   : nx_(nx)
   , ny_(ny)
   , nz_(nz)
@@ -52,6 +52,7 @@ Parameters<GO>::Parameters(Teuchos::CommandLineProcessor& clp, GO nx, GO ny, GO 
   , model_(model)
   , lx_(lx)
   , ly_(ly)
+  , lz_(lz)
   , conv_(conv)
   , diff_(diff) {
   clp.setOption("nx", &nx_, "mesh points in x-direction.");
@@ -86,6 +87,7 @@ Parameters<GO>::Parameters(Teuchos::CommandLineProcessor& clp, GO nx, GO ny, GO 
   clp.setOption("model", &model_, "velocity model");
   clp.setOption("lx", &lx_, "length in x-direction");
   clp.setOption("ly", &ly_, "length in y-direction");
+  clp.setOption("lz", &lz_, "length in z-direction");
   clp.setOption("convection", &conv_, "convection coefficient");
   clp.setOption("diffusion", &diff_, "diffusion coefficient");
 }
@@ -124,6 +126,9 @@ GO Parameters<GO>::GetNumGlobalElements() const {
 
   else if (matrixType == "Laplace3D" ||
            matrixType == "Brick3D" ||
+           matrixType == "Scalar3D_27PtSten" ||
+           matrixType == "HexFEM_LapStiff" ||
+           matrixType == "HexFEM_Mass" ||
            matrixType == "BigStar2D" ||
            matrixType == "Elasticity3D" ||
            matrixType == "Helmholtz3D")
@@ -180,6 +185,7 @@ Teuchos::ParameterList& Parameters<GO>::GetParameterList() const {
   paramList_->set("shift", shift_);
   paramList_->set("lx", lx_);
   paramList_->set("ly", ly_);
+  paramList_->set("lz", lz_);
   paramList_->set("convection", conv_);
   paramList_->set("diffusion", diff_);
 

--- a/packages/galeri/src/Galeri_XpetraParameters_def.hpp
+++ b/packages/galeri/src/Galeri_XpetraParameters_def.hpp
@@ -126,7 +126,7 @@ GO Parameters<GO>::GetNumGlobalElements() const {
 
   else if (matrixType == "Laplace3D" ||
            matrixType == "Brick3D" ||
-           matrixType == "Scalar3D_27PtSten" ||
+           matrixType == "Scalar3D_27Pt" ||
            matrixType == "HexFEM_LapStiff" ||
            matrixType == "HexFEM_Mass" ||
            matrixType == "BigStar2D" ||

--- a/packages/galeri/src/Galeri_XpetraProblemFactory.hpp
+++ b/packages/galeri/src/Galeri_XpetraProblemFactory.hpp
@@ -45,6 +45,12 @@ RCP<Problem<Map, Matrix, MultiVector> > BuildProblem(const std::string& MatrixTy
     P.reset(new Laplace3DProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>(list, map));
   else if (MatrixType == "Brick3D")
     P.reset(new Brick3DProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>(list, map));
+  else if (MatrixType == "Scalar3D_27Pt")
+    P.reset(new Scalar3D_27PtProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>(list, map));
+  else if (MatrixType == "HexFEM_LapStiff")
+    P.reset(new HexFEM_LapStiffProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>(list, map));
+  else if (MatrixType == "HexFEM_Mass")
+    P.reset(new HexFEM_MassProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>(list, map));
   else if (MatrixType == "Elasticity2D")
     P.reset(new Elasticity2DProblem<Scalar, LocalOrdinal, GlobalOrdinal, Map, Matrix, MultiVector>(list, map));
   else if (MatrixType == "Elasticity3D")

--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -618,7 +618,7 @@ ENDIF()
 MUELU_ADD_SERIAL_AND_MPI_TEST(
   Driver
   NAME "MinvA"
-  ARGS "--xml=MinvA.xml --its=30 --matrixType=Laplace1D --nx=1000 --tol=1e-6"
+  ARGS "--xml=MinvA.xml --its=30 --matrixType=HexFEM_LapStiff --nx=50 --ny=40 --nz=10   --stretchx=.013 --stretchy=.94 --stretchz=.97  --tol=1e-6 "
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "Belos converged"

--- a/packages/muelu/test/scaling/Driver.cpp
+++ b/packages/muelu/test/scaling/Driver.cpp
@@ -447,7 +447,7 @@ int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib& lib, int ar
   RCP<MultiVector> B;
 
   // Load the matrix off disk (or generate it via Galeri)
-  MatrixLoad<SC, LO, GO, NO>(comm, lib, binaryFormat, matrixFile, rhsFile, rowMapFile, colMapFile, domainMapFile, rangeMapFile, coordFile, coordMapFile, nullFile, materialFile, blockNumberFile, massFile, map, A, coordinates, nullspace, material, blocknumber, mass, X, B, numVectors, galeriParameters, xpetraParameters, galeriStream, repartitionParamList);
+  MatrixLoad<SC, LO, GO, NO>(comm, lib, binaryFormat, matrixFile, rhsFile, rowMapFile, colMapFile, domainMapFile, rangeMapFile, coordFile, coordMapFile, nullFile, materialFile, blockNumberFile, massFile, map, A, coordinates, nullspace, material, blocknumber, mass, X, B, numVectors, galeriParameters, xpetraParameters, galeriStream, repartitionParamList, Teuchos::rcpFromRef(paramList));
   comm->barrier();
   tm = Teuchos::null;
 

--- a/packages/muelu/test/scaling/MatrixLoad.hpp
+++ b/packages/muelu/test/scaling/MatrixLoad.hpp
@@ -92,7 +92,8 @@ void MatrixLoad(Teuchos::RCP<const Teuchos::Comm<int> >& comm, Xpetra::Underlyin
                 const int numVectors,
                 Galeri::Xpetra::Parameters<GlobalOrdinal>& galeriParameters, Xpetra::Parameters& xpetraParameters,
                 std::ostringstream& galeriStream,
-                Teuchos::RCP<Teuchos::ParameterList> repartitionParams = {}) {
+                Teuchos::RCP<Teuchos::ParameterList> repartitionParams = {},
+                Teuchos::RCP<Teuchos::ParameterList> paramList         = {}) {
 #include <MueLu_UseShortNames.hpp>
   using Teuchos::RCP;
   using Teuchos::rcp;
@@ -132,7 +133,7 @@ void MatrixLoad(Teuchos::RCP<const Teuchos::Comm<int> >& comm, Xpetra::Underlyin
       map         = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian2D", comm, galeriList);
       coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<real_type, LO, GO, Map, RealValuedMultiVector>("2D", map, galeriList);
 
-    } else if (matrixType == "Laplace3D" || matrixType == "Brick3D" || matrixType == "Elasticity3D") {
+    } else if (matrixType == "Laplace3D" || matrixType == "Brick3D" || matrixType == "Elasticity3D" || matrixType == "HexFEM_LapStiff") {
       map         = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian3D", comm, galeriList);
       coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<real_type, LO, GO, Map, RealValuedMultiVector>("3D", map, galeriList);
     }
@@ -156,11 +157,31 @@ void MatrixLoad(Teuchos::RCP<const Teuchos::Comm<int> >& comm, Xpetra::Underlyin
       galeriList.set("front boundary", "Neumann");
       galeriList.set("back boundary", "Neumann");
     }
-
+    if (matrixType == "HexFEM_LapStiff") {
+      galeriList.set("right boundary", "Dirichlet");
+      galeriList.set("left boundary", "Neumann");
+      galeriList.set("bottom boundary", "Neumann");
+      galeriList.set("top boundary", "Neumann");
+      galeriList.set("front boundary", "Neumann");
+      galeriList.set("back boundary", "Neumann");
+    }
     RCP<Galeri::Xpetra::Problem<Map, CrsMatrixWrap, MultiVector> > Pr =
         Galeri::Xpetra::BuildProblem<SC, LO, GO, Map, CrsMatrixWrap, MultiVector>(galeriParameters.GetMatrixType(), map, galeriList);
     A         = Pr->BuildMatrix();
     nullspace = Pr->BuildNullspace();
+
+    // check if we need to generate a mass matrix
+    if ((paramList) && (paramList->isParameter("aggregation: strength-of-connection: matrix")) &&
+        (paramList->get<std::string>("aggregation: strength-of-connection: matrix") == "MinvA") && (massFile.empty())) {
+      if (matrixType == "HexFEM_LapStiff") {
+        Teuchos::ParameterList mass_Pl(galeriList);
+        mass_Pl.set("matrixType", "HexFEM_Mass");
+        RCP<Galeri::Xpetra::Problem<Map, CrsMatrixWrap, MultiVector> > PrForMass = Galeri::Xpetra::BuildProblem<SC, LO, GO, Map, CrsMatrixWrap, MultiVector>(mass_Pl.get<std::string>("matrixType"), map, mass_Pl);
+        mass                                                                     = PrForMass->BuildMatrix();
+      } else
+        TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "MueLu options require mass matrix which galeri cannot generate");
+    }
+
     //  The coordinates used by Galeri here might not match the coordinates that come into this function.
     //  In particular, they might correspond to different stretch factors. To fix this, we overwrite the
     //  coordinate array with those that Galeri now provides.

--- a/packages/muelu/test/scaling/MatrixMatrixMultiply.cpp
+++ b/packages/muelu/test/scaling/MatrixMatrixMultiply.cpp
@@ -127,7 +127,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
                matrixType == "BigStar2D" || matrixType == "AnisotropicDiffusion" || matrixType == "Elasticity2D" || matrixType == "Recirc2D") {
       map = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian2D", comm, galeriList);
 
-    } else if (matrixType == "Laplace3D" || matrixType == "Brick3D" || matrixType == "Elasticity3D") {
+    } else if (matrixType == "Laplace3D" || matrixType == "Brick3D" || matrixType == "Elasticity3D" || matrixType == "HexFEM_LapStiff") {
       map = Galeri::Xpetra::CreateMap<LO, GO, Node>(xpetraParameters.GetLib(), "Cartesian3D", comm, galeriList);
     }
     // Expand map to do multiple DOF per node for block problems

--- a/packages/muelu/test/scaling/MinvA.xml
+++ b/packages/muelu/test/scaling/MinvA.xml
@@ -1,7 +1,7 @@
 <ParameterList name="MueLu">
   <!-- ===========  GENERAL ================ -->
   <Parameter        name="verbosity"                            type="string"   value="high"/>
-  <Parameter        name="coarse: max size"                     type="int"      value="40"/>
+  <Parameter        name="coarse: max size"                     type="int"      value="500"/>
   <Parameter        name="transpose: use implicit"              type="bool"     value="true"/>
   <Parameter        name="max levels"                	          type="int"      value="10"/>
   <Parameter        name="number of equations"                  type="int"      value="1"/>
@@ -42,7 +42,7 @@
     <Parameter        name="repartition: enable"                  type="bool"     value="true"/>
     <Parameter        name="repartition: partitioner"             type="string"   value="zoltan2"/>
     <Parameter        name="repartition: start level"             type="int"      value="1"/>
-    <Parameter        name="repartition: min rows per proc"       type="int"      value="150"/>
+    <Parameter        name="repartition: min rows per proc"       type="int"      value="800"/>
     <Parameter        name="repartition: max imbalance"           type="double"   value="1.1"/>
     <Parameter        name="repartition: remap parts"             type="bool"     value="false"/>
     <!-- start of default values for repartitioning (can be omitted) -->

--- a/packages/muelu/test/scaling/MinvA.xml
+++ b/packages/muelu/test/scaling/MinvA.xml
@@ -19,11 +19,11 @@
   <Parameter        name="tentative: calculate qr"              type="bool" value="false"/>
 
   <Parameter        name="aggregation: strength-of-connection: matrix" type="string"  value="MinvA"  />
-  <Parameter        name="aggregation: strength-of-connection: measure" type="string" value="smoothed aggregation"/>
+  <Parameter        name="aggregation: strength-of-connection: measure" type="string" value="signed ruge-stueben"/>
   <Parameter        name="aggregation: drop scheme" type="string"                     value="point-wise"          />
   <Parameter        name="filtered matrix: lumping choice"  type="string"             value="distributed lumping" />
   <Parameter        name="aggregation: symmetrize graph after dropping" type="bool"   value="false"               />
-  <Parameter        name="aggregation: drop tol" type="double"                        value=".02"                />
+  <Parameter        name="aggregation: drop tol" type="double"                        value=".1"                />
 
   <!-- ===========  SMOOTHING  =========== -->
   <Parameter        name="smoother: type"                       type="string"   value="RELAXATION"/>

--- a/packages/muelu/test/unit_tests_kokkos/CoalesceDropFactory_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/CoalesceDropFactory_kokkos.cpp
@@ -1075,6 +1075,88 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CoalesceDropFactory_kokkos, MassMatrixSOC, Sca
 
 }  // MassMatrixSOC
 
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CoalesceDropFactory_kokkos, MinvADropsTwoThirdsNNZ, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+#include <MueLu_UseShortNames.hpp>
+  typedef Teuchos::ScalarTraits<SC> STS;
+  typedef typename STS::magnitudeType real_type;
+  typedef Xpetra::MultiVector<real_type, LO, GO, NO> RealValuedMultiVector;
+
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
+  out << "version: " << MueLu::Version() << std::endl;
+
+  RCP<const Teuchos::Comm<int>> comm = Parameters::getDefaultComm();
+  Xpetra::UnderlyingLib lib          = TestHelpers_kokkos::Parameters::getLib();
+
+  RCP<Matrix> A;
+  const int nx = 20;
+  {
+    // Make a 2D Star2D Matrix with up/down as a "weak connection"
+    Teuchos::ParameterList stiff_Pl;
+    stiff_Pl.set("matrixType", "Star2D");
+    stiff_Pl.set("nx", (GO)nx);
+    stiff_Pl.set("ny", (GO)nx);
+    stiff_Pl.set("a", 17.0);
+    stiff_Pl.set("b", 3.5);
+    stiff_Pl.set("c", 3.5);
+    stiff_Pl.set("d", -7.75);
+    stiff_Pl.set("e", -7.75);
+    stiff_Pl.set("z1", -2.125);
+    stiff_Pl.set("z2", -2.125);
+    stiff_Pl.set("z3", -2.125);
+    stiff_Pl.set("z4", -2.125);
+    A = TestHelpers_kokkos::TestFactory<SC, LO, GO, NO>::BuildMatrix(stiff_Pl, lib);
+  }
+
+  RCP<Matrix> filteredA;
+  {
+    Level fineLevel;
+    TestHelpers_kokkos::TestFactory<SC, LO, GO, NO>::createSingleLevelHierarchy(fineLevel);
+    fineLevel.Set("A", A);
+    Teuchos::ParameterList mass_Pl;
+    mass_Pl.set("matrixType", "Star2D");
+
+    mass_Pl.set("nx", (GO)nx);
+    mass_Pl.set("ny", (GO)nx);
+    mass_Pl.set("a", 2.88);
+    mass_Pl.set("b", .72);
+    mass_Pl.set("c", .72);
+    mass_Pl.set("d", .72);
+    mass_Pl.set("e", .72);
+    mass_Pl.set("z1", .18);
+    mass_Pl.set("z2", .18);
+    mass_Pl.set("z3", .18);
+    mass_Pl.set("z4", .18);
+    RCP<Matrix> M = TestHelpers_kokkos::TestFactory<SC, LO, GO, NO>::BuildMatrix(mass_Pl, lib);
+    fineLevel.Set("M", M);
+
+    CoalesceDropFactory_kokkos coalesceDropFact;
+    coalesceDropFact.SetDefaultVerbLevel(MueLu::Extreme);
+    coalesceDropFact.SetParameter("aggregation: drop tol", Teuchos::ParameterEntry(.26));
+    coalesceDropFact.SetParameter("filtered matrix: reuse graph", Teuchos::ParameterEntry(false));
+    coalesceDropFact.SetParameter("aggregation: drop scheme", Teuchos::ParameterEntry(std::string("point-wise")));
+    coalesceDropFact.SetParameter("aggregation: strength-of-connection: measure", Teuchos::ParameterEntry(std::string("smoothed aggregation")));
+    coalesceDropFact.SetParameter("aggregation: strength-of-connection: matrix", Teuchos::ParameterEntry(std::string("MinvA")));
+    fineLevel.Request("Graph", &coalesceDropFact);
+    fineLevel.Request("A", &coalesceDropFact);
+    fineLevel.Request("M", &coalesceDropFact);
+    fineLevel.Request("DofsPerNode", &coalesceDropFact);
+
+    coalesceDropFact.Build(fineLevel);
+
+    filteredA = fineLevel.Get<RCP<Matrix>>("A", &coalesceDropFact);
+  }
+
+  // Interior rows of A are     [-1, 2, -1]
+  // Interior rows of MinvA are [-0.2, 0.8, 0.2]
+  // Boundary rows are similar.
+
+  // We picked the drop tolerance in a way that will drop all off-diagonal entries, but would not have dropped anything without Minv scaling.
+
+  out << "Global number of nonzeros in original A vs. filteredA is " << A->getGlobalNumEntries() << " vs. " << filteredA->getGlobalNumEntries() << std::endl;
+  TEUCHOS_ASSERT_EQUALITY(filteredA->getGlobalNumEntries(), (nx - 2) * (nx - 2) * 3 + (nx - 2) * 2 * 3 + (nx - 2) * 2 * 2 + 4 * 2);
+}
+
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CoalesceDropFactory_kokkos, ClassicalScaledCut, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
 #include <MueLu_UseShortNames.hpp>
   typedef Teuchos::ScalarTraits<SC> STS;
@@ -3492,6 +3574,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CoalesceDropFactory_kokkos, CountNegativeDiago
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CoalesceDropFactory_kokkos, 2x2, SC, LO, GO, NO)                                         \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CoalesceDropFactory_kokkos, SignedClassicalDistanceLaplacian, SC, LO, GO, NO)            \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CoalesceDropFactory_kokkos, SignedClassicalSADistanceLaplacian, SC, LO, GO, NO)          \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CoalesceDropFactory_kokkos, MinvADropsTwoThirdsNNZ, SC, LO, GO, NO)                      \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CoalesceDropFactory_kokkos, CountNegativeDiagonals, SC, LO, GO, NO)
 
 // TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CoalesceDropFactory_kokkos, ClassicBlockWithFiltering,     SC, LO, GO, NO) // not implemented yet


### PR DESCRIPTION
Adding new capabilities to Galeri so that we can create a mass and stiffness matrix for a stretched Cartesian mesh. Using this, a new muelu scaling test has been made to exercise MinvA soc option. Finally, a new MinvA kokkos unit test has also been added.

<!---  COMMENT BLOCK

 
 *

@trilinos/muelu

## Motivation
Needed to provide finite element tests for MueLu's MinvA strength-of-connection option

## Related Issues
 
## Stakeholder Feedback


## Testing
Tested using MueLu_Driver and a kokkos unit test. 

## Additional Information

-->
