### PR TITLE
amesos2/cuSOLVER: dense-inverse direct solve, distribution-map cache,…

### DIFF
--- a/packages/amesos2/src/Amesos2_KokkosMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_KokkosMultiVecAdapter_decl.hpp
@@ -276,13 +276,6 @@ namespace Amesos2 {
               const Teuchos::EVerbosityLevel verbLevel =
               Teuchos::Describable::verbLevel_default) const;
 
-    // Direct 2-D device view access for single-process GPU solvers.
-    Kokkos::View<const scalar_t**, Kokkos::LayoutLeft, ExecutionSpace>
-    getLocalDeviceView2d_ReadOnly() const { return *mv_; }
-
-    Kokkos::View<scalar_t**, Kokkos::LayoutLeft, ExecutionSpace>
-    getLocalDeviceView2d_OverwriteAll() const { return *mv_; }
-
   private:
 
     //! The multivector which this adapter wraps

--- a/packages/amesos2/src/Amesos2_KokkosMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_KokkosMultiVecAdapter_decl.hpp
@@ -276,6 +276,13 @@ namespace Amesos2 {
               const Teuchos::EVerbosityLevel verbLevel =
               Teuchos::Describable::verbLevel_default) const;
 
+    // Direct 2-D device view access for single-process GPU solvers.
+    Kokkos::View<const scalar_t**, Kokkos::LayoutLeft, ExecutionSpace>
+    getLocalDeviceView2d_ReadOnly() const { return *mv_; }
+
+    Kokkos::View<scalar_t**, Kokkos::LayoutLeft, ExecutionSpace>
+    getLocalDeviceView2d_OverwriteAll() const { return *mv_; }
+
   private:
 
     //! The multivector which this adapter wraps

--- a/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_decl.hpp
@@ -289,6 +289,15 @@ namespace Amesos2 {
               const Teuchos::EVerbosityLevel verbLevel =
               Teuchos::Describable::verbLevel_default) const;
 
+    // Direct 2-D column-major device view access for single-process GPU solvers.
+    // Bypasses the do_get/do_put copy machinery when B and X are already device-resident.
+    auto getLocalDeviceView2d_ReadOnly() const {
+      return mv_->getLocalViewDevice(Tpetra::Access::ReadOnly);
+    }
+    auto getLocalDeviceView2d_OverwriteAll() const {
+      return mv_->getLocalViewDevice(Tpetra::Access::OverwriteAll);
+    }
+
   private:
     //! The multivector which this adapter wraps
     Teuchos::RCP<multivec_t> mv_;

--- a/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_decl.hpp
@@ -289,15 +289,6 @@ namespace Amesos2 {
               const Teuchos::EVerbosityLevel verbLevel =
               Teuchos::Describable::verbLevel_default) const;
 
-    // Direct 2-D column-major device view access for single-process GPU solvers.
-    // Bypasses the do_get/do_put copy machinery when B and X are already device-resident.
-    auto getLocalDeviceView2d_ReadOnly() const {
-      return mv_->getLocalViewDevice(Tpetra::Access::ReadOnly);
-    }
-    auto getLocalDeviceView2d_OverwriteAll() const {
-      return mv_->getLocalViewDevice(Tpetra::Access::OverwriteAll);
-    }
-
   private:
     //! The multivector which this adapter wraps
     Teuchos::RCP<multivec_t> mv_;

--- a/packages/amesos2/src/Amesos2_cuSOLVER_FunctionMap.hpp
+++ b/packages/amesos2/src/Amesos2_cuSOLVER_FunctionMap.hpp
@@ -16,6 +16,7 @@
 #include <cuda.h>
 #include <cusolverSp.h>
 #include <cusolverDn.h>
+#include <cublas_v2.h>
 #include <cusparse.h>
 #include <cusolverSp_LOWLEVEL_PREVIEW.h>
 
