### PR TITLE
Add env for OLCF/Frontier

### DIFF
--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -1,0 +1,94 @@
+Environments and configurations for Trilinos builds
+================================================================
+
+This folder contains:
+
+- `get_dependencies.sh` script
+
+  This script pulls in all dependencies for managing runtime environments and build configurations.
+
+
+- `ini-files` folder
+
+  The folder contains environments and configurations for Trilinos PR builds (in containers) and select open systems.
+
+
+Usage
+======
+
+To initialize the scrips run
+```
+$TRILINOS_SRC/packages/framework/get_dependencies.sh
+```
+All scripts will be checked out in the Trilinos source directory under `packages/framework`.
+
+Two scripts are particularly useful: LoadEnv and GenConfig. 
+The scripts map a configuration string with keywords that are separated by underscores to an environment or a build configuration respectively.
+
+For example:
+```
+source $TRILINOS_SRC/packages/framework/GenConfig/LoadEnv/load-env.sh frontier_mi250x
+source $TRILINOS_SRC/packages/framework/GenConfig/gen-config.sh       frontier_mi250x_release_static_AMDgfx90a_Zen3_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_nightly-performance $TRILINOS_SRC
+```
+
+LoadEnv: Managing environments
+--------------------------------------
+
+LoadEnv manages runtime environments (environment variables, modules, etc).
+
+
+Getting help:
+```
+source $TRILINOS_SRC/packages/framework/GenConfig/LoadEnv/load-env.sh --help
+```
+
+Listing the available environments on the current system:
+```
+source $TRILINOS_SRC/packages/framework/GenConfig/LoadEnv/load-env.sh --list-envs
+```
+
+LoadEnv tries to identify the system by its hostname. This mechanism can be overridden by
+```
+source $TRILINOS_SRC/packages/framework/GenConfig/LoadEnv/load-env.sh --list-envs --force <SYSTEM_NAME>
+```
+
+Loading an environment in a new subshell:
+```
+source $TRILINOS_SRC/packages/framework/GenConfig/LoadEnv/load-env.sh <ENV_STRING>
+```
+
+Loading an environment in the current shell:
+```
+source $TRILINOS_SRC/packages/framework/GenConfig/LoadEnv/load-env.sh --ci-mode <ENV_STRING>
+```
+
+
+GenConfig: Managing build configurations and environments
+-----------------------------------------------------------------------
+
+In addition to loading an environment with LoadEnv, GenConfig also handles build configurations.
+
+Getting help:
+```
+source $TRILINOS_SRC/packages/framework/GenConfig/gen-config.sh --help
+```
+
+Listing the available configurations on the current system:
+```
+source $TRILINOS_SRC/packages/framework/GenConfig/gen-config.sh --list-configs
+```
+
+Listing  available configuration flags:
+```
+source $TRILINOS_SRC/packages/framework/GenConfig/gen-config.sh --list-config-flags
+```
+
+Loading an environment in a new subshell and configuring a build in the current directory:
+```
+source $TRILINOS_SRC/packages/framework/GenConfig/gen-config.sh <CONFIG_STRING> $TRILINOS_SRC
+```
+
+Loading an environment in the current shell and configuring a build in the current directory:
+```
+source $TRILINOS_SRC/packages/framework/GenConfig/gen-config.sh --ci-mode <CONFIG_STRING> $TRILINOS_SRC
+```

--- a/packages/framework/get_dependencies.sh
+++ b/packages/framework/get_dependencies.sh
@@ -3,8 +3,7 @@ ini_file_option=$1
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 # Data that needs to be updated when GenConfig changes!
-genconfig_sha1=88c44e347c0377a170ec9ca45a47732a9630b4ec
-
+genconfig_sha1=f0235b4bef904f8851d3edd953005bc5bbb8d05a
 
 # The following code contains no changing data
 

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -605,11 +605,17 @@ opt-set-cmake-var Kokkos_ARCH_VEGA908 BOOL : ON
 [KOKKOS-ARCH|AMDAVX]
 opt-set-cmake-var Kokkos_ARCH_AMDAVX BOOL : ON
 
