### PR TITLE
Zoltan: Add `-std=c99` to C compiler flags

### DIFF
--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -24,6 +24,8 @@ macro(enable_errors errors)
     endforeach()
 endmacro()
 
+message(STATUS "Adding '-std=c99' to C compiler flags for Zoltan")
+set(Zoltan_C_FLAGS "-std=c99 ${Zoltan_C_FLAGS} ${CMAKE_C_FLAGS}")
 
 IF (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
   IF(WIN32)
@@ -196,7 +198,6 @@ function(filter_valid_warnings_as_errors warnings output)
     endforeach()
     set(${output} ${valid_warnings} PARENT_SCOPE)
 endfunction()
-
 
 if("${Trilinos_WARNINGS_MODE}" STREQUAL "WARN")
     filter_valid_warnings("${upcoming_warnings}" upcoming_warnings)


### PR DESCRIPTION
@trilinos/zoltan 

We had to add this for the last two release branches to pass testing. e.g. #15256. Cherry pick the change back to develop.

Zoltan_ch_simple_zoltan_serial fails without this flag on GCC14 _without_ MPI enabled.  It was getting added via the strong C warnings flags, so with DEVELOPMENT_MODE disabled it doesn't get added.  Force it on here.
