### PR TITLE
tpetra: Ialltofewv properly reserves two tags

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.cpp
@@ -12,7 +12,8 @@
 namespace Tpetra::Details {
 
 DistributorActor::DistributorActor()
-  : mpiTag_(DEFAULT_MPI_TAG) {}
+  : mpiTag_(DEFAULT_MPI_TAG)
+  , ialltofewvRootTag_(DEFAULT_MPI_TAG) {}
 
 void DistributorActor::doWaits(const DistributorPlan& plan) {
   doWaitsRecv(plan);

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -160,6 +160,7 @@ class DistributorActor {
 #endif  // HAVE_TPETRA_MPI
 
   int mpiTag_;
+  int ialltofewvRootTag_;
 
   Teuchos::Array<Teuchos::RCP<Teuchos::CommRequest<int>>> requestsRecv_;
   Teuchos::Array<Teuchos::RCP<Teuchos::CommRequest<int>>> requestsSend_;
@@ -357,7 +358,7 @@ void DistributorActor::doPostsIalltofewvImpl(const DistributorPlan& plan,
                                                        imports.data(), ialltofewv_.recvcounts->data(), ialltofewv_.rdispls->data(),
                                                        roots, nroots,
                                                        rawType,
-                                                       mpiTag_, mpiComm, &(*ialltofewv_.req));
+                                                       mpiTag_, ialltofewvRootTag_, mpiComm, &(*ialltofewv_.req));
 
   TEUCHOS_TEST_FOR_EXCEPTION(err != MPI_SUCCESS, std::runtime_error,
                              "ialltofewv failed with error \""
@@ -564,9 +565,18 @@ void DistributorActor::doPostRecvsImpl(const DistributorPlan& plan,
   // the tag gets incremented by one, until it eventually gets looped around back to a
   // small value. This logic is implemented in Teuchos.
   auto comm = plan.getComm();
+#if defined(HAVE_TPETRA_MPI)
+  const Details::EDistributorSendType sendType = plan.getSendType();
+#endif
   {
     auto non_const_comm = Teuchos::rcp_const_cast<Teuchos::Comm<int>>(comm);
     mpiTag_             = non_const_comm->incrementTag();
+#if defined(HAVE_TPETRA_MPI)
+    // Ialltofewv uses a separate tag for its aggregator -> root phase.
+    ialltofewvRootTag_ = sendType == Details::DISTRIBUTOR_IALLTOFEWV
+                             ? non_const_comm->incrementTag()
+                             : mpiTag_;
+#endif
   }
 
 #ifdef KOKKOS_ENABLE_CUDA
@@ -586,7 +596,6 @@ void DistributorActor::doPostRecvsImpl(const DistributorPlan& plan,
   // point-to-point, so we handle it separately.
 
   // These send options require no matching receives, so we just return.
-  const Details::EDistributorSendType sendType = plan.getSendType();
   if ((sendType == Details::DISTRIBUTOR_ALLTOALL) || (sendType == Details::DISTRIBUTOR_IALLTOFEWV)
 #ifdef HAVE_TPETRACORE_MPI_ADVANCE
       || (sendType == Details::DISTRIBUTOR_MPIADVANCE_ALLTOALL) || (sendType == Details::DISTRIBUTOR_MPIADVANCE_NBRALLTOALLV)

--- a/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
@@ -227,9 +227,6 @@ int wait_impl(Ialltofewv::Req &req, Ialltofewv::Cache &cache) {
   // is this rank a root? linear search - nroots expected to be small
   const bool isRoot = std::find(req.roots, req.roots + req.nroots, rank) != req.roots + req.nroots;
 
-  const int AGG_TAG  = req.tag + 0;
-  const int ROOT_TAG = req.tag + 1;
-
   // Balance the number of incoming messages at each phase:
   // Aggregation = size / naggs * nroots
   // Root =        naggs
@@ -264,12 +261,12 @@ int wait_impl(Ialltofewv::Req &req, Ialltofewv::Cache &cache) {
       }
 #endif
       MPI_Irecv(&groupSendCounts[size_t(si) * size_t(req.nroots)], req.nroots, MPI_INT, si + rank,
-                req.tag, req.comm, &rreq);
+                req.aggTag, req.comm, &rreq);
       reqs.push_back(rreq);
     }
   }
   // send sendcounts to aggregator
-  MPI_Send(req.sendcounts, req.nroots, MPI_INT, myAgg, req.tag, req.comm);
+  MPI_Send(req.sendcounts, req.nroots, MPI_INT, myAgg, req.aggTag, req.comm);
 
   MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
   reqs.resize(0);
@@ -319,7 +316,7 @@ int wait_impl(Ialltofewv::Req &req, Ialltofewv::Cache &cache) {
 #endif
           MPI_Request rreq;
           // &aggBuf(displ)
-          MPI_Irecv(aggBuf.data() + displ, count, req.sendtype, si + rank, req.tag, req.comm, &rreq);
+          MPI_Irecv(aggBuf.data() + displ, count, req.sendtype, si + rank, req.aggTag, req.comm, &rreq);
           reqs.push_back(rreq);
           displ += size_t(count) * sendSize;
         }
@@ -336,7 +333,7 @@ int wait_impl(Ialltofewv::Req &req, Ialltofewv::Cache &cache) {
     if (count) {
       MPI_Request sreq;
       MPI_Isend(&reinterpret_cast<const char *>(req.sendbuf)[displ], req.sendcounts[ri],
-                req.sendtype, myAgg, AGG_TAG, req.comm, &sreq);
+                req.sendtype, myAgg, req.aggTag, req.comm, &sreq);
       reqs.push_back(sreq);
     }
   }
@@ -373,7 +370,7 @@ int wait_impl(Ialltofewv::Req &req, Ialltofewv::Cache &cache) {
 
       if (count) {
         MPI_Request rreq;
-        MPI_Irecv(rootBuf.data() + displ, count, req.recvtype, aggSrc, ROOT_TAG, req.comm, &rreq);
+        MPI_Irecv(rootBuf.data() + displ, count, req.recvtype, aggSrc, req.rootTag, req.comm, &rreq);
         reqs.push_back(rreq);
         displ += size_t(count) * recvSize;
       }
@@ -389,7 +386,7 @@ int wait_impl(Ialltofewv::Req &req, Ialltofewv::Cache &cache) {
       const size_t count = rootCount[ri];
       if (count) {
         // &aggBuf[displ]
-        MPI_Send(aggBuf.data() + displ, count, req.sendtype, req.roots[ri], ROOT_TAG, req.comm);
+        MPI_Send(aggBuf.data() + displ, count, req.sendtype, req.roots[ri], req.rootTag, req.comm);
         displ += count * sendSize;
       }
     }

--- a/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.hpp
@@ -27,7 +27,8 @@ struct Ialltofewv {
     const int *roots;
     int nroots;
     MPI_Datatype recvtype;
-    int tag;
+    int aggTag;
+    int rootTag;
     MPI_Comm comm;
 
     bool devAccess;
@@ -47,7 +48,8 @@ struct Ialltofewv {
            const int *roots,       // list of root ranks (must be same on all procs)
            int nroots,             // size of list of root ranks
            MPI_Datatype recvtype,
-           int tag,
+           int aggTag,
+           int rootTag,
            MPI_Comm comm,
            Req *req) {
     req->sendbuf    = sendbuf;
@@ -60,7 +62,8 @@ struct Ialltofewv {
     req->roots      = roots;
     req->nroots     = nroots;
     req->recvtype   = recvtype;
-    req->tag        = tag;
+    req->aggTag     = aggTag;
+    req->rootTag    = rootTag;
     req->comm       = comm;
 
     req->devAccess = DevAccess;


### PR DESCRIPTION
First step on a long road to making `Ialltofewv` properly async.

Before this, `Ialltofewv` mode would just take one tag, and then actually use both that `tag` and `tag+1`. I'm not sure this was ever okay, but it sort of worked since only one `Ialltofewv` could be in flight at a time. I've got a plan to make `Ialltofewv` live up to the `I` in its name, but this fix is a prerequisite.

This adds another tag to `DistributorActor` that is only used by `Ialltofewv`.