### PR TITLE
MueLu: Specify auxiliary matrices (via xml deck) projected down AMG hierarchy to support MinvA SOC

### DIFF
--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -1113,6 +1113,16 @@
     </parameter>
 
     <parameter>
+      <name>project auxiliary matrices</name>
+      <type>\parameterlist</type>
+      <description>Fine level matrices that will be projected down the hierarchy.
+      Currently, the list can contain any of the following parameter names
+      (``M'', ``Minv'', ``MinvA'') of type \texttt{string} and value
+      (``NoFactory'' or ``CoalesceDrop'') indicating factory which creates data.</description>
+      <comment-ML>not supported by ML</comment-ML>
+    </parameter>
+
+    <parameter>
       <name>keep data</name>
       <type>string</type>
       <default>"{}"</default>

--- a/packages/muelu/doc/UsersGuide/options_misc.tex
+++ b/packages/muelu/doc/UsersGuide/options_misc.tex
@@ -9,6 +9,11 @@
       \textit{rowmap\_X\_level.mm}; c) its column map (for matrices) is saved in
       \textit{colmap\_X\_level.mm}.}
           
+\cba{project auxiliary matrices}{\parameterlist}{Fine level matrices that will be projected down the hierarchy.
+      Currently, the list can contain any of the following parameter names
+      (``M'', ``Minv'', ``MinvA'') of type \texttt{string} and value
+      (``NoFactory'' or ``CoalesceDrop'') indicating factory which creates data.}
+          
 \cbb{print initial parameters}{bool}{true}{Print parameters provided for a hierarchy construction.}
           
 \cbb{print unused parameters}{bool}{true}{Print parameters unused during a hierarchy construction.}

--- a/packages/muelu/doc/UsersGuide/paramlist.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist.tex
@@ -169,6 +169,11 @@
       \textit{rowmap\_X\_level.mm}; c) its column map (for matrices) is saved in
       \textit{colmap\_X\_level.mm}.}
           
+\cba{project auxiliary matrices}{\parameterlist}{Fine level matrices that will be projected down the hierarchy.
+      Currently, the list can contain any of the following parameter names
+      (``M'', ``Minv'', ``MinvA'') of type \texttt{string} and value
+      (``NoFactory'' or ``CoalesceDrop'') indicating factory which creates data.}
+          
 \cbb{print initial parameters}{bool}{true}{Print parameters provided for a hierarchy construction.}
           
 \cbb{print unused parameters}{bool}{true}{Print parameters unused during a hierarchy construction.}

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -250,6 +250,11 @@
       \textit{rowmap\_X\_level.mm}; c) its column map (for matrices) is saved in
       \textit{colmap\_X\_level.mm}.}
         
+\cba{project auxiliary matrices}{\parameterlist}{Fine level matrices that will be projected down the hierarchy.
+      Currently, the list can contain any of the following parameter names
+      (``M'', ``Minv'', ``MinvA'') of type \texttt{string} and value
+      (``NoFactory'' or ``CoalesceDrop'') indicating factory which creates data.}
+        
 \cbb{keep data}{string}{"{}"}{Keep a subset of the hierarchy data after the
       hierarchy is constructed.  This could be for disk I/O, or for
       use in other preconditioners. Use comma-separated array in braces}

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
@@ -102,6 +102,11 @@ RCP<const ParameterList> CoalesceDropFactory_kokkos<Scalar, LocalOrdinal, Global
   validParamList->set<RCP<const FactoryBase>>("Minv", Teuchos::null, "Generating factory for Minv");
   validParamList->set<RCP<const FactoryBase>>("MinvA", Teuchos::null, "Generating factory for MinvA");
 
+  // Make sure we don't recursively validate options for project auxiliary matrices
+  ParameterList norecurse;
+  norecurse.disableRecursiveValidation();
+  validParamList->set<ParameterList>("project auxiliary matrices", norecurse, "matrices that will be projected on coarse levels");
+
   return validParamList;
 }
 
@@ -125,8 +130,14 @@ void CoalesceDropFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Decl
     if (distLaplMetric == "material")
       Input(currentLevel, "Material");
   }
-  if (needM)
-    Input(currentLevel, "M");
+  if (needM && (currentLevel.GetLevelID() != 0)) {
+    if (pL.isSublist("project auxiliary matrices")) {
+      auto projectList = pL.sublist("project auxiliary matrices");
+      if (projectList.isParameter("M")) Input(currentLevel, "M");
+      if (projectList.isParameter("Minv")) Input(currentLevel, "Minv");
+      if (projectList.isParameter("MinvA")) Input(currentLevel, "MinvA");
+    }
+  }
 
   bool useBlocking = pL.get<bool>("aggregation: use blocking");
 #ifdef HAVE_MUELU_COALESCEDROP_ALLOW_OLD_PARAMETERS
@@ -377,38 +388,43 @@ std::tuple<GlobalOrdinal, typename MueLu::LWGraph_kokkos<LocalOrdinal, GlobalOrd
       if (socUsesMatrix == "A")
         A_drop = A;
       else if (socUsesMatrix == "MinvA") {
-        if (currentLevel.IsAvailable("MinvA", NoFactory::get())) {
-          A_drop = currentLevel.Get<RCP<Matrix>>("MinvA", NoFactory::get());
+        bool storeMinvOnLevel = false, storeMinvAOnLevel = false;
+        if (pL.isSublist("project auxiliary matrices")) {
+          auto projectList = pL.sublist("project auxiliary matrices");
+          if (projectList.isParameter("Minv")) storeMinvOnLevel = true;
+          if (projectList.isParameter("MinvA")) storeMinvAOnLevel = true;
+          // project list appears to be empty, so default behavior is to store MinvA
+          if (!projectList.isParameter("M") && !storeMinvOnLevel && !storeMinvAOnLevel) storeMinvAOnLevel = true;
+        } else
+          storeMinvAOnLevel = true;  // default behavior is to project MinvA
+
+        if (IsAvailable(currentLevel, "MinvA")) {
+          A_drop = Get<RCP<Matrix>>(currentLevel, "MinvA");
         } else {
           RCP<Matrix> Minv;
-          if (currentLevel.IsAvailable("Minv", NoFactory::get())) {
+          if (IsAvailable(currentLevel, "Minv")) {
             Minv = Get<RCP<Matrix>>(currentLevel, "Minv");
-          } else {
-            auto M = Get<RCP<Matrix>>(currentLevel, "M");
-            // Create Minv via sparse approximate inverse
-            Minv = Utilities::SPAI(M);
-          }
+          } else {  // get M and create Minv
+            if (currentLevel.GetLevelID() == 0) {
+              auto M = currentLevel.Get<RCP<Matrix>>("M", NoFactory::get());
+              // Create Minv via sparse approximate inverse
+              Minv = Utilities::SPAI(M);
+            } else {
+              auto M = Get<RCP<Matrix>>(currentLevel, "M");
+              // Create Minv via sparse approximate inverse
+              Minv = Utilities::SPAI(M);
+            }
+            if (storeMinvOnLevel) currentLevel.Set("Minv", Minv);
+          }  // finished if/else (currentLevel.IsAvailable("Minv", *mtf)
 
           // build MinvA matrix with same sparsity pattern as A.
           A_drop      = Xpetra::MatrixFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildCopy(A);
           auto params = Teuchos::rcp(new Teuchos::ParameterList());
           params->set("MM Throw For Non-Existent Entries", false);
           A_drop = Xpetra::MatrixMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Multiply(*Minv, false, *A, false, A_drop, GetOStream(Statistics2), true, true, std::string("MinvA"), params);
-
-#ifdef JustUsingDiagMforInverse
-          {
-            // could perhaps be useful for debugging?
-            //
-            // get the diagonal inverse of M (TODO: using InverseApproximationFactory is likely better)
-            Teuchos::RCP<Vector> MinvDiag = Utilities::GetMatrixDiagonalInverse(*M);
-            // build MinvA using the graph of A
-            A_drop = MatrixFactory::BuildCopy(A);
-            // multiply MinvDiag through
-            A_drop->leftScale(*MinvDiag);
-          }
-#endif
-        }
-      }
+          if (storeMinvAOnLevel) currentLevel.Set("MinvA", A_drop);
+        }  // finished if/else  (currentLevel.IsAvailable("MinvA", NoFactory::get()))
+      }    // else if (socUsesMatrix == "MinvA") {
     }
   }
 

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_decl.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_decl.hpp
@@ -173,6 +173,7 @@ class ParameterListInterpreter : public HierarchyManager<Scalar, LocalOrdinal, G
   bool changedImplicitTranspose_;
 
   void SetEasyParameterList(const Teuchos::ParameterList& paramList);
