### PR TITLE
Panzer: change sideset naming function to align with changes to IOSS

### DIFF
--- a/packages/panzer/adapters-stk/src/Panzer_STK_TransformBCNameForIOSS.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_TransformBCNameForIOSS.cpp
@@ -13,20 +13,21 @@
 #include <algorithm>
 #include <cctype>
 
-std::string panzer_stk::transformBCNameForIOSS(std::string& name)
+std::string panzer_stk::transformBCNameForIOSS(std::string& name, const bool make_lower_case)
 {
   // strip off leading and trailing whitespace just in case this comes
   // in from input file.
   panzer::trim(name);
 
-  // replace internal whitespace with underscores and upper case with lower case.
   std::transform(name.begin(), name.end(), name.begin(),
-                 [](const char c)
+                 [&make_lower_case](const char c)
                  {
                    if (c == ' ')
                      return '_';
-                   else
+                   else if (make_lower_case)
                      return char(std::tolower(c));
+
+                   return char(c);
                  });
   return name;
 }

--- a/packages/panzer/adapters-stk/src/Panzer_STK_TransformBCNameForIOSS.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_TransformBCNameForIOSS.hpp
@@ -22,8 +22,17 @@ namespace panzer_stk {
       lowercase letters. This function allows you to use the name
       labels used in Cubit and tie them to the correct nodeset or
       sideset in a STK mesh database.
+
+      @param bc_name String to be converted - this object is transformed in-place
+      @param make_lower_case If set to true, convert to lower case.
+      @return Returns the transformed name
+
+      NOTE: On 2026.05.30, IOSS was changed to allow for upper case in
+      sideset names. We now only have to account for the spaces being
+      changed to underscores. This behavior can be reversed with IOSS
+      properties.
   */
-  std::string transformBCNameForIOSS(std::string& bc_name);
+  std::string transformBCNameForIOSS(std::string& bc_name, const bool make_lower_case=false);
 }
 
 #endif

--- a/packages/panzer/adapters-stk/test/transform_bc_names/transform_bc_names.cpp
+++ b/packages/panzer/adapters-stk/test/transform_bc_names/transform_bc_names.cpp
@@ -13,11 +13,36 @@
 
 TEUCHOS_UNIT_TEST(TransformBCNameForIOSS, basic)
 {
-  // Cubit converts whitespace to underscore when writing to exodus.
-  // STK converts capital letters to lower case when reading exodus.
-  std::string name = "My Awesome BC";
-  const std::string return_name = panzer_stk::transformBCNameForIOSS(name);
-  const std::string gold = "my_awesome_bc";
-  TEST_EQUALITY(name, gold);
-  TEST_EQUALITY(return_name, gold);
+  // Cubit converts whitespace in sideset names to underscore when
+  // writing to exodus.  Prior to 05/2026, IOSS/STK converted capital
+  // letters to lower case when reading exodus. It now supports upper
+  // case. We allow for supporting both as IOSS behavior can be
+  // changed through properties.
+
+  // Explicit false
+  {
+    std::string name = "My Awesome BC";
+    const std::string return_name = panzer_stk::transformBCNameForIOSS(name,false);
+    const std::string gold_preserving_case = "My_Awesome_BC";
+    TEST_EQUALITY(name, gold_preserving_case);
+    TEST_EQUALITY(return_name, gold_preserving_case);
+  }
+
+  // Explicit true
+  {
+    std::string name = "My Awesome BC";
+    const std::string return_name = panzer_stk::transformBCNameForIOSS(name,true);
+    const std::string gold_lower_case = "my_awesome_bc";
+    TEST_EQUALITY(name, gold_lower_case);
+    TEST_EQUALITY(return_name, gold_lower_case);
+  }
+  
+  // Default (false)
+  {
+    std::string name = "My Awesome BC";
+    const std::string return_name = panzer_stk::transformBCNameForIOSS(name);
+    const std::string gold_preserving_case = "My_Awesome_BC";
+    TEST_EQUALITY(name, gold_preserving_case);
+    TEST_EQUALITY(return_name, gold_preserving_case);
+  }
 }


### PR DESCRIPTION
@trilinos/panzer 

## Motivation
When using a cubit mesh, sideset names could be inconsistent with the sideset names in STK mesh when it loads the exodus mesh.

1.  Cubit replaces blank space in names with underscores when it write out the mesh.
2. IOSS was making the sideset names lower case when it reads in the exodus mesh.

This function was used by applications to make the naming consistent with what ended up in the stk mesh database. In May 2025 IOSS was changed to remove this restriction on sideset names (538fd236a0277c91b9919339b2fb921abdf3a958, 5268b3718cf70887e0f6d5089524e4f37e0cf273). Application code using this function would no longer be consistent with IOSS after this date. This commit fixes this function to be consistent with current Trilinos. The function is still needed to handle the underscores in cubit output.
 
## Stakeholder Feedback
Only impacts Empire code.

## Testing
Unit test was updated.

