### PR TITLE
master-merge action: Delete merged master-merge branches and adjust permissions

### DIFF
--- a/.github/workflows/master_merge.yml
+++ b/.github/workflows/master_merge.yml
@@ -10,9 +10,6 @@ permissions:
 jobs:
 
   master-merge:
-    permissions:
-      contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'trilinos/Trilinos' }}
     steps:
@@ -58,8 +55,8 @@ jobs:
               
               echo "Branch ${merged_branch_name} can be deleted on remote ${REMOTE}"
 
-              # Delete the branch on origin. Commented out for now.
-              # git push --delete ${REMOTE} ${merged_branch_name}
+              # Delete the branch on origin.
+              git push --delete ${REMOTE} ${merged_branch_name}
           done
 
       


### PR DESCRIPTION
@trilinos/framework 

## Motivation
- Delete merged branches. The last iterations listed the branches that should be deleted correctly:
  https://github.com/trilinos/Trilinos/actions/runs/27054353051/job/79855706687
- The generated token should already have the necessary permissions. No need to specify them at the job level (I think).