### PR TITLE
Framework: Generate coverage data with absolute paths

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -461,7 +461,7 @@ opt-set-cmake-var TPL_HDF5_LIBRARIES   STRING FORCE : ""
 #
 
 [COVERAGE]
-opt-set-cmake-var CMAKE_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} --coverage -O0
+opt-set-cmake-var CMAKE_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} --coverage -O0 -fprofile-abs-path
 
 
 #


### PR DESCRIPTION
@trilinos/framework

## Motivation
Currently seeing a lot of this in the coverage logs:
```
Cannot find file: /home/Trilinos/build/runner/_work/Trilinos/Trilinos/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
Cannot find file: /home/Trilinos/build/runner/_work/Trilinos/Trilinos/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTH.hpp
Cannot find file: /home/Trilinos/build/runner/_work/Trilinos/Trilinos/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTHDef.hpp
```

Try to remedy the issue by encoding full paths to the source files into the coverage output.