### PR TITLE
Framework: Unpin spack-packages for spack CI

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -36,4 +36,9 @@ jobs:
           spack develop --no-clone --path $GITHUB_WORKSPACE trilinos@develop
           spack add trilinos@develop
           spack concretize -f
-          spack install --cdash-upload-url=https://sems-cdash-son.sandia.gov/cdash/submit.php?project=Trilinos --cdash-track='Pull Request' --cdash-build='PR-${{ github.event.pull_request.number }}-spack' -j16 trilinos
+          spack install \
+            --cdash-upload-url=https://sems-cdash-son.sandia.gov/cdash/submit.php?project=Trilinos \
+            --cdash-track='Pull Request (Non-blocking)' \
+            --cdash-build='PR-${{ github.event.pull_request.number }}-spack' \
+            -j16 \
+            trilinos

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -31,7 +31,7 @@ jobs:
           git checkout develop && git pull --quiet
           echo -n "Spack version is: "
           git rev-parse HEAD
-          spack repo update
+          spack repo update builtin --branch develop
           spack reindex
           spack develop --no-clone --path $GITHUB_WORKSPACE trilinos@develop
           spack add trilinos@develop

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -18,7 +18,7 @@ jobs:
   develop-gcc-openmpi:
     permissions:
       contents: read  # for actions/checkout to fetch code
-    runs-on: [self-hosted, gcc-12.3.0-openmpi-4.1.6]
+    runs-on: [self-hosted, gcc-12.3.0-openmpi-4.1.6, 20260507]
     steps:
       - name: Clone Trilinos
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
@trilinos/framework 

## Motivation
We started pinning the spack-packages repo inside the container during the container build process, but the spack CI job needs the latest spack-packages.

## Related Issues
Closes #15332 