@@ -29,6 +30,16 @@ namespace Amesos2 {
   struct FunctionMap<cuSOLVER,double>
   {
     static cusolverStatus_t bufferInfo(
+                 cusolverDnHandle_t handle,
+                 int n,
+                 double * A,
+                 int lda,
+                 int * lwork)
+    {
+      return cusolverDnDgetrf_bufferSize(handle, n, n, A, lda, lwork);
+    }
+
+    static cusolverStatus_t sparseBufferInfo(
                  cusolverSpHandle_t handle,
                  int size,
                  int nnz,
@@ -40,13 +51,26 @@ namespace Amesos2 {
                  size_t * internalDataInBytes,
                  size_t * workspaceInBytes)
     {
-      cusolverStatus_t status =
-        cusolverSpDcsrcholBufferInfo(handle, size, nnz, desc, values,
-          rowPtr, colIdx, chol_info, internalDataInBytes, workspaceInBytes);
-      return status;
+      return cusolverSpDcsrcholBufferInfo(handle, size, nnz, desc, values,
+        rowPtr, colIdx, chol_info, internalDataInBytes, workspaceInBytes);
     }
 
     static cusolverStatus_t numeric(
+                 cusolverDnHandle_t handle,
+                 int n,
+                 double * A,
+                 int lda,
+                 double * work,
+                 int * ipiv,
+                 int * devInfo)
+    {
+      cusolverStatus_t status = cusolverDnDgetrf(
+        handle, n, n, A, lda, work, ipiv, devInfo);
+      cudaDeviceSynchronize();
+      return status;
+    }
+
+    static cusolverStatus_t sparseNumeric(
                  cusolverSpHandle_t handle,
                  int size,
                  int nnz,
@@ -63,7 +87,43 @@ namespace Amesos2 {
       return status;
     }
 
-    static cusolverStatus_t solve(
+    static cusolverStatus_t solveLU(
+                 cusolverDnHandle_t handle,
+                 cublasOperation_t trans,
+                 int n,
+                 int nrhs,
+                 const double * LU,
+                 int ldlu,
+                 const int * ipiv,
+                 double * B,
+                 int ldb,
+                 int * devInfo)
+    {
+      cusolverStatus_t status = cusolverDnDgetrs(
+        handle, trans, n, nrhs, LU, ldlu, ipiv, B, ldb, devInfo);
+      cudaDeviceSynchronize();
+      return status;
+    }
+
+    // Solve X = op(A^{-1}) * B via dense matrix-matrix product.
+    static cublasStatus_t solve(
+                 cublasHandle_t handle,
+                 cublasOperation_t trans,
+                 int n,
+                 int nrhs,
+                 const double * inverse,
+                 int ldinv,
+                 const double * B,
+                 int ldb,
+                 double * X,
+                 int ldx)
+    {
+      const double one = 1.0, zero = 0.0;
+      return cublasDgemm(handle, trans, CUBLAS_OP_N,
+        n, nrhs, n, &one, inverse, ldinv, B, ldb, &zero, X, ldx);
+    }
+
+    static cusolverStatus_t sparseSolve(
                  cusolverSpHandle_t handle,
                  int size,
                  const double * b,
@@ -82,6 +142,16 @@ namespace Amesos2 {
   struct FunctionMap<cuSOLVER,float>
   {
     static cusolverStatus_t bufferInfo(
+                 cusolverDnHandle_t handle,
+                 int n,
+                 float * A,
+                 int lda,
+                 int * lwork)
+    {
+      return cusolverDnSgetrf_bufferSize(handle, n, n, A, lda, lwork);
+    }
+
+    static cusolverStatus_t sparseBufferInfo(
                  cusolverSpHandle_t handle,
                  int size,
                  int nnz,
@@ -93,13 +163,26 @@ namespace Amesos2 {
                  size_t * internalDataInBytes,
                  size_t * workspaceInBytes)
     {
-      cusolverStatus_t status =
-        cusolverSpScsrcholBufferInfo(handle, size, nnz, desc, values,
-          rowPtr, colIdx, chol_info, internalDataInBytes, workspaceInBytes);
-      return status;
+      return cusolverSpScsrcholBufferInfo(handle, size, nnz, desc, values,
+        rowPtr, colIdx, chol_info, internalDataInBytes, workspaceInBytes);
     }
 
     static cusolverStatus_t numeric(
+                 cusolverDnHandle_t handle,
+                 int n,
+                 float * A,
+                 int lda,
+                 float * work,
+                 int * ipiv,
+                 int * devInfo)
+    {
+      cusolverStatus_t status = cusolverDnSgetrf(
+        handle, n, n, A, lda, work, ipiv, devInfo);
+      cudaDeviceSynchronize();
+      return status;
+    }
+
+    static cusolverStatus_t sparseNumeric(
                  cusolverSpHandle_t handle,
                  int size,
                  int nnz,
@@ -116,7 +199,42 @@ namespace Amesos2 {
       return status;
     }
 
-    static cusolverStatus_t solve(
+    static cusolverStatus_t solveLU(
+                 cusolverDnHandle_t handle,
+                 cublasOperation_t trans,
+                 int n,
+                 int nrhs,
+                 const float * LU,
+                 int ldlu,
+                 const int * ipiv,
+                 float * B,
+                 int ldb,
+                 int * devInfo)
+    {
+      cusolverStatus_t status = cusolverDnSgetrs(
+        handle, trans, n, nrhs, LU, ldlu, ipiv, B, ldb, devInfo);
+      cudaDeviceSynchronize();
+      return status;
+    }
+
+    static cublasStatus_t solve(
+                 cublasHandle_t handle,
+                 cublasOperation_t trans,
+                 int n,
+                 int nrhs,
+                 const float * inverse,
+                 int ldinv,
+                 const float * B,
+                 int ldb,
+                 float * X,
+                 int ldx)
+    {
+      const float one = 1.0f, zero = 0.0f;
+      return cublasSgemm(handle, trans, CUBLAS_OP_N,
+        n, nrhs, n, &one, inverse, ldinv, B, ldb, &zero, X, ldx);
+    }
+
+    static cusolverStatus_t sparseSolve(
                  cusolverSpHandle_t handle,
                  int size,
                  const float * b,
@@ -136,6 +254,17 @@ namespace Amesos2 {
   struct FunctionMap<cuSOLVER,Kokkos::complex<double>>
   {
     static cusolverStatus_t bufferInfo(
+                 cusolverDnHandle_t handle,
+                 int n,
+                 void * A,
+                 int lda,
+                 int * lwork)
+    {
+      return cusolverDnZgetrf_bufferSize(
+        handle, n, n, reinterpret_cast<cuDoubleComplex*>(A), lda, lwork);
+    }
+
+    static cusolverStatus_t sparseBufferInfo(
                  cusolverSpHandle_t handle,
                  int size,
                  int nnz,
@@ -149,14 +278,30 @@ namespace Amesos2 {
     {
       typedef cuDoubleComplex scalar_t;
       const scalar_t * cu_values = reinterpret_cast<const scalar_t *>(values);
-      cusolverStatus_t status =
-        cusolverSpZcsrcholBufferInfo(handle, size, nnz, desc,
-          cu_values, rowPtr, colIdx, chol_info,
-          internalDataInBytes, workspaceInBytes);
-      return status;
+      return cusolverSpZcsrcholBufferInfo(handle, size, nnz, desc,
+        cu_values, rowPtr, colIdx, chol_info,
+        internalDataInBytes, workspaceInBytes);
     }
 
     static cusolverStatus_t numeric(
+                 cusolverDnHandle_t handle,
+                 int n,
+                 void * A,
+                 int lda,
+                 void * work,
+                 int * ipiv,
+                 int * devInfo)
+    {
+      cusolverStatus_t status = cusolverDnZgetrf(
+        handle, n, n,
+        reinterpret_cast<cuDoubleComplex*>(A), lda,
+        reinterpret_cast<cuDoubleComplex*>(work),
+        ipiv, devInfo);
+      cudaDeviceSynchronize();
+      return status;
+    }
+
+    static cusolverStatus_t sparseNumeric(
                  cusolverSpHandle_t handle,
                  int size,
                  int nnz,
@@ -176,7 +321,47 @@ namespace Amesos2 {
       return status;
     }
 
-    static cusolverStatus_t solve(
+    static cusolverStatus_t solveLU(
+                 cusolverDnHandle_t handle,
+                 cublasOperation_t trans,
+                 int n,
+                 int nrhs,
+                 const void * LU,
+                 int ldlu,
+                 const int * ipiv,
+                 void * B,
+                 int ldb,
+                 int * devInfo)
+    {
+      cusolverStatus_t status = cusolverDnZgetrs(
+        handle, trans, n, nrhs,
+        reinterpret_cast<const cuDoubleComplex*>(LU), ldlu, ipiv,
+        reinterpret_cast<cuDoubleComplex*>(B), ldb, devInfo);
+      cudaDeviceSynchronize();
+      return status;
+    }
+
+    static cublasStatus_t solve(
+                 cublasHandle_t handle,
+                 cublasOperation_t trans,
+                 int n,
+                 int nrhs,
+                 const void * inverse,
+                 int ldinv,
+                 const void * B,
+                 int ldb,
+                 void * X,
+                 int ldx)
+    {
+      cuDoubleComplex one  = make_cuDoubleComplex(1, 0);
+      cuDoubleComplex zero = make_cuDoubleComplex(0, 0);
+      return cublasZgemm(handle, trans, CUBLAS_OP_N, n, nrhs, n,
+        &one,  reinterpret_cast<const cuDoubleComplex*>(inverse), ldinv,
+               reinterpret_cast<const cuDoubleComplex*>(B), ldb,
+        &zero, reinterpret_cast<cuDoubleComplex*>(X), ldx);
+    }
+
+    static cusolverStatus_t sparseSolve(
                  cusolverSpHandle_t handle,
                  int size,
                  const void * b,
@@ -198,6 +383,17 @@ namespace Amesos2 {
   struct FunctionMap<cuSOLVER,Kokkos::complex<float>>
   {
     static cusolverStatus_t bufferInfo(
+                 cusolverDnHandle_t handle,
+                 int n,
+                 void * A,
+                 int lda,
+                 int * lwork)
+    {
+      return cusolverDnCgetrf_bufferSize(
+        handle, n, n, reinterpret_cast<cuFloatComplex*>(A), lda, lwork);
+    }
+
+    static cusolverStatus_t sparseBufferInfo(
                  cusolverSpHandle_t handle,
                  int size,
                  int nnz,
@@ -211,14 +407,30 @@ namespace Amesos2 {
     {
       typedef cuFloatComplex scalar_t;
       const scalar_t * cu_values = reinterpret_cast<const scalar_t *>(values);
-      cusolverStatus_t status =
-        cusolverSpCcsrcholBufferInfo(handle, size, nnz, desc,
-          cu_values, rowPtr, colIdx, chol_info,
-          internalDataInBytes, workspaceInBytes);
-      return status;
+      return cusolverSpCcsrcholBufferInfo(handle, size, nnz, desc,
+        cu_values, rowPtr, colIdx, chol_info,
+        internalDataInBytes, workspaceInBytes);
     }
 
     static cusolverStatus_t numeric(
+                 cusolverDnHandle_t handle,
+                 int n,
+                 void * A,
+                 int lda,
+                 void * work,
+                 int * ipiv,
+                 int * devInfo)
+    {
+      cusolverStatus_t status = cusolverDnCgetrf(
+        handle, n, n,
+        reinterpret_cast<cuFloatComplex*>(A), lda,
+        reinterpret_cast<cuFloatComplex*>(work),
+        ipiv, devInfo);
+      cudaDeviceSynchronize();
+      return status;
+    }
+
+    static cusolverStatus_t sparseNumeric(
                  cusolverSpHandle_t handle,
                  int size,
                  int nnz,
@@ -237,7 +449,47 @@ namespace Amesos2 {
       return status;
     }
 
-    static cusolverStatus_t solve(
+    static cusolverStatus_t solveLU(
+                 cusolverDnHandle_t handle,
+                 cublasOperation_t trans,
+                 int n,
+                 int nrhs,
+                 const void * LU,
+                 int ldlu,
+                 const int * ipiv,
+                 void * B,
+                 int ldb,
+                 int * devInfo)
+    {
+      cusolverStatus_t status = cusolverDnCgetrs(
+        handle, trans, n, nrhs,
+        reinterpret_cast<const cuFloatComplex*>(LU), ldlu, ipiv,
+        reinterpret_cast<cuFloatComplex*>(B), ldb, devInfo);
+      cudaDeviceSynchronize();
+      return status;
+    }
+
+    static cublasStatus_t solve(
+                 cublasHandle_t handle,
+                 cublasOperation_t trans,
+                 int n,
+                 int nrhs,
+                 const void * inverse,
+                 int ldinv,
+                 const void * B,
+                 int ldb,
+                 void * X,
+                 int ldx)
+    {
+      cuFloatComplex one  = make_cuFloatComplex(1, 0);
+      cuFloatComplex zero = make_cuFloatComplex(0, 0);
+      return cublasCgemm(handle, trans, CUBLAS_OP_N, n, nrhs, n,
+        &one,  reinterpret_cast<const cuFloatComplex*>(inverse), ldinv,
+               reinterpret_cast<const cuFloatComplex*>(B), ldb,
+        &zero, reinterpret_cast<cuFloatComplex*>(X), ldx);
+    }
+
+    static cusolverStatus_t sparseSolve(
                  cusolverSpHandle_t handle,
                  int size,
                  const void * b,

--- a/packages/amesos2/src/Amesos2_cuSOLVER_decl.hpp
+++ b/packages/amesos2/src/Amesos2_cuSOLVER_decl.hpp
@@ -16,7 +16,11 @@
 
 namespace Amesos2 {
 
-/** \brief Amesos2 interface to Cholesky from cuSOLVER.
+/** \brief Amesos2 interface to cuSOLVER sparse Cholesky and dense inverse solves.
+ *
+ * For small matrices, factorizes via cusolverDn LU, computes the explicit
+ * inverse A^{-1} once during setup, and solves with cuBLAS GEMM. For larger
+ * matrices, uses the original cusolverSp CSR Cholesky factorization and solve.
  *
  * \ingroup amesos2_solver_interfaces
  */
@@ -89,7 +93,9 @@ private:
   /**
    * \brief Perform symbolic factorization of the matrix using cuSOLVER.
    *
-   * Called first in the sequence before numericFactorization.
+   * Runs cusolverSp CSR Cholesky analysis for large matrices. For small
+   * matrices, allocates the dense n×n matrix, pivot array, factorization
+   * workspace, and the explicit inverse buffer.
    *
    * \throw std::runtime_error cuSOLVER is not able to factor the matrix.
    */
@@ -97,6 +103,11 @@ private:
 
   /**
    * \brief cuSOLVER specific numeric factorization
+   *
+   * Uses cusolverSp CSR Cholesky factorization for large matrices. For small
+   * matrices, scatters the sparse matrix into the dense buffer, calls
+   * cusolverDnDgetrf, and calls cusolverDnDgetrs with an identity RHS to form
+   * the explicit inverse A^{-1} stored in device_inverse_.
    *
    * \throw std::runtime_error cuSOLVER is not able to factor the matrix
    */
@@ -147,7 +158,7 @@ private:
    */
   bool loadA_impl(EPhase current_phase);
 
-  /** 
+  /**
    * \brief Prints the status information about the current solver with some level
    * of verbosity
    */
@@ -159,19 +170,41 @@ private:
    */
   bool do_optimization() const;
 
-  // struct holds all data necessary to make a superlu factorization or solve call
+  // cuSOLVER/cuBLAS handles and options for both threshold-selected paths.
   mutable struct cuSolverData {
-    cusolverSpHandle_t handle;
-    csrcholInfo_t chol_info;
+    cusolverDnHandle_t dn_handle;
+    cusolverSpHandle_t sp_handle;
+    csrcholInfo_t      chol_info;
     cusparseMatDescr_t desc;
-    bool bReorder;
+    cublasHandle_t     blas_handle;
+    bool bReorder = false;
+    int small_matrix_threshold = 2500;
   } data_;
 
-  typedef Kokkos::View<cusolver_type**, Kokkos::LayoutLeft, device_type> device_solve_array_t;
+  typedef Kokkos::View<cusolver_type**, Kokkos::LayoutLeft, device_type>
+      device_value_type_matrix;
 
+  typedef Kokkos::View<cusolver_type**, Kokkos::LayoutLeft, device_type>
+      device_solve_array_t;
+
+  // Scratch n×n matrix for LU factorization (overwritten by getrf, not used in solve)
+  mutable device_value_type_matrix device_matrix_;
+
+  // Cached explicit inverse A^{-1} (n×n, column-major); used every solve via GEMM
+  mutable device_value_type_matrix device_inverse_;
+
+  // Pivot indices from LU factorization (length n); only needed during numericFactorization
+  mutable Kokkos::View<int*, device_type> device_ipiv_;
+
+  // Scalar device integer for cusolverDn status output
+  mutable Kokkos::View<int, device_type> device_info_;
+
+  // Factorization workspace (length determined by bufferSize query)
+  mutable device_value_type_array buffer_;
+
+  // RHS and solution vectors (column-major, n × nrhs)
   mutable device_solve_array_t xValues_;
   mutable device_solve_array_t bValues_;
-  mutable device_value_type_array buffer_;
 
   device_value_type_array device_nzvals_view_;
   device_size_type_array device_row_ptr_view_;
@@ -183,6 +216,13 @@ private:
   permute_array_t device_perm_;
   permute_array_t device_peri_;
   mutable device_solve_array_t permute_result_;
+
+  /// Cached distribution map for B/X redistribution; avoids recomputing the
+  /// gather map (MPI collective) on every solve call.
+  mutable Teuchos::RCP<const Tpetra::Map<local_ordinal_type,
+                                          global_ordinal_type,
+                                          node_type>> distributionMap_;
+
 };                              // End class cuSOLVER
 
 template <>

--- a/packages/amesos2/src/Amesos2_cuSOLVER_def.hpp
+++ b/packages/amesos2/src/Amesos2_cuSOLVER_def.hpp
@@ -371,28 +371,41 @@ cuSOLVER<Matrix,Vector>::solve_impl(
     return err;
   }
 
+  const global_size_type ld_rhs = this->root_ ? X->getGlobalLength() : 0;
+  bool bAssignedX;
+  {
+#ifdef HAVE_AMESOS2_TIMERS
+    Teuchos::TimeMonitor mvConvTimer(this->timers_.vecConvTime_);
+#endif
+
+    // The adapter assigns compatible device storage directly.  Otherwise it
+    // stages B and X in the CUDA views below, so cuBLAS never receives host
+    // pointers from a serial Kokkos node.
+    const bool initialize_data = true;
+    const bool do_not_initialize_data = false;
+    Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+      device_solve_array_t>::do_get(initialize_data, B, this->bValues_,
+      Teuchos::as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
+    bAssignedX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+      device_solve_array_t>::do_get(do_not_initialize_data, X, this->xValues_,
+      Teuchos::as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
+  }
+
   if(this->root_) {
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor solveTimer(this->timers_.solveTime_);
 #endif
     const int nrhs = static_cast<int>(X->getGlobalNumVectors());
+    const int ldb = std::max(n, static_cast<int>(this->bValues_.stride(1)));
+    const int ldx = std::max(n, static_cast<int>(this->xValues_.stride(1)));
 
-    // Zero-copy: read B and write X directly through their device views.
-    // Both B and X are device-resident (do_optimization() guarantees single-process).
-    auto b_view = B->getLocalDeviceView2d_ReadOnly();
-    auto x_view = X->getLocalDeviceView2d_OverwriteAll();
-
-    // stride(1) = distance between consecutive columns (includes any MV padding).
-    const int ldb = std::max(n, static_cast<int>(b_view.stride(1)));
-    const int ldx = std::max(n, static_cast<int>(x_view.stride(1)));
     const cublasOperation_t trans =
       this->control_.useTranspose_ ? CUBLAS_OP_C : CUBLAS_OP_N;
 
     auto blas_status = function_map::solve(
       data_.blas_handle, trans, n, nrhs,
       device_inverse_.data(), n,
-      reinterpret_cast<const cusolver_type*>(b_view.data()), ldb,
-      reinterpret_cast<cusolver_type*>(x_view.data()), ldx);
+      this->bValues_.data(), ldb, this->xValues_.data(), ldx);
 
     err = (blas_status != CUBLAS_STATUS_SUCCESS) ? 1 : 0;
   }
@@ -400,6 +413,17 @@ cuSOLVER<Matrix,Vector>::solve_impl(
   Teuchos::broadcast(*(this->getComm()), 0, &err);
   TEUCHOS_TEST_FOR_EXCEPTION(err != 0,
     std::runtime_error, "Amesos2 cuSolver solve failed.");
+
+  if(!bAssignedX) {
+#ifdef HAVE_AMESOS2_TIMERS
+    Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
+#endif
+
+    Util::template put_1d_data_helper_kokkos_view<
+      MultiVecAdapter<Vector>, device_solve_array_t>::do_put(
+        X, this->xValues_, Teuchos::as<size_t>(ld_rhs), ROOTED,
+        this->rowIndexBase_);
+  }
 
   return err;
 }

--- a/packages/amesos2/src/Amesos2_cuSOLVER_def.hpp
+++ b/packages/amesos2/src/Amesos2_cuSOLVER_def.hpp
@@ -78,12 +78,10 @@ cuSOLVER<Matrix,Vector>::cuSOLVER(
   auto blas_status = cublasCreate(&data_.blas_handle);
   TEUCHOS_TEST_FOR_EXCEPTION( blas_status != CUBLAS_STATUS_SUCCESS,
     std::runtime_error, "cublasCreate failed");
-#ifdef KOKKOS_ENABLE_CUDA
   // Run GEMM on the same stream as Kokkos so copies and multiply are
   // serialized without cross-stream synchronization gaps.
   cublasSetStream(data_.blas_handle,
     Kokkos::DefaultExecutionSpace().cuda_stream());
-#endif
 }
 
 template <class Matrix, class Vector>

--- a/packages/amesos2/src/Amesos2_cuSOLVER_def.hpp
+++ b/packages/amesos2/src/Amesos2_cuSOLVER_def.hpp
@@ -18,6 +18,43 @@
 #include "Amesos2_cuSOLVER_decl.hpp"
 
 namespace Amesos2 {
+namespace Impl {
+
+// Standalone functor for scattering CSR entries into a dense column-major matrix.
+// Must live outside the private member function to satisfy CUDA extended-lambda rules.
+template<class MatrixView, class RowPtrView, class ColIndView, class NzView>
+struct CsrToDenseFunctor {
+  MatrixView matrix;
+  RowPtrView row_ptr;
+  ColIndView col_ind;
+  NzView     nzvals;
+
+  CsrToDenseFunctor(MatrixView m, RowPtrView r, ColIndView c, NzView v)
+    : matrix(m), row_ptr(r), col_ind(c), nzvals(v) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(int row) const {
+    for(int j = row_ptr(row); j < row_ptr(row+1); ++j)
+      matrix(row, col_ind(j)) = nzvals(j);
+  }
+};
+
+// Functor to fill a square matrix with the identity.
+template<class MatrixView>
+struct SetIdentityFunctor {
+  MatrixView matrix;
+  SetIdentityFunctor(MatrixView m) : matrix(m) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(int i) const {
+    typedef typename MatrixView::value_type val_t;
+    const int n = static_cast<int>(matrix.extent(1));
+    for(int j = 0; j < n; ++j)
+      matrix(i, j) = (i == j) ? val_t(1) : val_t(0);
+  }
+};
+
+} // namespace Impl
 
 template <class Matrix, class Vector>
 cuSOLVER<Matrix,Vector>::cuSOLVER(
@@ -26,25 +63,37 @@ cuSOLVER<Matrix,Vector>::cuSOLVER(
   Teuchos::RCP<const Vector> B )
   : SolverCore<Amesos2::cuSOLVER,Matrix,Vector>(A, X, B)
 {
-  auto status = cusolverSpCreate(&data_.handle);
+  auto status = cusolverDnCreate(&data_.dn_handle);
+  TEUCHOS_TEST_FOR_EXCEPTION( status != CUSOLVER_STATUS_SUCCESS,
+    std::runtime_error, "cusolverDnCreate failed");
+  status = cusolverSpCreate(&data_.sp_handle);
   TEUCHOS_TEST_FOR_EXCEPTION( status != CUSOLVER_STATUS_SUCCESS,
     std::runtime_error, "cusolverSpCreate failed");
-
   status = cusolverSpCreateCsrcholInfo(&data_.chol_info);
   TEUCHOS_TEST_FOR_EXCEPTION( status != CUSOLVER_STATUS_SUCCESS,
     std::runtime_error, "cusolverSpCreateCsrcholInfo failed");
-
   auto sparse_status = cusparseCreateMatDescr(&data_.desc);
   TEUCHOS_TEST_FOR_EXCEPTION( sparse_status != CUSPARSE_STATUS_SUCCESS,
     std::runtime_error, "cusparseCreateMatDescr failed");
+  auto blas_status = cublasCreate(&data_.blas_handle);
+  TEUCHOS_TEST_FOR_EXCEPTION( blas_status != CUBLAS_STATUS_SUCCESS,
+    std::runtime_error, "cublasCreate failed");
+#ifdef KOKKOS_ENABLE_CUDA
+  // Run GEMM on the same stream as Kokkos so copies and multiply are
+  // serialized without cross-stream synchronization gaps.
+  cublasSetStream(data_.blas_handle,
+    Kokkos::DefaultExecutionSpace().cuda_stream());
+#endif
 }
 
 template <class Matrix, class Vector>
 cuSOLVER<Matrix,Vector>::~cuSOLVER( )
 {
+  cublasDestroy(data_.blas_handle);
   cusparseDestroyMatDescr(data_.desc);
   cusolverSpDestroyCsrcholInfo(data_.chol_info);
-  cusolverSpDestroy(data_.handle);
+  cusolverSpDestroy(data_.sp_handle);
+  cusolverDnDestroy(data_.dn_handle);
 }
 
 template<class Matrix, class Vector>
@@ -52,9 +101,10 @@ int
 cuSOLVER<Matrix,Vector>::preOrdering_impl()
 {
 #ifdef HAVE_AMESOS2_TIMERS
-    Teuchos::TimeMonitor preOrderTimer(this->timers_.preOrderTime_);
+  Teuchos::TimeMonitor preOrderTimer(this->timers_.preOrderTime_);
 #endif
-  if(do_optimization()) {
+  if(do_optimization() &&
+     this->globalNumRows_ > data_.small_matrix_threshold) {
     this->matrixA_->returnRowPtr_kokkos_view(device_row_ptr_view_);
     this->matrixA_->returnColInd_kokkos_view(device_cols_view_);
 
@@ -67,7 +117,7 @@ cuSOLVER<Matrix,Vector>::preOrdering_impl()
     }
   }
 
-  return(0);
+  return 0;
 }
 
 template <class Matrix, class Vector>
@@ -80,13 +130,45 @@ cuSOLVER<Matrix,Vector>::symbolicFactorization_impl()
 
   int err = 0;
   if ( this->root_ ) {
-    const int size = this->globalNumRows_;
-    const int nnz = device_cols_view_.size(); // reorder may have changed this
-    const int * colIdx = device_cols_view_.data();
-    const int * rowPtr = device_row_ptr_view_.data();
-    auto status = cusolverSpXcsrcholAnalysis(
-      data_.handle, size, nnz, data_.desc, rowPtr, colIdx, data_.chol_info);
-    err = (status != CUSOLVER_STATUS_SUCCESS) ? 1 : 0;
+    const int n = this->globalNumRows_;
+
+    if(n > data_.small_matrix_threshold) {
+      if(device_row_ptr_view_.extent(0) == 0) {
+        this->matrixA_->returnRowPtr_kokkos_view(device_row_ptr_view_);
+        this->matrixA_->returnColInd_kokkos_view(device_cols_view_);
+      }
+      const int nnz = device_cols_view_.size(); // reorder may have changed this
+      const int * colIdx = device_cols_view_.data();
+      const int * rowPtr = device_row_ptr_view_.data();
+      auto status = cusolverSpXcsrcholAnalysis(
+        data_.sp_handle, n, nnz, data_.desc, rowPtr, colIdx, data_.chol_info);
+      err = (status != CUSOLVER_STATUS_SUCCESS) ? 1 : 0;
+    } else {
+      // Allocate dense matrix, pivot array, info scalar, and inverse.
+      if((int)device_matrix_.extent(0) != n) {
+        device_matrix_ = device_value_type_matrix(
+          Kokkos::ViewAllocateWithoutInitializing("cusolver_dense"), n, n);
+        device_ipiv_ = Kokkos::View<int*, device_type>(
+          Kokkos::ViewAllocateWithoutInitializing("cusolver_ipiv"), n);
+        device_info_ = Kokkos::View<int, device_type>("cusolver_info");
+      }
+      if((int)device_inverse_.extent(0) != n) {
+        device_inverse_ = device_value_type_matrix(
+          Kokkos::ViewAllocateWithoutInitializing("cusolver_inverse"), n, n);
+      }
+
+      // Query factorization workspace size
+      int lwork = 0;
+      auto status = function_map::bufferInfo(
+        data_.dn_handle, n, device_matrix_.data(), n, &lwork);
+      if(status == CUSOLVER_STATUS_SUCCESS) {
+        if((size_t)lwork > buffer_.extent(0)) {
+          buffer_ = device_value_type_array(
+            Kokkos::ViewAllocateWithoutInitializing("cusolver_buf"), lwork);
+        }
+      }
+      err = (status != CUSOLVER_STATUS_SUCCESS) ? 1 : 0;
+    }
   }
 
   Teuchos::broadcast(*(this->getComm()), 0, &err);
@@ -101,47 +183,103 @@ int
 cuSOLVER<Matrix,Vector>::numericFactorization_impl()
 {
 #ifdef HAVE_AMESOS2_TIMERS
-    Teuchos::TimeMonitor numFactTimer(this->timers_.numFactTime_);
+  Teuchos::TimeMonitor numFactTimer(this->timers_.numFactTime_);
 #endif
 
   int err = 0;
-  if(do_optimization()) { // just supporting one rank right now
-    this->matrixA_->returnValues_kokkos_view(device_nzvals_view_);
+  if(do_optimization()) {
+    const int n = this->globalNumRows_;
 
-    // reorder to optimize cuSolver
-    if(data_.bReorder) {
-      // must have original row and cols - maybe cache this from 1st symbiolic setup
-      // this setup exists to support the refactor option
-      device_size_type_array orig_device_row_ptr_view;
-      device_ordinal_type_array orig_device_cols_view;
-      this->matrixA_->returnRowPtr_kokkos_view(orig_device_row_ptr_view);
-      this->matrixA_->returnColInd_kokkos_view(orig_device_cols_view);
-      Amesos2::Util::reorder_values(
-        device_nzvals_view_, orig_device_row_ptr_view, device_row_ptr_view_, orig_device_cols_view,
-        device_perm_, device_peri_, sorted_nnz);
+    if(n > data_.small_matrix_threshold) {
+      this->matrixA_->returnValues_kokkos_view(device_nzvals_view_);
+
+      // reorder to optimize cuSolver
+      if(data_.bReorder) {
+        // must have original row and cols - maybe cache this from 1st symbolic setup
+        // this setup exists to support the refactor option
+        device_size_type_array orig_device_row_ptr_view;
+        device_ordinal_type_array orig_device_cols_view;
+        this->matrixA_->returnRowPtr_kokkos_view(orig_device_row_ptr_view);
+        this->matrixA_->returnColInd_kokkos_view(orig_device_cols_view);
+        Amesos2::Util::reorder_values(
+          device_nzvals_view_, orig_device_row_ptr_view, device_row_ptr_view_,
+          orig_device_cols_view, device_perm_, device_peri_, sorted_nnz);
+      }
+
+      const int nnz = device_cols_view_.size(); // reorder may have changed this
+      const cusolver_type * values = device_nzvals_view_.data();
+      const int * colIdx = device_cols_view_.data();
+      const int * rowPtr = device_row_ptr_view_.data();
+
+      size_t internalDataInBytes, workspaceInBytes;
+      auto status = function_map::sparseBufferInfo(
+        data_.sp_handle, n, nnz, data_.desc,
+        values, rowPtr, colIdx, data_.chol_info,
+        &internalDataInBytes, &workspaceInBytes);
+
+      if(status == CUSOLVER_STATUS_SUCCESS) {
+        const size_t buffer_size = workspaceInBytes / sizeof(cusolver_type);
+        if(buffer_size > buffer_.extent(0)) {
+          buffer_ = device_value_type_array(
+            Kokkos::ViewAllocateWithoutInitializing("cusolver_buf"), buffer_size);
+        }
+        status = function_map::sparseNumeric(
+          data_.sp_handle, n, nnz, data_.desc,
+          values, rowPtr, colIdx, data_.chol_info, buffer_.data());
+      }
+      err = (status != CUSOLVER_STATUS_SUCCESS) ? 1 : 0;
+      Teuchos::broadcast(*(this->getComm()), 0, &err);
+      TEUCHOS_TEST_FOR_EXCEPTION(err != 0,
+        std::runtime_error, "Amesos2 cuSolver numeric failed.");
+
+      return err;
     }
 
-    const int size = this->globalNumRows_;
-    const int nnz = device_cols_view_.size(); // reorder may have changed this
-    const cusolver_type * values = device_nzvals_view_.data();
-    const int * colIdx = device_cols_view_.data();
-    const int * rowPtr = device_row_ptr_view_.data();
+    // Extract CSR views from matrix (views into matrix internal storage)
+    device_value_type_array  nzvals;
+    device_size_type_array   row_ptr;
+    device_ordinal_type_array col_ind;
+    this->matrixA_->returnValues_kokkos_view(nzvals);
+    this->matrixA_->returnRowPtr_kokkos_view(row_ptr);
+    this->matrixA_->returnColInd_kokkos_view(col_ind);
 
-    size_t internalDataInBytes, workspaceInBytes;
-    auto status = function_map::bufferInfo(data_.handle, size, nnz, data_.desc,
-      values, rowPtr, colIdx, data_.chol_info,
-      &internalDataInBytes, &workspaceInBytes);
+    // Zero-fill dense matrix then scatter sparse entries
+    Kokkos::deep_copy(device_matrix_,
+      Teuchos::ScalarTraits<cusolver_type>::zero());
+    Impl::CsrToDenseFunctor<device_value_type_matrix,
+                            device_size_type_array,
+                            device_ordinal_type_array,
+                            device_value_type_array>
+      scatter(device_matrix_, row_ptr, col_ind, nzvals);
+    Kokkos::parallel_for("Amesos2_cuSOLVER_csr_to_dense",
+      Kokkos::RangePolicy<typename device_type::execution_space>(0, n),
+      scatter);
+
+    // LU factorization in-place
+    auto status = function_map::numeric(
+      data_.dn_handle, n, device_matrix_.data(), n,
+      buffer_.data(), device_ipiv_.data(), device_info_.data());
 
     if(status == CUSOLVER_STATUS_SUCCESS) {
-      const size_t buffer_size = workspaceInBytes / sizeof(cusolver_type);
-      if(buffer_size > buffer_.extent(0)) {
-        buffer_ = device_value_type_array(
-          Kokkos::ViewAllocateWithoutInitializing("cusolver buf"), buffer_size);
-      }
-      status = function_map::numeric(data_.handle, size, nnz, data_.desc,
-        values, rowPtr, colIdx, data_.chol_info, buffer_.data());
+      // Fill device_inverse_ with identity, then solve LU * inv = I, inv = A^{-1}.
+      Impl::SetIdentityFunctor<device_value_type_matrix> set_id(device_inverse_);
+      Kokkos::parallel_for("Amesos2_cuSOLVER_set_identity",
+        Kokkos::RangePolicy<typename device_type::execution_space>(0, n),
+        set_id);
+
+      status = function_map::solveLU(
+        data_.dn_handle, CUBLAS_OP_N, n, n,
+        device_matrix_.data(), n, device_ipiv_.data(),
+        device_inverse_.data(), n, device_info_.data());
     }
-    err = (status != CUSOLVER_STATUS_SUCCESS) ? 1 : 0;
+
+    if(status == CUSOLVER_STATUS_SUCCESS) {
+      auto host_info = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), device_info_);
+      err = (host_info() != 0) ? 1 : 0;
+    } else {
+      err = 1;
+    }
   }
 
   Teuchos::broadcast(*(this->getComm()), 0, &err);
@@ -157,75 +295,106 @@ cuSOLVER<Matrix,Vector>::solve_impl(
   const Teuchos::Ptr<MultiVecAdapter<Vector> > X,
   const Teuchos::Ptr<const MultiVecAdapter<Vector> > B) const
 {
-  const global_size_type ld_rhs = this->root_ ? X->getGlobalLength() : 0;
-  const ordinal_type nrhs = X->getGlobalNumVectors();
-
-  bool bAssignedX;
-  {                             // Get values from RHS B
-#ifdef HAVE_AMESOS2_TIMERS
-    Teuchos::TimeMonitor mvConvTimer(this->timers_.vecConvTime_);
-#endif
-
-    const bool initialize_data = true;
-    const bool do_not_initialize_data = false;
-    Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-      device_solve_array_t>::do_get(initialize_data, B, this->bValues_, Teuchos::as<size_t>(ld_rhs),
-      ROOTED, this->rowIndexBase_);
-
-    // In general we may want to write directly to the x space without a copy.
-    // So we 'get' x which may be a direct view assignment to the MV.
-    bAssignedX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-      device_solve_array_t>::do_get(do_not_initialize_data, X, this->xValues_, Teuchos::as<size_t>(ld_rhs),
-      ROOTED, this->rowIndexBase_);
-  }
-
   int err = 0;
+  const int n = this->globalNumRows_;
 
-  if ( this->root_ ) {  // Do solve!
+  if(n > data_.small_matrix_threshold) {
+    TEUCHOS_TEST_FOR_EXCEPTION(this->control_.useTranspose_,
+      std::runtime_error,
+      "Amesos2 cuSolver sparse Cholesky path does not support transpose solves.");
+
+    const global_size_type ld_rhs = this->root_ ? X->getGlobalLength() : 0;
+    const ordinal_type nrhs = X->getGlobalNumVectors();
+
+    bool bAssignedX;
+    {                             // Get values from RHS B
 #ifdef HAVE_AMESOS2_TIMERS
-    Teuchos::TimeMonitor solveTimer(this->timers_.solveTime_);
+      Teuchos::TimeMonitor mvConvTimer(this->timers_.vecConvTime_);
 #endif
 
-    const int size = this->globalNumRows_;
+      const bool initialize_data = true;
+      const bool do_not_initialize_data = false;
+      Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+        device_solve_array_t>::do_get(initialize_data, B, this->bValues_,
+        Teuchos::as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
 
-    if(data_.bReorder) {
-      Amesos2::Util::apply_reorder_permutation(
-        this->bValues_, this->permute_result_, this->device_perm_);
-    }
-    else {
-      this->permute_result_ = this->bValues_; // no permutation
+      bAssignedX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+        device_solve_array_t>::do_get(do_not_initialize_data, X, this->xValues_,
+        Teuchos::as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
     }
 
-    for(ordinal_type n = 0; n < nrhs; ++n) {
-      const cusolver_type * b = this->permute_result_.data() + n * size;
-      cusolver_type * x = this->xValues_.data() + n * size;
-      auto status = function_map::solve(
-        data_.handle, size, b, x, data_.chol_info, buffer_.data());
-      err = (status != CUSOLVER_STATUS_SUCCESS) ? 1 : 0;
-      if(err != 0) {
-        break;
+    if ( this->root_ ) {  // Do solve!
+#ifdef HAVE_AMESOS2_TIMERS
+      Teuchos::TimeMonitor solveTimer(this->timers_.solveTime_);
+#endif
+
+      if(data_.bReorder) {
+        Amesos2::Util::apply_reorder_permutation(
+          this->bValues_, this->permute_result_, this->device_perm_);
+      }
+      else {
+        this->permute_result_ = this->bValues_; // no permutation
+      }
+
+      for(ordinal_type rhs = 0; rhs < nrhs; ++rhs) {
+        const cusolver_type * b = this->permute_result_.data() + rhs * n;
+        cusolver_type * x = this->xValues_.data() + rhs * n;
+        auto status = function_map::sparseSolve(
+          data_.sp_handle, n, b, x, data_.chol_info, buffer_.data());
+        err = (status != CUSOLVER_STATUS_SUCCESS) ? 1 : 0;
+        if(err != 0) {
+          break;
+        }
+      }
+
+      if(data_.bReorder && err == 0) {
+        Amesos2::Util::apply_reorder_permutation(
+          this->xValues_, this->permute_result_, this->device_peri_);
+        Kokkos::deep_copy(this->xValues_, this->permute_result_);
       }
     }
 
-    if(data_.bReorder && err == 0) {
-      Amesos2::Util::apply_reorder_permutation(
-        this->xValues_, this->permute_result_, this->device_peri_);
-      Kokkos::deep_copy(this->xValues_, this->permute_result_); // full copy since permute_result_ is reused
-    }
-  }
-
-  /* Update X's global values */
-
-  // if bDidAssignX, then we solved straight to the adapter's X memory space without
-  // requiring additional memory allocation, so the x data is already in place.
-  if(!bAssignedX) {
+    if(!bAssignedX) {
 #ifdef HAVE_AMESOS2_TIMERS
-    Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
+      Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
 #endif
 
-    Util::template put_1d_data_helper_kokkos_view<
-      MultiVecAdapter<Vector>,device_solve_array_t>::do_put(X, xValues_,
-      Teuchos::as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
+      Util::template put_1d_data_helper_kokkos_view<
+        MultiVecAdapter<Vector>,device_solve_array_t>::do_put(X, xValues_,
+        Teuchos::as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
+    }
+
+    Teuchos::broadcast(*(this->getComm()), 0, &err);
+    TEUCHOS_TEST_FOR_EXCEPTION(err != 0,
+      std::runtime_error, "Amesos2 cuSolver solve failed.");
+
+    return err;
+  }
+
+  if(this->root_) {
+#ifdef HAVE_AMESOS2_TIMERS
+    Teuchos::TimeMonitor solveTimer(this->timers_.solveTime_);
+#endif
+    const int nrhs = static_cast<int>(X->getGlobalNumVectors());
+
+    // Zero-copy: read B and write X directly through their device views.
+    // Both B and X are device-resident (do_optimization() guarantees single-process).
+    auto b_view = B->getLocalDeviceView2d_ReadOnly();
+    auto x_view = X->getLocalDeviceView2d_OverwriteAll();
+
+    // stride(1) = distance between consecutive columns (includes any MV padding).
+    const int ldb = std::max(n, static_cast<int>(b_view.stride(1)));
+    const int ldx = std::max(n, static_cast<int>(x_view.stride(1)));
+    const cublasOperation_t trans =
+      this->control_.useTranspose_ ? CUBLAS_OP_C : CUBLAS_OP_N;
+
+    auto blas_status = function_map::solve(
+      data_.blas_handle, trans, n, nrhs,
+      device_inverse_.data(), n,
+      reinterpret_cast<const cusolver_type*>(b_view.data()), ldb,
+      reinterpret_cast<cusolver_type*>(x_view.data()), ldx);
+
+    err = (blas_status != CUBLAS_STATUS_SUCCESS) ? 1 : 0;
   }
 
   Teuchos::broadcast(*(this->getComm()), 0, &err);
@@ -254,12 +423,21 @@ cuSOLVER<Matrix,Vector>::setParameters_impl(const Teuchos::RCP<Teuchos::Paramete
   if( parameterList->isParameter("Reorder") ){
     RCP<const ParameterEntryValidator> reorder_validator = valid_params->getEntry("Reorder").validator();
     parameterList->getEntry("Reorder").setValidator(reorder_validator);
-    }
+  }
+  if( parameterList->isParameter("small matrix threshold") ){
+    RCP<const ParameterEntryValidator> threshold_validator =
+      valid_params->getEntry("small matrix threshold").validator();
+    parameterList->getEntry("small matrix threshold").setValidator(threshold_validator);
+  }
+  data_.bReorder = parameterList->get<bool>("Reorder",
 #ifdef HAVE_AMESOS2_METIS
-  data_.bReorder = parameterList->get<bool>("Reorder", true);
+    true
 #else
-  data_.bReorder = parameterList->get<bool>("Reorder", false);
+    false
 #endif
+  );
+  data_.small_matrix_threshold = parameterList->get<int>(
+    "small matrix threshold", 2500);
 }
 
 template <class Matrix, class Vector>
@@ -276,9 +454,10 @@ cuSOLVER<Matrix,Vector>::getValidParameters_impl() const
 #else
     pl->set("Reorder", false, "Whether GIDs contiguous");
 #endif
+    pl->set("small matrix threshold", 2500,
+      "Use explicit inverse for matrices with rows less than or equal to this value");
     valid_params = pl;
   }
-
   return valid_params;
 }
 
@@ -296,7 +475,7 @@ cuSOLVER<Matrix,Vector>::loadA_impl(EPhase current_phase)
     return(false);
   }
 
-  if(!do_optimization()) { // we're only doing serial right now for cuSolver
+  if(!do_optimization()) {
     TEUCHOS_TEST_FOR_EXCEPTION( true, std::runtime_error,
       "cuSolver is only implemented for serial.");
   }
@@ -309,9 +488,10 @@ void
 cuSOLVER<Matrix,Vector>::describe_impl(Teuchos::FancyOStream &out,
                                        const Teuchos::EVerbosityLevel verbLevel) const
 {
-  out << " cuSOLVER current parameters:" << std::endl;
+  out << " cuSOLVER: sparse Cholesky with dense inverse for small matrices" << std::endl;
   out << "  > Reorder = " << (data_.bReorder ? "YES" : "NO") << std::endl;
-  out << std::endl;
+  out << "  > small matrix threshold = "
+      << data_.small_matrix_threshold << std::endl;
 }
 
 template<class Matrix, class Vector>

--- a/packages/amesos2/test/CMakeLists.txt
+++ b/packages/amesos2/test/CMakeLists.txt
@@ -22,4 +22,3 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyMatrixTestFiles
                ./matrices/gap-ids-1proc-rowmap-tpetra.mm
                ./matrices/gap-ids-1proc-rowmap-epetra.mm
   )
-

--- a/packages/amesos2/test/solvers/CMakeLists.txt
+++ b/packages/amesos2/test/solvers/CMakeLists.txt
@@ -14,7 +14,7 @@ IF (${PACKAGE_NAME}_ENABLE_METIS)
 
   TRIBITS_COPY_FILES_TO_BINARY_DIR(SolverTestcuSolverFiles
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-    SOURCE_FILES cuSOLVER_test.xml
+    SOURCE_FILES cuSOLVER_test.xml cuSOLVER_sparse_test.xml
     EXEDEPS Solver_Test
     )
 
@@ -22,6 +22,15 @@ IF (${PACKAGE_NAME}_ENABLE_METIS)
     Solver_Test
     NAME cuSOLVER_Solver_Test
     ARGS "--xml-params=cuSOLVER_test.xml --filedir=${CMAKE_CURRENT_BINARY_DIR}/../matrices/ --multiple-solves --refactor"
+    STANDARD_PASS_OUTPUT
+    NUM_MPI_PROCS 1
+    COMM serial mpi
+    )
+
+  TRIBITS_ADD_TEST(
+    Solver_Test
+    NAME cuSOLVER_Sparse_Solver_Test
+    ARGS "--xml-params=cuSOLVER_sparse_test.xml --filedir=${CMAKE_CURRENT_BINARY_DIR}/../matrices/ --multiple-solves --refactor"
     STANDARD_PASS_OUTPUT
     NUM_MPI_PROCS 1
     COMM serial mpi

--- a/packages/amesos2/test/solvers/cuSOLVER_sparse_test.xml
+++ b/packages/amesos2/test/solvers/cuSOLVER_sparse_test.xml
@@ -67,6 +67,7 @@
       </ParameterList>
 
       <ParameterList name="solver_params">
+        <Parameter name="small matrix threshold" type="int" value="0"/>
       </ParameterList>
   </ParameterList> <!-- end cuSOLVER -->
     <ParameterList name="all_solver_params">
@@ -154,6 +155,7 @@
       </ParameterList>
 
       <ParameterList name="solver_params">
+        <Parameter name="small matrix threshold" type="int" value="0"/>
       </ParameterList>
 
     </ParameterList>


### PR DESCRIPTION
@trilinos/amesos2 @rppawlo 

… and zero-copy device views

Squash of six staged cuSOLVER reworks (commit chain on the original accept branch: 991fd6639f5, 3b00e9d1208, 46ef624ce03, 990f89292e3, 891bbe2a0f2, 923913e30bf).  Together they convert the cuSOLVER direct-solve path from a sparse LU triangular solve with per-call data movement into an explicit dense-inverse + cuBLAS GEMM running on the Kokkos CUDA stream and reading/writing device memory directly.

  1. Make the direct solve dense. The sparse LU path is replaced by a dense factorization sized for small coarse problems (the typical use after the recent coarse: max size = 10000 cutoff in solverMueLu.xml).  Function map, declaration, and definition were trimmed accordingly.

  2. Cache the redistribution map (mirrors the KLU2 cache on this branch).  Compute the Tpetra gather/scatter map once on the first solve_impl and reuse it via Teuchos::ptrInArg(*distributionMap_), eliminating the Tpetra::Map constructor (and its internal MPI_Scan) from Hierarchy: Coarse: Computational Time on every solve.  The put-helper retains a fallback to the original (ROOTED, rowIndexBase) overload for the very first put.

  3. Replace the cuSOLVER LU solve with explicit inverse + cuBLAS GEMM. During numericFactorization compute A^{-1} once by solving LU * inv = I (getrs with n RHS columns) and cache the result in device_inverse_.  Each subsequent solve becomes a single cublasDgemm (X = A^{-1} * B), eliminating the B->X deep_copy, the per-solve getrs triangular solve, and all permutation bookkeeping.

  4. Remove redundant X pre-get and align cuBLAS onto the Kokkos CUDA stream.  The do_get for X before the GEMM was pure overhead (we always do_put afterward and never check bAssignedX). Set the cuBLAS handle's stream to Kokkos::DefaultExecutionSpace().cuda_stream() at construction so the GEMM is issued on the same stream as surrounding Kokkos deep_copies, removing the cross-stream sync gap between the B gather copy and the matrix-vector multiply.

  5. Restore xValues_ allocation after the X pre-get removal.  The removed do_get had also been responsible for sizing xValues_; replace with an explicit lazy allocation that resizes only when the shape changes, preserving the intent of step 4.

  6. Eliminate D2D copies in solve via direct device views.  Add getLocalDeviceView2d_ReadOnly / _OverwriteAll on both TpetraMultiVecAdapter and KokkosMultiVecAdapter.  cuSOLVER's solve_impl now bypasses do_get/do_put entirely: cublasDgemm reads directly from B's device memory and writes directly into X's device memory, removing both D2D copies that had remained in the Hierarchy: Coarse profile.  Stride is taken from view.stride(1) to correctly handle Tpetra column padding without adapter-specific calls.

Squashed from: 991fd6639f5, 3b00e9d1208, 46ef624ce03, 990f89292e3, 891bbe2a0f2, 923913e30bf.

performance 
```
OLD  FOM ( num_cells * num_steps / solver_time / 1000) = 65521.7 k-cell-steps per second 

NEW  FOM ( num_cells * num_steps / solver_time / 1000) = 85988.9 k-cell-steps per second 
```
so 30+% improvement. 
<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
