### PR TITLE
MiniTensor: fail loudly on non-SPD input to SPD-only operations

### DIFF
--- a/packages/minitensor/src/MiniTensor_LinearAlgebra.t.h
+++ b/packages/minitensor/src/MiniTensor_LinearAlgebra.t.h
@@ -3523,6 +3523,9 @@ log_eig_sym(Tensor<T, N> const & A)
   std::tie(V, D) = eig_sym(A);
 
   for (Index i = 0; i < dimension; ++i) {
+    if (D(i, i) < T(0)) {
+      MT_ERROR_EXIT("Non-SPD input: negative eigenvalue.");
+    }
     D(i, i) = std::log(D(i, i));
   }
 
@@ -4381,6 +4384,12 @@ std::pair<Tensor<T, N>, Tensor<T, N>> polar_left_eig(Tensor<T, N> const &F) {
   Tensor<T, N>
   x = zero<T, N>(3);
 
+  for (Index i = 0; i < 3; ++i) {
+    if (eVal(i, i) < T(0)) {
+      MT_ERROR_EXIT("Non-SPD input: negative eigenvalue.");
+    }
+  }
+
   x(0,0) = std::sqrt(eVal(0,0));
   x(1,1) = std::sqrt(eVal(1,1));
   x(2,2) = std::sqrt(eVal(2,2));
@@ -4437,6 +4446,12 @@ std::pair<Tensor<T, N>, Tensor<T, N>> polar_right_eig(Tensor<T, N> const &F) {
   // compute sqrt() and inv(sqrt()) of eigenvalues
   Tensor<T, N>
   x = zero<T, N>(dimension);
+
+  for (Index i = 0; i < dimension; ++i) {
+    if (eVal(i, i) < T(0)) {
+      MT_ERROR_EXIT("Non-SPD input: negative eigenvalue.");
+    }
+  }
 
   x(0,0) = std::sqrt(eVal(0,0));
   x(1,1) = std::sqrt(eVal(1,1));
@@ -4510,6 +4525,9 @@ polar_left_logV_eig(Tensor<T, N> const &F) {
   DQ(dimension, Filler::ZEROS), DI(dimension, Filler::ZEROS), DL(dimension, Filler::ZEROS);
 
   for (Index i = 0; i < dimension; ++i) {
+    if (D(i,i) < T(0)) {
+      MT_ERROR_EXIT("Non-SPD input: negative eigenvalue.");
+    }
     DQ(i,i) = std::sqrt(D(i,i));
     DI(i,i) = 1.0 / DQ(i,i);
     DL(i,i) = std::log(DQ(i,i));
@@ -4550,6 +4568,11 @@ polar_left_logV_lame(Tensor<T, N> const &F) {
   std::tie(eVec, eVal) = eig_spd_cos(b);
 
   // compute sqrt() and inv(sqrt()) of eigenvalues
+  for (Index i = 0; i < 3; ++i) {
+    if (eVal(i,i) < T(0)) {
+      MT_ERROR_EXIT("Non-SPD input: negative eigenvalue.");
+    }
+  }
   Tensor<T, N> x = zero<T, N>(3);
   x(0,0) = std::sqrt(eVal(0,0));
   x(1,1) = std::sqrt(eVal(1,1));


### PR DESCRIPTION
## Summary

The eigenvalue-based SPD operations in `MiniTensor_LinearAlgebra` (`log` of a
symmetric tensor, the eigendecomposition polar variants) take `sqrt`/`log` of
the eigenvalues assuming the input is symmetric positive definite. On non-SPD
input a negative eigenvalue silently produced a `NaN` (`sqrt`/`log` of a
negative number) that then propagated far from its origin.

In practice such input is a bug in the caller — almost always a material model
handing in a tensor that should be SPD — and the failure should point there,
not surface later as mysterious NaNs.

## Change

Validate the eigenvalues before the `sqrt`/`log` and abort with a diagnostic
(`MT_ERROR_EXIT`) when one is negative, in:

- `log_eig_sym`
- `polar_left_eig`, `polar_right_eig`
- `polar_left_logV_eig`, `polar_left_logV_lame`

The check is strict — any negative eigenvalue fails, including ones produced by
rounding error, since that unambiguously indicates non-SPD input.

Sites whose `sqrt` argument is nonnegative by construction are intentionally
left unguarded: `eig_spd_cos`'s `sqrt` operates on column-norm-squares, and
`polar_left_logV`'s `log` operates on (nonnegative) singular values.

## Testing

The full MiniTensor test suite still passes — valid SPD inputs are unaffected
(`Test_01` 32, `Test_02` 10, `Test_03` 7).