+[KOKKOS-ARCH|GFX90A]
+opt-set-cmake-var Kokkos_ARCH_AMD_GFX90A BOOL : ON
+
 [KOKKOS-ARCH|ZEN]
 opt-set-cmake-var Kokkos_ARCH_ZEN BOOL : ON
 
 [KOKKOS-ARCH|ZEN2]
 opt-set-cmake-var Kokkos_ARCH_ZEN2 BOOL : ON
+
+[KOKKOS-ARCH|ZEN3]
+opt-set-cmake-var Kokkos_ARCH_ZEN3 BOOL : ON
 
 
 
@@ -642,6 +648,18 @@ opt-set-cmake-var TPL_ENABLE_CUDA                 BOOL   : ON
 opt-set-cmake-var TPL_ENABLE_CUSPARSE             BOOL   : ON
 # FIXME: This really should be somewhere else (like CUDA+OpenMPI?)
 opt-set-cmake-var MPI_EXEC FILEPATH : mpiexec
+
+[NODE-TYPE|HIP]
+opt-set-cmake-var Trilinos_ENABLE_OpenMP          BOOL   : OFF
+opt-set-cmake-var Kokkos_ENABLE_OPENMP            BOOL   : OFF
+opt-set-cmake-var Phalanx_KOKKOS_DEVICE_TYPE      STRING : HIP
+opt-set-cmake-var Tpetra_INST_SERIAL              BOOL   : ON
+opt-set-cmake-var Kokkos_ENABLE_HIP               BOOL   : ON
+opt-set-cmake-var Tpetra_INST_HIP                 BOOL   : ON
+opt-set-cmake-var Sacado_ENABLE_HIERARCHICAL_DFAD BOOL   : ON
+opt-set-cmake-var TPL_ENABLE_ROCBLAS              BOOL   : ON
+opt-set-cmake-var TPL_ENABLE_ROCSOLVER            BOOL   : ON
+opt-set-cmake-var TPL_ENABLE_ROCSPARSE            BOOL   : ON
 
 [NODE-TYPE|OPENMP]
 opt-set-cmake-var Trilinos_ENABLE_OpenMP          BOOL   : ON
@@ -1440,3 +1458,84 @@ opt-set-cmake-var TFW_Python_Testing BOOL FORCE : ON
 opt-set-cmake-var PYTHON_PIP_EXECUTABLE STRING FORCE : pip3
 opt-set-cmake-var PYTHON_EXECUTABLE STRING FORCE : ${PYTHON_EXECUTABLE|ENV}
 opt-set-cmake-var Trilinos_ENABLE_BUILD_STATS BOOL FORCE   : OFF
