### PR TITLE
belos: cache per-solve scratch MVs to eliminate per-call cudaMalloc

### DIFF
--- a/packages/belos/src/BelosBlockFGmresIter.hpp
+++ b/packages/belos/src/BelosBlockFGmresIter.hpp
@@ -298,6 +298,19 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   // z_: Q applied to right-hand side of the least squares system
   Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > R_;
   Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > z_;
+
+  // Cached output of getCurrentUpdate(): a domain-Map MV with
+  // blockSize_ columns, holding Z*y.  Allocated once and reused
+  // across solves, eliminating a per-solve cudaMalloc.
+  mutable Teuchos::RCP<MV> currentUpdate_;
+  // Cached view of the first curDim_ columns of Z_, plus the dim it
+  // was created at.  Re-CloneView only when curDim_ changes.
+  mutable Teuchos::RCP<const MV> cachedZjp1_;
+  mutable int cachedZjp1_dim_ = -1;
+  // Cached host-side scratch for the LSQR-RHS copy used in
+  // getCurrentUpdate.  Reshaped via shapeUninitialized when the
+  // requested (curDim_, blockSize_) shape changes.
+  mutable Teuchos::SerialDenseMatrix<int,ScalarType> cachedY_;
 };
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -352,8 +365,14 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
       return;
     }
 
-    if (blockSize!=blockSize_ || numBlocks!=numBlocks_)
+    if (blockSize!=blockSize_ || numBlocks!=numBlocks_) {
       stateStorageInitialized_ = false;
+      // Drop cached scratch in getCurrentUpdate(): they all depend
+      // on V_/Z_'s map and on blockSize_/curDim_, which may change.
+      currentUpdate_  = Teuchos::null;
+      cachedZjp1_     = Teuchos::null;
+      cachedZjp1_dim_ = -1;
+    }
 
     blockSize_ = blockSize;
     numBlocks_ = numBlocks;
@@ -493,23 +512,45 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
       const ScalarType one = Teuchos::ScalarTraits<ScalarType>::one ();
       Teuchos::BLAS<int,ScalarType> blas;
 
-      currentUpdate = MVT::Clone (*Z_, blockSize_);
+      // Reuse the cached update MV when its column count matches.
+      // The map of Z_ doesn't change after setStateSize, so we avoid
+      // a fresh cudaMalloc on every solve.
+      if (currentUpdate_.is_null () ||
+          MVT::GetNumberVecs (*currentUpdate_) != blockSize_) {
+        currentUpdate_ = MVT::Clone (*Z_, blockSize_);
+      }
+      currentUpdate = currentUpdate_;
 
-      // Make a view and then copy the RHS of the least squares problem.  DON'T OVERWRITE IT!
-      SDM y (Teuchos::Copy, *z_, curDim_, blockSize_);
+      // Reuse cached host SDM for the LSQR RHS copy; reshape only
+      // when the (rows, cols) request changes.
+      if (cachedY_.numRows () < curDim_ || cachedY_.numCols () < blockSize_) {
+        cachedY_.shapeUninitialized (curDim_, blockSize_);
+      }
+      // Copy current curDim_ rows × blockSize_ cols of *z_ into the
+      // top-left block of cachedY_.  DON'T OVERWRITE *z_.
+      for (int j = 0; j < blockSize_; ++j) {
+        for (int i = 0; i < curDim_; ++i) {
+          cachedY_(i, j) = (*z_)(i, j);
+        }
+      }
+      SDM y (Teuchos::View, cachedY_, curDim_, blockSize_);
 
       // Solve the least squares problem.
       blas.TRSM (Teuchos::LEFT_SIDE, Teuchos::UPPER_TRI, Teuchos::NO_TRANS,
                  Teuchos::NON_UNIT_DIAG, curDim_, blockSize_, one,
                  R_->values (), R_->stride (), y.values (), y.stride ());
 
-      // Compute the current update.
-      std::vector<int> index (curDim_);
-      for (int i = 0; i < curDim_; ++i) {
-        index[i] = i;
+      // Compute the current update.  Reuse the cached view when
+      // curDim_ hasn't changed since the last call.
+      if (cachedZjp1_.is_null () || cachedZjp1_dim_ != curDim_) {
+        std::vector<int> index (curDim_);
+        for (int i = 0; i < curDim_; ++i) {
+          index[i] = i;
+        }
+        cachedZjp1_     = MVT::CloneView (*Z_, index);
+        cachedZjp1_dim_ = curDim_;
       }
-      Teuchos::RCP<const MV> Zjp1 = MVT::CloneView (*Z_, index);
-      MVT::MvTimesMatAddMv (one, *Zjp1, y, zero, *currentUpdate);
+      MVT::MvTimesMatAddMv (one, *cachedZjp1_, y, zero, *currentUpdate);
     }
     return currentUpdate;
   }

