### PR TITLE
Amesos2: add Kokkos backend to PardisoMKL

### DIFF
--- a/packages/amesos2/src/Amesos2_KLU2_def.hpp
+++ b/packages/amesos2/src/Amesos2_KLU2_def.hpp
@@ -241,7 +241,7 @@ KLU2<Matrix,Vector>::solve_impl(
     const bool initialize_data = true;
     const bool do_not_initialize_data = false;
     if ( single_proc_optimization() && nrhs == 1 ) {
-      // no msp creation
+      // no map creation
       bDidAssignB = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
         host_solve_array_t>::do_get(initialize_data, B, bValues_, as<size_t>(ld_rhs));
 
@@ -382,6 +382,7 @@ KLU2<Matrix,Vector>::solve_impl(
 
   // if bDidAssignX, then we solved straight to the adapter's X memory space without
   // requiring additional memory allocation, so the x data is already in place.
+  // TODO: should we check bDidAssignB?
   if(!bDidAssignX) {
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor redistTimer( this->timers_.vecRedistTime_ );

--- a/packages/amesos2/src/Amesos2_KokkosMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_KokkosMultiVecAdapter_decl.hpp
@@ -46,7 +46,7 @@ namespace Amesos2 {
     typedef Tpetra::Map<>::global_ordinal_type                  global_ordinal_t;
     typedef size_t                                                 global_size_t;
     typedef Scalar                                                      scalar_t;
-    typedef scalar_t host_value_t;
+    typedef scalar_t                                                host_value_t;
 
     typedef Kokkos::View<scalar_t**, Kokkos::LayoutLeft, ExecutionSpace> kokkos_view_t;
 

--- a/packages/amesos2/src/Amesos2_KokkosMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_KokkosMultiVecAdapter_decl.hpp
@@ -46,6 +46,7 @@ namespace Amesos2 {
     typedef Tpetra::Map<>::global_ordinal_type                  global_ordinal_t;
     typedef size_t                                                 global_size_t;
     typedef Scalar                                                      scalar_t;
+    typedef scalar_t host_value_t;
 
     typedef Kokkos::View<scalar_t**, Kokkos::LayoutLeft, ExecutionSpace> kokkos_view_t;
 

--- a/packages/amesos2/src/Amesos2_Kokkos_std_Impl.hpp
+++ b/packages/amesos2/src/Amesos2_Kokkos_std_Impl.hpp
@@ -15,8 +15,8 @@
   \brief  ETI for Solvers using Kokkos adapter
 */
 
-#ifndef AMESOS2_KOKKOS_IMPL_HPP
-#define AMESOS2_KOKKOS_IMPL_HPP
+#ifndef AMESOS2_KOKKOS_STD_IMPL_HPP
+#define AMESOS2_KOKKOS_STD_IMPL_HPP
 
 #include <type_traits>
 #include "Amesos2_KokkosMultiVecAdapter_decl.hpp"
@@ -24,112 +24,112 @@
 #include <KokkosSparse_CrsMatrix.hpp>
 #include <Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp>
 
-#define AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(S,LO,NODE_TYPE)                             \
+#define AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(S,LO,NODE_TYPE)                             \
   template class Amesos2::AMESOS2_KOKKOS_IMPL_SOLVER_NAME<KokkosSparse::CrsMatrix<S, LO,         \
     typename NODE_TYPE::device_type>,                                                           \
     Kokkos::View<S**, Kokkos::LayoutLeft, typename NODE_TYPE::device_type> >;
 
 #ifdef KOKKOS_ENABLE_CUDA_UVM
-#define AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER_UVM_OFF(S,LO)       \
+#define AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER_UVM_OFF(S,LO)       \
   template class Amesos2::AMESOS2_KOKKOS_IMPL_SOLVER_NAME<KokkosSparse::CrsMatrix<S, LO,          \
     Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace>>,                                              \
     Kokkos::View<S**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace>> >;
 #else
-#define AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER_UVM_OFF(S,LO)
+#define AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER_UVM_OFF(S,LO)
 #endif
 
 #if defined(KOKKOS_ENABLE_SERIAL)
 #ifdef HAVE_TPETRA_INST_FLOAT
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosSerialWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosSerialWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosSerialWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosSerialWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosSerialWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosSerialWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosSerialWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosSerialWrapperNode)
 #endif
 #endif
 
 #if defined(KOKKOS_ENABLE_THREADS)
 #ifdef HAVE_TPETRA_INST_FLOAT
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosThreadsWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosThreadsWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosThreadsWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosThreadsWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosThreadsWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosThreadsWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosThreadsWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosThreadsWrapperNode)
 #endif
 #endif // KOKKOS_ENABLE_THREADS
 
 #if defined(KOKKOS_ENABLE_OPENMP)
 #ifdef HAVE_TPETRA_INST_FLOAT
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode)
 #endif
 #endif // KOKKOS_ENABLE_OPENMP
 
 #if defined(KOKKOS_ENABLE_CUDA)
 #ifdef HAVE_TPETRA_INST_FLOAT
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosCudaWrapperNode)
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER_UVM_OFF(float, int)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosCudaWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER_UVM_OFF(float, int)
 #endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosCudaWrapperNode)
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER_UVM_OFF(double, int)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosCudaWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER_UVM_OFF(double, int)
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosCudaWrapperNode)
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER_UVM_OFF(std::complex<float>, int)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosCudaWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER_UVM_OFF(std::complex<float>, int)
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosCudaWrapperNode)
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER_UVM_OFF(std::complex<double>, int)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosCudaWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER_UVM_OFF(std::complex<double>, int)
 #endif
 #endif // KOKKOS_ENABLE_CUDA
 
 #if defined(KOKKOS_ENABLE_HIP)
 #ifdef HAVE_TPETRA_INST_FLOAT
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosHIPWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosHIPWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosHIPWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosHIPWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosHIPWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosHIPWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosHIPWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosHIPWrapperNode)
 #endif
 #endif // KOKKOS_ENABLE_HIP
 
 #if defined(KOKKOS_ENABLE_SYCL)
 #ifdef HAVE_TPETRA_INST_FLOAT
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosSYCLWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosSYCLWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosSYCLWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosSYCLWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosSYCLWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosSYCLWrapperNode)
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
-    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosSYCLWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_STD_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosSYCLWrapperNode)
 #endif
 #endif // KOKKOS_ENABLE_SYCL
 
