### PR TITLE
Split workflows that snapshot Kokkos and ROL

### DIFF
--- a/.github/workflows/snapshot-kokkos.yml
+++ b/.github/workflows/snapshot-kokkos.yml
@@ -1,4 +1,4 @@
-name: snapshot
+name: snapshot-kokkos
 on:
   workflow_dispatch:
   schedule:
@@ -19,7 +19,7 @@ jobs:
         with:
           app-id: ${{ secrets.SNAPSHOT_APP_ID }}
           private-key: ${{ secrets.SNAPSHOT_APP_PRIVATE_KEY }}
-          
+
       - name: Clone Trilinos
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -70,64 +70,3 @@ jobs:
           labels: |
             pkg: Kokkos
             pkg: KokkosKernels
-
-  rol-snapshot:
-    permissions:
-      contents: write
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: generate-token
-        with:
-          app-id: ${{ secrets.SNAPSHOT_APP_ID }}
-          private-key: ${{ secrets.SNAPSHOT_APP_PRIVATE_KEY }}
-          
-      - name: Clone Trilinos
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          ref: develop
-          path: Trilinos
-
-      - name: Clone Kokkos
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: kokkos/kokkos
-          ref: develop
-          path: kokkos
-
-      - name: Clone ROL
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          repository: sandialabs/rol
-          ref: develop
-          path: rol
-
-      - name: Configure git
-        run: |
-          git config --global user.name "Snapshot Action"
-          git config --global user.email "snapshot@action.com"
-
-      - name: Snapshot ROL
-        run: |
-          kokkos/scripts/snapshot.py --verbose rol Trilinos/packages/
-
-      - name: Create/update PR
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
-          path: Trilinos
-          token: ${{ steps.generate-token.outputs.token }}
-          commit-message: "Snapshot ROL"
-          title: "Snapshot of ROL"
-          body: |
-            Automatic snapshot of ROL.
-            This snapshot gets updated via a GitHub Action.
-          branch: rol-snapshot
-          base: develop
-          delete-branch: true
-          draft: true
-          labels: |
-            pkg: ROL
-
-
-

--- a/.github/workflows/snapshot-rol.yml
+++ b/.github/workflows/snapshot-rol.yml
@@ -1,0 +1,67 @@
+name: snapshot-rol
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 0 * * 0
+
+permissions:
+  contents: read
+
+jobs:
+  rol-snapshot:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.SNAPSHOT_APP_ID }}
+          private-key: ${{ secrets.SNAPSHOT_APP_PRIVATE_KEY }}
+
+      - name: Clone Trilinos
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: develop
+          path: Trilinos
+
+      - name: Clone Kokkos
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: kokkos/kokkos
+          ref: develop
+          path: kokkos
+
+      - name: Clone ROL
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: sandialabs/rol
+          ref: develop
+          path: rol
+
+      - name: Configure git
+        run: |
+          git config --global user.name "Snapshot Action"
+          git config --global user.email "snapshot@action.com"
+
+      - name: Snapshot ROL
+        run: |
+          kokkos/scripts/snapshot.py --verbose rol Trilinos/packages/
+
+      - name: Create/update PR
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          path: Trilinos
+          token: ${{ steps.generate-token.outputs.token }}
+          commit-message: "Snapshot ROL"
+          title: "Snapshot of ROL"
+          body: |
+            Automatic snapshot of ROL.
+            This snapshot gets updated via a GitHub Action.
+          branch: rol-snapshot
+          base: develop
+          delete-branch: true
+          draft: true
+          labels: |
+            pkg: ROL


### PR DESCRIPTION
# Motivation

This splits into two the GitHub action that updates PRs against Trilinos with snapshots of

* Kokkos and Kokkos Kernels,
* ROL.

See https://github.com/trilinos/Trilinos/pull/14825