### PR TITLE
MiniTensor: canonicalize singular values in the 2x2 SVD path

### DIFF
--- a/packages/minitensor/src/MiniTensor_LinearAlgebra.t.h
+++ b/packages/minitensor/src/MiniTensor_LinearAlgebra.t.h
@@ -4189,6 +4189,32 @@ svd(Tensor<T, N> const &A) {
 
     case 2:
       std::tie(U, S, V) = svd_2x2(A);
+      // svd_2x2 doubles as a building block inside svd_NxN's Jacobi sweep, so
+      // it returns the raw 2x2 factorization without the sign/order
+      // canonicalization that svd_NxN applies to its own result. Apply that
+      // canonicalization here, for the top-level 2D SVD only, so svd() returns
+      // the standard convention (nonnegative singular values in descending
+      // order) regardless of dimension. Folding a negative sign into the
+      // corresponding column of U preserves A = U S V^T.
+      for (Index i = 0; i < dimension; ++i) {
+        if (S(i, i) < 0.0) {
+          S(i, i) = -S(i, i);
+          for (Index j = 0; j < dimension; ++j) {
+            U(j, i) = -U(j, i);
+          }
+        }
+      }
+      // Sort descending. For 2x2 this is a single compare-and-swap of the two
+      // columns of U and V (and the two singular values), avoiding the heap
+      // allocation and matrix multiply that the general sort_permutation
+      // incurs.
+      if (S(0, 0) < S(1, 1)) {
+        std::swap(S(0, 0), S(1, 1));
+        std::swap(U(0, 0), U(0, 1));
+        std::swap(U(1, 0), U(1, 1));
+        std::swap(V(0, 0), V(0, 1));
+        std::swap(V(1, 0), V(1, 1));
+      }
       break;
 
   }

--- a/packages/minitensor/test/test_03.cc
+++ b/packages/minitensor/test/test_03.cc
@@ -209,16 +209,8 @@ TEST(MiniTensor, EigSpdProperties)
 }
 
 //
-// Singular value decomposition: A = U S V^T with U and V orthonormal and S
-// diagonal.
-//
-// Note: only the invariants that hold across all dimensions are asserted here.
-// The NxN path canonicalizes the singular values to be nonnegative and sorted
-// in descending order, but the 2x2-specialized path currently does not -- it
-// can return a negative diagonal entry and a non-descending order. Asserting
-// nonnegativity / descending order here would therefore fail on the 2x2 path.
-// That inconsistency between svd_2x2 and svd_NxN is a separate fix; once the
-// 2x2 path canonicalizes its output, those two assertions should be added back.
+// Singular value decomposition: A = U S V^T, U and V orthonormal, S diagonal
+// with nonnegative singular values sorted in descending order.
 //
 TEST(MiniTensor, SvdProperties)
 {
@@ -240,6 +232,12 @@ TEST(MiniTensor, SvdProperties)
           << "svd V not orthonormal, dim " << dimension;
       ASSERT_LE(off_diagonal_error(S), TOL_ITERATIVE)
           << "svd S not diagonal, dim " << dimension;
+      ASSERT_TRUE(is_descending(S))
+          << "svd singular values not descending, dim " << dimension << ", sample " << sample;
+      for (Index i = 0; i < dimension; ++i) {
+        ASSERT_GE(S(i, i), -TOL_ITERATIVE)
+            << "svd singular value negative, dim " << dimension << ", sample " << sample;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

`svd()` returned a non-canonical factorization for 2x2 inputs: the singular
values could be negative and were not sorted, whereas the NxN path returns
nonnegative singular values in descending order. This was found by the
randomized decomposition tests added in #15395.

## Cause

`svd_2x2` doubles as a building block inside `svd_NxN`'s Jacobi sweep, so it
returns the raw 2x2 factorization and (unlike `svd_NxN`) performs no sign/order
canonicalization on its result. The 2D dispatch returned that raw result
directly.

## Fix

Apply the canonicalization in the `svd()` dispatch for the 2D case only,
leaving `svd_2x2` itself — and therefore `svd_NxN`'s inner use of it —
untouched:

- fold any negative sign into the corresponding column of `U`, and
- sort the two singular values in descending order, which for 2x2 is a single
  compare-and-swap of the columns of `U` and `V` (avoiding the heap allocation
  and matrix multiply of the general `sort_permutation`).

The reconstruction `A = U S V^T` is preserved throughout, and `svd()` now
returns the standard convention (nonnegative singular values, descending)
regardless of dimension.

## Testing

Restores the nonnegativity and descending-order assertions to the SVD
property-based test (`test_03.cc`), which now hold for all dimensions. Full
MiniTensor suite passes: `Test_01` (32), `Test_02` (10), `Test_03` (7).