-#endif // AMESOS2_KOKKOS_IMPL_HPP
+#endif // AMESOS2_KOKKOS_STD_IMPL_HPP

--- a/packages/amesos2/src/Amesos2_Kokkos_std_Impl.hpp
+++ b/packages/amesos2/src/Amesos2_Kokkos_std_Impl.hpp
@@ -8,7 +8,7 @@
 // @HEADER
 
 /**
-  \file   Amesos2_Kokkos_Impl.hpp
+  \file   Amesos2_Kokkos_std_Impl.hpp
   \author
   \date
 

--- a/packages/amesos2/src/Amesos2_Kokkos_std_Impl.hpp
+++ b/packages/amesos2/src/Amesos2_Kokkos_std_Impl.hpp
@@ -1,0 +1,135 @@
+// @HEADER
+// *****************************************************************************
+//           Amesos2: Templated Direct Sparse Solver Package
+//
+// Copyright 2011 NTESS and the Amesos2 contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/**
+  \file   Amesos2_Kokkos_Impl.hpp
+  \author
+  \date
+
+  \brief  ETI for Solvers using Kokkos adapter
+*/
+
+#ifndef AMESOS2_KOKKOS_IMPL_HPP
+#define AMESOS2_KOKKOS_IMPL_HPP
+
+#include <type_traits>
+#include "Amesos2_KokkosMultiVecAdapter_decl.hpp"
+#include <Kokkos_Core.hpp>
+#include <KokkosSparse_CrsMatrix.hpp>
+#include <Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp>
+
+#define AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(S,LO,NODE_TYPE)                             \
+  template class Amesos2::AMESOS2_KOKKOS_IMPL_SOLVER_NAME<KokkosSparse::CrsMatrix<S, LO,         \
+    typename NODE_TYPE::device_type>,                                                           \
+    Kokkos::View<S**, Kokkos::LayoutLeft, typename NODE_TYPE::device_type> >;
+
+#ifdef KOKKOS_ENABLE_CUDA_UVM
+#define AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER_UVM_OFF(S,LO)       \
+  template class Amesos2::AMESOS2_KOKKOS_IMPL_SOLVER_NAME<KokkosSparse::CrsMatrix<S, LO,          \
+    Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace>>,                                              \
+    Kokkos::View<S**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace>> >;
+#else
+#define AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER_UVM_OFF(S,LO)
+#endif
+
+#if defined(KOKKOS_ENABLE_SERIAL)
+#ifdef HAVE_TPETRA_INST_FLOAT
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosSerialWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_DOUBLE
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosSerialWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosSerialWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosSerialWrapperNode)
+#endif
+#endif
+
+#if defined(KOKKOS_ENABLE_THREADS)
+#ifdef HAVE_TPETRA_INST_FLOAT
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosThreadsWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_DOUBLE
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosThreadsWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosThreadsWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosThreadsWrapperNode)
+#endif
+#endif // KOKKOS_ENABLE_THREADS
+
+#if defined(KOKKOS_ENABLE_OPENMP)
+#ifdef HAVE_TPETRA_INST_FLOAT
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_DOUBLE
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosOpenMPWrapperNode)
+#endif
+#endif // KOKKOS_ENABLE_OPENMP
+
+#if defined(KOKKOS_ENABLE_CUDA)
+#ifdef HAVE_TPETRA_INST_FLOAT
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosCudaWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER_UVM_OFF(float, int)
+#endif
+#ifdef HAVE_TPETRA_INST_DOUBLE
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosCudaWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER_UVM_OFF(double, int)
+#endif
+#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosCudaWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER_UVM_OFF(std::complex<float>, int)
+#endif
+#ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosCudaWrapperNode)
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER_UVM_OFF(std::complex<double>, int)
+#endif
+#endif // KOKKOS_ENABLE_CUDA
+
+#if defined(KOKKOS_ENABLE_HIP)
+#ifdef HAVE_TPETRA_INST_FLOAT
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosHIPWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_DOUBLE
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosHIPWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosHIPWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosHIPWrapperNode)
+#endif
+#endif // KOKKOS_ENABLE_HIP
+
+#if defined(KOKKOS_ENABLE_SYCL)
+#ifdef HAVE_TPETRA_INST_FLOAT
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(float, int, Tpetra::KokkosCompat::KokkosSYCLWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_DOUBLE
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(double, int, Tpetra::KokkosCompat::KokkosSYCLWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<float>, int, Tpetra::KokkosCompat::KokkosSYCLWrapperNode)
+#endif
+#ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
+    AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER(std::complex<double>, int, Tpetra::KokkosCompat::KokkosSYCLWrapperNode)
+#endif
+#endif // KOKKOS_ENABLE_SYCL
+
+#endif // AMESOS2_KOKKOS_IMPL_HPP

--- a/packages/amesos2/src/Amesos2_MultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_MultiVecAdapter_decl.hpp
@@ -208,6 +208,16 @@ namespace Amesos2 {
                         EDistribution distribution );
     };
 