--- a/packages/belos/src/BelosBlockGmresIter.hpp
+++ b/packages/belos/src/BelosBlockGmresIter.hpp
@@ -312,6 +312,14 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   // z_: Q applied to right-hand side of the least squares system
   Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > R_;
   Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > z_;
+
+  // Cached output of getCurrentUpdate(): a domain-Map MV with
+  // blockSize_ columns, holding V*y.  Allocated once and reused
+  // across solves with matching map and column count, to avoid the
+  // multi-millisecond cudaMalloc that would otherwise fire on every
+  // solve when the GPU memory pool can't satisfy the request from a
+  // freed slab.
+  mutable Teuchos::RCP<MV> currentUpdate_;
 };
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -368,8 +376,13 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
       return;
     }
 
-    if (blockSize!=blockSize_ || numBlocks!=numBlocks_)
+    if (blockSize!=blockSize_ || numBlocks!=numBlocks_) {
       stateStorageInitialized_ = false;
+      // Cached update MV depends on V_'s map and on blockSize_; drop
+      // it on any state-storage change so the next getCurrentUpdate()
+      // re-clones it against the fresh V_.
+      currentUpdate_ = Teuchos::null;
+    }
 
     blockSize_ = blockSize;
     numBlocks_ = numBlocks;
@@ -493,7 +506,15 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
       const ScalarType one  = SCT::one();
       const ScalarType zero = SCT::zero();
       Teuchos::BLAS<int,ScalarType> blas;
-      currentUpdate = MVT::Clone( *V_, blockSize_ );
+      // Reuse the cached update MV when its shape matches; otherwise
+      // (re)allocate.  The map of V_ doesn't change after setStateSize,
+      // so as long as the column count matches we can avoid a fresh
+      // cudaMalloc on every solve.
+      if (currentUpdate_.is_null() ||
+          MVT::GetNumberVecs(*currentUpdate_) != blockSize_) {
+        currentUpdate_ = MVT::Clone( *V_, blockSize_ );
+      }
+      currentUpdate = currentUpdate_;
       //
       //  Make a view and then copy the RHS of the least squares problem.  DON'T OVERWRITE IT!
       //

--- a/packages/belos/src/BelosBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGmresSolMgr.hpp
@@ -320,8 +320,9 @@ private:
   std::string label_;
   Teuchos::RCP<Teuchos::Time> timerSolve_;
 
-  // Cached iterator (reused across solve() calls to avoid reallocating Krylov subspace).
+  // Cached iterator and initial Krylov vector (reused across solve() calls to avoid reallocating).
   Teuchos::RCP<GmresIteration<ScalarType,MV,OP> > block_gmres_iter_;
+  Teuchos::RCP<MV> V_0_;
 
   // Internal state variables.
   bool isSet_, isSTSet_;
@@ -986,26 +987,22 @@ ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
       // Reset the number of calls that the status test output knows about.
       outputTest_->resetNumCalls();
 
-      // Create the first block in the current Krylov basis.
-      Teuchos::RCP<MV> V_0;
-      if (isFlexible_) {
-        // Load the correct residual if the system is augmented
+      // Create/reuse the first block in the current Krylov basis.
+      {
+        const MV& src = isFlexible_ ? *(problem_->getInitResVec()) : *(problem_->getInitPrecResVec());
+        if (V_0_.is_null() || MVT::GetNumberVecs(*V_0_) != blockSize_)
+          V_0_ = MVT::Clone(src, blockSize_);
         if (currIdx[blockSize_-1] == -1) {
-          V_0 = MVT::Clone( *(problem_->getInitResVec()), blockSize_ );
-          problem_->computeCurrResVec( &*V_0 );
+          // Augmented system: compute the residual directly into V_0_.
+          if (isFlexible_)
+            problem_->computeCurrResVec( &*V_0_ );
+          else
+            problem_->computeCurrPrecResVec( &*V_0_ );
         }
         else {
-          V_0 = MVT::CloneCopy( *(problem_->getInitResVec()), currIdx );
-        }
-      }
-      else {
-        // Load the correct residual if the system is augmented
-        if (currIdx[blockSize_-1] == -1) {
-          V_0 = MVT::Clone( *(problem_->getInitPrecResVec()), blockSize_ );
-          problem_->computeCurrPrecResVec( &*V_0 );
-        }
-        else {
-          V_0 = MVT::CloneCopy( *(problem_->getInitPrecResVec()), currIdx );
+          // Copy columns currIdx of src into V_0_ without allocating.
+          Teuchos::RCP<const MV> src_view = MVT::CloneView(src, currIdx);
+          MVT::MvAddMv(SCT::one(), *src_view, SCT::zero(), *src_view, *V_0_);
         }
       }
 
@@ -1013,14 +1010,14 @@ ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
       Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > z_0 =
         Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( blockSize_, blockSize_ ) );
 
