### PR TITLE
MiniTensor: fix eig_sym 2x2 to return a consistent (V, D)

### DIFF
--- a/packages/minitensor/src/MiniTensor_LinearAlgebra.t.h
+++ b/packages/minitensor/src/MiniTensor_LinearAlgebra.t.h
@@ -4760,11 +4760,18 @@ std::pair<Tensor<T, N>, Tensor<T, N>> eig_sym_2x2(Tensor<T, N> const &A) {
     s1 = -0.5 * r;
   }
 
-  Tensor<T, N>
-  D(s0, 0.0, 0.0, s1);
-
   //
-  // Eigenvectors
+  // Eigenvectors. schur_sym returns the Jacobi rotation J = [c, s; -s, c]
+  // whose columns are the eigenvectors and which diagonalizes A as
+  // A = J * diag(l0, l1) * transpose(J), with the eigenvalue attached to
+  // column 0 of J being l0 = f - tan(theta) * g and to column 1 being
+  // l1 = h + tan(theta) * g (tan(theta) = s / c).
+  //
+  // The previous implementation used transpose(J) as V and paired the
+  // magnitude-ordered eigenvalues (s0, s1) to the columns through swap_diag, so
+  // V * D * transpose(V) did not reconstruct A for general off-diagonal cases
+  // (Trilinos issue #15389). Build V = J directly, and attach the accurate
+  // (s0, s1) eigenvalues to their matching columns.
   //
   T
   c, s;
@@ -4772,13 +4779,34 @@ std::pair<Tensor<T, N>, Tensor<T, N>> eig_sym_2x2(Tensor<T, N> const &A) {
   std::tie(c, s) = schur_sym(f, g, h);
 
   Tensor<T, N>
-  V(c, -s, s, c);
+  V(c, s, -s, c);
 
-  if (swap_diag == true) {
-    // swap eigenvectors if eigenvalues were swapped
+  T const l0 = f - (s / c) * g;
+
+  T d0, d1;
+  if (std::abs(l0 - s0) <= std::abs(l0 - s1)) {
+    d0 = s0;
+    d1 = s1;
+  } else {
+    d0 = s1;
+    d1 = s0;
+  }
+
+  //
+  // Return eigenvalues in descending order, permuting the eigenvectors to
+  // match, for consistency with the eig_sym_NxN path. For 2x2 this is a single
+  // compare-and-swap; done inline to avoid the heap allocation and matrix
+  // multiply of the general sort_permutation, as eig_sym is called per
+  // integration point in 2D mechanics.
+  //
+  if (d0 < d1) {
+    std::swap(d0, d1);
     std::swap(V(0, 0), V(0, 1));
     std::swap(V(1, 0), V(1, 1));
   }
+
+  Tensor<T, N>
+  D(d0, 0.0, 0.0, d1);
 
   return std::make_pair(V, D);
 }

--- a/packages/minitensor/test/test_01.cc
+++ b/packages/minitensor/test/test_01.cc
@@ -1182,17 +1182,33 @@ TEST(MiniTensor, MixedTypes)
 
 TEST(MiniTensor, SymmetricEigen2x2)
 {
-  Tensor<Real> const A(2.0, 1.0, 1.0, 2.0);
+  // Reconstruction A = V * D * transpose(V) must hold for general symmetric
+  // 2x2 tensors, including unequal diagonals with shear. The unequal-diagonal
+  // cases below regress Trilinos issue #15389, where the 2x2 path returned an
+  // inconsistent (V, D) that flipped the off-diagonal sign on reconstruction.
+  std::vector<Tensor<Real>> const tensors = {
+      Tensor<Real>(2.0, 1.0, 1.0, 2.0),        // equal diagonals
+      Tensor<Real>(1.0025, 0.1, 0.1, 1.0025),  // equal diagonals, shear
+      Tensor<Real>(1.168, 0.06, 0.06, 0.922),  // f > h, shear
+      Tensor<Real>(0.922, 0.06, 0.06, 1.168),  // f < h, shear
+      Tensor<Real>(2.0, 0.0, 0.0, 3.0),        // diagonal (g == 0)
+      Tensor<Real>(-1.0, 0.5, 0.5, -2.0)       // negative eigenvalues
+  };
 
-  Tensor<Real> V(2), D(2);
+  for (Tensor<Real> const & A : tensors) {
+    Tensor<Real> V(2), D(2);
 
-  std::tie(V, D) = eig_sym(A);
+    std::tie(V, D) = eig_sym(A);
 
-  Tensor<Real> const B = V * D * transpose(V);
+    Tensor<Real> const B = V * D * transpose(V);
 
-  Real const error = norm(A - B) / norm(A);
+    Real const error = norm(A - B) / norm(A);
 
-  ASSERT_LE(error, machine_epsilon<Real>());
+    ASSERT_LE(error, 2.0 * machine_epsilon<Real>());
+
+    // Eigenvalues are returned in descending order (matches eig_sym_NxN).
+    ASSERT_GE(D(0, 0), D(1, 1));
+  }
 }
 
 TEST(MiniTensor, SymmetricEigen3x3)


### PR DESCRIPTION
## Summary

Fixes #15389.

`eig_sym_2x2` returned an eigendecomposition that did not satisfy
`A = V * D * transpose(V)` for general symmetric 2x2 tensors with a nonzero
off-diagonal. For equal diagonals the reconstruction happened to work; for
`f > h` it reconstructed only as `transpose(V) * D * V`; for `f < h` neither
form reconstructed `A`. Downstream this flipped the shear-stress sign in a 2D
Hencky elasticity model.

## Root cause

Two compounding errors:

- `V` was built as `[c, s; -s, c]^T = transpose(J)` rather than the Jacobi
  rotation `J = [c, s; -s, c]` that `schur_sym` diagonalizes `A` with
  (`A = J * diag(l0, l1) * transpose(J)`), so the eigenvectors were
  effectively transposed.
- The magnitude-ordered eigenvalues `(s0, s1)` from the dlae2-style
  computation were paired to the eigenvector columns through the
  `swap_diag` (`|h| > |f|`) heuristic, which does not reliably match the
  geometric column order, so `D` and `V` were mispaired.

## Fix

- Build `V = J` directly, and attach the accurate `(s0, s1)` eigenvalues to
  the matching columns: column 0 of `J` carries `l0 = f - tan(theta) * g`, so
  it takes whichever of `(s0, s1)` is closer to `l0`. LAPACK's accurate
  small-eigenvalue (dlae2) computation is unchanged.
- Eigenvalues are returned in descending order with eigenvectors permuted to
  match, for consistency with `eig_sym_NxN`. For 2x2 this is a single inline
  compare-and-swap rather than `sort_permutation`, avoiding a heap allocation
  and a permutation-matrix multiply on a routine called per integration point
  in 2D mechanics.

## Testing

`SymmetricEigen2x2` previously covered only the equal-diagonal case (the one
that happened to work). Extended it to unequal diagonals with shear, a
diagonal tensor, and negative eigenvalues, checking both the reconstruction
`A = V * D * transpose(V)` and the descending-order convention. The full
MiniTensor test suite passes (`test_01`: 32, `test_02`: 10).

The fix was additionally validated against a reference implementation on the
three reported cases plus edge cases (`g = 0`, negative and degenerate
eigenvalues, `sum == 0`, wide `1e8 / 1e-8` eigenvalue range) and 500k random
symmetric 2x2 tensors: reconstruction error <= 7e-16, orthonormal `V`, and
no descending-order violations.