### PR TITLE
Piro: add start/final time setters to TrapezoidRuleSolver

### DIFF
--- a/packages/piro/src/Piro_TrapezoidRuleSolver.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver.hpp
@@ -130,6 +130,27 @@ class TrapezoidRuleSolver
   void enableStaticInitSolve() { static_init_solve_ = true; };
   /** \brief .*/
   void disableStaticInitSolve() { static_init_solve_ = false; };
+
+  /** \brief Set the start time of the integration window.
+
+      By default the window (Initial Time, Final Time) is fixed at construction
+      from the "Trapezoid Rule" parameter list. These setters let a driver --
+      e.g. a coupling loop that advances the solver one outer step at a time --
+      retarget the window to successive segments of global simulation time
+      before each evalModel call, mirroring Piro::TempusSolver's
+      setStartTime/setFinalTime. The model then sees true simulation time
+      through InArgs::set_t (a time-dependent boundary condition, body force, or
+      material lookup gets the correct time instead of the fixed window's).
+      The internal time step delta_t = (Final - Initial) / Num Time Steps is
+      recomputed; the dynamics depend only on delta_t, so shifting the window's
+      origin leaves the integration unchanged. */
+  void setStartTime(const Scalar start_time) { t_init = start_time; delta_t = (t_final - t_init) / numTimeSteps; }
+  /** \brief Set the final time of the integration window (recomputes delta_t). */
+  void setFinalTime(const Scalar final_time) { t_final = final_time; delta_t = (t_final - t_init) / numTimeSteps; }
+  /** \brief Start time of the current integration window. */
+  Scalar getStartTime() const { return t_init; }
+  /** \brief Final time of the current integration window. */
+  Scalar getFinalTime() const { return t_final; }
   //@}
 
 


### PR DESCRIPTION
## What

Add `setStartTime` / `setFinalTime` (and `getStartTime` / `getFinalTime`) to
`Piro::TrapezoidRuleSolver`, mirroring `Piro::TempusSolver`'s existing
`setStartTime` / `setFinalTime` / `setInitTimeStep`.

`TrapezoidRuleSolver` reads its integration window (`Initial Time`,
`Final Time`) from the parameter list **at construction** and exposes no
way to change it afterward. A driver that advances the solver one outer step
at a time — e.g. a coupling loop — therefore cannot retarget the window to
successive segments of global simulation time: every `evalModel` reuses the
same fixed window, so the model sees a clock that never advances
(`InArgs::set_t` is ~the same window time each call).

The setters retarget the window and recompute the internal step
`delta_t = (Final - Initial) / Num Time Steps`. The dynamics depend only on
`delta_t`, so moving the window's origin leaves the integration unchanged
while letting the model see true simulation time. Behavior is unchanged for
existing single-window uses (the setters are simply never called).

## Motivation (Albany / ACE permafrost)

This fixes a bug Elyce Bayat reported on the ACE coastal-erosion ("bluff")
simulations. The ACE sequential thermo-mechanical coupling loop drives the
mechanical subproblem with `TrapezoidRule`, which ran a fixed local `[0, dt]`
window every coupling step. The erosion material models (`J2Erosion`,
`Permafrost`) read `workset.current_time` to interpolate a user-supplied
sea-level time history and to decide ocean exposure of erodible cells. With
the frozen clock the interpolation always returned the first table entry, so
the sea level stayed pinned at its initial value for the entire run
regardless of the prescribed history.

With these setters the coupling loop calls `setStartTime(current_time)` /
`setFinalTime(next_time)` per step, the model sees global time, and the sea
level evolves as specified (verified on Elyce's `MiniErosion-test-sea-level`:
the lookup now traces 0.5 → 0.625 → 0.75 → 1.0 → … matching the input array).

The Albany-side wiring (the coupling loop calling these setters, replacing
the previous fixed-window + time-shift workaround) is a separate Albany/LCM
commit.