### PR TITLE
master-merge action: Set permissions

### DIFF
--- a/.github/workflows/master_merge.yml
+++ b/.github/workflows/master_merge.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
 
   master-merge:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'trilinos/Trilinos' }}
     steps:


### PR DESCRIPTION
@trilinos/framework 

## Motivation
I wrongly believed that permissions for an app generated token would not have to be set in the action.