+  void SetMinvAProjectionVariables(const Teuchos::ParameterList& paramList);
   void Validate(const Teuchos::ParameterList& paramList) const;
 
   void UpdateFactoryManager(Teuchos::ParameterList& paramList, const Teuchos::ParameterList& defaultList, FactoryManager& manager,
@@ -233,6 +234,7 @@ class ParameterListInterpreter : public HierarchyManager<Scalar, LocalOrdinal, G
   bool useBlockNumber_;
   bool useMaterial_;
   bool useKokkos_;
+  bool projectM_ = false, projectMinv_ = false, projectMinvA_ = false;
   //@}
 
   //! Factory interpreter stuff

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -108,6 +108,7 @@ namespace MueLu {
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::ParameterListInterpreter(ParameterList& paramList, Teuchos::RCP<const Teuchos::Comm<int>> comm, Teuchos::RCP<FactoryFactory> factFact, Teuchos::RCP<FacadeClassFactory> facadeFact)
   : factFact_(factFact) {
+  SetMinvAProjectionVariables(paramList);
   RCP<Teuchos::TimeMonitor> tM = rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer(std::string("MueLu: ParameterListInterpreter (ParameterList)"))));
   if (facadeFact == Teuchos::null)
     facadeFact_ = Teuchos::rcp(new FacadeClassFactory());
@@ -143,6 +144,7 @@ ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::ParameterLi
 
   ParameterList paramList;
   Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<ParameterList>(&paramList), comm);
+  SetMinvAProjectionVariables(paramList);
   SetParameterList(paramList);
 }
 
@@ -173,6 +175,27 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetPar
     ExtractNonSerializableData(paramList, serialList, nonSerialList);
     Validate(serialList);
     SetEasyParameterList(paramList);
+  }
+  std::string socUsesMatrix = paramList.get<std::string>("aggregation: strength-of-connection: matrix");
+  if ((socUsesMatrix == "MinvA") && paramList.isSublist("user data")) {
+    //  check if Muelu option is inconsistent with user data provided. Here we
+    //  assume that data has not been stripped out of user list.
+    bool Minv_Supplied = false, M_Supplied = false, MinvA_Supplied = false;
+    const Teuchos::ParameterList& userList = paramList.sublist("user data");
+    if (userList.isParameter("M")) M_Supplied = true;
+    if (userList.isParameter("Minv")) Minv_Supplied = true;
+    if (userList.isParameter("MinvA")) MinvA_Supplied = true;
+
+    if (paramList.isSublist("project auxiliary matrices")) {
+      auto projectList = paramList.sublist("project auxiliary matrices");
+      TEUCHOS_TEST_FOR_EXCEPTION(projectList.isParameter("M") && !M_Supplied, Exceptions::Incompatible, "MueLu_CreateXpetraPreconditioner: Must supply M as it is listed in the project auxiliary matrices sublist");
+      TEUCHOS_TEST_FOR_EXCEPTION(projectList.isParameter("Minv") && (projectList.get("Minv", "") == "NoFactory") && !Minv_Supplied, Exceptions::Incompatible,
+                                 "MueLu_CreateXpetraPreconditioner: Must supply Minv  as NoFactory is listed as supplier of Minv  in the project auxiliary matrices sublist");
+      TEUCHOS_TEST_FOR_EXCEPTION(projectList.isParameter("MinvA") && (projectList.get("MinvA", "") == "NoFactory") && !MinvA_Supplied, Exceptions::Incompatible,
+                                 "MueLu_CreateXpetraPreconditioner: Must supply MinvA as NoFactory is listed as supplier of MinvA in the project auxiliary matrices sublist");
+    } else {  // default behavior if sublist("project auxiliary matrices") not user-supplied requires "M" to be user-supplied.
+      TEUCHOS_TEST_FOR_EXCEPTION(!M_Supplied, Exceptions::Incompatible, "MueLu_CreateXpetraPreconditioner: Must supply M when 'aggregation: strength-of-connection: matrix'= MinvA and sublist('project auxiliary matrices') not supplied.");
+    }
   }
 }
 
@@ -241,6 +264,32 @@ static inline bool test_param_2list(const Teuchos::ParameterList& paramList, con
   else                                                                \
     varName = rcp(new newFactory());
 
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+    SetMinvAProjectionVariables(const ParameterList& constParamList) {
+  ParameterList paramList;
+  projectM_     = false;
+  projectMinv_  = false;
+  projectMinvA_ = true;
+  if (constParamList.isSublist("project auxiliary matrices")) {
+    auto projectList = constParamList.sublist("project auxiliary matrices");
+    if (projectList.isParameter("M")) {
+      projectM_     = true;
+      projectMinvA_ = false;
+    }
+    if (projectList.isParameter("Minv")) {
+      projectMinv_  = true;
+      projectMinvA_ = false;
+    }
+    if (projectList.isParameter("MinvA")) {
+      projectMinvA_ = true;
+    }
+  } else {  // default settings when "project auxiliary matrices" not specified by user
+    projectM_     = false;
+    projectMinv_  = false;
+    projectMinvA_ = true;
+  }
+}
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     SetEasyParameterList(const ParameterList& constParamList) {
@@ -721,7 +770,62 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   // === Auxiliary mass matrix for MinvA ===
   auto socMatrix = set_var_2list<std::string>(paramList, defaultList, "aggregation: strength-of-connection: matrix");
   if (socMatrix == "MinvA") {
-    UpdateFactoryManager_MatrixTransfer("M", paramList, defaultList, manager, levelID, keeps);
+    // we can either project MinvA or Minv or M to coarse levels. If we decide to project M, then
+    // it must be provided as "user data". If we decide to project Minv, then either Minv or M
+    // must be provided as "user data". In the later case, Minv will be created from M and then
+    // projected. Projecting MinvA is handled in a similar fashion to Minv. It can be provided
+    // as user data, or either M or Minv can be provided as user data.  In these later cases,
+    // MinvA will be computed in CaolesceDrop factory.
+
+    // Default: M is provided on finest level and that Minv and MinvA are computed by CoalesceDrop.
+    std::string MinvFactory  = "CoalesceDrop";
+    std::string MinvAFactory = "CoalesceDrop";
+    if (paramList.isSublist("project auxiliary matrices")) {
+      auto projectList = paramList.sublist("project auxiliary matrices");
+      if (projectList.isParameter("M")) {
+        TEUCHOS_TEST_FOR_EXCEPTION(projectList.get("M", "") != "NoFactory", Exceptions::InvalidArgument, "Must specify \"NoFactory\" when projecting M");
+      }
+      if (projectList.isParameter("Minv")) {
+        MinvFactory = projectList.get("Minv", "");
+        TEUCHOS_TEST_FOR_EXCEPTION((MinvFactory != "NoFactory") && (MinvFactory != "CoalesceDrop"), Exceptions::InvalidArgument, "Must specify \"NoFactory\" or \"CoalesceDrop\"");
+      }
+      if (projectList.isParameter("MinvA")) {
+        MinvAFactory = projectList.get("MinvA", "");
+        TEUCHOS_TEST_FOR_EXCEPTION((MinvAFactory != "NoFactory") && (MinvAFactory != "CoalesceDrop"), Exceptions::InvalidArgument, "Must specify \"NoFactory\" or \"CoalesceDrop\"");
+      }
+    }
+
+    // We don't really know what user data is supplied here. We know that if  M is a parameter of sublist("project auxiliary matrices"), then M must be user-supplied.
+    // If Minv is a parameter of sublist("project auxiliary matrices") and MinvFactory == NoFactory,  Minv must be user-supplied.  If MinvA is a parameter of
+    // sublist("project auxiliary matrices") and MinvAFactory == NoFactory,  MinvA must be user-supplied.  However, M might be supplied even though it is not
+    // a parameter of sublist("project auxiliary matrices"). The same is true for Minv and MinvA. Notice that if Minv is parameter of sublist("project auxiliary matrices")
+    // and MinvFactory == CoalesceDrop, then M should be suuplied so that Minv can be computed by CoalesceDrop factory. Thus, we should set M's level 0 factory manager
+    // to NoFactory. The tricky part is when MinvA is parameter of sublist("project auxiliary matrices") and MinvAFactory == CoalesceDrop. In this case, there are
+    // two possibilities for CoalesceDrop() to compute MinvA: a) get user M, invert it, and do mat-mat mult or b) get user Minv and do mat-mat mult. Since we
+    // don't know what the user has supplied, it is safest to set the level 0 manager for both M and Minv to NoFactory.
+
+    if (projectM_) UpdateFactoryManager_MatrixTransfer("M", paramList, defaultList, manager, levelID, keeps);
+    if (!projectM_ && projectMinv_ && (MinvFactory == "CoalesceDrop") && (levelID == 0)) manager.SetFactory("M", NoFactory::getRCP());  // need to get M to created Minv
+    if (!projectM_ && !projectMinv_ && (MinvAFactory == "CoalesceDrop") && projectMinvA_ && (levelID == 0)) {
+      manager.SetFactory("M", NoFactory::getRCP());     // might need M    to compute MinvA
+      manager.SetFactory("Minv", NoFactory::getRCP());  // might need Minv to compute MinvA
+    }
+    if (projectMinvA_) {
+      if ((levelID > 0) || (MinvAFactory == "NoFactory"))
+        UpdateFactoryManager_MatrixTransfer("MinvA", paramList, defaultList, manager, levelID, keeps);
+      else {
+        auto coalFact = rcp(new CoalesceDropFactory_kokkos());
+        manager.SetFactory("MinvA", coalFact);
+      }  // kokkos guard ?????
+    }
+    if (projectMinv_) {
+      if ((levelID > 0) || (MinvFactory == "NoFactory"))
+        UpdateFactoryManager_MatrixTransfer("Minv", paramList, defaultList, manager, levelID, keeps);
+      else {
+        auto coalFact = rcp(new CoalesceDropFactory_kokkos());
+        manager.SetFactory("Minv", coalFact);
+      }  // kokkos guard ?????
+    }
   }
 
   // === Lower precision transfers ===
@@ -1257,10 +1361,17 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
     if (useKokkos_ && (levelID > 0)) {
       if (dropParams.isParameter("aggregation: strength-of-connection: matrix") && dropParams.get<std::string>("aggregation: strength-of-connection: matrix") == "MinvA") {
-        dropFactory->SetFactory("M", this->GetFactoryManager(levelID - 1)->GetFactory("M"));
+        if (projectM_) dropFactory->SetFactory("M", this->GetFactoryManager(levelID - 1)->GetFactory("M"));
+        if (projectMinv_) dropFactory->SetFactory("Minv", this->GetFactoryManager(levelID - 1)->GetFactory("Minv"));
+        if (projectMinvA_) dropFactory->SetFactory("MinvA", this->GetFactoryManager(levelID - 1)->GetFactory("MinvA"));
       }
     }
 
+    auto socMatrix = set_var_2list<std::string>(paramList, defaultList, "aggregation: strength-of-connection: matrix");
+    if ((socMatrix == "MinvA") && (paramList.isSublist("project auxiliary matrices"))) {
+      auto projectList = paramList.sublist("project auxiliary matrices");
+      dropParams.set("project auxiliary matrices", projectList);
+    }
     dropFactory->SetParameterList(dropParams);
   }
   manager.SetFactory("Graph", dropFactory);

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -176,8 +176,7 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetPar
     Validate(serialList);
     SetEasyParameterList(paramList);
   }
