### PR TITLE
PR reproducer scripts: tweak error message

### DIFF
--- a/commonTools/pr_reproducer/tools.py
+++ b/commonTools/pr_reproducer/tools.py
@@ -203,7 +203,7 @@ def launch_container(source_dir, packageEnablesFile, image, tag, genconfig_build
         in which this can happen. Some suggestions for narrowing down the problem:
 
         - The podman installation is simply broken. Try running
-            podman run -it --rm docker.io/rockylinux/rockylinux bash -c "echo \"That worked!!!\""
+            podman run -it --rm docker.io/rockylinux/rockylinux bash -c "echo \\"That worked\\""
           to run a minimal Linux container as a test.
 
         - Podman might be provided by a module. Try e.g.


### PR DESCRIPTION
Modify error message to be bash compatible.  (I had to modify the suggested command to run it locally.)
<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
