### PR TITLE
Piro: optional static-equilibrium initial solve in TrapezoidRuleSolver

### DIFF
--- a/packages/piro/src/Piro_TrapezoidRuleSolver.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver.hpp
@@ -118,9 +118,18 @@ class TrapezoidRuleSolver
   /** \brief . */
   Teuchos::RCP<Thyra::AdaptiveSolutionManager> getSolutionManager() const;
   /** \brief .*/
-  void disableCalcInitAccel() { calc_init_accel_ = false; }; 
+  void disableCalcInitAccel() { calc_init_accel_ = false; };
   /** \brief .*/
-  void enableCalcInitAccel() { calc_init_accel_ = true; }; 
+  void enableCalcInitAccel() { calc_init_accel_ = true; };
+  /** \brief Start from static equilibrium: solve K x = f (no inertia) once
+      before the time loop, then set v = a = 0. Takes precedence over the
+      initial-acceleration heuristic (calc_init_accel_), whose perturbation
+      parameter 4e6/dt^2 degenerates to a near-static solve anyway when dt
+      is large relative to the structural time scale, yielding a spurious
+      a_init = pert*x_static instead of a physical acceleration. */
+  void enableStaticInitSolve() { static_init_solve_ = true; };
+  /** \brief .*/
+  void disableStaticInitSolve() { static_init_solve_ = false; };
   //@}
 
 
@@ -160,7 +169,8 @@ private:
    int numTimeSteps;
    Scalar t_init, t_final, delta_t;
 
-   mutable bool calc_init_accel_{true}; 
+   mutable bool calc_init_accel_{true};
+   mutable bool static_init_solve_{false};
 };
 
 }

--- a/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
@@ -257,9 +257,28 @@ Piro::TrapezoidRuleSolver<Scalar>::evalModelImpl(
   Scalar nrm = norm_2(*v);
   *out << "Initial Velocity = " << nrm << std::endl;
 
+  // Static-equilibrium start: solve the static problem K x = f (no inertia)
+  // and begin the transient from there with v = a = 0. Injecting
+  // fdt2 = tdt = 0 makes the decorator hand the model xdot = xdotdot = 0
+  // with alpha = omega = 0, beta = 1 -- a pure static solve. This is the
+  // physically appropriate start for problems (e.g. gravity-loaded soil)
+  // that have been in equilibrium since long before t = 0: it produces no
+  // spurious initial transient for the undamped Newmark scheme to carry.
+  if (static_init_solve_ == true) {
+    assign(x_pred_a.ptr(), *x);
+    assign(x_pred_v.ptr(), *x);
+    model->injectData(x, x_pred_a, 0.0, x_pred_v, 0.0, t);
+
+    noxSolver->evalModel(nox_inargs, nox_outargs);
+
+    assign(x.ptr(), *gx_out);
+    Thyra::put_scalar(0.0, v.ptr());
+    Thyra::put_scalar(0.0, a.ptr());
+    *out << "Static-equilibrium init solve: ||x_static|| = " << norm_2(*x) << std::endl;
+  }
    //calculate intial acceleration using small time step (1.0e-3*delta_t)
    // AGS: Check this for inital velocity
-  if (calc_init_accel_ == true) {
+  else if (calc_init_accel_ == true) {
     Scalar pert= 1.0e6 * 4.0 / (delta_t * delta_t);
     assign(x_pred_a.ptr(), *x);
     assign(x_pred_v.ptr(), *x);


### PR DESCRIPTION
## Motivation

`Piro::TrapezoidRuleSolver` initializes the acceleration with a heuristic
(`calc_init_accel_`, on by default) that solves a fictitious fast-dynamics
problem with perturbation

```
pert = 1.0e6 * 4 / dt^2
```

intended to emulate a time step of `dt/1000` so that the mass term dominates
and `a_init = pert * (x_solved - x0) ~= M^-1 (f - K x0)`.

This is only valid when `dt/1000` resolves the structural time scale. For
applications that take large time steps -- e.g. quasi-static
thermo-mechanical coupling in Albany-LCM with `dt = 900 s`, where the
structural stiffness scale is `E/(rho h^2) ~ 5e7 s^-2` -- `pert ~ 5 s^-2` is
seven orders of magnitude too small. The "fast dynamics" solve then
degenerates to a *static* solve, and the heuristic returns

```
a_init = pert * x_static
```

which is an artifact unrelated to any physical acceleration (we verified
`a_init` matches `pert * ||x_static||` to 4 digits on our application
problem). Starting the undamped Newmark (average-acceleration) scheme from
this spurious acceleration injects a velocity transient that never decays and
can grow under external forcing. In our coastal-permafrost erosion runs this
manifested as a linearly growing velocity norm that eventually destabilized
the Newton solve.

## What this PR adds

`enableStaticInitSolve()` / `disableStaticInitSolve()` on
`Piro::TrapezoidRuleSolver`. When enabled, the solver starts the transient
from **static equilibrium**:

1. Solve the static problem `K x = f` once before the time loop. This reuses
   the existing NOX solver and `TrapezoidDecorator` plumbing: injecting
   `fdt2 = tdt = 0` makes the decorator hand the model `xdot = xdotdot = 0`
   with `alpha = omega = 0`, `beta = 1` -- a pure static residual/Jacobian.
2. Assign the converged static solution to `x`; set `v = a = 0`.
3. Proceed with the normal Newmark time loop.

This is the physically appropriate initialization for problems that have
been in equilibrium under their body force since long before `t = 0`
(e.g. gravity-loaded soil/structures), and produces no spurious transient.

The option is **off by default**; when enabled it takes precedence over
`calc_init_accel_`. No behavior change for existing users.

## Application validation

On the Albany-LCM ACE sequential thermo-mechanical coastal-permafrost
problem (`dt = 900 s`, 4 MPI ranks, ~15k steps):

| | velocity norm at step 1 | at step 100 | trend |
|---|---|---|---|
| `calc_init_accel_` (default) | 8.6e-4 | 2.0e-3 | grows without bound |
| static-equilibrium start | 7.0e-7 | 7.0e-7 | stationary |

@ikalash