+
+[PACKAGE-ENABLES|NIGHTLY-PERFORMANCE]
+opt-set-cmake-var Trilinos_TEST_CATEGORIES STRING : PERFORMANCE
+opt-set-cmake-var Trilinos_ENABLE_EXAMPLES BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_TESTS BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_SHADOW_WARNINGS BOOL : OFF
+
+opt-set-cmake-var Trilinos_ENABLE_Belos BOOL : ON
+opt-set-cmake-var  Belos_ENABLE_TESTS BOOL : ON
+opt-set-cmake-var Trilinos_ENABLE_Ifpack2 BOOL : ON
+opt-set-cmake-var  Ifpack2_ENABLE_TESTS BOOL : ON
+opt-set-cmake-var  Ifpack2_ENABLE_BlockTriDiContainer_Timers BOOL : ON
+opt-set-cmake-var Trilinos_ENABLE_Intrepid2 BOOL : ON
+opt-set-cmake-var  Intrepid2_ENABLE_TESTS BOOL : ON
+opt-set-cmake-var Trilinos_ENABLE_Kokkos BOOL : ON
+opt-set-cmake-var Trilinos_ENABLE_KokkosKernels BOOL : ON
+opt-set-cmake-var Trilinos_ENABLE_MueLu BOOL : ON
+opt-set-cmake-var  MueLu_ENABLE_TESTS BOOL : ON
+opt-set-cmake-var Trilinos_ENABLE_Panzer BOOL : ON
+opt-set-cmake-var Trilinos_ENABLE_PanzerMiniEM BOOL : ON
+opt-set-cmake-var  PanzerMiniEM_ENABLE_EXAMPLES BOOL : ON
+opt-set-cmake-var  PanzerMiniEM_ENABLE_TESTS BOOL : ON
+opt-set-cmake-var Trilinos_ENABLE_Percept BOOL : OFF
+opt-set-cmake-var Trilinos_ENABLE_ShyLU BOOL : ON
+opt-set-cmake-var Trilinos_ENABLE_ShyLU_Node BOOL : ON
+opt-set-cmake-var Trilinos_ENABLE_ShyLU_DDFROSch BOOL : ON
+opt-set-cmake-var  ShyLU_ENABLE_TESTS BOOL : ON
+opt-set-cmake-var  ShyLU_Node_ENABLE_TESTS BOOL : ON
+opt-set-cmake-var  ShyLU_DDFROSch_ENABLE_TESTS BOOL : ON
+opt-set-cmake-var Trilinos_ENABLE_Tpetra BOOL : ON
+opt-set-cmake-var  Tpetra_ENABLE_TESTS BOOL : ON
+opt-set-cmake-var Trilinos_ENABLE_Zoltan2 BOOL : ON
+opt-set-cmake-var  Zoltan2_ENABLE_TESTS BOOL : ON
+
+[FRONTIER]
+opt-set-cmake-var CMAKE_CXX_FLAGS STRING : "-I${MPICH_DIR|ENV}/include"
+
+opt-set-cmake-var TPL_ENABLE_MPI BOOL : ON
+opt-set-cmake-var MPI_EXEC STRING  : srun
+opt-set-cmake-var MPI_EXEC_NUMPROCS_FLAG STRING : "-c7;--gpus-per-task=1;--gpu-bind=closest;-n"
+
+opt-set-cmake-var TPL_ENABLE_BLAS BOOL : ON
+opt-set-cmake-var TPL_BLAS_LIBRARIES STRING : "${CRAY_LIBSCI_PREFIX_DIR|ENV}/lib/libsci_amd.so"
+
+opt-set-cmake-var TPL_ENABLE_LAPACK BOOL : ON
+opt-set-cmake-var TPL_LAPACK_LIBRARIES STRING : "${CRAY_LIBSCI_PREFIX_DIR|ENV}/lib/libsci_amd.so"
+
+opt-set-cmake-var TPL_ENABLE_Netcdf BOOL : ON
+opt-set-cmake-var Netcdf_INCLUDE_DIRS STRING : "${NETCDF_DIR|ENV}/include;${PNETCDF_DIR|ENV}/include"
+opt-set-cmake-var Netcdf_LIBRARY_DIRS STRING : "${NETCDF_DIR|ENV}/lib;${PNETCDF_DIR|ENV}/lib"
+opt-set-cmake-var TPL_Netcdf_PARALLEL BOOL : ON
+
+opt-set-cmake-var TPL_ENABLE_Pnetcdf BOOL : ON
+opt-set-cmake-var Pnetcdf_INCLUDE_DIRS STRING : ${PNETCDF_DIR|ENV}/include
+opt-set-cmake-var Pnetcdf_LIBRARY_DIRS STRING : ${PNETCDF_DIR|ENV}/lib
+
+opt-set-cmake-var TPL_ENABLE_HDF5 BOOL : ON
+opt-set-cmake-var HDF5_INCLUDE_DIRS STRING : ${HDF5_DIR|ENV}/include
+opt-set-cmake-var HDF5_LIBRARY_DIRS STRING : ${HDF5_DIR|ENV}/lib
+
+opt-set-cmake-var TPL_ENABLE_gtest BOOL : OFF
+
+[frontier_mi250x_release_static_AMDgfx90a_Zen3_no-asan_no-complex_fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_nightly-performance]
+use PACKAGE-ENABLES|NIGHTLY-PERFORMANCE
+use FRONTIER
+use NODE-TYPE|HIP
+
+opt-set-cmake-var Trilinos_EXTRA_LINK_FLAGS STRING : "${CRAY_XPMEM_POST_LINK_OPTS|ENV} -lxpmem ${PE_MPICH_GTL_DIR_amd_gfx90a|ENV} ${PE_MPICH_GTL_LIBS_amd_gfx90a|ENV}"
+
+# opt-set-cmake-var CMAKE_INSTALL_PREFIX : ${TRILINOS_INSTALL}
+
+opt-set-cmake-var Trilinos_ENABLE_Fortran BOOL : OFF
+opt-set-cmake-var CMAKE_C_COMPILER STRING : mpicc
+opt-set-cmake-var CMAKE_CXX_COMPILER STRING : mpicxx
+# opt-set-cmake-var CMAKE_C_FLAGS STRING : ""
+
+opt-set-cmake-var Tpetra_ENABLE_MMM_Timings BOOL : ON
+opt-set-cmake-var Tpetra_ASSUME_GPU_AWARE_MPI BOOL : ON
+opt-set-cmake-var Teuchos_TIMER_KOKKOS_FENCE BOOL : ON
+
+

