### PR TITLE
Stokhos:  Change warning to fatal error for PCE scalar type

### DIFF
--- a/packages/stokhos/CMakeLists.txt
+++ b/packages/stokhos/CMakeLists.txt
@@ -60,7 +60,7 @@ TRIBITS_ADD_OPTION_AND_DEFINE(Stokhos_ENABLE_Ensemble_Scalar_Type
   ${Stokhos_ENABLE_Ensemble_Scalar_Type_Default} )
 
 IF(Stokhos_ENABLE_PCE_Scalar_Type)
-  MESSAGE(WARNING "The Kokkos-based PCE scalar type has been removed from Stokhos and can no longer be enabled.")
+  MESSAGE(FATAL_ERROR "The Kokkos-based PCE scalar type has been removed from Stokhos and can no longer be enabled.")
 ENDIF()
 SET(Stokhos_ENABLE_PCE_Scalar_Type OFF CACHE BOOL "Kokkos-based PCE scalar type has been removed from Stokhos and can no longer be enabled.")
 SET(HAVE_STOKHOS_PCE_SCALAR_TYPE OFF)


### PR DESCRIPTION
As @rppawlo just proved, it is still possible to enable the PCE scalar type even though it is supposed to be disabled.  Now we emit a fatal error if it is enabled preventing CMake from going further.