-      // Orthonormalize the new V_0
-      int rank = ortho_->normalize( *V_0, z_0 );
+      // Orthonormalize the new V_0_
+      int rank = ortho_->normalize( *V_0_, z_0 );
       TEUCHOS_TEST_FOR_EXCEPTION(rank != blockSize_,BlockGmresSolMgrOrthoFailure,
         "Belos::BlockGmresSolMgr::solve(): Failed to compute initial block of orthonormal vectors.");
 
       // Set the new state and initialize the solver.
       GmresIterationState<ScalarType,MV> newstate;
-      newstate.V = V_0;
+      newstate.V = V_0_;
       newstate.z = z_0;
       newstate.curDim = 0;
       block_gmres_iter->initializeGmres(newstate);
@@ -1084,24 +1081,24 @@ ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
             // Get the state.
             GmresIterationState<ScalarType,MV> oldState = block_gmres_iter->getState();
 
-            // Compute the restart std::vector.
-            // Get a view of the current Krylov basis.
-            V_0  = MVT::Clone( *(oldState.V), blockSize_ );
+            // Compute the restart vector.
+            if (V_0_.is_null() || MVT::GetNumberVecs(*V_0_) != blockSize_)
+              V_0_ = MVT::Clone(*(oldState.V), blockSize_);
             if (isFlexible_)
-              problem_->computeCurrResVec( &*V_0 );
+              problem_->computeCurrResVec( &*V_0_ );
             else
-              problem_->computeCurrPrecResVec( &*V_0 );
+              problem_->computeCurrPrecResVec( &*V_0_ );
 
             // Get a view of the first block of the Krylov basis.
             z_0 = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( blockSize_, blockSize_ ) );
 
-            // Orthonormalize the new V_0
-            rank = ortho_->normalize( *V_0, z_0 );
+            // Orthonormalize the new V_0_
+            rank = ortho_->normalize( *V_0_, z_0 );
             TEUCHOS_TEST_FOR_EXCEPTION(rank != blockSize_,BlockGmresSolMgrOrthoFailure,
               "Belos::BlockGmresSolMgr::solve(): Failed to compute initial block of orthonormal vectors after restart.");
 
             // Set the new state and initialize the solver.
-            newstate.V = V_0;
+            newstate.V = V_0_;
             newstate.z = z_0;
             newstate.curDim = 0;
             block_gmres_iter->initializeGmres(newstate);

