### PR TITLE
tpetra: add Ialltofewv progress engine for multiple async ops

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
@@ -67,6 +67,15 @@ KOKKOS_INLINE_FUNCTION void team_memcpy(const Member &member, MemcpyArg &arg) {
   }
 }
 
+template <typename ArgsView, typename Member>
+struct ApplyRdispls {
+  ArgsView args;
+
+  KOKKOS_INLINE_FUNCTION void operator()(const Member &member) const {
+    team_memcpy(member, args(member.league_rank()));
+  }
+};
+
 }  // namespace
 
 namespace Tpetra::Details {
@@ -474,9 +483,7 @@ class StateImpl : public Ialltofewv::State {
       auto args = args_;
       Kokkos::parallel_for(
           "Tpetra::Details::Ialltofewv: apply rdispls to contiguous root buffer", policy,
-          KOKKOS_LAMBDA(typename Policy::member_type member) {
-            team_memcpy(member, args(member.league_rank()));
-          });
+          ApplyRdispls<decltype(args), typename Policy::member_type>{args});
       Kokkos::fence("Tpetra::Details::Ialltofewv: after apply rdispls to contiguous root buffer");
     }
     stage_         = Stage::complete;

--- a/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.cpp
@@ -178,274 +178,395 @@ struct Ialltofewv::Cache::impl {
   }
 };
 
-Ialltofewv::Cache::Cache()  = default;
+Ialltofewv::Cache::Cache() = default;
+
+// DistributorActor can be copied, but we don't want to share a single
+// cache since each actor can have its own Ialltofewv in flight.
+// This creates an empty cache in the copy.s
+Ialltofewv::Cache::Cache(const Cache &) {}
+
+// As with copy construction, assignment leaves this cache indepdendent.
+Ialltofewv::Cache &Ialltofewv::Cache::operator=(const Cache &other) {
+  if (this != &other) pimpl.reset();
+  return *this;
+}
+
 Ialltofewv::Cache::~Cache() = default;
 
