### PR TITLE
Tempus: refresh tutorial pages and add transition docs

### DIFF
--- a/packages/tempus/doc/Doxyfile
+++ b/packages/tempus/doc/Doxyfile
@@ -17,7 +17,7 @@ OUTPUT_DIRECTORY       = .
 #
 INPUT                  = index.doc ../src ../test ../unit_test ../examples
 
-#FILE_PATTERNS          = *.h *c *.hpp *.cpp
+FILE_PATTERNS          = *.doc *.dox *.h *.hpp *.c *.cpp
 RECURSIVE              = YES
 EXCLUDE                = 
 EXCLUDE_PATTERNS       = *.x *.o *.out

--- a/packages/tempus/doc/index.doc
+++ b/packages/tempus/doc/index.doc
@@ -1,12 +1,3 @@
-//@HEADER
-// *****************************************************************************
-//          Tempus: Time Integration and Sensitivity Analysis Package
-//
-// Copyright 2017 NTESS and the Tempus contributors.
-// SPDX-License-Identifier: BSD-3-Clause
-// *****************************************************************************
-//@HEADER
-
 /* ************************************************************************ */
 /* ************************************************************************ */
 /* ************************************************************************ */
@@ -16,21 +7,21 @@
 
   \section introduction Introduction
 
-  Tempus is a Latin word meaning time as in “tempus fugit” -> “time flies”.
+  \ref Tempus is a Latin word meaning time as in “tempus fugit” -> “time flies”.
 
-  The Tempus package is a time-integration framework for advanced
+  The \ref Tempus package is a time-integration framework for advanced
   transient analysis, including various time integrators and embedded
   sensitivity analysis for next-generation code architectures. This
   framework provides “out-of-the-box” time-integration capabilities,
   which allows users to supply governing equations and easily switch
-  between various time integrators.  Additionally Tempus provides
+  between various time integrators.  Additionally \ref Tempus provides
   “build-your-own” capabilities, which allows applications to
-  incorporate various Tempus components to augment or replace
+  incorporate various \ref Tempus components to augment or replace
   application transient capabilities.  Other capabilities include
   embedded error analysis, sensitivity analysis, transient optimization
   with ROL.
 