+    template <typename MV, typename KV>
+    struct same_type_get_view {
+      static bool apply (bool bInitialize,
+                        const Teuchos::Ptr<const MV>& mv,
+                        KV& kokkos_vals,
+                        const size_t ldx,
+                        Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                        EDistribution distribution);
+    };
+
     /*
      * In the case where the scalar type of the multi-vector and the
      * corresponding S type are different, then we need to first get a
@@ -221,6 +231,16 @@ namespace Amesos2 {
                         const size_t ldx,
                         Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
                         EDistribution distribution );
+    };
+
+    template <typename MV, typename KV>
+    struct diff_type_get_view {
+      static bool apply (bool bInitialize,
+                        const Teuchos::Ptr<const MV>& mv,
+                        KV& kokkos_vals,
+                        const size_t ldx,
+                        Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                        EDistribution distribution);
     };
 
     /** \internal
@@ -314,6 +334,15 @@ namespace Amesos2 {
                         EDistribution distribution );
     };
 
+    template <typename MV, typename KV>
+    struct same_type_put_view {
+      static void apply(const Teuchos::Ptr<MV>& mv,
+                        KV& data,
+                        const size_t ldx,
+                        Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                        EDistribution distribution );
+    };
+
     /*
      * In the case where the scalar type of the multi-vector and the
      * corresponding S type are different, then we need to first get a
@@ -324,6 +353,15 @@ namespace Amesos2 {
     struct diff_type_data_put {
       static void apply(const Teuchos::Ptr<MV>& mv,
                         const Teuchos::ArrayView<S>& data,
+                        const size_t ldx,
+                        Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                        EDistribution distribution );
+    };
+
+    template <typename MV, typename KV>
+    struct diff_type_put_view {
+      static void apply(const Teuchos::Ptr<MV>& mv,
+                        KV& kokkos_data,
                         const size_t ldx,
                         Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
                         EDistribution distribution );

--- a/packages/amesos2/src/Amesos2_MultiVecAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_MultiVecAdapter_def.hpp
@@ -191,16 +191,19 @@ namespace Amesos2{
       const size_t ncols = output_view.extent(1);
       Kokkos::resize(kokkos_vals, ldx, ncols);
 
+      #if 1
       auto h_output_view = Kokkos::create_mirror_view(output_view);
       auto h_kokkos_vals = Kokkos::create_mirror_view(kokkos_vals);
       Kokkos::deep_copy(output_view, h_output_view);
       for (size_t j=0; j<ncols; j++) {
         for (size_t i=0; i<nrows; i++) h_kokkos_vals(i,j) = Teuchos::as<output_scalar_type> (h_output_view(i,j));
-        //Kokkos::parallel_for("Amesos2::MultiVecAdapter::diff_type_get_view::apply", Kokkos::RangePolicy<execution_space>(0, nrows),
-        //  KOKKOS_LAMBDA(const int i) { kokkos_vals(i,j) = Teuchos::as<output_scalar_type> (output_view(i,j)); });
       }
       Kokkos::deep_copy(kokkos_vals, h_kokkos_vals);
-      // TODO: check this !!
+      #else
+      //Kokkos::parallel_for("Amesos2::MultiVecAdapter::diff_type_get_view::apply", Kokkos::RangePolicy<execution_space>(0, nrows),
+      //  KOKKOS_LAMBDA(const int i) { for (size_t j=0; j<ncols; j++) kokkos_vals(i,j) = Teuchos::as<output_scalar_type> (output_view(i,j)); });
+      #endif
+
       // made a copy, instead of assigning input pointer (so safe to shallow-copy, which won't over-write the original memory space)
       bAssigned = false;
       return bAssigned;
@@ -228,11 +231,12 @@ namespace Amesos2{
             Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
             EDistribution distribution)
     {
-      // call appropriate apply based on if the input and output scalar types are the same or different
       // TODO: check input-scalar (host vs non-host)
       //using input_scalar_type  = typename MV::scalar_t;
       using input_scalar_type  = typename MV::host_value_t;
       using output_scalar_type = typename KV::non_const_value_type;
+
+      // call appropriate apply based on if the input and output scalar types are the same or different
       bool bAssigned =  std::conditional_t<std::is_same_v<input_scalar_type, output_scalar_type>,
                same_type_get_view<MV, KV>,
                diff_type_get_view<MV, KV>>::apply (bInitialize, mv, kokkos_vals, ldx, distribution_map, distribution);
@@ -389,7 +393,6 @@ namespace Amesos2{
     }
 
     // KV
-    // TODO: static ? class vs typename ?
     template <class MV, class KV>
     void same_type_put_view<MV,KV>::apply(const Teuchos::Ptr<MV>& mv,
                                           KV& kokkos_data,
@@ -419,19 +422,6 @@ namespace Amesos2{
       const size_t ncols = kokkos_data.extent(1);
       Kokkos::View<output_scalar_type**, Kokkos::LayoutLeft, memory_space> output_view ("output_view", ldx, ncols);
 
-      #ifdef my_debug
-      {
-        auto h_output_view = Kokkos::create_mirror_view(output_view);
-        auto h_kokkos_data = Kokkos::create_mirror_view(kokkos_data);
-        Kokkos::deep_copy(h_kokkos_data, kokkos_data);
-        Kokkos::deep_copy(h_output_view, output_view);
-        for (size_t j=0; j<ncols; j++) {
-          for (size_t i=0; i<nrows; i++)
-            printf( " - %d:%d: (%e, %e) <- (%e, %e)\n",i,j,h_output_view(i,j).real(),h_output_view(i,j).imag(), h_kokkos_data(i,j).real(),h_kokkos_data(i,j).imag());
-        }
-	printf("\n");
-      }
-      #endif
       #if 1
       auto h_output_view = Kokkos::create_mirror_view(output_view);
       auto h_kokkos_data = Kokkos::create_mirror_view(kokkos_data);
@@ -442,23 +432,10 @@ namespace Amesos2{
       Kokkos::deep_copy(output_view, h_output_view);
       #else
       // TODO: how to custom-cast within parallel-for
-      for (size_t j=0; j<ncols; j++) {
-        Kokkos::parallel_for("Amesos2::MultiVecAdapter::diff_type_get_view::apply", Kokkos::RangePolicy<execution_space>(0, nrows),
-          KOKKOS_LAMBDA(const int i) { output_view(i,j) = Teuchos::as<output_scalar_type> (kokkos_data(i,j)); });
-      }
+      Kokkos::parallel_for("Amesos2::MultiVecAdapter::diff_type_get_view::apply", Kokkos::RangePolicy<execution_space>(0, nrows),
+        KOKKOS_LAMBDA(const int i) { for (size_t j=0; j<ncols; j++) output_view(i,j) = Teuchos::as<output_scalar_type> (kokkos_data(i,j)); });
       #endif
-      #ifdef my_debug
-      {
-        auto h_output_view = Kokkos::create_mirror_view(output_view);
-        auto h_kokkos_data = Kokkos::create_mirror_view(kokkos_data);
-        Kokkos::deep_copy(h_kokkos_data, kokkos_data);
-        Kokkos::deep_copy(h_output_view, output_view);
-        for (size_t j=0; j<ncols; j++) {
-          for (size_t i=0; i<nrows; i++)
-            printf( " + %d:%d: (%e, %e) <- (%e, %e)\n",i,j,h_output_view(i,j).real(),h_output_view(i,j).imag(), h_kokkos_data(i,j).real(),h_kokkos_data(i,j).imag());
-        }
-      }
-      #endif
+
       // put to output (of output scalar type)
       mv->put1dData_kokkos_view(output_view, ldx, distribution_map, distribution);
     }

--- a/packages/amesos2/src/Amesos2_MultiVecAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_MultiVecAdapter_def.hpp
@@ -164,10 +164,54 @@ namespace Amesos2{
         map.is_null (), std::invalid_argument,
         "Amesos2::get_1d_copy_helper::do_get(3 args): mv->getMap() is null.");
 
-
       do_get (mv, vals, ldx, Teuchos::ptrInArg (*map), ROOTED); // ROOTED the default here for now
     }
 
+    // KV
+    template <class MV, typename KV>
+    bool diff_type_get_view<MV, KV>::
+    apply (bool bInitialize,
+           const Teuchos::Ptr<const MV>& mv,
+           KV& kokkos_vals,
+           const size_t ldx,
+           Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+           EDistribution distribution)
+    {
+      using input_scalar_type  = typename MV::scalar_t;
+      using output_scalar_type = typename KV::non_const_value_type;
+      using execution_space = typename KV::execution_space;
+      using memory_space    = typename execution_space::memory_space;
+
+      // copy to workspace (of same type as input scalar type)
+      Kokkos::View<input_scalar_type**, Kokkos::LayoutLeft, memory_space> output_view;
+      bool bAssigned = mv->get1dCopy_kokkos_view(bInitialize, output_view, ldx, distribution_map, distribution);
+
+      // copy back (of the output scalar type)
+      const size_t nrows = output_view.extent(0);
+      const size_t ncols = output_view.extent(1);
+      Kokkos::resize(kokkos_vals, ldx, ncols);
+      for (size_t j=0; j<ncols; j++) {
+        for (size_t i=0; i<nrows; i++) kokkos_vals(i,j) = Teuchos::as<output_scalar_type> (output_view(i,j));
+      }
+      // TODO: check this !!
+      // made a copy, instead of assigning input pointer (so safe to shallow-copy, which won't over-write the original memory space)
+      bAssigned = false;
+      return bAssigned;
+    }
+
+    template <class MV, class KV>
+    bool same_type_get_view<MV, KV>::
+    apply (bool bInitialize,
+           const Teuchos::Ptr<const MV>& mv,
+           KV& kokkos_vals,
+           const size_t ldx,
+           Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+           EDistribution distribution)
+    {
+      return mv->get1dCopy_kokkos_view(bInitialize, kokkos_vals, ldx, distribution_map, distribution);
+    }
+
+    // > entry point
     template <class MV, typename KV>
     bool get_1d_copy_helper_kokkos_view<MV,KV>::
     do_get (bool bInitialize,
@@ -177,7 +221,13 @@ namespace Amesos2{
             Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
             EDistribution distribution)
     {
-      return mv->get1dCopy_kokkos_view(bInitialize, kokkos_vals, ldx, distribution_map, distribution);
+      // call appropriate apply based on if the input and output scalar types are the same or different
+      using input_scalar_type  = typename MV::scalar_t;
+      using output_scalar_type = typename KV::non_const_value_type;
+      bool bAssigned =  std::conditional_t<std::is_same_v<input_scalar_type, output_scalar_type>,
+               same_type_get_view<MV, KV>,
+               diff_type_get_view<MV, KV>>::apply (bInitialize, mv, kokkos_vals, ldx, distribution_map, distribution);
+      return bAssigned;
     }
 
     template <class MV, typename KV>
@@ -329,6 +379,41 @@ namespace Amesos2{
       do_put (mv, data, ldx, Teuchos::ptrInArg (*map), ROOTED); // Default as ROOTED for now
     }
 
+    // KV
+    // TODO: static ? class vs typename ?
+    template <class MV, class KV>
+    void same_type_put_view<MV,KV>::apply(const Teuchos::Ptr<MV>& mv,
+                                          KV& kokkos_data,
+                                          const size_t ldx,
+                                          Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                                          EDistribution distribution )
+    {
+      mv->put1dData_kokkos_view(kokkos_data, ldx, distribution_map, distribution);
+    }
+
+    template <class MV, class KV>
+    void diff_type_put_view<MV,KV>::apply(const Teuchos::Ptr<MV>& mv,
+                                          KV& kokkos_data,
+                                          const size_t ldx,
+                                          Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
+                                          EDistribution distribution )
+    {
+      using input_scalar_type   = typename KV::non_const_value_type;
+      using output_scalar_type  = typename MV::scalar_t;
+      using execution_space = typename KV::execution_space;
+      using memory_space    = typename execution_space::memory_space;
+
+      // copy to input workspace (of same type as output scalar type)
+      const size_t nrows = kokkos_data.extent(0);
+      const size_t ncols = kokkos_data.extent(1);
+      Kokkos::View<output_scalar_type**, Kokkos::LayoutLeft, memory_space> output_view ("output_view", ldx, ncols);
+      for (size_t j=0; j<ncols; j++) {
+        for (size_t i=0; i<nrows; i++) output_view(i,j) = Teuchos::as<output_scalar_type> (kokkos_data(i,j));
+      }
+      // put to output (of output scalar type)
+      mv->put1dData_kokkos_view(output_view, ldx, distribution_map, distribution);
+    }
+
     template <class MV, typename KV>
     void put_1d_data_helper_kokkos_view<MV,KV>::do_put(const Teuchos::Ptr<MV>& mv,
                                           KV& kokkos_data,
@@ -336,7 +421,12 @@ namespace Amesos2{
                                           Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
                                           EDistribution distribution )
     {
-      mv->put1dData_kokkos_view(kokkos_data, ldx, distribution_map, distribution);
+      // call appropriate apply based on if the input and output scalar types are the same or different
+      using input_scalar_type   = typename KV::non_const_value_type;
+      using output_scalar_type  = typename MV::scalar_t;
+      std::conditional_t<std::is_same_v<input_scalar_type, output_scalar_type>,
+               same_type_put_view<MV, KV>,
+               diff_type_put_view<MV, KV>>::apply (mv, kokkos_data, ldx, distribution_map, distribution);
     }
 
     template <class MV, typename KV>

--- a/packages/amesos2/src/Amesos2_MultiVecAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_MultiVecAdapter_def.hpp
@@ -410,7 +410,6 @@ namespace Amesos2{
                                           Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
                                           EDistribution distribution )
     {
-      using input_scalar_type   = typename KV::non_const_value_type;
       // TODO: check input-scalar (host vs non-host)
       //using output_scalar_type  = typename MV::scalar_t;
       using output_scalar_type  = typename MV::host_value_t;

--- a/packages/amesos2/src/Amesos2_MultiVecAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_MultiVecAdapter_def.hpp
@@ -190,9 +190,16 @@ namespace Amesos2{
       const size_t nrows = output_view.extent(0);
       const size_t ncols = output_view.extent(1);
       Kokkos::resize(kokkos_vals, ldx, ncols);
+
+      auto h_output_view = Kokkos::create_mirror_view(output_view);
+      auto h_kokkos_vals = Kokkos::create_mirror_view(kokkos_vals);
+      Kokkos::deep_copy(output_view, h_output_view);
       for (size_t j=0; j<ncols; j++) {
-        for (size_t i=0; i<nrows; i++) kokkos_vals(i,j) = Teuchos::as<output_scalar_type> (output_view(i,j));
+        for (size_t i=0; i<nrows; i++) h_kokkos_vals(i,j) = Teuchos::as<output_scalar_type> (h_output_view(i,j));
+        //Kokkos::parallel_for("Amesos2::MultiVecAdapter::diff_type_get_view::apply", Kokkos::RangePolicy<execution_space>(0, nrows),
+        //  KOKKOS_LAMBDA(const int i) { kokkos_vals(i,j) = Teuchos::as<output_scalar_type> (output_view(i,j)); });
       }
+      Kokkos::deep_copy(kokkos_vals, h_kokkos_vals);
       // TODO: check this !!
       // made a copy, instead of assigning input pointer (so safe to shallow-copy, which won't over-write the original memory space)
       bAssigned = false;
@@ -222,7 +229,9 @@ namespace Amesos2{
             EDistribution distribution)
     {
       // call appropriate apply based on if the input and output scalar types are the same or different
-      using input_scalar_type  = typename MV::scalar_t;
+      // TODO: check input-scalar (host vs non-host)
+      //using input_scalar_type  = typename MV::scalar_t;
+      using input_scalar_type  = typename MV::host_value_t;
       using output_scalar_type = typename KV::non_const_value_type;
       bool bAssigned =  std::conditional_t<std::is_same_v<input_scalar_type, output_scalar_type>,
                same_type_get_view<MV, KV>,
@@ -399,7 +408,9 @@ namespace Amesos2{
                                           EDistribution distribution )
     {
       using input_scalar_type   = typename KV::non_const_value_type;
-      using output_scalar_type  = typename MV::scalar_t;
+      // TODO: check input-scalar (host vs non-host)
+      //using output_scalar_type  = typename MV::scalar_t;
+      using output_scalar_type  = typename MV::host_value_t;
       using execution_space = typename KV::execution_space;
       using memory_space    = typename execution_space::memory_space;
 
@@ -407,9 +418,47 @@ namespace Amesos2{
       const size_t nrows = kokkos_data.extent(0);
       const size_t ncols = kokkos_data.extent(1);
       Kokkos::View<output_scalar_type**, Kokkos::LayoutLeft, memory_space> output_view ("output_view", ldx, ncols);
-      for (size_t j=0; j<ncols; j++) {
-        for (size_t i=0; i<nrows; i++) output_view(i,j) = Teuchos::as<output_scalar_type> (kokkos_data(i,j));
+
+      #ifdef my_debug
+      {
+        auto h_output_view = Kokkos::create_mirror_view(output_view);
+        auto h_kokkos_data = Kokkos::create_mirror_view(kokkos_data);
+        Kokkos::deep_copy(h_kokkos_data, kokkos_data);
+        Kokkos::deep_copy(h_output_view, output_view);
+        for (size_t j=0; j<ncols; j++) {
+          for (size_t i=0; i<nrows; i++)
+            printf( " - %d:%d: (%e, %e) <- (%e, %e)\n",i,j,h_output_view(i,j).real(),h_output_view(i,j).imag(), h_kokkos_data(i,j).real(),h_kokkos_data(i,j).imag());
+        }
+	printf("\n");
       }
+      #endif
+      #if 1
+      auto h_output_view = Kokkos::create_mirror_view(output_view);
+      auto h_kokkos_data = Kokkos::create_mirror_view(kokkos_data);
+      Kokkos::deep_copy(h_kokkos_data, kokkos_data);
+      for (size_t j=0; j<ncols; j++) {
+        for (size_t i=0; i<nrows; i++) h_output_view(i,j) = Teuchos::as<output_scalar_type> (h_kokkos_data(i,j));
+      }
+      Kokkos::deep_copy(output_view, h_output_view);
+      #else
+      // TODO: how to custom-cast within parallel-for
+      for (size_t j=0; j<ncols; j++) {
+        Kokkos::parallel_for("Amesos2::MultiVecAdapter::diff_type_get_view::apply", Kokkos::RangePolicy<execution_space>(0, nrows),
+          KOKKOS_LAMBDA(const int i) { output_view(i,j) = Teuchos::as<output_scalar_type> (kokkos_data(i,j)); });
+      }
+      #endif
+      #ifdef my_debug
+      {
+        auto h_output_view = Kokkos::create_mirror_view(output_view);
+        auto h_kokkos_data = Kokkos::create_mirror_view(kokkos_data);
+        Kokkos::deep_copy(h_kokkos_data, kokkos_data);
+        Kokkos::deep_copy(h_output_view, output_view);
+        for (size_t j=0; j<ncols; j++) {
+          for (size_t i=0; i<nrows; i++)
+            printf( " + %d:%d: (%e, %e) <- (%e, %e)\n",i,j,h_output_view(i,j).real(),h_output_view(i,j).imag(), h_kokkos_data(i,j).real(),h_kokkos_data(i,j).imag());
+        }
+      }
+      #endif
       // put to output (of output scalar type)
       mv->put1dData_kokkos_view(output_view, ldx, distribution_map, distribution);
     }

--- a/packages/amesos2/src/Amesos2_PardisoMKL.cpp
+++ b/packages/amesos2/src/Amesos2_PardisoMKL.cpp
@@ -7,14 +7,14 @@
 // *****************************************************************************
 // @HEADER
 
-
+#include "Amesos2_config.h"
 #include "Amesos2_PardisoMKL_decl.hpp"
 
 #ifdef HAVE_AMESOS2_EXPLICIT_INSTANTIATION
 
 #include "Amesos2_PardisoMKL_def.hpp"
 #include "Amesos2_ExplicitInstantiationHelpers.hpp"
-
+#include "TpetraCore_ETIHelperMacros.h"
 
 #ifdef HAVE_TPETRA_INST_INT_INT
 namespace Amesos2 {
@@ -86,8 +86,8 @@ namespace Amesos2 {
 #endif
 
 #include <Tpetra_KokkosCompat_DefaultNode.hpp>
-#include "TpetraCore_ETIHelperMacros.h"
 
+namespace Amesos2 {
 #define AMESOS2_PARDISOMKL_LOCAL_INSTANT(S,LO,GO,N)                        \
   template class Amesos2::PardisoMKL<Tpetra::CrsMatrix<S, LO, GO, N>,      \
                                   Tpetra::MultiVector<S, LO, GO,  N> >;
@@ -337,4 +337,9 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
 #endif
 #undef NODETYPE
 #endif
+
+// instantiate std::complex (not Kokkos::complex with Amesos2_Kokkos_Impl.hpp)
+#define AMESOS2_KOKKOS_IMPL_SOLVER_NAME PardisoMKL
+#include "Amesos2_Kokkos_std_Impl.hpp"
+}
 #endif  // HAVE_AMESOS2_EXPLICIT_INSTANTIATION

--- a/packages/amesos2/src/Amesos2_PardisoMKL_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_PardisoMKL_TypeMap.hpp
@@ -205,7 +205,6 @@ namespace Amesos2 {
     typedef PMKL::_DOUBLE_PRECISION_t magnitude_type;
   };
 
-
   template <>
   struct TypeMap<PardisoMKL,PMKL::_MKL_Complex8>
   {

--- a/packages/amesos2/src/Amesos2_PardisoMKL_decl.hpp
+++ b/packages/amesos2/src/Amesos2_PardisoMKL_decl.hpp
@@ -22,8 +22,6 @@
 #ifndef AMESOS2_PARDISOMKL_DECL_HPP
 #define AMESOS2_PARDISOMKL_DECL_HPP
 
-#include <map>
-
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 
 #include "Amesos2_SolverTraits.hpp"
@@ -85,6 +83,8 @@ namespace Amesos2 {
     typedef Kokkos::View<int_t*,              HostExecSpaceType>    host_size_type_array;
     typedef Kokkos::View<int_t*,              HostExecSpaceType>    host_ordinal_type_array;
     typedef Kokkos::View<solver_scalar_type*, HostExecSpaceType>    host_value_type_array;
+    typedef typename Kokkos::View<solver_scalar_type**, Kokkos::LayoutLeft,
+                                  typename HostExecSpaceType::memory_space> host_solver_scalar_view;
 
     /// \name Constructor/Destructor methods
     //@{
@@ -254,10 +254,10 @@ namespace Amesos2 {
     host_ordinal_type_array colind_view_;
     /// Stores the row indices of the nonzero entries
     host_size_type_array rowptr_view_;
-    /// Persisting, contiguous, 1D store for X
-    mutable Teuchos::Array<solver_scalar_type> xvals_;
-    /// Persisting, contiguous, 1D store for B
-    mutable Teuchos::Array<solver_scalar_type> bvals_;
+    /// Persisting, contiguous, 2D view for X
+    mutable host_solver_scalar_view xvals_;
+    /// Persisting, contiguous, 2D view for B
+    mutable host_solver_scalar_view bvals_;
 
     /// PardisoMKL internal data address pointer
     mutable void* pt_[64];
@@ -308,6 +308,11 @@ typedef Meta::make_list2<float,
 #endif
 };
 
+template <typename Scalar, typename LocalOrdinal, typename ExecutionSpace>
+struct solver_supports_matrix<PardisoMKL,
+  KokkosSparse::CrsMatrix<Scalar, LocalOrdinal, ExecutionSpace>> {
+  static const bool value = true;
+};
 } // end namespace Amesos
 
 #endif  // AMESOS2_PARDISOMKL_DECL_HPP

--- a/packages/amesos2/src/Amesos2_PardisoMKL_def.hpp
+++ b/packages/amesos2/src/Amesos2_PardisoMKL_def.hpp
@@ -19,8 +19,6 @@
 #ifndef AMESOS2_PARDISOMKL_DEF_HPP
 #define AMESOS2_PARDISOMKL_DEF_HPP
 
-#include <map>
-
 #include <Teuchos_Tuple.hpp>
 #include <Teuchos_toString.hpp>
 #include <Teuchos_StandardParameterEntryValidators.hpp>
@@ -220,19 +218,21 @@ namespace Amesos2 {
       }
     }
 
-    const size_t val_store_size = as<size_t>(ld_rhs * nrhs_);
-    xvals_.resize(val_store_size);
-    bvals_.resize(val_store_size);
-
     {                             // Get values from RHS B
 #ifdef HAVE_AMESOS2_TIMERS
       Teuchos::TimeMonitor mvConvTimer( this->timers_.vecConvTime_ );
       Teuchos::TimeMonitor redistTimer( this->timers_.vecRedistTime_ );
 #endif
 
-      Util::get_1d_copy_helper<
-        MultiVecAdapter<Vector>,
-        solver_scalar_type>::do_get(B, bvals_(),
+      const bool initialize_data = true;
+      const bool do_not_initialize_data = false;
+      Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+        host_solver_scalar_view>::do_get(initialize_data, B, bvals_,
+          as<size_t>(ld_rhs),
+          (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+          this->rowIndexBase_);
+      Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+        host_solver_scalar_view>::do_get(do_not_initialize_data, X, xvals_,
           as<size_t>(ld_rhs),
           (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
           this->rowIndexBase_);
@@ -257,8 +257,8 @@ namespace Amesos2 {
                              &nrhs_,
                              const_cast<int_t*>(iparm_),
                              const_cast<int_t*>(&msglvl_),
-                             as<void*>(bvals_.getRawPtr()),
-                             as<void*>(xvals_.getRawPtr()), &error );
+                             as<void*>(bvals_.data()),
+                             as<void*>(xvals_.data()), &error );
     }
 
     check_pardiso_mkl_error(Amesos2::SOLVE, error);
@@ -269,11 +269,11 @@ namespace Amesos2 {
       Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
 #endif
 
-      Util::put_1d_data_helper<
-      MultiVecAdapter<Vector>,
-        solver_scalar_type>::do_put(X, xvals_(),
+      Util::put_1d_data_helper_kokkos_view<
+        MultiVecAdapter<Vector>,host_solver_scalar_view>::do_put(X, xvals_,
           as<size_t>(ld_rhs),
-          (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED);
+          (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
+          this->rowIndexBase_);
     }
     if (debug_level_ > 0) {
       if (debug_level_ == 1) {

--- a/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_decl.hpp
@@ -54,6 +54,7 @@ namespace Amesos2 {
     typedef GlobalOrdinal                   global_ordinal_t;
     typedef Node                            node_t;
     typedef Tpetra::global_size_t           global_size_t;
+    typedef typename multivec_t::dual_view_type::t_host::value_type host_value_t;
 
     friend Teuchos::RCP<MultiVecAdapter<multivec_t> > createMultiVecAdapter<> (Teuchos::RCP<multivec_t>);
     friend Teuchos::RCP<const MultiVecAdapter<multivec_t> > createConstMultiVecAdapter<> (Teuchos::RCP<const multivec_t>);

--- a/packages/amesos2/test/solvers/pardiso_mkl_test.xml
+++ b/packages/amesos2/test/solvers/pardiso_mkl_test.xml
@@ -2,7 +2,15 @@
   <ParameterList name="arc130.mtx">
     <Parameter name="complex" type="bool" value="false"/>
     <ParameterList name="PARDISOMKL">
-      
+      <!-- Next test Kokkos objects -->
+      <ParameterList name="kokkos">
+       <ParameterList name="run1 - i">
+         <Parameter name="Scalar" type="string" value="double"/>
+         <Parameter name="LocalOrdinal" type="string" value="int"/>
+         <Parameter name="GlobalOrdinal" type="string" value="long long int"/>
+       </ParameterList>
+      </ParameterList>
+
       <!-- Next test Tpetra objects -->
       <ParameterList name="tpetra">
 	<!-- these `run*' sublist names are arbitrary -->

--- a/packages/amesos2/test/solvers/shylubasker_test.xml
+++ b/packages/amesos2/test/solvers/shylubasker_test.xml
@@ -5,6 +5,24 @@
 
   <ParameterList name="arc130.mtx">
     <ParameterList name="ShyLUBasker">
+      <!-- Test Kokkos objects -->
+      <ParameterList name="kokkos">
+        <ParameterList name="run-int-longlong-p1-default">
+          <Parameter name="Scalar" type="string" value="double"/>
+          <Parameter name="LocalOrdinal" type="string" value="int"/>
+          <Parameter name="GlobalOrdinal" type="string" value="long long int"/>
+          <ParameterList name="solver_run_params">
+            <Parameter name="num_threads"  type="int" value="1" />
+            <Parameter name="btf"   type="bool" value="true" />
+            <Parameter name="transpose" type="bool" value="false" />
+            <Parameter name="pivot"    type="bool"   value="false" />
+            <Parameter name="pivot_tol" type="double" value=".001" />
+            <Parameter name="symmetric" type="bool" value="false" />
+            <Parameter name="realloc" type="bool" value="false"/>
+           </ParameterList> <!-- end solver_run_params -->
+        </ParameterList> <!-- end run-int-longlong-p#-default -->
+      </ParameterList>
+
       <!-- Test Tpetra objects -->
       <ParameterList name="tpetra">
 	<ParameterList name="run-int-int-p1-default">


### PR DESCRIPTION

@trilinos/amesos2

## Motivation

This PR adds Kokkos-backend ETI to PardisoMKL

## Testing
 * added Kokkos-backend testing with PardisoMKL (also ShyLU-Basker) through solver-test 

## Additional Information
- added the functions to get/put with Kokkos-view using different scalar types (e.g., MKL's complex type and std::complex)