### PR TITLE
Teuchos: wrap MpiComm message tag at MPI_TAG_UB, not INT_MAX

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_DefaultMpiComm_decl.hpp
+++ b/packages/teuchos/comm/src/Teuchos_DefaultMpiComm_decl.hpp
@@ -473,8 +473,18 @@ public:
 
   int incrementTag() {
     ++tag_;
-    if (tag_ == std::numeric_limits<int>::max())
-      tag_ = 0;
+    // Wrap at MPI_TAG_UB, NOT std::numeric_limits<int>::max(). The tag is
+    // passed straight to MPI_Isend/Irecv, and MPI rejects any tag above
+    // MPI_TAG_UB with MPI_ERR_TAG. MPI_TAG_UB is far below INT_MAX on real
+    // implementations (e.g. 2^23-1 = 8388607 on OpenMPI), so wrapping only
+    // at INT_MAX let the tag climb out of the valid range: the Tpetra
+    // Distributor calls this once per communication round, and a long run
+    // (~8.4M rounds) eventually aborts mid-solve with MPI_ERR_TAG. tagUb_
+    // is the queried MPI_TAG_UB (see setupMembersFromComm); wrapping back
+    // to minTag_ keeps the tag valid and matches the documented intent of
+    // "loop around back to a small value".
+    if (tag_ >= tagUb_)
+      tag_ = minTag_;
     return tag_;
   }
 
@@ -509,6 +519,13 @@ private:
   /// <a href="https://software.sandia.gov/bugzilla/show_bug.cgi?id=5740">Bug 5740</a>
   /// for further discussion.
   int tag_;
+
+  /// \brief Upper bound for a valid MPI message tag (the queried
+  ///   MPI_TAG_UB attribute of rawMpiComm_), used by incrementTag to wrap
+  ///   the tag before it exceeds what MPI accepts. Set in
+  ///   setupMembersFromComm. Defaulted to the MPI-standard guaranteed
+  ///   minimum so it is never garbage even on an unforeseen ctor path.
+  int tagUb_ = 32767;
 
   //! MPI error handler.  If null, MPI uses the default error handler.
   RCP<const OpaqueWrapper<MPI_Errhandler> > customErrorHandler_;

--- a/packages/teuchos/comm/src/Teuchos_DefaultMpiComm_def.hpp
+++ b/packages/teuchos/comm/src/Teuchos_DefaultMpiComm_def.hpp
@@ -250,6 +250,14 @@ MpiComm (const RCP<const OpaqueWrapper<MPI_Comm> >& rawMpiComm,
     "Teuchos::MpiComm constructor: MPI_Comm_rank failed with "
     "error \"" << mpiErrorCodeToString (err) << "\".");
   tag_ = defaultTag; // set the default message tag
+  // Cache MPI_TAG_UB so incrementTag wraps within the valid tag range
+  // (see setupMembersFromComm and incrementTag).
+  {
+    int* tag_ub_val = nullptr;
+    int  found      = 0;
+    int const aerr  = MPI_Comm_get_attr (*rawMpiComm_, MPI_TAG_UB, &tag_ub_val, &found);
+    tagUb_ = (aerr == MPI_SUCCESS && found && tag_ub_val != nullptr && *tag_ub_val > minTag_) ? *tag_ub_val : 32767;
+  }
 }
 
 
@@ -327,6 +335,19 @@ void MpiComm<Ordinal>::setupMembersFromComm ()
   TEUCHOS_TEST_FOR_EXCEPTION(err != MPI_SUCCESS, std::runtime_error,
     "Teuchos::MpiComm constructor: MPI_Comm_rank failed with "
     "error \"" << mpiErrorCodeToString (err) << "\".");
+
+  // Query the largest tag MPI will accept on this communicator. Tags
+  // above MPI_TAG_UB are rejected with MPI_ERR_TAG, and on real MPI
+  // implementations MPI_TAG_UB is far below INT_MAX (e.g. 2^23-1 on
+  // OpenMPI). incrementTag uses this to wrap the tag before it leaves the
+  // valid range. Fall back to the MPI-standard guaranteed minimum (32767)
+  // if the attribute is somehow unavailable.
+  {
+    int* tag_ub_val = nullptr;
+    int  found      = 0;
+    int const aerr  = MPI_Comm_get_attr (*rawMpiComm_, MPI_TAG_UB, &tag_ub_val, &found);
+    tagUb_ = (aerr == MPI_SUCCESS && found && tag_ub_val != nullptr && *tag_ub_val > minTag_) ? *tag_ub_val : 32767;
+  }
 
   // Set the default tag to make unique across all communicators
   if (tagCounter_ > maxTag_) {


### PR DESCRIPTION
MpiComm::incrementTag() wrapped the message tag at
std::numeric_limits<int>::max(). The tag it returns is handed straight to
MPI_Isend/Irecv (e.g. Tpetra's DistributorActor calls incrementTag once
per communication round and uses the result as the MPI tag). MPI rejects
any tag greater than MPI_TAG_UB with MPI_ERR_TAG, and MPI_TAG_UB is far
below INT_MAX on real implementations -- 2^23-1 = 8388607 on OpenMPI.
Wrapping only at INT_MAX therefore let the tag climb out of the valid
range: a long-running Tpetra application (~8.4M communication rounds on
OpenMPI) aborts mid-solve with MPI_ERR_TAG. Short runs never reach that
many rounds, which is why this went unnoticed. DistributorActor's comment
already states the intent -- the tag should "loop around back to a small
value" -- but the wrap point was wrong.

Query MPI_TAG_UB once via MPI_Comm_get_attr in the MpiComm constructors
(setupMembersFromComm and the explicit-default-tag ctor), cache it in a
new tagUb_ member (defaulted to the MPI-standard guaranteed minimum,
32767, so it is never garbage), and wrap incrementTag at tagUb_ back to
minTag_. This keeps every tag MpiComm produces within the range MPI
accepts.

Reproduced on OpenMPI 4.1.1 (MPI_TAG_UB = 8388607) with a coupled
thermo-mechanical Albany run that aborted deterministically in MPI_Irecv
at the same step on every attempt, independent of the simulated physics.