-  Tempus provides a general infrastructure for the time evolution
+  \ref Tempus provides a general infrastructure for the time evolution
   of solutions through a variety of general integration schemes,
   and can be used from small systems of equations (e.g., single
   ODEs for the time evolution of plasticity models, and multiple
@@ -40,7 +31,7 @@
   
   \section capabilities Capabilities
 
-  Tempus provides time-integration methods for first and second-order ODEs
+  \ref Tempus provides time-integration methods for first and second-order ODEs
   in their explicit and implicit forms, 
   \f{eqnarray*}{
     \mbox{Explicit:} & \dot{x} = \mathbf{f}(x,t)    & \ddot{x} = \mathbf{f}(\dot{x},x,t) \\
@@ -49,19 +40,19 @@
 
   \subsection integrators Integrators
 
-  Tempus Integrators (e.g., Tempus::IntegratorBasic) are the time loop
+  \ref Tempus Integrators (e.g., \ref Tempus::IntegratorBasic) are the time loop
   structure for time integration and provide several features, e.g.,
   - Control the advancement of the solution from timestep to the next, e.g.,
     restart from failed timestep, selection of the next timestep size,
     solution output.
   - holds the solution history for the time integration
   - Applications can insert application-specific functionality into
-    Tempus::IntegratorBasic through observers, e.g., Tempus::IntegratorObserver.
-  - Applications can create their own integrators, derived from Tempus::Integrator.
+    \ref Tempus::IntegratorBasic through observers, e.g., \ref Tempus::IntegratorObserver.
+  - Applications can create their own integrators, derived from \ref Tempus::Integrator.
 
   \subsection steppers Time Steppers
 
-  Some features of Tempus::Stepper are
+  Some features of \ref Tempus::Stepper are
   - Timesteppers take a single timestep (PASS/FAIL) and operate on
     the supplied solution.
   - Steppers are stateless (i.e., do not hold on to data related to
@@ -75,10 +66,10 @@
   - Many Steppers take advantage of the First-Same-As-Last (FSAL) property,
     when possible, to reduce computational costs.
   - Applications can insert application-specific functionality into the
-    Tempus::Stepper through application actions, e.g., Tempus::StepperRKAppAction.
+    \ref Tempus::Stepper through application actions, e.g., \ref Tempus::StepperRKAppAction.
   - Applications can create their own steppers, derived from Stepper,
-    that can be used with other Tempus capabilities, e.g.,
-    \ref Tempus::IntegratorBasic "Integrator Basic" and \ref Tempus::SolutionHistory
+    that can be used with other \ref Tempus capabilities, e.g.,
+    \ref Tempus::IntegratorBasic and \ref Tempus::SolutionHistory
     "Solution History".
   - Steppers can mark solutions as failed (e.g., failure to reach solver
     tolerances), suggest timestep sizes, and calculate error estimates.
@@ -151,18 +142,18 @@
 
   \subsection solutions Solution State and Solution History
 
-  Solutions in Tempus are maintained in Tempus::SolutionState and incapsulate
+  Solutions in \ref Tempus are maintained in \ref Tempus::SolutionState and incapsulate
   the complete state of the solution for a particular time.  The primary
   requirement for SolutionState is that it contains all the information
   needed to restart the solution from scratch, e.g., check-pointing and
   recover from a failed timestep.  The four primary components of the
-  Tempus::SolutionState are
+  \ref Tempus::SolutionState are
   - The state - \f$x(t)\f$, \f$\dot{x}(t)\f$ (optional), and \f$\ddot{x}(t)\f$ (optional)
   - The metastate - timestep, time, order, error, etc.
   - The StepperState - any data needed by the stepper
   - The PhysicsState - any application-specific data
 
-  Tempus::SolutionState are stored in a Tempus::SolutionHistory, which
+  \ref Tempus::SolutionState are stored in a \ref Tempus::SolutionHistory, which
   is simply a container of SolutionStates, and
   - allows chronological and index access to SolutionStates
   - has multiple methods to handle the number of SolutionStates, e.g., all and last two states.
@@ -173,7 +164,7 @@
 
   \subsection timestepControl Timestep Control and Strategies
 
-  Tempus::TimeStepControl is used by the Tempus::IntegratorBasic to select
+  \ref Tempus::TimeStepControl is used by the \ref Tempus::IntegratorBasic to select
   the next timestep size, and has several basic capabilities:
   - simulation time min/max bounding
   - time index min/max bounding
@@ -184,8 +175,8 @@
   - ensure constant time steps
   - incorporate Stepper suggested time step
   
-  Additionally, Tempus provides timestep control strategies (e.g.,
-  Tempus::TimeStepControlStrategy) for various variable-timestepping
+  Additionally, \ref Tempus provides timestep control strategies (e.g.,
+  \ref Tempus::TimeStepControlStrategy) for various variable-timestepping
   capabilities, and include
   - constant and variable timestep control
   - PID integral timestep controller
@@ -194,40 +185,10 @@
 
   \section tutorials Tutorials
 
-  Here are some basic tutorials to illustrate how convert an application
-  use Tempus, and some of the features available.
+  These tutorials illustrate how an application can adopt \ref Tempus in a
+  stepwise fashion, beginning with a hand-written time integration loop
+  and progressively introducing \ref Thyra and \ref Tempus abstractions.
 
-  <table>
-    <tr><th> Title <th> Description
-    <tr><td> \ref example-00
-        <td> Introduces the problem used in following examples.
-    <tr><td> \ref example-01
-        <td> Utilize Thyra Vectors instead of C++ arrays.
-    <tr><td> \ref example-02
-        <td> Use ModelEvaluator for the problem description.
-    <tr><td> \ref example-03
-        <td> Introduce SolutionState to manage the solution evoluation.
-             Covers: solution vectors (\f$x\f$, \f$\dot{x}\f$, and
-             \f$\ddot{x}\f$) and metadata.
-    <tr><td> Adding SolutionHistory
-        <td> Adding SolutionHistory to store and interpolate solutions.
-             (under construction).
-    <tr><td> Use Steppers
-        <td> Use Steppers to enable various time steppers.
-             Covers: explicit and implicit ODE time steppers,
-             consistent initial conditions, and AppActions.
-    <tr><td> Introduce Time-step Controllers 
-        <td> Introduce TimeStepControllers to change the timestep size for
-             variable timestepping.
-             Covers: time step strategies and TimeEvents.
-    <tr><td> Utilize IntegratorBasic
-        <td> utilize IntegratorBasic to provide all the basic features
-             for Tempus time integrators.
-             Covers: IntegratorBasic and IntegratorObservers.
-  </table>
+  A tutorial overview page is available at \ref tempus_tutorials_overview.
 
-  Also, one can look at the tests and unit tests for examples of usage,
-  but these may not show standard usage or context as they are meant for
-  testing.
-
- */
+*/

--- a/packages/tempus/examples/00_Basic_Problem/00_Basic_Problem.cpp
+++ b/packages/tempus/examples/00_Basic_Problem/00_Basic_Problem.cpp
@@ -17,202 +17,66 @@ using namespace std;
 
 /** @file */
 
-/** \brief Description:
+/** \page example-00 Example 0: Basic Problem
  *
- *  \section example-00 Example 0: Basic Problem
+ *  This example provides a minimal application code for integrating the
+ *  van der Pol problem using a hand-written Forward Euler time loop.
+ *  It does not yet use Tempus, Thyra, or other Trilinos abstractions for
+ *  the state or time integration algorithm.
  *
- *  This problem is an example of a typical application code before
- *  utilizing Tempus, thus it has no Tempus or other Trilinos
- *  functionality at this point.  It is the starting point to help
- *  illustrate the various stages an application can do to take
- *  advantage of Tempus's capabilities (additionally see the other
- *  Tempus examples).
+ *  The purpose of this example is to establish the baseline structure used
+ *  throughout the tutorial sequence.  Later examples introduce \ref Tempus
+ *  and Trilinos capabilities one step at a time while preserving the same
+ *  basic problem setup whenever possible.
  *
- *  We have kept the problem itself fairly simple, Van Der Pol problem,
- *  with a simple time stepper, Forward Euler, to allow us to focus
- *  on the time integration structure and Tempus features as we add them.
- *  With this, the implementation is not the most compact or efficient
- *  for this simple problem and stepper, but it does have features
- *  one would want in a more capable time integrator.
+ *  \section vanderpol van der Pol Problem
  *
- *  \subsection vanderpol van der Pol Problem
- *
- *  van der Pol problem is a nonlinear electrical circuit, and is a
- *  canonical equation of a nonlinear oscillator (Hairer, Norsett,
- *  and Wanner, pp. 111-115, and Hairer and Wanner, pp. 4-5) for an
- *  electrical circuit.  The explicit ODE form, \f$ \dot{x} = f(x,t)\f$,
- *  of the scaled problem is
+ *  The scaled explicit first-order ODE is
  *  \f{eqnarray*}{
- *    \dot{x}_0(t) & = & f_0 = x_1(t) \\
- *    \dot{x}_1(t) & = & f_1 = [(1-x_0^2)x_1-x_0]/\epsilon
+ *    \dot{x}_0(t) & = & x_1(t) \\
+ *    \dot{x}_1(t) & = & \left[(1-x_0^2)x_1-x_0\right]/\epsilon
  *  \f}
- *  where the initial conditions are
+ *  with initial conditions
  *  \f{eqnarray*}{
- *    x_0(t_0=0) & = & 2 \\
- *    x_1(t_0=0) & = & 0
- *  \f}
- *  and the initial time derivatives are
- *  \f{eqnarray*}{
- *    \dot{x}_0(t_0=0) & = & x_1(t_0=0) = 0 \\
- *    \dot{x}_1(t_0=0) & = & [(1-x_0^2)x_1-x_0]/\epsilon = -2/\epsilon
+ *    x_0(0) & = & 2 \\
+ *    x_1(0) & = & 0.
  *  \f}
  *
- *  \section basicCodeStructure Basic Code Structure
+ *  For the model definition and additional details, 
+ *  see \ref Tempus_Test::VanDerPolModel
+ *  and \ref tempus_vanderpol_model "van der Pol Model".
  *
- *  We will review this program's code structure, 00_Basic_Problem.cpp,
- *  and go over its basic details.
+ *  \section example-00-outline Outline
  *
- *  <table>
- *    <tr> <th> Comments <th> "Basic Problem" Code Snippet
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Solution Declaration.</b>  One of the first things an application
- *      does is to define the solution.
- *    <td>
- *      @code
- *        // Solution and its time-derivative.
- *        double x_n[2];      // at time index n
- *        double xDot_n[2];   // at time index n
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Initial Conditions.</b>  Here we are using an array of two doubles
- *      for the solution and its time derivative, and set their initial
- *      values (see \ref vanderpol).  Note that xDot_n is the time
- *      derivative, \f$ \dot{x} \f$, but is also the right-hand side
- *      evaluation, \f$ f(x,t) \f$.
- *    <td>
- *      @code
- *        // Initial Conditions
- *        int n = 0;
- *        double time = 0.0;
- *        bool passed = true;   // ICs are considered passed.
- *        double epsilon = 1.0e-1;
- *        x_n   [0] = 2.0;
- *        x_n   [1] = 0.0;
- *        xDot_n[0] = 0.0;
- *        xDot_n[1] = -2.0/epsilon;
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Timestep Parameters.</b>  The next piece of code sets parameters
- *      associated with time-integration, e.g., length of time integration,
- *      number of timesteps and the timestep size.
- *    <td>
- *      @code
- *        // Timestep size
- *        double finalTime = 2.0;
- *        int nTimeSteps = 2001;
- *        const double constDT = finalTime/(nTimeSteps-1);
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Time-Integration Loop.</b>  The time-integration loop simply
- *      advances the solution until the solution is not "passed", the
- *      time has reached the final time, or the number timesteps is reached.
- *    <td>
- *      @code
- *        // Advance the solution to the next timestep.
- *        cout << n << "  " << time << "  " << x_n[0] << "  " << x_n[1] << endl;
- *        while (passed && time < finalTime && n < nTimeSteps) {
+ *  This example demonstrates the basic structure of an application-level
+ *  time integration loop:
+ *  - declare the state and its time derivative
+ *  - set the initial conditions
+ *  - advance the solution from the initial time to the final time
+ *    - select the timestep size
+ *    - evaluate the right-hand side of the governing equations
+ *    - apply the Forward Euler update
+ *    - check a simple pass/fail criterion
+ *    - accept the step and promote the solution
  *
- *          ...
+ *  The regression check at the end of the run is secondary to the tutorial
+ *  discussion and can be ignored on a first reading.
  *
- *        }
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b> Initialize the Next Timestep.</b>  Within the time loop,
- *      we initialize the next timestep, \f$ x^{n+1} \f$, to the
- *      previous timestep, \f$ x^n \f$.  Although this is not needed
- *      in this simple case, if one wants to recover from a failed
- *      timestep, the previous timestep, \f$ x^n \f$, needs to be
- *      perserved until the next timestep is accepted.
- *    <td>
- *      @code
- *        // Initialize next time step
- *        double x_np1[2];    // at time index n+1
- *        x_np1[0] = x_n[0];
- *        x_np1[1] = x_n[1];
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Set the Timestep and Time.</b>  Although this a constant
- *      timestep example, for variable timestepping, the timestep size
- *      needs to be determined and the related time for the next
- *      timestep set.
- *    <td>
- *      @code
- *        // Set the timestep and time.
- *        double dt = constDT;
- *        time = (n+1)*dt;
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Evaluate Righthand Side Function.</b>  This is a simple
- *      evaluation of the van der Pol problem and setting it to
- *      \f$ \dot{x} \f$.
- *    <td>
- *      @code
- *        // Righthand side evaluation and time-derivative at n.
- *        xDot_n[0] = x_n[1];
- *        xDot_n[1] = ((1.0 - x_n[0]*x_n[0])*x_n[1] - x_n[0])/epsilon;
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Take the Timestep.</b>  For Forward Euler, the timestep
- *      is a simple daxpy.
- *    <td>
- *      @code
- *        // Take the timestep - Forward Euler
- *        x_np1[0] = x_n[0] + dt*xDot_n[0];
- *        x_np1[1] = x_n[1] + dt*xDot_n[1];
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Test If Solution is Passing.</b>  Here we have a simple
- *      test if the solution has passed, i.e., the solution does not
- *      have a NAN.  Otherwise "promote" the solution to the next
- *      timestep and increment the timestep index.
- *    <td>
- *      @code
- *        // Test if solution has passed.
- *        if ( std::isnan(x_n[0]) || std::isnan(x_n[1]) ) {
- *          passed = false;
- *        } else {
- *          // Promote to next step (n -> n+1).
- *          x_n[0] = x_np1[0];
- *          x_n[1] = x_np1[1];
- *          n++;
- *        }
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Output Solution.</b>  Of course, we would like to know
- *      that progress of the solution during the simulation.
- *    <td>
- *    @code
- *      // Output
- *      if ( n%100 == 0 )
- *        cout << n << "  " << time << "  " << x_n[0] << "  " << x_n[1] << endl;
- *    @endcode
- *  </table>
+ *  In this version:
+ *  - the solution is stored in raw C++ arrays,
+ *  - the right-hand side is evaluated directly in the application code,
+ *  - timestep management is handled manually,
+ *  - solution status is tracked with local scalar variables.
  *
- *  <b>Following the Time-Integration Loop.</b>  Following the time
- *  loop is some basic regression testing, but serves to show tasks
- *  that one may want to complete after completion of time integration.
+ *  The next example replaces raw arrays with \ref Thyra vectors while
+ *  preserving the same overall algorithmic structure.
  *
- *  \section example-00-summary Example 0: Basic Problem Summary
- *
- *  So this outlines the basic time integration of the van der Pol
- *  problem with a few features.  We will use this example
- *  and introduce Tempus and Trilinos capabilities in the following
- *  examples.
- *
- *  \subsection example-00_Next Links
- *
- *  - Back to: \ref tutorials
- *  - Next: \ref example-01
+ *  \htmlonly
+ *  <div style="text-align:center;">
+ *    <a href="tempus_tutorials_overview.html">Tutorial Overview</a> |
+ *    <a href="example-01.html">Next Example →</a>
+ *  </div>
+ *  \endhtmlonly
  */
 int main(int argc, char *argv[])
 {
@@ -259,7 +123,7 @@ int main(int argc, char *argv[])
       x_np1[0] = x_n[0] + dt*xDot_n[0];
       x_np1[1] = x_n[1] + dt*xDot_n[1];
 
-      // Test if solution is passed.
+      // Test if solution has passed.
       if ( std::isnan(x_n[0]) || std::isnan(x_n[1]) ) {
         passed = false;
       } else {

--- a/packages/tempus/examples/01_Utilize_Thyra/01_Utilize_Thyra.cpp
+++ b/packages/tempus/examples/01_Utilize_Thyra/01_Utilize_Thyra.cpp
@@ -23,193 +23,39 @@ using Teuchos::RCP;
 
 /** @file */
 
-/** \brief Description:
+/** \page example-01 Example 1: Utilize Thyra
  *
- *  \section example-01 Example 1: Utilize Thyra
+ *  This example replaces the raw C++ arrays from \ref example-00 with
+ *  Thyra vectors and vector spaces.  The mathematical problem, timestepper,
+ *  and overall time-integration structure remain essentially unchanged,
+ *  The main purpose is to introduce the abstract vector interfaces used
+ *  throughout \ref Tempus and other Trilinos packages.
  *
- *  This problem takes \ref 00_Basic_Problem.cpp "Basic Problem"
- *  and utilizes Thyra vectors, replacing the C++ double arrays,
- *  01_Utilize_Thyra.cpp.  Tempus uses Thyra for its Abstract Numerical
- *  Algorithms (ANAs), which are the mathematical concepts of
- *  vectors, vector spaces, and linear operators. All other ANA
- *  interfaces and support software are built on these fundamental
- *  operator/vector interfaces (including ModelEvaluators).
+ *  Changes relative to \ref example-00:
+ *  - state storage moves from raw arrays to `Thyra::VectorBase`,
+ *  - a `Thyra::VectorSpaceBase` is introduced to define the state space,
+ *  - vector initialization and element access use `Thyra::DetachedVectorView`,
+ *  - vector algebra uses Thyra helper routines, `Thyra::V_VpStV`, `Thyra::norm`, `Thyra::V_V`
+ *  - `Teuchos::RCP` is used for memory management.
  *
- *  In the following table, code snippets from the \ref 00_Basic_Problem.cpp
- *  "Basic Problem" tutorial are replaced with snippets using Thyra to create
- *  01_Utilize_Thyra.cpp for the \ref 01_Utilize_Thyra.cpp "Utilize Thyra"
- *  tutorial.  This is similar to performing a diff between
- *  00_Basic_Problem.cpp and 01_Utilize_Thyra.cpp, but the first column
- *  provides comments related to the changes.  You may want to to do a
- *  diff (e.g., vimdiff or tkdiff) to see these changes within main
- *  (e.g., vimdiff 00_Basic_Problem/00_Basic_Problem.cpp 01_Utilize_Thyra/01_Utilize_Thyra.cpp).
+ *  This example shows how the same application logic can be expressed in
+ *  terms of abstract numerical objects rather than concrete array storage.
+ *  That abstraction is a prerequisite for later examples that introduce
+ *  `Thyra::ModelEvaluator` and \ref Tempus solution-management objects.
  *
- *  <table>
- *    <tr> <th> Comments <th> Original "Basic Problem" Code Snippet
- *                        <th> Replacement "Utilize Thyra" Code Snippet
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Setup Thyra vectors.</b> We first need to replace the C++
- *      double arrays with a vector space to construct the Thyra::Vector.
- *      We additionally have introduced the use of Teuchos
- *      Reference-Counted Pointers (Teuchos:RCP), which are Trilinos's
- *      smart pointers.  Details on RCP can be found at
- *      https://www.osti.gov/servlets/purl/919177.
- *    <td>
- *      @code
- *        // Solution and its time-derivative.
- *        double x_n[2];      // at time index n
- *        double xDot_n[2];   // at time index n
- *      @endcode
- *    <td>
- *      @code
- *        // Solution and its time-derivative.
- *        int vectorLength = 2;  // number state unknowns
- *        RCP<const Thyra::VectorSpaceBase<double> >  xSpace =
- *          Thyra::defaultSpmdVectorSpace<double>(vectorLength);
+ *  A more detailed explanation of what changed from \ref example-00 is given in
+ *  \ref tempus_tutorial_transition_00_01.
  *
- *        RCP<Thyra::VectorBase<double> > x_n    = Thyra::createMember(xSpace);
- *        RCP<Thyra::VectorBase<double> > xDot_n = Thyra::createMember(xSpace);
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Initialize Thyra vectors.</b>
- *      The initialization can be achieved with the
- *      Thyra::DetachedVectorView's.  The scoping ensures they are deleted
- *      after use.
- *    <td>
- *      @code
- *        // Initial Conditions
- *        double time = 0.0;
- *        double epsilon = 1.0e-1;
- *        x_n   [0] = 2.0;
- *        x_n   [1] = 0.0;
- *        xDot_n[0] = 0.0;
- *        xDot_n[1] = -2.0/epsilon;
- *      @endcode
- *    <td>
- *      @code
- *        // Initial Conditions
- *        double time = 0.0;
- *        double epsilon = 1.0e-1;
- *        { // Scope to delete DetachedVectorViews
- *          Thyra::DetachedVectorView<double> x_n_view(*x_n);
- *          x_n_view[0] = 2.0;
- *          x_n_view[1] = 0.0;
- *          Thyra::DetachedVectorView<double> xDot_n_view(*xDot_n);
- *          xDot_n_view[0] = 0.0;
- *          xDot_n_view[1] = -2.0/epsilon;
- *        }
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Access Thyra vectors.</b>
- *      Elements of the Thyra::Vector can be quickly accessed with get_ele.
- *    <td>
- *      @code
- *        cout << n << "  " << time << "  " << x_n[0] << "  " << x_n[1] << endl;
- *      @endcode
- *    <td>
- *      @code
- *        cout << n << "  " << time << "  " << get_ele(*(x_n), 0)
- *                                  << "  " << get_ele(*(x_n), 1) << endl;
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Clone Thyra vectors.</b>
- *      To initialize the solution at the next time step, we can simply
- *      clone the current timestep.
- *    <td>
- *      @code
- *        // Initialize next time step
- *        double x_np1[2];    // at time index n+1
- *        x_np1[0] = x_n[0];
- *        x_np1[1] = x_n[1];
- *      @endcode
- *    <td>
- *      @code
- *        // Initialize next time step
- *        RCP<Thyra::VectorBase<double> > x_np1 = x_n->clone_v(); // at time index n+1
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Accessing elements of Thyra vectors.</b>
- *      The model evaluation is achieved through Thyra::DetachedVectorView.
- *    <td>
- *      @code
- *        // Righthand side evaluation and time-derivative at n.
- *        xDot_n[0] = x_n[1];
- *        xDot_n[1] = ((1.0 - x_n[0]*x_n[0])*x_n[1] - x_n[0])/epsilon;
- *      @endcode
- *    <td>
- *      @code
- *        // Righthand side evaluation and time-derivative at n.
- *        {
- *          Thyra::ConstDetachedVectorView<double> x_n_view(*x_n);
- *          Thyra::DetachedVectorView<double> xDot_n_view(*xDot_n);
- *          xDot_n_view[0] = x_n_view[1];
- *          xDot_n_view[1] =
- *            ((1.0-x_n_view[0]*x_n_view[0])*x_n_view[1]-x_n_view[0])/epsilon;
- *        }
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Compute with Thyra vectors.</b>
- *      The Forward Euler time stepping is achieved by using
- *      Thyra::V_VpStV, which performs an axpy.
- *    <td>
- *      @code
- *        // Take the timestep - Forward Euler
- *        x_np1[0] = x_n[0] + dt*xDot_n[0];
- *        x_np1[1] = x_n[1] + dt*xDot_n[1];
- *      @endcode
- *    <td>
- *      @code
- *        // Take the timestep - Forward Euler
- *        Thyra::V_VpStV(x_np1.ptr(), *x_n, dt, *xDot_n);
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Other Thyra vector utilities.</b>
- *      We can also take advantage other Thyra features, Thyra::norm, to check
- *      if the solution has passed.
- *    <td>
- *      @code
- *        // Test if solution has passed.
- *        if ( std::isnan(x_n[0]) || std::isnan(x_n[1]) ) {
- *      @endcode
- *    <td>
- *      @code
- *        // Test if solution has passed.
- *        if ( std::isnan(Thyra::norm(*x_np1) ) {
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Use Thyra vector assignment.</b>
- *      The solution update is achieved via Thyra::V_V.
- *    <td>
- *      @code
- *          // Promote to next step (n <- n+1).
- *          x_n[0] = x_np1[0];
- *          x_n[1] = x_np1[1];
- *          n++;
- *      @endcode
- *    <td>
- *      @code
- *          // Promote to next step (n <- n+1).
- *          Thyra::V_V(x_n.ptr(), *x_np1);
- *          n++;
- *      @endcode
- *  </table>
+ *  The next example moves the problem definition into a
+ *  \ref Thyra::ModelEvaluator while preserving the same Forward Euler update.
  *
- *  The remainder of 01_Utilize_Thyra.cpp (e.g., regression testing) has
- *  similar changes to those from above.
- *
- *  \subsection example-01_Next Links
- *
- *  - Back to: \ref tutorials
- *  - Previous: \ref example-00
- *  - Next: \ref example-02
+ *  \htmlonly
+ *  <div style="text-align:center;">
+ *    <a href="example-00.html">← Previous Example</a> |
+ *    <a href="tempus_tutorials_overview.html">Tutorial Overview</a> |
+ *    <a href="example-02.html">Next Example →</a>
+ *  </div>
+ *  \endhtmlonly
  */
 int main(int argc, char *argv[])
 {

--- a/packages/tempus/examples/02_Use_ModelEvaluator/02_Use_ModelEvaluator.cpp
+++ b/packages/tempus/examples/02_Use_ModelEvaluator/02_Use_ModelEvaluator.cpp
@@ -25,180 +25,44 @@ using Teuchos::RCP;
 
 /** @file */
 
-/** \brief Description:
+/** \page example-02 Example 2: Use ModelEvaluator
  *
- *  \section example-02 Example 2: Use ModelEvaluator
+ *  This example moves the van der Pol model into a
+ *  \ref Thyra::ModelEvaluator.  The time integration loop still performs a
+ *  hand-written Forward Euler update, but the right-hand side evaluation and
+ *  nominal initial conditions are now obtained through the model interface.
  *
- *  The next step in our progression is to use a Thyra::ModelEvaluator
- *  for the application problem, i.e., \ref vanderpol, and will
- *  provide a common interface to Abstract Numerical Algorithms
- *  (ANAs), e.g., nonlinear equations, NOX; stability analysis,
- *  LOCA; transient nonlinear ODEs, Tempus; and sensitivity analysis,
- *  Sacado.  For this example, we will be focusing on setting up a
- *  ModelEvaluator for transient nonlinear equations (e.g., explicit
- *  and implicit ODEs), and therefore this is not meant to be an
- *  indepth tutorial on ModelEvaluators.  Please refer to
- *  https://docs.trilinos.org/dev/packages/thyra/doc/html/classThyra_1_1ModelEvaluator.html
- *  and https://bartlettroscoe.github.io/publications/ModelEvaluator_HPCSW2008.pdf.
- *  for additional details on ModelEvaluators.
+ *  The main purpose of this step is to separate the problem physics from the
+ *  time integration algorithm.
  *
- *  \subsection MEbasics ModelEvaluator Basics
+ *  Relative to \ref example-01:
+ *  - the problem physics are encapsulated in `VanDerPol_ModelEvaluator_02`
+ *  - initial conditions are obtained from `getNominalValues()`
+ *  - right-hand-side evaluation is performed through `evalModel()`
+ *  - the application begins to separate the model definition from the
+ *    time integration logic
  *
- *  Because the ModelEvaluator is a generic interface to all the ANAs,
- *  the primary function to evaluate the various quantities is simply
- *  @code
- *    Thyra::ModelEvaluator< Scalar >::evalModel(
- *      const ModelEvaluatorBase::InArgs< Scalar > & inArgs,
- *      const ModelEvaluatorBase::OutArgs< Scalar > & outArgs ) const
- *  @endcode
- *  where InArgs contains all the required information for the
- *  ModelEvaluator to compute the request from the ANA (i.e.,
- *  Tempus), and OutArgs will contain the computed quantities.
- *  In Tempus's case of explicit first-order ODEs (\f$ \dot{x} = f(x,t)\f$),
- *  the InArgs is just \f$x\f$ and \f$t\f$ and the OutArgs is
- *  \f$\dot{x}\f$.
- *  For implicit first-order ODEs (\f$ f(\dot{x},x,t) \f$),
- *  the InArgs is \f$ \dot{x} \f$, \f$x\f$ and \f$t\f$ and the OutArgs is
- *  the function evaluation, \f$ f(\dot{x},x,t) \f$.  Thus through the
- *  InArgs and OutArgs, the ModelEvaluator can determine which evaluation
- *  is being requested.
+ *  \ref Thyra::ModelEvaluator provides a common Trilinos interface between
+ *  application models and abstract numerical algorithms.  For \ref Tempus,
+ *  this interface is the standard mechanism for exposing governing equations
+ *  to steppers and integrators.
  *
- *  One important attribute of ModelEvaluators is they are
- *  <b>stateless</b>!  This means they do not storage any information
- *  that might change over the duration of the simulation, i.e., the
- *  ModelEvaluator does <b>not</b> contain any state information.
- *  Any state information must be passed in through the inputs (i.e.,
- *  InArgs).  A simple test for this attribute is the ModelEvaluator
- *  will return the exact same evaluation (i.e., OutArgs) for two
- *  consecutive evaluations, i.e.,
- *  @code
- *    evalModel(inArgs, outArgs1);
- *    evalModel(inArgs, outArgs2);
- *  @endcode
- *  and outArgs1 = outArgs2!
- *  The stateless attribute is very important for Tempus, because
- *  timesteps may fail and need to be retried with a new timestep size.
- *  If the ModelEvaluator is not stateless, then the re-evaluation will
- *  change!  The solvers (e.g., NOX) have a similar issue with multiple
- *  evaluations, and also require the stateless attribute.
+ *  This example focuses only on the subset of \ref Thyra::ModelEvaluator
+ *  behavior needed for explicit first-order ODEs.
  *
- *  For details on the ModelEvaluator for the \ref vanderpol implemented
- *  in this example, please review VanDerPol_ModelEvaluator_02.
+ *  A more detailed explanation of the changes from \ref example-01 is given in
+ *  \ref tempus_tutorial_transition_01_02.
  *
- *  \subsection changesToUseME Changes to Use ModelEvaluator
+ *  The next example introduces \ref Tempus::SolutionState to store the
+ *  evolving solution together with selected time-integration metadata.
  *
- *  In the following table are code snippets of the changes from the
- *  \ref 01_Utilize_Thyra.cpp to 02_Use_ModelEvaluator.cpp.  This is
- *  similar taking a difference between them for the main() function.
- *
- *  <table>
- *    <tr> <th> Comments <th> "Utilize Thyra" Code Snippet
- *                       <th> "Use ModelEvaluator" Code Snippet
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Construct the ModelEvaluator.</b>
- *      The ModelEvaluator, VanDerPol_ModelEvaluator_02, now has all
- *      information to construct the problem, including the problem
- *      size, vectorLength, parameters, and initial conditions.
- *    <td>
- *      @code
- *        // Solution and its time-derivative.
- *        int vectorLength = 2;  // number state unknowns
- *        RCP<const Thyra::VectorSpaceBase<double> >  xSpace =
- *          Thyra::defaultSpmdVectorSpace<double>(vectorLength);
- *      @endcode
- *    <td>
- *      @code
- *        // Construct ModelEvaluator
- *        Teuchos::RCP<const Thyra::ModelEvaluator<double> >
- *          model = Teuchos::rcp(new VanDerPol_ModelEvaluator_02<double>());
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Get ICs from the ModelEvaluator.</b>
- *      The initial conditions (i.e., nominal values) have moved to
- *      the VanDerPol_ModelEvaluator_02 constructor, and can retrieved
- *      via getNominalValues().
- *    <td>
- *      @code
- *        RCP<Thyra::VectorBase<double> > x_n    = Thyra::createMember(xSpace);
- *        RCP<Thyra::VectorBase<double> > xDot_n = Thyra::createMember(xSpace);
- *        // Initial Conditions
- *        double time = 0.0;
- *        double epsilon = 1.0e-1;
- *        { // Scope to delete DetachedVectorViews
- *          Thyra::DetachedVectorView<double> x_n_view(*x_n);
- *          x_n_view[0] = 2.0;
- *          x_n_view[1] = 0.0;
- *          Thyra::DetachedVectorView<double> xDot_n_view(*xDot_n);
- *          xDot_n_view[0] = 0.0;
- *          xDot_n_view[1] = -2.0/epsilon;
- *        }
- *      @endcode
- *    <td>
- *      @code
- *        // Get initial conditions from ModelEvaluator::getNominalValues.
- *        RCP<Thyra::VectorBase<double> > x_n    =
- *          model->getNominalValues().get_x()->clone_v();
- *        RCP<Thyra::VectorBase<double> > xDot_n =
- *          model->getNominalValues().get_x_dot()->clone_v();
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Setup InArgs and OutArgs for the ModelEvaluator.</b>
- *      Before calling evalModel(InArgs, OutArgs), the InArgs and
- *      OutArgs need to be setup.  For an explicit ODE, we need to
- *      set the time, the solution vector, x, and the time derivative,
- *      x_dot. In InArgs, x_dot needs to be set to null to indicate
- *      it is an explicit ODE evaluation.  Finally, we set the outArgs
- *      f evaluation to the time derivative, xDot, so it is filled
- *      with the result.
- *    <td>
- *      @code
- *      @endcode
- *    <td>
- *      @code
- *        // For explicit ODE formulation, xDot = f(x, t),
- *        // xDot is part of the outArgs.
- *        auto inArgs  = model->createInArgs();
- *        auto outArgs = model->createOutArgs();
- *        inArgs.set_t(time);
- *        inArgs.set_x(x_n);
- *        inArgs.set_x_dot(Teuchos::null);
- *        outArgs.set_f(xDot_n);
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Evaluate the ModelEvaluator.</b>
- *      The righthand-side evaluation is now in the ModelEvaluator,
- *      and is called with evalModel(InArgs, OutArgs).  Note that
- *      xDot has been filled in and can be accessed for the Forward-Euler
- *      update.
- *    <td>
- *      @code
- *        // Righthand side evaluation and time-derivative at n.
- *        {
- *          Thyra::ConstDetachedVectorView<double> x_n_view(*x_n);
- *          Thyra::DetachedVectorView<double> xDot_n_view(*xDot_n);
- *          xDot_n_view[0] = x_n_view[1];
- *          xDot_n_view[1] =
- *            ((1.0-x_n_view[0]*x_n_view[0])*x_n_view[1]-x_n_view[0])/epsilon;
- *        }
- *      @endcode
- *    <td>
- *      @code
- *        // Righthand side evaluation and time-derivative at n.
- *        model->evalModel(inArgs, outArgs);
- *      @endcode
- *  </table>
- *
- *  The remainder of 02_Use_ModelEvaluator.cpp is regression testing, etc.
- *
- *  \subsection example-02_Next Links
- *
- *  - Back to: \ref tutorials
- *  - Previous: \ref example-01
- *  - Next: \ref example-03
+ *  \htmlonly
+ *  <div style="text-align:center;">
+ *    <a href="example-01.html">← Previous Example</a> |
+ *    <a href="tempus_tutorials_overview.html">Tutorial Overview</a> |
+ *    <a href="example-03.html">Next Example →</a>
+ *  </div>
+ *  \endhtmlonly
  */
 int main(int argc, char *argv[])
 {

--- a/packages/tempus/examples/03_Intro_SolutionState/03_Intro_SolutionState.cpp
+++ b/packages/tempus/examples/03_Intro_SolutionState/03_Intro_SolutionState.cpp
@@ -27,188 +27,50 @@ using Teuchos::RCP;
 
 /** @file */
 
-/** \brief Description:
+/** \page example-03 Example 3: Introduce SolutionState
  *
- *  \section example-03 Example 3: Introduce SolutionState
+ *  This example introduces \ref Tempus::SolutionState, which stores the
+ *  solution and selected metadata at a particular time.  The model is still
+ *  provided through a \ref Thyra::ModelEvaluator, and the Forward Euler update
+ *  is still written explicitly in the application code, but the evolving state
+ *  of the integration is now organized using a core \ref Tempus data structure.
  *
+ *  The main purpose of this step is to move from ad hoc scalar bookkeeping to
+ *  a structured representation of the solution and its integration metadata.
  *
- *  The basic idea behind the SolutionState object is that it
- *  contains all the information about the solution at a particular
- *  time, i.e., \f$x(t)\f$.  The primary requirement for SolutionState
- *  is that it contains all the information needed to restart the
- *  solution from scratch, e.g., check-pointing and recover from a
- *  failed timestep.  The four primary components of the
- *  Tempus::SolutionState are
- *  - The state - \f$x(t)\f$, \f$\dot{x}(t)\f$ (optional), and \f$\ddot{x}(t)\f$ (optional)
- *  - The metastate - timestep, time, order, error, etc.
- *  - The StepperState - any data needed by the stepper
- *  - The PhysicsState - any application-specific data
+ *  Relative to \ref example-02:
+ *  - the primary solution is stored in a \ref Tempus::SolutionState
+ *  - metadata such as index, time, timestep size, and status are tracked
+ *    through that object
+ *  - pass/fail logic is expressed through \ref Tempus::Status
+ *  - the example begins to follow \ref Tempus conventions for managing
+ *    solution state during time integration
  *
- *  <b>For additional details about the Tempus::SolutionState, please see
- *  \ref SolutionState_Description!</b>
+ *  The central idea behind \ref Tempus::SolutionState is that it should contain
+ *  the information needed to represent a solution at a specific time in a form
+ *  suitable for restart, checkpointing, diagnostics, and recovery from failed
+ *  timesteps.
  *
- *  For this example, we will only utilize and demonstrate the state
- *  and the metastate (Tempus::SolutionStateMetaData).
+ *  This example uses only part of the full \ref Tempus::SolutionState
+ *  capability:
+ *  - the solution vector \f$x(t)\f$
+ *  - selected metadata from \ref Tempus::SolutionStateMetaData
  *
- *  \subsection changesToUseSolutionState Changes to Use SolutionState
+ *  For additional details, see \ref SolutionState_Description.
  *
- *  In the following table are code snippets of the changes from the
- *  \ref 02_Use_ModelEvaluator.cpp to 03_Intro_SolutionState.cpp.  This is
- *  similar taking a difference between them for the main() function.
+ *  A more detailed explanation of the changes from \ref example-02 is given in
+ *  \ref tempus_tutorial_transition_02_03.
  *
- *  <table>
- *    <tr> <th> Comments <th> "Use ModelEvaluator" Code Snippet
- *                       <th> "Intro SolutionState" Code Snippet
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Initial the SolutionState.</b>
- *      Create a SolutionState object with the initial-condition
- *      solution, \f$x\f$, from the ModelEvaluator, using the one
- *      of the non-member constructors.  These non-member constructors
- *      set the remaining member data to default values (see
- *      Tempus::createSolutionStateX).  Member data can also be set
- *      through the basic set functions, e.g., setIndex(0).
+ *  The next example extends this idea by introducing
+ *  \ref Tempus::SolutionHistory to manage multiple solution states.
  *
- *      <b>Note:</b> we did not include its time derivative, \f$\dot{x}\f$,
- *      as part of the SolutionState because it is not needed for
- *      output or diagnostics.  However we still require memory for it
- *      in the Forward Euler timestepping.  Foreshadowing: the time
- *      derivative can be handled and maintained by all the
- *      time steppers internally.
- *    <td>
- *      @code
- *        // Get initial conditions from ModelEvaluator::getNominalValues.
- *        int n = 0;
- *        double time = 0.0;
- *        RCP<Thyra::VectorBase<double> > x_n    =
- *          model->getNominalValues().get_x()->clone_v();
- *        RCP<Thyra::VectorBase<double> > xDot_n =
- *          model->getNominalValues().get_x_dot()->clone_v();
- *      @endcode
- *    <td>
- *      @code
- *        // Setup initial condition SolutionState --------------------
- *        auto solState = Tempus::createSolutionStateX(
- *                          model->getNominalValues().get_x()->clone_v());
- *        solState->setIndex   (0);
- *        solState->setTime    (0.0);
- *        solState->setTimeStep(0.0);  // By convention, the IC has dt=0.
- *        solState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are considered passed.
- *        RCP<Thyra::VectorBase<double> > xDot_n =
- *          model->getNominalValues().get_x_dot()->clone_v();
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Access member data of the SolutionState.</b>
- *      All the information about the solution and state are within the
- *      SolutionState object, and can be accessed through get functions,
- *      e.g., the index, time, solution, and solution status.
- *    <td>
- *      @code
- *        cout << n << "  " << time << "  " << get_ele(*(x_n), 0)
- *                                  << "  " << get_ele(*(x_n), 1) << endl;
- *        while (passed && time < finalTime && n < nTimeSteps) {
- *      @endcode
- *    <td>
- *      @code
- *        cout << solState->getIndex() << "  " << solState->getTime()
- *             << "  " << get_ele(*(solState->getX()), 0)
- *             << "  " << get_ele(*(solState->getX()), 1) << endl;
- *        while (solState->getSolutionStatus() == Tempus::Status::PASSED &&
- *               solState->getTime() < finalTime &&
- *               solState->getIndex() < nTimeSteps) {
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Setup the next timestep.</b>
- *      To initialize the next time step, we set some Referenced
- *      Counted Pointers (RCPs), and create a scratch vector.
- *      Additionally, we set the index, time and timestep for the
- *      next ("working") time step solution.  Although, not evident
- *      at this point, we will use the label "working" to help
- *      manage solutions that have not met the "passing" criteria,
- *      and we can try again with new settings, e.g., timestep size.
- *    <td>
- *      @code
- *        // Initialize next time step
- *        RCP<Thyra::VectorBase<double> > x_np1 = x_n->clone_v(); // at time index n+1
-
- *        // Set the timestep and time.
- *        double dt = constDT;
- *        time = (n+1)*dt;
- *      @endcode
- *    <td>
- *      @code
- *        // Initialize next time step
- *        RCP<Thyra::VectorBase<double> > x_n    = solState->getX();
- *        RCP<Thyra::VectorBase<double> > x_np1  = solState->getX()->clone_v(); // at time index n+1
- *        solState->setSolutionStatus(Tempus::Status::WORKING);
-
- *        // Set the timestep and time for the working solution i.e., n+1.
- *        int index = solState->getIndex()+1;
- *        double dt = constDT;
- *        double time = index*dt;
-
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Set status of SolutionState.</b>
- *        Need to set SolutionState status to PASSED or FAILED, increment
- *        the index and time, and set the timestep.
- *    <td>
- *      @code
- *        // Test if solution has passed.
- *        if ( std::isnan(Thyra::norm(*x_np1)) ) {
- *          passed = false;
- *        } else {
- *          // Promote to next step (n <- n+1).
- *          Thyra::V_V(x_n.ptr(), *x_np1);
- *          n++;
- *        }
- *      @endcode
- *    <td>
- *      @code
- *        // Test if solution has passed.
- *        if ( std::isnan(Thyra::norm(*x_np1)) ) {
- *          solState->setSolutionStatus(Tempus::Status::FAILED);
- *        } else {
- *          // Promote to next step (n <- n+1).
- *          Thyra::V_V(x_n.ptr(), *x_np1);
- *          solState->setIndex   (index);
- *          solState->setTime    (time);
- *          solState->setTimeStep(constDT);
- *          solState->setSolutionStatus(Tempus::Status::PASSED);
- *        }
- *      @endcode
- *    <tr VALIGN=TOP>
- *    <td>
- *      <b>Access the SolutionState.</b>
- *      Need to access the SolutionState for the solution index.
- *      Note the RCP x_n still has access to the solution vector.
- *    <td>
- *      @code
- *        // Output
- *        if ( n%100 == 0 )
- *          cout << n << "  " << time << "  " << get_ele(*(x_n), 0)
- *                                    << "  " << get_ele(*(x_n), 1) << endl;
- *      @endcode
- *    <td>
- *      @code
- *        // Output
- *        if ( solState->getIndex()%100 == 0 )
- *          cout << solState->getIndex() << "  " << time
- *               << "  " << get_ele(*(x_n), 0)
- *               << "  " << get_ele(*(x_n), 1) << endl;
- *      @endcode
- *  </table>
- *
- *  The remainder of 03_Intro_SolutionState.cpp is regression testing, etc.
- *
- *  \subsection example-03_Next Links
- *
- *  - Back to: \ref tutorials
- *  - Previous: \ref example-02
- *  - Next: Adding SolutionHistory
+ *  \htmlonly
+ *  <div style="text-align:center;">
+ *    <a href="example-02.html">← Previous Example</a> |
+ *    <a href="tempus_tutorials_overview.html">Tutorial Overview</a> |
+ *    <a href="example-04.html">Next Example →</a>
+ *  </div>
+ *  \endhtmlonly
  */
 int main(int argc, char *argv[])
 {

--- a/packages/tempus/examples/Tempus_Tutorial_00_to_01.dox
+++ b/packages/tempus/examples/Tempus_Tutorial_00_to_01.dox
@@ -1,0 +1,185 @@
+/*! \page tempus_tutorial_transition_00_01 Transition from Example 0 to Example 1
+ *
+ *  \section tempus_tutorial_transition_00_01_goal Goal
+ *
+ *  The primary goal of \ref example-01 is to replace the raw arrays
+ *  with Thyra vectors, while preserving the same van der Pol
+ *  problem and the same Forward Euler stepping logic used in
+ *  \ref example-00.
+ *
+ *  New concepts introduced from `Teuchos` and `Thyra` are
+ *
+ *  - Teuchos::RCP
+ *    - <a href="https://www.osti.gov/servlets/purl/919177">Teuchos::RCP</a>
+ *      memory management can be compared to `std::shared_ptr`
+ *  - Thyra::VectorBase
+ *    - Replaces raw C++ arrays
+ *  - Thyra::VectorSpaceBase
+ *    - Introduced to define the state space.
+ *  - Thyra::DetactedVectorView and Thyra::ConstDetactedVectorView
+ *    - Detached vector views are used for direct element access.
+ *  - Thyra::V_VpSV, Thra::_V, Thyra::norm, Thyra::norm_2
+ *    - Thyra helper routines to express vector algebra.
+ *
+ *  This allows \ref Tempus and other Trilinos packages to operate on
+ *  abstract numerical interfaces rather than concrete array types.
+ *  Moving from raw arrays to Thyra vectors is the first step
+ *  toward interoperability with \ref Tempus steppers, model evaluators,
+ *  and solver infrastructure.
+ *
+ *  \section tempus_tutorial_transition_00_01_same What stays the same
+ *
+ *  - The van der Pol equations are unchanged.
+ *  - The timestepper is still Forward Euler.
+ *  - The time loop structure is the same.
+ *  - The regression check follows the same pattern.
+ *
+ *  \section tempus_tutorial_transition_00_01_snippets Selected code excerpts
+ *
+ *  Below are select code snippets and comments on the uses Teuchos::RCP
+ *  and Thyra functionality.
+ *
+ *  <hr style="border:0; border-top:5px solid #ccc;">
+ *  \subsection tempus_tutorial_transition_00_01_snippet1 Memory Allocation
+ *
+ *  <b>Setup Thyra vectors.</b> The raw `double` arrays are replaced by
+ *  Thyra vectors, which are created from a `Thyra::VectorSpaceBase`.
+ *  This step also introduces Teuchos::RCP, Trilinos's reference-counted
+ *  smart pointer.
+ *  
+ *  <b>Before</b>
+ *  @code
+ *  double x_n[2];
+ *  double xDot_n[2];
+ *  @endcode
+ *
+ *  <b>After</b>
+ *  @code
+ *  int vectorLength = 2;
+ *  RCP<const Thyra::VectorSpaceBase<double> > xSpace =
+ *    Thyra::defaultSpmdVectorSpace<double>(vectorLength);
+ *
+ *  RCP<Thyra::VectorBase<double> > x_n    = Thyra::createMember(xSpace);
+ *  RCP<Thyra::VectorBase<double> > xDot_n = Thyra::createMember(xSpace);
+ *  @endcode
+ *
+ *  The state is now represented through abstract vector interfaces rather
+ *  than fixed-size arrays.
+ *
+ *  <hr style="border:0; border-top:5px solid #ccc;">
+ *  \subsection tempus_tutorial_transition_00_01_snippet2 Assign Initial Conditions
+ *  <b>Initialize Thyra vectors.</b> Initial values are assigned through
+ *  `Thyra::DetachedVectorView`.  The local scope ensures the detached views
+ *  are destroyed immediately after use. 
+ *
+ *  <b>Before</b>
+ *  @code
+ *  x_n   [0] = 2.0;
+ *  x_n   [1] = 0.0;
+ *  xDot_n[0] = 0.0;
+ *  xDot_n[1] = -2.0/epsilon;
+ *  @endcode
+ *
+ *  <b>After</b>
+ *  @code
+ *  { // Scope to delete DetachedVectorViews
+ *    Thyra::DetachedVectorView<double> x_n_view(*x_n);
+ *    x_n_view[0] = 2.0;
+ *    x_n_view[1] = 0.0;
+ *    Thyra::DetachedVectorView<double> xDot_n_view(*xDot_n);
+ *    xDot_n_view[0] = 0.0;
+ *    xDot_n_view[1] = -2.0/epsilon;
+ *  }
+ *  @endcode
+ *
+ *  <hr style="border:0; border-top:5px solid #ccc;">
+ *  \subsection tempus_tutorial_transition_00_01_snippet3 Evaluate the RHS
+ *
+ *  <b>Evaluating the Right-Hand Side</b> The van der Pol right-hand side is
+ *  still evaluated directly in the application code, but element access now
+ *  goes through detached vector views.
+ *
+ *  <b>Before</b>
+ *  @code
+ *  xDot_n[0] = x_n[1];
+ *  xDot_n[1] = ((1.0 - x_n[0]*x_n[0])*x_n[1] - x_n[0])/epsilon;
+ *  @endcode
+ *
+ *  <b>After</b>
+ *  @code
+ *  {
+ *    Thyra::ConstDetachedVectorView<double> x_n_view(*x_n);
+ *    Thyra::DetachedVectorView<double> xDot_n_view(*xDot_n);
+ *    xDot_n_view[0] = x_n_view[1];
+ *    xDot_n_view[1] =
+ *      ((1.0-x_n_view[0]*x_n_view[0])*x_n_view[1]-x_n_view[0])/epsilon;
+ *  }
+ *  @endcode
+ *
+ *  Element-wise access is still possible, but it now uses Thyra utilities.
+ *
+ *  <hr style="border:0; border-top:5px solid #ccc;">
+ *  \subsection tempus_tutorial_transition_00_01_snippet4 Perform Forward Euler
+ *
+ *  <b>Use Thyra vector algebra.</b>  The Forward Euler update is expressed
+ *  with `Thyra::V_VpStV`, which performs the vector operation
+ *  \f$x^{n+1} = x^n + dt\,\dot{x}^n\f$.
+ *
+ *  <b>Before</b>
+ *  @code
+ *  x_np1[0] = x_n[0] + dt*xDot_n[0];
+ *  x_np1[1] = x_n[1] + dt*xDot_n[1];
+ *  @endcode
+ *
+ *  <b>After</b>
+ *  @code
+ *  Thyra::V_VpStV(x_np1.ptr(), *x_n, dt, *xDot_n);
+ *  @endcode
+ *
+ *  <hr style="border:0; border-top:5px solid #ccc;">
+ *  \subsection tempus_tutorial_transition_00_01_snippet5 Promote to the next time step
+ *
+ *  <b>Use Thyra vector assignment.</b> The accepted solution is copied into
+ *  the current state using `Thyra::V_V`.
+ *
+ *  <b>Before</b>
+ *  @code
+ *  x_n[0] = x_np1[0];
+ *  x_n[1] = x_np1[1];
+ *  n++;
+ *  @endcode
+ *
+ *  <b>After</b>
+ *  @code
+ *  Thyra::V_V(x_n.ptr(), *x_np1);
+ *  n++;
+ *  @endcode
+ *
+ *  <hr style="border:0; border-top:5px solid #ccc;">
+ *  \section tempus_tutorial_transition_00_01_compare How to compare the examples
+ *
+ *  A more detailed comparison can be viewed by diffing:
+ *  - `examples/00_Basic_Problem/00_Basic_Problem.cpp`
+ *  - `examples/01_Utilize_Thyra/01_Utilize_Thyra.cpp`
+ *
+ *  From the `packages/tempus` directory, a focused comparison of the main
+ *  time-integration logic between these two examples can be generated locally
+ *  in `bash` or `zsh` with:
+ *
+ *  @code{.sh}
+ *  git diff --no-index \
+ *    <(sed -n '81,141p' examples/00_Basic_Problem/00_Basic_Problem.cpp) \
+ *    <(sed -n '60,130p' examples/01_Utilize_Thyra/01_Utilize_Thyra.cpp)
+ *  @endcode
+ *
+ *  This ignores leading header lines (for example, `#include` statements and
+ *  Doxygen comments) and trailing regression-testing lines.
+ *
+ *  \htmlonly
+ *  <div style="text-align:center;">
+ *    <a href="example-00.html">← Previous Example</a> |
+ *    <a href="example-01.html">Current Example</a> |
+ *    <a href="example-02.html">Next Example →</a>
+ *  </div>
+ *  \endhtmlonly
+ */

--- a/packages/tempus/examples/Tempus_Tutorial_01_to_02.dox
+++ b/packages/tempus/examples/Tempus_Tutorial_01_to_02.dox
@@ -1,0 +1,144 @@
+/*! \page tempus_tutorial_transition_01_02 Transition from Example 1 to Example 2
+ *
+ *  \section tempus_tutorial_transition_01_02_goal Goal
+ *
+ *  The primary goal of \ref example-02 is to move the van der Pol problem
+ *  definition into a \ref Thyra::ModelEvaluator while preserving the same
+ *  \ref Thyra-based state representation and the same Forward Euler stepping
+ *  logic used in \ref example-01.
+ *
+ *  New concepts introduced are:
+ *
+ *  - \ref Thyra::ModelEvaluator
+ *    - provides a standard Trilinos interface for evaluating the application model
+ *  - `Thyra::ModelEvaluatorBase::InArgs`
+ *    - supplies the model inputs such as time and state
+ *  - `Thyra::ModelEvaluatorBase::OutArgs`
+ *    - receives the model outputs such as the right-hand side
+ *  - `getNominalValues()`
+ *    - provides nominal initial conditions from the model
+ *  - `evalModel()`
+ *    - evaluates the model using the supplied input and output arguments
+ *
+ *  This is the first step in separating the problem physics from the
+ *  time integration algorithm.  Rather than evaluating the right-hand side
+ *  directly in the application, the code now requests that evaluation through
+ *  a common model interface.  This is a key part of how \ref Tempus steppers
+ *  and integrators interact with application models.
+ *
+ *  \section tempus_tutorial_transition_01_02_same What stays the same
+ *
+ *  - The state is still stored in \ref Thyra vectors.
+ *  - The timestepper is still Forward Euler.
+ *  - The application still controls the time loop directly.
+ *  - The regression check follows the same pattern.
+ *
+ *  \section tempus_tutorial_transition_01_02_snippets Selected code excerpts
+ *
+ *  The code excerpts below highlight the main changes needed to move from
+ *  direct application-level right-hand-side evaluation to the use of a
+ *  \ref Thyra::ModelEvaluator.
+ *
+ *  <hr style="border:0; border-top:5px solid #ccc;">
+ *  \subsection tempus_tutorial_transition_01_02_snippet1 Construct the model
+ *
+ *  <b>Construct a ModelEvaluator.</b>  The application now creates an object
+ *  that represents the problem model.
+ *
+ *  <b>Before</b>
+ *  @code
+ *  int vectorLength = 2;
+ *  RCP<const Thyra::VectorSpaceBase<double> > xSpace =
+ *    Thyra::defaultSpmdVectorSpace<double>(vectorLength);
+ *  @endcode
+ *
+ *  <b>After</b>
+ *  @code
+ *  Teuchos::RCP<const Thyra::ModelEvaluator<double> >
+ *    model = Teuchos::rcp(new VanDerPol_ModelEvaluator_02<double>());
+ *  @endcode
+ *
+ *  The application now delegates model-specific information to a dedicated
+ *  model object.
+ *
+ *  <hr style="border:0; border-top:5px solid #ccc;">
+ *  \subsection tempus_tutorial_transition_01_02_snippet2 Get initial conditions
+ *
+ *  <b>Obtain nominal initial conditions from the model.</b>  The nominal
+ *  solution and its time derivative are no longer assembled manually.
+ *
+ *  <b>Before</b>
+ *  @code
+ *  RCP<Thyra::VectorBase<double> > x_n    = Thyra::createMember(xSpace);
+ *  RCP<Thyra::VectorBase<double> > xDot_n = Thyra::createMember(xSpace);
+ *  @endcode
+ *
+ *  <b>After</b>
+ *  @code
+ *  RCP<Thyra::VectorBase<double> > x_n =
+ *    model->getNominalValues().get_x()->clone_v();
+ *  RCP<Thyra::VectorBase<double> > xDot_n =
+ *    model->getNominalValues().get_x_dot()->clone_v();
+ *  @endcode
+ *
+ *  <hr style="border:0; border-top:5px solid #ccc;">
+ *  \subsection tempus_tutorial_transition_01_02_snippet3 Evaluate the model
+ *
+ *  <b>Evaluate the right-hand side through ModelEvaluator.</b>  The
+ *  application fills `InArgs` and `OutArgs` and then requests the model
+ *  evaluation.
+ *
+ *  <b>Before</b>
+ *  @code
+ *  {
+ *    Thyra::ConstDetachedVectorView<double> x_n_view(*x_n);
+ *    Thyra::DetachedVectorView<double> xDot_n_view(*xDot_n);
+ *    xDot_n_view[0] = x_n_view[1];
+ *    xDot_n_view[1] =
+ *      ((1.0-x_n_view[0]*x_n_view[0])*x_n_view[1]-x_n_view[0])/epsilon;
+ *  }
+ *  @endcode
+ *
+ *  <b>After</b>
+ *  @code
+ *  auto inArgs  = model->createInArgs();
+ *  auto outArgs = model->createOutArgs();
+ *  inArgs.set_t(time);
+ *  inArgs.set_x(x_n);
+ *  inArgs.set_x_dot(Teuchos::null);
+ *  outArgs.set_f(xDot_n);
+ *
+ *  model->evalModel(inArgs, outArgs);
+ *  @endcode
+ *
+ *  The right-hand side is now obtained through the model interface rather
+ *  than being coded directly in the time loop.
+ *
+ *  <hr style="border:0; border-top:5px solid #ccc;">
+ *  \section tempus_tutorial_transition_01_02_compare How to compare the examples
+ *
+ *  A more detailed comparison can be made by diffing:
+ *  - `examples/01_Utilize_Thyra/01_Utilize_Thyra.cpp`
+ *  - `examples/02_Use_ModelEvaluator/02_Use_ModelEvaluator.cpp`
+ *
+ *  From the `packages/tempus` directory, a focused comparison of the main
+ *  time-integration logic between these two examples can be generated locally
+ *  in `bash` or `zsh` with:
+ *
+ *  @code{.sh}
+ *  git diff --no-index \
+ *    <(sed -n '60,130p' examples/01_Utilize_Thyra/01_Utilize_Thyra.cpp) \
+ *    <(sed -n '67,131p' examples/02_Use_ModelEvaluator/02_Use_ModelEvaluator.cpp)
+ *  @endcode
+ *
+ *  This ignores leading header lines (for example, `#include` statements and
+ *  Doxygen comments) and trailing regression-testing lines.
+ *
+ *  \htmlonly
+ *  <div style="text-align:center;">
+ *    <a href="example-01.html">← Previous Example</a> |
+ *    <a href="example-02.html">Current Example</a> |
+ *    <a href="example-03.html">Next Example →</a>
+ *  </div>
+ *  \endhtmlonly
+ */

--- a/packages/tempus/examples/Tempus_Tutorial_02_to_03.dox
+++ b/packages/tempus/examples/Tempus_Tutorial_02_to_03.dox
@@ -1,0 +1,141 @@
+/*! \page tempus_tutorial_transition_02_03 Transition from Example 2 to Example 3
+ *
+ *  \section tempus_tutorial_transition_02_03_goal Goal
+ *
+ *  The primary goal of \ref example-03 is to move the evolving solution and
+ *  selected time-integration metadata into \ref Tempus::SolutionState while
+ *  preserving the same \ref Thyra::ModelEvaluator-based model and the same
+ *  explicit Forward Euler update used in \ref example-02.
+ *
+ *  New concepts introduced are:
+ *
+ *  - \ref Tempus::SolutionState
+ *    - stores the solution together with metadata describing its role in the
+ *      time integration process
+ *  - \ref Tempus::SolutionStateMetaData
+ *    - stores quantities such as time, index, timestep size, and status
+ *  - \ref Tempus::Status
+ *    - represents whether a solution is working, passed, or failed
+ *  - `Tempus::createSolutionStateX()`
+ *    - creates a solution state containing the primary solution vector
+ *
+ *  This is the first step in moving from application-local scalar bookkeeping
+ *  to a \ref Tempus-managed representation of the evolving solution state.
+ *  That organization becomes increasingly important in later examples that
+ *  introduce solution histories, steppers, and integrators.
+ *
+ *  \section tempus_tutorial_transition_02_03_same What stays the same
+ *
+ *  - The van der Pol model is still provided by a \ref Thyra::ModelEvaluator.
+ *  - The timestepper is still Forward Euler.
+ *  - The application still controls the time loop directly.
+ *  - The regression check follows the same pattern.
+ *
+ *  \section tempus_tutorial_transition_02_03_snippets Selected code excerpts
+ *
+ *  The code excerpts below highlight the main changes needed to move from
+ *  separate scalar bookkeeping variables to a \ref Tempus::SolutionState.
+ *
+ *  <hr style="border:0; border-top:5px solid #ccc;">
+ *  \subsection tempus_tutorial_transition_02_03_snippet1 Create the solution state
+ *
+ *  <b>Create a SolutionState.</b>  The current solution is now stored in a
+ *  \ref Tempus::SolutionState together with selected metadata.
+ *
+ *  <b>Before</b>
+ *  @code
+ *  int n = 0;
+ *  double time = 0.0;
+ *  bool passed = true;
+ *  RCP<Thyra::VectorBase<double> > x_n =
+ *    model->getNominalValues().get_x()->clone_v();
+ *  @endcode
+ *
+ *  <b>After</b>
+ *  @code
+ *  auto solState = Tempus::createSolutionStateX(
+ *                    model->getNominalValues().get_x()->clone_v());
+ *  solState->setIndex   (0);
+ *  solState->setTime    (0.0);
+ *  solState->setTimeStep(0.0);
+ *  solState->setSolutionStatus(Tempus::Status::PASSED);
+ *  @endcode
+ *
+ *  This replaces several scalar bookkeeping variables with a single
+ *  \ref Tempus::SolutionState object.
+ *
+ *  <hr style="border:0; border-top:5px solid #ccc;">
+ *  \subsection tempus_tutorial_transition_02_03_snippet2 Use solution-state metadata
+ *
+ *  <b>Use metadata from the solution state.</b>  The loop condition is now
+ *  expressed in terms of the solution state's index, time, and status.
+ *
+ *  <b>Before</b>
+ *  @code
+ *  while (passed && time < finalTime && n < nTimeSteps) {
+ *  @endcode
+ *
+ *  <b>After</b>
+ *  @code
+ *  while (solState->getSolutionStatus() == Tempus::Status::PASSED &&
+ *         solState->getTime() < finalTime &&
+ *         solState->getIndex() < nTimeSteps) {
+ *  @endcode
+ *
+ *  <hr style="border:0; border-top:5px solid #ccc;">
+ *  \subsection tempus_tutorial_transition_02_03_snippet3 Record step outcome
+ *
+ *  <b>Record step success or failure through the solution state.</b>  Step
+ *  acceptance and failure are now reflected in the solution status and metadata.
+ *
+ *  <b>Before</b>
+ *  @code
+ *  if ( std::isnan(Thyra::norm(*x_np1)) ) {
+ *    passed = false;
+ *  } else {
+ *    Thyra::V_V(x_n.ptr(), *x_np1);
+ *    n++;
+ *  }
+ *  @endcode
+ *
+ *  <b>After</b>
+ *  @code
+ *  if ( std::isnan(Thyra::norm(*x_np1)) ) {
+ *    solState->setSolutionStatus(Tempus::Status::FAILED);
+ *  } else {
+ *    Thyra::V_V(x_n.ptr(), *x_np1);
+ *    solState->setIndex   (index);
+ *    solState->setTime    (time);
+ *    solState->setTimeStep(constDT);
+ *    solState->setSolutionStatus(Tempus::Status::PASSED);
+ *  }
+ *  @endcode
+ *
+ *  <hr style="border:0; border-top:5px solid #ccc;">
+ *  \section tempus_tutorial_transition_02_03_compare How to compare the examples
+ *
+ *  A more detailed comparison can be made by diffing:
+ *  - `examples/02_Use_ModelEvaluator/02_Use_ModelEvaluator.cpp`
+ *  - `examples/03_Intro_SolutionState/03_Intro_SolutionState.cpp`
+ *
+ *  From the `packages/tempus` directory, a focused comparison of the main
+ *  time-integration logic between these two examples can be generated locally
+ *  in `bash` or `zsh` with:
+ *
+ *  @code{.sh}
+ *  git diff --no-index \
+ *    <(sed -n '67,131p' examples/02_Use_ModelEvaluator/02_Use_ModelEvaluator.cpp) \
+ *    <(sed -n '75,148p' examples/03_Intro_SolutionState/03_Intro_SolutionState.cpp)
+ *  @endcode
+ *
+ *  This ignores leading header lines (for example, `#include` statements and
+ *  Doxygen comments) and trailing regression-testing lines.
+ *
+ *  \htmlonly
+ *  <div style="text-align:center;">
+ *    <a href="example-02.html">← Previous Example</a> |
+ *    <a href="example-03.html">Current Example</a> |
+ *    <a href="example-04.html">Next Example →</a>
+ *  </div>
+ *  \endhtmlonly
+ */

--- a/packages/tempus/examples/Tempus_Tutorials_Overview.dox
+++ b/packages/tempus/examples/Tempus_Tutorials_Overview.dox
@@ -1,0 +1,81 @@
+/*! \page tempus_tutorials_overview Tempus Tutorials
+ *
+ *  \brief \ref Tempus tutorials demonstrating its capabilities.
+ *
+ *  \section progression_tutorial Progression Tutorial
+ *
+ *  These tutorials use the van der Pol problem to introduce \ref Tempus
+ *  capabilities in a stepwise manner.  Starting from a simple application with
+ *  a hand-written Forward Euler loop, the examples progressively introduce core
+ *  \ref Tempus and Trilinos abstractions.  Each example is runnable on its own,
+ *  and each step adds one major concept while preserving as much of the
+ *  previous example structure as possible.
+ *
+ *  The tutorial sequence introduces the following concepts:
+ *
+ *  <div style="margin:0.5em 0; padding:0.6em 0.8em; border:1px solid #ddd; border-radius:6px;">
+ *    <b>Example 0: Problem Description</b><br>
+ *    \ref example-00 "Basic Problem" - baseline application code for the
+ *    van der Pol problem using raw C++ arrays and a hand-written
+ *    Forward Euler loop.
+ *  </div>
+ *
+ *  <div style="margin:0.5em 0; padding:0.6em 0.8em; border:1px solid #ddd; border-radius:6px;">
+ *    <b>Example 1: Solution Data Representation</b><br>
+ *    \ref example-01 "Utilize Thyra" - Replace raw arrays with
+ *    \ref Thyra vectors and vector-space abstractions.
+ *  </div>
+ *
+ *  <div style="margin:0.5em 0; padding:0.6em 0.8em; border:1px solid #ddd; border-radius:6px;">
+ *    <b>Example 2: Problem Model Evaluation</b><br>
+ *    \ref example-02 "Use ModelEvaluator" - Use \ref Thyra::ModelEvaluator to
+ *    describe the problem model.
+ *  </div>
+ *
+ *  <div style="margin:0.5em 0; padding:0.6em 0.8em; border:1px solid #ddd; border-radius:6px;">
+ *    <b>Example 3: Solution Data Management</b><br>
+ *    \ref example-03 "Introduce Solution State" - Introduce
+ *    \ref Tempus::SolutionState to store the solution and selected
+ *    integration metadata.
+ *  </div>
+ *
+ *  <div style="margin:0.5em 0; padding:0.6em 0.8em; border:1px solid #ddd; border-radius:6px;">
+ *    <b>Example 4: Solution State History</b><br>
+ *    Add Solution History - Add \ref Tempus::SolutionHistory
+ *    to manage multiple solution states.
+ *  </div>
+ *
+ *  <div style="margin:0.5em 0; padding:0.6em 0.8em; border:1px solid #ddd; border-radius:6px;">
+ *    <b>Example 5: Time Stepping Algorithms</b><br>
+ *    Introduce Stepper - introduce \ref Tempus::Stepper to perform Forward Euler timesteps.
+ *  </div>
+ *
+ *  <div style="margin:0.5em 0; padding:0.6em 0.8em; border:1px solid #ddd; border-radius:6px;">
+ *    <b>Example 6: Time Step Control</b><br>
+ *    Introduce TimeStepControl — introduce \ref Tempus::TimeStepControl
+ *    to control timesteps with various strategies.
+ *  </div>
+ *
+ *  <div style="margin:0.5em 0; padding:0.6em 0.8em; border:1px solid #ddd; border-radius:6px;">
+ *    <b>Example 7: Orchestrate Multiple Time Steps</b><br>
+ *    Utilize IntegratorBasic — use \ref Tempus::IntegratorBasic to manage
+ *    the overall time integration process.
+ *  </div>
+ *
+ *  This progression is intended to show how applications can adopt
+ *  \ref Tempus incrementally rather than all at once.
+ *
+ *  \section how_to_read_tutorials How to read these examples
+ *
+ *  A recommended reading order is:
+ *
+ *  - read the current example source,
+ *  - read the transition page describing what changed from the previous step,
+ *  - compare the files directly when line-by-line detail is needed.
+ *
+ *  \htmlonly
+ *  <div style="text-align:center;">
+ *    <a href="example-00.html">Begin with Example 0: Problem Description →</a>
+ *  </div>
+ *  \endhtmlonly
+ */

--- a/packages/tempus/test/TestModels/VanDerPolModel_decl.hpp
+++ b/packages/tempus/test/TestModels/VanDerPolModel_decl.hpp
@@ -20,6 +20,8 @@ namespace Tempus_Test {
 
 /** \brief van der Pol model problem for nonlinear electrical circuit.
  *
+ * \section tempus_vanderpol_model van der Pol Model
+ *
  * This is a canonical equation of a nonlinear oscillator (Hairer, Norsett,
  * and Wanner, pp. 111-115, and Hairer and Wanner, pp. 4-5) for an electrical
  * circuit.  In implicit ODE form, \f$ \mathcal{F}(\dot{x},x,t) = 0 \f$,


### PR DESCRIPTION
Revise the Tempus tutorial documentation to better support the stepwise example progression from 00_Basic_Problem through 03_Intro_SolutionState.

Changes include:
- simplify and modernize the main Tempus tutorial/example page content
- replace large in-source tutorial tables in examples 00-03 with shorter, clearer page-style descriptions
- add explicit Doxygen example pages for examples 00-03
- add a shared van der Pol model documentation anchor in VanDerPolModel_decl.hpp for cross-referencing
- add/prepare transition-oriented tutorial documentation between examples

The updated documentation emphasizes:
- cleaner example source files
- separate narrative explanation of what changes between steps
- improved navigation through the tutorial sequence
- more robust Doxygen cross-references for key Tempus and Thyra concepts

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/tempus 

## Motivation
 * Needed to improve the tutorials.

## Testing
 * Basic testing of building the doxygen docs, and viewed resulting pages.
 