### PR TITLE
Framework: Fix CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,12 +74,12 @@ jobs:
     - if: matrix.build-mode == 'manual'
       name: Generate CMake fragments
       run: |
-          git fetch origin ${GITHUB_BASE_REF}
+          git fetch origin ${GITHUB_BASE_REF:-${GITHUB_REF}}
 
           mkdir -p trilinos_build && cd trilinos_build
 
           source ${GITHUB_WORKSPACE}/packages/framework/GenConfig/gen-config.sh --force --cmake-fragment genconfig_fragment.cmake rhel8_gcc-openmpi_debug_shared_no-kokkos-arch_no-asan_complex_no-fpic_mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
-          ${GITHUB_WORKSPACE}/commonTools/framework/get-changed-trilinos-packages.sh origin/${GITHUB_BASE_REF} HEAD package_enables.cmake package_subprojects.cmake
+          ${GITHUB_WORKSPACE}/commonTools/framework/get-changed-trilinos-packages.sh origin/${GITHUB_BASE_REF:-${GITHUB_REF}} HEAD package_enables.cmake package_subprojects.cmake
 
     - if: matrix.build-mode == 'manual'
       name: Configure and build Trilinos

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -89,21 +89,7 @@ jobs:
             -DTrilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES=OFF \
             -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES=OFF \
             -DTrilinos_ENABLE_SECONDARY_TESTED_CODE=OFF \
-            -DTrilinos_ENABLE_Amesos=OFF \
-            -DTrilinos_ENABLE_AztecOO=OFF \
-            -DTrilinos_ENABLE_Epetra=OFF \
-            -DTrilinos_ENABLE_EpetraExt=OFF \
-            -DTrilinos_ENABLE_Ifpack=OFF \
-            -DTrilinos_ENABLE_Intrepid=OFF \
-            -DTrilinos_ENABLE_Isorropia=OFF \
-            -DTrilinos_ENABLE_ML=OFF \
-            -DTrilinos_ENABLE_NewPackage=OFF \
-            -DTrilinos_ENABLE_Pliris=OFF \
-            -DTrilinos_ENABLE_PyTrilinos=OFF \
-            -DTrilinos_ENABLE_ShyLU_DDCore=OFF \
-            -DTrilinos_ENABLE_ThyraEpetraAdapters=OFF \
-            -DTrilinos_ENABLE_ThyraEpetraExtAdapters=OFF \
-            -DTrilinos_ENABLE_Triutils=OFF ..
+            ..
 
           ninja -j 16
 


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Fix this recurring error in the scheduled CodeQL job:
```
git diff --name-only origin/..HEAD > /home/runner/_work/Trilinos/Trilinos/trilinos_build/changed-files.txt
fatal: ambiguous argument 'origin/..HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```
