### PR TITLE
amesos2/KLU2: cache redistribution map to skip MPI collective per solve

### DIFF
--- a/packages/amesos2/src/Amesos2_KLU2_decl.hpp
+++ b/packages/amesos2/src/Amesos2_KLU2_decl.hpp
@@ -54,6 +54,7 @@ public:
   typedef typename super_type::local_ordinal_type        local_ordinal_type;
   typedef typename super_type::global_ordinal_type      global_ordinal_type;
   typedef typename super_type::global_size_type            global_size_type;
+  typedef typename super_type::node_type                         node_type;
 
   typedef TypeMap<Amesos2::KLU2,scalar_type>                    type_map;
 
@@ -232,6 +233,12 @@ private:
 
   /// Persisting 1D store for B
   mutable host_solve_array_t bValues_;
+
+  /// Cached distribution map for B/X redistribution; avoids recomputing the
+  /// gather map (MPI collective) on every solve call.
+  mutable Teuchos::RCP<const Tpetra::Map<local_ordinal_type,
+                                          global_ordinal_type,
+                                          node_type>> distributionMap_;
 
   /// Transpose flag
   /// 0: Non-transpose, 1: Transpose, 2: Conjugate-transpose

--- a/packages/amesos2/src/Amesos2_KLU2_def.hpp
+++ b/packages/amesos2/src/Amesos2_KLU2_def.hpp
@@ -262,17 +262,23 @@ KLU2<Matrix,Vector>::solve_impl(
         }
       }
       if (!use_gather) {
+        const EDistribution dist = (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED;
+        if (distributionMap_.is_null()) {
+          typedef MultiVecAdapter<Vector> MVA;
+          distributionMap_ = Util::getDistributionMap<
+            typename MVA::local_ordinal_t, typename MVA::global_ordinal_t,
+            typename MVA::global_size_t,   typename MVA::node_t>(
+              dist, B->getGlobalLength(), B->getComm(),
+              this->rowIndexBase_, B->getMap());
+        }
+        auto distMapPtr = Teuchos::ptrInArg(*distributionMap_);
         bDidAssignB = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
           host_solve_array_t>::do_get(initialize_data, B, bValues_,
-            as<size_t>(ld_rhs),
-            (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
-            this->rowIndexBase_);
+            as<size_t>(ld_rhs), distMapPtr, dist);
         // see Amesos2_Tacho_def.hpp for an explanation of why we 'get' X
         bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
           host_solve_array_t>::do_get(do_not_initialize_data, X, xValues_,
-            as<size_t>(ld_rhs),
-            (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
-            this->rowIndexBase_);
+            as<size_t>(ld_rhs), distMapPtr, dist);
       }
 
       // klu_tsolve is going to put the solution x into the input b.
@@ -392,11 +398,16 @@ KLU2<Matrix,Vector>::solve_impl(
       if (rval != 0) use_gather = false;
     }
     if (!use_gather) {
-      Util::put_1d_data_helper_kokkos_view<
-        MultiVecAdapter<Vector>,host_solve_array_t>::do_put(X, xValues_,
-          as<size_t>(ld_rhs),
-          (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
-          this->rowIndexBase_);
+      const EDistribution dist = (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED;
+      if (!distributionMap_.is_null()) {
+        Util::put_1d_data_helper_kokkos_view<
+          MultiVecAdapter<Vector>,host_solve_array_t>::do_put(X, xValues_,
+            as<size_t>(ld_rhs), Teuchos::ptrInArg(*distributionMap_), dist);
+      } else {
+        Util::put_1d_data_helper_kokkos_view<
+          MultiVecAdapter<Vector>,host_solve_array_t>::do_put(X, xValues_,
+            as<size_t>(ld_rhs), dist, this->rowIndexBase_);
+      }
     }
   }
   if (debug_level_ > 0) {


### PR DESCRIPTION
Cache the Tpetra distribution map computed by Util::getDistributionMap in a mutable member (distributionMap_) on KLU2's first solve_impl call, then reuse it on subsequent calls.  Eliminates the Tpetra::Map constructor (which internally calls MPI_Scan) from the hot path, alongside the gather/scatter helpers' rebuild work.

Both the get_1d_copy_helper paths (B and X) and the put_1d_data_helper path (final write of X back) now go through ptrInArg(*distributionMap_). A fallback retains the original (dist, rowIndexBase) overload for the first put before the map has been computed.

@trilinos/amesos2 
@rppawlo  this does nothing to the FOM in miniEM as we don't use this for a bottom solve, but I fixed some super redundant work in this patch.  When we were using this bottom solve it sped up the runs about 20% and the scaling a lot since everyone was stalled for this process.


<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