--- a/packages/belos/src/BelosLinearProblem.hpp
+++ b/packages/belos/src/BelosLinearProblem.hpp
@@ -510,6 +510,17 @@ namespace Belos {
     //! Scratch vector for use in apply()
     mutable Teuchos::RCP<MV> Y_temp_;
 
+    //! Cached output buffer for the non-in-place branch of
+    //! updateSolution() (updateLP = false).  Reused across calls
+    //! when its column count matches the requested update; otherwise
+    //! re-Cloned.  Eliminates a per-call cudaMalloc of a domain-Map
+    //! MV when the status test computes an explicit residual.
+    mutable Teuchos::RCP<MV> cachedNewSoln_;
+    //! Cached buffer for the right-preconditioner-applied update.
+    //! Same caching logic; only allocated when there is a right
+    //! preconditioner.
+    mutable Teuchos::RCP<MV> cachedRightPrecUpdate_;
+
     //! Timers
     mutable Teuchos::RCP<Teuchos::Time> timerOp_, timerPrec_;
 
@@ -731,44 +742,52 @@ namespace Belos {
       }
     else // the update vector is NOT null.
       { 
+	const int updateNumVecs = MVT::GetNumberVecs (*update);
+	auto ensureBuffer = [&updateNumVecs, &update] (RCP<MV>& buf) {
+	  if (buf.is_null () ||
+	      MVT::GetNumberVecs (*buf) != updateNumVecs) {
+	    buf = MVT::Clone (*update, updateNumVecs);
+	  }
+	};
 	if (updateLP) // The caller wants us to update the linear problem.
-	  { 
-	    if (RP_.is_null()) 
+	  {
+	    if (RP_.is_null())
 	      { // There is no right preconditioner.
 		// curX_ := curX_ + scale * update.
-		MVT::MvAddMv( 1.0, *curX_, scale, *update, *curX_ ); 
+		MVT::MvAddMv( 1.0, *curX_, scale, *update, *curX_ );
 	      }
-	    else 
+	    else
 	      { // There is indeed a right preconditioner, so apply it
-		// before computing the new solution.
-		RCP<MV> rightPrecUpdate = 
-		  MVT::Clone (*update, MVT::GetNumberVecs (*update));
-                applyRightPrec( *update, *rightPrecUpdate ); 
+		// before computing the new solution.  Reuse the cached
+		// rightPrecUpdate buffer across calls.
+		ensureBuffer (cachedRightPrecUpdate_);
+		applyRightPrec( *update, *cachedRightPrecUpdate_ );
 		// curX_ := curX_ + scale * rightPrecUpdate.
-		MVT::MvAddMv( 1.0, *curX_, scale, *rightPrecUpdate, *curX_ ); 
-	      } 
-	    solutionUpdated_ = true; 
+		MVT::MvAddMv( 1.0, *curX_, scale, *cachedRightPrecUpdate_, *curX_ );
+	      }
+	    solutionUpdated_ = true;
 	    newSoln = curX_;
 	  }
-	else 
+	else
 	  { // Rather than updating our stored current solution curX_,
 	    // we make a copy and compute the new solution in the
-	    // copy, without modifying curX_.
-	    newSoln = MVT::Clone (*update, MVT::GetNumberVecs (*update));
+	    // copy, without modifying curX_.  Cache the copy across
+	    // calls to avoid a per-call cudaMalloc.
+	    ensureBuffer (cachedNewSoln_);
+	    newSoln = cachedNewSoln_;
 	    if (RP_.is_null())
 	      { // There is no right preconditioner.
 		// newSoln := curX_ + scale * update.
-		MVT::MvAddMv( 1.0, *curX_, scale, *update, *newSoln ); 
+		MVT::MvAddMv( 1.0, *curX_, scale, *update, *newSoln );
 	      }
-	    else 
+	    else
 	      { // There is indeed a right preconditioner, so apply it
 		// before computing the new solution.
-		RCP<MV> rightPrecUpdate = 
-		  MVT::Clone (*update, MVT::GetNumberVecs (*update));
-                applyRightPrec( *update, *rightPrecUpdate ); 
+		ensureBuffer (cachedRightPrecUpdate_);
+		applyRightPrec( *update, *cachedRightPrecUpdate_ );
 		// newSoln := curX_ + scale * rightPrecUpdate.
-		MVT::MvAddMv( 1.0, *curX_, scale, *rightPrecUpdate, *newSoln ); 
-	      } 
+		MVT::MvAddMv( 1.0, *curX_, scale, *cachedRightPrecUpdate_, *newSoln );
+	      }
 	  }
       }
     return newSoln;