-  std::string socUsesMatrix = paramList.get<std::string>("aggregation: strength-of-connection: matrix");
-  if ((socUsesMatrix == "MinvA") && paramList.isSublist("user data")) {
+  if (paramList.isParameter("aggregation: strength-of-connection: matrix") && (paramList.get<std::string>("aggregation: strength-of-connection: matrix") == "MinvA") && paramList.isSublist("user data")) {
     //  check if Muelu option is inconsistent with user data provided. Here we
     //  assume that data has not been stripped out of user list.
     bool Minv_Supplied = false, M_Supplied = false, MinvA_Supplied = false;

--- a/packages/muelu/src/MueCentral/MueLu_FactoryManager_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_FactoryManager_def.hpp
@@ -103,6 +103,8 @@ const RCP<const FactoryBase> FactoryManager<Scalar, LocalOrdinal, GlobalOrdinal,
   } else {
     // No factory was created for this name, but we may know which one to create
     if (varName == "A") return SetAndReturnDefaultFactory(varName, rcp(new RAPFactory()));
+    if (varName == "MinvA") return NoFactory::getRCP();
+    if (varName == "Minv") return NoFactory::getRCP();
     if (varName == "Ainv") return SetAndReturnDefaultFactory(varName, rcp(new InverseApproximationFactory()));
     if (varName == "RAP Pattern") return GetFactory("A");
     if (varName == "AP Pattern") return GetFactory("A");

--- a/packages/muelu/src/MueCentral/MueLu_HierarchyUtils_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_HierarchyUtils_def.hpp
@@ -96,8 +96,8 @@ void HierarchyUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::AddNonSerializab
       const ParameterList& levelList = nonSerialList.sublist(levelName);
       for (ParameterList::ConstIterator levelListEntry = levelList.begin(); levelListEntry != levelList.end(); levelListEntry++) {
         const std::string& name = levelListEntry->first;
-        TEUCHOS_TEST_FOR_EXCEPTION(name != "A" && name != "P" && name != "R" && name != "K" && name != "M" && name != "Mdiag" &&
-                                       name != "D0" && name != "Dk_1" && name != "Dk_2" &&
+        TEUCHOS_TEST_FOR_EXCEPTION(name != "A" && name != "P" && name != "R" && name != "K" && name != "M" && name != "Mdiag" && name != "Minv" &&
+                                       name != "MinvA" && name != "D0" && name != "Dk_1" && name != "Dk_2" &&
                                        name != "Mk_one" && name != "Mk_1_one" && name != "M1_beta" && name != "M1_alpha" &&
                                        name != "invMk_1_invBeta" && name != "invMk_2_invAlpha" &&
                                        name != "M1" && name != "Ms" && name != "M0inv" &&
@@ -140,7 +140,7 @@ void HierarchyUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::AddNonSerializab
           M->SetFactory(name, NoFactory::getRCP());  // TAW: not sure about this: be aware that this affects all levels
                                                      //      However, A is accessible through NoFactory anyway, so it should
                                                      //      be fine here.
-        } else if (name == "P" || name == "R" || name == "K" || name == "M") {
+        } else if (name == "P" || name == "R" || name == "K" || name == "M" || name == "Minv" || name == "MinvA") {
           if (levelListEntry->second.isType<RCP<Operator>>()) {
             RCP<Operator> mat;
             mat = Teuchos::getValue<RCP<Operator>>(levelListEntry->second);
@@ -301,8 +301,8 @@ void HierarchyUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::AddNonSerializab
         // Check if the name starts with "Nullspace", has length > 9, and the last character is a digit
         bool isNumberedNullspace = (name.rfind("Nullspace", 0) == 0 && name.length() > 9 && std::isdigit(name.back(), std::locale::classic()));
 
-        TEUCHOS_TEST_FOR_EXCEPTION(name != "P" && name != "R" && name != "K" && name != "M" && name != "Mdiag" &&
-                                       name != "D0" && name != "Dk_1" && name != "Dk_2" &&
+        TEUCHOS_TEST_FOR_EXCEPTION(name != "P" && name != "R" && name != "K" && name != "M" && name != "Mdiag" && name != "Minv" &&
+                                       name != "MinvA" && name != "D0" && name != "Dk_1" && name != "Dk_2" &&
                                        name != "Mk_one" && name != "Mk_1_one" && name != "M1_beta" && name != "M1_alpha" &&
                                        name != "invMk_1_invBeta" && name != "invMk_2_invAlpha" &&
                                        name != "M1" && name != "Ms" && name != "M0inv" &&
@@ -316,7 +316,7 @@ void HierarchyUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::AddNonSerializab
                                        !IsParamValidVariable(name),
                                    Exceptions::InvalidArgument,
                                    std::string("MueLu::Utils::AddNonSerializableDataToHierarchy: user data parameter list contains unknown data type (") + name + ")");
-        if (name == "P" || name == "R" || name == "K" || name == "M" ||
+        if (name == "P" || name == "R" || name == "K" || name == "M" || name == "Minv" || name == "MinvA" ||
             name == "D0" || name == "Dk_1" || name == "Dk_2" ||
             name == "Mk_one" || name == "Mk_1_one" || name == "M1_beta" || name == "M1_alpha" ||
             name == "invMk_1_invBeta" || name == "invMk_2_invAlpha" ||

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -251,6 +251,7 @@ namespace MueLu {
   "<Parameter name=\"aggregate qualities: percentiles\" type=\"Array(double)\" value=\"{}\"/>"
   "<Parameter name=\"aggregate qualities: mode\" type=\"string\" value=\"eigenvalue\"/>"
   "<ParameterList name=\"export data\"/>"
+  "<ParameterList name=\"project auxiliary matrices\"/>"
   "<Parameter name=\"keep data\" type=\"string\" value=\"{}\"/>"
   "<Parameter name=\"print initial parameters\" type=\"bool\" value=\"true\"/>"
   "<Parameter name=\"print unused parameters\" type=\"bool\" value=\"true\"/>"
@@ -781,6 +782,8 @@ namespace MueLu {
          ("aggregate qualities: mode","aggregate qualities: mode")
       
          ("export data","export data")
+      
+         ("project auxiliary matrices","project auxiliary matrices")
       
          ("keep data","keep data")
       

--- a/packages/muelu/src/Operators/MueLu_CreateXpetraPreconditioner.hpp
+++ b/packages/muelu/src/Operators/MueLu_CreateXpetraPreconditioner.hpp
@@ -105,6 +105,28 @@ CreateXpetraPreconditioner(Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, Glo
     std::string paramXML = MueLu::ML2MueLuParameterTranslator::translate(paramList, "");
     paramList            = *Teuchos::getParametersFromXmlString(paramXML);
   }
+  //  Need to check if Muelu option is inconsistent with user data provided
+  bool Minv_Supplied = false, M_Supplied = false, MinvA_Supplied = false;
+  if (inParamList.isSublist("user data")) {
+    const Teuchos::ParameterList& userList = inParamList.sublist("user data");
+    if (userList.isParameter("M")) M_Supplied = true;
+    if (userList.isParameter("Minv")) Minv_Supplied = true;
+    if (userList.isParameter("MinvA")) Minv_Supplied = true;
+  }
+  std::string socUsesMatrix = inParamList.get<std::string>("aggregation: strength-of-connection: matrix");
+  if (socUsesMatrix == "MinvA") {
+    if (inParamList.isSublist("project auxiliary matrices")) {
+      auto projectList = inParamList.sublist("project auxiliary matrices");
+      TEUCHOS_TEST_FOR_EXCEPTION(projectList.isParameter("M") && !M_Supplied, Exceptions::Incompatible, "MueLu_CreateXpetraPreconditioner: Must supply M as it is listed in the project auxiliary matrices sublist");
+      TEUCHOS_TEST_FOR_EXCEPTION(projectList.isParameter("Minv") && (projectList.get("Minv", "") == "NoFactory") && !Minv_Supplied, Exceptions::Incompatible,
+                                 "MueLu_CreateXpetraPreconditioner: Must supply Minv  as NoFactory is listed as supplier of Minv  in the project auxiliary matrices sublist");
+      TEUCHOS_TEST_FOR_EXCEPTION(projectList.isParameter("MinvA") && (projectList.get("MinvA", "") == "NoFactory") && !MinvA_Supplied, Exceptions::Incompatible,
+                                 "MueLu_CreateXpetraPreconditioner: Must supply MinvA as NoFactory is listed as supplier of MinvA in the project auxiliary matrices sublist");
+    } else {  // default behavior if sublist("project auxiliary matrices") not user-supplied requires "M" to be user-supplied.
+      TEUCHOS_TEST_FOR_EXCEPTION(!M_Supplied, Exceptions::Incompatible, "MueLu_CreateXpetraPreconditioner: Must supply M when 'aggregation: strength-of-connection: matrix'= MinvA and sublist('project auxiliary matrices') not supplied.");
+    }
+  }
+
   mueLuFactory = rcp(new ParameterListInterpreter(paramList, op->getDomainMap()->getComm()));
 
   // Create Hierarchy

--- a/packages/muelu/src/Operators/MueLu_CreateXpetraPreconditioner.hpp
+++ b/packages/muelu/src/Operators/MueLu_CreateXpetraPreconditioner.hpp
@@ -113,8 +113,7 @@ CreateXpetraPreconditioner(Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, Glo
     if (userList.isParameter("Minv")) Minv_Supplied = true;
     if (userList.isParameter("MinvA")) Minv_Supplied = true;
   }
-  std::string socUsesMatrix = inParamList.get<std::string>("aggregation: strength-of-connection: matrix");
-  if (socUsesMatrix == "MinvA") {
+  if (inParamList.isParameter("aggregation: strength-of-connection: matrix") && (inParamList.get<std::string>("aggregation: strength-of-connection: matrix") == "MinvA")) {
     if (inParamList.isSublist("project auxiliary matrices")) {
       auto projectList = inParamList.sublist("project auxiliary matrices");
       TEUCHOS_TEST_FOR_EXCEPTION(projectList.isParameter("M") && !M_Supplied, Exceptions::Incompatible, "MueLu_CreateXpetraPreconditioner: Must supply M as it is listed in the project auxiliary matrices sublist");

--- a/packages/muelu/src/Utils/MueLu_Utilities.cpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities.cpp
@@ -54,7 +54,7 @@ long ExtractNonSerializableData(const Teuchos::ParameterList& inList, Teuchos::P
         // Check if the name starts with "Nullspace", has length > 9, and the last character is a digit
         bool isNumberedNullspace = (name.rfind("Nullspace", 0) == 0 && name.length() > 9 && std::isdigit(name.back(), std::locale::classic()));
 
-        if (name == "A" || name == "P" || name == "R" || name == "M" || name == "Mdiag" || name == "K" || name == "Nullspace" || name == "Material" || name == "Coordinates" || name == "BlockNumber" || name == "D0" || name == "Dk_1" || name == "Dk_2" || name == "Mk_one" || name == "Mk_1_one" || name == "M1_beta" || name == "M1_alpha" || name == "invMk_1_invBeta" || name == "invMk_2_invAlpha" || name == "M1" || name == "Ms" || name == "M0inv" || name == "Pnodal" || name == "NodeMatrix" || name == "NodeAggMatrix" || name == "CurlCurl" || name == "Node Comm" || name == "DualNodeID2PrimalNodeID"
+        if (name == "A" || name == "P" || name == "R" || name == "M" || name == "Mdiag" || name == "K" || name == "Nullspace" || name == "Material" || name == "Coordinates" || name == "BlockNumber" || name == "D0" || name == "Dk_1" || name == "Dk_2" || name == "Mk_one" || name == "Mk_1_one" || name == "M1_beta" || name == "M1_alpha" || name == "invMk_1_invBeta" || name == "invMk_2_invAlpha" || name == "M1" || name == "Ms" || name == "M0inv" || name == "Pnodal" || name == "NodeMatrix" || name == "NodeAggMatrix" || name == "CurlCurl" || name == "Node Comm" || name == "DualNodeID2PrimalNodeID" || name == "Minv" || name == "MinvA"
 #if defined(HAVE_MUELU_INTREPID2) && defined(HAVE_MUELU_EXPERIMENTAL)  // For the IntrepidPCoarsenFactory
             || name == "pcoarsen: element to node map"
 #endif

--- a/packages/muelu/test/interface/default/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin1_tpetra.gold
@@ -32,6 +32,8 @@ Matrix filtering (MueLu::FilteredAFactory)
 Filtered matrix is not being constructed as no filtering is being done
 PrepareLeastSquaresSolveDirect (MueLu::DenseConstraint)
 Getting P from coarseLevel
+Reuse C pattern
+Reuse C pattern
 
 *******************************************************
 ***** Belos Iterative Solver:  Pseudo Block CG 
@@ -41,7 +43,9 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestGenResNorm<>: (2-Norm Imp Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    6.665458e+01
-Iter 1, [ 1] :    2.307178e-13
+Reuse C pattern
+Reuse C pattern
+Iter 1, [ 1] :    6.447167e-12
 Transpose P (MueLu::TransPFactory)
 matrixmatrix: kernel params -> 
  [empty list]
@@ -79,6 +83,8 @@ Matrix filtering (MueLu::FilteredAFactory)
 Filtered matrix is not being constructed as no filtering is being done
 PrepareLeastSquaresSolveDirect (MueLu::DenseConstraint)
 Getting P from coarseLevel
+Reuse C pattern
+Reuse C pattern
 
 *******************************************************
 ***** Belos Iterative Solver:  Pseudo Block CG 
@@ -88,7 +94,9 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestGenResNorm<>: (2-Norm Imp Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    4.275004e+00
-Iter 1, [ 1] :    1.202650e-14
+Reuse C pattern
+Reuse C pattern
+Iter 1, [ 1] :    5.179015e-13
 Transpose P (MueLu::TransPFactory)
 matrixmatrix: kernel params -> 
  [empty list]

--- a/packages/muelu/test/interface/default/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin3_tpetra.gold
@@ -32,6 +32,7 @@ Matrix filtering (MueLu::FilteredAFactory)
 Filtered matrix is not being constructed as no filtering is being done
 PrepareLeastSquaresSolveDirect (MueLu::DenseConstraint)
 Getting P from coarseLevel
+Reuse C pattern
 
 *******************************************************
 ***** Belos Iterative Solver:  Pseudo Block Gmres 
@@ -41,7 +42,11 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestImpResNorm<>: (2-Norm Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    6.665458e+01
-Iter 1, [ 1] :    1.690194e-16
+Reuse C pattern
+Reuse C pattern
+Reuse C pattern
+Reuse C pattern
+Iter 1, [ 1] :    1.473085e-16
 emin: num iterations = 1
 emin: iterative method = gmres
 Transpose P (MueLu::TransPFactory)
@@ -81,6 +86,7 @@ Matrix filtering (MueLu::FilteredAFactory)
 Filtered matrix is not being constructed as no filtering is being done
 PrepareLeastSquaresSolveDirect (MueLu::DenseConstraint)
 Getting P from coarseLevel
+Reuse C pattern
 
 *******************************************************
 ***** Belos Iterative Solver:  Pseudo Block Gmres 
@@ -90,7 +96,11 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestImpResNorm<>: (2-Norm Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    4.275004e+00
-Iter 1, [ 1] :    7.387975e-16
+Reuse C pattern
+Reuse C pattern
+Reuse C pattern
+Reuse C pattern
+Iter 1, [ 1] :    7.060568e-17
 emin: num iterations = 1
 emin: iterative method = gmres
 Transpose P (MueLu::TransPFactory)

--- a/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
@@ -12,6 +12,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -44,6 +46,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -79,10 +83,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation3_tpetra.gold
@@ -14,6 +14,8 @@ BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0.02, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop tol = 0.02
 aggregation: drop scheme = classical
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -48,6 +50,8 @@ BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0.02, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop tol = 0.02
 aggregation: drop scheme = classical
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -83,10 +87,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation4_tpetra.gold
@@ -14,6 +14,8 @@ BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "distance laplacian", distance laplacian metric = "unweighted", threshold = 0.05, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop tol = 0.05
 aggregation: drop scheme = distance laplacian
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -51,6 +53,8 @@ BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "distance laplacian", distance laplacian metric = "unweighted", threshold = 0.05, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop tol = 0.05
 aggregation: drop scheme = distance laplacian
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -89,10 +93,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse1_tpetra.gold
@@ -12,6 +12,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -44,6 +46,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -76,6 +80,8 @@ Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -109,11 +115,11 @@ Operator complexity = 1.48
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
-  3  371   1111   2.99     2.99         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
+  3     371   1111     2.99     2.99      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/coarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse2_tpetra.gold
@@ -12,6 +12,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -44,6 +46,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -76,6 +80,8 @@ Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -106,6 +112,8 @@ Level 4
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -136,6 +144,8 @@ Level 5
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -165,13 +175,13 @@ Operator complexity = 1.50
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
-  3  371   1111   2.99     2.99         1  
-  4  124   370    2.98     2.99         1  
-  5  42    124    2.95     2.95         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
+  3     371   1111     2.99     2.99      1
+  4     124    370     2.98     2.99      1
+  5      42    124     2.95     2.95      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/coarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse3_tpetra.gold
@@ -12,6 +12,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -44,6 +46,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -78,10 +82,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
@@ -13,6 +13,8 @@ BuildVector (MueLu::CoalesceDropFactory_kokkos)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 3, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -44,6 +46,8 @@ BuildVector (MueLu::CoalesceDropFactory_kokkos)
 Build (MueLu::AmalgamationFactory)
 [empty list]
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 3, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -75,10 +79,10 @@ Operator complexity = 2.11
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  23319  7.00     3.00         1  
-  2  1113  9999   8.98     2.99         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333  23319     7.00     3.00      1
+  2    1113   9999     8.98     2.99      1
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_mhd_np4_tpetra.gold
@@ -19,6 +19,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 Build (MueLu::AmalgamationFactory)
@@ -51,6 +53,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -81,10 +85,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10003  3.00     3.00         4  
-  2  1112  3334   3.00     3.00         4  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10003     3.00     3.00      4
+  2    1112   3334     3.00     3.00      4
 
 Smoother (level 0) both : "Ifpack2::AdditiveSchwarz": {Initialized: true, Computed: true, Iterations: 1, Overlap level: 1, Subdomain reordering: "none", Combine mode: "ZERO", Global matrix dimensions: [9999, 9999], Inner solver: {"Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [2500, 2500], Global nnz: 7498, "Ifpack2::LocalSparseTriangularSolver": {Label: "lower", Initialized: true, Computed: true, Matrix dimensions: [2500, 2500], Number of nonzeros: 2499}, "Ifpack2::LocalSparseTriangularSolver": {Label: "upper", Initialized: true, Computed: true, Matrix dimensions: [2500, 2500], Number of nonzeros: 2499}}}}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_mhd_tpetra.gold
@@ -19,6 +19,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -53,6 +55,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -83,10 +87,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::AdditiveSchwarz": {Initialized: true, Computed: true, Iterations: 1, Overlap level: 0, Subdomain reordering: "none", Combine mode: "ZERO", Global matrix dimensions: [9999, 9999], Inner solver: {"Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995, "Ifpack2::LocalSparseTriangularSolver": {Label: "lower", Initialized: true, Computed: true, Matrix dimensions: [9999, 9999], Number of nonzeros: 9998}, "Ifpack2::LocalSparseTriangularSolver": {Label: "upper", Initialized: true, Computed: true, Matrix dimensions: [9999, 9999], Number of nonzeros: 9998}}}}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
@@ -11,6 +11,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -42,6 +44,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -77,10 +81,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
@@ -11,6 +11,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -42,6 +44,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -77,10 +81,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_np4_tpetra.gold
@@ -12,6 +12,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 Build (MueLu::AmalgamationFactory)
@@ -40,6 +42,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -73,10 +77,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         4  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      4
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_tpetra.gold
@@ -12,6 +12,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -42,6 +44,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -75,10 +79,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
@@ -18,6 +18,8 @@ BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "distance laplacian", distance laplacian metric = "unweighted", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop scheme = distance laplacian
 filtered matrix: use lumping = 1
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -65,11 +67,11 @@ Operator complexity = 1.48
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
-  3  371   1111   2.99     2.99         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
+  3     371   1111     2.99     2.99      1
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -97,6 +99,8 @@ BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "distance laplacian", distance laplacian metric = "unweighted", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop scheme = distance laplacian
 filtered matrix: use lumping = 1
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -151,6 +155,8 @@ BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "distance laplacian", distance laplacian metric = "unweighted", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop scheme = distance laplacian
 filtered matrix: use lumping = 1
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
@@ -18,6 +18,8 @@ BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "distance laplacian", distance laplacian metric = "unweighted", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop scheme = distance laplacian
 filtered matrix: use lumping = 1
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -74,6 +76,8 @@ BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "distance laplacian", distance laplacian metric = "unweighted", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop scheme = distance laplacian
 filtered matrix: use lumping = 1
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -130,6 +134,8 @@ BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "distance laplacian", distance laplacian metric = "unweighted", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop scheme = distance laplacian
 filtered matrix: use lumping = 1
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -181,11 +187,11 @@ Operator complexity = 1.48
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
-  3  371   1111   2.99     2.99         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
+  3     371   1111     2.99     2.99      1
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
@@ -19,6 +19,8 @@ dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggre
 aggregation: drop tol = 0.02
 aggregation: drop scheme = distance laplacian
 filtered matrix: use lumping = 1
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -66,11 +68,11 @@ Operator complexity = 1.48
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
-  3  371   1111   2.99     2.99         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
+  3     371   1111     2.99     2.99      1
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -99,6 +101,8 @@ dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggre
 aggregation: drop tol = 0.02
 aggregation: drop scheme = distance laplacian
 filtered matrix: use lumping = 1
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -154,6 +158,8 @@ dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggre
 aggregation: drop tol = 0.02
 aggregation: drop scheme = distance laplacian
 filtered matrix: use lumping = 1
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
@@ -19,6 +19,8 @@ dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggre
 aggregation: drop tol = 0.02
 aggregation: drop scheme = distance laplacian
 filtered matrix: use lumping = 1
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -76,6 +78,8 @@ dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggre
 aggregation: drop tol = 0.02
 aggregation: drop scheme = distance laplacian
 filtered matrix: use lumping = 1
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -133,6 +137,8 @@ dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggre
 aggregation: drop tol = 0.02
 aggregation: drop scheme = distance laplacian
 filtered matrix: use lumping = 1
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -184,11 +190,11 @@ Operator complexity = 1.48
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
-  3  371   1111   2.99     2.99         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
+  3     371   1111     2.99     2.99      1
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
@@ -16,6 +16,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -29,6 +31,8 @@ matrixmatrix: kernel params ->
  [empty list]
 PrepareLeastSquaresSolveDirect (MueLu::DenseConstraint)
 Getting P from coarseLevel
+Reuse C pattern
+Reuse C pattern
 
 *******************************************************
 ***** Belos Iterative Solver:  Pseudo Block CG 
@@ -38,7 +42,9 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestGenResNorm<>: (2-Norm Imp Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    6.665458e+01
-Iter 1, [ 1] :    2.307178e-13
+Reuse C pattern
+Reuse C pattern
+Iter 1, [ 1] :    6.447167e-12
 Transpose P (MueLu::TransPFactory)
 matrixmatrix: kernel params -> 
  [empty list]
@@ -60,6 +66,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -73,6 +81,8 @@ matrixmatrix: kernel params ->
  [empty list]
 PrepareLeastSquaresSolveDirect (MueLu::DenseConstraint)
 Getting P from coarseLevel
+Reuse C pattern
+Reuse C pattern
 
 *******************************************************
 ***** Belos Iterative Solver:  Pseudo Block CG 
@@ -82,7 +92,9 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestGenResNorm<>: (2-Norm Imp Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    4.275004e+00
-Iter 1, [ 1] :    1.202650e-14
+Reuse C pattern
+Reuse C pattern
+Iter 1, [ 1] :    5.179015e-13
 Transpose P (MueLu::TransPFactory)
 matrixmatrix: kernel params -> 
  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
@@ -16,6 +16,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -29,6 +31,7 @@ matrixmatrix: kernel params ->
  [empty list]
 PrepareLeastSquaresSolveDirect (MueLu::DenseConstraint)
 Getting P from coarseLevel
+Reuse C pattern
 
 *******************************************************
 ***** Belos Iterative Solver:  Pseudo Block Gmres 
@@ -38,7 +41,11 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestImpResNorm<>: (2-Norm Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    6.665458e+01
-Iter 1, [ 1] :    1.690194e-16
+Reuse C pattern
+Reuse C pattern
+Reuse C pattern
+Reuse C pattern
+Iter 1, [ 1] :    1.473085e-16
 emin: num iterations = 1
 emin: iterative method = gmres
 Transpose P (MueLu::TransPFactory)
@@ -62,6 +69,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -75,6 +84,7 @@ matrixmatrix: kernel params ->
  [empty list]
 PrepareLeastSquaresSolveDirect (MueLu::DenseConstraint)
 Getting P from coarseLevel
+Reuse C pattern
 
 *******************************************************
 ***** Belos Iterative Solver:  Pseudo Block Gmres 
@@ -84,7 +94,11 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestImpResNorm<>: (2-Norm Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    4.275004e+00
-Iter 1, [ 1] :    7.387975e-16
+Reuse C pattern
+Reuse C pattern
+Reuse C pattern
+Reuse C pattern
+Iter 1, [ 1] :    7.060568e-17
 emin: num iterations = 1
 emin: iterative method = gmres
 Transpose P (MueLu::TransPFactory)

--- a/packages/muelu/test/interface/kokkos/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/empty_tpetra.gold
@@ -12,6 +12,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -44,6 +46,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -79,10 +83,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_tpetra.gold
@@ -12,6 +12,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -45,6 +47,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -78,6 +82,8 @@ Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -114,11 +120,11 @@ Operator complexity = 1.34
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows   nnz    nnz/row  c ratio  procs
-  0  10000  49600  4.96                  1  
-  1  1700   14928  8.78     5.88         1  
-  2  192    1674   8.72     8.85         1  
-  3  24     190    7.92     8.00         1  
+level   rows    nnz  nnz/row  c ratio  procs
+  0    10000  49600     4.96               1
+  1     1700  14928     8.78     5.88      1
+  2      192   1674     8.72     8.85      1
+  3       24    190     7.92     8.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_tpetra.gold
@@ -12,6 +12,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -45,6 +47,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -76,6 +80,8 @@ Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -112,11 +118,11 @@ Operator complexity = 1.36
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows   nnz    nnz/row  c ratio  procs
-  0  10000  49600  4.96                  4  
-  1  1700   15318  9.01     5.88         4  
-  2  216    2150   9.95     7.87         4  
-  3  32     434    13.56    6.75         4  
+level   rows    nnz  nnz/row  c ratio  procs
+  0    10000  49600     4.96               4
+  1     1700  15318     9.01     5.88      4
+  2      216   2150     9.95     7.87      4
+  3       32    434    13.56     6.75      4
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
@@ -23,6 +23,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -54,6 +56,8 @@ Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -90,11 +94,11 @@ Operator complexity = 1.34
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows   nnz    nnz/row  c ratio  procs
-  0  10000  49600  4.96                  1  
-  1  1700   14928  8.78     5.88         1  
-  2  192    1674   8.72     8.85         1  
-  3  24     190    7.92     8.00         1  
+level   rows    nnz  nnz/row  c ratio  procs
+  0    10000  49600     4.96               1
+  1     1700  14928     8.78     5.88      1
+  2      192   1674     8.72     8.85      1
+  3       24    190     7.92     8.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
@@ -23,6 +23,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -52,6 +54,8 @@ Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -88,11 +92,11 @@ Operator complexity = 1.36
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows   nnz    nnz/row  c ratio  procs
-  0  10000  49600  4.96                  4  
-  1  1700   15318  9.01     5.88         4  
-  2  216    2150   9.95     7.87         4  
-  3  32     434    13.56    6.75         4  
+level   rows    nnz  nnz/row  c ratio  procs
+  0    10000  49600     4.96               4
+  1     1700  15318     9.01     5.88      4
+  2      216   2150     9.95     7.87      4
+  3       32    434    13.56     6.75      4
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
@@ -27,6 +27,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -59,6 +61,8 @@ Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -95,11 +99,11 @@ Operator complexity = 1.34
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows   nnz    nnz/row  c ratio  procs
-  0  10000  49600  4.96                  1  
-  1  1700   14928  8.78     5.88         1  
-  2  192    1674   8.72     8.85         1  
-  3  24     190    7.92     8.00         1  
+level   rows    nnz  nnz/row  c ratio  procs
+  0    10000  49600     4.96               1
+  1     1700  14928     8.78     5.88      1
+  2      192   1674     8.72     8.85      1
+  3       24    190     7.92     8.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
@@ -27,6 +27,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -57,6 +59,8 @@ Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -93,11 +97,11 @@ Operator complexity = 1.36
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows   nnz    nnz/row  c ratio  procs
-  0  10000  49600  4.96                  4  
-  1  1700   15318  9.01     5.88         4  
-  2  216    2150   9.95     7.87         4  
-  3  32     434    13.56    6.75         4  
+level   rows    nnz  nnz/row  c ratio  procs
+  0    10000  49600     4.96               4
+  1     1700  15318     9.01     5.88      4
+  2      216   2150     9.95     7.87      4
+  3       32    434    13.56     6.75      4
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg1_tpetra.gold
@@ -14,6 +14,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -46,6 +48,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -79,10 +83,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg2_tpetra.gold
@@ -14,6 +14,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -46,6 +48,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -79,10 +83,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -58,6 +60,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -103,10 +107,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -60,6 +62,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -109,10 +113,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -59,6 +61,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -110,10 +114,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -61,6 +63,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -111,10 +115,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -63,6 +65,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -117,10 +121,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         4  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      4
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -65,6 +67,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -119,10 +123,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
@@ -14,6 +14,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -62,6 +64,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -107,10 +111,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -142,10 +146,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
@@ -14,6 +14,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -64,6 +66,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -116,10 +120,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -151,10 +155,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
@@ -14,6 +14,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -56,6 +58,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -97,10 +101,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -132,10 +136,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
@@ -14,6 +14,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -58,6 +60,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -104,10 +108,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -139,10 +143,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
@@ -14,6 +14,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -56,6 +58,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -97,10 +101,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -170,10 +174,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
@@ -14,6 +14,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -58,6 +60,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -104,10 +108,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -181,10 +185,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
@@ -14,6 +14,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -62,6 +64,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -107,10 +111,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -135,6 +139,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -183,6 +189,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -228,10 +236,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
@@ -14,6 +14,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -64,6 +66,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -116,10 +120,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -144,6 +148,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -194,6 +200,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -245,10 +253,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
@@ -14,6 +14,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -62,6 +64,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -107,10 +111,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -135,10 +139,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
@@ -14,6 +14,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -64,6 +66,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -116,10 +120,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -144,10 +148,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -58,6 +60,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -103,10 +107,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -130,6 +134,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -175,6 +181,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -220,10 +228,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -60,6 +62,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -109,10 +113,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -136,6 +140,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -183,6 +189,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -231,10 +239,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
@@ -14,6 +14,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -62,6 +64,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -109,10 +113,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -137,6 +141,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Reusing previous AP data
 matrixmatrix: kernel params -> 
  [empty list]
@@ -173,6 +179,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Reusing previous AP data
 matrixmatrix: kernel params -> 
  [empty list]
@@ -206,10 +214,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
@@ -14,6 +14,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -64,6 +66,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -116,10 +120,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -144,6 +148,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Reusing previous AP data
 matrixmatrix: kernel params -> 
  [empty list]
@@ -180,6 +186,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Reusing previous AP data
 matrixmatrix: kernel params -> 
  [empty list]
@@ -217,10 +225,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
@@ -14,6 +14,8 @@ Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0.02, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop tol = 0.02
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -63,6 +65,8 @@ Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0.02, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop tol = 0.02
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -110,10 +114,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -138,6 +142,8 @@ Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0.02, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop tol = 0.02
+project auxiliary matrices -> 
+ [empty list]
 matrixmatrix: kernel params -> 
  [empty list]
 Using original prolongator
@@ -172,6 +178,8 @@ Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0.02, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop tol = 0.02
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -219,10 +227,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
@@ -14,6 +14,8 @@ Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0.02, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop tol = 0.02
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -65,6 +67,8 @@ Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0.02, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop tol = 0.02
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -116,10 +120,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -144,6 +148,8 @@ Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0.02, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop tol = 0.02
+project auxiliary matrices -> 
+ [empty list]
 matrixmatrix: kernel params -> 
  [empty list]
 Using original prolongator
@@ -178,6 +184,8 @@ Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0.02, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
 aggregation: drop tol = 0.02
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -228,10 +236,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -61,6 +63,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -108,10 +112,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -135,6 +139,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Reusing previous AP data
 matrixmatrix: kernel params -> 
  [empty list]
@@ -171,6 +177,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -218,10 +226,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -63,6 +65,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -114,10 +118,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -141,6 +145,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Reusing previous AP data
 matrixmatrix: kernel params -> 
  [empty list]
@@ -177,6 +183,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -227,10 +235,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother10_tpetra.gold
@@ -11,6 +11,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -42,6 +44,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -77,10 +81,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 3, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother11_tpetra.gold
@@ -16,6 +16,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -52,6 +54,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -87,10 +91,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 3, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 0, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
@@ -11,6 +11,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -42,6 +44,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -73,6 +77,8 @@ Level 3
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -102,6 +108,8 @@ Level 4
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -131,6 +139,8 @@ Level 5
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -164,13 +174,13 @@ Operator complexity = 1.50
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
-  3  371   1111   2.99     2.99         1  
-  4  124   370    2.98     2.99         1  
-  5  42    124    2.95     2.95         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
+  3     371   1111     2.99     2.99      1
+  4     124    370     2.98     2.99      1
+  5      42    124     2.95     2.95      1
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
@@ -14,6 +14,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -48,6 +50,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -83,10 +87,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995, "Ifpack2::LocalSparseTriangularSolver": {Label: "lower", Initialized: true, Computed: true, Matrix dimensions: [9999, 9999], Number of nonzeros: 9998}, "Ifpack2::LocalSparseTriangularSolver": {Label: "upper", Initialized: true, Computed: true, Matrix dimensions: [9999, 9999], Number of nonzeros: 9998}}

--- a/packages/muelu/test/interface/kokkos/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother1_tpetra.gold
@@ -12,6 +12,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -44,6 +46,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -79,10 +83,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother2_tpetra.gold
@@ -12,6 +12,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -44,6 +46,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -79,10 +83,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother3_tpetra.gold
@@ -12,6 +12,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -44,6 +46,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -79,10 +83,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/kokkos/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother4_tpetra.gold
@@ -6,6 +6,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -32,6 +34,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -67,10 +71,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
@@ -11,6 +11,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -42,6 +44,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -77,10 +81,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother6_tpetra.gold
@@ -9,6 +9,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -38,6 +40,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -73,10 +77,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::ILUT": {Initialized: true, Computed: true, Level-of-fill: 1, absolute threshold: 0, relative threshold: 1, relaxation value: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
@@ -14,6 +14,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -48,6 +50,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -83,10 +87,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1, algorithm: first}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::ILUT": {Initialized: true, Computed: true, Level-of-fill: 1, absolute threshold: 0, relative threshold: 1, relaxation value: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/kokkos/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/sync1_tpetra.gold
@@ -12,6 +12,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -44,6 +46,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -79,10 +83,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose1_tpetra.gold
@@ -12,6 +12,8 @@ Level 1
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -42,6 +44,8 @@ Level 2
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -75,10 +79,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -53,6 +55,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -93,10 +97,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -55,6 +57,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -99,10 +103,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -54,6 +56,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -95,10 +99,10 @@ Operator complexity = 1.45
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  4  
-  1  3335  10015  3.00     3.00         4  
-  2  1112  3340   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335  10015     3.00     3.00      4
+  2    1112   3340     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -56,6 +58,8 @@ Build (MueLu::RebalanceTransferFactory)
 Prolongator smoothing (MueLu::SaPFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
@@ -101,10 +105,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -43,6 +45,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -75,10 +79,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
@@ -13,6 +13,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -44,6 +46,8 @@ Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory)
 BuildScalar (MueLu::CoalesceDropFactory_kokkos)
 dropping scheme = "point-wise", strength-of-connection measure = "smoothed aggregation", strength-of-connection matrix = "A", threshold = 0, blocksize = 1, useBlocking = 0, symmetrizeDroppedGraph = 0
+project auxiliary matrices -> 
+ [empty list]
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregatesRandom (Phase 1 (main))
 BuildAggregatesRandom (Phase 2a (secondary))
@@ -77,10 +81,10 @@ Operator complexity = 1.44
 Smoother complexity = <ignored>
 Cycle type          = V
 
-level  rows  nnz    nnz/row  c ratio  procs
-  0  9999  29995  3.00                  1  
-  1  3333  9997   3.00     3.00         1  
-  2  1111  3331   3.00     3.00         1  
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               1
+  1    3333   9997     3.00     3.00      1
+  2    1111   3331     3.00     3.00      1
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -105,6 +105,8 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(
     material.mm
     material.xml
     MinvA.xml
+    MinvA_ProjM.xml
+    MinvA_ProjMinv.xml
     multiPhys4x4.mat
     multiPhys4x4.mat
     multiphys_blocked_smoother.xml
@@ -629,6 +631,24 @@ MUELU_ADD_SERIAL_AND_MPI_TEST(
   Driver
   NAME "MinvA"
   ARGS "--xml=MinvA.xml --its=30 --matrixType=HexFEM_LapStiff --nx=50 --ny=40 --nz=10   --stretchx=.013 --stretchy=.94 --stretchz=.97  --tol=1e-6 "
+  NUM_MPI_PROCS 4
+  COMM serial mpi
+  PASS_REGULAR_EXPRESSION "Belos converged"
+)
+
+MUELU_ADD_SERIAL_AND_MPI_TEST(
+  Driver
+  NAME "ProjectM"
+  ARGS "--xml=MinvA_ProjM.xml --its=30 --matrixType=HexFEM_LapStiff --nx=50 --ny=40 --nz=10   --stretchx=.013 --stretchy=.94 --stretchz=.97  --tol=1e-6 "
+  NUM_MPI_PROCS 4
+  COMM serial mpi
+  PASS_REGULAR_EXPRESSION "Belos converged"
+)
+
+MUELU_ADD_SERIAL_AND_MPI_TEST(
+  Driver
+  NAME "ProjectMinv"
+  ARGS "--xml=MinvA_ProjMinv.xml --its=30 --matrixType=HexFEM_LapStiff --nx=50 --ny=40 --nz=10   --stretchx=.013 --stretchy=.94 --stretchz=.97  --tol=1e-6 "
   NUM_MPI_PROCS 4
   COMM serial mpi
   PASS_REGULAR_EXPRESSION "Belos converged"

--- a/packages/muelu/test/scaling/MinvA_ProjM.xml
+++ b/packages/muelu/test/scaling/MinvA_ProjM.xml
@@ -1,0 +1,58 @@
+<ParameterList name="MueLu">
+  <!-- ===========  GENERAL ================ -->
+  <Parameter        name="verbosity"                            type="string"   value="high"/>
+  <Parameter        name="coarse: max size"                     type="int"      value="500"/>
+  <Parameter        name="transpose: use implicit"              type="bool"     value="true"/>
+  <Parameter        name="max levels"                	          type="int"      value="10"/>
+  <Parameter        name="number of equations"                  type="int"      value="1"/>
+
+  <Parameter        name="multigrid algorithm"                  type="string"   value="sa"/>
+  <Parameter        name="sa: use filtered matrix"              type="bool"     value="true"/>
+  <Parameter        name="filtered matrix: use spread lumping"  type="bool"   value="false" />
+  <Parameter        name="filtered matrix: reuse graph"  type="bool"   value="false"        />
+
+  <!-- ===========  AGGREGATION  =========== -->
+  <Parameter        name="aggregation: type"                    type="string"   value="uncoupled"/>
+  <Parameter        name="aggregation: backend"                 type="string"   value="kokkos"/>
+  <Parameter        name="aggregation: ordering"                type="string"   value="natural"/>
+  <Parameter        name="use kokkos refactor"                  type="bool" value="true"/>
+  <Parameter        name="tentative: calculate qr"              type="bool" value="false"/>
+
+  <Parameter        name="aggregation: strength-of-connection: matrix" type="string"  value="MinvA"  />
+  <Parameter        name="aggregation: strength-of-connection: measure" type="string" value="signed ruge-stueben"/>
+  <Parameter        name="aggregation: drop scheme" type="string"                     value="point-wise"          />
+  <Parameter        name="filtered matrix: lumping choice"  type="string"             value="distributed lumping" />
+  <Parameter        name="aggregation: symmetrize graph after dropping" type="bool"   value="false"               />
+  <Parameter        name="aggregation: drop tol" type="double"                        value=".1"                />
+
+  <!-- ===========  SMOOTHING  =========== -->
+  <Parameter        name="smoother: type"                       type="string"   value="RELAXATION"/>
+  <ParameterList name="smoother: params">
+    <Parameter name="relaxation: sweeps"                      type="int"       value="1"/>
+    <Parameter name="relaxation: type"             type="string"    value="Symmetric Gauss-Seidel"/>
+  </ParameterList>
+  <ParameterList name="project auxiliary matrices">
+    <Parameter name="M" type="string" value="NoFactory"/>
+  </ParameterList>
+
+  <!-- ===========  REPARTITIONING  =========== -->
+
+  <!-- The repartitioning parameters are chosen so that we get 3
+       levels on 4, 2 and 1 ranks. This is because we want to test
+       that rebalancing of M works correctly. These settings are most
+       likely not great for performance. -->
+  
+    <Parameter        name="repartition: enable"                  type="bool"     value="true"/>
+    <Parameter        name="repartition: partitioner"             type="string"   value="zoltan2"/>
+    <Parameter        name="repartition: start level"             type="int"      value="1"/>
+    <Parameter        name="repartition: min rows per proc"       type="int"      value="800"/>
+    <Parameter        name="repartition: max imbalance"           type="double"   value="1.1"/>
+    <Parameter        name="repartition: remap parts"             type="bool"     value="false"/>
+    <!-- start of default values for repartitioning (can be omitted) -->
+    <Parameter name="repartition: remap parts"                type="bool"     value="true"/>
+    <Parameter name="repartition: rebalance P and R"          type="bool"     value="false"/>
+    <ParameterList name="repartition: params">
+       <Parameter name="algorithm" type="string" value="multijagged"/>
+    </ParameterList>
+</ParameterList>
+

--- a/packages/muelu/test/scaling/MinvA_ProjMinv.xml
+++ b/packages/muelu/test/scaling/MinvA_ProjMinv.xml
@@ -1,0 +1,58 @@
+<ParameterList name="MueLu">
+  <!-- ===========  GENERAL ================ -->
+  <Parameter        name="verbosity"                            type="string"   value="high"/>
+  <Parameter        name="coarse: max size"                     type="int"      value="500"/>
+  <Parameter        name="transpose: use implicit"              type="bool"     value="true"/>
+  <Parameter        name="max levels"                	          type="int"      value="10"/>
+  <Parameter        name="number of equations"                  type="int"      value="1"/>
+
+  <Parameter        name="multigrid algorithm"                  type="string"   value="sa"/>
+  <Parameter        name="sa: use filtered matrix"              type="bool"     value="true"/>
+  <Parameter        name="filtered matrix: use spread lumping"  type="bool"   value="false" />
+  <Parameter        name="filtered matrix: reuse graph"  type="bool"   value="false"        />
+
+  <!-- ===========  AGGREGATION  =========== -->
+  <Parameter        name="aggregation: type"                    type="string"   value="uncoupled"/>
+  <Parameter        name="aggregation: backend"                 type="string"   value="kokkos"/>
+  <Parameter        name="aggregation: ordering"                type="string"   value="natural"/>
+  <Parameter        name="use kokkos refactor"                  type="bool" value="true"/>
+  <Parameter        name="tentative: calculate qr"              type="bool" value="false"/>
+
+  <Parameter        name="aggregation: strength-of-connection: matrix" type="string"  value="MinvA"  />
+  <Parameter        name="aggregation: strength-of-connection: measure" type="string" value="signed ruge-stueben"/>
+  <Parameter        name="aggregation: drop scheme" type="string"                     value="point-wise"          />
+  <Parameter        name="filtered matrix: lumping choice"  type="string"             value="distributed lumping" />
+  <Parameter        name="aggregation: symmetrize graph after dropping" type="bool"   value="false"               />
+  <Parameter        name="aggregation: drop tol" type="double"                        value=".1"                />
+
+  <!-- ===========  SMOOTHING  =========== -->
+  <Parameter        name="smoother: type"                       type="string"   value="RELAXATION"/>
+  <ParameterList name="smoother: params">
+    <Parameter name="relaxation: sweeps"                      type="int"       value="1"/>
+    <Parameter name="relaxation: type"             type="string"    value="Symmetric Gauss-Seidel"/>
+  </ParameterList>
+  <ParameterList name="project auxiliary matrices">
+    <Parameter name="Minv" type="string" value="CoalesceDrop"/>
+  </ParameterList>
+
+  <!-- ===========  REPARTITIONING  =========== -->
+
+  <!-- The repartitioning parameters are chosen so that we get 3
+       levels on 4, 2 and 1 ranks. This is because we want to test
+       that rebalancing of M works correctly. These settings are most
+       likely not great for performance. -->
+  
+    <Parameter        name="repartition: enable"                  type="bool"     value="true"/>
+    <Parameter        name="repartition: partitioner"             type="string"   value="zoltan2"/>
+    <Parameter        name="repartition: start level"             type="int"      value="1"/>
+    <Parameter        name="repartition: min rows per proc"       type="int"      value="800"/>
+    <Parameter        name="repartition: max imbalance"           type="double"   value="1.1"/>
+    <Parameter        name="repartition: remap parts"             type="bool"     value="false"/>
+    <!-- start of default values for repartitioning (can be omitted) -->
+    <Parameter name="repartition: remap parts"                type="bool"     value="true"/>
+    <Parameter name="repartition: rebalance P and R"          type="bool"     value="false"/>
+    <ParameterList name="repartition: params">
+       <Parameter name="algorithm" type="string" value="multijagged"/>
+    </ParameterList>
+</ParameterList>
+


### PR DESCRIPTION
New capability to specify in an xml deck that auxiliary matrices be projected down the entire hierarchy. This is intended to support the MinvA SOC matrix. At this point only 3 auxiliary matrices can be specified: M, Minv, and MinvA. The XML file also specifies the factory that is responsible for creating the data that will be pushed down the hierarchy. Currently, these factories must be either NoFactory or CoalesceDrop. NoFactory indicates that the matrix is user supplied on Level 0. CoalesceDrop indicates that MueLu_CoalesceDropFactory_kokkos_def.hpp created the matrix. When 'M' is supplied, the factory specification must be NoFactory.

@trilinos/muelu 

## Motivation
 * Provides user ability to specify which matrices are projected down the hierarchy to support MinvA SOC option. Previously, MueLu would automatically project M and then recompute both Minv and then MinvA. The new option allows one to avoid the high setup cost associated with computing a sparse approximate inverse on each level. It also allows users/applications to define M and then use MueLu to compute Minv which can be then be reused over multiple solves or even the entire simulation. This is handy as M and so Minv often do not change within a simulation and so the cost to calculate Minv is amortized. The new MinvA default behavior (for xml decks that do not specify auxiliary matrices to be projected) is to take a user defined M and use this to compute MinvA and then project this down the hierarchy.

## Testing
 * 2 new scaling tests have been added to the repo using MueLu_Driver.exe . One test takes the user defined M and projects it down the hierarchy. The other test takes the user defined M and computes Minv inside MueLu, which then gets projected down the hierarchy. 