--- a/packages/framework/ini-files/environment-specs.ini
+++ b/packages/framework/ini-files/environment-specs.ini
@@ -156,6 +156,14 @@ envvar-find-in-path MPICC  : mpicc
 envvar-find-in-path MPICXX : mpicxx
 envvar-find-in-path MPIF90 : mpif90
 
+[EAGER-LOADING]
+envvar-set CUDA_MODULE_LOADING : EAGER
+envvar-set HIP_ENABLE_DEFERRED_LOADING : 0
+
+[DEVICE-AWARE-MPI]
+envvar-set MPICH_GPU_SUPPORT_ENABLED : 1
+envvar-set TPETRA_ASSUME_GPU_AWARE_MPI : 1
+
 [rhel_gcc]
 [rhel_clang-openmpi]
 
@@ -189,3 +197,22 @@ envvar-set MPIR_CVAR_CH4_OFI_RANK_BITS : 8
 
 [rhel8_oneapi-intelmpi]
 use rhel_oneapi-intelmpi
+
+[frontier_mi250x]
+use EAGER-LOADING
+use DEVICE-AWARE-MPI
+module-purge
+module-load DefApps
+module-load PrgEnv-amd
+module-load amd/6.4.1
+module-load rocm/6.4.1
+module-swap cray-mpich : cray-mpich/8.1.30
+module-load craype-accel-amd-gfx90a
+module-load cray-libsci
+module-load zlib
+module-load cray-hdf5-parallel
+module-load cray-netcdf-hdf5parallel
+module-load cray-parallel-netcdf
+module-load ninja
+module-load xpmem
+envvar-prepend LD_LIBRARY_PATH : ${CRAY_LD_LIBRARY_PATH}

--- a/packages/framework/ini-files/supported-config-flags.ini
+++ b/packages/framework/ini-files/supported-config-flags.ini
@@ -194,11 +194,13 @@ kokkos-arch:  SELECT_MANY
     Vega900
     Vega906
     Vega908
+    AMDgfx90a
 
     # AMD-CPUS
     AMDAVX
     Zen
     Zen2
+    Zen3
 
 # Whether or not to turn on the Clang address sanitizer.
 use-asan:  SELECT_ONE
@@ -257,3 +259,4 @@ package-enables:  SELECT_MANY
     all-no-epetra # all packages, with Epetra stack disabled
     compsim      # set of package enables for CompSim
     ramses       # RAMSES customer configuration
+    nightly-performance # setting for nightly performance builds

--- a/packages/framework/ini-files/supported-envs.ini
+++ b/packages/framework/ini-files/supported-envs.ini
@@ -197,3 +197,7 @@ sems-intel-2021.3-sems-openmpi-4.1.6
 
 [ats2]
 cuda-11.2.152-gnu-8.3.1-spmpi-rolling
+
+
+[frontier]
+mi250x

--- a/packages/framework/ini-files/supported-systems.ini
+++ b/packages/framework/ini-files/supported-systems.ini
@@ -62,4 +62,7 @@ weaver.*
 [ats2]
 vortex.*
 
+[frontier]
+.*frontier.*
+
 [rhel]


### PR DESCRIPTION
@trilinos/framework

## Motivation
Add a build environment and configuration on OLCF/Frontier.

I also needed to make these changes:
https://github.com/sandialabs/DetermineSystem/pull/1
https://github.com/sandialabs/GenConfig/pull/1
and hence bumped the SHA in `get_dependencies.sh`.

I tried to summarize how LoadEnv and GenConfig work by adding a readme to packages/framework/.