--- a/packages/belos/src/BelosStatusTestGenResNorm.hpp
+++ b/packages/belos/src/BelosStatusTestGenResNorm.hpp
@@ -319,6 +319,12 @@ class StatusTestGenResNorm: public StatusTestResNorm<ScalarType,MV,OP> {
   //! Most recent solution vector used by this status test.
   Teuchos::RCP<MV> curSoln_;
 
+  //! Cached MV used to hold the explicit residual computed inside
+  //! checkStatus() (Explicit residual path).  Reused across solves on
+  //! the same linear problem so the status test does not allocate a
+  //! fresh domain-Map MV on every convergence check.
+  mutable Teuchos::RCP<MV> cachedCurRes_;
+
   //! Status
   StatusType status_;
 
@@ -488,7 +494,19 @@ StatusType StatusTestGenResNorm<ScalarType,MV,OP>::checkStatus( Iteration<Scalar
     //
     Teuchos::RCP<MV> cur_update = iSolver->getCurrentUpdate();
     curSoln_ = lp.updateSolution( cur_update );
-    Teuchos::RCP<MV> cur_res = MVT::Clone( *curSoln_, MVT::GetNumberVecs( *curSoln_ ) );
+    // Reuse the cached explicit-residual MV when its column count
+    // matches; otherwise (re)allocate.  curSoln_'s map does not
+    // change between solves on the same linear problem, so the
+    // buffer is reusable and we save a per-solve cudaMalloc of a
+    // domain-Map MV.
+    {
+      const int need = MVT::GetNumberVecs( *curSoln_ );
+      if (cachedCurRes_.is_null() ||
+          MVT::GetNumberVecs( *cachedCurRes_ ) != need) {
+        cachedCurRes_ = MVT::Clone( *curSoln_, need );
+      }
+    }
+    Teuchos::RCP<MV> cur_res = cachedCurRes_;
     lp.computeCurrResVec( &*cur_res, &*curSoln_ );
     std::vector<MagnitudeType> tmp_resvector( MVT::GetNumberVecs( *cur_res ) );
     MVT::MvNorm( *cur_res, tmp_resvector, resnormtype_ );

--- a/packages/belos/src/BelosStatusTestImpResNorm.hpp
+++ b/packages/belos/src/BelosStatusTestImpResNorm.hpp
@@ -372,6 +372,15 @@ public:
   //! Is this the first time CheckStatus is called?
   bool firstcallCheckStatus_;
 
+  //! Cached MV used to hold the explicit residual computed in
+  //! checkStatus().  The map of curSoln_ does not change between
+  //! solves on the same linear problem and the column count is
+  //! determined by the current solver block size, so we keep a
+  //! single MV alive across calls and only re-Clone it when the
+  //! column count changes.  Eliminates a per-solve cudaMalloc of a
+  //! domain-Map MV.
+  mutable Teuchos::RCP<MV> cachedCurRes_;
+
   //! Is this the first time DefineResForm is called?
   bool firstcallDefineResForm_;
 
@@ -615,7 +624,19 @@ checkStatus (Iteration<ScalarType,MV,OP>* iSolver)
     //
     RCP<MV> cur_update = iSolver->getCurrentUpdate ();
     curSoln_ = lp.updateSolution (cur_update);
-    RCP<MV> cur_res = MVT::Clone (*curSoln_, MVT::GetNumberVecs (*curSoln_));
+    // Reuse the cached explicit-residual MV when its column count
+    // matches; otherwise (re)allocate.  curSoln_'s map is fixed for
+    // a given linear problem, so once allocated the MV is reusable
+    // across solves and we avoid a cudaMalloc on each convergence
+    // check.
+    {
+      const int need = MVT::GetNumberVecs (*curSoln_);
+      if (cachedCurRes_.is_null () ||
+          MVT::GetNumberVecs (*cachedCurRes_) != need) {
+        cachedCurRes_ = MVT::Clone (*curSoln_, need);
+      }
+    }
+    RCP<MV> cur_res = cachedCurRes_;
     lp.computeCurrResVec (&*cur_res, &*curSoln_);
     tmp_resvector.resize (MVT::GetNumberVecs (*cur_res));
     std::vector<MagnitudeType> tmp_testvector (have);


### PR DESCRIPTION
Across BlockGmresIter, BlockFGmresIter, LinearProblem, and the two StatusTestResNorm variants, promote scratch MultiVectors and SerialDenseMatrices that were Cloned per call into mutable members rebuilt only when their column count changes:

  * BlockGmresIter / BlockFGmresIter::getCurrentUpdate(): cache currentUpdate_ (domain-Map MV holding V*y or Z*y).  In the flexible variant additionally cache the cur-Dim view cachedZjp1_ (re-CloneView only when curDim_ changes) and the host-side LSQR-RHS scratch cachedY_ (reshaped uninitialized).  setStateSize drops these caches when blockSize_ or numBlocks_ changes.

  * LinearProblem::updateSolution: cache cachedNewSoln_ for the non-in-place (updateLP=false) branch and cachedRightPrecUpdate_ for the right-preconditioner-applied update.  An ensureBuffer lambda factors the "is_null || wrong column count -> Clone" pattern.

  * StatusTestGenResNorm and StatusTestImpResNorm: cache cachedCurRes_, the domain-Map MV holding the explicit residual computed inside checkStatus().  curSoln_'s map is fixed for the duration of a linear problem, so the MV is reusable across solves.

Each cache eliminates a cudaMalloc that would otherwise fire on every solve / every convergence check, where the GPU memory pool cannot always satisfy the request from a freed slab.

Note: the original commit also touched StatusTestImpResNorm to thread a device-resident MvNorm path (devNorms_) which depends on the unrelated kernel commit "minor perf improvement in MvDot and MvNorm by keeping it on device".  That hunk is intentionally dropped here so this branch contains only the caching changes; the device-norm path will be reintroduced when its parent kernel commit lands.

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