+// Intermediate buffers and MPI requests for one asynchronous
+// Ialltofewv. Inherited by actual imlpementation, which is specialized on the
+// execution space.
+struct Ialltofewv::State {
+  virtual ~State()                = default;
+  virtual int start()             = 0;
+  virtual int progress()          = 0;
+  virtual bool isComplete() const = 0;
+  virtual MPI_Comm comm() const   = 0;
+  // Copies completion state back to the request that Ialltofewv callers maintain.
+  // Needed when progress on one Ialltofewv completes a different operation.
+  virtual void updateReq(Req &req) const = 0;
+};
+
 namespace {
-template <typename RecvExecSpace>
-int wait_impl(Ialltofewv::Req &req, Ialltofewv::Cache &cache) {
-  auto finalize = [&]() -> int {
-    req.completed = true;
+enum class Stage { counts,
+                   payload,
+                   forwarding,
+                   complete };
+
+int test_all(std::vector<MPI_Request> &reqs, int &flag) {
+  if (reqs.empty()) {
+    flag = 1;
     return MPI_SUCCESS;
-  };
-
-  if (0 == req.nroots) {
-    return finalize();
   }
+  return MPI_Testall(static_cast<int>(reqs.size()), reqs.data(), &flag, MPI_STATUSES_IGNORE);
+}
 
-  ProfilingRegion pr("alltofewv::wait");
+template <typename RecvExecSpace>
+class StateImpl : public Ialltofewv::State {
+ public:
+  using byte_view_type = Kokkos::View<char *, typename RecvExecSpace::memory_space>;
+  using root_view_type = Kokkos::View<uint8_t *, typename RecvExecSpace::memory_space>;
+  using args_view_type = Kokkos::View<MemcpyArg *, typename RecvExecSpace::memory_space>;
 
-  // lazy-init view cache
-  if (!cache.pimpl) {
-    cache.pimpl = std::make_shared<Ialltofewv::Cache::impl>();
-  }
+  StateImpl(Ialltofewv::Req &req, std::shared_ptr<Ialltofewv::Cache::impl> cache)
+    : req_(req)
+    , cache_(std::move(cache))
+    , rank_(getRank())
+    , size_(getSize())
+    , sendSize_(getTypeSize(req_.sendtype))
+    , recvSize_(getTypeSize(req_.recvtype))
+    // Is this rank a root? Linear search because nroots is expected to be small.
+    , isRoot_(std::find(req_.roots, req_.roots + req_.nroots, rank_) != req_.roots + req_.nroots)
+    // Balance the number of incoming messages at each phase:
+    // Aggregation = size / naggs * nroots
+    // Root =        naggs
+    // so size / naggs * nroots = naggs, and naggs = sqrt(size * nroots).
+    , naggs_(std::max(1, int(std::sqrt(size_t(size_) * size_t(req_.nroots)) + 0.5)))
+    // How many sources send to each aggregator.
+    , srcsPerAgg_((size_ + naggs_ - 1) / naggs_)
+    // The aggregator this rank sends to.
+    , myAgg_(rank_ / srcsPerAgg_ * srcsPerAgg_)
+    // [si * nroots + ri] is how much source si in this group sends to root ri.
+    , groupSendCounts_(rank_ == myAgg_ ? size_t(req_.nroots) * size_t(srcsPerAgg_) : 0)
+    , rootCount_(req_.nroots, 0) {}
 
-  const int rank = [&]() -> int {
-    int _rank;
-    MPI_Comm_rank(req.comm, &_rank);
-    return _rank;
-  }();
-
-  const int size = [&]() -> int {
-    int _size;
-    MPI_Comm_size(req.comm, &_size);
-    return _size;
-  }();
-
-  const size_t sendSize = [&]() -> size_t {
-    int _size;
-    MPI_Type_size(req.sendtype, &_size);
-    return _size;
-  }();
-
-  const size_t recvSize = [&]() -> size_t {
-    int _size;
-    MPI_Type_size(req.recvtype, &_size);
-    return _size;
-  }();
-
-  // is this rank a root? linear search - nroots expected to be small
-  const bool isRoot = std::find(req.roots, req.roots + req.nroots, rank) != req.roots + req.nroots;
-
-  // Balance the number of incoming messages at each phase:
-  // Aggregation = size / naggs * nroots
-  // Root =        naggs
-  // so
-  // size / naggs * nroots = naggs
-  // size * nroots = naggs^2
-  // naggs = sqrt(size * nroots)
-  const int naggs = std::sqrt(size_t(size) * size_t(req.nroots)) + /*rounding*/ 0.5;
-
-  // how many srcs go to each aggregator
-  const int srcsPerAgg = (size + naggs - 1) / naggs;
-
-  // the aggregator I send to
-  const int myAgg = rank / srcsPerAgg * srcsPerAgg;
-
-  // ensure aggregators know how much data each rank is sending to the root
-  // [si * nroots + r1] -> how much si'th rank in group wants to send to root ri
-  std::vector<int> groupSendCounts(size_t(req.nroots) * size_t(srcsPerAgg));
-  std::vector<MPI_Request> reqs;
-  if (rank == myAgg) {
-    reqs.reserve(srcsPerAgg);
-    // recv counts from each member of my group
-    for (int si = 0; si < srcsPerAgg && si + rank < size; ++si) {
-      MPI_Request rreq;
-
-#ifndef NDEBUG
-      if (size_t(si) * req.nroots + req.nroots > groupSendCounts.size()) {
-        std::stringstream ss;
-        ss << __FILE__ << ":" << __LINE__
-           << " [" << rank << "] tpetra internal Ialltofewv error: OOB access in recv buffer\n";
-        std::cerr << ss.str();
-      }
-#endif
-      MPI_Irecv(&groupSendCounts[size_t(si) * size_t(req.nroots)], req.nroots, MPI_INT, si + rank,
-                req.aggTag, req.comm, &rreq);
-      reqs.push_back(rreq);
+  int start() override {
+    if (req_.nroots == 0) {
+      stage_         = Stage::complete;
+      req_.completed = true;
+      return MPI_SUCCESS;
     }
-  }
-  // send sendcounts to aggregator
-  MPI_Send(req.sendcounts, req.nroots, MPI_INT, myAgg, req.aggTag, req.comm);
 
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
-  reqs.resize(0);
+    int err = postRootReceives();
+    if (err != MPI_SUCCESS) return setError(err);
 
-  // at this point, in each aggregator, groupSendCounts holds the send counts
-  // from each member of the aggregator. The first nroots entries are from the first rank,
-  // the second nroots entries are from the second rank, etc
-
-  // a temporary buffer to aggregate data. Data for a root is contiguous.
-  auto aggBuf = cache.pimpl->get_aggBuf<RecvExecSpace>(0);
-  std::vector<size_t> rootCount(req.nroots, 0);  // [ri] the count of data held for root ri
-  if (rank == myAgg) {
-    size_t aggBytes = 0;
-    for (int si = 0; si < srcsPerAgg && si + rank < size; ++si) {
-      for (int ri = 0; ri < req.nroots; ++ri) {
-        int count = groupSendCounts[si * req.nroots + ri];
-        rootCount[ri] += count;
-        aggBytes += count * sendSize;
+    // Ensure aggregators know how much data each rank is sending to each root.
+    if (rank_ == myAgg_) {
+      countReqs_.reserve(srcsPerAgg_ + 1);
+      // Receive counts from each member of this aggregation group.
+      for (int si = 0; si < srcsPerAgg_ && si + rank_ < size_; ++si) {
+        MPI_Request mpiReq;
+        err = MPI_Irecv(&groupSendCounts_[size_t(si) * size_t(req_.nroots)], req_.nroots,
+                        MPI_INT, si + rank_, req_.aggTag, req_.comm, &mpiReq);
+        if (err != MPI_SUCCESS) return setError(err);
+        countReqs_.push_back(mpiReq);
       }
     }
 
-    aggBuf = cache.pimpl->get_aggBuf<RecvExecSpace>(aggBytes);
+    // Send this rank's counts to its aggregator.
+    MPI_Request mpiReq;
+    err = MPI_Isend(req_.sendcounts, req_.nroots, MPI_INT, myAgg_, req_.aggTag,
+                    req_.comm, &mpiReq);
+    if (err != MPI_SUCCESS) return setError(err);
+    countReqs_.push_back(mpiReq);
+    return MPI_SUCCESS;
   }
-  // now, on the aggregator ranks,
-  // * aggBuf is resized to accomodate all incoming data
-  // * rootCount holds how much data i hold for each root
 
-  // Send the actual data to the aggregator
-  if (rank == myAgg) {
-    reqs.reserve(srcsPerAgg + req.nroots);
-    // receive from all ranks in my group
+  int progress() override {
+    if (error_ != MPI_SUCCESS || stage_ == Stage::complete) return error_;
+
+    int flag = 0;
+    int err  = MPI_SUCCESS;
+    if (stage_ == Stage::counts) {
+      err = test_all(countReqs_, flag);
+      if (err != MPI_SUCCESS) return setError(err);
+      if (!flag) return MPI_SUCCESS;
+      err = postPayload();
+      if (err != MPI_SUCCESS) return setError(err);
+    }
+
+    if (stage_ == Stage::payload) {
+      err = test_all(payloadReqs_, flag);
+      if (err != MPI_SUCCESS) return setError(err);
+      if (!flag) return MPI_SUCCESS;
+      err = postForwards();
+      if (err != MPI_SUCCESS) return setError(err);
+    }
+
+    if (stage_ == Stage::forwarding) {
+      int rootFlag    = 0;
+      int forwardFlag = 0;
+      err             = test_all(rootReqs_, rootFlag);
+      if (err != MPI_SUCCESS) return setError(err);
+      err = test_all(forwardReqs_, forwardFlag);
+      if (err != MPI_SUCCESS) return setError(err);
+      if (!rootFlag || !forwardFlag) return MPI_SUCCESS;
+      finish();
+    }
+    return MPI_SUCCESS;
+  }
+
+  bool isComplete() const override {
+    return stage_ == Stage::complete;
+  }
+
+  MPI_Comm comm() const override {
+    return req_.comm;
+  }
+
+  void updateReq(Ialltofewv::Req &req) const override {
+    req.completed = isComplete();
+  }
+
+ private:
+  int getRank() const {
+    int rank;
+    MPI_Comm_rank(req_.comm, &rank);
+    return rank;
+  }
+
+  int getSize() const {
+    int size;
+    MPI_Comm_size(req_.comm, &size);
+    return size;
+  }
+
+  static size_t getTypeSize(MPI_Datatype type) {
+    int size;
+    MPI_Type_size(type, &size);
+    return size_t(size);
+  }
+
+  int setError(int err) {
+    error_ = err;
+    return err;
+  }
+
+  int postRootReceives() {
+    if (!isRoot_) return MPI_SUCCESS;
+
+    // An aggregator sends contiguous data, which the root later scatters
+    // according to rdispls.
+    size_t totalRecvd = 0;
+    for (int i = 0; i < size_; ++i) totalRecvd += size_t(req_.recvcounts[i]) * recvSize_;
+    rootBuf_ = cache_->get_rootBuf<RecvExecSpace>(totalRecvd);
+
+    // Aggregators send data in rank order, which is also the order used in the
+    // root's contiguous receive buffer.
     size_t displ = 0;
-    // senders will send in root order, so we will recv in that order as well
-    // this puts all data for a root contiguous in the aggregation buffer
-    for (int ri = 0; ri < req.nroots; ++ri) {
-      for (int si = 0; si < srcsPerAgg && si + rank < size; ++si) {
-        // receive data for the ri'th root from the si'th sender
-        const int count = groupSendCounts[si * req.nroots + ri];
-        if (count) {
-#ifndef NDEBUG
-          if (displ + count * sendSize > aggBuf.size()) {
-            std::stringstream ss;
-            ss << __FILE__ << ":" << __LINE__
-               << " [" << rank << "] tpetra internal Ialltofewv error: OOB access in send buffer\n";
-            std::cerr << ss.str();
+    for (int aggSrc = 0; aggSrc < size_; aggSrc += srcsPerAgg_) {
+      // Tally the data received from this aggregator.
+      int count = 0;
+      for (int origSrc = aggSrc; origSrc < aggSrc + srcsPerAgg_ && origSrc < size_; ++origSrc) {
+        count += req_.recvcounts[origSrc];
+      }
+      if (count) {
+        MPI_Request mpiReq;
+        const int err = MPI_Irecv(rootBuf_.data() + displ, count, req_.recvtype, aggSrc,
+                                  req_.rootTag, req_.comm, &mpiReq);
+        if (err != MPI_SUCCESS) return err;
+        rootReqs_.push_back(mpiReq);
+        displ += size_t(count) * recvSize_;
+      }
+    }
+    return MPI_SUCCESS;
+  }
+
+  int postPayload() {
+    stage_ = Stage::payload;
+    if (rank_ == myAgg_) {
+      // groupSendCounts now holds counts from every member of this aggregation
+      // group. Size the aggregation buffer and record how much goes to each root.
+      size_t aggBytes = 0;
+      for (int si = 0; si < srcsPerAgg_ && si + rank_ < size_; ++si) {
+        for (int ri = 0; ri < req_.nroots; ++ri) {
+          const int count = groupSendCounts_[size_t(si) * size_t(req_.nroots) + size_t(ri)];
+          rootCount_[ri] += count;
+          aggBytes += size_t(count) * sendSize_;
+        }
+      }
+      aggBuf_ = cache_->get_aggBuf<RecvExecSpace>(aggBytes);
+
+      // Senders transmit in root order. Receive in the same order so all data
+      // for each root is contiguous in the aggregation buffer.
+      size_t displ = 0;
+      for (int ri = 0; ri < req_.nroots; ++ri) {
+        for (int si = 0; si < srcsPerAgg_ && si + rank_ < size_; ++si) {
+          // Receive data for root ri from source si in this group.
+          const int count = groupSendCounts_[size_t(si) * size_t(req_.nroots) + size_t(ri)];
+          if (count) {
+            MPI_Request mpiReq;
+            const int err = MPI_Irecv(aggBuf_.data() + displ, count, req_.sendtype, si + rank_,
+                                      req_.aggTag, req_.comm, &mpiReq);
+            if (err != MPI_SUCCESS) return err;
+            payloadReqs_.push_back(mpiReq);
+            displ += size_t(count) * sendSize_;
           }
-#endif
-          MPI_Request rreq;
-          // &aggBuf(displ)
-          MPI_Irecv(aggBuf.data() + displ, count, req.sendtype, si + rank, req.aggTag, req.comm, &rreq);
-          reqs.push_back(rreq);
-          displ += size_t(count) * sendSize;
         }
       }
     }
-  } else {
-    reqs.reserve(req.nroots);  // prepare for one send per root
-  }
 
-  // send data to aggregator
-  for (int ri = 0; ri < req.nroots; ++ri) {
-    const size_t displ = size_t(req.sdispls[ri]) * sendSize;
-    const int count    = req.sendcounts[ri];
-    if (count) {
-      MPI_Request sreq;
-      MPI_Isend(&reinterpret_cast<const char *>(req.sendbuf)[displ], req.sendcounts[ri],
-                req.sendtype, myAgg, req.aggTag, req.comm, &sreq);
-      reqs.push_back(sreq);
-    }
-  }
-
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
-  reqs.resize(0);
-
-  // if I am a root, receive data from each aggregator
-  // The aggregator will send contiguous data, which we may need to spread out according to rdispls
-  auto rootBuf = cache.pimpl->get_rootBuf<RecvExecSpace>(0);
-  if (isRoot) {
-    reqs.reserve(naggs);  // receive from each aggregator
-
-    const size_t totalRecvd = recvSize * [&]() -> size_t {
-      size_t acc = 0;
-      for (int i = 0; i < size; ++i) {
-        acc += req.recvcounts[i];
+    // Send this rank's data to its aggregator.
+    for (int ri = 0; ri < req_.nroots; ++ri) {
+      if (req_.sendcounts[ri]) {
+        MPI_Request mpiReq;
+        const size_t displ = size_t(req_.sdispls[ri]) * sendSize_;
+        const int err      = MPI_Isend(reinterpret_cast<const char *>(req_.sendbuf) + displ,
+                                       req_.sendcounts[ri], req_.sendtype, myAgg_, req_.aggTag,
+                                       req_.comm, &mpiReq);
+        if (err != MPI_SUCCESS) return err;
+        payloadReqs_.push_back(mpiReq);
       }
-      return acc;
-    }();
-    rootBuf = cache.pimpl->get_rootBuf<RecvExecSpace>(totalRecvd);
+    }
+    return MPI_SUCCESS;
+  }
 
-    // Receive data from each aggregator.
-    // Aggregators send data in order of the ranks they're aggregating,
-    // which is also the order the root needs in its recv buffer.
+  int postForwards() {
+    stage_ = Stage::forwarding;
+    if (rank_ != myAgg_) return MPI_SUCCESS;
+
+    // Forward each root's contiguous data in source-rank order, which is the
+    // order expected by the root's contiguous receive buffer.
     size_t displ = 0;
-    for (int aggSrc = 0; aggSrc < size; aggSrc += srcsPerAgg) {
-      // tally up the total data to recv from the sending aggregator
-      int count = 0;
-      for (int origSrc = aggSrc;
-           origSrc < aggSrc + srcsPerAgg && origSrc < size; ++origSrc) {
-        count += req.recvcounts[origSrc];
-      }
-
+    for (int ri = 0; ri < req_.nroots; ++ri) {
+      const size_t count = rootCount_[ri];
       if (count) {
-        MPI_Request rreq;
-        MPI_Irecv(rootBuf.data() + displ, count, req.recvtype, aggSrc, req.rootTag, req.comm, &rreq);
-        reqs.push_back(rreq);
-        displ += size_t(count) * recvSize;
+        MPI_Request mpiReq;
+        const int err = MPI_Isend(aggBuf_.data() + displ, int(count), req_.sendtype,
+                                  req_.roots[ri], req_.rootTag, req_.comm, &mpiReq);
+        if (err != MPI_SUCCESS) return err;
+        forwardReqs_.push_back(mpiReq);
+        displ += count * sendSize_;
       }
     }
+    return MPI_SUCCESS;
   }
 
-  // if I am an aggregator, forward data to the roots
-  // To each root, send my data in order of the ranks that sent to me
-  // which is the order the recvers expect
-  if (rank == myAgg) {
-    size_t displ = 0;
-    for (int ri = 0; ri < req.nroots; ++ri) {
-      const size_t count = rootCount[ri];
-      if (count) {
-        // &aggBuf[displ]
-        MPI_Send(aggBuf.data() + displ, count, req.sendtype, req.roots[ri], req.rootTag, req.comm);
-        displ += count * sendSize;
+  void finish() {
+    if (isRoot_) {
+      // Spread the contiguous root buffer into recvbuf according to rdispls.
+      // First set up the source and destination for each block.
+      args_         = cache_->get_args<RecvExecSpace>(size_);
+      auto args_h   = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, args_);
+      size_t srcOff = 0;
+      for (int srcRank = 0; srcRank < size_; ++srcRank) {
+        const size_t dstOff = size_t(req_.rdispls[srcRank]) * recvSize_;
+        const size_t count  = size_t(req_.recvcounts[srcRank]) * recvSize_;
+        args_h(srcRank)     = MemcpyArg{reinterpret_cast<char *>(req_.recvbuf) + dstOff,
+                                    rootBuf_.data() + srcOff, count};
+        srcOff += count;
       }
+
+      // Actually copy the data.
+      Kokkos::deep_copy(args_, args_h);
+      using Policy = Kokkos::TeamPolicy<RecvExecSpace>;
+      Policy policy(size_, Kokkos::AUTO);
+      auto args = args_;
+      Kokkos::parallel_for(
+          "Tpetra::Details::Ialltofewv: apply rdispls to contiguous root buffer", policy,
+          KOKKOS_LAMBDA(typename Policy::member_type member) {
+            team_memcpy(member, args(member.league_rank()));
+          });
+      Kokkos::fence("Tpetra::Details::Ialltofewv: after apply rdispls to contiguous root buffer");
     }
+    stage_         = Stage::complete;
+    req_.completed = true;
   }
 
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
+  Ialltofewv::Req &req_;
+  std::shared_ptr<Ialltofewv::Cache::impl> cache_;
+  int rank_;
+  int size_;
+  size_t sendSize_;
+  size_t recvSize_;
+  bool isRoot_;
+  int naggs_;
+  int srcsPerAgg_;
+  int myAgg_;
+  Stage stage_ = Stage::counts;
+  int error_   = MPI_SUCCESS;
+  std::vector<int> groupSendCounts_;
+  std::vector<size_t> rootCount_;
+  byte_view_type aggBuf_;
+  root_view_type rootBuf_;
+  args_view_type args_;
+  std::vector<MPI_Request> countReqs_;
+  std::vector<MPI_Request> payloadReqs_;
+  std::vector<MPI_Request> rootReqs_;
+  std::vector<MPI_Request> forwardReqs_;
+};
 
-  // at root, copy data from contiguous buffer into recv buffer
-  if (isRoot) {
-    // set up src and dst for each block
-    auto args   = cache.pimpl->get_args<RecvExecSpace>(size);
-    auto args_h = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, args);
-
-    size_t srcOff = 0;
-    for (int sRank = 0; sRank < size; ++sRank) {
-      const size_t dstOff = req.rdispls[sRank] * recvSize;
-
-      void *dst          = &reinterpret_cast<char *>(req.recvbuf)[dstOff];
-      void *const src    = rootBuf.data() + srcOff;  // &rootBuf(srcOff);
-      const size_t count = req.recvcounts[sRank] * recvSize;
-      args_h(sRank)      = MemcpyArg{dst, src, count};
-
-#ifndef NDEBUG
-      if (srcOff + count > rootBuf.extent(0)) {
-        std::stringstream ss;
-        ss << __FILE__ << ":" << __LINE__ << " Tpetra internal Ialltofewv error: src access OOB in memcpy\n";
-        std::cerr << ss.str();
-      }
-#endif
-      srcOff += count;
-    }
-
-    // Actually copy the data
-    Kokkos::deep_copy(args, args_h);
-    using Policy = Kokkos::TeamPolicy<RecvExecSpace>;
-    Policy policy(size, Kokkos::AUTO);
-    Kokkos::parallel_for(
-        "Tpetra::Details::Ialltofewv: apply rdispls to contiguous root buffer", policy,
-        KOKKOS_LAMBDA(typename Policy::member_type member) {
-          team_memcpy(member, args(member.league_rank()));
-        });
-    Kokkos::fence("Tpetra::Details::Ialltofewv: after apply rdispls to contiguous root buffer");
-  }
-
-  return finalize();
+std::vector<std::weak_ptr<Ialltofewv::State>> &activeStates() {
+  // Weak ownership lets each Req control its state lifetime while still making
+  // every local operation available for cooperative progress.
+  static std::vector<std::weak_ptr<Ialltofewv::State>> states;
+  return states;
 }
-}  //  namespace
+
+int progressAll(MPI_Comm comm) {
+  int result   = MPI_SUCCESS;
+  auto &states = activeStates();
+  for (auto it = states.begin(); it != states.end();) {
+    if (auto state = it->lock()) {
+      int comparison       = MPI_UNEQUAL;
+      const int compareErr = MPI_Comm_compare(comm, state->comm(), &comparison);
+      if (result == MPI_SUCCESS && compareErr != MPI_SUCCESS) result = compareErr;
+      if (comparison == MPI_IDENT) {
+        const int err = state->progress();
+        if (result == MPI_SUCCESS && err != MPI_SUCCESS) result = err;
+      }
+      if (state->isComplete()) {
+        it = states.erase(it);
+      } else {
+        ++it;
+      }
+    } else {
+      it = states.erase(it);
+    }
+  }
+  return result;
+}
+}  // namespace
+
+int Ialltofewv::start(Req &req) {
+  if (!cache_.pimpl) cache_.pimpl = std::make_shared<Cache::impl>();
+
+  if (req.devAccess) {
+    req.state = std::make_shared<StateImpl<Kokkos::DefaultExecutionSpace>>(req, cache_.pimpl);
+  } else {
+    req.state = std::make_shared<StateImpl<Kokkos::DefaultHostExecutionSpace>>(req, cache_.pimpl);
+  }
+
+  const int err = req.state->start();
+  req.state->updateReq(req);
+  if (!req.completed) activeStates().push_back(req.state);
+  return err;
+}
 
 int Ialltofewv::wait(Req &req) {
-  if (req.devAccess) {
-    return wait_impl<Kokkos::DefaultExecutionSpace>(req, cache_);
-  } else {
-    return wait_impl<Kokkos::DefaultHostExecutionSpace>(req, cache_);
+  ProfilingRegion pr("alltofewv::wait");
+  while (!req.state->isComplete()) {
+    const int err = progressAll(req.comm);
+    if (err != MPI_SUCCESS) return err;
   }
+  req.state->updateReq(req);
+  return MPI_SUCCESS;
 }
 
 int Ialltofewv::get_status(const Req &req, int *flag, MPI_Status * /*status*/) const {
-  *flag = req.completed;
-  return MPI_SUCCESS;
+  const int err = progressAll(req.comm);
+  *flag         = req.state->isComplete();
+  return err;
 }
 
 }  // namespace Tpetra::Details

--- a/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Ialltofewv.hpp
@@ -16,6 +16,8 @@
 namespace Tpetra::Details {
 
 struct Ialltofewv {
+  struct State;
+
   struct Req {
     const void *sendbuf;
     const int *sendcounts;
@@ -33,6 +35,7 @@ struct Ialltofewv {
 
     bool devAccess;
     bool completed;
+    std::shared_ptr<State> state;
   };
 
   template <bool DevAccess>
@@ -68,6 +71,7 @@ struct Ialltofewv {
 
     req->devAccess = DevAccess;
     req->completed = false;
+    req->state.reset();
 #ifndef NDEBUG
     // {
     //   std::stringstream ss;
@@ -75,7 +79,7 @@ struct Ialltofewv {
     //   std::cerr << ss.str();
     // }
 #endif
-    return MPI_SUCCESS;
+    return start(*req);
   }
 
   int wait(Req &req);
@@ -87,10 +91,14 @@ struct Ialltofewv {
     std::shared_ptr<impl> pimpl;
 
     Cache();
+    Cache(const Cache &);
+    Cache &operator=(const Cache &);
     ~Cache();
   };
 
  private:
+  int start(Req &req);
+
   Cache cache_;
 
 };  // struct Ialltofewv

--- a/packages/tpetra/core/test/Comm/CMakeLists.txt
+++ b/packages/tpetra/core/test/Comm/CMakeLists.txt
@@ -12,6 +12,14 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   COMM mpi
 )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Ialltofewv
+  SOURCES
+    Ialltofewv.cpp
+  NUM_MPI_PROCS 4
+  COMM mpi
+  )
+
 # This test is best done with at least 2 MPI processes.
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   isInterComm

--- a/packages/tpetra/core/test/Comm/CMakeLists.txt
+++ b/packages/tpetra/core/test/Comm/CMakeLists.txt
@@ -14,11 +14,10 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Ialltofewv
-  SOURCES
-    Ialltofewv.cpp
+  SOURCES Ialltofewv.cpp
   NUM_MPI_PROCS 4
   COMM mpi
-  )
+)
 
 # This test is best done with at least 2 MPI processes.
 TRIBITS_ADD_EXECUTABLE_AND_TEST(

--- a/packages/tpetra/core/test/Comm/Ialltofewv.cpp
+++ b/packages/tpetra/core/test/Comm/Ialltofewv.cpp
@@ -95,8 +95,9 @@ void checkResult(const Fixture &fixture, int offset,
 }
 
 TEUCHOS_UNIT_TEST(Ialltofewv, differentWaitOrder) {
-  // Test that we don't deadlock when different ranks wait on different Ialltofewv
-  // in different orders.
+  // Two concurrent Ialltofewv operations can complete without deadlocking
+  // when ranks wait for them in different orders.  Post distinct operations with
+  // distinct tags, reverse the wait order on odd ranks, and check both results.
 
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -121,7 +122,9 @@ TEUCHOS_UNIT_TEST(Ialltofewv, differentWaitOrder) {
 }
 
 TEUCHOS_UNIT_TEST(Ialltofewv, pollingOneProgressesAll) {
-  // Check that get_status() on a request makes progress on other Ialltofewvs
+  // Polling one request also progresses every active Ialltofewv.
+  // Poll only the first request and observe the second request's
+  // completion, then check that both operations produced their data.
 
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -147,7 +150,8 @@ TEUCHOS_UNIT_TEST(Ialltofewv, pollingOneProgressesAll) {
 }
 
 TEUCHOS_UNIT_TEST(Ialltofewv, zeroCountsMultipleRoots) {
-  // Mutliple source/root pairs send nothing
+  // Multiple roots handle zero-count source/root pairs correctly.  Every
+  // rank sends one value to root 0, while only odd ranks send to root 1.
   int rank = 0;
   int size = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -194,6 +198,10 @@ TEUCHOS_UNIT_TEST(Ialltofewv, zeroCountsMultipleRoots) {
 }
 
 TEUCHOS_UNIT_TEST(Ialltofewv, reusesCachedViews) {
+  // Ialltofewv instance reuses cached temporary views.  First run an
+  // operation large enough to populate the cache, then run a smaller operation while
+  // counting named Kokkos allocations and require that no cached view is reallocated.
+
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
@@ -211,6 +219,9 @@ TEUCHOS_UNIT_TEST(Ialltofewv, reusesCachedViews) {
 }
 
 TEUCHOS_UNIT_TEST(Ialltofewv, copyHasIndependentCache) {
+  // Copy construction does not share an Ialltofewv instance's cache.
+  // Populate the original's cache, copy it, then require the copy to allocate.
+
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 

--- a/packages/tpetra/core/test/Comm/Ialltofewv.cpp
+++ b/packages/tpetra/core/test/Comm/Ialltofewv.cpp
@@ -1,0 +1,236 @@
+// @HEADER
+// *****************************************************************************
+//          Tpetra: Templated Linear Algebra Services Package
+//
+// Copyright 2026 NTESS and the Tpetra contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#include "Tpetra_Details_Ialltofewv.hpp"
+#include "Tpetra_TestingUtilities.hpp"
+
+#include <Teuchos_UnitTestHarness.hpp>
+
+#include <array>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+using Tpetra::Details::Ialltofewv;
+
+int cachedAllocations = 0;
+
+void countCachedAllocation(Kokkos::Tools::SpaceHandle, const char *label, const void *, uint64_t) {
+  const std::string_view name(label);
+  if (name == "rootBufDev" || name == "rootBufHost" ||
+      name == "aggBufDev" || name == "argsDev" || name == "argsHost") {
+    ++cachedAllocations;
+  }
+}
+
+struct CachedAllocationCounter {
+  CachedAllocationCounter()
+    : previous_(Kokkos::Tools::Experimental::get_callbacks().allocate_data) {
+    cachedAllocations = 0;
+    Kokkos::Tools::Experimental::set_allocate_data_callback(countCachedAllocation);
+  }
+
+  ~CachedAllocationCounter() {
+    Kokkos::Tools::Experimental::set_allocate_data_callback(previous_);
+  }
+
+  int globalCount() const {
+    int result = 0;
+    MPI_Allreduce(&cachedAllocations, &result, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    return result;
+  }
+
+ private:
+  Kokkos::Tools::allocateDataFunction previous_;
+};
+
+struct Fixture {
+  explicit Fixture(int value, int count = 1)
+    : send(count, value)
+    , sendcounts{count} {
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    if (rank == root) {
+      recv.resize(size * count, -1);
+      recvcounts.resize(size, count);
+      rdispls.resize(size);
+      for (int i = 0; i < size; ++i) rdispls[i] = i * count;
+    }
+  }
+
+  void post(Ialltofewv &impl, int aggTag, int rootTag) {
+    const int err = impl.post<false>(send.data(), sendcounts.data(), sdispls.data(), MPI_INT,
+                                     recv.data(), recvcounts.data(), rdispls.data(),
+                                     roots.data(), int(roots.size()), MPI_INT, aggTag, rootTag,
+                                     MPI_COMM_WORLD, &req);
+    TEUCHOS_ASSERT_EQUALITY(err, MPI_SUCCESS);
+  }
+
+  int rank = 0;
+  int size = 0;
+  std::vector<int> send;
+  int root = 0;
+  std::array<int, 1> sendcounts{1};
+  std::array<int, 1> sdispls{0};
+  std::array<int, 1> roots{root};
+  std::vector<int> recv;
+  std::vector<int> recvcounts;
+  std::vector<int> rdispls;
+  Ialltofewv::Req req;
+};
+
+void checkResult(const Fixture &fixture, int offset,
+                 Teuchos::FancyOStream &out, bool &success) {
+  if (fixture.rank != fixture.root) return;
+  for (int rank = 0; rank < fixture.size; ++rank) {
+    TEST_EQUALITY(fixture.recv[rank], offset + rank);
+  }
+}
+
+TEUCHOS_UNIT_TEST(Ialltofewv, differentWaitOrder) {
+  // Test that we don't deadlock when different ranks wait on different Ialltofewv
+  // in different orders.
+
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  Ialltofewv firstImpl;
+  Ialltofewv secondImpl;
+  Fixture first(rank);
+  Fixture second(100 + rank);
+  first.post(firstImpl, 101, 102);
+  second.post(secondImpl, 103, 104);
+
+  if (rank % 2 == 0) {
+    TEST_EQUALITY(firstImpl.wait(first.req), MPI_SUCCESS);
+    TEST_EQUALITY(secondImpl.wait(second.req), MPI_SUCCESS);
+  } else {
+    TEST_EQUALITY(secondImpl.wait(second.req), MPI_SUCCESS);
+    TEST_EQUALITY(firstImpl.wait(first.req), MPI_SUCCESS);
+  }
+
+  checkResult(first, 0, out, success);
+  checkResult(second, 100, out, success);
+}
+
+TEUCHOS_UNIT_TEST(Ialltofewv, pollingOneProgressesAll) {
+  // Check that get_status() on a request makes progress on other Ialltofewvs
+
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  Ialltofewv firstImpl;
+  Ialltofewv secondImpl;
+  Fixture first(rank);
+  Fixture second(100 + rank);
+  first.post(firstImpl, 105, 106);
+  second.post(secondImpl, 107, 108);
+
+  int firstComplete  = 0;
+  int secondComplete = 0;
+  while (!firstComplete || !secondComplete) {
+    TEST_EQUALITY(firstImpl.get_status(first.req, &firstComplete, MPI_STATUS_IGNORE), MPI_SUCCESS);
+    secondComplete = second.req.completed;
+  }
+
+  TEST_EQUALITY(firstImpl.wait(first.req), MPI_SUCCESS);
+  TEST_EQUALITY(secondImpl.wait(second.req), MPI_SUCCESS);
+  checkResult(first, 0, out, success);
+  checkResult(second, 100, out, success);
+}
+
+TEUCHOS_UNIT_TEST(Ialltofewv, zeroCountsMultipleRoots) {
+  // Mutliple source/root pairs send nothing
+  int rank = 0;
+  int size = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+  std::array<int, 2> send{rank, 100 + rank};
+  std::array<int, 2> sendcounts{1, rank % 2};
+  std::array<int, 2> sdispls{0, 1};
+  std::array<int, 2> roots{0, 1};
+  std::vector<int> recvcounts;
+  std::vector<int> rdispls;
+  std::vector<int> recv;
+  if (rank == roots[0] || rank == roots[1]) {
+    recvcounts.resize(size);
+    rdispls.resize(size);
+    int total = 0;
+    for (int src = 0; src < size; ++src) {
+      recvcounts[src] = rank == roots[0] ? 1 : src % 2;
+      rdispls[src]    = total;
+      total += recvcounts[src];
+    }
+    recv.resize(total, -1);
+  }
+
+  Ialltofewv impl;
+  Ialltofewv::Req req;
+  const int postErr = impl.post<false>(send.data(), sendcounts.data(), sdispls.data(), MPI_INT,
+                                       recv.data(), recvcounts.data(), rdispls.data(), roots.data(),
+                                       int(roots.size()), MPI_INT, 109, 110, MPI_COMM_WORLD, &req);
+  TEST_EQUALITY(postErr, MPI_SUCCESS);
+  TEST_EQUALITY(impl.wait(req), MPI_SUCCESS);
+
+  if (rank == roots[0]) {
+    for (int src = 0; src < size; ++src) TEST_EQUALITY(recv[src], src);
+  } else if (rank == roots[1]) {
+    int offset = 0;
+    for (int src = 0; src < size; ++src) {
+      if (src % 2) {
+        TEST_EQUALITY(recv[offset], 100 + src);
+        ++offset;
+      }
+    }
+  }
+}
+
+TEUCHOS_UNIT_TEST(Ialltofewv, reusesCachedViews) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  Ialltofewv impl;
+  Fixture first(rank, 2);
+  first.post(impl, 111, 112);
+  TEST_EQUALITY(impl.wait(first.req), MPI_SUCCESS);
+
+  CachedAllocationCounter counter;
+  Fixture second(100 + rank);
+  second.post(impl, 113, 114);
+  TEST_EQUALITY(impl.wait(second.req), MPI_SUCCESS);
+  TEST_EQUALITY(counter.globalCount(), 0);
+  checkResult(second, 100, out, success);
+}
+
+TEUCHOS_UNIT_TEST(Ialltofewv, copyHasIndependentCache) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  Ialltofewv original;
+  Fixture first(rank, 2);
+  first.post(original, 115, 116);
+  TEST_EQUALITY(original.wait(first.req), MPI_SUCCESS);
+
+  Ialltofewv copy(original);
+  CachedAllocationCounter counter;
+  Fixture second(100 + rank);
+  second.post(copy, 117, 118);
+  TEST_EQUALITY(copy.wait(second.req), MPI_SUCCESS);
+  TEST_ASSERT(counter.globalCount() > 0);
+  checkResult(second, 100, out, success);
+}
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  Tpetra::ScopeGuard scopeGuard(&argc, &argv);
+  return Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
+}

--- a/packages/tpetra/core/test/Comm/Ialltofewv.cpp
+++ b/packages/tpetra/core/test/Comm/Ialltofewv.cpp
@@ -58,7 +58,8 @@ struct Fixture {
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     if (rank == root) {
-      recv.resize(size * count, -1);
+      using recv_size_type = decltype(recv)::size_type;
+      recv.resize(recv_size_type(size) * recv_size_type(count), -1);
       recvcounts.resize(size, count);
       rdispls.resize(size);
       for (int i = 0; i < size; ++i) rdispls[i] = i * count;

--- a/packages/tpetra/core/test/ImportExport2/AsyncTransfer_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/AsyncTransfer_UnitTests.cpp
@@ -31,6 +31,7 @@ using Teuchos::as;
 using Teuchos::Comm;
 using Teuchos::FancyOStream;
 using Teuchos::OrdinalTraits;
+using Teuchos::ParameterList;
 using Teuchos::RCP;
 using Teuchos::rcp;
 using Teuchos::ScalarTraits;
@@ -45,6 +46,23 @@ using Tpetra::Import;
 using Tpetra::INSERT;
 using Tpetra::Map;
 using Tpetra::MultiVector;
+
+std::string distributorSendType("Send");
+
+TEUCHOS_STATIC_SETUP() {
+  Teuchos::CommandLineProcessor& clp = Teuchos::UnitTestRepository::getCLP();
+  clp.setOption("distributor-send-type", &distributorSendType,
+                "In MPI tests, the type of send operation that the Tpetra::Distributor will use.");
+}
+
+RCP<ParameterList> getDistributorParameterList() {
+  static RCP<ParameterList> plist;
+  if (plist.is_null()) {
+    plist = Teuchos::parameterList("Tpetra::Distributor");
+    plist->set("Send type", distributorSendType);
+  }
+  return plist;
+}
 
 //
 // UNIT TEST FIXTURES
@@ -136,7 +154,7 @@ class ReferenceImportMultiVector {
  public:
   RCP<mv_type> generateWithClassicalCodePath(RCP<mv_type> sourceMV, RCP<const map_type> targetMap) const {
     RCP<const map_type> sourceMap = sourceMV->getMap();
-    Import<LO, GO> importer(sourceMap, targetMap);
+    Import<LO, GO> importer(sourceMap, targetMap, getDistributorParameterList());
     expertSetRemoteLIDsContiguous(importer, false);
     TEUCHOS_ASSERT(!importer.areRemoteLIDsContiguous());
 
@@ -158,7 +176,7 @@ class ReferenceExportMultiVector {
  public:
   RCP<mv_type> generateWithClassicalCodePath(RCP<mv_type> sourceMV, RCP<const map_type> targetMap) const {
     RCP<const map_type> sourceMap = sourceMV->getMap();
-    Export<LO, GO> exporter(sourceMap, targetMap);
+    Export<LO, GO> exporter(sourceMap, targetMap, getDistributorParameterList());
     expertSetRemoteLIDsContiguous(exporter, false);
     TEUCHOS_ASSERT(!exporter.areRemoteLIDsContiguous());
 
@@ -394,7 +412,7 @@ class ReferenceImportMatrix {
  public:
   RCP<crs_type> generateUsingAllInOne(RCP<crs_type> sourceMat, RCP<const map_type> targetMap) const {
     RCP<const map_type> sourceMap = sourceMat->getMap();
-    Import<LO, GO> importer(sourceMap, targetMap);
+    Import<LO, GO> importer(sourceMap, targetMap, getDistributorParameterList());
 
     Teuchos::ParameterList dummy;
     RCP<crs_type> referenceMat = Tpetra::importAndFillCompleteCrsMatrix<crs_type>(
@@ -412,7 +430,7 @@ class ReferenceExportMatrix {
  public:
   RCP<crs_type> generateUsingAllInOne(RCP<crs_type> sourceMat, RCP<const map_type> targetMap) const {
     RCP<const map_type> sourceMap = sourceMat->getMap();
-    Export<LO, GO> exporter(sourceMap, targetMap);
+    Export<LO, GO> exporter(sourceMap, targetMap, getDistributorParameterList());
 
     Teuchos::ParameterList dummy;
     RCP<crs_type> referenceMat = Tpetra::exportAndFillCompleteCrsMatrix<crs_type>(
@@ -541,7 +559,7 @@ class ForwardImport {
 
  public:
   void operator()(DistObjectRCP source, DistObjectRCP target) const {
-    Import<LO, GO> importer(source->getMap(), target->getMap());
+    Import<LO, GO> importer(source->getMap(), target->getMap(), getDistributorParameterList());
     target->beginImport(*source, importer, INSERT);
     target->endImport(*source, importer, INSERT);
   }
@@ -586,7 +604,7 @@ class ReverseImport {
 
  public:
   void operator()(DistObjectRCP source, DistObjectRCP target) const {
-    Export<LO, GO> exporter(target->getMap(), source->getMap());
+    Export<LO, GO> exporter(target->getMap(), source->getMap(), getDistributorParameterList());
     target->beginImport(*source, exporter, INSERT);
     target->endImport(*source, exporter, INSERT);
   }
@@ -631,7 +649,7 @@ class ForwardExport {
 
  public:
   void operator()(DistObjectRCP source, DistObjectRCP target) const {
-    Export<LO, GO> exporter(source->getMap(), target->getMap());
+    Export<LO, GO> exporter(source->getMap(), target->getMap(), getDistributorParameterList());
     target->beginExport(*source, exporter, INSERT);
     target->endExport(*source, exporter, INSERT);
   }
@@ -676,7 +694,7 @@ class ReverseExport {
 
  public:
   void operator()(DistObjectRCP source, DistObjectRCP target) const {
-    Import<LO, GO> importer(target->getMap(), source->getMap());
+    Import<LO, GO> importer(target->getMap(), source->getMap(), getDistributorParameterList());
     target->beginExport(*source, importer, INSERT);
     target->endExport(*source, importer, INSERT);
   }
@@ -758,7 +776,7 @@ class CheckTransferArrivedForwardImport {
     , success(s) {}
 
   void operator()(DistObjectRCP source, DistObjectRCP target) const {
-    Import<LO, GO> importer(source->getMap(), target->getMap());
+    Import<LO, GO> importer(source->getMap(), target->getMap(), getDistributorParameterList());
 
     target->beginImport(*source, importer, INSERT);
     while (!target->transferArrived())
@@ -800,7 +818,7 @@ class CheckTransferArrivedForwardExport {
     , success(s) {}
 
   void operator()(DistObjectRCP source, DistObjectRCP target) const {
-    Export<LO, GO> exporter(source->getMap(), target->getMap());
+    Export<LO, GO> exporter(source->getMap(), target->getMap(), getDistributorParameterList());
 
     target->beginExport(*source, exporter, INSERT);
     while (!target->transferArrived())
@@ -846,7 +864,7 @@ class CheckTransferNotArrivedForwardImport {
     int myRank   = comm->getRank();
     int numProcs = comm->getSize();
 
-    Import<LO, GO> importer(source->getMap(), target->getMap());
+    Import<LO, GO> importer(source->getMap(), target->getMap(), getDistributorParameterList());
 
     if (numProcs > 1) {
       if (myRank == 0) {
@@ -888,7 +906,7 @@ class CheckTransferNotArrivedForwardExport {
     int myRank   = comm->getRank();
     int numProcs = comm->getSize();
 
-    Export<LO, GO> exporter(source->getMap(), target->getMap());
+    Export<LO, GO> exporter(source->getMap(), target->getMap(), getDistributorParameterList());
 
     if (numProcs > 1) {
       if (myRank == 0) {
@@ -922,7 +940,7 @@ class ForwardImportGroup {
 
  public:
   void operator()(std::vector<DistObjectRCP>& sources, std::vector<DistObjectRCP>& targets) const {
-    Import<LO, GO> importer(sources[0]->getMap(), targets[0]->getMap());
+    Import<LO, GO> importer(sources[0]->getMap(), targets[0]->getMap(), getDistributorParameterList());
 
     for (unsigned i = 0; i < sources.size(); i++) {
       targets[i]->beginImport(*sources[i], importer, INSERT);

--- a/packages/tpetra/core/test/ImportExport2/CMakeLists.txt
+++ b/packages/tpetra/core/test/ImportExport2/CMakeLists.txt
@@ -58,13 +58,28 @@ IF(${PACKAGE_NAME}_ENABLE_mpi_advance)
   )
 ENDIF()
 
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
+TRIBITS_ADD_EXECUTABLE(
   AsyncTransfer_UnitTests
   SOURCES AsyncTransfer_UnitTests.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  COMM serial mpi
+  )
+
+TRIBITS_ADD_TEST(
+  AsyncTransfer_UnitTests
   COMM serial mpi
   ARGS "--globally-reduce-test-result --output-show-proc-rank --output-to-root-rank-only=-1"
   STANDARD_PASS_OUTPUT
 )
+
+if (TPL_ENABLE_MPI)
+  TRIBITS_ADD_TEST(
+    AsyncTransfer_UnitTests
+    NAME AsyncTransfer_UnitTests_Ialltofewv
+    COMM mpi
+    ARGS "--distributor-send-type=Ialltofewv --globally-reduce-test-result --output-show-proc-rank --output-to-root-rank-only=-1"
+    STANDARD_PASS_OUTPUT
+    )
+endif()
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   ImportExport2_CrsSortingUtils

--- a/packages/tpetra/core/test/ImportExport2/CMakeLists.txt
+++ b/packages/tpetra/core/test/ImportExport2/CMakeLists.txt
@@ -62,7 +62,7 @@ TRIBITS_ADD_EXECUTABLE(
   AsyncTransfer_UnitTests
   SOURCES AsyncTransfer_UnitTests.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
   COMM serial mpi
-  )
+)
 
 TRIBITS_ADD_TEST(
   AsyncTransfer_UnitTests
@@ -71,15 +71,15 @@ TRIBITS_ADD_TEST(
   STANDARD_PASS_OUTPUT
 )
 
-if (TPL_ENABLE_MPI)
+IF(TPL_ENABLE_MPI)
   TRIBITS_ADD_TEST(
     AsyncTransfer_UnitTests
     NAME AsyncTransfer_UnitTests_Ialltofewv
     COMM mpi
     ARGS "--distributor-send-type=Ialltofewv --globally-reduce-test-result --output-show-proc-rank --output-to-root-rank-only=-1"
     STANDARD_PASS_OUTPUT
-    )
-endif()
+  )
+ENDIF()
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   ImportExport2_CrsSortingUtils


### PR DESCRIPTION
This makes Tpetra's `Ialltofewv` send type asynchronous, i.e. multiple `DistributorActor`s can each do one `Ialltofewv` at the same time. This is not possible in a straightforward way because there are two communication phases, and the first one needs to end before the MPI ops in the second one can be posted. Since everythign previously happened in `wait_impl`, trying to overlap would actually work like this:

```c++
op.start(); // op 1
op.start(); // op 2
op.wait(); // starts and completes op 1
op.wait(); // starts and completes op 2
```

This PR introduces a mini "progress engine" specific to `Ialltofewv`. `Ialltofewv` now has a few phases, and each test of the operation's state gives every `Ialltofewv` an opportunity to advance. The previously monolithic `wait_impl` code is distributed across `postPayloads` and `postForwards`.

There is a registry of active `Ialltofewv` in `activeStates`. `lock` promotes the `weak_ptr` to a `shared_ptr`, which is `null` if the communication has already ended. The request manages the lifetime, so if a request goes away in the caller's code, the owning `shared_ptr` would go away, and the `weak_ptr` in the registry no longer points to anything.