### PR TITLE
[WIP] Belos:  Add dense matrix abstraction and Kokkos::DualView implementation

### DIFF
--- a/packages/belos/kokkos/example/GCRODRComplexKokkosExFile.cpp
+++ b/packages/belos/kokkos/example/GCRODRComplexKokkosExFile.cpp
@@ -17,6 +17,7 @@
 #include "BelosGCRODRSolMgr.hpp"
 #include "BelosOutputManager.hpp"
 
+#include "Teuchos_SerialDenseMatrix.hpp"
 #include "Teuchos_CommandLineProcessor.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_StandardCatchMacros.hpp"
@@ -41,11 +42,12 @@ bool success = true;
   typedef Kokkos::complex<double>           ST;
   typedef int                               OT;
   typedef Kokkos::DefaultExecutionSpace     EXSP;
-  typedef Teuchos::ScalarTraits<ST>        SCT;
+  typedef Teuchos::ScalarTraits<ST>         SCT;
+  typedef Teuchos::SerialDenseMatrix<int,ST>DM;
   typedef SCT::magnitudeType                MT;
-  typedef Belos::KokkosMultiVec<ST, EXSP>         MV;
-  typedef Belos::MultiVec<ST> KMV;
-  typedef Belos::Operator<ST> KOP; 
+  typedef Belos::KokkosMultiVec<ST, EXSP>   MV;
+  typedef Belos::MultiVec<ST>               KMV;
+  typedef Belos::Operator<ST>               KOP; 
   typedef Belos::MultiVecTraits<ST,KMV>     MVT;
   typedef Belos::OperatorTraits<ST,KMV,KOP>  OPT;
 
@@ -141,8 +143,8 @@ try {
   // *******************************************************************
   //
   // Create an iterative solver manager.
-  RCP< Belos::SolverManager<ST,KMV,KOP> > newSolver
-    = rcp( new Belos::GCRODRSolMgr<ST,KMV,KOP,true>(rcpFromRef(problem), rcpFromRef(belosList)) );
+  RCP< Belos::SolverManager<ST,KMV,KOP,DM> > newSolver
+    = rcp( new Belos::GCRODRSolMgr<ST,KMV,KOP,DM,true>(rcpFromRef(problem), rcpFromRef(belosList)) );
 
   //
   // **********Print out information about problem*******************

--- a/packages/belos/kokkos/example/GCRODRKokkosExFile.cpp
+++ b/packages/belos/kokkos/example/GCRODRKokkosExFile.cpp
@@ -137,7 +137,7 @@ try {
   //
   // Create an iterative solver manager.
   RCP< Belos::SolverManager<ST,KMV,KOP> > newSolver
-    = rcp( new Belos::GCRODRSolMgr<ST,KMV,KOP,true>(rcpFromRef(problem), rcpFromRef(belosList)) );
+    = rcp( new Belos::GCRODRSolMgr<ST,KMV,KOP>(rcpFromRef(problem), rcpFromRef(belosList)) );
 
   //
   // **********Print out information about problem*******************

--- a/packages/belos/src/BelosBiCGStabIter.hpp
+++ b/packages/belos/src/BelosBiCGStabIter.hpp
@@ -25,8 +25,6 @@
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
 
-#include "Teuchos_SerialDenseMatrix.hpp"
-#include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
@@ -77,15 +75,15 @@ namespace Belos {
     }
   };
 
-  template<class ScalarType, class MV, class OP>
-  class BiCGStabIter : virtual public Iteration<ScalarType,MV,OP> {
+  template<class ScalarType, class MV, class OP, class DM>
+  class BiCGStabIter : virtual public Iteration<ScalarType,MV,OP,DM> {
 
   public:
 
     //
     // Convenience typedefs
     //
-    typedef MultiVecTraits<ScalarType,MV> MVT;
+    typedef MultiVecTraits<ScalarType,MV,DM> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename SCT::magnitudeType MagnitudeType;
@@ -101,7 +99,7 @@ namespace Belos {
      */
     BiCGStabIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                           const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-                          const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
+                          const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
                           Teuchos::ParameterList &params );
 
     //! Destructor.
@@ -235,7 +233,7 @@ namespace Belos {
     //
     const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
     const Teuchos::RCP<OutputManager<ScalarType> >          om_;
-    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
+    const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >       stest_;
 
     //
     // Algorithmic parameters
@@ -277,10 +275,10 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
-  template<class ScalarType, class MV, class OP>
-  BiCGStabIter<ScalarType,MV,OP>::BiCGStabIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
+  template<class ScalarType, class MV, class OP, class DM>
+  BiCGStabIter<ScalarType,MV,OP,DM>::BiCGStabIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                                                                const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-                                                               const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
+                                                               const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
                                                                Teuchos::ParameterList &/* params */ ):
     lp_(problem),
     om_(printer),
@@ -295,8 +293,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Initialize this iteration object
-  template <class ScalarType, class MV, class OP>
-  void BiCGStabIter<ScalarType,MV,OP>::initializeBiCGStab(BiCGStabIterationState<ScalarType,MV>& newstate)
+  template<class ScalarType, class MV, class OP, class DM>
+  void BiCGStabIter<ScalarType,MV,OP,DM>::initializeBiCGStab(BiCGStabIterationState<ScalarType,MV>& newstate)
   {
     // Check if there is any multivector to clone from.
     Teuchos::RCP<const MV> lhsMV = lp_->getCurrLHSVec();
@@ -425,8 +423,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Iterate until the status test informs us we should stop.
-  template <class ScalarType, class MV, class OP>
-  void BiCGStabIter<ScalarType,MV,OP>::iterate()
+  template<class ScalarType, class MV, class OP, class DM>
+  void BiCGStabIter<ScalarType,MV,OP,DM>::iterate()
   {
     using Teuchos::RCP;
 
@@ -588,8 +586,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Iterate until the status test informs us we should stop.
-  template <class ScalarType, class MV, class OP>
-  void BiCGStabIter<ScalarType,MV,OP>::axpy(const ScalarType alpha, const MV & A,
+  template<class ScalarType, class MV, class OP, class DM>
+  void BiCGStabIter<ScalarType,MV,OP,DM>::axpy(const ScalarType alpha, const MV & A,
                                             const std::vector<ScalarType> beta, const MV& B, MV& mv, bool minus)
   {
     Teuchos::RCP<const MV> A1, B1;

--- a/packages/belos/src/BelosBlockFGmresIter.hpp
+++ b/packages/belos/src/BelosBlockFGmresIter.hpp
@@ -24,13 +24,14 @@
 #include "BelosStatusTest.hpp"
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
+#include "BelosDenseMatTraits.hpp"
 
 #include "Teuchos_BLAS.hpp"
-#include "Teuchos_SerialDenseMatrix.hpp"
-#include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
+
+#include <vector>
 
 /*!
   \class Belos::BlockFGmresIter
@@ -47,15 +48,16 @@
 
 namespace Belos {
 
-template<class ScalarType, class MV, class OP>
-class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
+template<class ScalarType, class MV, class OP, class DM>
+class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP,DM> {
 
   public:
 
   //
   // Convenience typedefs
   //
-  typedef MultiVecTraits<ScalarType,MV> MVT;
+  typedef MultiVecTraits<ScalarType,MV,DM> MVT;
+  typedef DenseMatTraits<ScalarType,DM> DMT;
   typedef OperatorTraits<ScalarType,MV,OP> OPT;
   typedef Teuchos::ScalarTraits<ScalarType> SCT;
   typedef typename SCT::magnitudeType MagnitudeType;
@@ -74,8 +76,8 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
    */
   BlockFGmresIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                    const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-                   const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-                   const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > &ortho,
+                   const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
+                   const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP,DM> > &ortho,
                    Teuchos::ParameterList &params );
 
   //! Destructor.
@@ -130,14 +132,14 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
    * \note For any pointer in \c newstate which directly points to the multivectors in
    * the solver, the data is not copied.
    */
-  void initializeGmres(GmresIterationState<ScalarType,MV>& newstate);
+  void initializeGmres(GmresIterationState<ScalarType,MV,DM>& newstate);
 
   /*! \brief Initialize the solver with the initial vectors from the linear problem
    *  or random data.
    */
   void initialize()
   {
-    GmresIterationState<ScalarType,MV> empty;
+    GmresIterationState<ScalarType,MV,DM> empty;
     initializeGmres(empty);
   }
 
@@ -148,8 +150,8 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
    * \returns A GmresIterationState object containing const pointers to the current
    * solver state.
    */
-  GmresIterationState<ScalarType,MV> getState() const {
-    GmresIterationState<ScalarType,MV> state;
+  GmresIterationState<ScalarType,MV,DM> getState() const {
+    GmresIterationState<ScalarType,MV,DM> state;
     state.curDim = curDim_;
     state.V = V_;
     state.Z = Z_;
@@ -245,8 +247,8 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   //
   const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
   const Teuchos::RCP<OutputManager<ScalarType> >          om_;
-  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
-  const Teuchos::RCP<OrthoManager<ScalarType,MV> >        ortho_;
+  const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >       stest_;
+  const Teuchos::RCP<OrthoManager<ScalarType,MV,DM> >        ortho_;
 
   //
   // Algorithmic parameters
@@ -258,8 +260,8 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   int numBlocks_;
 
   // Storage for QR factorization of the least squares system.
-  Teuchos::SerialDenseVector<int,ScalarType> beta, sn;
-  Teuchos::SerialDenseVector<int,MagnitudeType> cs;
+  std::vector<ScalarType> beta, sn;
+  std::vector<MagnitudeType> cs;
 
   //
   // Current solver state
@@ -291,23 +293,23 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   // Projected matrices
   // H_ : Projected matrix from the Krylov factorization AV = VH + FE^T
   //
-  Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > H_;
+  Teuchos::RCP<DM> H_;
   //
   // QR decomposition of Projected matrices for solving the least squares system HY = B.
   // R_: Upper triangular reduction of H
   // z_: Q applied to right-hand side of the least squares system
-  Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > R_;
-  Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > z_;
+  Teuchos::RCP<DM> R_;
+  Teuchos::RCP<DM> z_;
 };
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
-  template<class ScalarType, class MV, class OP>
-  BlockFGmresIter<ScalarType,MV,OP>::
+  template<class ScalarType, class MV, class OP, class DM>
+  BlockFGmresIter<ScalarType,MV,OP,DM>::
   BlockFGmresIter (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                    const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-                   const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-                   const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > &ortho,
+                   const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
+                   const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP,DM> > &ortho,
                    Teuchos::ParameterList &params ):
     lp_(problem),
     om_(printer),
@@ -340,8 +342,8 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Set the block size and make necessary adjustments.
-  template <class ScalarType, class MV, class OP>
-  void BlockFGmresIter<ScalarType,MV,OP>::setSize (int blockSize, int numBlocks)
+  template <class ScalarType, class MV, class OP, class DM>
+  void BlockFGmresIter<ScalarType,MV,OP,DM>::setSize (int blockSize, int numBlocks)
   {
     // This routine only allocates space; it doesn't not perform any computation
     // any change in size will invalidate the state of the solver.
@@ -368,12 +370,11 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Setup the state storage.
-  template <class ScalarType, class MV, class OP>
-  void BlockFGmresIter<ScalarType,MV,OP>::setStateSize ()
+  template <class ScalarType, class MV, class OP, class DM>
+  void BlockFGmresIter<ScalarType,MV,OP,DM>::setStateSize ()
   {
     using Teuchos::RCP;
     using Teuchos::rcp;
-    typedef Teuchos::SerialDenseMatrix<int, ScalarType> SDM;
 
     if (! stateStorageInitialized_) {
       // Check if there is any multivector to clone from.
@@ -440,10 +441,10 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
         // R_ holds the QR-factored least squares system. Always allocated.
         if (R_ == Teuchos::null) {
-          R_ = rcp (new SDM (newsd, newsd-blockSize_));
+          R_ = DMT::Create(newsd, newsd-blockSize_);
         }
         else {
-          R_->shapeUninitialized (newsd, newsd - blockSize_);
+          DMT::Reshape(*R_, newsd, newsd - blockSize_);
         }
 
         // H_ holds the raw (pre-QR) upper Hessenberg matrix.
@@ -451,10 +452,10 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
         // (matching BlockGmresIter behavior).
         if (keepHessenberg_) {
           if (H_ == Teuchos::null) {
-            H_ = rcp (new SDM (newsd, newsd-blockSize_));
+            H_ = DMT::Create(newsd, newsd-blockSize_);
           }
           else {
-            H_->shapeUninitialized (newsd, newsd - blockSize_);
+            DMT::Reshape(*H_, newsd, newsd - blockSize_);
           }
         }
         else {
@@ -463,10 +464,10 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
         // Generate z_ only if it doesn't exist, otherwise resize it.
         if (z_ == Teuchos::null) {
-          z_ = rcp (new SDM (newsd, blockSize_));
+          z_ = DMT::Create(newsd, blockSize_);
         }
         else {
-          z_->shapeUninitialized (newsd, blockSize_);
+          DMT::Reshape(*z_, newsd, blockSize_);
         }
 
         // State storage has now been initialized.
@@ -476,12 +477,10 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   }
 
 
-  template <class ScalarType, class MV, class OP>
+  template <class ScalarType, class MV, class OP, class DM>
   Teuchos::RCP<MV>
-  BlockFGmresIter<ScalarType,MV,OP>::getCurrentUpdate() const
+  BlockFGmresIter<ScalarType,MV,OP,DM>::getCurrentUpdate() const
   {
-    typedef Teuchos::SerialDenseMatrix<int, ScalarType> SDM;
-
     Teuchos::RCP<MV> currentUpdate = Teuchos::null;
     if (curDim_ == 0) {
       // If this is the first iteration of the Arnoldi factorization,
@@ -496,12 +495,19 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
       currentUpdate = MVT::Clone (*Z_, blockSize_);
 
       // Make a view and then copy the RHS of the least squares problem.  DON'T OVERWRITE IT!
-      SDM y (Teuchos::Copy, *z_, curDim_, blockSize_);
+      DMT::SyncDeviceToHost( *z_ );
+      DMT::SyncDeviceToHost( *H_ );
+
+      Teuchos::RCP<DM> y = DMT::SubviewCopy(*z_, curDim_, blockSize_);
 
       // Solve the least squares problem.
       blas.TRSM (Teuchos::LEFT_SIDE, Teuchos::UPPER_TRI, Teuchos::NO_TRANS,
                  Teuchos::NON_UNIT_DIAG, curDim_, blockSize_, one,
-                 R_->values (), R_->stride (), y.values (), y.stride ());
+                 DMT::GetConstRawHostPtr(*R_), DMT::GetStride(*R_), 
+                 DMT::GetRawHostPtr(*y), DMT::GetStride(*y));
+
+      // Make sure the result goes back to the device
+      DMT::SyncHostToDevice( *y );
 
       // Compute the current update.
       std::vector<int> index (curDim_);
@@ -509,15 +515,15 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
         index[i] = i;
       }
       Teuchos::RCP<const MV> Zjp1 = MVT::CloneView (*Z_, index);
-      MVT::MvTimesMatAddMv (one, *Zjp1, y, zero, *currentUpdate);
+      MVT::MvTimesMatAddMv (one, *Zjp1, *y, zero, *currentUpdate);
     }
     return currentUpdate;
   }
 
 
-  template <class ScalarType, class MV, class OP>
+  template <class ScalarType, class MV, class OP, class DM>
   Teuchos::RCP<const MV>
-  BlockFGmresIter<ScalarType,MV,OP>::
+  BlockFGmresIter<ScalarType,MV,OP,DM>::
   getNativeResiduals (std::vector<MagnitudeType> *norms) const
   {
     // NOTE: Make sure the incoming std::vector is the correct size!
@@ -527,8 +533,9 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
     if (norms != NULL) {
       Teuchos::BLAS<int, ScalarType> blas;
+      DMT::SyncDeviceToHost( *z_ );
       for (int j = 0; j < blockSize_; ++j) {
-        (*norms)[j] = blas.NRM2 (blockSize_, &(*z_)(curDim_, j), 1);
+        (*norms)[j] = blas.NRM2 (blockSize_, &DMT::Value(*z_, curDim_, j), 1);
       }
     }
 
@@ -537,17 +544,13 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   }
 
 
-  template <class ScalarType, class MV, class OP>
-  void BlockFGmresIter<ScalarType,MV,OP>::
-  initializeGmres (GmresIterationState<ScalarType,MV>& newstate)
+  template <class ScalarType, class MV, class OP, class DM>
+  void BlockFGmresIter<ScalarType,MV,OP,DM>::
+  initializeGmres (GmresIterationState<ScalarType,MV,DM>& newstate)
   {
     using Teuchos::RCP;
     using Teuchos::rcp;
     using std::endl;
-    typedef Teuchos::ScalarTraits<ScalarType> STS;
-    typedef Teuchos::SerialDenseMatrix<int, ScalarType> SDM;
-    const ScalarType ZERO = STS::zero ();
-    const ScalarType ONE = STS::one ();
 
     // Initialize the state storage if it isn't already.
     if (! stateStorageInitialized_) {
@@ -583,7 +586,7 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
       // check size of Z
       TEUCHOS_TEST_FOR_EXCEPTION(
-        newstate.z->numRows() < curDim_ || newstate.z->numCols() < blockSize_,
+        DMT::GetNumRows(*newstate.z) < curDim_ || DMT::GetNumCols(*newstate.z) < blockSize_,
         std::invalid_argument, errstr);
 
       // copy basis vectors from newstate into V
@@ -603,7 +606,7 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
         }
         RCP<const MV> newV = MVT::CloneView (*newstate.V, nevind);
         RCP<MV> lclV = MVT::CloneViewNonConst (*V_, nevind);
-        MVT::MvAddMv (ONE, *newV, ZERO, *newV, *lclV);
+        MVT::Assign(*newV, *lclV);
 
         // done with local pointers
         lclV = Teuchos::null;
@@ -611,11 +614,10 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
       // put data into z_, make sure old information is not still hanging around.
       if (newstate.z != z_) {
-        z_->putScalar();
-        SDM newZ (Teuchos::View, *newstate.z, curDim_ + blockSize_, blockSize_);
-        RCP<SDM> lclz;
-        lclz = rcp (new SDM (Teuchos::View, *z_, curDim_ + blockSize_, blockSize_));
-        lclz->assign (newZ);
+        DMT::PutScalar(*z_);
+        RCP<const DM> newZ = DMT::SubviewConst(*newstate.z, curDim_ + blockSize_, blockSize_);
+        RCP<DM> lclz = DMT::Subview(*z_, curDim_ + blockSize_, blockSize_);
+        DMT::Assign(*lclz, *newZ);
         lclz = Teuchos::null; // done with local pointers
       }
     }
@@ -634,15 +636,11 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   }
 
 
-  template <class ScalarType, class MV, class OP>
-  void BlockFGmresIter<ScalarType,MV,OP>::iterate()
+  template <class ScalarType, class MV, class OP, class DM>
+  void BlockFGmresIter<ScalarType,MV,OP,DM>::iterate()
   {
-    using Teuchos::Array;
-    using Teuchos::null;
     using Teuchos::RCP;
     using Teuchos::rcp;
-    using Teuchos::View;
-    typedef Teuchos::SerialDenseMatrix<int, ScalarType> SDM;
 
     // Allocate/initialize data structures
     if (initialized_ == false) {
@@ -677,11 +675,11 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
       // Compute the next (multi)vector in the Krylov basis:  Znext = M*Vprev
       lp_->applyRightPrec (*Vprev, *Znext);
-      Vprev = null;
+      Vprev = Teuchos::null;
 
       // Compute the next (multi)vector in the Krylov basis:  Vnext = A*Znext
       lp_->applyOp (*Znext, *Vnext);
-      Znext = null;
+      Znext = Teuchos::null;
 
       // Remove all previous Krylov basis vectors from Vnext
       // Get a view of all the previous vectors
@@ -690,16 +688,16 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
         prevind[i] = i;
       }
       Vprev = MVT::CloneView (*V_, prevind);
-      Array<RCP<const MV> > AVprev (1, Vprev);
+      Teuchos::Array<RCP<const MV> > AVprev (1, Vprev);
 
       // Get a view of the part of the Hessenberg matrix needed to hold the ortho coeffs.
       // Ortho always writes into H_ (the raw Hessenberg).
-      RCP<SDM> subH = rcp (new SDM (View, *H_, lclDim, blockSize_, 0, curDim_));
-      Array<RCP<SDM> > AsubH;
+      RCP<DM> subH = DMT::Subview(*H_, lclDim, blockSize_, 0, curDim_);
+      Teuchos::Array<RCP<DM> > AsubH;
       AsubH.append (subH);
 
       // Get a view of the part of the Hessenberg matrix needed to hold the norm coeffs.
-      RCP<SDM> subH2 = rcp (new SDM (View, *H_, blockSize_, blockSize_, lclDim, curDim_));
+      RCP<DM> subH2 = DMT::Subview(*H_, blockSize_, blockSize_, lclDim, curDim_);
       const int rank = ortho_->projectAndNormalize (*Vnext, AsubH, subH2, AVprev);
       TEUCHOS_TEST_FOR_EXCEPTION(
         rank != blockSize_, GmresIterationOrthoFailure,
@@ -711,10 +709,13 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
       // If keeping the Hessenberg separately, copy the new columns into R_
       // before updateLSQR() overwrites them with the QR factorization.
       if (keepHessenberg_) {
-        RCP<SDM> subR = rcp (new SDM (View, *R_, lclDim, blockSize_, 0, curDim_));
-        subR->assign (*subH);
-        RCP<SDM> subR2 = rcp (new SDM (View, *R_, blockSize_, blockSize_, lclDim, curDim_));
-        subR2->assign (*subH2);
+        // Copy over the orthogonalization coefficients.
+        RCP<DM> subR = DMT::Subview(*R_,lclDim,blockSize_,0,curDim_ );
+        DMT::Assign(*subR,*subH);
+
+        // Copy over the lower diagonal block of the Hessenberg matrix.
+        RCP<DM> subR2 = DMT::Subview(*R_,blockSize_,blockSize_,lclDim,curDim_ );
+        DMT::Assign(*subR2,*subH2);
       }
 
       //
@@ -726,14 +727,14 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
       //
       // Update basis dim and release all pointers.
       //
-      Vnext = null;
+      Vnext = Teuchos::null;
       curDim_ += blockSize_;
     } // end while (statusTest == false)
   }
 
 
-  template<class ScalarType, class MV, class OP>
-  void BlockFGmresIter<ScalarType,MV,OP>::updateLSQR (int dim)
+  template<class ScalarType, class MV, class OP, class DM>
+  void BlockFGmresIter<ScalarType,MV,OP,DM>::updateLSQR (int dim)
   {
     typedef Teuchos::ScalarTraits<ScalarType> STS;
     typedef Teuchos::ScalarTraits<MagnitudeType> STM;
@@ -757,67 +758,75 @@ class BlockFGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
     // The type of transformation we use depends the block size.  We
     // use Givens rotations for a block size of 1, and Householder
     // reflectors otherwise.
+    DMT::SyncDeviceToHost( *H_ );
+    DMT::SyncDeviceToHost( *z_ );
+
     if (blockSize_ == 1) {
+
       // QR factorization of upper Hessenberg matrix using Givens rotations
       for (int i = 0; i < curDim; ++i) {
         // Apply previous Givens rotations to new column of Hessenberg matrix
-        blas.ROT (1, &(*R_)(i, curDim), 1, &(*R_)(i+1, curDim), 1, &cs[i], &sn[i]);
+        blas.ROT (1, &DMT::Value(*R_,i, curDim), 1, &DMT::Value(*R_,i+1, curDim), 1, &cs[i], &sn[i]);
       }
+
       // Calculate new Givens rotation
-      blas.ROTG (&(*R_)(curDim, curDim), &(*R_)(curDim+1, curDim), &cs[curDim], &sn[curDim]);
-      (*R_)(curDim+1, curDim) = zero;
+      blas.ROTG (&DMT::Value(*R_,curDim, curDim), &DMT::Value(*R_,curDim+1, curDim), &cs[curDim], &sn[curDim]);
+      DMT::Value(*R_,curDim+1, curDim) = zero;
 
       // Update RHS w/ new transformation
-      blas.ROT (1, &(*z_)(curDim,0), 1, &(*z_)(curDim+1,0), 1, &cs[curDim], &sn[curDim]);
+      blas.ROT (1, &DMT::Value(*z_,curDim,0), 1, &DMT::Value(*z_,curDim+1,0), 1, &cs[curDim], &sn[curDim]);
     }
     else {
       // QR factorization of least-squares system using Householder reflectors.
       for (int j = 0; j < blockSize_; ++j) {
         // Apply previous Householder reflectors to new block of Hessenberg matrix
         for (int i = 0; i < curDim + j; ++i) {
-          sigma = blas.DOT (blockSize_, &(*R_)(i+1,i), 1, &(*R_)(i+1,curDim+j), 1);
-          sigma += (*R_)(i,curDim+j);
+          sigma = blas.DOT (blockSize_, &DMT::Value(*R_,i+1,i), 1, &DMT::Value(*R_,i+1,curDim+j), 1);
+          sigma += DMT::ValueConst(*R_,i,curDim+j);
           sigma *= beta[i];
-          blas.AXPY (blockSize_, ScalarType(-sigma), &(*R_)(i+1,i), 1, &(*R_)(i+1,curDim+j), 1);
-          (*R_)(i,curDim+j) -= sigma;
+          blas.AXPY (blockSize_, ScalarType(-sigma), &DMT::Value(*R_,i+1,i), 1, &DMT::Value(*R_,i+1,curDim+j), 1);
+          DMT::Value(*R_,i,curDim+j) -= sigma;
         }
 
         // Compute new Householder reflector
-        const int maxidx = blas.IAMAX (blockSize_+1, &(*R_)(curDim+j,curDim+j), 1);
-        maxelem = (*R_)(curDim + j + maxidx - 1, curDim + j);
+        const int maxidx = blas.IAMAX (blockSize_+1, &DMT::Value(*R_,curDim+j,curDim+j), 1);
+        maxelem = DMT::ValueConst(*R_,curDim + j + maxidx - 1, curDim + j);
         for (int i = 0; i < blockSize_ + 1; ++i) {
-          (*R_)(curDim+j+i,curDim+j) /= maxelem;
+          DMT::Value(*R_,curDim+j+i,curDim+j) /= maxelem;
         }
-        sigma = blas.DOT (blockSize_, &(*R_)(curDim + j + 1, curDim + j), 1,
-                          &(*R_)(curDim + j + 1, curDim + j), 1);
+        sigma = blas.DOT (blockSize_, &DMT::Value(*R_,curDim + j + 1, curDim + j), 1,
+                          &DMT::Value(*R_,curDim + j + 1, curDim + j), 1);
         if (sigma == zero) {
           beta[curDim + j] = zero;
         } else {
-          mu = STS::squareroot ((*R_)(curDim+j,curDim+j)*(*R_)(curDim+j,curDim+j)+sigma);
-          if (STS::real ((*R_)(curDim + j, curDim + j)) < STM::zero ()) {
-            vscale = (*R_)(curDim+j,curDim+j) - mu;
+          mu = STS::squareroot (DMT::Value(*R_,curDim+j,curDim+j)*DMT::Value(*R_,curDim+j,curDim+j)+sigma);
+          if (STS::real (DMT::Value(*R_,curDim + j, curDim + j)) < STM::zero ()) {
+            vscale = DMT::ValueConst(*R_,curDim+j,curDim+j) - mu;
           } else {
-            vscale = -sigma / ((*R_)(curDim+j, curDim+j) + mu);
+            vscale = -sigma / (DMT::Value(*R_,curDim+j, curDim+j) + mu);
           }
           beta[curDim+j] = two * vscale * vscale / (sigma + vscale*vscale);
-          (*R_)(curDim+j, curDim+j) = maxelem*mu;
+          DMT::Value(*R_,curDim+j, curDim+j) = maxelem*mu;
           for (int i = 0; i < blockSize_; ++i) {
-            (*R_)(curDim+j+1+i,curDim+j) /= vscale;
+            DMT::Value(*R_,curDim+j+1+i,curDim+j) /= vscale;
           }
         }
 
         // Apply new Householder reflector to the right-hand side.
         for (int i = 0; i < blockSize_; ++i) {
-          sigma = blas.DOT (blockSize_, &(*R_)(curDim+j+1,curDim+j),
-                            1, &(*z_)(curDim+j+1,i), 1);
-          sigma += (*z_)(curDim+j,i);
+          sigma = blas.DOT (blockSize_, &DMT::Value(*R_,curDim+j+1,curDim+j),
+                            1, &DMT::Value(*z_,curDim+j+1,i), 1);
+          sigma += DMT::ValueConst(*z_,curDim+j,i);
           sigma *= beta[curDim+j];
-          blas.AXPY (blockSize_, ScalarType(-sigma), &(*R_)(curDim+j+1,curDim+j),
-                     1, &(*z_)(curDim+j+1,i), 1);
-          (*z_)(curDim+j,i) -= sigma;
+          blas.AXPY (blockSize_, ScalarType(-sigma), &DMT::Value(*R_,curDim+j+1,curDim+j),
+                     1, &DMT::Value(*z_,curDim+j+1,i), 1);
+          DMT::Value(*z_,curDim+j,i) -= sigma;
         }
       }
     } // end if (blockSize_ == 1)
+
+    DMT::SyncHostToDevice( *H_ );
+    DMT::SyncHostToDevice( *z_ );
 
     // If the least-squares problem is updated wrt "dim" then update curDim_.
     if (dim >= curDim_ && dim < getMaxSubspaceDim ()) {

--- a/packages/belos/src/BelosBlockGmresIter.hpp
+++ b/packages/belos/src/BelosBlockGmresIter.hpp
@@ -24,14 +24,15 @@
 #include "BelosStatusTest.hpp"
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
+#include "BelosDenseMatTraits.hpp"
 
 #include "Teuchos_BLAS.hpp"
 #include "Teuchos_LAPACK.hpp"
-#include "Teuchos_SerialDenseMatrix.hpp"
-#include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
+
+#include <vector>
 
 /*!
   \class Belos::BlockGmresIter
@@ -48,15 +49,16 @@
 
 namespace Belos {
 
-template<class ScalarType, class MV, class OP>
-class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
+template<class ScalarType, class MV, class OP, class DM>
+class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP,DM> {
 
   public:
 
   //
   // Convenience typedefs
   //
-  typedef MultiVecTraits<ScalarType,MV> MVT;
+  typedef MultiVecTraits<ScalarType,MV,DM> MVT;
+  typedef DenseMatTraits<ScalarType,DM> DMT;
   typedef OperatorTraits<ScalarType,MV,OP> OPT;
   typedef Teuchos::ScalarTraits<ScalarType> SCT;
   typedef typename SCT::magnitudeType MagnitudeType;
@@ -75,8 +77,8 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
    */
   BlockGmresIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                   const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-                  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-                  const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > &ortho,
+                  const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
+                  const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP,DM> > &ortho,
                   Teuchos::ParameterList &params );
 
   //! Destructor.
@@ -131,14 +133,14 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
    * \note For any pointer in \c newstate which directly points to the multivectors in
    * the solver, the data is not copied.
    */
-  void initializeGmres(GmresIterationState<ScalarType,MV>& newstate);
+  void initializeGmres(GmresIterationState<ScalarType,MV,DM>& newstate);
 
   /*! \brief Initialize the solver with the initial vectors from the linear problem
    *  or random data.
    */
   void initialize()
   {
-    GmresIterationState<ScalarType,MV> empty;
+    GmresIterationState<ScalarType,MV,DM> empty;
     initializeGmres(empty);
   }
 
@@ -149,8 +151,8 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
    * \returns A GmresIterationState object containing const pointers to the current
    * solver state.
    */
-  GmresIterationState<ScalarType,MV> getState() const {
-    GmresIterationState<ScalarType,MV> state;
+  GmresIterationState<ScalarType,MV,DM> getState() const {
+    GmresIterationState<ScalarType,MV,DM> state;
     state.curDim = curDim_;
     state.V = V_;
     state.H = H_;
@@ -256,8 +258,8 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   //
   const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
   const Teuchos::RCP<OutputManager<ScalarType> >          om_;
-  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
-  const Teuchos::RCP<OrthoManager<ScalarType,MV> >        ortho_;
+  const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >       stest_;
+  const Teuchos::RCP<OrthoManager<ScalarType,MV,DM> >        ortho_;
 
   //
   // Algorithmic parameters
@@ -269,8 +271,8 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   int numBlocks_;
 
   // Storage for QR factorization of the least squares system.
-  Teuchos::SerialDenseVector<int,ScalarType> beta, sn;
-  Teuchos::SerialDenseVector<int,MagnitudeType> cs;
+  std::vector<ScalarType> beta, sn;
+  std::vector<MagnitudeType> cs;
 
   //
   // Current solver state
@@ -305,22 +307,22 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   // Projected matrices
   // H_ : Projected matrix from the Krylov factorization AV = VH + FE^T
   //
-  Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > H_;
+  Teuchos::RCP<DM> H_;
   //
   // QR decomposition of Projected matrices for solving the least squares system HY = B.
   // R_: Upper triangular reduction of H
   // z_: Q applied to right-hand side of the least squares system
-  Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > R_;
-  Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > z_;
+  Teuchos::RCP<DM> R_;
+  Teuchos::RCP<DM> z_;
 };
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
-  template<class ScalarType, class MV, class OP>
-  BlockGmresIter<ScalarType,MV,OP>::BlockGmresIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
+  template<class ScalarType, class MV, class OP, class DM>
+  BlockGmresIter<ScalarType,MV,OP,DM>::BlockGmresIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                                                    const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-                                                   const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-                                                   const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > &ortho,
+                                                   const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
+                                                   const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP,DM> > &ortho,
                                                    Teuchos::ParameterList &params ):
     lp_(problem),
     om_(printer),
@@ -356,8 +358,8 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Set the block size and make necessary adjustments.
-  template <class ScalarType, class MV, class OP>
-  void BlockGmresIter<ScalarType,MV,OP>::setSize (int blockSize, int numBlocks)
+  template <class ScalarType, class MV, class OP, class DM>
+  void BlockGmresIter<ScalarType,MV,OP,DM>::setSize (int blockSize, int numBlocks)
   {
     // This routine only allocates space; it doesn't not perform any computation
     // any change in size will invalidate the state of the solver.
@@ -384,8 +386,8 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Setup the state storage.
-  template <class ScalarType, class MV, class OP>
-  void BlockGmresIter<ScalarType,MV,OP>::setStateSize ()
+  template <class ScalarType, class MV, class OP, class DM>
+  void BlockGmresIter<ScalarType,MV,OP,DM>::setStateSize ()
   {
     if (!stateStorageInitialized_) {
 
@@ -433,28 +435,28 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
         // Generate R_ only if it doesn't exist, otherwise resize it.
         if (R_ == Teuchos::null) {
-          R_ = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>() );
+          R_ = DMT::Create();
         }
         if (initHessenberg_) {
-          R_->shape( newsd, newsd-blockSize_ );
+          DMT::Reshape(*R_, newsd, newsd-blockSize_, true);
         }
         else {
-          if (R_->numRows() < newsd || R_->numCols() < newsd-blockSize_) {
-            R_->shapeUninitialized( newsd, newsd-blockSize_ );
+          if (DMT::GetNumRows(*R_) < newsd || DMT::GetNumCols(*R_) < newsd-blockSize_) {
+            DMT::Reshape(*R_, newsd, newsd-blockSize_, false);
           }
         }
 
         // Generate H_ only if it doesn't exist, and we are keeping the upper Hessenberg matrix.
         if (keepHessenberg_) {
           if (H_ == Teuchos::null) {
-            H_ = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>() );
+            H_ = DMT::Create();
           }
           if (initHessenberg_) {
-            H_->shape( newsd, newsd-blockSize_ );
+            DMT::Reshape(*H_, newsd, newsd-blockSize_, true);
           }
           else {
-            if (H_->numRows() < newsd || H_->numCols() < newsd-blockSize_) {
-              H_->shapeUninitialized( newsd, newsd-blockSize_ );
+            if (DMT::GetNumRows(*H_)< newsd || DMT::GetNumCols(*H_)< newsd-blockSize_) {
+              DMT::Reshape(*H_, newsd, newsd-blockSize_, false);
             }
           }
         }
@@ -465,10 +467,10 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
         // Generate z_ only if it doesn't exist, otherwise resize it.
         if (z_ == Teuchos::null) {
-          z_ = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>() );
+          z_ = DMT::Create();
         }
-        if (z_-> numRows() < newsd || z_->numCols() < blockSize_) {
-          z_->shapeUninitialized( newsd, blockSize_ );
+        if (DMT::GetNumRows(*z_) < newsd || DMT::GetNumCols(*z_) < blockSize_) {
+          DMT::Reshape(*z_, newsd, blockSize_);
         }
 
         // State storage has now been initialized.
@@ -479,8 +481,8 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Get the current update from this subspace.
-  template <class ScalarType, class MV, class OP>
-  Teuchos::RCP<MV> BlockGmresIter<ScalarType,MV,OP>::getCurrentUpdate() const
+  template <class ScalarType, class MV, class OP, class DM>
+  Teuchos::RCP<MV> BlockGmresIter<ScalarType,MV,OP,DM>::getCurrentUpdate() const
   {
     //
     // If this is the first iteration of the Arnoldi factorization,
@@ -497,13 +499,15 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
       //
       //  Make a view and then copy the RHS of the least squares problem.  DON'T OVERWRITE IT!
       //
-      Teuchos::SerialDenseMatrix<int,ScalarType> y( Teuchos::Copy, *z_, curDim_, blockSize_ );
+      Teuchos::RCP<DM> y = DMT::SubviewCopy(*z_, curDim_, blockSize_);
       //
       //  Solve the least squares problem.
       //
       blas.TRSM( Teuchos::LEFT_SIDE, Teuchos::UPPER_TRI, Teuchos::NO_TRANS,
                  Teuchos::NON_UNIT_DIAG, curDim_, blockSize_, one,
-                 R_->values(), R_->stride(), y.values(), y.stride() );
+                 DMT::GetRawHostPtr(*R_), DMT::GetStride(*R_), DMT::GetRawHostPtr(*y), DMT::GetStride(*y) );
+      DMT::SyncHostToDevice(*R_);  // Why sync this when the result is in y? Shouldn't y be sync'ed before update is computed? 
+      DMT::SyncHostToDevice(*y);  
       //
       //  Compute the current update.
       //
@@ -512,7 +516,7 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
         index[i] = i;
       }
       Teuchos::RCP<const MV> Vjp1 = MVT::CloneView( *V_, index );
-      MVT::MvTimesMatAddMv( one, *Vjp1, y, zero, *currentUpdate );
+      MVT::MvTimesMatAddMv( one, *Vjp1, *y, zero, *currentUpdate );
     }
     return currentUpdate;
   }
@@ -521,8 +525,8 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Get the native residuals stored in this iteration.
   // Note:  No residual std::vector will be returned by Gmres.
-  template <class ScalarType, class MV, class OP>
-  Teuchos::RCP<const MV> BlockGmresIter<ScalarType,MV,OP>::getNativeResiduals( std::vector<MagnitudeType> *norms ) const
+  template <class ScalarType, class MV, class OP, class DM>
+  Teuchos::RCP<const MV> BlockGmresIter<ScalarType,MV,OP,DM>::getNativeResiduals( std::vector<MagnitudeType> *norms ) const
   {
     //
     // NOTE: Make sure the incoming std::vector is the correct size!
@@ -532,8 +536,10 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
     if (norms) {
       Teuchos::BLAS<int,ScalarType> blas;
+      DMT::SyncDeviceToHost(*z_);
       for (int j=0; j<blockSize_; j++) {
-        (*norms)[j] = blas.NRM2( blockSize_, &(*z_)(curDim_, j), 1);
+        Teuchos::RCP<DM> z_j = DMT::Subview(*z_, blockSize_, 1, curDim_, j);
+        (*norms)[j] = blas.NRM2( blockSize_, DMT::GetRawHostPtr(*z_j), 1);
       }
     }
     return Teuchos::null;
@@ -543,8 +549,8 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Initialize this iteration object
-  template <class ScalarType, class MV, class OP>
-  void BlockGmresIter<ScalarType,MV,OP>::initializeGmres(GmresIterationState<ScalarType,MV>& newstate)
+  template <class ScalarType, class MV, class OP, class DM>
+  void BlockGmresIter<ScalarType,MV,OP,DM>::initializeGmres(GmresIterationState<ScalarType,MV,DM>& newstate)
   {
     // Initialize the state storage if it isn't already.
     if (!stateStorageInitialized_)
@@ -552,8 +558,6 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
     TEUCHOS_TEST_FOR_EXCEPTION(!stateStorageInitialized_,std::invalid_argument,
                                "Belos::BlockGmresIter::initialize(): Cannot initialize state storage!");
-
-    const ScalarType zero = SCT::zero(), one = SCT::one();
 
     // NOTE:  In BlockGmresIter, V and Z are required!!!
     // inconsitent multivectors widths and lengths will not be tolerated, and
@@ -576,7 +580,7 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
       int lclDim = MVT::GetNumberVecs(*newstate.V);
 
       // check size of Z
-      TEUCHOS_TEST_FOR_EXCEPTION(newstate.z->numRows() < curDim_ || newstate.z->numCols() < blockSize_, std::invalid_argument, errstr);
+      TEUCHOS_TEST_FOR_EXCEPTION(DMT::GetNumRows(*newstate.z) < curDim_ || DMT::GetNumCols(*newstate.z) < blockSize_, std::invalid_argument, errstr);
 
 
       // copy basis vectors from newstate into V
@@ -591,7 +595,7 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
         for (int i=0; i<curDim_+blockSize_; i++) nevind[i] = i;
         Teuchos::RCP<const MV> newV = MVT::CloneView( *newstate.V, nevind );
         Teuchos::RCP<MV> lclV = MVT::CloneViewNonConst( *V_, nevind );
-        MVT::MvAddMv( one, *newV, zero, *newV, *lclV );
+        MVT::Assign( *newV, *lclV );
 
         // done with local pointers
         lclV = Teuchos::null;
@@ -599,11 +603,11 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
       // put data into z_, make sure old information is not still hanging around.
       if (newstate.z != z_) {
-        z_->putScalar();
-        Teuchos::SerialDenseMatrix<int,ScalarType> newZ(Teuchos::View,*newstate.z,curDim_+blockSize_,blockSize_);
-        Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > lclZ;
-        lclZ = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(Teuchos::View,*z_,curDim_+blockSize_,blockSize_) );
-        lclZ->assign(newZ);
+        DMT::PutScalar(*z_);
+        //Note: Need a SubviewConst here because the z in GMRES Iteration State is defined as const.
+        Teuchos::RCP<const DM> newZ = DMT::SubviewConst(*newstate.z,curDim_+blockSize_,blockSize_);
+        Teuchos::RCP<DM> lclZ = DMT::Subview(*z_,curDim_+blockSize_,blockSize_);
+        DMT::Assign(*lclZ,*newZ);
 
         // done with local pointers
         lclZ = Teuchos::null;
@@ -635,8 +639,8 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Iterate until the status test informs us we should stop.
-  template <class ScalarType, class MV, class OP>
-  void BlockGmresIter<ScalarType,MV,OP>::iterate()
+  template <class ScalarType, class MV, class OP, class DM>
+  void BlockGmresIter<ScalarType,MV,OP,DM>::iterate()
   {
     //
     // Allocate/initialize data structures
@@ -682,33 +686,33 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
       Teuchos::Array<Teuchos::RCP<const MV> > AVprev(1, Vprev);
 
       // Get a view of the part of the Hessenberg matrix needed to hold the ortho coeffs.
-      Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> >
-        subH = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>
-                             ( Teuchos::View,*H_,lclDim,blockSize_,0,curDim_ ) );
-      Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > AsubH;
+      Teuchos::RCP<DM> subH = DMT::Subview(*H_,lclDim,blockSize_,0,curDim_ );
+      Teuchos::Array<Teuchos::RCP<DM> > AsubH;
       AsubH.append( subH );
 
       // Get a view of the part of the Hessenberg matrix needed to hold the norm coeffs.
-      Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> >
-        subH2 = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>
-                              ( Teuchos::View,*H_,blockSize_,blockSize_,lclDim,curDim_ ) );
-      subH2->putScalar();  // Initialize subdiagonal to zero
+      Teuchos::RCP<DM> subH2 = DMT::Subview(*H_,blockSize_,blockSize_,lclDim,curDim_);
+      DMT::PutScalar(*subH2);  // Initialize subdiagonal to zero
+      
+      // TODO
+      // Make an abstract dense matrix that holds the data of subH2 (an RCP of serialDense.)
+      // Do the same for AsubH. ????
+      // subH needs to be a new rcp to an abstract dense. No, keep subH how it is.
+      // Then make a subHAbstract that grabs the pointer from subH, making it an abstract dense guy. 
+      // Then AsubH can be a Teuchos::Array
+      // of the abstract dense guys. 
       int rank = ortho_->projectAndNormalize(*Vnext,AsubH,subH2,AVprev);
 
       // Copy over the coefficients if we are saving the upper Hessenberg matrix,
       // just in case we run into an error.
       if (keepHessenberg_) {
         // Copy over the orthogonalization coefficients.
-        Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> >
-          subR = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>
-                               ( Teuchos::View,*R_,lclDim,blockSize_,0,curDim_ ) );
-        subR->assign(*subH);
+        Teuchos::RCP<DM> subR = DMT::Subview(*R_,lclDim,blockSize_,0,curDim_ );
+        DMT::Assign(*subR,*subH);
 
         // Copy over the lower diagonal block of the Hessenberg matrix.
-        Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> >
-          subR2 = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>
-                            ( Teuchos::View,*R_,blockSize_,blockSize_,lclDim,curDim_ ) );
-        subR2->assign(*subH2);
+        Teuchos::RCP<DM> subR2 = DMT::Subview(*R_,blockSize_,blockSize_,lclDim,curDim_ );
+        DMT::Assign(*subR2,*subH2);
       }
 
       TEUCHOS_TEST_FOR_EXCEPTION(rank != blockSize_,GmresIterationOrthoFailure,
@@ -744,8 +748,8 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   }
 
 
-  template<class ScalarType, class MV, class OP>
-  void BlockGmresIter<ScalarType,MV,OP>::updateLSQR( int dim )
+  template<class ScalarType, class MV, class OP, class DM>
+  void BlockGmresIter<ScalarType,MV,OP,DM>::updateLSQR( int dim )
   {
     int i, j, maxidx;
     ScalarType sigma, mu, vscale, maxelem;
@@ -764,6 +768,9 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
     // Apply previous transformations and compute new transformation to reduce upper-Hessenberg
     // system to upper-triangular form.
     //
+    DMT::SyncDeviceToHost(*R_);
+    DMT::SyncDeviceToHost(*z_);
+
     if (blockSize_ == 1) {
       //
       // QR factorization of Least-Squares system with Givens rotations
@@ -772,17 +779,17 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
         //
         // Apply previous Givens rotations to new column of Hessenberg matrix
         //
-        blas.ROT( 1, &(*R_)(i,curDim), 1, &(*R_)(i+1, curDim), 1, &cs[i], &sn[i] );
+        blas.ROT( 1, &DMT::Value(*R_,i,curDim), 1, &DMT::Value(*R_,i+1, curDim), 1, &cs[i], &sn[i] );
       }
       //
       // Calculate new Givens rotation
       //
-      blas.ROTG( &(*R_)(curDim,curDim), &(*R_)(curDim+1,curDim), &cs[curDim], &sn[curDim] );
-      (*R_)(curDim+1,curDim) = zero;
+      blas.ROTG( &DMT::Value(*R_,curDim,curDim), &DMT::Value(*R_,curDim+1,curDim), &cs[curDim], &sn[curDim] );
+      DMT::Value(*R_,curDim+1,curDim) = zero;
       //
       // Update RHS w/ new transformation
       //
-      blas.ROT( 1, &(*z_)(curDim,0), 1, &(*z_)(curDim+1,0), 1, &cs[curDim], &sn[curDim] );
+      blas.ROT( 1, &DMT::Value(*z_,curDim,0), 1, &DMT::Value(*z_,curDim+1,0), 1, &cs[curDim], &sn[curDim] );
     }
     else {
       //
@@ -793,53 +800,55 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
         // Apply previous Householder reflectors to new block of Hessenberg matrix
         //
         for (i=0; i<curDim+j; i++) {
-          sigma = blas.DOT( blockSize_, &(*R_)(i+1,i), 1, &(*R_)(i+1,curDim+j), 1);
-          sigma += (*R_)(i,curDim+j);
+          sigma = blas.DOT( blockSize_, &DMT::Value(*R_,i+1,i), 1, &DMT::Value(*R_,i+1,curDim+j), 1);
+          sigma += DMT::ValueConst(*R_,i,curDim+j);
           sigma *= SCT::conjugate(beta[i]);
-          blas.AXPY(blockSize_, ScalarType(-sigma), &(*R_)(i+1,i), 1, &(*R_)(i+1,curDim+j), 1);
-          (*R_)(i,curDim+j) -= sigma;
+          blas.AXPY(blockSize_, ScalarType(-sigma), &DMT::Value(*R_,i+1,i), 1, &DMT::Value(*R_,i+1,curDim+j), 1);
+          DMT::Value(*R_,i,curDim+j) -= sigma;
         }
         //
         // Compute new Householder reflector
         //
-        maxidx = blas.IAMAX( blockSize_+1, &(*R_)(curDim+j,curDim+j), 1 );
-        maxelem = SCT::magnitude((*R_)(curDim+j+maxidx-1,curDim+j));
+        maxidx = blas.IAMAX( blockSize_+1, &DMT::Value(*R_,curDim+j,curDim+j), 1 );
+        maxelem = SCT::magnitude(DMT::Value(*R_,curDim+j+maxidx-1,curDim+j));
         for (i=0; i<blockSize_+1; i++)
-          (*R_)(curDim+j+i,curDim+j) /= maxelem;
-        sigma = blas.DOT( blockSize_, &(*R_)(curDim+j+1,curDim+j), 1,
-                          &(*R_)(curDim+j+1,curDim+j), 1 );
-        MagnitudeType sign_Rjj = -SCT::real((*R_)(curDim+j,curDim+j)) /
-                 SCT::magnitude(SCT::real(((*R_)(curDim+j,curDim+j))));
+          DMT::Value(*R_,curDim+j+i,curDim+j) /= maxelem;
+        sigma = blas.DOT( blockSize_, &DMT::Value(*R_,curDim+j+1,curDim+j), 1,
+                          &DMT::Value(*R_,curDim+j+1,curDim+j), 1 );
+        MagnitudeType sign_Rjj = -SCT::real(DMT::Value(*R_,curDim+j,curDim+j)) /
+                 SCT::magnitude(SCT::real((DMT::Value(*R_,curDim+j,curDim+j))));
         if (sigma == zero) {
           beta[curDim + j] = zero;
         } else {
-          mu = SCT::squareroot(SCT::conjugate((*R_)(curDim+j,curDim+j))*(*R_)(curDim+j,curDim+j)+sigma);
-          vscale = (*R_)(curDim+j,curDim+j) - Teuchos::as<ScalarType>(sign_Rjj)*mu;
+          mu = SCT::squareroot(SCT::conjugate(DMT::Value(*R_,curDim+j,curDim+j))*DMT::Value(*R_,curDim+j,curDim+j)+sigma);
+          vscale = DMT::ValueConst(*R_,curDim+j,curDim+j) - Teuchos::as<ScalarType>(sign_Rjj)*mu;
           beta[curDim+j] = -Teuchos::as<ScalarType>(sign_Rjj) * vscale / mu;
-          (*R_)(curDim+j,curDim+j) = Teuchos::as<ScalarType>(sign_Rjj)*maxelem*mu;
+          DMT::Value(*R_,curDim+j,curDim+j) = Teuchos::as<ScalarType>(sign_Rjj)*maxelem*mu;
           for (i=0; i<blockSize_; i++)
-            (*R_)(curDim+j+1+i,curDim+j) /= vscale;
+            DMT::Value(*R_,curDim+j+1+i,curDim+j) /= vscale;
         }
         //
         // Apply new Householder reflector to rhs
         //
         for (i=0; i<blockSize_; i++) {
-          sigma = blas.DOT( blockSize_, &(*R_)(curDim+j+1,curDim+j),
-                            1, &(*z_)(curDim+j+1,i), 1);
-          sigma += (*z_)(curDim+j,i);
+          sigma = blas.DOT( blockSize_, &DMT::Value(*R_,curDim+j+1,curDim+j),
+                            1, &DMT::Value(*z_,curDim+j+1,i), 1);
+          sigma += DMT::ValueConst(*z_,curDim+j,i);
           sigma *= SCT::conjugate(beta[curDim+j]);
-          blas.AXPY(blockSize_, ScalarType(-sigma), &(*R_)(curDim+j+1,curDim+j),
-                    1, &(*z_)(curDim+j+1,i), 1);
-          (*z_)(curDim+j,i) -= sigma;
+          blas.AXPY(blockSize_, ScalarType(-sigma), &DMT::Value(*R_,curDim+j+1,curDim+j),
+                    1, &DMT::Value(*z_,curDim+j+1,i), 1);
+          DMT::Value(*z_,curDim+j,i) -= sigma;
         }
       }
     } // end if (blockSize_ == 1)
+
+    DMT::SyncHostToDevice(*z_); 
+    DMT::SyncHostToDevice(*R_); 
 
     // If the least-squares problem is updated wrt "dim" then update the curDim_.
     if (dim >= curDim_ && dim < getMaxSubspaceDim()) {
       curDim_ = dim + blockSize_;
     }
-
   } // end updateLSQR()
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -853,8 +862,8 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
   //
   // NOTE:  This method needs to check the current dimension of the subspace, since it is possible to
   //        call this method when curDim_ = 0 (after initialization).
-  template <class ScalarType, class MV, class OP>
-  std::string BlockGmresIter<ScalarType,MV,OP>::accuracyCheck( const CheckList &chk, const std::string &where ) const
+  template <class ScalarType, class MV, class OP, class DM>
+  std::string BlockGmresIter<ScalarType,MV,OP,DM>::accuracyCheck( const CheckList &chk, const std::string &where ) const
   {
     std::stringstream os;
     os.precision(2);
@@ -897,13 +906,12 @@ class BlockGmresIter : virtual public GmresIteration<ScalarType,MV,OP> {
 
         // Compute AV - VH
         const ScalarType one  = Teuchos::ScalarTraits<ScalarType>::one();
-        Teuchos::SerialDenseMatrix<int,ScalarType> subH(Teuchos::View,*H_,curDim_,curDim_);
-        MVT::MvTimesMatAddMv( -one, *lclV, subH, one, *lclAV );
+        Teuchos::RCP<DM> subH = DMT::Subview(*H_,curDim_,curDim_);
+        MVT::MvTimesMatAddMv( -one, *lclV, *subH, one, *lclAV );
 
         // Compute FB_k^T - (AV-VH)
-        Teuchos::SerialDenseMatrix<int,ScalarType> curB(Teuchos::View,*H_,
-                                                        blockSize_,curDim_, curDim_ );
-        MVT::MvTimesMatAddMv( -one, *lclF, curB, one, *lclAV );
+        Teuchos::RCP<DM> curB = DMT::Subview(*H_,blockSize_,curDim_,curDim_);
+        MVT::MvTimesMatAddMv( -one, *lclF, *curB, one, *lclAV );
 
         // Compute || FE_k^T - (AV-VH) ||
         std::vector<MagnitudeType> arnNorms( curDim_ );

--- a/packages/belos/src/BelosBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGmresSolMgr.hpp
@@ -19,6 +19,8 @@
 
 #include "BelosLinearProblem.hpp"
 #include "BelosSolverManager.hpp"
+#include "BelosDenseMatTraits.hpp"
+#include "BelosTeuchosDenseAdapter.hpp"
 
 #include "BelosGmresIteration.hpp"
 #include "BelosBlockGmresIter.hpp"
@@ -92,11 +94,12 @@ class BlockGmresSolMgrOrthoFailure : public BelosError {public:
  * PseudoBlockGmresSolMgr.  If you want Flexible GMRES, use this class
  * with the "Flexible Gmres" parameter set to true.
  */
-template<class ScalarType, class MV, class OP>
-class BlockGmresSolMgr : public SolverManager<ScalarType,MV,OP> {
+template<class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int, ScalarType>>
+class BlockGmresSolMgr : public SolverManager<ScalarType,MV,OP,DM> {
 
 private:
-  typedef MultiVecTraits<ScalarType,MV> MVT;
+  typedef MultiVecTraits<ScalarType,MV,DM> MVT;
+  typedef DenseMatTraits<ScalarType,DM> DMT;
   typedef OperatorTraits<ScalarType,MV,OP> OPT;
   typedef Teuchos::ScalarTraits<ScalarType> SCT;
   typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
@@ -141,8 +144,8 @@ public:
   virtual ~BlockGmresSolMgr() {};
 
   //! clone for Inverted Injection (DII)
-  Teuchos::RCP<SolverManager<ScalarType, MV, OP> > clone () const override {
-    return Teuchos::rcp(new BlockGmresSolMgr<ScalarType,MV,OP>);
+  Teuchos::RCP<SolverManager<ScalarType, MV, OP, DM> > clone () const override {
+    return Teuchos::rcp(new BlockGmresSolMgr<ScalarType,MV,OP,DM>);
   }
   //@}
 
@@ -208,7 +211,7 @@ public:
   void setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params ) override;
 
   //! Set a debug status test that will be checked at the same time as the top-level status test.
-  void setDebugStatusTest( const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &debugStatusTest ) override;
+  void setDebugStatusTest( const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &debugStatusTest ) override;
 
   //@}
 
@@ -277,15 +280,15 @@ private:
   Teuchos::RCP<std::ostream> outputStream_;
 
   // Status test.
-  Teuchos::RCP<StatusTest<ScalarType,MV,OP> > debugStatusTest_;
-  Teuchos::RCP<StatusTest<ScalarType,MV,OP> > sTest_;
-  Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP> > maxIterTest_;
-  Teuchos::RCP<StatusTest<ScalarType,MV,OP> > convTest_;
-  Teuchos::RCP<StatusTestResNorm<ScalarType,MV,OP> > expConvTest_, impConvTest_;
-  Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP> > outputTest_;
+  Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > debugStatusTest_;
+  Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > sTest_;
+  Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP,DM> > maxIterTest_;
+  Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > convTest_;
+  Teuchos::RCP<StatusTestResNorm<ScalarType,MV,OP,DM> > expConvTest_, impConvTest_;
+  Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP,DM> > outputTest_;
 
   // Orthogonalization manager.
-  Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > ortho_;
+  Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP,DM> > ortho_;
 
   // Current parameter list.
   Teuchos::RCP<Teuchos::ParameterList> params_;
@@ -321,7 +324,7 @@ private:
   Teuchos::RCP<Teuchos::Time> timerSolve_;
 
   // Cached iterator (reused across solve() calls to avoid reallocating Krylov subspace).
-  Teuchos::RCP<GmresIteration<ScalarType,MV,OP> > block_gmres_iter_;
+  Teuchos::RCP<GmresIteration<ScalarType,MV,OP,DM> > block_gmres_iter_;
 
   // Internal state variables.
   bool isSet_, isSTSet_;
@@ -331,8 +334,8 @@ private:
 
 
 // Empty Constructor
-template<class ScalarType, class MV, class OP>
-BlockGmresSolMgr<ScalarType,MV,OP>::BlockGmresSolMgr() :
+template<class ScalarType, class MV, class OP, class DM>
+BlockGmresSolMgr<ScalarType,MV,OP,DM>::BlockGmresSolMgr() :
   outputStream_(Teuchos::rcpFromRef(std::cout)),
   convtol_(DefaultSolverParameters::convTol),
   orthoKappa_(DefaultSolverParameters::orthoKappa),
@@ -362,8 +365,8 @@ BlockGmresSolMgr<ScalarType,MV,OP>::BlockGmresSolMgr() :
 
 
 // Basic Constructor
-template<class ScalarType, class MV, class OP>
-BlockGmresSolMgr<ScalarType,MV,OP>::
+template<class ScalarType, class MV, class OP, class DM>
+BlockGmresSolMgr<ScalarType,MV,OP,DM>::
 BlockGmresSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                   const Teuchos::RCP<Teuchos::ParameterList> &pl) :
   problem_(problem),
@@ -404,9 +407,9 @@ BlockGmresSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 }
 
 
-template<class ScalarType, class MV, class OP>
+template<class ScalarType, class MV, class OP, class DM>
 Teuchos::RCP<const Teuchos::ParameterList>
-BlockGmresSolMgr<ScalarType,MV,OP>::getValidParameters() const
+BlockGmresSolMgr<ScalarType,MV,OP,DM>::getValidParameters() const
 {
   static Teuchos::RCP<const Teuchos::ParameterList> validPL;
   if (is_null(validPL)) {
@@ -473,8 +476,8 @@ BlockGmresSolMgr<ScalarType,MV,OP>::getValidParameters() const
 }
 
 
-template<class ScalarType, class MV, class OP>
-void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params )
+template<class ScalarType, class MV, class OP, class DM>
+void BlockGmresSolMgr<ScalarType,MV,OP,DM>::setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params )
 {
 
   // Create the internal parameter list if ones doesn't already exist.
@@ -647,14 +650,14 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuch
     params_->set("Orthogonalization Constant",orthoKappa_);
     if (orthoType_=="DGKS") {
       if (orthoKappa_ > 0 && ortho_ != Teuchos::null && !changedOrthoType) {
-        Teuchos::rcp_dynamic_cast<DGKSOrthoManager<ScalarType,MV,OP> >(ortho_)->setDepTol( orthoKappa_ );
+        Teuchos::rcp_dynamic_cast<DGKSOrthoManager<ScalarType,MV,OP,DM> >(ortho_)->setDepTol( orthoKappa_ );//TODO
       }
     }
   }
 
   // Create orthogonalization manager if we need to.
   if (ortho_ == Teuchos::null || changedOrthoType) {
-    Belos::OrthoManagerFactory<ScalarType, MV, OP> factory;
+    Belos::OrthoManagerFactory<ScalarType,MV,OP,DM> factory; 
     Teuchos::RCP<Teuchos::ParameterList> paramsOrtho;   
     if (orthoType_=="DGKS" && orthoKappa_ > 0) {
       paramsOrtho = Teuchos::rcp(new Teuchos::ParameterList());
@@ -764,15 +767,15 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuch
 }
 
 // Check the status test versus the defined linear problem
-template<class ScalarType, class MV, class OP>
-bool BlockGmresSolMgr<ScalarType,MV,OP>::checkStatusTest() {
+template<class ScalarType, class MV, class OP, class DM>
+bool BlockGmresSolMgr<ScalarType,MV,OP,DM>::checkStatusTest() {
 
-  typedef Belos::StatusTestCombo<ScalarType,MV,OP>  StatusTestCombo_t;
-  typedef Belos::StatusTestGenResNorm<ScalarType,MV,OP>  StatusTestGenResNorm_t;
-  typedef Belos::StatusTestImpResNorm<ScalarType,MV,OP>  StatusTestImpResNorm_t;
+  typedef Belos::StatusTestCombo<ScalarType,MV,OP,DM>  StatusTestCombo_t;
+  typedef Belos::StatusTestGenResNorm<ScalarType,MV,OP,DM>  StatusTestGenResNorm_t;
+  typedef Belos::StatusTestImpResNorm<ScalarType,MV,OP,DM>  StatusTestImpResNorm_t;
 
   // Basic test checks maximum iterations and native residual.
-  maxIterTest_ = Teuchos::rcp( new StatusTestMaxIters<ScalarType,MV,OP>( maxIters_ ) );
+  maxIterTest_ = Teuchos::rcp( new StatusTestMaxIters<ScalarType,MV,OP,DM>( maxIters_ ) );
 
   // Perform sanity checking for flexible Gmres here.
   // NOTE:  If the user requests that the solver manager use flexible GMRES, but there is no right preconditioner, don't use flexible GMRES.
@@ -848,7 +851,7 @@ bool BlockGmresSolMgr<ScalarType,MV,OP>::checkStatusTest() {
 
   // Create the status test output class.
   // This class manages and formats the output from the status test.
-  StatusTestOutputFactory<ScalarType,MV,OP> stoFactory( outputStyle_ );
+  StatusTestOutputFactory<ScalarType,MV,OP,DM> stoFactory( outputStyle_ );
   outputTest_ = stoFactory.create( printer_, sTest_, outputFreq_, Passed+Failed+Undefined );
 
   // Set the solver string for the output test
@@ -863,9 +866,9 @@ bool BlockGmresSolMgr<ScalarType,MV,OP>::checkStatusTest() {
   return false;
 }
 
-template<class ScalarType, class MV, class OP>
-void BlockGmresSolMgr<ScalarType,MV,OP>::setDebugStatusTest(
-  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &debugStatusTest
+template<class ScalarType, class MV, class OP, class DM>
+void BlockGmresSolMgr<ScalarType,MV,OP,DM>::setDebugStatusTest(
+  const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &debugStatusTest
   )
 {
   debugStatusTest_ = debugStatusTest;
@@ -873,8 +876,8 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setDebugStatusTest(
 
 
 // solve()
-template<class ScalarType, class MV, class OP>
-ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
+template<class ScalarType, class MV, class OP, class DM>
+ReturnType BlockGmresSolMgr<ScalarType,MV,OP,DM>::solve() {
 
   // Set the current parameters if they were not set before.
   // NOTE:  This may occur if the user generated the solver manager with the default constructor and
@@ -953,12 +956,12 @@ ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
 
   if (needsIterRebuild_) {
     if (isFlexible_)
-      block_gmres_iter_ = Teuchos::rcp( new BlockFGmresIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,ortho_,plist) );
+      block_gmres_iter_ = Teuchos::rcp( new BlockFGmresIter<ScalarType,MV,OP,DM>(problem_,printer_,outputTest_,ortho_,plist) );
     else
-      block_gmres_iter_ = Teuchos::rcp( new BlockGmresIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,ortho_,plist) );
+      block_gmres_iter_ = Teuchos::rcp( new BlockGmresIter<ScalarType,MV,OP,DM>(problem_,printer_,outputTest_,ortho_,plist) );
     needsIterRebuild_ = false;
   }
-  Teuchos::RCP<GmresIteration<ScalarType,MV,OP> > &block_gmres_iter = block_gmres_iter_;
+  Teuchos::RCP<GmresIteration<ScalarType,MV,OP,DM> > &block_gmres_iter = block_gmres_iter_;
 
   // Enter solve() iterations
   {
@@ -1010,8 +1013,7 @@ ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
       }
 
       // Get a matrix to hold the orthonormalization coefficients.
-      Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > z_0 =
-        Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( blockSize_, blockSize_ ) );
+      Teuchos::RCP<DM> z_0 = DMT::Create(blockSize_, blockSize_);
 
       // Orthonormalize the new V_0
       int rank = ortho_->normalize( *V_0, z_0 );
@@ -1019,7 +1021,7 @@ ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
         "Belos::BlockGmresSolMgr::solve(): Failed to compute initial block of orthonormal vectors.");
 
       // Set the new state and initialize the solver.
-      GmresIterationState<ScalarType,MV> newstate;
+      GmresIterationState<ScalarType,MV,DM> newstate;
       newstate.V = V_0;
       newstate.z = z_0;
       newstate.curDim = 0;
@@ -1082,7 +1084,7 @@ ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
               problem_->updateSolution( update, true );
 
             // Get the state.
-            GmresIterationState<ScalarType,MV> oldState = block_gmres_iter->getState();
+            GmresIterationState<ScalarType,MV,DM> oldState = block_gmres_iter->getState();
 
             // Compute the restart std::vector.
             // Get a view of the current Krylov basis.
@@ -1093,7 +1095,7 @@ ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
               problem_->computeCurrPrecResVec( &*V_0 );
 
             // Get a view of the first block of the Krylov basis.
-            z_0 = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( blockSize_, blockSize_ ) );
+            z_0 = DMT::Create(blockSize_, blockSize_);
 
             // Orthonormalize the new V_0
             rank = ortho_->normalize( *V_0, z_0 );
@@ -1173,7 +1175,7 @@ ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
         if ( !Teuchos::is_null(expConvTest_->getSolution()) ) {
           Teuchos::RCP<MV> newX = expConvTest_->getSolution();
           Teuchos::RCP<MV> curX = problem_->getCurrLHSVec();
-          MVT::MvAddMv( 0.0, *newX, 1.0, *newX, *curX );
+          MVT::Assign( *newX, *curX );
         }
         else {
           Teuchos::RCP<MV> update = block_gmres_iter->getCurrentUpdate();
@@ -1274,8 +1276,8 @@ ReturnType BlockGmresSolMgr<ScalarType,MV,OP>::solve() {
 }
 
 
-template<class ScalarType, class MV, class OP>
-std::string BlockGmresSolMgr<ScalarType,MV,OP>::description() const
+template<class ScalarType, class MV, class OP, class DM>
+std::string BlockGmresSolMgr<ScalarType,MV,OP,DM>::description() const
 {
   std::ostringstream out;
   out << "\"Belos::BlockGmresSolMgr\": {";
@@ -1292,9 +1294,9 @@ std::string BlockGmresSolMgr<ScalarType,MV,OP>::description() const
 }
 
 
-template<class ScalarType, class MV, class OP>
+template<class ScalarType, class MV, class OP, class DM>
 void
-BlockGmresSolMgr<ScalarType, MV, OP>::
+BlockGmresSolMgr<ScalarType, MV, OP, DM>::
 describe (Teuchos::FancyOStream &out,
           const Teuchos::EVerbosityLevel verbLevel) const
 {

--- a/packages/belos/src/BelosCGIter.hpp
+++ b/packages/belos/src/BelosCGIter.hpp
@@ -24,9 +24,8 @@
 #include "BelosStatusTestGenResNorm.hpp"
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
+#include "BelosDenseMatTraits.hpp"
 
-#include "Teuchos_SerialDenseMatrix.hpp"
-#include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
@@ -90,16 +89,17 @@ namespace Belos {
 
 };
 
-template<class ScalarType, class MV, class OP>
-class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
+template<class ScalarType, class MV, class OP, class DM>
+class CGIter : virtual public CGIteration<ScalarType,MV,OP,DM> {
 
   public:
 
   //
   // Convenience typedefs
   //
-  using MVT = MultiVecTraits<ScalarType, MV>;
+  using MVT = MultiVecTraits<ScalarType, MV, DM>;
   using OPT = OperatorTraits<ScalarType, MV, OP>;
+  using DMT = DenseMatTraits<ScalarType,DM>;
   using SCT = Teuchos::ScalarTraits<ScalarType>;
   using MagnitudeType = typename SCT::magnitudeType;
 
@@ -113,8 +113,8 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
    */
   CGIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 		  const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-		  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-                  const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > &convTester,
+		  const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
+                  const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP,DM> > &convTester,
 		  Teuchos::ParameterList &params );
 
   //! Destructor.
@@ -280,8 +280,8 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
   //
   const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
   const Teuchos::RCP<OutputManager<ScalarType> >          om_;
-  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
-  const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> >       convTest_;
+  const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >       stest_;
+  const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP,DM> >       convTest_;
 
   //
   // Current solver state
@@ -331,12 +331,12 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
-  template<class ScalarType, class MV, class OP>
-  CGIter<ScalarType,MV,OP>::CGIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
-						   const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-						   const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-                                                   const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > &convTester,
-						   Teuchos::ParameterList &params ):
+  template<class ScalarType, class MV, class OP, class DM>
+  CGIter<ScalarType,MV,OP,DM>::CGIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
+				      const Teuchos::RCP<OutputManager<ScalarType> > &printer,
+				      const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
+                                      const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP,DM> > &convTester,
+				      Teuchos::ParameterList &params ):
     lp_(problem),
     om_(printer),
     stest_(tester),
@@ -353,8 +353,8 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Initialize this iteration object
-  template <class ScalarType, class MV, class OP>
-  void CGIter<ScalarType,MV,OP>::initializeCG(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > newstate, Teuchos::RCP<MV> R_0)
+  template <class ScalarType, class MV, class OP, class DM>
+  void CGIter<ScalarType,MV,OP,DM>::initializeCG(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > newstate, Teuchos::RCP<MV> R_0)
   {
     // Initialize the state storage if it isn't already.
     Teuchos::RCP<const MV> lhsMV = lp_->getLHS();
@@ -364,7 +364,7 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
     if (!Teuchos::rcp_dynamic_cast<CGIterationState<ScalarType,MV> >(newstate, true)->matches(tmp, 1))
       newstate->initialize(tmp, 1);
     setState(newstate);
-
+  
     // Tracking information for condition number estimation
     if(numEntriesForCondEst_ > 0) {
       diag_.resize(numEntriesForCondEst_);
@@ -373,7 +373,7 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
 
     std::string errstr("Belos::CGIter::initialize(): Specified multivectors must have a consistent length and width.");
     {
-
+    
       TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetGlobalLength(*R_0) != MVT::GetGlobalLength(*R_),
                           std::invalid_argument, errstr );
       TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetNumberVecs(*R_0) != 1,
@@ -382,7 +382,7 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
       // Copy basis vectors from newstate into V
       if (R_0 != R_) {
         // copy over the initial residual (unpreconditioned).
-	MVT::Assign( *R_0, *R_ );
+        MVT::Assign( *R_0, *R_ );
       }
 
       // Compute initial direction vectors
@@ -411,8 +411,8 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Iterate until the status test informs us we should stop.
-  template <class ScalarType, class MV, class OP>
-  void CGIter<ScalarType,MV,OP>::iterate()
+  template<class ScalarType, class MV, class OP, class DM>
+  void CGIter<ScalarType,MV,OP,DM>::iterate()
   {
     //
     // Allocate/initialize data structures
@@ -427,7 +427,7 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
     std::vector<ScalarType> rHz(1);
     std::vector<ScalarType> rHz_old(1);
     std::vector<ScalarType> pAp(1);
-    Teuchos::SerialDenseMatrix<int,ScalarType> rHs( 1, 2 );
+    Teuchos::RCP<DM> rHs = DMT::Create( 1, 2 );
 
     // Create convenience variables for zero and one.
     const ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
@@ -447,9 +447,10 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
 
     // Compute first <r,z> a.k.a. rHz
     if (foldConvergenceDetectionIntoAllreduce_ && convTest_->getResNormType() == Belos::TwoNorm) {
-      MVT::MvTransMv( one, *R_, *S_, rHs );
-      rHr_ = rHs(0,0);
-      rHz[0] = rHs(0,1);
+      MVT::MvTransMv( one, *R_, *S_, *rHs );
+      DMT::SyncDeviceToHost( *rHs );
+      rHr_ = DMT::ValueConst(*rHs,0,0);
+      rHz[0] = DMT::ValueConst(*rHs,0,1);
     } else
       MVT::MvDot( *R_, *Z_, rHz );
 
@@ -506,9 +507,10 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
       }
       //
       if (foldConvergenceDetectionIntoAllreduce_ && convTest_->getResNormType() == Belos::TwoNorm) {
-        MVT::MvTransMv( one, *R_, *S_, rHs );
-        rHr_ = rHs(0,0);
-        rHz[0] = rHs(0,1);
+        MVT::MvTransMv( one, *R_, *S_, *rHs );
+        DMT::SyncDeviceToHost( *rHs );
+        rHr_ = DMT::ValueConst(*rHs,0,0);
+        rHz[0] = DMT::ValueConst(*rHs,0,1);
       } else
         MVT::MvDot( *R_, *Z_, rHz );
       //

--- a/packages/belos/src/BelosCGIteration.hpp
+++ b/packages/belos/src/BelosCGIteration.hpp
@@ -138,8 +138,8 @@ namespace Belos {
   //@}
 
 
-template<class ScalarType, class MV, class OP>
-class CGIteration : virtual public Iteration<ScalarType,MV,OP> {
+template<class ScalarType, class MV, class OP, class DM>
+class CGIteration : virtual public Iteration<ScalarType,MV,OP,DM> {
 
   public:
 

--- a/packages/belos/src/BelosCGSingleRedIter.hpp
+++ b/packages/belos/src/BelosCGSingleRedIter.hpp
@@ -24,9 +24,8 @@
 #include "BelosStatusTestGenResNorm.hpp"
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
+#include "BelosDenseMatTraits.hpp"
 
-#include "Teuchos_SerialDenseMatrix.hpp"
-#include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
@@ -43,7 +42,7 @@
 
 namespace Belos {
 
-//! @name CGSingleRedIteration Structures
+  //! @name CGSingleRedIteration Structures
   //@{
 
   /** \brief Structure to contain pointers to CGSingleRedIteration state variables.
@@ -123,16 +122,17 @@ namespace Belos {
 
   };
 
-template<class ScalarType, class MV, class OP>
-class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
+template<class ScalarType, class MV, class OP, class DM>
+class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP,DM> {
 
   public:
 
   //
   // Convenience typedefs
   //
-  using MVT = MultiVecTraits<ScalarType, MV>;
+  using MVT = MultiVecTraits<ScalarType, MV, DM>;
   using OPT = OperatorTraits<ScalarType, MV, OP>;
+  using DMT = DenseMatTraits<ScalarType, DM>;
   using SCT = Teuchos::ScalarTraits<ScalarType>;
   using MagnitudeType = typename SCT::magnitudeType;
 
@@ -146,8 +146,8 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
    */
   CGSingleRedIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                    const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-                   const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-                   const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > &convTester,
+                   const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
+                   const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP,DM> > &convTester,
                    Teuchos::ParameterList &params );
 
   //! Destructor.
@@ -299,8 +299,8 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
   //
   const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
   const Teuchos::RCP<OutputManager<ScalarType> >          om_;
-  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
-  const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> >       convTest_;
+  const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >       stest_;
+  const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP,DM> >       convTest_;
 
   //
   // Current solver state
@@ -350,11 +350,11 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
-  template<class ScalarType, class MV, class OP>
-  CGSingleRedIter<ScalarType,MV,OP>::CGSingleRedIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
+  template<class ScalarType, class MV, class OP, class DM>
+  CGSingleRedIter<ScalarType,MV,OP,DM>::CGSingleRedIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
 						     const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-						     const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-                                                     const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > &convTester,
+						     const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
+                                                     const Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP,DM> > &convTester,
 						     Teuchos::ParameterList &params ):
     lp_(problem),
     om_(printer),
@@ -367,9 +367,9 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
-  // Initialize this iteration object
-  template <class ScalarType, class MV, class OP>
-  void CGSingleRedIter<ScalarType,MV,OP>::initializeCG(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > newstate, Teuchos::RCP<MV> R_0)
+  // Setup the state storage.
+  template<class ScalarType, class MV, class OP, class DM>
+  void CGSingleRedIter<ScalarType,MV,OP,DM>::initializeCG(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> > newstate, Teuchos::RCP<MV> R_0)
   {
     // Initialize the state storage if it isn't already.
     Teuchos::RCP<const MV> lhsMV = lp_->getLHS();
@@ -428,9 +428,9 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Get the norms of the residuals native to the solver.
-  template <class ScalarType, class MV, class OP>
+  template<class ScalarType, class MV, class OP, class DM>
   Teuchos::RCP<const MV>
-  CGSingleRedIter<ScalarType,MV,OP>::getNativeResiduals( std::vector<MagnitudeType> *norms ) const {
+  CGSingleRedIter<ScalarType,MV,OP,DM>::getNativeResiduals( std::vector<MagnitudeType> *norms ) const {
     if (convTest_->getResNormType() == Belos::PreconditionerNorm) {
       (*norms)[0] = std::sqrt(Teuchos::ScalarTraits<ScalarType>::magnitude(rHz_));
       return Teuchos::null;
@@ -444,8 +444,8 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Iterate until the status test informs us we should stop.
-  template <class ScalarType, class MV, class OP>
-  void CGSingleRedIter<ScalarType,MV,OP>::iterate()
+  template<class ScalarType, class MV, class OP, class DM>
+  void CGSingleRedIter<ScalarType,MV,OP,DM>::iterate()
   {
     //
     // Allocate/initialize data structures
@@ -455,12 +455,9 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
     }
 
     // Allocate memory for scalars.
-    Teuchos::SerialDenseMatrix<int,ScalarType> sHz( 2, 1 );
-    Teuchos::SerialDenseMatrix<int,ScalarType> sHt( 2, 2 );
-    ScalarType rHz_old;
-    ScalarType alpha;
-    ScalarType beta;
-    ScalarType delta;
+    Teuchos::RCP<DM> sHz = DMT::Create( 2, 1 );
+    Teuchos::RCP<DM> sHt = DMT::Create( 2, 2 );
+    ScalarType rHz_old, alpha, beta, delta;
 
     // Create convenience variables for zero and one.
     const ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
@@ -475,15 +472,17 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
 
     if (foldConvergenceDetectionIntoAllreduce_ && convTest_->getResNormType() == Belos::TwoNorm) {
       // Compute first <S_,T_> a.k.a. <R_,Z_>, <AZ_,Z_> and <R_,R_> combined (also computes unneeded <AZ_,R_>)
-      MVT::MvTransMv( one, *S_, *T_, sHt );
-      rHz_ = sHt(1,1);
-      delta = sHt(0,1);
-      rHr_ = sHt(1,0);
+      MVT::MvTransMv( one, *S_, *T_, *sHt );
+      DMT::SyncDeviceToHost( *sHt );
+      rHz_ = DMT::ValueConst(*sHt,1,1);
+      delta = DMT::ValueConst(*sHt,0,1);
+      rHr_ = DMT::ValueConst(*sHt,1,0);
     } else {
       // Compute first <s,z> a.k.a. <r,z> and <Az,z> combined
-      MVT::MvTransMv( one, *S_, *Z_, sHz );
-      rHz_ = sHz(1,0);
-      delta = sHz(0,0);
+      MVT::MvTransMv( one, *S_, *Z_, *sHz );
+      DMT::SyncDeviceToHost( *sHz );
+      rHz_ = DMT::ValueConst(*sHz,1,0);
+      delta = DMT::ValueConst(*sHz,0,0);
     }
     if ((Teuchos::ScalarTraits<ScalarType>::magnitude(delta) < Teuchos::ScalarTraits<ScalarType>::eps()) &&
         (stest_->checkStatus(this) == Passed))
@@ -531,13 +530,14 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
         lp_->applyOp( *Z_, *AZ_ );
         //
         // Compute <S_,T_> a.k.a. <R_,Z_>, <AZ_,Z_> and <R_,R_> combined (also computes unneeded <AZ_,R_>)
-        MVT::MvTransMv( one, *S_, *T_, sHt );
+        MVT::MvTransMv( one, *S_, *T_, *sHt );
+        DMT::SyncDeviceToHost( *sHt ); 
         //
         // Update scalars.
         rHz_old = rHz_;
-        rHz_ = sHt(1,1);
-        delta = sHt(0,1);
-        rHr_ = sHt(1,0);
+        rHz_ = DMT::ValueConst(*sHt,1,1);
+        delta = DMT::ValueConst(*sHt,0,1);
+        rHr_ = DMT::ValueConst(*sHt,1,0);
 
         // Increment the iteration
         iter_++;
@@ -606,12 +606,13 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
         lp_->applyOp( *Z_, *AZ_ );
         //
         // Compute <S_,Z_> a.k.a. <R_,Z_> and <AZ_,Z_> combined
-        MVT::MvTransMv( one, *S_, *Z_, sHz );
+        MVT::MvTransMv( one, *S_, *Z_, *sHz );
+        DMT::SyncDeviceToHost( *sHz );
         //
         // Update scalars.
         rHz_old = rHz_;
-        rHz_ = sHz(1,0);
-        delta = sHz(0,0);
+        rHz_ = DMT::ValueConst(*sHz,1,0);
+        delta = DMT::ValueConst(*sHz,0,0);
         //
         beta = rHz_ / rHz_old;
         alpha = rHz_ / (delta - (beta*rHz_ / alpha));

--- a/packages/belos/src/BelosCustomSolverFactory.hpp
+++ b/packages/belos/src/BelosCustomSolverFactory.hpp
@@ -25,7 +25,7 @@ namespace Belos {
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 // Forward declaration
-template<class Scalar, class MV, class OP>
+template<class Scalar, class MV, class OP, class DM>
 class SolverManager;
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
@@ -45,7 +45,7 @@ class SolverManager;
 ///
 /// For a test and example of how to do this (with a trivial solver),
 /// see <tt>Trilinos/packages/belos/tpetra/test/CustomSolverFactory.cpp</tt>.
-template<class Scalar, class MV, class OP>
+template<class Scalar, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,Scalar>>
 class CustomSolverFactory {
 public:
   /// \brief Return an instance of the specified solver, or
@@ -78,7 +78,7 @@ public:
   /// Teuchos::RCP<Teuchos::ParameterList>.  We allow a null parameter
   /// list only for convenience, and will use default parameter values
   /// in that case.
-  virtual Teuchos::RCP<SolverManager<Scalar, MV, OP> >
+  virtual Teuchos::RCP<SolverManager<Scalar, MV, OP, DM> >
   getSolver (const std::string& solverName,
              const Teuchos::RCP<Teuchos::ParameterList>& solverParams) = 0;
 

--- a/packages/belos/src/BelosDGKSOrthoManager.hpp
+++ b/packages/belos/src/BelosDGKSOrthoManager.hpp
@@ -27,6 +27,7 @@
 #include "BelosConfigDefs.hpp"
 #include "BelosMultiVecTraits.hpp"
 #include "BelosOperatorTraits.hpp"
+#include "BelosDenseMatTraits.hpp"
 #include "BelosMatOrthoManager.hpp"
 
 #include "Teuchos_as.hpp"
@@ -37,22 +38,23 @@
 namespace Belos {
 
   /// \brief "Default" parameters for robustness and accuracy.
-  template<class ScalarType, class MV, class OP>
+  template<class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
   Teuchos::RCP<Teuchos::ParameterList> getDGKSDefaultParameters ();
 
   /// \brief "Fast" but possibly unsafe or less accurate parameters.
-  template<class ScalarType, class MV, class OP>
+  template<class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
   Teuchos::RCP<Teuchos::ParameterList> getDGKSFastParameters();
 
-  template<class ScalarType, class MV, class OP>
+  template<class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
   class DGKSOrthoManager :
-    public MatOrthoManager<ScalarType,MV,OP>
+    public MatOrthoManager<ScalarType,MV,OP,DM>
   {
   private:
     typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
     typedef typename Teuchos::ScalarTraits<MagnitudeType> MGT;
     typedef Teuchos::ScalarTraits<ScalarType>  SCT;
-    typedef MultiVecTraits<ScalarType,MV>      MVT;
+    typedef MultiVecTraits<ScalarType,MV,DM>      MVT;
+    typedef DenseMatTraits<ScalarType,DM> DMT;
     typedef OperatorTraits<ScalarType,MV,OP>   OPT;
 
   public:
@@ -66,7 +68,7 @@ namespace Belos {
                       const MagnitudeType blk_tol = blk_tol_default_,
                       const MagnitudeType dep_tol = dep_tol_default_,
                       const MagnitudeType sing_tol = sing_tol_default_ )
-      : MatOrthoManager<ScalarType,MV,OP>(Op),
+      : MatOrthoManager<ScalarType,MV,OP,DM>(Op),
         max_blk_ortho_( max_blk_ortho ),
         blk_tol_( blk_tol ),
         dep_tol_( dep_tol ),
@@ -95,7 +97,7 @@ namespace Belos {
     DGKSOrthoManager (const Teuchos::RCP<Teuchos::ParameterList>& plist,
                       const std::string& label = "Belos",
                       Teuchos::RCP<const OP> Op = Teuchos::null)
-      : MatOrthoManager<ScalarType,MV,OP>(Op),
+      : MatOrthoManager<ScalarType,MV,OP,DM>(Op),
         max_blk_ortho_ ( max_blk_ortho_default_ ),
         blk_tol_ ( blk_tol_default_ ),
         dep_tol_ ( dep_tol_default_ ),
@@ -168,7 +170,7 @@ namespace Belos {
     getValidParameters () const
     {
       if (defaultParams_.is_null()) {
-        defaultParams_ = Belos::getDGKSDefaultParameters<ScalarType, MV, OP>();
+        defaultParams_ = Belos::getDGKSDefaultParameters<ScalarType, MV, OP, DM>();
       }
 
       return defaultParams_;
@@ -256,18 +258,17 @@ namespace Belos {
      orthonormal columns, and the <tt>Q[i]</tt> are assumed to be mutually orthogonal.
     */
     void project ( MV &X, Teuchos::RCP<MV> MX,
-                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
-                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
+                   Teuchos::Array<Teuchos::RCP<DM>> C,
+                   Teuchos::ArrayView<Teuchos::RCP<const MV>> Q) const;
 
 
     /*! \brief This method calls project(X,Teuchos::null,C,Q); see documentation for that function.
     */
     void project ( MV &X,
-                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
-                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const {
+                   Teuchos::Array<Teuchos::RCP<DM>> C,
+                   Teuchos::ArrayView<Teuchos::RCP<const MV>> Q) const {
       project(X,Teuchos::null,C,Q);
     }
-
 
 
     /*! \brief This method takes a multivector \c X and attempts to compute an orthonormal basis for \f$colspan(X)\f$, with respect to innerProd().
@@ -295,12 +296,12 @@ namespace Belos {
      @return Rank of the basis computed by this method.
     */
     int normalize ( MV &X, Teuchos::RCP<MV> MX,
-                    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B) const;
+                    Teuchos::RCP<DM> B) const;
 
 
     /*! \brief This method calls normalize(X,Teuchos::null,B); see documentation for that function.
     */
-    int normalize ( MV &X, Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B ) const {
+    int normalize ( MV &X, Teuchos::RCP<DM> B ) const {
       return normalize(X,Teuchos::null,B);
     }
 
@@ -364,8 +365,8 @@ namespace Belos {
     virtual int
     projectAndNormalizeWithMxImpl (MV &X,
                                    Teuchos::RCP<MV> MX,
-                                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
-                                   Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                                   Teuchos::Array<Teuchos::RCP<DM> > C,
+                                   Teuchos::RCP<DM> B,
                                    Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
 
   public:
@@ -467,17 +468,17 @@ namespace Belos {
 
     //! Routine to find an orthonormal basis for X
     int findBasis(MV &X, Teuchos::RCP<MV> MX,
-                  Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > C,
+                  Teuchos::RCP<DM> C,
                   bool completeBasis, int howMany = -1 ) const;
 
     //! Routine to compute the block orthogonalization
     bool blkOrtho1 ( MV &X, Teuchos::RCP<MV> MX,
-                    Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
-                    Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
+                     Teuchos::Array<Teuchos::RCP<DM>> C,
+                     Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
 
     //! Routine to compute the block orthogonalization
     bool blkOrtho ( MV &X, Teuchos::RCP<MV> MX,
-                    Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                    Teuchos::Array<Teuchos::RCP<DM>> C,
                     Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
 
     /// Project X against QQ and normalize X, one vector at a time
@@ -494,55 +495,55 @@ namespace Belos {
     ///   it likes to the Q array without changing it from the
     ///   caller's perspective.
     int blkOrthoSing ( MV &X, Teuchos::RCP<MV> MX,
-                       Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
-                       Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                       Teuchos::Array<Teuchos::RCP<DM> > C,
+                       Teuchos::RCP<DM> B,
                        Teuchos::ArrayView<Teuchos::RCP<const MV> > QQ) const;
   };
 
   // Set static variables.
-  template<class ScalarType, class MV, class OP>
-  const int DGKSOrthoManager<ScalarType,MV,OP>::max_blk_ortho_default_ = 2;
+  template<class ScalarType, class MV, class OP, class DM>
+  const int DGKSOrthoManager<ScalarType,MV,OP,DM>::max_blk_ortho_default_ = 2;
 
-  template<class ScalarType, class MV, class OP>
-  const typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType
-  DGKSOrthoManager<ScalarType,MV,OP>::blk_tol_default_
-    = 10*Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType>::squareroot(
-      Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType>::eps() );
+  template<class ScalarType, class MV, class OP, class DM>
+  const typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType
+  DGKSOrthoManager<ScalarType,MV,OP,DM>::blk_tol_default_
+    = 10*Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType>::squareroot(
+      Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType>::eps() );
 
-  template<class ScalarType, class MV, class OP>
-  const typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType
-  DGKSOrthoManager<ScalarType,MV,OP>::dep_tol_default_ 
-    = Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType>::one()
-      / Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType>::squareroot( 
-      2*Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType>::one() );
+  template<class ScalarType, class MV, class OP, class DM>
+  const typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType
+  DGKSOrthoManager<ScalarType,MV,OP,DM>::dep_tol_default_ 
+    = Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType>::one()
+      / Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType>::squareroot( 
+      2*Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType>::one() );
 
-  template<class ScalarType, class MV, class OP>
-  const typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType
-  DGKSOrthoManager<ScalarType,MV,OP>::sing_tol_default_ 
-    = 10*Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType>::eps();
+  template<class ScalarType, class MV, class OP, class DM>
+  const typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType
+  DGKSOrthoManager<ScalarType,MV,OP,DM>::sing_tol_default_ 
+    = 10*Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType>::eps();
 
-  template<class ScalarType, class MV, class OP>
-  const int DGKSOrthoManager<ScalarType,MV,OP>::max_blk_ortho_fast_ = 1;
+  template<class ScalarType, class MV, class OP, class DM>
+  const int DGKSOrthoManager<ScalarType,MV,OP,DM>::max_blk_ortho_fast_ = 1;
 
-  template<class ScalarType, class MV, class OP>
-  const typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType
-  DGKSOrthoManager<ScalarType,MV,OP>::blk_tol_fast_
-    = Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType>::zero();
+  template<class ScalarType, class MV, class OP, class DM>
+  const typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType
+  DGKSOrthoManager<ScalarType,MV,OP,DM>::blk_tol_fast_
+    = Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType>::zero();
 
-  template<class ScalarType, class MV, class OP>
-  const typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType
-  DGKSOrthoManager<ScalarType,MV,OP>::dep_tol_fast_
-    = Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType>::zero();
+  template<class ScalarType, class MV, class OP, class DM>
+  const typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType
+  DGKSOrthoManager<ScalarType,MV,OP,DM>::dep_tol_fast_
+    = Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType>::zero();
 
-  template<class ScalarType, class MV, class OP>
-  const typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType
-  DGKSOrthoManager<ScalarType,MV,OP>::sing_tol_fast_
-    = Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType>::zero();
+  template<class ScalarType, class MV, class OP, class DM>
+  const typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType
+  DGKSOrthoManager<ScalarType,MV,OP,DM>::sing_tol_fast_
+    = Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP,DM>::MagnitudeType>::zero();
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Set the label for this orthogonalization manager and create new timers if it's changed
-  template<class ScalarType, class MV, class OP>
-  void DGKSOrthoManager<ScalarType,MV,OP>::setLabel(const std::string& label)
+  template<class ScalarType, class MV, class OP, class DM>
+  void DGKSOrthoManager<ScalarType,MV,OP,DM>::setLabel(const std::string& label)
   {
     if (label != label_) {
       label_ = label;
@@ -567,50 +568,52 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Compute the distance from orthonormality
-  template<class ScalarType, class MV, class OP>
+  template<class ScalarType, class MV, class OP, class DM>
   typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
-  DGKSOrthoManager<ScalarType,MV,OP>::orthonormError(const MV &X, Teuchos::RCP<const MV> MX) const {
+  DGKSOrthoManager<ScalarType,MV,OP,DM>::orthonormError(const MV &X, Teuchos::RCP<const MV> MX) const {
     const ScalarType ONE = SCT::one();
     int rank = MVT::GetNumberVecs(X);
-    Teuchos::SerialDenseMatrix<int,ScalarType> xTx(rank,rank);
+    Teuchos::RCP<DM> xTx = DMT::Create(rank,rank);
     {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
     Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
 #endif
-    MatOrthoManager<ScalarType,MV,OP>::innerProd(X,X,MX,xTx);
+    MatOrthoManager<ScalarType,MV,OP,DM>::innerProd(X,X,MX,*xTx);
     }
+    DMT::SyncDeviceToHost(*xTx);
     for (int i=0; i<rank; i++) {
-      xTx(i,i) -= ONE;
+      DMT::Value(*xTx,i,i) -= ONE;
     }
-    return xTx.normFrobenius();
+    DMT::SyncHostToDevice(*xTx);
+    return DMT::NormFrobenius(*xTx);
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Compute the distance from orthogonality
-  template<class ScalarType, class MV, class OP>
+  template<class ScalarType, class MV, class OP, class DM>
   typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
-  DGKSOrthoManager<ScalarType,MV,OP>::orthogError(const MV &X1, Teuchos::RCP<const MV> MX1, const MV &X2) const {
+  DGKSOrthoManager<ScalarType,MV,OP,DM>::orthogError(const MV &X1, Teuchos::RCP<const MV> MX1, const MV &X2) const {
     int r1 = MVT::GetNumberVecs(X1);
     int r2  = MVT::GetNumberVecs(X2);
-    Teuchos::SerialDenseMatrix<int,ScalarType> xTx(r2,r1);
+    Teuchos::RCP<DM> xTx = DMT::Create(r2,r1);
     {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
     Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
 #endif
-    MatOrthoManager<ScalarType,MV,OP>::innerProd(X2,X1,MX1,xTx);
+    MatOrthoManager<ScalarType,MV,OP,DM>::innerProd(X2,X1,MX1,*xTx);
     }
-    return xTx.normFrobenius();
+    return DMT::NormFrobenius(*xTx);
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Find an Op-orthonormal basis for span(X) - span(W)
-  template<class ScalarType, class MV, class OP>
+  template<class ScalarType, class MV, class OP, class DM>
   int
-  DGKSOrthoManager<ScalarType, MV, OP>::
+  DGKSOrthoManager<ScalarType, MV, OP, DM>::
   projectAndNormalizeWithMxImpl (MV &X,
                                  Teuchos::RCP<MV> MX,
-                                 Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
-                                 Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                                 Teuchos::Array<Teuchos::RCP<DM> > C,
+                                 Teuchos::RCP<DM> B,
                                  Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const
   {
     using Teuchos::Array;
@@ -618,8 +621,6 @@ namespace Belos {
     using Teuchos::is_null;
     using Teuchos::RCP;
     using Teuchos::rcp;
-    using Teuchos::SerialDenseMatrix;
-    typedef SerialDenseMatrix< int, ScalarType > serial_dense_matrix_type;
     typedef typename Array< RCP< const MV > >::size_type size_type;
 
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
@@ -638,7 +639,7 @@ namespace Belos {
     // coefficients, allocate some local memory for them.  This will
     // go away at the end of this method.
     if (is_null (B)) {
-      B = rcp (new serial_dense_matrix_type (xc, xc));
+      B = DMT::Create(xc,xc);
     }
     // Likewise, if the user doesn't want to store the projection
     // coefficients, allocate some local memory for them.  Also make
@@ -653,17 +654,12 @@ namespace Belos {
         const int numRows = MVT::GetNumberVecs (*Q[k]);
         const int numCols = xc; // Number of vectors in X
 
-        if (is_null (C[k]))
-          C[k] = rcp (new serial_dense_matrix_type (numRows, numCols));
-        else if (C[k]->numRows() != numRows || C[k]->numCols() != numCols)
-          {
-            int err = C[k]->reshape (numRows, numCols);
-            TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error,
-                               "DGKS orthogonalization: failed to reshape "
-                               "C[" << k << "] (the array of block "
-                               "coefficients resulting from projecting X "
-                               "against Q[1:" << nq << "]).");
-          }
+        if (is_null (C[k])){
+          C[k] = DMT::Create(numRows,numCols);
+        }
+        else if (DMT::GetNumRows(*C[k]) != numRows || DMT::GetNumCols(*C[k]) != numCols) {
+          DMT::Reshape(*C[k],numRows,numCols);
+        }
       }
 
     /******   DO NO MODIFY *MX IF _hasOp == false   ******/
@@ -691,7 +687,7 @@ namespace Belos {
     }
 
     // check size of B
-    TEUCHOS_TEST_FOR_EXCEPTION( B->numRows() != xc || B->numCols() != xc, std::invalid_argument,
+    TEUCHOS_TEST_FOR_EXCEPTION( DMT::GetNumRows(*B) != xc || DMT::GetNumCols(*B) != xc, std::invalid_argument,
                         "Belos::DGKSOrthoManager::projectAndNormalize(): Size of X must be consistant with size of B" );
     // check size of X and MX
     TEUCHOS_TEST_FOR_EXCEPTION( xc<0 || xr<0 || mxc<0 || mxr<0, std::invalid_argument,
@@ -714,23 +710,26 @@ namespace Belos {
 
       // Normalize the new block X
       if ( B == Teuchos::null ) {
-        B = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(xc,xc) );
+        B = DMT::Create(xc,xc);
       }
-      std::vector<ScalarType> diag(1);
+      std::vector<ScalarType> dot(1);
       {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
         Teuchos::TimeMonitor normTimer( *timerNorm_ );
 #endif
-        MVT::MvDot( X, *MX, diag );
+        MVT::MvDot( X, *MX, dot );
       }
-      (*B)(0,0) = SCT::squareroot(SCT::magnitude(diag[0]));
 
-      if (SCT::magnitude((*B)(0,0)) > ZERO) {
+      ScalarType diag = SCT::squareroot(SCT::magnitude(dot[0])); 
+      Teuchos::RCP<DM> B00 = DMT::Subview(*B,1,1);
+      DMT::PutScalar( *B00, diag );
+
+      if (SCT::magnitude(diag) > ZERO) {
         rank = 1;
-        MVT::MvScale( X, ONE/(*B)(0,0) );
+        MVT::MvScale( X, ONE/diag );
         if (this->_hasOp) {
           // Update MXj.
-          MVT::MvScale( *MX, ONE/(*B)(0,0) );
+          MVT::MvScale( *MX, ONE/diag );
         }
       }
     }
@@ -786,10 +785,10 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Find an Op-orthonormal basis for span(X), with rank numvectors(X)
-  template<class ScalarType, class MV, class OP>
-  int DGKSOrthoManager<ScalarType, MV, OP>::normalize(
+  template<class ScalarType, class MV, class OP, class DM>
+  int DGKSOrthoManager<ScalarType, MV, OP, DM>::normalize(
                                 MV &X, Teuchos::RCP<MV> MX,
-                                Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B ) const {
+                                Teuchos::RCP<DM> B ) const {
 
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
     Teuchos::TimeMonitor orthotimer(*timerOrtho_);
@@ -803,10 +802,10 @@ namespace Belos {
 
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
-  template<class ScalarType, class MV, class OP>
-  void DGKSOrthoManager<ScalarType, MV, OP>::project(
+  template<class ScalarType, class MV, class OP, class DM>
+  void DGKSOrthoManager<ScalarType, MV, OP, DM>::project(
                           MV &X, Teuchos::RCP<MV> MX,
-                          Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                          Teuchos::Array<Teuchos::RCP<DM> > C,
                           Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const {
     // For the inner product defined by the operator Op or the identity (Op == 0)
     //   -> Orthogonalize X against each Q[i]
@@ -874,10 +873,10 @@ namespace Belos {
 
       // check size of C[i]
       if ( C[i] == Teuchos::null ) {
-        C[i] = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(qcs[i],xc) );
+        C[i] = DMT::Create(qcs[i],xc);
       }
       else {
-        TEUCHOS_TEST_FOR_EXCEPTION( C[i]->numRows() != qcs[i] || C[i]->numCols() != xc , std::invalid_argument,
+        TEUCHOS_TEST_FOR_EXCEPTION( DMT::GetNumRows(*C[i]) != qcs[i] || DMT::GetNumCols(*C[i]) != xc , std::invalid_argument,
                            "Belos::DGKSOrthoManager::project(): Size of Q not consistant with size of C" );
       }
     }
@@ -890,10 +889,9 @@ namespace Belos {
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Find an Op-orthonormal basis for span(X), with the option of extending the subspace so that
   // the rank is numvectors(X)
-  template<class ScalarType, class MV, class OP>
-  int DGKSOrthoManager<ScalarType, MV, OP>::findBasis(
-                                                      MV &X, Teuchos::RCP<MV> MX,
-                                                      Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+  template<class ScalarType, class MV, class OP, class DM>
+  int DGKSOrthoManager<ScalarType, MV, OP, DM>::findBasis( MV &X, Teuchos::RCP<MV> MX,
+                                                      Teuchos::RCP<DM> B,
                                                       bool completeBasis, int howMany ) const {
     // For the inner product defined by the operator Op or the identity (Op == 0)
     //   -> Orthonormalize X
@@ -939,7 +937,7 @@ namespace Belos {
      * allocate some local memory for them
      */
     if ( B == Teuchos::null ) {
-      B = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(xc,xc) );
+      B = DMT::Create(xc,xc);
     }
 
     int mxc = (this->_hasOp) ? MVT::GetNumberVecs( *MX ) : xc;
@@ -948,7 +946,7 @@ namespace Belos {
     // check size of C, B
     TEUCHOS_TEST_FOR_EXCEPTION( xc == 0 || xr == 0, std::invalid_argument,
                         "Belos::DGKSOrthoManager::findBasis(): X must be non-empty" );
-    TEUCHOS_TEST_FOR_EXCEPTION( B->numRows() != xc || B->numCols() != xc, std::invalid_argument,
+    TEUCHOS_TEST_FOR_EXCEPTION( DMT::GetNumRows(*B) != xc || DMT::GetNumCols(*B) != xc, std::invalid_argument,
                         "Belos::DGKSOrthoManager::findBasis(): Size of X not consistant with size of B" );
     TEUCHOS_TEST_FOR_EXCEPTION( xc != mxc || xr != mxr, std::invalid_argument,
                         "Belos::DGKSOrthoManager::findBasis(): Size of X not consistant with size of MX" );
@@ -1002,7 +1000,7 @@ namespace Belos {
       }
 
       // Make storage for these Gram-Schmidt iterations.
-      Teuchos::SerialDenseMatrix<int,ScalarType> product(numX, 1);
+      Teuchos::RCP<DM> product = DMT::Create(numX,1);
       std::vector<ScalarType> oldDot( 1 ), newDot( 1 );
       //
       // Save old MXj vector and compute Op-norm
@@ -1025,7 +1023,7 @@ namespace Belos {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
         Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
 #endif
-        MatOrthoManager<ScalarType,MV,OP>::innerProd(*prevX,*Xj,MXj,product);
+        MatOrthoManager<ScalarType,MV,OP,DM>::innerProd(*prevX,*Xj,MXj,*product);
         }
         // Xj <- Xj - prevX prevX^T MXj
         //     = Xj - prevX product
@@ -1033,7 +1031,7 @@ namespace Belos {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
         Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
-        MVT::MvTimesMatAddMv( -ONE, *prevX, product, ONE, *Xj );
+        MVT::MvTimesMatAddMv( -ONE, *prevX, *product, ONE, *Xj );
         }
 
         // Update MXj
@@ -1044,7 +1042,7 @@ namespace Belos {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
           Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
-          MVT::MvTimesMatAddMv( -ONE, *prevMX, product, ONE, *MXj );
+          MVT::MvTimesMatAddMv( -ONE, *prevMX, *product, ONE, *MXj );
         }
 
         // Compute new Op-norm
@@ -1059,26 +1057,26 @@ namespace Belos {
         if ( MGT::squareroot(SCT::magnitude(newDot[0])) < dep_tol_*MGT::squareroot(SCT::magnitude(oldDot[0])) ) {
           // Apply the second step of Gram-Schmidt
           // This is the same as above
-          Teuchos::SerialDenseMatrix<int,ScalarType> P2(numX,1);
+          Teuchos::RCP<DM> P2 = DMT::Create(numX,1);
           {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
           Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
 #endif
-          MatOrthoManager<ScalarType,MV,OP>::innerProd(*prevX,*Xj,MXj,P2);
+          MatOrthoManager<ScalarType,MV,OP,DM>::innerProd(*prevX,*Xj,MXj,*P2);
           }
-          product += P2;
+          DMT::Add(*product,*P2);
  
           {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
           Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
-          MVT::MvTimesMatAddMv( -ONE, *prevX, P2, ONE, *Xj );
+          MVT::MvTimesMatAddMv( -ONE, *prevX, *P2, ONE, *Xj );
           }
           if ((this->_hasOp)) {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
             Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
-            MVT::MvTimesMatAddMv( -ONE, *prevMX, P2, ONE, *MXj );
+            MVT::MvTimesMatAddMv( -ONE, *prevMX, *P2, ONE, *MXj );
           }
         } // if (newDot[0] < dep_tol_*oldDot[0])
 
@@ -1130,19 +1128,19 @@ namespace Belos {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
             Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
 #endif
-            MatOrthoManager<ScalarType,MV,OP>::innerProd(*prevX,*tempXj,tempMXj,product);
+            MatOrthoManager<ScalarType,MV,OP,DM>::innerProd(*prevX,*tempXj,tempMXj,*product);
             }
             {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
             Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
-            MVT::MvTimesMatAddMv( -ONE, *prevX, product, ONE, *tempXj );
+            MVT::MvTimesMatAddMv( -ONE, *prevX, *product, ONE, *tempXj );
             }
             if (this->_hasOp) {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
               Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
-              MVT::MvTimesMatAddMv( -ONE, *prevMX, product, ONE, *tempMXj );
+              MVT::MvTimesMatAddMv( -ONE, *prevMX, *product, ONE, *tempMXj );
             }
           }
           // Compute new Op-norm
@@ -1188,20 +1186,19 @@ namespace Belos {
       }
 
       // If we've added a random vector, enter a zero in the j'th diagonal element.
+      Teuchos::RCP<DM> Bjj = DMT::Subview(*B,1,1,j,j);
       if (addVec) {
-        (*B)(j,j) = ZERO;
+        DMT::PutScalar(*Bjj, ZERO);
       }
       else {
-        (*B)(j,j) = diag;
+        DMT::PutScalar(*Bjj, diag);
       }
 
       // Save the coefficients, if we are working on the original vector and not a randomly generated one
       if (!addVec) {
-        for (int i=0; i<numX; i++) {
-          (*B)(i,j) = product(i,0);
-        }
+        Teuchos::RCP<DM> Bcolj = DMT::Subview(*B,numX,1,0,j); 
+        DMT::Assign(*Bcolj,*product);
       }
-
     } // for (j = 0; j < xc; ++j)
 
     return xc;
@@ -1209,10 +1206,10 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Routine to compute the block orthogonalization
-  template<class ScalarType, class MV, class OP>
+  template<class ScalarType, class MV, class OP, class DM>
   bool
-  DGKSOrthoManager<ScalarType, MV, OP>::blkOrtho1 ( MV &X, Teuchos::RCP<MV> MX,
-                                                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+  DGKSOrthoManager<ScalarType, MV, OP, DM>::blkOrtho1 ( MV &X, Teuchos::RCP<MV> MX,
+                                                   Teuchos::Array<Teuchos::RCP<DM> > C,
                                                    Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const
   {
     int nq = Q.size();
@@ -1241,7 +1238,7 @@ namespace Belos {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
       Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
 #endif
-      MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],X,MX,*C[i]);
+      MatOrthoManager<ScalarType,MV,OP,DM>::innerProd(*Q[i],X,MX,*C[i]);
       }
       // Multiply by Q and subtract the result in X
       {
@@ -1292,22 +1289,22 @@ namespace Belos {
     // Apply the second step of Gram-Schmidt
 
       for (int i=0; i<nq; i++) {
-        Teuchos::SerialDenseMatrix<int,ScalarType> C2(C[i]->numRows(), C[i]->numCols());
+        Teuchos::RCP<DM> C2 = DMT::Create(DMT::GetNumRows(*C[i]),DMT::GetNumCols(*C[i]));
 
         // Apply another step of classical Gram-Schmidt
         {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
         Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
 #endif
-        MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],X,MX,C2);
+        MatOrthoManager<ScalarType,MV,OP,DM>::innerProd(*Q[i],X,MX,*C2);
         }
-        *C[i] += C2;
+        DMT::Add(*C[i],*C2);
 
         {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
         Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
-        MVT::MvTimesMatAddMv( -ONE, *Q[i], C2, ONE, X );
+        MVT::MvTimesMatAddMv( -ONE, *Q[i], *C2, ONE, X );
         }
 
         // Update MX, with the least number of applications of Op as possible
@@ -1317,7 +1314,7 @@ namespace Belos {
             Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
             // MQ was allocated and computed above; use it
-            MVT::MvTimesMatAddMv( -ONE, *MQ[i], C2, ONE, *MX );
+            MVT::MvTimesMatAddMv( -ONE, *MQ[i], *C2, ONE, *MX );
           }
           else if (xc <= qcs[i]) {
             // MQ was not allocated and computed above; it was cheaper to use X before and it still is
@@ -1332,10 +1329,10 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Routine to compute the block orthogonalization
-  template<class ScalarType, class MV, class OP>
+  template<class ScalarType, class MV, class OP, class DM>
   bool
-  DGKSOrthoManager<ScalarType, MV, OP>::blkOrtho ( MV &X, Teuchos::RCP<MV> MX,
-                                                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+  DGKSOrthoManager<ScalarType, MV, OP, DM>::blkOrtho ( MV &X, Teuchos::RCP<MV> MX,
+                                                   Teuchos::Array<Teuchos::RCP<DM> > C,
                                                    Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const
   {
     int nq = Q.size();
@@ -1367,7 +1364,7 @@ namespace Belos {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
       Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
 #endif
-      MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],X,MX,*C[i]);
+      MatOrthoManager<ScalarType,MV,OP,DM>::innerProd(*Q[i],X,MX,*C[i]);
       }
       // Multiply by Q and subtract the result in X
       {
@@ -1400,22 +1397,22 @@ namespace Belos {
     for (int j = 1; j < max_blk_ortho_; ++j) {
 
       for (int i=0; i<nq; i++) {
-        Teuchos::SerialDenseMatrix<int,ScalarType> C2(C[i]->numRows(), C[i]->numCols());
+        Teuchos::RCP<DM> C2 = DMT::Create(DMT::GetNumRows(*C[i]),DMT::GetNumCols(*C[i]));
 
         // Apply another step of classical Gram-Schmidt
         {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
         Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
 #endif
-        MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],X,MX,C2);
+        MatOrthoManager<ScalarType,MV,OP,DM>::innerProd(*Q[i],X,MX,*C2);
         }
-        *C[i] += C2;
+        DMT::Add(*C[i],*C2);
 
         {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
         Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
-        MVT::MvTimesMatAddMv( -ONE, *Q[i], C2, ONE, X );
+        MVT::MvTimesMatAddMv( -ONE, *Q[i], *C2, ONE, X );
         }
 
         // Update MX, with the least number of applications of Op as possible
@@ -1425,7 +1422,7 @@ namespace Belos {
             Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
             // MQ was allocated and computed above; use it
-            MVT::MvTimesMatAddMv( -ONE, *MQ[i], C2, ONE, *MX );
+            MVT::MvTimesMatAddMv( -ONE, *MQ[i], *C2, ONE, *MX );
           }
           else if (xc <= qcs[i]) {
             // MQ was not allocated and computed above; it was cheaper to use X before and it still is
@@ -1456,11 +1453,11 @@ namespace Belos {
   }
 
 
-  template<class ScalarType, class MV, class OP>
+  template<class ScalarType, class MV, class OP, class DM>
   int
-  DGKSOrthoManager<ScalarType, MV, OP>::blkOrthoSing ( MV &X, Teuchos::RCP<MV> MX,
-                                                       Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
-                                                       Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+  DGKSOrthoManager<ScalarType, MV, OP, DM>::blkOrthoSing ( MV &X, Teuchos::RCP<MV> MX,
+                                                       Teuchos::Array<Teuchos::RCP<DM> > C,
+                                                       Teuchos::RCP<DM> B,
                                                        Teuchos::ArrayView<Teuchos::RCP<const MV> > QQ) const
   {
     Teuchos::Array<Teuchos::RCP<const MV> > Q (QQ);
@@ -1481,7 +1478,7 @@ namespace Belos {
     // Create pointers for the previous vectors of X that have already been orthonormalized.
     Teuchos::RCP<const MV> lastQ;
     Teuchos::RCP<MV> Xj, MXj;
-    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > lastC;
+    Teuchos::RCP<DM> lastC = DMT::Create();
 
     // Perform the Gram-Schmidt transformation for each vector in the block of vectors.
     for (int j=0; j<xc; j++) {
@@ -1525,21 +1522,21 @@ namespace Belos {
       for (int i=0; i<Q.size(); i++) {
 
         // Get a view of the current serial dense matrix
-        Teuchos::SerialDenseMatrix<int,ScalarType> tempC( Teuchos::View, *C[i], qcs[i], 1, 0, j );
+        Teuchos::RCP<DM> tempC = DMT::Subview(*C[i], qcs[i], 1, 0, j);
 
         // Multiply Q' with MX
         {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
         Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
 #endif
-        MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],*Xj,MXj,tempC);
+        MatOrthoManager<ScalarType,MV,OP,DM>::innerProd(*Q[i],*Xj,MXj,*tempC);
         }
         // Multiply by Q and subtract the result in Xj
         {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
         Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
-        MVT::MvTimesMatAddMv( -ONE, *Q[i], tempC, ONE, *Xj );
+        MVT::MvTimesMatAddMv( -ONE, *Q[i], *tempC, ONE, *Xj );
         }
 
         // Update MXj, with the least number of applications of Op as possible
@@ -1555,7 +1552,7 @@ namespace Belos {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
             Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
-            MVT::MvTimesMatAddMv( -ONE, *MQ[i], tempC, ONE, *MXj );
+            MVT::MvTimesMatAddMv( -ONE, *MQ[i], *tempC, ONE, *MXj );
             }
           }
         }
@@ -1575,22 +1572,22 @@ namespace Belos {
       if ( SCT::magnitude(newDot[0]) < SCT::magnitude(oldDot[0]*dep_tol_) ) {
 
         for (int i=0; i<Q.size(); i++) {
-          Teuchos::SerialDenseMatrix<int,ScalarType> tempC( Teuchos::View, *C[i], qcs[i], 1, 0, j );
-          Teuchos::SerialDenseMatrix<int,ScalarType> C2( qcs[i], 1 );
+          Teuchos::RCP<DM> tempC = DMT::Subview(*C[i], qcs[i], 1, 0, j);
+          Teuchos::RCP<DM> C2 = DMT::Create(qcs[i],1);
 
           // Apply another step of classical Gram-Schmidt
           {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
           Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
 #endif
-          MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],*Xj,MXj,C2);
+          MatOrthoManager<ScalarType,MV,OP,DM>::innerProd(*Q[i],*Xj,MXj,*C2);
           }
-          tempC += C2;
+          DMT::Add(*tempC,*C2);
           {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
           Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
-          MVT::MvTimesMatAddMv( -ONE, *Q[i], C2, ONE, *Xj );
+          MVT::MvTimesMatAddMv( -ONE, *Q[i], *C2, ONE, *Xj );
           }
 
           // Update MXj, with the least number of applications of Op as possible
@@ -1600,7 +1597,7 @@ namespace Belos {
               Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
               // MQ was allocated and computed above; use it
-              MVT::MvTimesMatAddMv( -ONE, *MQ[i], C2, ONE, *MXj );
+              MVT::MvTimesMatAddMv( -ONE, *MQ[i], *C2, ONE, *MXj );
             }
             else if (xc <= qcs[i]) {
               // MQ was not allocated and computed above; it was cheaper to use X before and it still is
@@ -1634,7 +1631,8 @@ namespace Belos {
         }
 
         // Enter value on diagonal of B.
-        (*B)(j,j) = diag;
+        Teuchos::RCP<DM> Bjj = DMT::Subview(*B,1,1,j,j);
+        DMT::PutScalar(*Bjj, diag);
       }
       else {
         // Create a random vector and orthogonalize it against all previous columns of Q.
@@ -1658,20 +1656,20 @@ namespace Belos {
         for (int num_orth=0; num_orth<max_blk_ortho_; num_orth++) {
 
           for (int i=0; i<Q.size(); i++) {
-            Teuchos::SerialDenseMatrix<int,ScalarType> product( qcs[i], 1 );
+            Teuchos::RCP<DM> product = DMT::Create( qcs[i], 1 );
 
             // Apply another step of classical Gram-Schmidt
             {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
             Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
 #endif
-            MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],*tempXj,tempMXj,product);
+            MatOrthoManager<ScalarType,MV,OP,DM>::innerProd(*Q[i],*tempXj,tempMXj,*product);
             }
             {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
             Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
-            MVT::MvTimesMatAddMv( -ONE, *Q[i], product, ONE, *tempXj );
+            MVT::MvTimesMatAddMv( -ONE, *Q[i], *product, ONE, *tempXj );
             }
 
             // Update MXj, with the least number of applications of Op as possible
@@ -1681,7 +1679,7 @@ namespace Belos {
                 Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
 #endif
                 // MQ was allocated and computed above; use it
-                MVT::MvTimesMatAddMv( -ONE, *MQ[i], product, ONE, *tempMXj );
+                MVT::MvTimesMatAddMv( -ONE, *MQ[i], *product, ONE, *tempMXj );
               }
               else if (xc <= qcs[i]) {
                 // MQ was not allocated and computed above; it was cheaper to use X before and it still is
@@ -1705,7 +1703,8 @@ namespace Belos {
           ScalarType diag = SCT::squareroot(SCT::magnitude(newDot[0]));
 
           // Enter value on diagonal of B.
-          (*B)(j,j) = ZERO;
+          Teuchos::RCP<DM> Bjj = DMT::Subview(*B,1,1,j,j);
+          DMT::PutScalar(*Bjj, ZERO);
 
           // Copy vector into current column of _basisvecs
           MVT::MvAddMv( ONE/diag, *tempXj, ZERO, *tempXj, *Xj );
@@ -1730,7 +1729,7 @@ namespace Belos {
     return xc;
   }
 
-  template<class ScalarType, class MV, class OP>
+  template<class ScalarType, class MV, class OP, class DM>
   Teuchos::RCP<Teuchos::ParameterList> getDGKSDefaultParameters ()
   {
     using Teuchos::ParameterList;
@@ -1741,36 +1740,36 @@ namespace Belos {
 
     // Default parameter values for DGKS orthogonalization.
     // Documentation will be embedded in the parameter list.
-    params->set ("maxNumOrthogPasses", DGKSOrthoManager<ScalarType, MV, OP>::max_blk_ortho_default_,
+    params->set ("maxNumOrthogPasses", DGKSOrthoManager<ScalarType, MV, OP, DM>::max_blk_ortho_default_,
                  "Maximum number of orthogonalization passes (includes the "
                  "first).  Default is 2, since \"twice is enough\" for Krylov "
                  "methods.");
-    params->set ("blkTol", DGKSOrthoManager<ScalarType, MV, OP>::blk_tol_default_, 
+    params->set ("blkTol", DGKSOrthoManager<ScalarType, MV, OP, DM>::blk_tol_default_, 
                  "Block reorthogonalization threshold.");
-    params->set ("depTol", DGKSOrthoManager<ScalarType, MV, OP>::dep_tol_default_,
+    params->set ("depTol", DGKSOrthoManager<ScalarType, MV, OP, DM>::dep_tol_default_,
                  "(Non-block) reorthogonalization threshold.");
-    params->set ("singTol", DGKSOrthoManager<ScalarType, MV, OP>::sing_tol_default_, 
+    params->set ("singTol", DGKSOrthoManager<ScalarType, MV, OP, DM>::sing_tol_default_, 
                  "Singular block detection threshold.");
 
     return params;
   }
 
-  template<class ScalarType, class MV, class OP>
+  template<class ScalarType, class MV, class OP, class DM>
   Teuchos::RCP<Teuchos::ParameterList> getDGKSFastParameters ()
   {
     using Teuchos::ParameterList;
     using Teuchos::RCP;
 
-    RCP<ParameterList> params = getDGKSDefaultParameters<ScalarType, MV, OP>();
+    RCP<ParameterList> params = getDGKSDefaultParameters<ScalarType, MV, OP, DM>();
 
     params->set ("maxNumOrthogPasses", 
-                 DGKSOrthoManager<ScalarType, MV, OP>::max_blk_ortho_fast_);
+                 DGKSOrthoManager<ScalarType, MV, OP, DM>::max_blk_ortho_fast_);
     params->set ("blkTol", 
-                 DGKSOrthoManager<ScalarType, MV, OP>::blk_tol_fast_);
+                 DGKSOrthoManager<ScalarType, MV, OP, DM>::blk_tol_fast_);
     params->set ("depTol", 
-                 DGKSOrthoManager<ScalarType, MV, OP>::dep_tol_fast_);
+                 DGKSOrthoManager<ScalarType, MV, OP, DM>::dep_tol_fast_);
     params->set ("singTol", 
-                 DGKSOrthoManager<ScalarType, MV, OP>::sing_tol_fast_);
+                 DGKSOrthoManager<ScalarType, MV, OP, DM>::sing_tol_fast_);
 
     return params;
   }

--- a/packages/belos/src/BelosDenseMatTester.hpp
+++ b/packages/belos/src/BelosDenseMatTester.hpp
@@ -1,0 +1,317 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+#ifndef BELOS_DENSETRAITS_TESTER_HPP
+#define BELOS_DENSETRAITS_TESTER_HPP
+
+/*! \file BelosDenseTraitsTester.hpp
+  \brief Test routines for MultiVecTraits and OperatorTraits conformity.
+*/
+
+#include "BelosConfigDefs.hpp"//TODO is this needed?
+#include "BelosTypes.hpp"//TODO is this needed?
+
+#include "BelosOutputManager.hpp"
+#include "BelosDenseMatTraits.hpp"
+
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_SetScientific.hpp"//TODO is this needed?
+
+namespace Belos {
+
+  /// \brief Test correctness of a MultiVecTraits specialization and
+  ///   multivector implementation.
+  ///
+  /// \tparam ScalarType The type of the entries in the multivectors;
+  ///   the first template parameter of MultiVecTraits.
+  /// \tparam MV The multivector type; the second template parameter
+  ///   of MultiVecTraits.
+  ///
+  /// \param om [in/out] A valid OutputManager, for displaying test results.
+  ///
+  /// \param A [in] An initial multivector, to use for making new
+  ///   multivectors.  (Belos doesn't currently have a "vector space"
+  ///   abstraction; making a new multivector requires a valid input
+  ///   multivector to clone.)
+  ///
+  /// \return Test result: true if all tests passed, else false.
+  template< class ScalarType, class DM > 
+  bool
+  TestDenseMatTraits (const Teuchos::RCP<OutputManager<ScalarType> > &om)
+  {
+    using Teuchos::SetScientific;
+    using Teuchos::RCP;
+    using std::endl;
+    typedef DenseMatTraits<ScalarType, DM>    DMT;
+    typedef Teuchos::ScalarTraits<ScalarType> STS;
+
+    // Make sure that all floating-point numbers are printed with the
+    // right precision.
+    SetScientific<ScalarType> sci (om->stream (Warnings));
+
+    // Arbitrary tolerance in case
+    // norms are not computed deterministically (which is possible
+    // even with MPI only, and more likely with threads).
+
+    /* Dense Traits Contract:
+        
+        //Example: 
+         CloneCopy(MV,vector<int>)
+           USER: will request positive number of vectors
+             MV: will return a multivector with exactly the number of
+                   requested vectors.
+                 vectors are the same dimension as the cloned MV
+
+
+    *********************************************************************/
+
+    //TODO const ScalarType one      = STS::one();
+    const ScalarType zero     = STS::zero();
+
+    /*********** Basic Functions: *****************************************
+       Verify:
+       1) Can call DM constructor.
+       2) Number of rows and cols matches requested.
+       3) Init to zero if requested. 
+       4) Call constructor with no init to zero.
+       5) Can randomize matrix values. 
+       6) Can change a matrix value.
+       7) Const value access is const.
+       8) 
+       Basic tester: Just call all the functions. 
+    *********************************************************************/
+    { //begin test scope
+      int numrows = 4;
+      int numcols = 3;
+      RCP<DM> dm1 = DMT::Create(numrows,numcols);
+
+      //Check number of rows and cols.
+      int checknumrows = DMT::GetNumRows(*dm1);
+      int checknumcols = DMT::GetNumCols(*dm1);
+      if( checknumrows != numrows || checknumcols != numcols){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::GetNumRows or GetNumCols" << endl
+          << "Returned incorrect value." << endl;
+        return false;
+      }
+     
+      DMT::SyncDeviceToHost(*dm1); 
+      //Check init to zero on create.
+      for(int i = 0; i<numrows; i++){
+        for(int j = 0; j<numcols; j++){
+          ScalarType val = DMT::ValueConst(*dm1,i,j);
+          if(val != zero){
+            om->stream(Warnings)
+              << "*** ERROR *** DenseMatTraits::Create(-,-,true)" << endl
+              << "Did not initialize to zero!" << endl;
+            return false;
+          }
+        }
+      }
+
+      //Try to change a value.
+      DMT::Value(*dm1,0,0) = (ScalarType)5.0; //TODO: Does this compile? Is an lvalue?
+      if(DMT::ValueConst(*dm1,0,0) != (ScalarType)5.0){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::Value" << endl
+          << "Does not give write access to matrix values!!" << endl;
+        return false;
+      }
+
+      //Try to sync to host and vice-versa
+      DMT::SyncHostToDevice(*dm1);
+      
+      //Call create with non-default third arg.
+      RCP<DM> dm2 = DMT::Create(numrows, numcols, false);
+      DMT::PutScalar(*dm2,(ScalarType)47.2);
+      DMT::SyncDeviceToHost(*dm2);
+      if( DMT::ValueConst(*dm2,0,0) != (ScalarType)47.2){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::PutScalar " << endl
+          << "Value at dm2 0,0 is: " << DMT::ValueConst(*dm2,0,0) << endl;
+        return false;
+      }
+      DMT::PutScalar(*dm2);
+      DMT::SyncDeviceToHost(*dm2);
+      if( DMT::ValueConst(*dm2,0,0) != zero){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "PutScalar default args failed" << endl;
+        return false;
+      }
+      
+      //get stride
+      int stride = DMT::GetStride(*dm2);
+      if (stride != numrows) {
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "Stride failed" << endl;
+        return false;
+      }
+
+      //randomize and add
+      DMT::Randomize(*dm2);
+      DMT::SyncDeviceToHost(*dm2);
+      ScalarType tmpVal = DMT::ValueConst(*dm1,numrows-1,numcols-1) + DMT::ValueConst(*dm2,numrows-1,numcols-1);
+      ScalarType tmpVal2 = DMT::ValueConst(*dm1,0,0) + DMT::ValueConst(*dm2,0,0);
+      DMT::Add(*dm1,*dm2);
+      DMT::SyncDeviceToHost(*dm1);
+      if(DMT::ValueConst(*dm1,numrows-1,numcols-1) != tmpVal ||
+      DMT::ValueConst(*dm1,0,0) != tmpVal2){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "Add failed" << endl;
+        return false;
+      }
+
+      //Test assign and scale: 
+      DMT::Assign(*dm1,*dm2);
+      DMT::Scale(*dm1,2.0);
+      DMT::SyncDeviceToHost(*dm1);
+      if(DMT::ValueConst(*dm1,1,1) != (ScalarType)DMT::ValueConst(*dm2,1,1)*(ScalarType)2.0){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "Assign or scale failed" << endl;
+        return false;
+      }
+
+      RCP<DM> dm3 = DMT::Subview(*dm1, numrows-1, numcols-1, 1, 1);
+      DMT::SyncDeviceToHost(*dm3);
+      if(DMT::ValueConst(*dm3,0,0) != DMT::ValueConst(*dm1,1,1)){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "Subview failed" << endl;
+        return false;
+      }
+      if(DMT::GetNumRows(*dm3) != numrows-1 ||
+         DMT::GetNumCols(*dm3) != numcols-1){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "Subview gives wrong dimensions." << endl;
+        return false;
+      }
+      // Try to change a value in the subview.
+      ScalarType testVal = 237.1;
+      DMT::Value(*dm3,0,0) = testVal;
+      if(DMT::ValueConst(*dm3,0,0) != DMT::ValueConst(*dm1,1,1) ||
+         DMT::ValueConst(*dm3,0,0) != testVal){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "Subview did not edit value or did not edit original." << endl;
+        return false;
+      }
+
+      RCP<DM> dm4 = DMT::SubviewCopy(*dm1, numrows-2, numcols-2, 2, 2);
+      if(DMT::ValueConst(*dm4,0,0) != DMT::ValueConst(*dm1,2,2)){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "SubviewCopy failed" << endl;
+        return false;
+      }
+      if(DMT::GetNumRows(*dm4) != numrows-2 ||
+         DMT::GetNumCols(*dm4) != numcols-2){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "SubviewCopy gives wrong dimensions." << endl;
+        return false;
+      }
+      // Try to change a value in the subview.
+      DMT::Value(*dm4,0,0) = testVal-(ScalarType)5;
+      if(DMT::ValueConst(*dm4,0,0) == DMT::ValueConst(*dm1,2,2) ||
+         DMT::ValueConst(*dm4,0,0) != testVal-(ScalarType)5){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "SubviewCopy is incorrect. Possible view but not copy." << endl;
+        return false;
+      }
+      // Try to take a subview of a subview
+      RCP<DM> dm5 = DMT::Subview(*dm3, 1, 1);
+      DMT::Value(*dm5,0,0) = testVal-(ScalarType)10; 
+      if (DMT::ValueConst(*dm3,0,0) != DMT::ValueConst(*dm5,0,0) ||
+	  DMT::ValueConst(*dm1,1,1) != (testVal-(ScalarType)10)) {
+          om->stream(Warnings)
+            << "*** ERROR *** DenseMatTraits::" << endl
+            << "Subview of a subview is incorrect. Possibly can't take hierarchical subviews." << endl;
+        return false;
+      }
+
+
+      //TODO: Try to add matrices of mismatched size (eg dm3, dm4) and make sure it throws error. 
+      //
+      //Try reshaping:
+      //TODO: What should happen if reshape is called on a subview?
+      //Increase Dimensions
+      DMT::Reshape(*dm2, numrows+5, numcols+5);
+      if(DMT::GetNumRows(*dm2) != numrows+5 ||
+         DMT::GetNumCols(*dm2) != numcols+5){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "Reshape test 1 gives wrong dimensions." << endl;
+        return false;
+      }
+      //Decrease dimensions. 
+      DMT::Reshape(*dm2, numrows-2, numcols-2);
+      if(DMT::GetNumRows(*dm2) != numrows-2 ||
+         DMT::GetNumCols(*dm2) != numcols-2){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "Reshape test 2 gives wrong dimensions." << endl;
+        return false;
+      }
+      //Increase Dimensions and init to zeros.
+      DMT::Reshape(*dm2, numrows+5, numcols+5, true);
+      if(DMT::GetNumRows(*dm2) != numrows+5 ||
+         DMT::GetNumCols(*dm2) != numcols+5){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "Reshape test 3 gives wrong dimensions." << endl;
+        return false;
+      }
+      if(DMT::ValueConst(*dm2,0,0) != zero || DMT::ValueConst(*dm2,numrows+4,numcols+4) != zero){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "Reshape test 3 does not init to zero." << endl;
+        return false;
+      }
+
+      // Check that we can get a raw pointer from a non-const and const object for BLAS/LAPACK calls
+      DMT::SyncDeviceToHost( *dm2 );
+      ScalarType * testPtr = DMT::GetRawHostPtr(*dm2);
+      if (testPtr == 0) {
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "GetRawHostPtr returns NULL." << endl;
+        return false;
+      }
+      RCP<const DM> cdm2 = DMT::SubviewConst(*dm2, DMT::GetNumRows(*dm2), DMT::GetNumCols(*dm2)); 
+      if(DMT::GetNumRows(*cdm2) != numrows+5 ||
+         DMT::GetNumCols(*cdm2) != numcols+5){
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "SubviewConst did not create the right size matrix." << endl;
+        return false;
+      }
+      const ScalarType * testPtr2 = DMT::GetConstRawHostPtr(*cdm2);
+      if (testPtr2 == 0) {
+        om->stream(Warnings)
+          << "*** ERROR *** DenseMatTraits::" << endl
+          << "GetConstRawHostPtr returns NULL." << endl;
+        return false;
+      }
+      //
+      //Compute Frobenius norm. //TODO: Do Frob norm of a matrix we know the answer for and check it. 
+      DMT::NormFrobenius(*dm2);
+
+      //TODO: Definitely need testing to check host/device sync semantics. 
+      return true;
+    } //end test scope
+  } //end test function
+} //namespace Belos
+
+#endif

--- a/packages/belos/src/BelosDenseMatTraits.hpp
+++ b/packages/belos/src/BelosDenseMatTraits.hpp
@@ -1,0 +1,221 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+#ifndef BELOS_DENSE_MAT_TRAITS_HPP
+#define BELOS_DENSE_MAT_TRAITS_HPP
+
+/*! \file BelosDenseMatrixTraits.hpp
+  \brief Virtual base class which defines basic traits for the dense matrix type
+*/
+
+//#include "BelosConfigDefs.hpp"
+
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_ScalarTraits.hpp"
+
+#include "BelosDenseSolver.hpp"
+
+namespace Belos {
+
+/*! \struct UndefinedDenseMatTraits
+   \brief This is the default struct used by DenseMatrixTraits<OrdinalType, ScalarType> class to 
+   produce a compile time error when the specialization does not exist for
+   dense matrix type <tt>DM</tt>.
+*/
+
+  template< class ScalarType, class DM >
+  struct UndefinedDenseMatTraits
+  {
+    //! This function should not compile if there is an attempt to instantiate!
+    /*! \note Any attempt to compile this function results in a compile time error.  This means
+      that the template specialization of Anasazi::DenseMatTraits class for type <tt>DM</tt> does 
+      not exist, or is not complete.
+    */
+    static inline ScalarType notDefined() { return DM::this_type_is_missing_a_specialization(); };
+  };
+  
+  /*! \class DenseMatTraits
+    \brief Virtual base class which defines basic traits for the multi-vector type.
+    
+    An adapter for this traits class must exist for the <tt>DM</tt> type.
+    If not, this class will produce a compile-time error.
+  */
+
+  template<class ScalarType, class DM>
+  class DenseMatTraits 
+  {
+  public:
+    
+    //@{ \name Creation methods
+
+    /*! \brief Creates a new empty \c DM with no dimension.
+
+    \return Reference-counted pointer to a new dense matrix of type \c DM.
+    */
+    static Teuchos::RCP<DM> Create()
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); return Teuchos::null; }     
+
+    /*! \brief Creates a new empty \c DM containing \c numvecs columns.
+     *         Will be initialized to zeros if last parameter is true.
+
+    \return Reference-counted pointer to a new dense matrix of type \c DM.
+    */
+    static Teuchos::RCP<DM> Create( const int numrows, const int numcols, bool initZero = true)
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); return Teuchos::null; }     
+
+    /*! \brief Create a new copy \c DM, possibly transposed.
+  
+    \return Reference-counted pointer to a new dense matrix of type \c DM.
+    */
+    static Teuchos::RCP<DM> CreateCopy(const DM & dm, bool transpose=false)
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); return Teuchos::null; }
+
+/* Kokkos Ex View-from-ptr constructor: 
+View(const pointer_type &ptr, const IntType&... indices)
+
+    Unmanaged data wrapping constructor.
+
+        ptr: pointer to a user provided memory allocation. Must provide storage of size View::required_allocation_size(n0,...,nR)
+        indices: Extents of the View.
+        Requires: sizeof(IntType...)==rank_dynamic() or sizeof(IntType...)==rank(). In the latter case, the extents corresponding to compile-time dimensions must match the View type’s compile-time extents.
+        Requires: array_layout::is_regular == true.
+*/
+
+    //! \brief Returns a raw pointer to the (non-const) data on the host.
+    /// \note We assume that return data in in a column-major format
+    /// because this is what is expected by LAPACK.
+    /// \note This raw pointer is intended only for passing data to LAPACK
+    /// functions. Other operations on the raw data may result in undefined behavior!
+    static ScalarType* GetRawHostPtr(DM & dm )
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); return Teuchos::null; }     
+
+    //! \brief Returns a raw pointer to const data on the host.
+    static ScalarType const * GetConstRawHostPtr(const DM & dm )  
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); return Teuchos::null; }     
+
+    //! \brief Marks host data modified to avoid device sync errors. 
+    /// \note Belos developers must call this function after EVERY
+    ///   call to LAPACK that modifies dense matrix data accessed via raw pointer. 
+    //static void RawPtrDataModified(DM & dm)
+    //{ UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); }
+
+    //! \brief Returns an RCP to a DM which has a subview of the given DM.
+    //        Row and column indexing is zero-based.
+    //        Source  - Reference to another dense matrix from which values are to be copied.
+    //        numRows - The number of rows in this matrix.
+    //        numCols - The number of columns in this matrix.
+    //        startRow  - The row of Source from which the submatrix copy should start.
+    //        startCol  - The column of Source from which the submatrix copy should start.
+    //
+    //        Should ints be const? Should they be ints or some other ordinal type?
+    static Teuchos::RCP<DM> Subview( DM & source, int numRows, int numCols, int startRow=0, int startCol=0)
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); return Teuchos::null; }     
+
+    static Teuchos::RCP<const DM> SubviewConst( const DM & source, int numRows, int numCols, int startRow=0, int startCol=0)
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); return Teuchos::null; }     
+
+    //! \brief Returns a deep copy of the requested subview.
+    static Teuchos::RCP<DM> SubviewCopy( const DM & source, int numRows, int numCols, int startRow=0, int startCol=0)
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); return Teuchos::null; }     
+    //@}
+
+    //@{ \name Attribute methods
+
+    //! \brief Obtain the number of rows of \c dm.
+    static int GetNumRows( const DM& dm )
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); return 0; }     
+
+    //! \brief Obtain the number of columns of \c dm.
+    static int GetNumCols( const DM& dm )
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); return 0; }     
+
+    //! \brief Obtain the stride between the columns of \c dm.
+    static int GetStride( const DM& dm )
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); return 0; }     
+
+    //@}
+
+    //@{ \name Shaping methods
+
+    /* \brief Reshaping method for changing the size of \c dm,
+    *         keeping the entries. 
+    */
+    
+    /* \brief Reshaping method for changing the size of \c dm to have \c numrows rows and \c numcols columns.
+     *        All values will be initialized to zero if the final argument is true. 
+     *        If the final argument is fale, the previous entries in 
+     *        the matrix will be maintained. For new entries that did not exist in the previous matrix, values will
+     *        contain noise from memory. 
+    */
+    static void Reshape( DM& dm, const int numrows, const int numcols, bool initZero = true)
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); }     
+
+    //@}
+
+    //@{ \name Data access methods
+
+    //! \brief Access a reference to the (i,j) entry of \c dm, \c e_i^T dm e_j.
+    static ScalarType & Value( DM& dm, const int i, const int j )
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); }
+
+    //! \brief Access a const reference to the (i,j) entry of \c dm, \c e_i^T dm e_j.
+    static const ScalarType & ValueConst( const DM& dm, const int i, const int j ) 
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); }
+    
+    static void SyncDeviceToHost(DM & dm)
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); }
+
+    static void SyncHostToDevice(DM & dm)
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); }
+
+    //@}
+    //@{ \name Operator methods
+    
+    //!  \brief Adds sourceDM to thisDM and returns answer in thisDM.
+    static void Add( DM& thisDM, const DM& sourceDM)
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); }
+
+    //!  \brief Fill all entries with \c value. Value is zero if not specified.
+    static void PutScalar( DM& dm, ScalarType value = Teuchos::ScalarTraits<ScalarType>::zero()) 
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); }
+
+    //!  \brief Multiply all entries by a scalar. DM = value.*DM
+    static void Scale( DM& dm, ScalarType value)
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); }
+
+    //!  \brief Fill the DM with random entries.
+    //!   Entries are assumed to be the same on each MPI rank (each matrix copy). 
+    static void Randomize( DM& dm)
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); }
+
+    //!  \brief Copies entries of sourceDM to thisDM (deep copy). 
+    static void Assign( DM& thisDM, const DM& sourceDM)
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); }
+
+    //!  \brief Returns the Frobenius norm of the dense matrix.
+    static typename Teuchos::ScalarTraits<ScalarType>::magnitudeType NormFrobenius( DM& dm)
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); }
+
+    //!  \brief Returns the one-norm of the dense matrix.
+    static typename Teuchos::ScalarTraits<ScalarType>::magnitudeType NormOne( DM& dm)
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); }
+
+    //@}
+    //@{ \name Solver methods
+
+    //!  \brief Returns a dense solver object for the dense matrix.
+    static Teuchos::RCP<DenseSolver<ScalarType, DM>> createDenseSolver()
+    { UndefinedDenseMatTraits<ScalarType, DM>::notDefined(); return Teuchos::null; }
+    //@}
+ 
+  };
+
+} // namespace Belos
+
+#endif // end file BELOS_DENSE_MAT_TRAITS_HPP

--- a/packages/belos/src/BelosDenseSolver.hpp
+++ b/packages/belos/src/BelosDenseSolver.hpp
@@ -1,0 +1,99 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+#ifndef BELOS_DENSE_SOLVER_HPP
+#define BELOS_DENSE_SOLVER_HPP
+
+/*! \file BelosDenseSolver.hpp
+  \brief Virtual base class which defines solvers for dense matrix type
+*/
+
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_BLAS_types.hpp"
+
+namespace Belos {
+
+  template<class ScalarType, class DM>
+  class DenseSolver 
+  {
+  public:
+ 
+    //! @name Constructor/Destructor Methods
+    //@{
+    //! Default constructor; matrix should be set using setMatrix(), LHS and RHS set with setVectors().
+    DenseSolver()
+    : spd_(false),
+      equilibrate_(false),
+      TRANS_(Teuchos::NO_TRANS),
+      newMatrix_(false)
+    {}
+
+    //! SerialDenseSolver destructor.
+    virtual ~DenseSolver() {}
+    //@}
+
+    //! @name Set Methods
+    //@{
+
+    //! Sets the pointers for coefficient matrix
+    virtual int setMatrix(const Teuchos::RCP<DM>& A) { A_ = A; newMatrix_ = true; return 0; }
+
+    //! Sets the pointers for left and right hand side vector(s).
+    /*! Row dimension of X must match column dimension of matrix A, row dimension of B
+      must match row dimension of A.  X and B must have the same dimensions.
+    */
+    virtual int setVectors(const Teuchos::RCP<DM>& X, const Teuchos::RCP<DM>& B) { X_ = X; B_ = B; return 0; }
+    //@}
+
+    //! @name Strategy Modifying Methods
+    //@{
+
+    //! Set if dense matrix is symmetric positive definite
+    //! \note This method must be called before the factorization is performed, otherwise it will have no effect.
+    void setSPD(bool flag) {spd_ = flag; return;}
+
+    //! Causes equilibration to be called just before the matrix factorization as part of the call to \c factor.
+    /*! \note This method must be called before the factorization is performed, otherwise it will have no effect.
+    */
+    void factorWithEquilibration(bool flag) {equilibrate_ = flag; return;}
+
+    //! All subsequent function calls will work with the transpose-type set by this method (\c Teuchos::NO_TRANS, \c Teuchos::TRANS, and \c Teuchos::CONJ_TRANS).
+    /*! \note This interface will set correct transpose flag for matrix, including complex-valued linear systems.
+    */
+    void solveWithTransposeFlag(Teuchos::ETransp trans) {TRANS_ = trans; return;}
+    //@}
+
+    //! @name Factor/Solve Methods
+    //@{
+
+    //! Computes the in-place LU factorization of the matrix.
+    /*!
+      \return Integer error code, set to 0 if successful.
+    */
+    virtual int factor() = 0;
+
+    //! Computes the solution X to AX = B for the \e this matrix and the B provided.
+    /*!
+      \return Integer error code, set to 0 if successful.
+    */
+    virtual int solve() = 0;
+    //@}
+
+  protected:
+  
+    bool spd_, equilibrate_;
+    Teuchos::ETransp TRANS_;
+
+    bool newMatrix_; 
+    Teuchos::RCP<DM> A_, X_, B_;
+  };
+
+} // namespace Belos
+
+#endif // end file BELOS_DENSE_SOLVER_HPP

--- a/packages/belos/src/BelosFixedPointIter.hpp
+++ b/packages/belos/src/BelosFixedPointIter.hpp
@@ -24,8 +24,6 @@
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
 
-#include "Teuchos_SerialDenseMatrix.hpp"
-#include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
@@ -41,15 +39,15 @@
 
 namespace Belos {
 
-template<class ScalarType, class MV, class OP>
-class FixedPointIter : virtual public FixedPointIteration<ScalarType,MV,OP> {
+template<class ScalarType, class MV, class OP, class DM>
+class FixedPointIter : virtual public FixedPointIteration<ScalarType,MV,OP,DM> {
 
   public:
 
   //
   // Convenience typedefs
   //
-  typedef MultiVecTraits<ScalarType,MV> MVT;
+  typedef MultiVecTraits<ScalarType,MV,DM> MVT;
   typedef OperatorTraits<ScalarType,MV,OP> OPT;
   typedef Teuchos::ScalarTraits<ScalarType> SCT;
   typedef typename SCT::magnitudeType MagnitudeType;
@@ -64,7 +62,7 @@ class FixedPointIter : virtual public FixedPointIteration<ScalarType,MV,OP> {
    */
   FixedPointIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                   const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-                  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
+                  const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
                   Teuchos::ParameterList &params );
 
   //! Destructor.
@@ -180,7 +178,7 @@ class FixedPointIter : virtual public FixedPointIteration<ScalarType,MV,OP> {
   //
   const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
   const Teuchos::RCP<OutputManager<ScalarType> >          om_;
-  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
+  const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >       stest_;
 
   // Algorithmic parameters
   //
@@ -217,11 +215,11 @@ class FixedPointIter : virtual public FixedPointIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
-  template<class ScalarType, class MV, class OP>
-  FixedPointIter<ScalarType,MV,OP>::FixedPointIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
-                                                   const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-                                                   const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-                                                   Teuchos::ParameterList &params ):
+  template<class ScalarType, class MV, class OP, class DM>
+  FixedPointIter<ScalarType,MV,OP,DM>::FixedPointIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
+                                                      const Teuchos::RCP<OutputManager<ScalarType> > &printer,
+                                                      const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
+                                                      Teuchos::ParameterList &params ):
     lp_(problem),
     om_(printer),
     stest_(tester),
@@ -235,8 +233,8 @@ class FixedPointIter : virtual public FixedPointIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Setup the state storage.
-  template <class ScalarType, class MV, class OP>
-  void FixedPointIter<ScalarType,MV,OP>::setStateSize ()
+  template<class ScalarType, class MV, class OP, class DM>
+  void FixedPointIter<ScalarType,MV,OP,DM>::setStateSize ()
   {
     if (!stateStorageInitialized_) {
       // Check if there is any multivector to clone from.
@@ -267,8 +265,8 @@ class FixedPointIter : virtual public FixedPointIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Set the block size and make necessary adjustments.
-  template <class ScalarType, class MV, class OP>
-  void FixedPointIter<ScalarType,MV,OP>::setBlockSize(int blockSize)
+  template<class ScalarType, class MV, class OP, class DM>
+  void FixedPointIter<ScalarType,MV,OP,DM>::setBlockSize(int blockSize)
   {
     // This routine only allocates space; it doesn't not perform any computation
     // any change in size will invalidate the state of the solver.
@@ -295,8 +293,8 @@ class FixedPointIter : virtual public FixedPointIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Initialize this iteration object
-  template <class ScalarType, class MV, class OP>
-  void FixedPointIter<ScalarType,MV,OP>::initializeFixedPoint(FixedPointIterationState<ScalarType,MV>& newstate)
+  template<class ScalarType, class MV, class OP, class DM>
+  void FixedPointIter<ScalarType,MV,OP,DM>::initializeFixedPoint(FixedPointIterationState<ScalarType,MV>& newstate)
   {
     // Initialize the state storage if it isn't already.
     if (!stateStorageInitialized_)
@@ -308,10 +306,6 @@ class FixedPointIter : virtual public FixedPointIteration<ScalarType,MV,OP> {
     // NOTE:  In FixedPointIter R_, the initial residual, is required!!!
     //
     std::string errstr("Belos::FixedPointIter::initialize(): Specified multivectors must have a consistent length and width.");
-
-    // Create convenience variables for zero and one.
-    const ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
-    const ScalarType zero = Teuchos::ScalarTraits<ScalarType>::zero();
 
     if (newstate.R != Teuchos::null) {
       TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetNumberVecs(*R_) != MVT::GetNumberVecs(*newstate.R),
@@ -325,7 +319,7 @@ class FixedPointIter : virtual public FixedPointIteration<ScalarType,MV,OP> {
       // Copy basis vectors from newstate into V
       if (newstate.R != R_) {
         // copy over the initial residual (unpreconditioned).
-        MVT::MvAddMv( one, *newstate.R, zero, *newstate.R, *R_ );
+        MVT::Assign( *newstate.R, *R_ );
       }
 
     }
@@ -341,8 +335,8 @@ class FixedPointIter : virtual public FixedPointIteration<ScalarType,MV,OP> {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Iterate until the status test informs us we should stop.
-  template <class ScalarType, class MV, class OP>
-  void FixedPointIter<ScalarType,MV,OP>::iterate()
+  template<class ScalarType, class MV, class OP, class DM>
+  void FixedPointIter<ScalarType,MV,OP,DM>::iterate()
   {
     //
     // Allocate/initialize data structures

--- a/packages/belos/src/BelosFixedPointIteration.hpp
+++ b/packages/belos/src/BelosFixedPointIteration.hpp
@@ -40,8 +40,8 @@ namespace Belos {
     {}
   };
 
-template<class ScalarType, class MV, class OP>
-class FixedPointIteration : virtual public Iteration<ScalarType,MV,OP> {
+template<class ScalarType, class MV, class OP, class DM>
+class FixedPointIteration : virtual public Iteration<ScalarType,MV,OP,DM> {
 
   public:
 

--- a/packages/belos/src/BelosGCRODRIter.hpp
+++ b/packages/belos/src/BelosGCRODRIter.hpp
@@ -23,10 +23,9 @@
 #include "BelosStatusTest.hpp"
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
+#include "BelosDenseMatTraits.hpp"
 
 #include "Teuchos_BLAS.hpp"
-#include "Teuchos_SerialDenseMatrix.hpp"
-#include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
@@ -35,7 +34,7 @@
   \class Belos::GCRODRIter
   
   \brief This class implements the GCRODR iteration, where a
-  single-std::vector Krylov subspace is constructed.  The QR decomposition of 
+  single-vector Krylov subspace is constructed.  The QR decomposition of 
   block, upper Hessenberg matrix is performed each iteration to update
   the least squares system and give the current linear system residuals.
   \ingroup belos_solver_framework
@@ -52,7 +51,7 @@ namespace Belos {
    *
    * This struct is utilized by GCRODRIter::initialize() and GCRODRIter::getState().
    */
-  template <class ScalarType, class MV>
+  template <class ScalarType, class MV, class DM>
   struct GCRODRIterState {
     /*! \brief The current dimension of the reduction.
      *
@@ -66,20 +65,25 @@ namespace Belos {
     /*! \brief The recycled subspace and its projection. */
     Teuchos::RCP<MV> U, C;
 
+    /*! \brief The global projection matrix including Krylov subpace and recycled subspace
+     */
+    Teuchos::RCP<DM> H2;
+
     /*! \brief The current Hessenberg matrix.
      *
      * The \c curDim by \c curDim leading submatrix of H is the
      * projection of problem->getOperator() by the first \c curDim vectors in V.
      */
-    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > H;
+    Teuchos::RCP<DM> H;
 
     /*! \brief The projection of the Krylov subspace against the recycled subspace
      */
-    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B;
+    Teuchos::RCP<DM> B;
 
     GCRODRIterState() : curDim(0), V(Teuchos::null), 
 			U(Teuchos::null), C(Teuchos::null),
-			H(Teuchos::null), B(Teuchos::null)
+			H2(Teuchos::null), H(Teuchos::null), 
+			B(Teuchos::null)
     {}
   };
   
@@ -117,17 +121,18 @@ namespace Belos {
   
   //@}
   
-  
-  template<class ScalarType, class MV, class OP>
-  class GCRODRIter : virtual public Iteration<ScalarType,MV,OP> {
+ 
+  template<class ScalarType, class MV, class OP, class DM>
+  class GCRODRIter : virtual public Iteration<ScalarType,MV,OP,DM> {
     
   public:
     
     //
     // Convenience typedefs
     //
-    typedef MultiVecTraits<ScalarType,MV> MVT;
+    typedef MultiVecTraits<ScalarType,MV,DM> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
+    typedef DenseMatTraits<ScalarType,DM>    DMT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename SCT::magnitudeType MagnitudeType;
     
@@ -144,8 +149,8 @@ namespace Belos {
      */
     GCRODRIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
 		const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-		const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-		const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > &ortho,
+		const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
+		const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP,DM> > &ortho,
 		Teuchos::ParameterList &params );
     
     //! Destructor.
@@ -200,13 +205,13 @@ namespace Belos {
      * \note For any pointer in \c newstate which directly points to the multivectors in 
      * the solver, the data is not copied.
      */
-    void initialize(GCRODRIterState<ScalarType,MV>& newstate);
+    void initialize(GCRODRIterState<ScalarType,MV,DM>& newstate);
     
     /*! \brief Initialize the solver with empty data. Calling this method will result in error,
      *  as GCRODRIter must be initialized with a valid state.
      */
     void initialize() {
-      GCRODRIterState<ScalarType,MV> empty;
+      GCRODRIterState<ScalarType,MV,DM> empty;
       initialize(empty);
     }
     
@@ -217,14 +222,16 @@ namespace Belos {
      * \returns A GCRODRIterState object containing const pointers to the current
      * solver state.
      */
-    GCRODRIterState<ScalarType,MV> getState() const {
-      GCRODRIterState<ScalarType,MV> state;
+    GCRODRIterState<ScalarType,MV,DM> getState() const {
+      GCRODRIterState<ScalarType,MV,DM> state;
       state.curDim = curDim_;
       state.V = V_;
       state.U = U_;
       state.C = C_;
+      state.H2 = H2_;
       state.H = H_;
       state.B = B_;
+
       return state;
     }
     
@@ -247,7 +254,7 @@ namespace Belos {
     //! Get the current update to the linear system.
     /*! \note Some solvers, like GMRES, do not compute updates to the solution every iteration.
       This method forces its computation.  Other solvers, like CG, update the solution
-      each iteration, so this method will return a zero std::vector indicating that the linear
+      each iteration, so this method will return a zero vector indicating that the linear
       problem contains the current solution.
     */
     Teuchos::RCP<MV> getCurrentUpdate() const;
@@ -282,12 +289,6 @@ namespace Belos {
     //! \brief Set the maximum number of blocks used by the iterative solver.
     void setNumBlocks(int numBlocks) { setSize( recycledBlocks_, numBlocks ); };
     
-    //! \brief Get the maximum number of recycled blocks used by the iterative solver in solving this linear problem.
-    int getRecycledBlocks() const { return recycledBlocks_; }
-
-    //! \brief Set the maximum number of recycled blocks used by the iterative solver.
-    void setRecycledBlocks(int recycledBlocks) { setSize( recycledBlocks, numBlocks_ ); };
-    
     //! Get the blocksize to be used by the iterative solver in solving this linear problem.
     int getBlockSize() const { return 1; }
     
@@ -299,13 +300,14 @@ namespace Belos {
     //! \brief Set the maximum number of blocks used by the iterative solver and the number of recycled vectors.
     void setSize( int recycledBlocks, int numBlocks ) {
       // only call resize if size changed
-      if ( (recycledBlocks_ != recycledBlocks) || (numBlocks_ != numBlocks) ) {
+      if ( recycledBlocks_ != recycledBlocks )
         recycledBlocks_ = recycledBlocks;
+      if ( numBlocks_ != numBlocks ) {
         numBlocks_ = numBlocks;
-        cs_.sizeUninitialized( numBlocks_+1 );
-        sn_.sizeUninitialized( numBlocks_+1 );
-        z_.sizeUninitialized( numBlocks_+1 );
-        R_.shapeUninitialized( numBlocks_+1,numBlocks );
+        cs_.resize( numBlocks_+1 );
+        sn_.resize( numBlocks_+1 );
+        z_ = DMT::Create( numBlocks_+1, 1, false );
+        R_ = DMT::Create( numBlocks_+1, numBlocks, false );
       }
     }
 
@@ -325,8 +327,8 @@ namespace Belos {
     //
     const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
     const Teuchos::RCP<OutputManager<ScalarType> >          om_;
-    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
-    const Teuchos::RCP<OrthoManager<ScalarType,MV> >        ortho_;
+    const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >       stest_;
+    const Teuchos::RCP<OrthoManager<ScalarType,MV,DM> >        ortho_;
     
     //
     // Algorithmic parameters
@@ -336,10 +338,10 @@ namespace Belos {
 
     // recycledBlocks_ is the size of the allocated space for the recycled subspace, in blocks.
     int recycledBlocks_; 
-    
+   
     // Storage for QR factorization of the least squares system.
-    Teuchos::SerialDenseVector<int,ScalarType> sn_;
-    Teuchos::SerialDenseVector<int,MagnitudeType> cs_;
+    std::vector<ScalarType> sn_;
+    std::vector<MagnitudeType> cs_;
 
     // 
     // Current solver state
@@ -351,7 +353,9 @@ namespace Belos {
     
     // Current subspace dimension, and number of iterations performed.
     int curDim_, iter_;
-    
+   
+    // Pointer to the (0,0) position of the upper Hessenberg matrix.
+    int ptrH00_; 
     // 
     // State Storage
     //
@@ -361,27 +365,30 @@ namespace Belos {
     // Recycled subspace vectors.
     Teuchos::RCP<MV> U_, C_;
     //
+    // Global projected matrix, including H_ and B_
+    Teuchos::RCP<DM> H2_;
+    //
     // Projected matrices
     // H_ : Projected matrix from the Krylov factorization AV = VH + FE^T
-    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > H_;
+    Teuchos::RCP<DM> H_;
     //
     // B_ : Projected matrix from the recycled subspace B = C^H*A*V
-    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B_;
+    Teuchos::RCP<DM> B_;
     //
     // QR decomposition of Projected matrices for solving the least squares system HY = B.
     // R_: Upper triangular reduction of H
     // z_: Q applied to right-hand side of the least squares system
-    Teuchos::SerialDenseMatrix<int,ScalarType> R_;
-    Teuchos::SerialDenseVector<int,ScalarType> z_;  
+    Teuchos::RCP<DM> R_;
+    Teuchos::RCP<DM> z_;  
   };
   
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
-  template<class ScalarType, class MV, class OP>
-  GCRODRIter<ScalarType,MV,OP>::GCRODRIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
+  template<class ScalarType, class MV, class OP, class DM>
+  GCRODRIter<ScalarType,MV,OP,DM>::GCRODRIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
 					   const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-					   const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-					   const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > &ortho,
+					   const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
+					   const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP,DM> > &ortho,
 					   Teuchos::ParameterList &params ):
     lp_(problem), om_(printer), stest_(tester), ortho_(ortho) {
     numBlocks_      = 0;
@@ -389,9 +396,11 @@ namespace Belos {
     initialized_    = false;
     curDim_         = 0;
     iter_           = 0;
+    ptrH00_         = 0;
     V_              = Teuchos::null;
     U_              = Teuchos::null;
     C_              = Teuchos::null;
+    H2_             = Teuchos::null;
     H_              = Teuchos::null;
     B_              = Teuchos::null;
 
@@ -407,18 +416,17 @@ namespace Belos {
 
     numBlocks_ = nb;
     recycledBlocks_ = rb;
-
-    cs_.sizeUninitialized( numBlocks_+1 );
-    sn_.sizeUninitialized( numBlocks_+1 );
-    z_.sizeUninitialized( numBlocks_+1 );
-    R_.shapeUninitialized( numBlocks_+1,numBlocks_ );
+    cs_.resize( numBlocks_+1 );
+    sn_.resize( numBlocks_+1 );
+    z_ = DMT::Create( numBlocks_+1, 1, false );
+    R_ = DMT::Create( numBlocks_+1, numBlocks_, false );
 
   }
   
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Get the current update from this subspace.
-  template <class ScalarType, class MV, class OP>
-  Teuchos::RCP<MV> GCRODRIter<ScalarType,MV,OP>::getCurrentUpdate() const {
+  template<class ScalarType, class MV, class OP, class DM>
+  Teuchos::RCP<MV> GCRODRIter<ScalarType,MV,OP,DM>::getCurrentUpdate() const {
     //
     // If this is the first iteration of the Arnoldi factorization, 
     // there is no update, so return Teuchos::null. 
@@ -434,30 +442,40 @@ namespace Belos {
       //
       //  Make a view and then copy the RHS of the least squares problem.  DON'T OVERWRITE IT!
       //
-      Teuchos::SerialDenseMatrix<int,ScalarType> y( Teuchos::Copy, z_, curDim_, 1 );
+      Teuchos::RCP<DM> y = DMT::SubviewCopy(*z_, curDim_, 1);
+      DMT::SyncDeviceToHost( *y );
+      DMT::SyncDeviceToHost( *R_ );
       //
       //  Solve the least squares problem.
       //
       blas.TRSM( Teuchos::LEFT_SIDE, Teuchos::UPPER_TRI, Teuchos::NO_TRANS,
 		 Teuchos::NON_UNIT_DIAG, curDim_, 1, one,  
-		 R_.values(), R_.stride(), y.values(), y.stride() );
+		 DMT::GetConstRawHostPtr(*R_), DMT::GetStride(*R_), 
+		 DMT::GetRawHostPtr(*y), DMT::GetStride(*y) );
       //
       //  Compute the current update from the Krylov basis; V(:,1:curDim_)*y.
       //
       std::vector<int> index(curDim_);
       for ( int i=0; i<curDim_; i++ ) index[i] = i;
       Teuchos::RCP<const MV> Vjp1 = MVT::CloneView( *V_, index );
-      MVT::MvTimesMatAddMv( one, *Vjp1, y, zero, *currentUpdate );
+      MVT::MvTimesMatAddMv( one, *Vjp1, *y, zero, *currentUpdate );
       //
       //  Add in portion of update from recycled subspace U; U(:,1:recycledBlocks_)*B*y.
       //
       if (U_ != Teuchos::null) {
-        Teuchos::SerialDenseMatrix<int,ScalarType> z(recycledBlocks_,1);
-        Teuchos::SerialDenseMatrix<int,ScalarType> subB( Teuchos::View, *B_, recycledBlocks_, curDim_ );
-        z.multiply( Teuchos::NO_TRANS, Teuchos::NO_TRANS, one, subB, y, zero );
-        MVT::MvTimesMatAddMv( -one, *U_, z, one, *currentUpdate );
+	Teuchos::RCP<DM> z = DMT::Create( recycledBlocks_, 1 );
+	DMT::SyncDeviceToHost( *H2_ );
+        blas.GEMM( Teuchos::NO_TRANS, Teuchos::NO_TRANS, recycledBlocks_, 1, curDim_, one, 
+		   DMT::GetConstRawHostPtr(*B_), DMT::GetStride(*B_),
+		   DMT::GetConstRawHostPtr(*y), DMT::GetStride(*y),
+		   zero, DMT::GetRawHostPtr(*z), DMT::GetStride(*z));
+        DMT::SyncHostToDevice( *z );
+        MVT::MvTimesMatAddMv( -one, *U_, *z, one, *currentUpdate );
       }
     }
+    std::vector<MagnitudeType> normUpdate( 1 );
+    MVT::MvNorm( *currentUpdate, normUpdate );
+
     return currentUpdate;
   }
 
@@ -465,8 +483,8 @@ namespace Belos {
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Get the native residuals stored in this iteration.  
   // Note: This method does not return a MultiVector of the residual vectors, only return Teuchos::null
-  template <class ScalarType, class MV, class OP>
-  Teuchos::RCP<const MV> GCRODRIter<ScalarType,MV,OP>::getNativeResiduals( std::vector<MagnitudeType> *norms ) const {
+  template<class ScalarType, class MV, class OP, class DM>
+  Teuchos::RCP<const MV> GCRODRIter<ScalarType,MV,OP,DM>::getNativeResiduals( std::vector<MagnitudeType> *norms ) const {
     //
     // NOTE: Make sure the incoming std::vector is the correct size!
     //
@@ -474,8 +492,9 @@ namespace Belos {
       norms->resize( 1 );                                          
     
     if (norms) {
-      Teuchos::BLAS<int,ScalarType> blas;
-      (*norms)[0] = blas.NRM2( 1, &z_(curDim_), 1);
+      DMT::SyncDeviceToHost( *z_ );
+      const ScalarType curNativeResid = DMT::ValueConst(*z_,curDim_,0);
+      (*norms)[0] = SCT::magnitude (curNativeResid);
     }
     return Teuchos::null;
   }
@@ -484,20 +503,30 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Initialize this iteration object
-  template <class ScalarType, class MV, class OP>
-  void GCRODRIter<ScalarType,MV,OP>::initialize(GCRODRIterState<ScalarType,MV>& newstate) {
-    
-    if (newstate.V != Teuchos::null &&  newstate.H != Teuchos::null) {
+  template<class ScalarType, class MV, class OP, class DM>
+  void GCRODRIter<ScalarType,MV,OP,DM>::initialize(GCRODRIterState<ScalarType,MV,DM>& newstate) {
+   
+    if (newstate.V != Teuchos::null && newstate.H2 != Teuchos::null) {
       curDim_ = newstate.curDim;
       V_      = newstate.V;
       U_      = newstate.U;
       C_      = newstate.C;
-      H_      = newstate.H;
-      B_      = newstate.B;
+      H2_     = newstate.H2;
+      // There is no recycled space, so this iteration is creating the first one.
+      if (newstate.U == Teuchos::null) {
+        ptrH00_ = recycledBlocks_+1;
+        H_ = DMT::Subview( *H2_, numBlocks_+1, numBlocks_, ptrH00_, ptrH00_ );
+        B_ = Teuchos::null;
+      }
+      else {	      
+        ptrH00_ = recycledBlocks_;
+        H_ = DMT::Subview( *H2_, numBlocks_+1, numBlocks_, ptrH00_, ptrH00_ );
+        B_ = DMT::Subview( *H2_, recycledBlocks_, numBlocks_, 0, ptrH00_ );
+      }
     }
     else {
       TEUCHOS_TEST_FOR_EXCEPTION(newstate.V == Teuchos::null,std::invalid_argument,"Belos::GCRODRIter::initialize(): GCRODRIterState does not have V initialized.");
-      TEUCHOS_TEST_FOR_EXCEPTION(newstate.H == Teuchos::null,std::invalid_argument,"Belos::GCRODRIter::initialize(): GCRODRIterState does not have H initialized.");
+      TEUCHOS_TEST_FOR_EXCEPTION(newstate.H2 == Teuchos::null,std::invalid_argument,"Belos::GCRODRIter::initialize(): GCRODRIterState does not have H2 initialized.");
     }
 
     // the solver is initialized
@@ -508,8 +537,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Iterate until the status test informs us we should stop.
-  template <class ScalarType, class MV, class OP>
-  void GCRODRIter<ScalarType,MV,OP>::iterate() {
+  template<class ScalarType, class MV, class OP, class DM>
+  void GCRODRIter<ScalarType,MV,OP,DM>::iterate() {
 
     TEUCHOS_TEST_FOR_EXCEPTION( initialized_ == false, GCRODRIterInitFailure,"Belos::GCRODRIter::iterate(): GCRODRIter class not initialized." );
 
@@ -521,19 +550,16 @@ namespace Belos {
     std::vector<int> curind(1);
 
     // z_ must be zeroed out in order to compute Givens rotations correctly
-    z_.putScalar(0.0);
+    DMT::PutScalar(*z_);
 
     // Orthonormalize the new V_0
     curind[0] = 0;
     Vnext = MVT::CloneViewNonConst(*V_,curind);
     // Orthonormalize first column
-    // First, get a monoelemental matrix to hold the orthonormalization coefficients
-    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > z0 =
-      Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(1,1) );
+    // First, get a view of the first element of z_ to hold the orthonormalization coefficients
+    Teuchos::RCP<DM> z0 = DMT::Subview( *z_, 1, 1 );
     int rank = ortho_->normalize( *Vnext, z0 );
     TEUCHOS_TEST_FOR_EXCEPTION(rank != 1,GCRODRIterOrthoFailure, "Belos::GCRODRIter::iterate(): couldn't generate basis of full rank.");
-    // Copy the scalar coefficient back into the z_ vector
-    z_(0) = (*z0)(0,0);
 
     std::vector<int> prevind(numBlocks_+1);
 
@@ -567,22 +593,20 @@ namespace Belos {
         Teuchos::Array<Teuchos::RCP<const MV> > AVprev(1, Vprev);
 
         // Get a view of the part of the Hessenberg matrix needed to hold the ortho coeffs.
-        Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> >
-          subH = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>  ( Teuchos::View,*H_,lclDim,1,0,curDim_ ) );
-        Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > AsubH;
-        AsubH.append( subH );
+	Teuchos::RCP<DM> subH = DMT::Subview(*H2_, lclDim, 1, ptrH00_, ptrH00_+curDim_);
+        Teuchos::Array<Teuchos::RCP<DM> > AsubH( 1, subH );
 
         // Get a view of the part of the Hessenberg matrix needed to hold the norm coeffs.
-        Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> >
-          subR = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType> ( Teuchos::View,*H_,1,1,lclDim,curDim_ ) );
+        Teuchos::RCP<DM> subR = DMT::Subview(*H2_, 1, 1, ptrH00_+lclDim, ptrH00_+curDim_);
 
         // Project out the previous Krylov vectors and normalize the next vector.
-        rank = ortho_->projectAndNormalize(*Vnext,AsubH,subR,AVprev);
+	rank = ortho_->projectAndNormalize(*Vnext, AsubH, subR, AVprev);
 
-        // Copy over the coefficients to R just in case we run into an error.
-        Teuchos::SerialDenseMatrix<int,ScalarType> subR2( Teuchos::View,R_,lclDim+1,1,0,curDim_ );
-        Teuchos::SerialDenseMatrix<int,ScalarType> subH2( Teuchos::View,*H_,lclDim+1,1,0,curDim_ );
-        subR2.assign(subH2);
+	// Copy over the coefficients to R just in case we run into an error.
+	Teuchos::RCP<DM> subR2 = DMT::Subview(*R_, lclDim+1, 1, 0, curDim_);
+        Teuchos::RCP<const DM> subH2 = DMT::SubviewConst(*H2_, lclDim+1, 1, ptrH00_, ptrH00_+curDim_);
+	DMT::Assign(*subR2, *subH2);
+	subR2 = Teuchos::null;
 
         TEUCHOS_TEST_FOR_EXCEPTION(rank != 1,GCRODRIterOrthoFailure, "Belos::GCRODRIter::iterate(): couldn't generate basis of full rank.");
 
@@ -611,12 +635,13 @@ namespace Belos {
         lp_->apply(*Vprev,*Vnext);
         Vprev = Teuchos::null;
 
+	DMT::SyncHostToDevice(*H2_);
+
         // First, remove the recycled subspace (C) from Vnext and put coefficients in B.
         Teuchos::Array<Teuchos::RCP<const MV> > C(1, C_);
-        Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> >
-  	  subB = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType> ( Teuchos::View,*B_,recycledBlocks_,1,0,curDim_ ) );
-        Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > AsubB;
-        AsubB.append( subB );
+        Teuchos::RCP<DM> subB = DMT::Subview(*H2_, recycledBlocks_, 1, 0, ptrH00_+curDim_);
+        Teuchos::RCP<DM> tmpB = DMT::Create(recycledBlocks_, 1);
+	Teuchos::Array<Teuchos::RCP<DM> > AsubB( 1, subB );
 
         // Project out the recycled subspace.
         ortho_->project( *Vnext, AsubB, C );
@@ -629,20 +654,20 @@ namespace Belos {
         Teuchos::Array<Teuchos::RCP<const MV> > AVprev(1, Vprev);
 	
         // Get a view of the part of the Hessenberg matrix needed to hold the ortho coeffs.
-        Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > subH = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>  ( Teuchos::View,*H_,lclDim,1,0,curDim_ ) );
-        Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > AsubH;
-        AsubH.append( subH );
+        Teuchos::RCP<DM> subH = DMT::Subview(*H2_, lclDim, 1, ptrH00_, ptrH00_+curDim_);
+        Teuchos::Array<Teuchos::RCP<DM> > AsubH(1, subH);
       
         // Get a view of the part of the Hessenberg matrix needed to hold the norm coeffs.
-        Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> >  subR = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType> ( Teuchos::View,*H_,1,1,lclDim,curDim_ ) );
+        Teuchos::RCP<DM> subR = DMT::Subview(*H2_, 1, 1, ptrH00_+lclDim, ptrH00_+curDim_);
 
         // Project out the previous Krylov vectors and normalize the next vector.
-        rank = ortho_->projectAndNormalize(*Vnext,AsubH,subR,AVprev);
-
+        rank = ortho_->projectAndNormalize(*Vnext, AsubH, subR, AVprev);
+ 
         // Copy over the coefficients to R just in case we run into an error.
-        Teuchos::SerialDenseMatrix<int,ScalarType> subR2( Teuchos::View,R_,lclDim+1,1,0,curDim_ );
-        Teuchos::SerialDenseMatrix<int,ScalarType> subH2( Teuchos::View,*H_,lclDim+1,1,0,curDim_ );
-        subR2.assign(subH2);
+	Teuchos::RCP<DM> subR2 = DMT::Subview(*R_, lclDim+1, 1, 0, curDim_);
+        Teuchos::RCP<const DM> subH2 = DMT::SubviewConst(*H2_, lclDim+1, 1, ptrH00_, ptrH00_+curDim_);
+	DMT::Assign(*subR2, *subH2);
+	subR2 = Teuchos::null;
       
         TEUCHOS_TEST_FOR_EXCEPTION(rank != 1,GCRODRIterOrthoFailure, "Belos::GCRODRIter::iterate(): couldn't generate basis of full rank.");
 
@@ -658,12 +683,12 @@ namespace Belos {
   }
 
   
-  template<class ScalarType, class MV, class OP>
-  void GCRODRIter<ScalarType,MV,OP>::updateLSQR( int dim ) {
+  template<class ScalarType, class MV, class OP, class DM>
+  void GCRODRIter<ScalarType,MV,OP,DM>::updateLSQR( int dim ) {
 
     int i;
     const ScalarType zero = Teuchos::ScalarTraits<ScalarType>::zero();
-    
+   
     // Get correct dimension based on input "dim"
     // Remember that ortho failures result in an exit before updateLSQR() is called.
     // Therefore, it is possible that dim == curDim_.
@@ -678,22 +703,29 @@ namespace Belos {
     //
     // QR factorization of Least-Squares system with Givens rotations
     //
+    DMT::SyncDeviceToHost(*R_);
+    DMT::SyncDeviceToHost(*z_);
+    //
     for (i=0; i<curDim; i++) {
       //
       // Apply previous Givens rotations to new column of Hessenberg matrix
       //
-      blas.ROT( 1, &R_(i,curDim), 1, &R_(i+1, curDim), 1, &cs_[i], &sn_[i] );
+      blas.ROT( 1, &(DMT::Value(*R_,i,curDim)), 1, &(DMT::Value(*R_,i+1, curDim)), 1, &cs_[i], &sn_[i] );
+ 
     }
     //
     // Calculate new Givens rotation
     //
-    blas.ROTG( &R_(curDim,curDim), &R_(curDim+1,curDim), &cs_[curDim], &sn_[curDim] );
-    R_(curDim+1,curDim) = zero;
+    blas.ROTG( &(DMT::Value(*R_,curDim,curDim)), &(DMT::Value(*R_,curDim+1,curDim)), &cs_[curDim], &sn_[curDim] );
+    DMT::Value(*R_,curDim+1,curDim) = zero;
     //
     // Update RHS w/ new transformation
     //
-    blas.ROT( 1, &z_(curDim), 1, &z_(curDim+1), 1, &cs_[curDim], &sn_[curDim] );
-
+    blas.ROT( 1, &(DMT::Value(*z_,curDim,0)), 1, &(DMT::Value(*z_,curDim+1,0)), 1, &cs_[curDim], &sn_[curDim] );
+    //
+    DMT::SyncHostToDevice(*R_);
+    DMT::SyncHostToDevice(*z_);
+    //
   } // end updateLSQR()
 
 } // end Belos namespace

--- a/packages/belos/src/BelosGCRODRSolMgr.hpp
+++ b/packages/belos/src/BelosGCRODRSolMgr.hpp
@@ -21,7 +21,6 @@
 #include "BelosTypes.hpp"
 
 #include "BelosGCRODRIter.hpp"
-#include "BelosBlockFGmresIter.hpp"
 #include "BelosStatusTestMaxIters.hpp"
 #include "BelosStatusTestGenResNorm.hpp"
 #include "BelosStatusTestCombo.hpp"
@@ -127,15 +126,15 @@ Spandan Maiti.  "Recycling Krylov Subspaces for Sequences of Linear
 Systems," SIAM Journal on Scientific Computing, 28(5), pp. 1651-1674,
 2006.*/
 
-  template<class ScalarType, class MV, class OP,
+  template<class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>,
            const bool lapackSupportsScalarType =
            Belos::Details::LapackSupportsScalar<ScalarType>::value>
   class GCRODRSolMgr :
-    public Details::SolverManagerRequiresLapack<ScalarType,MV,OP>
+    public Details::SolverManagerRequiresLapack<ScalarType,MV,OP,DM>
   {
     static const bool requiresLapack =
       Belos::Details::LapackSupportsScalar<ScalarType>::value;
-    typedef Details::SolverManagerRequiresLapack<ScalarType, MV, OP,
+    typedef Details::SolverManagerRequiresLapack<ScalarType, MV, OP,DM,
                                                  requiresLapack> base_type;
 
   public:
@@ -152,9 +151,9 @@ Systems," SIAM Journal on Scientific Computing, 28(5), pp. 1651-1674,
   /// \brief Partial specialization for ScalarType types for which
   ///   Teuchos::LAPACK has a valid implementation.  This contains the
   ///   actual working implementation of GCRODR.
-  template<class ScalarType, class MV, class OP>
-  class GCRODRSolMgr<ScalarType, MV, OP, true> :
-    public Details::SolverManagerRequiresLapack<ScalarType, MV, OP, true>
+  template<class ScalarType, class MV, class OP, class DM>
+  class GCRODRSolMgr<ScalarType, MV, OP, DM, true> :
+    public Details::SolverManagerRequiresLapack<ScalarType, MV, OP, DM, true>
   {
 
 #if defined(HAVE_TEUCHOSCORE_CXX11)
@@ -196,12 +195,13 @@ Systems," SIAM Journal on Scientific Computing, 28(5), pp. 1651-1674,
 #endif // defined(HAVE_TEUCHOSCORE_CXX11)
 
   private:
-    typedef MultiVecTraits<ScalarType,MV> MVT;
+    typedef MultiVecTraits<ScalarType,MV,DM> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
+    typedef DenseMatTraits<ScalarType,DM>    DMT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
     typedef Teuchos::ScalarTraits<MagnitudeType> MT;
-    typedef OrthoManagerFactory<ScalarType, MV, OP> ortho_factory_type;
+    typedef OrthoManagerFactory<ScalarType, MV, OP, DM> ortho_factory_type;
 
   public:
     //! @name Constructors/Destructor
@@ -273,8 +273,8 @@ Systems," SIAM Journal on Scientific Computing, 28(5), pp. 1651-1674,
     virtual ~GCRODRSolMgr() {};
 
     //! clone for Inverted Injection (DII)
-    Teuchos::RCP<SolverManager<ScalarType, MV, OP> > clone () const override {
-      return Teuchos::rcp(new GCRODRSolMgr<ScalarType,MV,OP,true>);
+    Teuchos::RCP<SolverManager<ScalarType, MV, OP, DM> > clone () const override {
+      return Teuchos::rcp(new GCRODRSolMgr<ScalarType,MV,OP,DM,true>);
     }
     //@}
 
@@ -406,25 +406,21 @@ Systems," SIAM Journal on Scientific Computing, 28(5), pp. 1651-1674,
     void initializeStateStorage();
 
     // Compute updated recycle space given existing recycle space and newly generated Krylov space
-    void buildRecycleSpace2(Teuchos::RCP<GCRODRIter<ScalarType,MV,OP> > gcrodr_iter);
+    void buildRecycleSpace2(Teuchos::RCP<GCRODRIter<ScalarType,MV,OP,DM> > gcrodr_iter);
 
     //  Computes harmonic eigenpairs of projected matrix created during the priming solve.
     //  HH is the projected problem from the initial cycle of Gmres, it is (at least) of dimension m+1 x m.
     //  PP contains the harmonic eigenvectors corresponding to the recycledBlocks eigenvalues of smallest magnitude.
     //  The return value is the number of vectors needed to be stored, recycledBlocks or recycledBlocks+1.
-    int getHarmonicVecs1(int m,
-                         const Teuchos::SerialDenseMatrix<int,ScalarType>& HH,
-                         Teuchos::SerialDenseMatrix<int,ScalarType>& PP);
+    int getHarmonicVecs1(int m, const DM& HH, DM& PP);
 
     //  Computes harmonic eigenpairs of projected matrix created during one cycle.
     //  HH is the total block projected problem from the GCRO-DR algorithm, it is (at least) of dimension keff+m+1 x keff+m.
     //  VV is the Krylov vectors from the projected GMRES algorithm, which has (at least) m+1 vectors.
     //  PP contains the harmonic eigenvectors corresponding to the recycledBlocks eigenvalues of smallest magnitude.
     //  The return value is the number of vectors needed to be stored, recycledBlocks or recycledBlocks+1.
-    int getHarmonicVecs2(int keff, int m,
-                         const Teuchos::SerialDenseMatrix<int,ScalarType>& HH,
-                         const Teuchos::RCP<const MV>& VV,
-                         Teuchos::SerialDenseMatrix<int,ScalarType>& PP);
+    int getHarmonicVecs2(int keff, int m, const DM& HH,
+                         const Teuchos::RCP<const MV>& VV, DM& PP);
 
     // Sort list of n floating-point numbers and return permutation vector
     void sort(std::vector<MagnitudeType>& dlist, int n, std::vector<int>& iperm);
@@ -440,16 +436,16 @@ Systems," SIAM Journal on Scientific Computing, 28(5), pp. 1651-1674,
     Teuchos::RCP<std::ostream> outputStream_;
 
     // Status test.
-    Teuchos::RCP<StatusTest<ScalarType,MV,OP> > sTest_;
-    Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP> > maxIterTest_;
-    Teuchos::RCP<StatusTest<ScalarType,MV,OP> > convTest_;
-    Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > expConvTest_, impConvTest_;
-    Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP> > outputTest_;
+    Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > sTest_;
+    Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP,DM> > maxIterTest_;
+    Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > convTest_;
+    Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP,DM> > expConvTest_, impConvTest_;
+    Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP,DM> > outputTest_;
 
     /// Orthogonalization manager.  It is created by the
     /// OrthoManagerFactory instance, and may be changed if the
     /// parameters to this solver manager are changed.
-    Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > ortho_;
+    Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP,DM> > ortho_;
 
     // Current parameter list.
     Teuchos::RCP<Teuchos::ParameterList> params_;
@@ -498,14 +494,13 @@ Systems," SIAM Journal on Scientific Computing, 28(5), pp. 1651-1674,
     Teuchos::RCP<MV> U1_, C1_;
     //
     // Storage used in constructing harmonic Ritz values/vectors
-    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > H2_;
-    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > H_;
-    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B_;
-    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > PP_;
-    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > HP_;
+    Teuchos::RCP<DM> H2_;
+    Teuchos::RCP<DM> H_;
+    Teuchos::RCP<DM> PP_;
+    Teuchos::RCP<DM> HP_;
     std::vector<ScalarType> tau_;
     std::vector<ScalarType> work_;
-    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > R_;
+    Teuchos::RCP<DM> R_;
     std::vector<int> ipiv_;
     /////////////////////////////////////////////////////////////////////////
 
@@ -522,8 +517,8 @@ Systems," SIAM Journal on Scientific Computing, 28(5), pp. 1651-1674,
 
 
 // Empty Constructor
-template<class ScalarType, class MV, class OP>
-GCRODRSolMgr<ScalarType,MV,OP,true>::GCRODRSolMgr():
+template<class ScalarType, class MV, class OP, class DM>
+GCRODRSolMgr<ScalarType,MV,OP,DM,true>::GCRODRSolMgr():
   achievedTol_(0.0),
   numIters_(0)
 {
@@ -532,8 +527,8 @@ GCRODRSolMgr<ScalarType,MV,OP,true>::GCRODRSolMgr():
 
 
 // Basic Constructor
-template<class ScalarType, class MV, class OP>
-GCRODRSolMgr<ScalarType,MV,OP,true>::
+template<class ScalarType, class MV, class OP, class DM>
+GCRODRSolMgr<ScalarType,MV,OP,DM,true>::
 GCRODRSolMgr(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >& problem,
              const Teuchos::RCP<Teuchos::ParameterList>& pl):
   achievedTol_(0.0),
@@ -561,8 +556,8 @@ GCRODRSolMgr(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >& problem,
 }
 
 // Common instructions executed in all constructors
-template<class ScalarType, class MV, class OP>
-void GCRODRSolMgr<ScalarType,MV,OP,true>::init () {
+template<class ScalarType, class MV, class OP, class DM>
+void GCRODRSolMgr<ScalarType,MV,OP,DM,true>::init () {
   outputStream_ = Teuchos::rcpFromRef(std::cout);
   convTol_ = DefaultSolverParameters::convTol;
   orthoKappa_ = orthoKappa_default_;
@@ -591,12 +586,10 @@ void GCRODRSolMgr<ScalarType,MV,OP,true>::init () {
   H2_ = Teuchos::null;
   R_ = Teuchos::null;
   H_ = Teuchos::null;
-  B_ = Teuchos::null;
 }
 
-template<class ScalarType, class MV, class OP>
-void
-GCRODRSolMgr<ScalarType,MV,OP,true>::
+template<class ScalarType, class MV, class OP, class DM>
+void GCRODRSolMgr<ScalarType,MV,OP,DM,true>::
 setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
 {
   using Teuchos::isParameterType;
@@ -843,7 +836,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
   // parameters ("Orthogonalization Parameters") requires knowing the
   // orthogonalization manager name.  Save it for later, and also
   // record whether it's different than before.
-  OrthoManagerFactory<ScalarType, MV, OP> factory;
+  OrthoManagerFactory<ScalarType, MV, OP, DM> factory;
   bool changedOrthoType = false;
   if (params->isParameter ("Orthogonalization")) {
     const std::string& tempOrthoType =
@@ -953,7 +946,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
       params_->set("Orthogonalization Constant", orthoKappa_);
       // Only DGKS currently accepts this parameter.
       if (orthoType_ == "DGKS" && ! ortho_.is_null()) {
-        typedef DGKSOrthoManager<ScalarType, MV, OP> ortho_man_type;
+        typedef DGKSOrthoManager<ScalarType, MV, OP, DM> ortho_man_type;
         // This cast should always succeed; it's a bug
         // otherwise.  (If the cast fails, then orthoType_
         // doesn't correspond to the OrthoManager subclass
@@ -965,8 +958,8 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
   }
 
   // Convergence
-  typedef Belos::StatusTestCombo<ScalarType,MV,OP>  StatusTestCombo_t;
-  typedef Belos::StatusTestGenResNorm<ScalarType,MV,OP>  StatusTestResNorm_t;
+  typedef Belos::StatusTestCombo<ScalarType,MV,OP,DM>  StatusTestCombo_t;
+  typedef Belos::StatusTestGenResNorm<ScalarType,MV,OP,DM>  StatusTestResNorm_t;
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
@@ -1051,7 +1044,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
   //
   // First, construct maximum-number-of-iterations stopping criterion.
   if (maxIterTest_.is_null())
-    maxIterTest_ = rcp (new StatusTestMaxIters<ScalarType,MV,OP> (maxIters_));
+    maxIterTest_ = rcp (new StatusTestMaxIters<ScalarType,MV,OP,DM> (maxIters_));
 
   // Implicit residual test, using the native residual to determine if
   // convergence was achieved.
@@ -1084,7 +1077,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
                                        convTest_));
   // Create the status test output class.
   // This class manages and formats the output from the status test.
-  StatusTestOutputFactory<ScalarType,MV,OP> stoFactory (outputStyle_);
+  StatusTestOutputFactory<ScalarType,MV,OP,DM> stoFactory (outputStyle_);
   outputTest_ = stoFactory.create (printer_, sTest_, outputFreq_,
                                    Passed+Failed+Undefined);
 
@@ -1105,9 +1098,9 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList> &params)
 }
 
 
-template<class ScalarType, class MV, class OP>
+template<class ScalarType, class MV, class OP, class DM>
 Teuchos::RCP<const Teuchos::ParameterList>
-GCRODRSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
+GCRODRSolMgr<ScalarType,MV,OP,DM,true>::getValidParameters() const
 {
   using Teuchos::ParameterList;
   using Teuchos::parameterList;
@@ -1156,7 +1149,7 @@ GCRODRSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
     pl->set("Timer Label", static_cast<const char *>(label_default_),
       "The string to use as a prefix for the timer labels.");
     {
-      OrthoManagerFactory<ScalarType, MV, OP> factory;
+      OrthoManagerFactory<ScalarType, MV, OP, DM> factory;
       pl->set("Orthogonalization", static_cast<const char *>(orthoType_default_),
               "The type of orthogonalization to use.  Valid options: " +
               factory.validNamesString());
@@ -1175,8 +1168,8 @@ GCRODRSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
 }
 
 // initializeStateStorage
-template<class ScalarType, class MV, class OP>
-void GCRODRSolMgr<ScalarType,MV,OP,true>::initializeStateStorage() {
+template<class ScalarType, class MV, class OP, class DM>
+void GCRODRSolMgr<ScalarType,MV,OP,DM,true>::initializeStateStorage() {
 
     ScalarType zero = Teuchos::ScalarTraits<ScalarType>::zero();
 
@@ -1267,36 +1260,36 @@ void GCRODRSolMgr<ScalarType,MV,OP,true>::initializeStateStorage() {
 
       // Generate H2_ only if it doesn't exist, otherwise resize it.
       if (H2_ == Teuchos::null)
-        H2_ = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( numBlocks_+recycledBlocks_+2, numBlocks_+recycledBlocks_+1 ) );
+        H2_ = DMT::Create( numBlocks_+recycledBlocks_+2, numBlocks_+recycledBlocks_+1 );
       else {
-        if ( (H2_->numRows() != numBlocks_+recycledBlocks_+2) || (H2_->numCols() != numBlocks_+recycledBlocks_+1) )
-          H2_->reshape( numBlocks_+recycledBlocks_+2, numBlocks_+recycledBlocks_+1 );
+        if ( (DMT::GetNumRows(*H2_) != numBlocks_+recycledBlocks_+2) || (DMT::GetNumCols(*H2_) != numBlocks_+recycledBlocks_+1) )
+          DMT::Reshape( *H2_, numBlocks_+recycledBlocks_+2, numBlocks_+recycledBlocks_+1 );
       }
-      H2_->putScalar(zero);
+      DMT::PutScalar(*H2_, zero);
 
       // Generate R_ only if it doesn't exist, otherwise resize it.
       if (R_ == Teuchos::null)
-        R_ = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( recycledBlocks_+1, recycledBlocks_+1 ) );
+        R_ = DMT::Create( recycledBlocks_+1, recycledBlocks_+1 );
       else {
-        if ( (R_->numRows() != recycledBlocks_+1) || (R_->numCols() != recycledBlocks_+1) )
-          R_->reshape( recycledBlocks_+1, recycledBlocks_+1 );
+        if ( (DMT::GetNumRows(*R_) != recycledBlocks_+1) || (DMT::GetNumCols(*R_) != recycledBlocks_+1) )
+          DMT::Reshape( *R_, recycledBlocks_+1, recycledBlocks_+1 );
       }
-      R_->putScalar(zero);
+      DMT::PutScalar(*R_,zero);
 
       // Generate PP_ only if it doesn't exist, otherwise resize it.
       if (PP_ == Teuchos::null)
-        PP_ = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( numBlocks_+recycledBlocks_+2, recycledBlocks_+1 ) );
+        PP_ = DMT::Create( numBlocks_+recycledBlocks_+2, recycledBlocks_+1 );
       else {
-        if ( (PP_->numRows() != numBlocks_+recycledBlocks_+2) || (PP_->numCols() != recycledBlocks_+1) )
-          PP_->reshape( numBlocks_+recycledBlocks_+2, recycledBlocks_+1 );
+        if ( (DMT::GetNumRows(*PP_) != numBlocks_+recycledBlocks_+2) || (DMT::GetNumCols(*PP_) != recycledBlocks_+1) )
+          DMT::Reshape( *PP_, numBlocks_+recycledBlocks_+2, recycledBlocks_+1 );
       }
 
       // Generate HP_ only if it doesn't exist, otherwise resize it.
       if (HP_ == Teuchos::null)
-        HP_ = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( numBlocks_+recycledBlocks_+2, numBlocks_+recycledBlocks_+1 ) );
+        HP_ = DMT::Create( numBlocks_+recycledBlocks_+2, numBlocks_+recycledBlocks_+1 );
       else {
-        if ( (HP_->numRows() != numBlocks_+recycledBlocks_+2) || (HP_->numCols() != numBlocks_+recycledBlocks_+1) )
-          HP_->reshape( numBlocks_+recycledBlocks_+2, numBlocks_+recycledBlocks_+1 );
+        if ( (DMT::GetNumRows(*HP_) != numBlocks_+recycledBlocks_+2) || (DMT::GetNumCols(*HP_) != numBlocks_+recycledBlocks_+1) )
+          DMT::Reshape( *HP_, numBlocks_+recycledBlocks_+2, numBlocks_+recycledBlocks_+1 );
       }
 
     } // end else
@@ -1304,8 +1297,8 @@ void GCRODRSolMgr<ScalarType,MV,OP,true>::initializeStateStorage() {
 
 
 // solve()
-template<class ScalarType, class MV, class OP>
-ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
+template<class ScalarType, class MV, class OP, class DM>
+ReturnType GCRODRSolMgr<ScalarType,MV,OP,DM,true>::solve() {
   using Teuchos::RCP;
   using Teuchos::rcp;
 
@@ -1356,8 +1349,8 @@ ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
   //////////////////////////////////////////////////////////////////////////////////////
   // GCRODR solver
 
-  RCP<GCRODRIter<ScalarType,MV,OP> > gcrodr_iter;
-  gcrodr_iter = rcp( new GCRODRIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,ortho_,plist) );
+  RCP<GCRODRIter<ScalarType,MV,OP,DM> > gcrodr_iter;
+  gcrodr_iter = rcp( new GCRODRIter<ScalarType,MV,OP,DM>(problem_,printer_,outputTest_,ortho_,plist) );
   // Number of iterations required to generate initial recycle space (if needed)
   int prime_iterations = 0;
 
@@ -1395,26 +1388,31 @@ ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
 
         // Orthogonalize this block
         // Get a matrix to hold the orthonormalization coefficients.
-        Teuchos::SerialDenseMatrix<int,ScalarType> Rtmp( Teuchos::View, *R_, keff, keff );
-        int rank = ortho_->normalize(*Ctmp, rcp(&Rtmp,false));
+	Teuchos::RCP<DM> Rtmp = DMT::Subview( *R_, keff, keff );
+        int rank = ortho_->normalize(*Ctmp, Rtmp);
         // Throw an error if we could not orthogonalize this block
         TEUCHOS_TEST_FOR_EXCEPTION(rank != keff,GCRODRSolMgrOrthoFailure,"Belos::GCRODRSolMgr::solve(): Failed to compute orthonormal basis for initial recycled subspace.");
 
-        // U_ = U_*R^{-1}
+	// Synchronize R_ before calling LAPACK
+        DMT::SyncDeviceToHost(*R_);
+
+	// U_ = U_*R^{-1}
         // First, compute LU factorization of R
         int info = 0;
-        ipiv_.resize(Rtmp.numRows());
-        lapack.GETRF(Rtmp.numRows(),Rtmp.numCols(),Rtmp.values(),Rtmp.stride(),&ipiv_[0],&info);
+        ipiv_.resize(DMT::GetNumRows(*Rtmp));
+	lapack.GETRF(DMT::GetNumRows(*Rtmp), DMT::GetNumCols(*Rtmp), DMT::GetRawHostPtr(*Rtmp), DMT::GetStride(*Rtmp), &ipiv_[0], &info);
         TEUCHOS_TEST_FOR_EXCEPTION(info != 0, GCRODRSolMgrLAPACKFailure,"Belos::GCRODRSolMgr::solve(): LAPACK _GETRF failed to compute an LU factorization.");
 
         // Now, form inv(R)
-        int lwork = Rtmp.numRows();
+        int lwork = DMT::GetNumRows(*Rtmp);
         work_.resize(lwork);
-        lapack.GETRI(Rtmp.numRows(),Rtmp.values(),Rtmp.stride(),&ipiv_[0],&work_[0],lwork,&info);
+        lapack.GETRI(DMT::GetNumRows(*Rtmp), DMT::GetRawHostPtr(*Rtmp), DMT::GetStride(*Rtmp), &ipiv_[0], &work_[0], lwork, &info);
         TEUCHOS_TEST_FOR_EXCEPTION(info != 0, GCRODRSolMgrLAPACKFailure,"Belos::GCRODRSolMgr::solve(): LAPACK _GETRI failed to invert triangular matrix.");
 
+	DMT::SyncHostToDevice(*R_);
+
         // U_ = U1_; (via a swap)
-        MVT::MvTimesMatAddMv( one, *Utmp, Rtmp, zero, *U1tmp );
+        MVT::MvTimesMatAddMv( one, *Utmp, *Rtmp, zero, *U1tmp );
         std::swap(U_, U1_);
 
         // Must reinitialize after swap
@@ -1424,18 +1422,18 @@ ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
         Utmp  = MVT::CloneView( *U_, index );
 
         // Compute C_'*r_
-        Teuchos::SerialDenseMatrix<int,ScalarType> Ctr(keff,1);
+        Teuchos::RCP<DM> Ctr = DMT::Create(keff, 1);
         problem_->computeCurrPrecResVec( &*r_ );
-        MVT::MvTransMv( one, *Ctmp, *r_, Ctr );
+        MVT::MvTransMv( one, *Ctmp, *r_, *Ctr );
 
         // Update solution ( x += U_*C_'*r_ )
         RCP<MV> update = MVT::Clone( *problem_->getCurrLHSVec(), 1 );
         MVT::MvInit( *update, 0.0 );
-        MVT::MvTimesMatAddMv( one, *Utmp, Ctr, one, *update );
+        MVT::MvTimesMatAddMv( one, *Utmp, *Ctr, one, *update );
         problem_->updateSolution( update, true );
 
         // Update residual norm ( r -= C_*C_'*r_ )
-        MVT::MvTimesMatAddMv( -one, *Ctmp, Ctr, one, *r_ );
+        MVT::MvTimesMatAddMv( -one, *Ctmp, *Ctr, one, *r_ );
 
         // We recycled space from previous call
         prime_iterations = 0;
@@ -1447,30 +1445,27 @@ ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
         printer_->stream(Debug) << " No recycled subspace available for RHS index " << currIdx[0] << std::endl << std::endl;
 
         Teuchos::ParameterList primeList;
-
-        // Tell the block solver that the block size is one.
         primeList.set("Num Blocks",numBlocks_);
-        primeList.set("Recycled Blocks",0);
+        primeList.set("Recycled Blocks",recycledBlocks_);
 
         //  Create GCRODR iterator object to perform one cycle of GMRES.
-        RCP<GCRODRIter<ScalarType,MV,OP> > gcrodr_prime_iter;
-        gcrodr_prime_iter = rcp( new GCRODRIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,ortho_,primeList) );
+        RCP<GCRODRIter<ScalarType,MV,OP,DM> > gcrodr_prime_iter;
+        gcrodr_prime_iter = rcp( new GCRODRIter<ScalarType,MV,OP,DM>(problem_,printer_,outputTest_,ortho_,primeList) );
 
         // Create the first block in the current Krylov basis (residual).
-        problem_->computeCurrPrecResVec( &*r_ );
+	problem_->computeCurrPrecResVec( &*r_ );
         index.resize( 1 ); index[0] = 0;
         RCP<MV> v0 =  MVT::CloneViewNonConst( *V_,  index );
         MVT::SetBlock(*r_,index,*v0); // V(:,0) = r
 
         // Set the new state and initialize the solver.
-        GCRODRIterState<ScalarType,MV> newstate;
+        GCRODRIterState<ScalarType,MV,DM> newstate;
         index.resize( numBlocks_+1 );
         for (int ii=0; ii<(numBlocks_+1); ++ii) { index[ii] = ii; }
-        newstate.V  = MVT::CloneViewNonConst( *V_,  index );
+        newstate.V = MVT::CloneViewNonConst( *V_,  index );
         newstate.U = Teuchos::null;
         newstate.C = Teuchos::null;
-        newstate.H = rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( Teuchos::View, *H2_, numBlocks_+1, numBlocks_, recycledBlocks_+1, recycledBlocks_+1 ) );
-        newstate.B = Teuchos::null;
+        newstate.H2 = H2_;
         newstate.curDim = 0;
         gcrodr_prime_iter->initialize(newstate);
 
@@ -1527,12 +1522,21 @@ ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
         //        too early, move on to the next linear system and try to generate a subspace again.
         if (recycledBlocks_ < p+1) {
           int info = 0;
-          RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > PPtmp = rcp (new Teuchos::SerialDenseMatrix<int,ScalarType> ( Teuchos::View, *PP_, p, recycledBlocks_+1 ) );
+          
+	  // Synchronize before calling getHarmonicVecs1; H2_ is const
+	  DMT::SyncDeviceToHost( *H2_ );
+          DMT::SyncDeviceToHost( *PP_ );
+	  RCP<DM> PPtmp = DMT::Subview( *PP_, p, recycledBlocks_+1 );
+
           // getHarmonicVecs1 assumes PP has recycledBlocks_+1 columns available
-          keff = getHarmonicVecs1( p, *newstate.H, *PPtmp );
-          // Hereafter, only keff columns of PP are needed
-          PPtmp = rcp (new Teuchos::SerialDenseMatrix<int,ScalarType> ( Teuchos::View, *PP_, p, keff ) );
-          // Now get views into C, U, V
+	  keff = getHarmonicVecs1( p, *newstate.H, *PPtmp );
+
+	  // Synchronize before forming U (the subspace to recycle)
+          DMT::SyncHostToDevice( *PP_ );
+	  // Hereafter, only keff columns of PP are needed
+          PPtmp = DMT::Subview( *PP_, p, keff );
+
+	  // Now get views into C, U, V
           index.resize(keff);
           for (int ii=0; ii<keff; ++ii) { index[ii] = ii; }
           RCP<MV> Ctmp  = MVT::CloneViewNonConst( *C_, index );
@@ -1551,17 +1555,24 @@ ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
           // First, compute [Q, R] = qr(H*P);
 
           // Step #1: Form HP = H*P
-          Teuchos::SerialDenseMatrix<int,ScalarType> Htmp( Teuchos::View, *H2_, p+1, p, recycledBlocks_+1,recycledBlocks_+1);
-          Teuchos::SerialDenseMatrix<int,ScalarType> HPtmp( Teuchos::View, *HP_, p+1, keff );
-          HPtmp.multiply( Teuchos::NO_TRANS, Teuchos::NO_TRANS, one, Htmp, *PPtmp, zero );
+	  DMT::SyncDeviceToHost( *HP_ );
 
-          // Step #1.5: Perform workspace size query for QR
+          RCP<DM> Htmp = DMT::Subview( *H2_, p+1, p, recycledBlocks_+1,recycledBlocks_+1 );
+          RCP<DM> HPtmp = DMT::Subview( *HP_, p+1, keff );
+
+          Teuchos::BLAS<int,ScalarType> blas;
+	  blas.GEMM( Teuchos::NO_TRANS, Teuchos::NO_TRANS, p+1, keff, p, one,
+                   DMT::GetConstRawHostPtr(*Htmp), DMT::GetStride(*Htmp),
+                   DMT::GetConstRawHostPtr(*PPtmp), DMT::GetStride(*PPtmp),
+                   zero, DMT::GetRawHostPtr(*HPtmp), DMT::GetStride(*HPtmp));
+
+	  // Step #1.5: Perform workspace size query for QR
           // factorization of HP.  On input, lwork must be -1.
           // _GEQRF will put the workspace size in work_[0].
           int lwork = -1;
           tau_.resize (keff);
-          lapack.GEQRF (HPtmp.numRows (), HPtmp.numCols (), HPtmp.values (),
-                        HPtmp.stride (), &tau_[0], &work_[0], lwork, &info);
+          lapack.GEQRF (DMT::GetNumRows(*HPtmp), DMT::GetNumCols(*HPtmp), DMT::GetRawHostPtr(*HPtmp),
+                        DMT::GetStride(*HPtmp), &tau_[0], &work_[0], lwork, &info);
           TEUCHOS_TEST_FOR_EXCEPTION(
             info != 0, GCRODRSolMgrLAPACKFailure, "Belos::GCRODRSolMgr::solve:"
             " LAPACK's _GEQRF failed to compute a workspace size.");
@@ -1574,32 +1585,37 @@ ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
           // static_cast from std::complex to int doesn't work.
           lwork = std::abs (static_cast<int> (Teuchos::ScalarTraits<ScalarType>::real (work_[0])));
           work_.resize (lwork); // Allocate workspace for the QR factorization
-          lapack.GEQRF (HPtmp.numRows (), HPtmp.numCols (), HPtmp.values (),
-                        HPtmp.stride (), &tau_[0], &work_[0], lwork, &info);
+          lapack.GEQRF (DMT::GetNumRows(*HPtmp), DMT::GetNumCols(*HPtmp), DMT::GetRawHostPtr(*HPtmp),
+                        DMT::GetStride(*HPtmp), &tau_[0], &work_[0], lwork, &info);
           TEUCHOS_TEST_FOR_EXCEPTION(
             info != 0, GCRODRSolMgrLAPACKFailure,  "Belos::GCRODRSolMgr::solve:"
             " LAPACK's _GEQRF failed to compute a QR factorization.");
 
           // Step #3: Explicitly construct Q and R factors
           // NOTE:  The upper triangular part of HP is copied into R and HP becomes Q.
-          Teuchos::SerialDenseMatrix<int,ScalarType> Rtmp( Teuchos::View, *R_, keff, keff );
+          // Synchronize R_ before and after copying over diagonal of HP
+	  DMT::SyncDeviceToHost( *R_ );
+          RCP<DM> Rtmp = DMT::Subview( *R_, keff, keff );
           for (int ii = 0; ii < keff; ++ii) {
             for (int jj = ii; jj < keff; ++jj) {
-              Rtmp(ii,jj) = HPtmp(ii,jj);
-            }
+              DMT::Value(*Rtmp,ii,jj) = DMT::ValueConst(*HPtmp,ii,jj);
+	    }
           }
-          // NOTE (mfh 17 Apr 2014): Teuchos::LAPACK's wrapper for
+          DMT::SyncHostToDevice( *R_ );
+	  // NOTE (mfh 17 Apr 2014): Teuchos::LAPACK's wrapper for
           // UNGQR dispatches to the correct Scalar-specific routine.
           // It calls {S,D}ORGQR if Scalar is real, and {C,Z}UNGQR if
           // Scalar is complex.
-          lapack.UNGQR (HPtmp.numRows (), HPtmp.numCols (), HPtmp.numCols (),
-                        HPtmp.values (), HPtmp.stride (), &tau_[0], &work_[0],
+          lapack.UNGQR (DMT::GetNumRows(*HPtmp), DMT::GetNumCols(*HPtmp), DMT::GetNumCols(*HPtmp),
+                        DMT::GetRawHostPtr(*HPtmp), DMT::GetStride(*HPtmp), &tau_[0], &work_[0],
                         lwork, &info);
           TEUCHOS_TEST_FOR_EXCEPTION(
             info != 0, GCRODRSolMgrLAPACKFailure, "Belos::GCRODRSolMgr::solve: "
             "LAPACK's _UNGQR failed to construct the Q factor.");
 
           // Now we have [Q,R] = qr(H*P)
+          // Synchronize HP_ after call to LAPACK
+	  DMT::SyncHostToDevice( *HP_ );
 
           // Now compute C = V(:,1:p+1) * Q
           index.resize (p + 1);
@@ -1607,15 +1623,16 @@ ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
             index[ii] = ii;
           }
           Vtmp = MVT::CloneView( *V_, index ); // need new view into V (p+1 vectors now; needed p above)
-          MVT::MvTimesMatAddMv( one, *Vtmp, HPtmp, zero, *Ctmp );
+          MVT::MvTimesMatAddMv( one, *Vtmp, *HPtmp, zero, *Ctmp );
 
           // Finally, compute U = U*R^{-1}.
           // This unfortuntely requires me to form R^{-1} explicitly and execute U = U * R^{-1}, as
           // backsolve capabilities don't exist in the Belos::MultiVec class
 
           // Step #1: First, compute LU factorization of R
-          ipiv_.resize(Rtmp.numRows());
-          lapack.GETRF(Rtmp.numRows(),Rtmp.numCols(),Rtmp.values(),Rtmp.stride(),&ipiv_[0],&info);
+          ipiv_.resize(DMT::GetNumRows(*Rtmp));
+          lapack.GETRF(DMT::GetNumRows(*Rtmp), DMT::GetNumCols(*Rtmp), DMT::GetRawHostPtr(*Rtmp),
+		       DMT::GetStride(*Rtmp), &ipiv_[0], &info);
           TEUCHOS_TEST_FOR_EXCEPTION(
             info != 0, GCRODRSolMgrLAPACKFailure, "Belos::GCRODRSolMgr::solve: "
             "LAPACK's _GETRF failed to compute an LU factorization.");
@@ -1627,15 +1644,18 @@ ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
           // distributed MultiVector).
 
           // Step #2: Form inv(R)
-          lwork = Rtmp.numRows();
+          lwork = DMT::GetNumRows(*Rtmp);
           work_.resize(lwork);
-          lapack.GETRI(Rtmp.numRows(),Rtmp.values(),Rtmp.stride(),&ipiv_[0],&work_[0],lwork,&info);
+          lapack.GETRI(DMT::GetNumRows(*Rtmp), DMT::GetRawHostPtr(*Rtmp), DMT::GetStride(*Rtmp), 
+		       &ipiv_[0], &work_[0], lwork, &info);
           TEUCHOS_TEST_FOR_EXCEPTION(
             info != 0, GCRODRSolMgrLAPACKFailure, "Belos::GCRODRSolMgr::solve: "
             "LAPACK's _GETRI failed to invert triangular matrix.");
 
+	  DMT::SyncHostToDevice( *R_ );
+
           // Step #3: Let U = U * R^{-1}
-          MVT::MvTimesMatAddMv( one, *U1tmp, Rtmp, zero, *Utmp );
+          MVT::MvTimesMatAddMv( one, *U1tmp, *Rtmp, zero, *Utmp );
 
           printer_->stream(Debug)
             << " Generated recycled subspace using RHS index " << currIdx[0]
@@ -1680,7 +1700,8 @@ ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
       MVT::SetBlock(*r_,index,*v0); // V(:,0) = r
 
       // Set the new state and initialize the solver.
-      GCRODRIterState<ScalarType,MV> newstate;
+      DMT::SyncDeviceToHost( *H2_ );
+      GCRODRIterState<ScalarType,MV,DM> newstate;
       index.resize( numBlocks_+1 );
       for (int ii=0; ii<(numBlocks_+1); ++ii) { index[ii] = ii; }
       newstate.V  = MVT::CloneViewNonConst( *V_,  index );
@@ -1688,8 +1709,7 @@ ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
       for (int ii=0; ii<keff; ++ii) { index[ii] = ii; }
       newstate.C  = MVT::CloneViewNonConst( *C_,  index );
       newstate.U  = MVT::CloneViewNonConst( *U_,  index );
-      newstate.B = rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( Teuchos::View, *H2_,         keff, numBlocks_,    0, keff ) );
-      newstate.H = rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( Teuchos::View, *H2_, numBlocks_+1, numBlocks_, keff, keff ) );
+      newstate.H2 = H2_;
       newstate.curDim = 0;
       gcrodr_iter->initialize(newstate);
 
@@ -1758,16 +1778,16 @@ ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
             MVT::SetBlock(*r_,index,*v00); // V(:,0) = r
 
             // Set the new state and initialize the solver.
-            GCRODRIterState<ScalarType,MV> restartState;
+	    DMT::SyncDeviceToHost( *H2_ );
+            GCRODRIterState<ScalarType,MV,DM> restartState;
             index.resize( numBlocks_+1 );
             for (int ii=0; ii<(numBlocks_+1); ++ii) { index[ii] = ii; }
             restartState.V  = MVT::CloneViewNonConst( *V_,  index );
             index.resize( keff );
             for (int ii=0; ii<keff; ++ii) { index[ii] = ii; }
-            restartState.U  = MVT::CloneViewNonConst( *U_,  index );
-            restartState.C  = MVT::CloneViewNonConst( *C_,  index );
-            restartState.B = rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( Teuchos::View, *H2_, keff, numBlocks_, 0, keff ) );
-            restartState.H = rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( Teuchos::View, *H2_, numBlocks_+1, numBlocks_, keff, keff ) );
+            restartState.U = MVT::CloneViewNonConst( *U_,  index );
+            restartState.C = MVT::CloneViewNonConst( *C_,  index );
+            restartState.H2 = H2_;
             restartState.curDim = 0;
             gcrodr_iter->initialize(restartState);
 
@@ -1881,8 +1901,8 @@ ReturnType GCRODRSolMgr<ScalarType,MV,OP,true>::solve() {
 }
 
 //  Given existing recycle space and Krylov space, build new recycle space
-template<class ScalarType, class MV, class OP>
-void GCRODRSolMgr<ScalarType,MV,OP,true>::buildRecycleSpace2(Teuchos::RCP<GCRODRIter<ScalarType,MV,OP> > gcrodr_iter) {
+template<class ScalarType, class MV, class OP, class DM>
+void GCRODRSolMgr<ScalarType,MV,OP,DM,true>::buildRecycleSpace2(Teuchos::RCP<GCRODRIter<ScalarType,MV,OP,DM> > gcrodr_iter) {
 
   MagnitudeType one = Teuchos::ScalarTraits<MagnitudeType>::one();
   ScalarType zero = Teuchos::ScalarTraits<ScalarType>::zero();
@@ -1892,7 +1912,7 @@ void GCRODRSolMgr<ScalarType,MV,OP,true>::buildRecycleSpace2(Teuchos::RCP<GCRODR
   std::vector<int> index(numBlocks_+1);
 
   // Get the state
-  GCRODRIterState<ScalarType,MV> oldState = gcrodr_iter->getState();
+  GCRODRIterState<ScalarType,MV,DM> oldState = gcrodr_iter->getState();
   int p = oldState.curDim;
 
   // insufficient new information to update recycle space
@@ -1913,20 +1933,25 @@ void GCRODRSolMgr<ScalarType,MV,OP,true>::buildRecycleSpace2(Teuchos::RCP<GCRODR
     MVT::MvScale( *Utmp, dscalar );
   }
 
-  // Get view into current "full" upper Hessnburg matrix
-  Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > H2tmp = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>( Teuchos::View, *H2_, p+keff+1, p+keff ) );
+  // Get view into current "full" upper Hessenburg matrix
+  DMT::SyncDeviceToHost( *H2_ );
+  Teuchos::RCP<DM> H2tmp = DMT::Subview( *H2_, p+keff+1, p+keff );
 
   // Insert D into the leading keff x keff  block of H2
   for (int i=0; i<keff; ++i) {
-    (*H2tmp)(i,i) = d[i];
+    DMT::Value(*H2tmp,i,i) = d[i];
   }
+
+  DMT::SyncHostToDevice( *H2_ );
 
   // Compute the harmoic Ritz pairs for the generalized eigenproblem
   // getHarmonicVecs2 assumes PP has recycledBlocks_+1 columns available
   int keff_new;
   {
-    Teuchos::SerialDenseMatrix<int,ScalarType> PPtmp( Teuchos::View, *PP_, p+keff, recycledBlocks_+1 );
-    keff_new = getHarmonicVecs2( keff, p, *H2tmp, oldState.V, PPtmp );
+    DMT::SyncDeviceToHost( *PP_ );
+    Teuchos::RCP<DM> PPtmp = DMT::Subview( *PP_, p+keff, recycledBlocks_+1 );
+    keff_new = getHarmonicVecs2( keff, p, *H2tmp, oldState.V, *PPtmp );
+    DMT::SyncHostToDevice( *PP_ );
   }
 
   // Code to form new U, C
@@ -1941,8 +1966,8 @@ void GCRODRSolMgr<ScalarType,MV,OP,true>::buildRecycleSpace2(Teuchos::RCP<GCRODR
     index.resize( keff_new );
     for (int ii=0; ii<keff_new; ++ii) { index[ii] = ii; }
     U1tmp  = MVT::CloneViewNonConst( *U1_,  index );
-    Teuchos::SerialDenseMatrix<int,ScalarType> PPtmp( Teuchos::View, *PP_, keff, keff_new );
-    MVT::MvTimesMatAddMv( one, *Utmp, PPtmp, zero, *U1tmp );
+    Teuchos::RCP<const DM> PPtmp = DMT::SubviewConst( *PP_, keff, keff_new );
+    MVT::MvTimesMatAddMv( one, *Utmp, *PPtmp, zero, *U1tmp );
   }
 
   // U(:,1:keff) = U(:,1:keff) + matmul(V(:,1:m-k),PP(keff_old+1:m-k+keff_old,1:keff)) (step 2)
@@ -1950,22 +1975,29 @@ void GCRODRSolMgr<ScalarType,MV,OP,true>::buildRecycleSpace2(Teuchos::RCP<GCRODR
     index.resize(p);
     for (int ii=0; ii < p; ii++) { index[ii] = ii; }
     Teuchos::RCP<const MV> Vtmp = MVT::CloneView( *V_, index );
-    Teuchos::SerialDenseMatrix<int,ScalarType> PPtmp( Teuchos::View, *PP_, p, keff_new, keff );
-    MVT::MvTimesMatAddMv( one, *Vtmp, PPtmp, one, *U1tmp );
+    Teuchos::RCP<const DM> PPtmp = DMT::SubviewConst( *PP_, p, keff_new, keff );
+    MVT::MvTimesMatAddMv( one, *Vtmp, *PPtmp, one, *U1tmp );
   }
 
   // Form HP = H*P
-  Teuchos::SerialDenseMatrix<int,ScalarType> HPtmp( Teuchos::View, *HP_, p+keff+1, keff_new );
+  DMT::SyncDeviceToHost( *HP_ );
+  Teuchos::RCP<DM> HPtmp = DMT::Subview( *HP_, p+keff+1, keff_new );
   {
-    Teuchos::SerialDenseMatrix<int,ScalarType> PPtmp( Teuchos::View, *PP_, p+keff, keff_new );
-    HPtmp.multiply(Teuchos::NO_TRANS,Teuchos::NO_TRANS,one,*H2tmp,PPtmp,zero);
+    DMT::SyncDeviceToHost( *PP_ );
+    Teuchos::RCP<DM> PPtmp = DMT::Subview( *PP_, p+keff, keff_new );
+
+    Teuchos::BLAS<int,ScalarType> blas;
+    blas.GEMM( Teuchos::NO_TRANS, Teuchos::NO_TRANS, p+keff+1, keff_new, p+keff, one,
+                   DMT::GetConstRawHostPtr(*H2tmp), DMT::GetStride(*H2tmp),
+                   DMT::GetConstRawHostPtr(*PPtmp), DMT::GetStride(*PPtmp),
+                   zero, DMT::GetRawHostPtr(*HPtmp), DMT::GetStride(*HPtmp));
   }
 
   // Workspace size query for QR factorization of HP (the worksize will be placed in work_[0])
   int info = 0, lwork = -1;
   tau_.resize (keff_new);
-  lapack.GEQRF (HPtmp.numRows (), HPtmp.numCols (), HPtmp.values (),
-                HPtmp.stride (), &tau_[0], &work_[0], lwork, &info);
+  lapack.GEQRF (DMT::GetNumRows(*HPtmp), DMT::GetNumCols(*HPtmp), DMT::GetRawHostPtr(*HPtmp),
+                DMT::GetStride(*HPtmp), &tau_[0], &work_[0], lwork, &info);
   TEUCHOS_TEST_FOR_EXCEPTION(
     info != 0, GCRODRSolMgrLAPACKFailure, "Belos::GCRODRSolMgr::solve: "
     "LAPACK's _GEQRF failed to compute a workspace size.");
@@ -1976,27 +2008,31 @@ void GCRODRSolMgr<ScalarType,MV,OP,true>::buildRecycleSpace2(Teuchos::RCP<GCRODR
   // to int doesn't work.
   lwork = std::abs (static_cast<int> (Teuchos::ScalarTraits<ScalarType>::real (work_[0])));
   work_.resize (lwork); // Allocate workspace for the QR factorization
-  lapack.GEQRF (HPtmp.numRows (), HPtmp.numCols (), HPtmp.values (),
-                HPtmp.stride (), &tau_[0], &work_[0], lwork, &info);
+  lapack.GEQRF (DMT::GetNumRows(*HPtmp), DMT::GetNumCols(*HPtmp), DMT::GetRawHostPtr(*HPtmp),
+                DMT::GetStride(*HPtmp), &tau_[0], &work_[0], lwork, &info);
   TEUCHOS_TEST_FOR_EXCEPTION(
     info != 0, GCRODRSolMgrLAPACKFailure, "Belos::GCRODRSolMgr::solve: "
     "LAPACK's _GEQRF failed to compute a QR factorization.");
 
   // Explicitly construct Q and R factors
   // NOTE:  The upper triangular part of HP is copied into R and HP becomes Q.
-  Teuchos::SerialDenseMatrix<int,ScalarType> Rtmp( Teuchos::View, *R_, keff_new, keff_new );
-  for(int i=0;i<keff_new;i++) { for(int j=i;j<keff_new;j++) Rtmp(i,j) = HPtmp(i,j); }
+  DMT::SyncDeviceToHost( *R_ );
+  Teuchos::RCP<DM> Rtmp = DMT::Subview( *R_, keff_new, keff_new );
+  for(int i=0;i<keff_new;i++) { for(int j=i;j<keff_new;j++) DMT::Value(*Rtmp,i,j) = DMT::ValueConst(*HPtmp,i,j); }
 
   // NOTE (mfh 18 Apr 2014): Teuchos::LAPACK's wrapper for UNGQR
   // dispatches to the correct Scalar-specific routine.  It calls
   // {S,D}ORGQR if Scalar is real, and {C,Z}UNGQR if Scalar is
   // complex.
-  lapack.UNGQR (HPtmp.numRows (), HPtmp.numCols (), HPtmp.numCols (),
-                HPtmp.values (), HPtmp.stride (), &tau_[0], &work_[0],
+  lapack.UNGQR (DMT::GetNumRows(*HPtmp), DMT::GetNumCols(*HPtmp), DMT::GetNumCols(*HPtmp),
+                DMT::GetRawHostPtr(*HPtmp), DMT::GetStride(*HPtmp), &tau_[0], &work_[0],
                 lwork, &info);
   TEUCHOS_TEST_FOR_EXCEPTION(
     info != 0, GCRODRSolMgrLAPACKFailure, "Belos::GCRODRSolMgr::solve: "
     "LAPACK's _UNGQR failed to construct the Q factor.");
+
+  DMT::SyncHostToDevice( *HP_ );
+  HPtmp = Teuchos::null;
 
   // Form orthonormalized C and adjust U accordingly so that C = A*U
   // C = [C V] * Q;
@@ -2011,16 +2047,16 @@ void GCRODRSolMgr<ScalarType,MV,OP,true>::buildRecycleSpace2(Teuchos::RCP<GCRODR
       index.resize(keff_new);
       for (int i=0; i < keff_new; i++) { index[i] = i; }
       C1tmp  = MVT::CloneViewNonConst( *C1_,  index );
-      Teuchos::SerialDenseMatrix<int,ScalarType> PPtmp( Teuchos::View, *HP_, keff, keff_new );
-      MVT::MvTimesMatAddMv( one, *Ctmp, PPtmp, zero, *C1tmp );
+      Teuchos::RCP<const DM> PPtmp = DMT::SubviewConst( *HP_, keff, keff_new );
+      MVT::MvTimesMatAddMv( one, *Ctmp, *PPtmp, zero, *C1tmp );
     }
     // Now compute C += V(:,1:p+1) * Q
     {
       index.resize( p+1 );
       for (int i=0; i < p+1; ++i) { index[i] = i; }
       Teuchos::RCP<const MV> Vtmp = MVT::CloneView( *V_, index );
-      Teuchos::SerialDenseMatrix<int,ScalarType> PPtmp( Teuchos::View, *HP_, p+1, keff_new, keff, 0 );
-      MVT::MvTimesMatAddMv( one, *Vtmp, PPtmp, one, *C1tmp );
+      Teuchos::RCP<const DM> PPtmp = DMT::SubviewConst( *HP_, p+1, keff_new, keff, 0 );
+      MVT::MvTimesMatAddMv( one, *Vtmp, *PPtmp, one, *C1tmp );
     }
   }
 
@@ -2029,21 +2065,23 @@ void GCRODRSolMgr<ScalarType,MV,OP,true>::buildRecycleSpace2(Teuchos::RCP<GCRODR
 
   // Finally, compute U_ = U_*R^{-1}
   // First, compute LU factorization of R
-  ipiv_.resize(Rtmp.numRows());
-  lapack.GETRF(Rtmp.numRows(),Rtmp.numCols(),Rtmp.values(),Rtmp.stride(),&ipiv_[0],&info);
-  TEUCHOS_TEST_FOR_EXCEPTION(info != 0,GCRODRSolMgrLAPACKFailure,"Belos::GCRODRSolMgr::solve(): LAPACK _GETRF failed to compute an LU factorization.");
+  ipiv_.resize(DMT::GetNumRows(*Rtmp));
+  lapack.GETRF(DMT::GetNumRows(*Rtmp),DMT::GetNumCols(*Rtmp),DMT::GetRawHostPtr(*Rtmp),DMT::GetStride(*Rtmp),&ipiv_[0],&info);
+  TEUCHOS_TEST_FOR_EXCEPTION(info != 0,GCRODRSolMgrLAPACKFailure,"Belos::GCRODRSolMgr::buildRecycleSpace2(): LAPACK _GETRF failed to compute an LU factorization.");
 
   // Now, form inv(R)
-  lwork = Rtmp.numRows();
+  lwork = DMT::GetNumRows(*Rtmp);
   work_.resize(lwork);
-  lapack.GETRI(Rtmp.numRows(),Rtmp.values(),Rtmp.stride(),&ipiv_[0],&work_[0],lwork,&info);
-  TEUCHOS_TEST_FOR_EXCEPTION(info != 0, GCRODRSolMgrLAPACKFailure,"Belos::GCRODRSolMgr::solve(): LAPACK _GETRI failed to compute an LU factorization.");
+  lapack.GETRI(DMT::GetNumRows(*Rtmp),DMT::GetRawHostPtr(*Rtmp),DMT::GetStride(*Rtmp),&ipiv_[0],&work_[0],lwork,&info);
+  TEUCHOS_TEST_FOR_EXCEPTION(info != 0, GCRODRSolMgrLAPACKFailure,"Belos::GCRODRSolMgr::buildRecycleSpace2(): LAPACK _GETRI failed to compute an LU factorization.");
+
+  DMT::SyncHostToDevice(*R_);
 
   {
     index.resize(keff_new);
     for (int i=0; i < keff_new; i++) { index[i] = i; }
     Teuchos::RCP<MV> Utmp  = MVT::CloneViewNonConst( *U_,  index );
-    MVT::MvTimesMatAddMv( one, *U1tmp, Rtmp, zero, *Utmp );
+    MVT::MvTimesMatAddMv( one, *U1tmp, *Rtmp, zero, *Utmp );
   }
 
   // Set the current number of recycled blocks and subspace dimension with the GCRO-DR iteration.
@@ -2051,18 +2089,17 @@ void GCRODRSolMgr<ScalarType,MV,OP,true>::buildRecycleSpace2(Teuchos::RCP<GCRODR
     keff = keff_new;
     gcrodr_iter->setSize( keff, numBlocks_ );
     // Important to zero this out before next cyle
-    Teuchos::SerialDenseMatrix<int,ScalarType> b1( Teuchos::View, *H2_, recycledBlocks_+2, 1, 0, recycledBlocks_ );
-    b1.putScalar(zero);
+    Teuchos::RCP<DM> b1 = DMT::Subview( *H2_, recycledBlocks_+2, 1, 0, recycledBlocks_ );
+    DMT::PutScalar( *b1, zero );
   }
 
 }
 
 
 //  Compute the harmonic eigenpairs of the projected, dense system.
-template<class ScalarType, class MV, class OP>
-int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs1(int m,
-                                                     const Teuchos::SerialDenseMatrix<int,ScalarType>& HH,
-                                                     Teuchos::SerialDenseMatrix<int,ScalarType>& PP) {
+template<class ScalarType, class MV, class OP, class DM>
+int GCRODRSolMgr<ScalarType,MV,OP,DM,true>::getHarmonicVecs1(int m, const DM& HH, DM& PP) {
+
   int i, j;
   bool xtraVec = false;
   ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
@@ -2071,7 +2108,7 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs1(int m,
   std::vector<MagnitudeType> wr(m), wi(m);
 
   // Real and imaginary (right) eigenvectors; Don't zero out matrix when constructing
-  Teuchos::SerialDenseMatrix<int,ScalarType> vr(m,m,false);
+  Teuchos::RCP<DM> vr = DMT::Create(m,m,false);
 
   // Magnitude of harmonic Ritz values
   std::vector<MagnitudeType> w(m);
@@ -2086,17 +2123,22 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs1(int m,
   builtRecycleSpace_ = true;
 
   // Solve linear system:  H_m^{-H}*e_m
-  Teuchos::SerialDenseMatrix<int, ScalarType> HHt( HH, Teuchos::TRANS );
-  Teuchos::SerialDenseVector<int, ScalarType> e_m( m );
-  e_m[m-1] = one;
-  lapack.GESV(m, 1, HHt.values(), HHt.stride(), &iperm[0], e_m.values(), e_m.stride(), &info);
+  Teuchos::RCP<DM> HHt = DMT::CreateCopy( HH, true );
+  Teuchos::RCP<DM> e_m = DMT::Create( m, 1 );
+  DMT::SyncDeviceToHost( *HHt );
+
+  DMT::Value( *e_m, m-1, 0 ) = one;
+  lapack.GESV(m, 1, DMT::GetRawHostPtr(*HHt), DMT::GetStride(*HHt), &iperm[0], DMT::GetRawHostPtr(*e_m), DMT::GetStride(*e_m), &info);
   TEUCHOS_TEST_FOR_EXCEPTION(info != 0, GCRODRSolMgrLAPACKFailure, "Belos::GCRODRSolMgr::solve(): LAPACK GESV failed to compute a solution.");
 
   // Compute H_m + d*H_m^{-H}*e_m*e_m^H
-  ScalarType d = HH(m, m-1) * HH(m, m-1);
-  Teuchos::SerialDenseMatrix<int, ScalarType> harmHH( Teuchos::Copy, HH, m, m );
+  Teuchos::RCP<DM> tmpHH = DMT::CreateCopy( HH );
+  DMT::SyncDeviceToHost( *tmpHH );
+
+  ScalarType d = DMT::ValueConst(*tmpHH, m, m-1) * DMT::ValueConst(*tmpHH, m, m-1);
+  Teuchos::RCP<DM> harmHH = DMT::Subview( *tmpHH, m, m );
   for( i=0; i<m; ++i )
-    harmHH(i, m-1) += d * e_m[i];
+    DMT::Value(*harmHH, i, m-1) += d * DMT::ValueConst(*e_m, i, 0);
 
   // Revise to do query for optimal workspace first
   // Create simple storage for the left eigenvectors, which we don't care about.
@@ -2109,14 +2151,14 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs1(int m,
   std::vector<MagnitudeType> rwork(2*m);
 
   // First query GEEV for the optimal workspace size
-  lapack.GEEV('N', 'V', m, harmHH.values(), harmHH.stride(), &wr[0], &wi[0],
-              vl, ldvl, vr.values(), vr.stride(), &work[0], lwork, &rwork[0], &info);
+  lapack.GEEV('N', 'V', m, DMT::GetRawHostPtr(*harmHH), DMT::GetStride(*harmHH), &wr[0], &wi[0],
+              vl, ldvl, DMT::GetRawHostPtr(*vr), DMT::GetStride(*vr), &work[0], lwork, &rwork[0], &info);
 
   lwork = std::abs (static_cast<int> (Teuchos::ScalarTraits<ScalarType>::real (work[0])));
   work.resize( lwork );
 
-  lapack.GEEV('N', 'V', m, harmHH.values(), harmHH.stride(), &wr[0], &wi[0],
-              vl, ldvl, vr.values(), vr.stride(), &work[0], lwork, &rwork[0], &info);
+  lapack.GEEV('N', 'V', m, DMT::GetRawHostPtr(*harmHH), DMT::GetStride(*harmHH), &wr[0], &wi[0],
+              vl, ldvl, DMT::GetRawHostPtr(*vr), DMT::GetStride(*vr), &work[0], lwork, &rwork[0], &info);
   TEUCHOS_TEST_FOR_EXCEPTION(info != 0, GCRODRSolMgrLAPACKFailure,"Belos::GCRODRSolMgr::solve(): LAPACK GEEV failed to compute eigensolutions.");
 
   // Construct magnitude of each harmonic Ritz value
@@ -2131,7 +2173,7 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs1(int m,
   // Select recycledBlocks_ smallest eigenvectors
   for( i=0; i<recycledBlocks_; ++i ) {
     for( j=0; j<m; j++ ) {
-      PP(j,i) = vr(j,iperm[i]);
+      DMT::Value(PP,j,i) = DMT::ValueConst(*vr,j,iperm[i]);
     }
   }
 
@@ -2152,12 +2194,12 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs1(int m,
     if (xtraVec) { // we need to store one more vector
       if (wi[iperm[recycledBlocks_-1]] > 0.0) { // I picked the "real" component
         for( j=0; j<m; ++j ) {   // so get the "imag" component
-          PP(j,recycledBlocks_) = vr(j,iperm[recycledBlocks_-1]+1);
+	  DMT::Value(PP,j,recycledBlocks_) = DMT::ValueConst(*vr,j,iperm[recycledBlocks_-1]+1);
         }
       }
       else { //  I picked the "imag" component
         for( j=0; j<m; ++j ) {   // so get the "real" component
-          PP(j,recycledBlocks_) = vr(j,iperm[recycledBlocks_-1]-1);
+	  DMT::Value(PP,j,recycledBlocks_) = DMT::ValueConst(*vr,j,iperm[recycledBlocks_-1]-1);
         }
       }
     }
@@ -2175,13 +2217,13 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs1(int m,
 }
 
 //  Compute the harmonic eigenpairs of the projected, dense system.
-template<class ScalarType, class MV, class OP>
-int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs2(int keffloc, int m,
-                                                     const Teuchos::SerialDenseMatrix<int,ScalarType>& HH,
+template<class ScalarType, class MV, class OP, class DM>
+int GCRODRSolMgr<ScalarType,MV,OP,DM,true>::getHarmonicVecs2(int keffloc, int m,
+                                                     const DM& HH,
                                                      const Teuchos::RCP<const MV>& VV,
-                                                     Teuchos::SerialDenseMatrix<int,ScalarType>& PP) {
+                                                     DM& PP) {
   int i, j;
-  int m2 = HH.numCols();
+  int m2 = DMT::GetNumCols(HH);
   bool xtraVec = false;
   ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
   ScalarType zero = Teuchos::ScalarTraits<ScalarType>::zero();
@@ -2194,7 +2236,7 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs2(int keffloc, int m,
   std::vector<MagnitudeType> w(m2);
 
   // Real and imaginary (right) eigenvectors; Don't zero out matrix when constructing
-  Teuchos::SerialDenseMatrix<int,ScalarType> vr(m2,m2,false);
+  Teuchos::RCP<DM> vr = DMT::Create(m2,m2,false);
 
   // Sorted order of harmonic Ritz values
   std::vector<int> iperm(m2);
@@ -2205,36 +2247,48 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs2(int keffloc, int m,
   // Form matrices for generalized eigenproblem
 
   // B = H2' * H2; Don't zero out matrix when constructing
-  Teuchos::SerialDenseMatrix<int,ScalarType> B(m2,m2,false);
-  B.multiply(Teuchos::TRANS,Teuchos::NO_TRANS,one,HH,HH,zero);
+  Teuchos::RCP<DM> B = DMT::Create(m2,m2,false);
+
+  Teuchos::BLAS<int,ScalarType> blas;
+  blas.GEMM( Teuchos::TRANS, Teuchos::NO_TRANS, m2, m2, DMT::GetNumRows(HH), one,
+             DMT::GetConstRawHostPtr(HH), DMT::GetStride(HH),
+             DMT::GetConstRawHostPtr(HH), DMT::GetStride(HH),
+             zero, DMT::GetRawHostPtr(*B), DMT::GetStride(*B));
 
   // A_tmp = | C'*U        0 |
   //         | V_{m+1}'*U  I |
-  Teuchos::SerialDenseMatrix<int,ScalarType> A_tmp( keffloc+m+1, keffloc+m );
+  Teuchos::RCP<DM> A_tmp = DMT::Create( keffloc+m+1, keffloc+m );
 
   // A_tmp(1:keffloc,1:keffloc) = C' * U;
   index.resize(keffloc);
   for (i=0; i<keffloc; ++i) { index[i] = i; }
   Teuchos::RCP<const MV> Ctmp  = MVT::CloneView( *C_, index );
   Teuchos::RCP<const MV> Utmp  = MVT::CloneView( *U_, index );
-  Teuchos::SerialDenseMatrix<int,ScalarType> A11( Teuchos::View, A_tmp, keffloc, keffloc );
-  MVT::MvTransMv( one, *Ctmp, *Utmp, A11 );
+  Teuchos::RCP<DM> A11 = DMT::Subview( *A_tmp, keffloc, keffloc );
+  MVT::MvTransMv( one, *Ctmp, *Utmp, *A11 );
 
   // A_tmp(keffloc+1:m-k+keffloc+1,1:keffloc) = V' * U;
-  Teuchos::SerialDenseMatrix<int,ScalarType> A21( Teuchos::View, A_tmp, m+1, keffloc, keffloc );
+  Teuchos::RCP<DM> A21 = DMT::Subview( *A_tmp, m+1, keffloc, keffloc );
   index.resize(m+1);
   for (i=0; i < m+1; i++) { index[i] = i; }
   Teuchos::RCP<const MV> Vp = MVT::CloneView( *VV, index );
-  MVT::MvTransMv( one, *Vp, *Utmp, A21 );
+  MVT::MvTransMv( one, *Vp, *Utmp, *A21 );
+
+  A11 = Teuchos::null;
+  A21 = Teuchos::null;
+  DMT::SyncDeviceToHost(*A_tmp);
 
   // A_tmp(keffloc+1:m-k+keffloc,keffloc+1:m-k+keffloc) = eye(m-k);
   for( i=keffloc; i<keffloc+m; i++ ) {
-    A_tmp(i,i) = one;
+    DMT::Value(*A_tmp,i,i) = one;
   }
 
   // A = H2' * A_tmp;
-  Teuchos::SerialDenseMatrix<int,ScalarType> A( m2, A_tmp.numCols() );
-  A.multiply( Teuchos::TRANS, Teuchos::NO_TRANS, one, HH, A_tmp, zero );
+  Teuchos::RCP<DM> A = DMT::Create( m2, DMT::GetNumCols(*A_tmp) );
+  blas.GEMM( Teuchos::TRANS, Teuchos::NO_TRANS, m2, DMT::GetNumCols(*A_tmp), DMT::GetNumRows(*A_tmp),
+             one, DMT::GetConstRawHostPtr(HH), DMT::GetStride(HH),
+	     DMT::GetConstRawHostPtr(*A_tmp), DMT::GetStride(*A_tmp),
+	     zero, DMT::GetRawHostPtr(*A), DMT::GetStride(*A) );
 
   // Compute k smallest harmonic Ritz pairs
   // SUBROUTINE DGGEVX( BALANC, JOBVL, JOBVR, SENSE, N, A, LDA, B, LDB,
@@ -2243,7 +2297,7 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs2(int keffloc, int m,
   //                   RCONDV, WORK, LWORK, IWORK, BWORK, INFO )
   // MLP: 'SCALING' in DGGEVX generates incorrect eigenvalues. Therefore, only permuting
   char balanc='P', jobvl='N', jobvr='V', sense='N';
-  int ld = A.numRows();
+  int ld = DMT::GetNumRows(*A);
   int lwork = 6*ld;
   int ldvl = ld, ldvr = ld;
   int info = 0,ilo = 0,ihi = 0;
@@ -2259,9 +2313,9 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs2(int keffloc, int m,
   //lapack.GGEVX(balanc, jobvl, jobvr, sense, ld, A.values(), ld, B.values(), ld, &wr[0], &wi[0],
   //             &beta[0], vl, ldvl, vr.values(), ldvr, &ilo, &ihi, &lscale[0], &rscale[0],
   //             &abnrm, &bbnrm, &rconde[0], &rcondv[0], &work[0], lwork, &iwork[0], bwork, &info);
-  lapack.GGEVX(balanc, jobvl, jobvr, sense, ld, A.values(), ld, B.values(), ld, &wr[0], &wi[0],
-               &beta[0], vl, ldvl, vr.values(), ldvr, &ilo, &ihi, &lscale[0], &rscale[0],
-               &abnrm, &bbnrm, &rconde[0], &rcondv[0], &work[0], lwork, &rwork[0],
+  lapack.GGEVX(balanc, jobvl, jobvr, sense, ld, DMT::GetRawHostPtr(*A), ld, DMT::GetRawHostPtr(*B), 
+	       ld, &wr[0], &wi[0], &beta[0], vl, ldvl, DMT::GetRawHostPtr(*vr), ldvr, &ilo, &ihi, 
+	       &lscale[0], &rscale[0], &abnrm, &bbnrm, &rconde[0], &rcondv[0], &work[0], lwork, &rwork[0],
                &iwork[0], bwork, &info);
   TEUCHOS_TEST_FOR_EXCEPTION(info != 0, GCRODRSolMgrLAPACKFailure, "Belos::GCRODRSolMgr::solve(): LAPACK GGEVX failed to compute eigensolutions.");
 
@@ -2280,7 +2334,7 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs2(int keffloc, int m,
   // Select recycledBlocks_ smallest eigenvectors
   for( i=0; i<recycledBlocks_; i++ ) {
     for( j=0; j<ld; j++ ) {
-      PP(j,i) = vr(j,iperm[ld-recycledBlocks_+i]);
+      DMT::Value(PP,j,i) = DMT::ValueConst(*vr,j,iperm[ld-recycledBlocks_+i]);
     }
   }
 
@@ -2301,12 +2355,12 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs2(int keffloc, int m,
     if (xtraVec) { // we need to store one more vector
       if (wi[iperm[ld-recycledBlocks_]] > 0.0) { // I picked the "real" component
         for( j=0; j<ld; j++ ) {   // so get the "imag" component
-          PP(j,recycledBlocks_) = vr(j,iperm[ld-recycledBlocks_]+1);
+	  DMT::Value(PP,j,recycledBlocks_) = DMT::ValueConst(*vr,j,iperm[ld-recycledBlocks_]+1);
         }
       }
       else { // I picked the "imag" component
         for( j=0; j<ld; j++ ) {   // so get the "real" component
-          PP(j,recycledBlocks_) = vr(j,iperm[ld-recycledBlocks_]-1);
+	  DMT::Value(PP,j,recycledBlocks_) = DMT::ValueConst(*vr,j,iperm[ld-recycledBlocks_]-1);
         }
       }
     }
@@ -2325,8 +2379,8 @@ int GCRODRSolMgr<ScalarType,MV,OP,true>::getHarmonicVecs2(int keffloc, int m,
 
 
 // This method sorts list of n floating-point numbers and return permutation vector
-template<class ScalarType, class MV, class OP>
-void GCRODRSolMgr<ScalarType,MV,OP,true>::sort(std::vector<MagnitudeType>& dlist, int n, std::vector<int>& iperm) {
+template<class ScalarType, class MV, class OP, class DM>
+void GCRODRSolMgr<ScalarType,MV,OP,DM,true>::sort(std::vector<MagnitudeType>& dlist, int n, std::vector<int>& iperm) {
   int l, r, j, i, flag;
   int    RR2;
   MagnitudeType dRR, dK;
@@ -2390,8 +2444,8 @@ void GCRODRSolMgr<ScalarType,MV,OP,true>::sort(std::vector<MagnitudeType>& dlist
 }
 
 
-template<class ScalarType, class MV, class OP>
-std::string GCRODRSolMgr<ScalarType,MV,OP,true>::description () const {
+template<class ScalarType, class MV, class OP, class DM>
+std::string GCRODRSolMgr<ScalarType,MV,OP,DM,true>::description () const {
   std::ostringstream out;
   out << "Belos::GCRODRSolMgr<...,"<<Teuchos::ScalarTraits<ScalarType>::name()<<">";
   out << "{";

--- a/packages/belos/src/BelosGmresPolySolMgr.hpp
+++ b/packages/belos/src/BelosGmresPolySolMgr.hpp
@@ -118,13 +118,14 @@ class GmresPolySolMgrPolynomialFailure : public BelosError {public:
 ///   - Any parameter not explicitly set in the input ParameterList
 ///     retains its current value
 
-template<class ScalarType, class MV, class OP>
-class GmresPolySolMgr : public SolverManager<ScalarType,MV,OP> {
+template<class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
+class GmresPolySolMgr : public SolverManager<ScalarType,MV,OP,DM> {
 private:
 
   typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
 
   typedef Teuchos::ScalarTraits<MagnitudeType> MTS;
+  typedef Teuchos::SerialDenseMatrix<int,ScalarType> dm_t; // Internally, we use a different SDM
   typedef Belos::GmresPolyOp<ScalarType,MV,OP> gmres_poly_t;
   typedef Belos::GmresPolyMv<ScalarType,MV>    gmres_poly_mv_t;
 
@@ -165,8 +166,8 @@ public:
   virtual ~GmresPolySolMgr() {};
 
   //! clone for Inverted Injection (DII)
-  Teuchos::RCP<SolverManager<ScalarType, MV, OP> > clone () const override {
-    return Teuchos::rcp(new GmresPolySolMgr<ScalarType,MV,OP>);
+  Teuchos::RCP<SolverManager<ScalarType, MV, OP, DM> > clone () const override {
+    return Teuchos::rcp(new GmresPolySolMgr<ScalarType,MV,OP,DM>);
   }
   //@}
 
@@ -342,8 +343,8 @@ private:
 };
 
 
-template<class ScalarType, class MV, class OP>
-GmresPolySolMgr<ScalarType,MV,OP>::GmresPolySolMgr () :
+template<class ScalarType, class MV, class OP, class DM>
+GmresPolySolMgr<ScalarType,MV,OP,DM>::GmresPolySolMgr () :
   outputStream_ (Teuchos::rcpFromRef(std::cout)),
   polyTol_ (DefaultSolverParameters::polyTol),
   achievedTol_(MTS::zero()),
@@ -364,8 +365,8 @@ GmresPolySolMgr<ScalarType,MV,OP>::GmresPolySolMgr () :
 {}
 
 
-template<class ScalarType, class MV, class OP>
-GmresPolySolMgr<ScalarType,MV,OP>::
+template<class ScalarType, class MV, class OP, class DM>
+GmresPolySolMgr<ScalarType,MV,OP,DM>::
 GmresPolySolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                  const Teuchos::RCP<Teuchos::ParameterList> &pl) :
   problem_ (problem),
@@ -400,9 +401,9 @@ GmresPolySolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 }
 
 
-template<class ScalarType, class MV, class OP>
+template<class ScalarType, class MV, class OP, class DM>
 Teuchos::RCP<const Teuchos::ParameterList>
-GmresPolySolMgr<ScalarType,MV,OP>::getValidParameters() const
+GmresPolySolMgr<ScalarType,MV,OP,DM>::getValidParameters() const
 {
   if (validPL_.is_null ()) {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList ();
@@ -441,8 +442,8 @@ GmresPolySolMgr<ScalarType,MV,OP>::getValidParameters() const
 }
 
 
-template<class ScalarType, class MV, class OP>
-void GmresPolySolMgr<ScalarType,MV,OP>::
+template<class ScalarType, class MV, class OP, class DM>
+void GmresPolySolMgr<ScalarType,MV,OP,DM>::
 setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
 {
   // Create the internal parameter list if ones doesn't already exist.
@@ -502,11 +503,11 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
   // Check if the orthogonalization changed.
   if (params->isParameter("Orthogonalization")) {
     std::string tempOrthoType = params->get("Orthogonalization",orthoType_default_);
-    OrthoManagerFactory<ScalarType, MV, OP> factory;
+    OrthoManagerFactory<ScalarType, MV, OP, dm_t> factory;
     // Ensure that the specified orthogonalization type is valid.
     if (! factory.isValidName (tempOrthoType)) {
       std::ostringstream os;
-      os << "Belos::GCRODRSolMgr: Invalid orthogonalization name \""
+      os << "Belos::GmresPolySolMgr: Invalid orthogonalization name \""
          << tempOrthoType << "\".  The following are valid options "
          << "for the \"Orthogonalization\" name parameter: ";
       factory.printValidNames (os);
@@ -596,8 +597,8 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
 }
 
 
-template<class ScalarType, class MV, class OP>
-ReturnType GmresPolySolMgr<ScalarType,MV,OP>::solve ()
+template<class ScalarType, class MV, class OP, class DM>
+ReturnType GmresPolySolMgr<ScalarType,MV,OP,DM>::solve ()
 {
   using Teuchos::RCP;
   using Teuchos::rcp;
@@ -644,8 +645,8 @@ ReturnType GmresPolySolMgr<ScalarType,MV,OP>::solve ()
 
     // Then the polynomial will be used as an operator for an outer solver.
     // Use outer solver parameter list passed in a sublist.
-    Belos::GenericSolverFactory<ScalarType, MultiVec<ScalarType>, Operator<ScalarType> > factory;
-    RCP<SolverManager<ScalarType, MultiVec<ScalarType>, Operator<ScalarType> > > solver = factory.create( outerSolverType_, outerParams_ );
+    Belos::GenericSolverFactory<ScalarType, MultiVec<ScalarType,dm_t>, Operator<ScalarType> > factory;
+    RCP<SolverManager<ScalarType, MultiVec<ScalarType,dm_t>, Operator<ScalarType> > > solver = factory.create( outerSolverType_, outerParams_ );
     TEUCHOS_TEST_FOR_EXCEPTION( solver == Teuchos::null, std::invalid_argument,
       "Belos::GmresPolySolMgr::solve(): Selected solver is not valid.");
 
@@ -654,8 +655,8 @@ ReturnType GmresPolySolMgr<ScalarType,MV,OP>::solve ()
     RCP<gmres_poly_mv_t> new_lhs = rcp( new gmres_poly_mv_t( problem_->getLHS() ) );
     RCP<gmres_poly_mv_t> new_rhs = rcp( new gmres_poly_mv_t( rcp_const_cast<MV>( problem_->getRHS() ) ) );
     RCP<gmres_poly_t> A = rcp( new gmres_poly_t( problem_ ) );  // This just performs problem_->applyOp
-    RCP<LinearProblem<ScalarType,MultiVec<ScalarType>,Operator<ScalarType> > > newProblem =
-      rcp( new LinearProblem<ScalarType,MultiVec<ScalarType>,Operator<ScalarType> >( A, new_lhs, new_rhs ) );
+    RCP<LinearProblem<ScalarType,MultiVec<ScalarType,dm_t>,Operator<ScalarType> > > newProblem =
+      rcp( new LinearProblem<ScalarType,MultiVec<ScalarType,dm_t>,Operator<ScalarType> >( A, new_lhs, new_rhs ) );
     std::string solverLabel = label_ + ": Hybrid Gmres";
     newProblem->setLabel(solverLabel); 
 
@@ -681,8 +682,8 @@ ReturnType GmresPolySolMgr<ScalarType,MV,OP>::solve ()
   else if (hasOuterSolver_) {
 
     // There is no polynomial, just create the outer solver with the outerSolverType_ and outerParams_.
-    Belos::SolverFactory<ScalarType, MV, OP> factory;
-    RCP<SolverManager<ScalarType, MV, OP> > solver = factory.create( outerSolverType_, outerParams_ );
+    Belos::SolverFactory<ScalarType, MV, OP, dm_t> factory;
+    RCP<SolverManager<ScalarType, MV, OP, dm_t> > solver = factory.create( outerSolverType_, outerParams_ );
     TEUCHOS_TEST_FOR_EXCEPTION( solver == Teuchos::null, std::invalid_argument,
       "Belos::GmresPolySolMgr::solve(): Selected solver is not valid.");
 
@@ -706,8 +707,8 @@ ReturnType GmresPolySolMgr<ScalarType,MV,OP>::solve ()
 }
 
 
-template<class ScalarType, class MV, class OP>
-std::string GmresPolySolMgr<ScalarType,MV,OP>::description () const
+template<class ScalarType, class MV, class OP, class DM>
+std::string GmresPolySolMgr<ScalarType,MV,OP,DM>::description () const
 {
   std::ostringstream out;
 

--- a/packages/belos/src/BelosIteration.hpp
+++ b/packages/belos/src/BelosIteration.hpp
@@ -21,6 +21,7 @@
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_ScalarTraits.hpp"
+#include "Teuchos_SerialDenseMatrix.hpp"
 
 
 namespace Belos {
@@ -31,13 +32,13 @@ class LinearProblem;
 template <class ScalarType>
 class OutputManager;
 
-template <class ScalarType, class MV, class OP>
+template <class ScalarType, class MV, class OP, class DM>
 class StatusTest;
 
-template <class ScalarType, class MV, class OP>
+template <class ScalarType, class MV, class OP, class DM>
 class MatOrthoManager;
 
-template<class ScalarType, class MV, class OP>
+template<class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int, ScalarType>>
 class Iteration {
 
   public:

--- a/packages/belos/src/BelosKokkosDenseAdapter.hpp
+++ b/packages/belos/src/BelosKokkosDenseAdapter.hpp
@@ -1,0 +1,590 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+#ifndef BELOS_KOKKOS_DENSE_MAT_TRAITS_HPP
+#define BELOS_KOKKOS_DENSE_MAT_TRAITS_HPP
+
+/*! \file BelosKokkosDenseAdapter.hpp
+  \brief Full specialization of Belos::DenseMatTraits for Kokkos::DualView
+  with arbitrary scalarType. All views are expected to
+  have 2 dimensions. We hard-code LayoutLeft because LAPACK expects
+  column-major matrices. 
+*/
+
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_ScalarTraits.hpp"
+#include "Teuchos_LAPACK.hpp"
+#include "BelosDenseMatTraits.hpp"
+
+#include "Kokkos_Random.hpp"
+#include "Kokkos_ArithTraits.hpp"
+//Kokkos BLAS files:
+#include "KokkosBlas1_scal.hpp"
+#include "KokkosBlas1_axpby.hpp"
+
+#include <vector>
+
+namespace Belos {
+
+  //! Helper function for copying Kokkos::DualView into conjugate Kokkos::DualView
+  template<typename V>
+  void kokkos_transpose(const V& dst, const V& src)
+  {
+    Kokkos::parallel_for(Kokkos::MDRangePolicy<typename V::execution_space, Kokkos::Rank<2>>({0, 0}, {dst.extent(0), dst.extent(1)}),
+    KOKKOS_LAMBDA(int i, int j)
+    {
+      dst(i, j) = Kokkos::ArithTraits<typename V::non_const_value_type>::conj( src(j, i) );
+    });
+  }
+
+  //! Full specialization of Belos::DenseMatSolver for Kokkos::DualView.
+  template<class Scalar>
+  class KokkosDenseSolver : public DenseSolver<Scalar, Kokkos::DualView<typename Kokkos::Details::ArithTraits<Scalar>::val_type **,Kokkos::LayoutLeft>>
+  {
+  public:
+    typedef typename Kokkos::Details::ArithTraits<Scalar>::val_type IST; //Impl Scalar Type, as used in Tpetra
+    typedef DenseMatTraits<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>     DMT;
+ 
+    //! @name Constructor/Destructor Methods
+    //@{
+    //! Default constructor; matrix should be set using setMatrix(), LHS and RHS set with setVectors().
+    KokkosDenseSolver() {}
+
+    //! KokkosDenseSolver destructor.
+    virtual ~KokkosDenseSolver() {}
+    //@}
+
+    //! @name Set Methods
+    //@{
+    //! Sets the pointers for coefficient matrix
+    using DenseSolver<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>::setMatrix;
+
+    //! Sets the pointers for left and right hand side vector(s).
+    using DenseSolver<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>::setVectors;
+    //@}
+
+    //! @name Strategy Modifying Methods
+    //@{
+
+    //! Set if dense matrix is symmetric positive definite
+    //! \note This method must be called before the factorization is performed, otherwise it will have no effect.
+    using DenseSolver<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>::setSPD;
+
+    //! Causes equilibration to be called just before the matrix factorization as part of the call to \c factor.
+    /*! \note This method must be called before the factorization is performed, otherwise it will have no effect.
+    */
+    using DenseSolver<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>::factorWithEquilibration;
+
+    //! All subsequent function calls will work with the transpose-type set by this method (\c Teuchos::NO_TRANS, \c Teuchos::TRANS, and \c Teuchos::CONJ_TRANS).
+    /*! \note This interface will set correct transpose flag for matrix, including complex-valued linear systems.
+    */
+    using DenseSolver<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>::solveWithTransposeFlag;
+    //@}
+
+    //! @name Factor/Solve Methods
+    //@{
+
+    //! Computes the in-place LU factorization of the matrix.
+    /*!
+      \return Integer error code, set to 0 if successful.
+    */
+    int factor()
+    {
+      int INFO = 0;
+
+      // Only factor matrix if it is new, otherwise factors have been computed
+      if (newMatrix_)
+      {
+        Teuchos::LAPACK<int,Scalar> lapack;
+
+        int M = DMT::GetNumRows(*A_);
+        int N = DMT::GetNumCols(*A_);
+        int Min_MN = TEUCHOS_MIN(M,N);
+        int LDA = DMT::GetStride(*A_);
+
+        IPIV_.resize( Min_MN );
+
+        DMT::SyncDeviceToHost(*A_);
+        Scalar * Aptr = DMT::GetRawHostPtr(*A_);
+
+        if (equilibrate_) 
+        {
+          // Compute equilibration scalings
+          R_.resize(M);
+          if (!spd_)
+            C_.resize(N);
+
+          MagnitudeType ROWCND, COLCND, AMAX;
+          if (spd_)
+            lapack.POEQU (M, Aptr, LDA, &R_[0], &ROWCND, &AMAX, &INFO);
+          else
+            lapack.GEEQU (M, N, Aptr, LDA, &R_[0], &C_[0], &ROWCND, &COLCND, &AMAX, &INFO); 
+
+          if (INFO)
+            return INFO;
+
+          // Apply equilibration to matrix
+          if (spd_) {
+            Scalar * ptr = 0;
+            for (int j=0; j<N; j++) {
+              ptr = Aptr + j*LDA;
+              Scalar s1 = R_[j];
+              for (int i=0; i<=j; i++) {
+                *ptr = *ptr*s1*R_[i];
+                ptr++;
+              }
+            }
+          }
+          else {
+            Scalar * ptr = 0;
+            for (int j=0; j<N; j++) {
+              ptr = Aptr + j*LDA;
+              Scalar s1 = C_[j];
+              for (int i=0; i<M; i++) {
+                *ptr = *ptr*s1*R_[i];
+                ptr++;
+              }
+            }
+          }
+        }
+
+        // Compute LU factor
+        if (spd_) {
+          lapack.POTRF('U', M, Aptr, LDA, &INFO);
+        }
+        else {
+          lapack.GETRF(M, N, Aptr, LDA, &IPIV_[0], &INFO);
+        }
+
+        DMT::SyncHostToDevice(*A_);
+      }
+
+      return INFO;
+    }
+
+    //! Computes the solution X to AX = B for the \e this matrix and the B provided.
+    /*!
+      \return Integer error code, set to 0 if successful.
+    */
+    int solve()
+    {
+      bool transpose = (TRANS_ != Teuchos::NO_TRANS) ? true : false;
+
+      DMT::SyncDeviceToHost(*X_);
+
+      // LAPACK overwrites RHS vector with solution vector, so copy if necessary
+      if (B_ != X_)
+        DMT::Assign(*X_, *B_); // Copy B to X if needed
+
+      // Since B_ = X_, perform operations on X_.
+
+      int M = DMT::GetNumRows(*X_); 
+      int NRHS = DMT::GetNumCols(*X_);
+      int LDX = DMT::GetStride(*X_); 
+      Scalar * X = DMT::GetRawHostPtr(*X_);
+
+      if (equilibrate_) 
+      {
+        // Apply equilibration scalings to RHS vector
+        MagnitudeType * R_tmp = &R_[0];
+        if (transpose && !spd_) R_tmp = &C_[0];
+  
+        Scalar * ptr = 0;              
+        for (int j=0; j<NRHS; j++) {
+          ptr = X + j*LDX;
+          for (int i=0; i<M; i++) {
+            *ptr = *ptr*R_tmp[i];
+            ptr++;
+          }
+        } 
+      }
+
+      int INFO = 0;
+
+      int LDA = DMT::GetStride(*A_);
+      Scalar * Aptr = DMT::GetRawHostPtr(*A_);
+      Teuchos::LAPACK<int,Scalar> lapack;
+
+      if (spd_) {
+        lapack.POTRS('U', M, NRHS, Aptr, LDA, X, LDX, &INFO);
+      }
+      else {
+        lapack.GETRS(Teuchos::ETranspChar[TRANS_], M, NRHS, 
+                     Aptr, LDA, &IPIV_[0], X, LDX, &INFO);
+      }
+
+      if (equilibrate_)
+      {
+        Scalar * ptr = 0;
+        for (int j=0; j<NRHS; j++) {
+          ptr = X + j*LDX; 
+            for (int i=0; i<M; i++) {
+            *ptr = *ptr*R_[i];
+            ptr++;
+          }
+        }
+      }
+
+      // Synchronize solution vector to the device
+      DMT::SyncHostToDevice(*X_);
+
+      return INFO;
+    }
+    //@}
+
+  private:
+
+    typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType MagnitudeType;
+  
+    std::vector<int> IPIV_;
+    std::vector<MagnitudeType> R_, C_;
+
+    using DenseSolver<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>::newMatrix_;
+    using DenseSolver<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>::equilibrate_;
+    using DenseSolver<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>::TRANS_;
+    using DenseSolver<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>::spd_;
+
+    using DenseSolver<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>::A_;
+    using DenseSolver<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>::X_;
+    using DenseSolver<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>::B_;
+
+  };
+
+  //! Full specialization of Belos::DenseMatTraits for Kokkos::DualView.
+  //
+  //TODO: It seems like all of Tpetra Details returning views 
+  // (e.g. getStatic2dDualView) return a LayoutLeft view.  Should we 
+  // hard-code that parameter he
+  template<class Scalar>
+  class DenseMatTraits<Scalar, Kokkos::DualView<typename Kokkos::Details::ArithTraits<Scalar>::val_type **,Kokkos::LayoutLeft>>{
+
+  public:
+    typedef typename Kokkos::Details::ArithTraits<Scalar>::val_type IST; //Impl Scalar Type, as used in Tpetra
+    
+    //@{ \name Creation methods
+
+    /*! \brief Creates a new empty \c Kokkos::DualView<IST**,Kokkos::LayoutLeft> with no dimension.
+
+    \return Reference-counted pointer to a new dense matrix of type \c Kokkos::DualView<IST**,Kokkos::LayoutLeft>.
+    */
+    static Teuchos::RCP<Kokkos::DualView<IST**,Kokkos::LayoutLeft>> Create() { 
+      return Teuchos::rcp(new Kokkos::DualView<IST**,Kokkos::LayoutLeft>("BelosDenseCreate",0,0));
+    }     
+
+    /*! \brief Creates a new empty \c Kokkos::DualView<IST**,Kokkos::LayoutLeft> containing 
+     *     and \c numRows rows and \c numCols columns.
+     *         Will be initialized to zeros if last parameter is true.
+
+    \return Reference-counted pointer to a new dense matrix of type \c Kokkos::DualView<IST**,Kokkos::LayoutLeft>.
+    */
+    static Teuchos::RCP<Kokkos::DualView<IST**,Kokkos::LayoutLeft>> 
+           Create( const int numRows, const int numCols, bool initZero = true) { 
+      if(initZero){
+        return Teuchos::rcp(new Kokkos::DualView<IST**,Kokkos::LayoutLeft>("BelosDenseCreate2",numRows,numCols));
+      }
+      else {
+        return Teuchos::rcp(new Kokkos::DualView<IST**,Kokkos::LayoutLeft>(Kokkos::view_alloc(Kokkos::WithoutInitializing,"BelosDenseCreate2"),numRows,numCols));
+      }
+    }     
+   
+    /*! \brief Create a new copy \c DM, possibly transposed.
+   
+       \return Reference-counted pointer to a new dense matrix of type \c DM.
+    */
+    static Teuchos::RCP<Kokkos::DualView<IST**,Kokkos::LayoutLeft>> 
+           CreateCopy(const Kokkos::DualView<IST**,Kokkos::LayoutLeft> & dm, bool transpose=false)
+    {
+      Teuchos::RCP<Kokkos::DualView<IST**,Kokkos::LayoutLeft>> tmpCopyRCP = Teuchos::null;
+
+      if (transpose) {
+        // want tmpCopyRCP to end up as dm^H in the end. Prefer doing transpose on device
+        tmpCopyRCP = Teuchos::rcp(new Kokkos::DualView<IST**,Kokkos::LayoutLeft>
+                                 (Kokkos::view_alloc(Kokkos::WithoutInitializing,"BelosDenseCreateCopy"),dm.extent_int(1),dm.extent_int(0)));
+        if(tmpCopyRCP->need_sync_device()) {
+          // tmpCopyRCP is only up to date on the host
+          kokkos_transpose(tmpCopyRCP->view_host(), dm.view_host());
+          tmpCopyRCP->clear_sync_state();
+          tmpCopyRCP->modify_host();
+        }
+        else {
+          kokkos_transpose(tmpCopyRCP->view_device(), dm.view_device());
+          tmpCopyRCP->clear_sync_state();
+          tmpCopyRCP->modify_device();
+        }
+      }
+      else {
+        tmpCopyRCP = Teuchos::rcp(new Kokkos::DualView<IST**,Kokkos::LayoutLeft>
+                                 (Kokkos::view_alloc(Kokkos::WithoutInitializing,"BelosDenseCreateCopy"),dm.extent_int(0),dm.extent_int(1)));
+        Kokkos::deep_copy(*tmpCopyRCP, dm);
+      }
+      return tmpCopyRCP;
+    }
+ 
+    //TODO make const and non-const function for raw pointer. 
+    //! \brief Returns a raw pointer to the (non-const) data on the host.
+    /// \note We assume that return data in in a column-major format
+    /// because this is what is expected by LAPACK.
+    /// \note This raw pointer is intended only for passing data to LAPACK
+    /// functions. Other operations on the raw data may result in undefined behavior!
+    /// \note We assume that getting this pointer to non-const data means that data
+    /// will be modified. If that is not true, use of this function could result in 
+    /// extra data syncs.
+    /// The user must NOT hold onto this pointer after any data syncs. If you modify the
+    /// data again after a sync, the view will not be marked as modified the second time.
+    static Scalar* GetRawHostPtr(Kokkos::DualView<IST**,Kokkos::LayoutLeft> & dm ) { 
+    //LAPACK could use the host ptr to modify entries, so mark as modified.
+    //TODO: Is there a better way to handle this?
+        dm.modify_host();
+        return reinterpret_cast<Scalar*>(dm.view_host().data());
+    //TODO: Is there any way that the user could hold on to this pointer...
+    // and everything works fine the first time they pass to LAPACK. 
+    // But then... they call MvTimesMatAddMv which syncs to device. 
+    // But then they keep the same pointer and pass to LAPACK again.
+    // Then they call MvTimesMatAddMv... but since they didn't call this 
+    // function again, we miss the sync... See thread with Heidi on this. 
+    }
+
+    //! \brief Returns a raw pointer to const data on the host.
+    static Scalar const * GetConstRawHostPtr(const Kokkos::DualView<IST**,Kokkos::LayoutLeft> & dm ) { 
+        return reinterpret_cast<Scalar const *>(dm.view_host().data());
+    }
+
+    //! \brief Marks host data modified to avoid device sync errors. 
+    /// \note Belos developers must call this function after EVERY
+    ///   call to LAPACK that modifies dense matrix data accessed via raw pointer. 
+    //static void RawPtrDataModified(Kokkos::DualView<IST**,Kokkos::LayoutLeft> & dm ) {
+      //dm.modify_host();
+    //}
+
+    //! \brief Returns an RCP to a Kokkos::DualView<IST**,Kokkos::LayoutLeft> which has a subview of the given Kokkos::DualView<IST**,Kokkos::LayoutLeft>.
+    //        Row and column indexing is zero-based.
+    static Teuchos::RCP<Kokkos::DualView<IST**,Kokkos::LayoutLeft>> 
+    Subview( Kokkos::DualView<IST**,Kokkos::LayoutLeft> & source, int numRows, int numCols, int startRow=0, int startCol=0){
+      return Teuchos::rcp(new Kokkos::DualView<IST**,Kokkos::LayoutLeft>(source, 
+          Kokkos::pair<int,int>(startRow,startRow+numRows), Kokkos::pair<int,int>(startCol,startCol+numCols))); 
+      //Does subview work on dual views? Brian says yes. 
+    }     
+
+    static Teuchos::RCP<const Kokkos::DualView<IST**,Kokkos::LayoutLeft>> 
+    SubviewConst( const Kokkos::DualView<IST**,Kokkos::LayoutLeft>& source, int numRows, int numCols, int startRow=0, int startCol=0){
+      return Teuchos::rcp(new Kokkos::DualView<IST**,Kokkos::LayoutLeft>(source, 
+          Kokkos::pair<int,int>(startRow,startRow+numRows), Kokkos::pair<int,int>(startCol,startCol+numCols))); 
+          //TODO: Check const-ness semantics here?
+    }     
+
+    //! \brief Returns a deep copy of the requested subview.
+    static Teuchos::RCP<Kokkos::DualView<IST**,Kokkos::LayoutLeft>> 
+    SubviewCopy( const Kokkos::DualView<IST**,Kokkos::LayoutLeft>& source, int numRows, int numCols, int startRow=0, int startCol=0){ 
+      //Maaybe we could get away with just a host copy here??
+      //Hmmm... but it says we return a dual view. 
+      //Maybe it should return a dual view with only host data copied in. Require sync to work on device. 
+      //This is related to the functionality of the Assign function. 
+      auto tmpViewRCP = Teuchos::rcp(new Kokkos::DualView<IST**,Kokkos::LayoutLeft>
+                                  (Kokkos::view_alloc(Kokkos::WithoutInitializing,"BelosDenseSubViewCopy"),numRows,numCols));
+      // I am keeping this where it copies the whole view on host and device because:
+      // a) I feel like we might be inviting some weird bugs later if we don't.
+      // But TODO Clarify to developer that this function needs to work on both host and device.
+      // b) It's not a host-device copy or vice versa. Its a copy from device to same device and from host to host. 
+      // So shouldn't add much extra overhead. 
+      Kokkos::deep_copy(*tmpViewRCP, Kokkos::subview(source, 
+          Kokkos::pair<int,int>(startRow,startRow+numRows), Kokkos::pair<int,int>(startCol,startCol+numCols))); 
+      return tmpViewRCP;
+    }     
+    //@}
+
+    //@{ \name Attribute methods
+
+    //! \brief Obtain the number of rows of \c dm.
+    static int GetNumRows( const Kokkos::DualView<IST**,Kokkos::LayoutLeft>& dm ) { 
+      return dm.extent_int(0); 
+    }     
+
+    //! \brief Obtain the number of columns of \c dm.
+    static int GetNumCols( const Kokkos::DualView<IST**,Kokkos::LayoutLeft>& dm ) { 
+      return dm.extent_int(1); 
+    }     
+
+    //! \brief Obtain the stride between the columns of \c dm.
+    static int GetStride( const Kokkos::DualView<IST**,Kokkos::LayoutLeft>& dm ) { 
+      // Note: We force LayoutLeft, which is column major, so the stride_0 is always 1.
+      // (This is the distance between two elts in same col, different rows.)
+      // Lapack wants stride_1, the distance from one col to the next col if we stay
+      // in the same row. 
+      int strides[8]; // There are 8 possible strides and all will be returned
+      dm.stride(strides);
+      return strides[1]; 
+      //return dm.stride_1();  //This shortcut doesn't work for dualView.
+    }
+
+    //@}
+
+    //@{ \name Shaping methods
+
+    /* \brief Reshaping method for changing the size of \c dm to have \c numRows rows and \c numCols columns.
+     *        All values will be initialized to zero if the final argument is true. 
+     *        If the final argument is fale, the previous entries in 
+     *        the matrix will be maintained. For new entries that did not exist in the previous matrix, values will
+     *        contain noise from memory. 
+    */
+    static void Reshape( Kokkos::DualView<IST**,Kokkos::LayoutLeft>& dm, const int numRows, const int numCols, bool initZero = false) {
+      if(initZero){
+        dm.realloc(numRows,numCols); //changes size of both host and device view.
+        Kokkos::deep_copy(dm.view_device(), 0.0);
+        dm.modify_device();
+      }
+      else{
+        dm.resize(numRows,numCols); //keeps values in old array.
+      }
+    }     
+
+    //@}
+
+    //@{ \name Data access methods
+
+    //! \brief Access a reference to the (i,j) entry of \c dm, \c e_i^T dm e_j.
+    static Scalar & Value( Kokkos::DualView<IST**,Kokkos::LayoutLeft>& dm, const int i, const int j )
+    { 
+    //Mark as modified on host, since we don't know if it will be. 
+      dm.modify_host();
+      return reinterpret_cast<Scalar&>((dm.view_host())(i,j));
+      // TODO Will this result in extra syncs? Is always marking modified the best way?
+    }
+
+    //! \brief Access a const reference to the (i,j) entry of \c dm, \c e_i^T dm e_j.
+    static const Scalar & ValueConst( const Kokkos::DualView<IST**,Kokkos::LayoutLeft>& dm, const int i, const int j ) { 
+      return reinterpret_cast<Scalar const &>((dm.view_host())(i,j));
+      //TODO check const semantics here?
+    }
+
+    //TODO: Check formatting of ALL doxygen comments!
+    //
+    //! \brief If an accelorator is in use, sync it to device on this call.
+    //  
+    //  \note The only Belos function that results in a need to sync to 
+    //  host is MvTransMv. You MUST call SyncDeviceToHost before calling
+    //  any other DenseMatTraits functions after a call to MvTransMv. 
+    //  All DenseMatTraits functions assume the necessary data is on host
+    //  and perform computations only on the host. 
+    //
+    static void SyncDeviceToHost(Kokkos::DualView<IST**,Kokkos::LayoutLeft> & dm) { 
+      if(dm.need_sync_host()){
+        if(dm.view_host().span_is_contiguous() && dm.view_device().span_is_contiguous()){
+        dm.sync_host();}
+        else{
+          Kokkos::DualView<IST**,Kokkos::LayoutLeft> compat_view("compat view",dm.extent_int(0),dm.extent_int(1));
+          Kokkos::deep_copy(compat_view,dm);
+          compat_view.sync_host();
+          Kokkos::deep_copy(dm,compat_view);
+          dm.clear_sync_state();
+        }
+      }    
+    }
+
+    static void SyncHostToDevice(Kokkos::DualView<IST**,Kokkos::LayoutLeft> & dm) { 
+      if(dm.need_sync_device()){
+        if(dm.view_host().span_is_contiguous() && dm.view_device().span_is_contiguous()){
+          dm.sync_device();
+        }
+        else{
+          Kokkos::DualView<IST**,Kokkos::LayoutLeft> compat_view("compat view",dm.extent_int(0),dm.extent_int(1));
+          Kokkos::deep_copy(compat_view,dm);
+          compat_view.sync_host();
+          Kokkos::deep_copy(dm,compat_view);
+          dm.clear_sync_state();
+        }
+      }    
+    }
+    //@}
+    //@{ \name Operator methods
+    
+    //!  \brief Adds sourceDM to thisDM and returns answer in thisDM.
+    static void Add( Kokkos::DualView<IST**,Kokkos::LayoutLeft>& thisDM, const Kokkos::DualView<IST**,Kokkos::LayoutLeft>& sourceDM) {
+      KokkosBlas::axpy(1.0,sourceDM.view_device(), thisDM.view_device()); //axpy(alpha,x,y), y = y + alpha*x
+      thisDM.modify_device();
+    }
+
+    //!  \brief Fill all entries with \c value. Value is zero if not specified.
+    static void PutScalar( Kokkos::DualView<IST**,Kokkos::LayoutLeft>& dm, Scalar value = Teuchos::ScalarTraits<Scalar>::zero()){ 
+      Kokkos::deep_copy( dm.view_device(), value);
+      dm.modify_device();
+    }
+
+    //!  \brief Multiply all entries by a scalar. DM = value.*DM
+    static void Scale( Kokkos::DualView<IST**,Kokkos::LayoutLeft>& dm, Scalar value) { 
+      KokkosBlas::scal( dm.view_device(), value, dm.view_device());
+      dm.modify_device();
+    }
+
+    //!  \brief Fill the Kokkos::DualView with random entries.
+    //!   Entries are assumed to be the same on each MPI rank (each matrix copy). 
+    static void Randomize( Kokkos::DualView<IST**,Kokkos::LayoutLeft>& dm) { 
+      int rand_seed = std::rand();
+      Kokkos::Random_XorShift64_Pool<> pool(rand_seed); 
+      Kokkos::fill_random(dm.view_device(), pool, -1,1);
+      dm.modify_device();
+    }
+
+    //!  \brief Copies entries of source to dest (deep copy). 
+    static void Assign( Kokkos::DualView<IST**,Kokkos::LayoutLeft>& dest, const Kokkos::DualView<IST**,Kokkos::LayoutLeft>& source) { 
+      Kokkos::deep_copy(dest,source); //Brian Kelley says this works on dual views.
+      //TODO: But do we really want to do this? What if we only need the host pieces copied right now?
+      // Note: going with first solution. See discussion on SubViewCopy. 
+    }
+
+    //!  \brief Returns the Frobenius norm of the dense matrix.
+    static typename Teuchos::ScalarTraits<Scalar>::magnitudeType NormFrobenius(const Kokkos::DualView<const IST**,Kokkos::LayoutLeft>& dm) { 
+      using KAT = Kokkos::ArithTraits<IST>;
+      using mag_t = typename KAT::mag_type;
+      mag_t frobNorm;
+      Kokkos::parallel_reduce(Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {dm.extent(0), dm.extent(1)}),
+          KOKKOS_LAMBDA(size_t i, size_t j, mag_t& lfrobNorm)
+          {
+          mag_t absVal = KAT::abs((dm.view_device())(i, j));
+          lfrobNorm += absVal * absVal;
+          }, frobNorm);
+      return Kokkos::sqrt(frobNorm);
+    }
+
+    //!  \brief Returns the one-norm of the dense matrix.
+    static typename Teuchos::ScalarTraits<Scalar>::magnitudeType NormOne( Kokkos::DualView<IST**,Kokkos::LayoutLeft>& dm) {  
+      using KAT = Kokkos::ArithTraits<IST>;
+      IST sum = 0, max_sum = 0; 
+      SyncDeviceToHost(dm); //TODO Kokkos-ify this
+      //Kokkos::parallel_for(dm.extent_int(1), 
+          //KOKKOS_LAMBDA(
+      for(int j = 0; j < dm.extent_int(1); j++){ //cols
+        for(int i = 0; i < dm.extent_int(0); i++){  //rows
+          sum += KAT::abs((dm.view_host())(i,j));
+        }
+        if(KAT::abs(sum) > KAT::abs(max_sum)){
+          max_sum = sum;
+        }
+        sum = 0;
+      }
+      return KAT::abs(max_sum); //TODO: Check this impl is correct
+    }
+    //@}
+
+    //@{ \name Solver methods
+
+    //!  \brief Returns a dense solver object for the dense matrix.
+    static Teuchos::RCP<DenseSolver<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>>
+      createDenseSolver() {
+
+      Teuchos::RCP<DenseSolver<Scalar, Kokkos::DualView<IST**,Kokkos::LayoutLeft>>> newSolver
+        = Teuchos::rcp( new KokkosDenseSolver<Scalar>() );
+      return newSolver;
+    }
+    //@}
+
+  };
+
+} // namespace Belos
+
+#endif // end file BELOS_KOKKOS_DENSE_MAT_TRAITS_HPP

--- a/packages/belos/src/BelosLSQRStatusTest.hpp
+++ b/packages/belos/src/BelosLSQRStatusTest.hpp
@@ -29,15 +29,15 @@
 namespace Belos {
 
 
-template <class ScalarType, class MV, class OP>
-class LSQRStatusTest: public Belos::StatusTest<ScalarType,MV,OP> {
+template <class ScalarType, class MV, class OP, class DM>
+class LSQRStatusTest: public Belos::StatusTest<ScalarType,MV,OP,DM> {
 
 public:
 
   // Convenience typedefs
   typedef Teuchos::ScalarTraits<ScalarType> SCT;
   typedef typename SCT::magnitudeType MagnitudeType;
-  typedef Belos::MultiVecTraits<ScalarType,MV>  MVT;
+  typedef Belos::MultiVecTraits<ScalarType,MV,DM>  MVT;
 
   //! @name Constructor/Destructor.
   //@{
@@ -63,7 +63,7 @@ public:
   //! Check convergence status of the iterative solver: Unconverged, Converged, Failed.
   /*! This method checks if the convergence criteria are met using the current information from the iterative solver.
    */
-  Belos::StatusType checkStatus(Belos::Iteration<ScalarType,MV,OP> *iSolver );
+  Belos::StatusType checkStatus(Belos::Iteration<ScalarType,MV,OP,DM> *iSolver );
 
   //! Return the result of the most recent CheckStatus call.
   Belos::StatusType getStatus() const {return(status_);}
@@ -146,7 +146,7 @@ public:
 
   /// \brief Called in checkStatus exactly once, on the first call to checkStatus.
   ///
-  Belos::StatusType firstCallCheckStatusSetup(Belos::Iteration<ScalarType,MV,OP>* iSolver);
+  Belos::StatusType firstCallCheckStatusSetup(Belos::Iteration<ScalarType,MV,OP,DM>* iSolver);
   //@}
 
   /** \name Overridden from Teuchos::Describable */
@@ -204,8 +204,8 @@ private:
 
 };
 
-template <class ScalarType, class MV, class OP>
-LSQRStatusTest<ScalarType,MV,OP>::
+template <class ScalarType, class MV, class OP, class DM>
+LSQRStatusTest<ScalarType,MV,OP,DM>::
 LSQRStatusTest (MagnitudeType condMax /* = 0 */,
                 int term_iter_max /* = 1 */,
                 MagnitudeType rel_rhs_err /* = 0 */,
@@ -223,18 +223,18 @@ LSQRStatusTest (MagnitudeType condMax /* = 0 */,
     matResNorm_ ( Teuchos::ScalarTraits<MagnitudeType>::zero() )
 {}
 
-template <class ScalarType, class MV, class OP>
-LSQRStatusTest<ScalarType,MV,OP>::~LSQRStatusTest()
+template <class ScalarType, class MV, class OP, class DM>
+LSQRStatusTest<ScalarType,MV,OP,DM>::~LSQRStatusTest()
 {}
 
-template <class ScalarType, class MV, class OP>
-void LSQRStatusTest<ScalarType,MV,OP>::reset()
+template <class ScalarType, class MV, class OP, class DM>
+void LSQRStatusTest<ScalarType,MV,OP,DM>::reset()
 {
   status_ = Belos::Undefined;
 }
 
-template <class ScalarType, class MV, class OP>
-Belos::StatusType LSQRStatusTest<ScalarType,MV,OP>::checkStatus( Belos::Iteration<ScalarType,MV,OP>* iSolver)
+template <class ScalarType, class MV, class OP, class DM>
+Belos::StatusType LSQRStatusTest<ScalarType,MV,OP,DM>::checkStatus( Belos::Iteration<ScalarType,MV,OP,DM>* iSolver)
 {
   const MagnitudeType MTzero = Teuchos::ScalarTraits<MagnitudeType>::zero();
   const MagnitudeType MTone = Teuchos::ScalarTraits<MagnitudeType>::one();
@@ -248,7 +248,7 @@ Belos::StatusType LSQRStatusTest<ScalarType,MV,OP>::checkStatus( Belos::Iteratio
     }
 
   bool termIterFlag = false;
-  LSQRIter<ScalarType,MV,OP>* solver = dynamic_cast< LSQRIter<ScalarType,MV,OP>* > (iSolver);
+  LSQRIter<ScalarType,MV,OP,DM>* solver = dynamic_cast< LSQRIter<ScalarType,MV,OP,DM>* > (iSolver);
   TEUCHOS_ASSERT(solver != NULL);
   LSQRIterationState< ScalarType, MV > state = solver->getState();
   //
@@ -359,8 +359,8 @@ Belos::StatusType LSQRStatusTest<ScalarType,MV,OP>::checkStatus( Belos::Iteratio
   return status_;
 }
 
-template <class ScalarType, class MV, class OP>
-void LSQRStatusTest<ScalarType,MV,OP>::print(std::ostream& os, int indent) const
+template <class ScalarType, class MV, class OP, class DM>
+void LSQRStatusTest<ScalarType,MV,OP,DM>::print(std::ostream& os, int indent) const
 {
   for (int j = 0; j < indent; j++)
     os << ' ';
@@ -369,8 +369,8 @@ void LSQRStatusTest<ScalarType,MV,OP>::print(std::ostream& os, int indent) const
   os << "limit of condition number = " << condMax_ << std::endl;
 }
 
-template <class ScalarType, class MV, class OP>
-void LSQRStatusTest<ScalarType,MV,OP>::printStatus(std::ostream&os, Belos::StatusType type) const
+template <class ScalarType, class MV, class OP, class DM>
+void LSQRStatusTest<ScalarType,MV,OP,DM>::printStatus(std::ostream&os, Belos::StatusType type) const
 {
   os << std::left << std::setw(13) << std::setfill('.');
   switch (type) {

--- a/packages/belos/src/BelosMVOPTester.hpp
+++ b/packages/belos/src/BelosMVOPTester.hpp
@@ -24,14 +24,55 @@
 #include "BelosTypes.hpp"
 
 #include "BelosMultiVecTraits.hpp"
+#include "BelosDenseMatTraits.hpp"
 #include "BelosOperatorTraits.hpp"
 #include "BelosOutputManager.hpp"
 
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_SetScientific.hpp"
-#include "Teuchos_SerialDenseHelpers.hpp"
+
+// Used in RandomSyncedMpiMatrix
+#include "Teuchos_CommHelpers.hpp"
+#include "Teuchos_DefaultComm.hpp"
+#include "Teuchos_DefaultSerialComm.hpp"
 
 namespace Belos {
+    //!  \brief Returns the dense matrix A with random values that is the synchronized across all 
+    //!   MPI ranks. Uses existing dimensions of A to determin the size needed.
+    //!   Note: This utility is only used within Belos MultiVectorTraits testing. 
+    //
+    //TODO: If ScalarType is complex valued and the random matrix is simply real-valued, is that
+    // still okay for the test??
+    template <class ScalarType, class DM>
+    static void RandomSyncedMpiMatrix( DM & A ) {
+      typedef Belos::DenseMatTraits<ScalarType, DM> DMT;
+      Teuchos::RCP<const Teuchos::Comm<int>> comm;
+      //TODO: is there any problem with hard-coding OrdinalType to int in the template param for comm?
+
+#ifdef HAVE_MPI
+      int mpiStarted = 0;
+      MPI_Initialized(&mpiStarted);
+      if (mpiStarted)
+        comm = Teuchos::DefaultComm<int>::getComm();
+      else
+        comm = rcp(new Teuchos::SerialComm<int>);
+#else
+        comm = Teuchos::DefaultComm<int>::getComm();
+#endif
+
+        const int procRank = rank(*comm);
+
+        // Construct a separate serial dense matrix and synchronize it to get around
+        // input matrices that are subviews of a larger matrix.
+        if (procRank == 0)
+          DMT::Randomize(A);
+        else
+          DMT::PutScalar(A);
+
+        DMT::SyncDeviceToHost(A);
+        broadcast(*comm, 0, DMT::GetNumRows(A)*DMT::GetNumCols(A), DMT::GetRawHostPtr(A));
+        DMT::SyncHostToDevice(A);
+      }
 
   /// \brief Test correctness of a MultiVecTraits specialization and
   ///   multivector implementation.
@@ -49,14 +90,15 @@ namespace Belos {
   ///   multivector to clone.)
   ///
   /// \return Test result: true if all tests passed, else false.
-  template< class ScalarType, class MV >
+  template< class ScalarType, class MV, class DM >
   bool
   TestMultiVecTraits (const Teuchos::RCP<OutputManager<ScalarType> > &om,
                       const Teuchos::RCP<const MV> &A)
   {
     using Teuchos::SetScientific;
     using std::endl;
-    typedef MultiVecTraits<ScalarType, MV>    MVT;
+    typedef MultiVecTraits<ScalarType, MV, DM>    MVT;
+    typedef Belos::DenseMatTraits<ScalarType, DM> DMT;
     typedef Teuchos::ScalarTraits<ScalarType> STS;
     typedef typename STS::magnitudeType       MagType;
 
@@ -99,18 +141,23 @@ namespace Belos {
                  performing C=0*A+1*B will assign B to C exactly
 
          MvTimesMatAddMv
-           USER: multivecs and serialdensematrix will be of the proper shape
-             MV: input arguments will not be modified
+           USER: Multivecs and serialdensematrix will be of the proper shape.
+                 Any host-device or device-host syncs needed will be handled
+                 within this function call. Belos will NOT do any syncs
+                 before calling MvTimesMatAddMv. 
+             MV: Input arguments will not be modified
                  following arithmetic relations hold exactly:
                    A*I = A
                    0*B = B
                    1*B = B
 
          MvTransMv
-           USER: SerialDenseMatrix will be large enough to hold results.
-             MV: SerialDenseMatrix will not be resized.
+           USER: DenseMatrix will be large enough to hold results.
+             MV: DenseMatrix will not be resized.
                  Inner products will satisfy |a'*b| <= |a|*|b|
-                 alpha == 0  =>  SerialDenseMatrix == 0
+                 alpha == 0  =>  DenseMatrix == 0
+          BELOS: will call SyncDeviceToHost before calling any more
+                 DenseMatTraits functions after the MvTransMv call. 
 
          MvDot
           USER: Results vector will be large enough for results.
@@ -762,7 +809,7 @@ namespace Belos {
       Performs C = alpha * A^H * B, where
         alpha is type ScalarType
         A,B are type MV with p and q vectors, respectively
-        C is a SerialDenseMatrix<int,ScalarType> ALREADY sized to p by q
+        C is a DenseMatrix ALREADY sized to p by q
 
         Verify:
         1) C is not resized by the routine
@@ -782,7 +829,7 @@ namespace Belos {
       const int q = 9;
       Teuchos::RCP<MV> B, C;
       std::vector<MagType> normsB(p), normsC(q);
-      Teuchos::SerialDenseMatrix<int,ScalarType> SDM(p,q);
+      Teuchos::RCP<DM> SDM = DMT::Create(p,q);
 
       B = MVT::Clone(*A,p);
       C = MVT::Clone(*A,q);
@@ -794,18 +841,19 @@ namespace Belos {
       MVT::MvNorm(*C,normsC);
 
       // perform SDM  = zero() * B^H * C
-      MVT::MvTransMv( zero, *B, *C, SDM );
+      MVT::MvTransMv( zero, *B, *C, *SDM );
+      DMT::SyncDeviceToHost(*SDM);
 
       // check the sizes: not allowed to have shrunk
-      if ( SDM.numRows() != p || SDM.numCols() != q ) {
+      if ( DMT::GetNumRows(*SDM) != p || DMT::GetNumCols(*SDM) != q ) {
         om->stream(Warnings)
           << "*** ERROR *** MultiVecTraits::MvTransMv()." << endl
-          << "Routine resized SerialDenseMatrix." << endl;
+          << "Routine resized DenseMatrix." << endl;
         return false;
       }
 
       // check that zero**A^H*B == zero
-      if ( SDM.normOne() != zero ) {
+      if (DMT::NormOne(*SDM) != zero ) {
         om->stream(Warnings)
           << "*** ERROR *** MultiVecTraits::MvTransMv()." << endl
           << "Scalar argument processed incorrectly." << endl;
@@ -813,18 +861,19 @@ namespace Belos {
       }
 
       // perform SDM  = one * B^H * C
-      MVT::MvTransMv( one, *B, *C, SDM );
+      MVT::MvTransMv( one, *B, *C, *SDM );
+      DMT::SyncDeviceToHost(*SDM);
 
       // check the norms: a^H b = |a| |b| cos(theta) <= |a| |b|
       // with equality only when a and b are colinear
       for (int i=0; i<p; i++) {
         for (int j=0; j<q; j++) {
-          if (   STS::magnitude(SDM(i,j))
+          if (   STS::magnitude(DMT::ValueConst(*SDM,i,j))
                > STS::magnitude(normsB[i]*normsC[j]) ) {
             om->stream(Warnings)
               << "*** ERROR *** MultiVecTraits::MvTransMv()." << endl
               << "Triangle inequality did not hold: "
-              << STS::magnitude(SDM(i,j))
+              << STS::magnitude(DMT::ValueConst(*SDM,i,j))
               << " > "
               << STS::magnitude(normsB[i]*normsC[j])
               << endl;
@@ -834,10 +883,11 @@ namespace Belos {
       }
       MVT::MvInit(*C);
       MVT::MvRandom(*B);
-      MVT::MvTransMv( one, *B, *C, SDM );
+      MVT::MvTransMv( one, *B, *C, *SDM );
+      DMT::SyncDeviceToHost(*SDM);
       for (int i=0; i<p; i++) {
         for (int j=0; j<q; j++) {
-          if ( SDM(i,j) != zero ) {
+          if ( DMT::ValueConst(*SDM,i,j) != zero ) {
             om->stream(Warnings)
               << "*** ERROR *** MultiVecTraits::MvTransMv()." << endl
               << "Inner products not zero for C==0." << endl;
@@ -847,10 +897,11 @@ namespace Belos {
       }
       MVT::MvInit(*B);
       MVT::MvRandom(*C);
-      MVT::MvTransMv( one, *B, *C, SDM );
+      MVT::MvTransMv( one, *B, *C, *SDM );
+      DMT::SyncDeviceToHost(*SDM);
       for (int i=0; i<p; i++) {
         for (int j=0; j<q; j++) {
-          if ( SDM(i,j) != zero ) {
+          if ( DMT::ValueConst(*SDM,i,j) != zero ) {
             om->stream(Warnings)
               << "*** ERROR *** MultiVecTraits::MvTransMv()." << endl
               << "Inner products not zero for B==0." << endl;
@@ -859,7 +910,6 @@ namespace Belos {
         }
       }
     }
-
 
     /*********** MvDot() *************************************************
         Verify:
@@ -921,7 +971,6 @@ namespace Belos {
       }
     }
 
-
     /*********** MvAddMv() ***********************************************
        D = alpha*B + beta*C
        1) Use alpha==0,beta==1 and check that D == C
@@ -936,11 +985,12 @@ namespace Belos {
                            normsC1(p), normsC2(p),
                            normsD1(p), normsD2(p);
 
-      Teuchos::SerialDenseMatrix<int,ScalarType> Alpha(1,1), Beta(1,1);
-      Teuchos::randomSyncedMatrix( Alpha );
-      Teuchos::randomSyncedMatrix( Beta );
-      ScalarType alpha = Alpha(0,0),
-                  beta = Beta(0,0);
+      Teuchos::RCP<DM> Alpha = DMT::Create(1,1);
+      Teuchos::RCP<DM> Beta = DMT::Create(1,1);
+      RandomSyncedMpiMatrix<ScalarType,DM>(*Alpha);
+      RandomSyncedMpiMatrix<ScalarType,DM>(*Beta);
+      ScalarType alpha = DMT::ValueConst(*Alpha,0,0),
+                 beta = DMT::ValueConst(*Beta,0,0);
 
       B = MVT::Clone(*A,p);
       C = MVT::Clone(*A,p);
@@ -1128,7 +1178,7 @@ namespace Belos {
     {
       const int p = 7, q = 5;
       Teuchos::RCP<MV> B, C;
-      Teuchos::SerialDenseMatrix<int,ScalarType> SDM(p,q);
+      Teuchos::RCP<DM> SDM = DMT::Create(p,q);
       std::vector<MagType> normsC1(q), normsC2(q),
                            normsB1(p), normsB2(p);
 
@@ -1140,8 +1190,8 @@ namespace Belos {
       MVT::MvRandom(*C);
       MVT::MvNorm(*B,normsB1);
       MVT::MvNorm(*C,normsC1);
-      Teuchos::randomSyncedMatrix(SDM);
-      MVT::MvTimesMatAddMv(zero,*B,SDM,one,*C);
+      RandomSyncedMpiMatrix<ScalarType,DM>(*SDM);
+      MVT::MvTimesMatAddMv(zero,*B,*SDM,one,*C);
       MVT::MvNorm(*B,normsB2);
       MVT::MvNorm(*C,normsC2);
       for (int i=0; i<p; i++) {
@@ -1166,8 +1216,8 @@ namespace Belos {
       MVT::MvRandom(*C);
       MVT::MvNorm(*B,normsB1);
       MVT::MvNorm(*C,normsC1);
-      Teuchos::randomSyncedMatrix(SDM);
-      MVT::MvTimesMatAddMv(zero,*B,SDM,zero,*C);
+      RandomSyncedMpiMatrix<ScalarType,DM>(*SDM);
+      MVT::MvTimesMatAddMv(zero,*B,*SDM,zero,*C);
       MVT::MvNorm(*B,normsB2);
       MVT::MvNorm(*C,normsC2);
       for (int i=0; i<p; i++) {
@@ -1197,11 +1247,13 @@ namespace Belos {
       MVT::MvRandom(*C);
       MVT::MvNorm(*B,normsB1);
       MVT::MvNorm(*C,normsC1);
-      SDM.scale(zero);
+      DMT::Scale(*SDM,zero);
+      DMT::SyncDeviceToHost(*SDM);
       for (int i=0; i<q; i++) {
-        SDM(i,i) = one;
+        DMT::Value(*SDM,i,i) = one;
       }
-      MVT::MvTimesMatAddMv(one,*B,SDM,zero,*C);
+      DMT::SyncHostToDevice(*SDM);
+      MVT::MvTimesMatAddMv(one,*B,*SDM,zero,*C);
       MVT::MvNorm(*B,normsB2);
       MVT::MvNorm(*C,normsC2);
       for (int i=0; i<p; i++) {
@@ -1230,8 +1282,8 @@ namespace Belos {
       MVT::MvRandom(*C);
       MVT::MvNorm(*B,normsB1);
       MVT::MvNorm(*C,normsC1);
-      SDM.scale(zero);
-      MVT::MvTimesMatAddMv(one,*B,SDM,one,*C);
+      DMT::Scale(*SDM,zero);
+      MVT::MvTimesMatAddMv(one,*B,*SDM,one,*C);
       MVT::MvNorm(*B,normsB2);
       MVT::MvNorm(*C,normsC2);
       for (int i=0; i<p; i++) {
@@ -1264,7 +1316,7 @@ namespace Belos {
     {
       const int p = 5, q = 7;
       Teuchos::RCP<MV> B, C;
-      Teuchos::SerialDenseMatrix<int,ScalarType> SDM(p,q);
+      Teuchos::RCP<DM> SDM = DMT::Create(p,q);
       std::vector<MagType> normsC1(q), normsC2(q),
                            normsB1(p), normsB2(p);
 
@@ -1276,8 +1328,8 @@ namespace Belos {
       MVT::MvRandom(*C);
       MVT::MvNorm(*B,normsB1);
       MVT::MvNorm(*C,normsC1);
-      Teuchos::randomSyncedMatrix(SDM);
-      MVT::MvTimesMatAddMv(zero,*B,SDM,one,*C);
+      RandomSyncedMpiMatrix<ScalarType,DM>(*SDM);
+      MVT::MvTimesMatAddMv(zero,*B,*SDM,one,*C);
       MVT::MvNorm(*B,normsB2);
       MVT::MvNorm(*C,normsC2);
       for (int i=0; i<p; i++) {
@@ -1302,8 +1354,8 @@ namespace Belos {
       MVT::MvRandom(*C);
       MVT::MvNorm(*B,normsB1);
       MVT::MvNorm(*C,normsC1);
-      Teuchos::randomSyncedMatrix(SDM);
-      MVT::MvTimesMatAddMv(zero,*B,SDM,zero,*C);
+      RandomSyncedMpiMatrix<ScalarType,DM>(*SDM);
+      MVT::MvTimesMatAddMv(zero,*B,*SDM,zero,*C);
       MVT::MvNorm(*B,normsB2);
       MVT::MvNorm(*C,normsC2);
       for (int i=0; i<p; i++) {
@@ -1332,11 +1384,13 @@ namespace Belos {
       MVT::MvRandom(*C);
       MVT::MvNorm(*B,normsB1);
       MVT::MvNorm(*C,normsC1);
-      SDM.scale(zero);
+      DMT::Scale(*SDM,zero);
+      DMT::SyncDeviceToHost(*SDM);
       for (int i=0; i<p; i++) {
-        SDM(i,i) = one;
+        DMT::Value(*SDM,i,i) = one;
       }
-      MVT::MvTimesMatAddMv(one,*B,SDM,zero,*C);
+      DMT::SyncHostToDevice(*SDM);  
+      MVT::MvTimesMatAddMv(one,*B,*SDM,zero,*C);
       MVT::MvNorm(*B,normsB2);
       MVT::MvNorm(*C,normsC2);
       for (int i=0; i<p; i++) {
@@ -1369,8 +1423,8 @@ namespace Belos {
       MVT::MvRandom(*C);
       MVT::MvNorm(*B,normsB1);
       MVT::MvNorm(*C,normsC1);
-      SDM.scale(zero);
-      MVT::MvTimesMatAddMv(one,*B,SDM,one,*C);
+      DMT::Scale(*SDM,zero);
+      MVT::MvTimesMatAddMv(one,*B,*SDM,one,*C);
       MVT::MvNorm(*B,normsB2);
       MVT::MvNorm(*C,normsC2);
       for (int i=0; i<p; i++) {

--- a/packages/belos/src/BelosMinresIteration.hpp
+++ b/packages/belos/src/BelosMinresIteration.hpp
@@ -73,8 +73,8 @@ namespace Belos {
   //@}
 
 
-template<class ScalarType, class MV, class OP>
-class MinresIteration : virtual public Iteration<ScalarType,MV,OP> {
+template<class ScalarType, class MV, class OP, class DM>
+class MinresIteration : virtual public Iteration<ScalarType,MV,OP,DM> {
 
   public:
 

--- a/packages/belos/src/BelosMultiVec.hpp
+++ b/packages/belos/src/BelosMultiVec.hpp
@@ -55,7 +55,7 @@ namespace Belos {
 /// MultiVec<ScalarType>, where ScalarType is the type of entries in
 /// the multivector.  For example, a multivector with entries of type
 /// double would inherit from MultiVec<double>.
-template <class ScalarType>
+template <class ScalarType, class DM = Teuchos::SerialDenseMatrix<int, ScalarType>>
 class MultiVec {
 public:
   //! @name Constructor/Destructor
@@ -72,11 +72,11 @@ public:
   
   /// \brief Create a new MultiVec with \c numvecs columns.
   /// \return Pointer to the new multivector with uninitialized values.
-  virtual MultiVec<ScalarType> * Clone ( const int numvecs ) const = 0;
+  virtual MultiVec<ScalarType,DM> * Clone ( const int numvecs ) const = 0;
   
   /// \brief Create a new MultiVec and copy contents of \c *this into it (deep copy).
   /// \return Pointer to the new multivector	
-  virtual MultiVec<ScalarType> * CloneCopy () const = 0;
+  virtual MultiVec<ScalarType,DM> * CloneCopy () const = 0;
   
   /*! \brief Creates a new %Belos::MultiVec and copies the selected contents of \c *this 
     into the new multivector (deep copy).  The copied 
@@ -84,7 +84,7 @@ public:
     
     \return Pointer to the new multivector	
   */
-  virtual MultiVec<ScalarType> * CloneCopy ( const std::vector<int>& index ) const = 0;
+  virtual MultiVec<ScalarType,DM> * CloneCopy ( const std::vector<int>& index ) const = 0;
   
   /*! \brief Creates a new %Belos::MultiVec that shares the selected contents of \c *this.
     The index of the \c numvecs vectors copied from \c *this are indicated by the
@@ -92,7 +92,7 @@ public:
     
     \return Pointer to the new multivector	
   */
-  virtual MultiVec<ScalarType> * CloneViewNonConst ( const std::vector<int>& index ) = 0;
+  virtual MultiVec<ScalarType,DM> * CloneViewNonConst ( const std::vector<int>& index ) = 0;
   
   /*! \brief Creates a new %Belos::MultiVec that shares the selected contents of \c *this.
     The index of the \c numvecs vectors copied from \c *this are indicated by the
@@ -100,7 +100,7 @@ public:
     
     \return Pointer to the new multivector	
   */
-  virtual const MultiVec<ScalarType> * CloneView ( const std::vector<int>& index ) const = 0;
+  virtual const MultiVec<ScalarType,DM> * CloneView ( const std::vector<int>& index ) const = 0;
 
   //@}
   //! @name Dimension information methods	
@@ -119,11 +119,14 @@ public:
   //! Update \c *this with \c alpha * \c A * \c B + \c beta * (\c *this).
   virtual void 
   MvTimesMatAddMv (const ScalarType alpha, 
-		   const MultiVec<ScalarType>& A, 
-		   const Teuchos::SerialDenseMatrix<int,ScalarType>& B, const ScalarType beta) = 0;
+		   const MultiVec<ScalarType,DM>& A, 
+		   const DM& B, const ScalarType beta) = 0;
   
   //! Replace \c *this with \c alpha * \c A + \c beta * \c B.
-  virtual void MvAddMv ( const ScalarType alpha, const MultiVec<ScalarType>& A, const ScalarType beta, const MultiVec<ScalarType>& B ) = 0;
+  virtual void MvAddMv ( const ScalarType alpha, 
+                         const MultiVec<ScalarType,DM>& A, 
+                         const ScalarType beta, 
+                         const MultiVec<ScalarType,DM>& B ) = 0;
   
   //! Scale each element of the vectors in \c *this with \c alpha.
   virtual void MvScale ( const ScalarType alpha ) = 0;
@@ -134,14 +137,14 @@ public:
   /*! \brief Compute a dense matrix \c B through the matrix-matrix multiply 
     \c alpha * \c A^T * (\c *this).
   */
-  virtual void MvTransMv ( const ScalarType alpha, const MultiVec<ScalarType>& A, Teuchos::SerialDenseMatrix<int,ScalarType>& B) const = 0;
+  virtual void MvTransMv ( const ScalarType alpha, const MultiVec<ScalarType,DM>& A, DM& B) const = 0;
 
   /// \brief Compute the dot product of each column of *this with the corresponding column of A.
   ///
   /// Compute a vector \c b whose entries are the individual
   /// dot-products.  That is, <tt>b[i] = A[i]^H * (*this)[i]</tt>
   /// where <tt>A[i]</tt> is the i-th column of A.
-  virtual void MvDot ( const MultiVec<ScalarType>& A, std::vector<ScalarType>& b ) const = 0;
+  virtual void MvDot ( const MultiVec<ScalarType,DM>& A, std::vector<ScalarType>& b ) const = 0;
   
   //@}
   //! @name Norm method
@@ -162,7 +165,7 @@ public:
   ///
   /// The \c numvecs vectors in \c A are copied to a subset of vectors
   /// in \c *this indicated by the indices given in \c index.
-  virtual void SetBlock ( const MultiVec<ScalarType>& A, const std::vector<int>& index ) = 0;
+  virtual void SetBlock ( const MultiVec<ScalarType,DM>& A, const std::vector<int>& index ) = 0;
 
   //! Fill all the vectors in \c *this with random numbers.  
   virtual void MvRandom () = 0;
@@ -205,8 +208,8 @@ public:
   /// method if you intend to use TsqrOrthoManager or
   /// TsqrMatOrthoManager with your subclass of MultiVec.
   virtual void 
-  factorExplicit (MultiVec<ScalarType>& Q, 
-		  Teuchos::SerialDenseMatrix<int, ScalarType>& R,
+  factorExplicit (MultiVec<ScalarType,DM>& Q, 
+		  DM& R,
 		  const bool forceNonnegativeDiagonal=false)
   {
     TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "The Belos::MultiVec<" 
@@ -249,7 +252,7 @@ public:
   /// method if you intend to use TsqrOrthoManager or
   /// TsqrMatOrthoManager with your subclass of MultiVec.
   virtual int
-  revealRank (Teuchos::SerialDenseMatrix<int, ScalarType>& R,
+  revealRank (DM& R,
 	      const typename Teuchos::ScalarTraits<ScalarType>::magnitudeType& tol)
   {
     TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "The Belos::MultiVec<" 
@@ -280,21 +283,20 @@ namespace details {
 ///
 /// This class is the TSQR adapter for MultiVec.  It merely calls 
 /// MultiVec's corresponding methods for TSQR functionality.
-template<class ScalarType>
+template<class ScalarType, class DM = Teuchos::SerialDenseMatrix<int, ScalarType>>
 class MultiVecTsqrAdapter {
 public:
   typedef MultiVec<ScalarType> MV;
   typedef ScalarType scalar_type; 
   typedef int ordinal_type; // This doesn't matter either
   typedef int node_type; // Nor does this
-  typedef Teuchos::SerialDenseMatrix<ordinal_type, scalar_type> dense_matrix_type;
   typedef typename Teuchos::ScalarTraits<scalar_type>::magnitudeType magnitude_type;
   
   //! Compute QR factorization A = QR, using TSQR.
   void
   factorExplicit (MV& A,
 		  MV& Q,
-		  dense_matrix_type& R,
+		  DM& R,
 		  const bool forceNonnegativeDiagonal=false)
   {
     A.factorExplicit (Q, R, forceNonnegativeDiagonal);
@@ -303,7 +305,7 @@ public:
   //! Compute rank-revealing decomposition using results of factorExplicit().
   int
   revealRank (MV& Q,
-	      dense_matrix_type& R,
+	      DM& R,
 	      const magnitude_type& tol)
   {
     return Q.revealRank (R, tol);
@@ -328,33 +330,33 @@ public:
   ///
   /// \tparam ScalarType The type of entries in the multivector; the
   ///   template parameter of MultiVec.
-  template<class ScalarType>
-  class MultiVecTraits<ScalarType,MultiVec<ScalarType> > {
+  template<class ScalarType, class DM>
+  class MultiVecTraits<ScalarType,MultiVec<ScalarType,DM>,DM> {
   public:
     //! @name Creation methods
     //@{ 
 
     /// \brief Create a new empty \c MultiVec containing \c numvecs columns.
     /// \return Reference-counted pointer to the new \c MultiVec.
-    static Teuchos::RCP<MultiVec<ScalarType> > 
-    Clone (const MultiVec<ScalarType>& mv, const int numvecs) {
-      return Teuchos::rcp (const_cast<MultiVec<ScalarType>&> (mv).Clone (numvecs)); 
+    static Teuchos::RCP<MultiVec<ScalarType,DM> > 
+    Clone (const MultiVec<ScalarType,DM>& mv, const int numvecs) {
+      return Teuchos::rcp (const_cast<MultiVec<ScalarType,DM>&> (mv).Clone (numvecs)); 
     }
     ///
-    static Teuchos::RCP<MultiVec<ScalarType> > CloneCopy( const MultiVec<ScalarType>& mv )
-    { return Teuchos::rcp( const_cast<MultiVec<ScalarType>&>(mv).CloneCopy() ); }
+    static Teuchos::RCP<MultiVec<ScalarType,DM> > CloneCopy( const MultiVec<ScalarType,DM>& mv )
+    { return Teuchos::rcp( const_cast<MultiVec<ScalarType,DM>&>(mv).CloneCopy() ); }
     ///
-    static Teuchos::RCP<MultiVec<ScalarType> > CloneCopy( const MultiVec<ScalarType>& mv, const std::vector<int>& index )
-    { return Teuchos::rcp( const_cast<MultiVec<ScalarType>&>(mv).CloneCopy(index) ); }
+    static Teuchos::RCP<MultiVec<ScalarType,DM> > CloneCopy( const MultiVec<ScalarType,DM>& mv, const std::vector<int>& index )
+    { return Teuchos::rcp( const_cast<MultiVec<ScalarType,DM>&>(mv).CloneCopy(index) ); }
     ///
-    static Teuchos::RCP<MultiVec<ScalarType> > 
-    CloneViewNonConst (MultiVec<ScalarType>& mv, const std::vector<int>& index)
+    static Teuchos::RCP<MultiVec<ScalarType,DM> > 
+    CloneViewNonConst (MultiVec<ScalarType,DM>& mv, const std::vector<int>& index)
     { 
       return Teuchos::rcp( mv.CloneViewNonConst(index) ); 
     }
 
-    static Teuchos::RCP<MultiVec<ScalarType> > 
-    CloneViewNonConst (MultiVec<ScalarType>& mv, const Teuchos::Range1D& index)
+    static Teuchos::RCP<MultiVec<ScalarType,DM> > 
+    CloneViewNonConst (MultiVec<ScalarType,DM>& mv, const Teuchos::Range1D& index)
     { 
       // mfh 02 Mar 2013: For now, we'll just use the above index
       // vector version of CloneViewNonConst to implement this, since
@@ -367,13 +369,13 @@ public:
     }
 
     ///
-    static Teuchos::RCP<const MultiVec<ScalarType> > 
-    CloneView (const MultiVec<ScalarType>& mv, const std::vector<int>& index) {
-      return Teuchos::rcp( const_cast<MultiVec<ScalarType>&>(mv).CloneView(index) ); 
+    static Teuchos::RCP<const MultiVec<ScalarType,DM> > 
+    CloneView (const MultiVec<ScalarType,DM>& mv, const std::vector<int>& index) {
+      return Teuchos::rcp( const_cast<MultiVec<ScalarType,DM>&>(mv).CloneView(index) ); 
     }
 
-    static Teuchos::RCP<const MultiVec<ScalarType> > 
-    CloneView (const MultiVec<ScalarType>& mv, const Teuchos::Range1D& index)
+    static Teuchos::RCP<const MultiVec<ScalarType,DM> > 
+    CloneView (const MultiVec<ScalarType,DM>& mv, const Teuchos::Range1D& index)
     { 
       // mfh 02 Mar 2013: For now, we'll just use the above index
       // vector version of CloneView to implement this, since that
@@ -386,41 +388,41 @@ public:
     }
 
     ///
-    static ptrdiff_t GetGlobalLength( const MultiVec<ScalarType>& mv )
+    static ptrdiff_t GetGlobalLength( const MultiVec<ScalarType,DM>& mv )
     { return mv.GetGlobalLength(); }
     ///
-    static int GetNumberVecs( const MultiVec<ScalarType>& mv )
+    static int GetNumberVecs( const MultiVec<ScalarType,DM>& mv )
     { return mv.GetNumberVecs(); }
     ///
-    static void MvTimesMatAddMv( ScalarType alpha, const MultiVec<ScalarType>& A, 
-				 const Teuchos::SerialDenseMatrix<int,ScalarType>& B, 
-				 ScalarType beta, MultiVec<ScalarType>& mv )
+    static void MvTimesMatAddMv( ScalarType alpha, const MultiVec<ScalarType,DM>& A, 
+				 const DM& B, 
+				 ScalarType beta, MultiVec<ScalarType,DM>& mv )
     { mv.MvTimesMatAddMv(alpha, A, B, beta); }
     ///
-    static void MvAddMv( ScalarType alpha, const MultiVec<ScalarType>& A, ScalarType beta, const MultiVec<ScalarType>& B, MultiVec<ScalarType>& mv )
+    static void MvAddMv( ScalarType alpha, const MultiVec<ScalarType,DM>& A, ScalarType beta, const MultiVec<ScalarType,DM>& B, MultiVec<ScalarType,DM>& mv )
     { mv.MvAddMv(alpha, A, beta, B); }
     ///
-    static void MvScale ( MultiVec<ScalarType>& mv, const ScalarType alpha )
+    static void MvScale ( MultiVec<ScalarType,DM>& mv, const ScalarType alpha )
     { mv.MvScale( alpha ); } 
 
-    static void MvScale ( MultiVec<ScalarType>& mv, const std::vector<ScalarType>& alpha )
+    static void MvScale ( MultiVec<ScalarType,DM>& mv, const std::vector<ScalarType>& alpha )
     { mv.MvScale(alpha); }
     ///
-    static void MvTransMv( const ScalarType alpha, const MultiVec<ScalarType>& A, const MultiVec<ScalarType>& mv, Teuchos::SerialDenseMatrix<int,ScalarType>& B )
+    static void MvTransMv( const ScalarType alpha, const MultiVec<ScalarType,DM>& A, const MultiVec<ScalarType,DM>& mv, DM& B )
     { mv.MvTransMv(alpha, A, B); }
     ///
-    static void MvDot( const MultiVec<ScalarType>& mv, const MultiVec<ScalarType>& A, std::vector<ScalarType>& b )
+    static void MvDot( const MultiVec<ScalarType,DM>& mv, const MultiVec<ScalarType,DM>& A, std::vector<ScalarType>& b )
     { mv.MvDot( A, b ); }
     ///
-    static void MvNorm( const MultiVec<ScalarType>& mv, std::vector<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>& normvec, NormType type = TwoNorm )
+    static void MvNorm( const MultiVec<ScalarType,DM>& mv, std::vector<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>& normvec, NormType type = TwoNorm )
     { mv.MvNorm(normvec,type); }
     ///
-    static void SetBlock( const MultiVec<ScalarType>& A, const std::vector<int>& index, MultiVec<ScalarType>& mv )
+    static void SetBlock( const MultiVec<ScalarType,DM>& A, const std::vector<int>& index, MultiVec<ScalarType,DM>& mv )
     { mv.SetBlock(A, index); }
 
     static void 
-    Assign (const MultiVec<ScalarType>& A, 
-	    MultiVec<ScalarType>& mv) 
+    Assign (const MultiVec<ScalarType,DM>& A, 
+	    MultiVec<ScalarType,DM>& mv) 
     {
       // mfh 02 Mar 2013: For now, we'll just use SetBlock to implement this,
       // since that doesn't require adding to the MultiVec interface.
@@ -443,13 +445,13 @@ public:
     }
 
     ///
-    static void MvRandom( MultiVec<ScalarType>& mv )
+    static void MvRandom( MultiVec<ScalarType, DM>& mv )
     { mv.MvRandom(); }
     ///
-    static void MvInit( MultiVec<ScalarType>& mv, ScalarType alpha = Teuchos::ScalarTraits<ScalarType>::zero() )
+    static void MvInit( MultiVec<ScalarType, DM>& mv, ScalarType alpha = Teuchos::ScalarTraits<ScalarType>::zero() )
     { mv.MvInit(alpha); }
     ///
-    static void MvPrint( const MultiVec<ScalarType>& mv, std::ostream& os )
+    static void MvPrint( const MultiVec<ScalarType, DM>& mv, std::ostream& os )
     { mv.MvPrint(os); }
 
 #ifdef HAVE_BELOS_TSQR
@@ -460,7 +462,7 @@ public:
     /// methods.  If you want to use TSQR with your MultiVec subclass,
     /// you must implement these methods yourself, as the default
     /// implementations throw std::logic_error.
-    typedef details::MultiVecTsqrAdapter<ScalarType> tsqr_adaptor_type;
+    typedef details::MultiVecTsqrAdapter<ScalarType,DM> tsqr_adaptor_type;
 #endif // HAVE_BELOS_TSQR
   };
 

--- a/packages/belos/src/BelosMultiVecTraits.hpp
+++ b/packages/belos/src/BelosMultiVecTraits.hpp
@@ -25,7 +25,11 @@
 #include "BelosStubTsqrAdapter.hpp"
 #include "Teuchos_Range1D.hpp"
 #include "Teuchos_RCP.hpp"
-#include "Teuchos_SerialDenseMatrix.hpp"
+
+// This is included for backwards compatibility
+// for all codes using the default template parameter
+// DM = Teuchos::SerialDenseMatrix<int,ScalarType>
+#include "BelosDenseMatTraits.hpp" 
 
 namespace Belos {
 
@@ -35,7 +39,7 @@ namespace Belos {
   /// MultiVecTraits<ScalarType, MV> uses this struct to produce a
   /// compile-time error when no specialization exists for the scalar
   /// type ScalarType and multivector type MV.
-  template<class ScalarType, class MV>
+  template<class ScalarType, class MV, class DM>
   struct UndefinedMultiVecTraits
   {
     /// \brief Any attempt to compile this method will result in a compile-time error.
@@ -54,6 +58,7 @@ namespace Belos {
   ///
   /// \tparam ScalarType The type of the entries in the multivectors.
   /// \tparam MV The type of the multivectors themselves.
+  /// \tparam DM Type of Dense Matrix (default= Teuchos::SerialDenseMatrix)
   ///
   /// This traits class tells Belos' solvers how to perform
   /// multivector operations for the multivector type MV.  These
@@ -93,7 +98,7 @@ namespace Belos {
   ///   Epetra and Tpetra multivector types, and Stratimikos provides
   ///   a specialization for the Thyra type.  Just relax and enjoy
   ///   using the solvers!
-  template<class ScalarType, class MV>
+  template<class ScalarType, class MV, class DM = Teuchos::SerialDenseMatrix<int, ScalarType>>
   class MultiVecTraits {
   public:
     //! @name Creation methods
@@ -104,14 +109,14 @@ namespace Belos {
     \return Reference-counted pointer to the new multivector of type \c MV.
     */
     static Teuchos::RCP<MV> Clone( const MV& mv, const int numvecs )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); return Teuchos::null; }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); return Teuchos::null; }
 
     /*! \brief Creates a new \c MV and copies contents of \c mv into the new vector (deep copy).
 
       \return Reference-counted pointer to the new multivector of type \c MV.
     */
     static Teuchos::RCP<MV> CloneCopy( const MV& mv )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); return Teuchos::null; }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); return Teuchos::null; }
 
     /*! \brief Creates a new \c MV and copies the selected contents of \c mv into the new vector (deep copy).
 
@@ -119,7 +124,7 @@ namespace Belos {
       \return Reference-counted pointer to the new multivector of type \c MV.
     */
     static Teuchos::RCP<MV> CloneCopy( const MV& mv, const std::vector<int>& index )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); return Teuchos::null; }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); return Teuchos::null; }
 
     /// \brief Deep copy of specified columns of mv
     ///
@@ -131,7 +136,7 @@ namespace Belos {
     /// \param index [in] Inclusive index range of columns of mv
     /// \return Reference-counted pointer to the new multivector of type \c MV.
     static Teuchos::RCP<MV> CloneCopy( const MV& mv, const Teuchos::Range1D& index )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); return Teuchos::null; }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); return Teuchos::null; }
 
     /*! \brief Creates a new \c MV that shares the selected contents of \c mv (shallow copy).
 
@@ -139,7 +144,7 @@ namespace Belos {
     \return Reference-counted pointer to the new multivector of type \c MV.
     */
     static Teuchos::RCP<MV> CloneViewNonConst( MV& mv, const std::vector<int>& index )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); return Teuchos::null; }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); return Teuchos::null; }
 
     /// \brief Non-const view of specified columns of mv
     ///
@@ -150,7 +155,7 @@ namespace Belos {
     /// \param index [in] Inclusive index range of columns of mv
     /// \return Reference-counted pointer to the non-const view of specified columns of mv
     static Teuchos::RCP<MV> CloneViewNonConst( MV& mv, const Teuchos::Range1D& index )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); return Teuchos::null; }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); return Teuchos::null; }
 
     /*! \brief Creates a new const \c MV that shares the selected contents of \c mv (shallow copy).
 
@@ -158,7 +163,7 @@ namespace Belos {
     \return Reference-counted pointer to the new const multivector of type \c MV.
     */
     static Teuchos::RCP<const MV> CloneView( const MV& mv, const std::vector<int>& index )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); return Teuchos::null; }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); return Teuchos::null; }
 
     /// \brief Const view of specified columns of mv
     ///
@@ -169,7 +174,7 @@ namespace Belos {
     /// \param index [in] Inclusive index range of columns of mv
     /// \return Reference-counted pointer to the const view of specified columns of mv
     static Teuchos::RCP<MV> CloneView( MV& mv, const Teuchos::Range1D& index )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); return Teuchos::null; }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); return Teuchos::null; }
 
     //@}
 
@@ -180,11 +185,11 @@ namespace Belos {
     ///
     //! Obtain the vector length of \c mv.
     static ptrdiff_t GetGlobalLength( const MV& mv )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); return 0; }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); return 0; }
 
     //! Obtain the number of vectors in \c mv
     static int GetNumberVecs( const MV& mv )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); return 0; }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); return 0; }
 
     /// Whether the given multivector \c mv has constant stride
     ///
@@ -209,7 +214,7 @@ namespace Belos {
     ///   performance penalty for cache blocks, and doesn't require
     ///   an extra cache block's worth of storage.
     static bool HasConstantStride( const MV& mv )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); return false; }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); return false; }
 
     //@}
 
@@ -217,36 +222,41 @@ namespace Belos {
     //@{
 
     /*! \brief Update \c mv with \f$ \alpha AB + \beta mv \f$.
+     *  \note User is responsible for calling any necessary 
+     *  host-device or device-host syncs within this function.
+     *  Belos will NOT call any syncs before calling MvTimesMatAddMv. 
      */
     static void MvTimesMatAddMv( const ScalarType alpha, const MV& A,
-                                 const Teuchos::SerialDenseMatrix<int,ScalarType>& B,
+                                 const DM& B,
                                  const ScalarType beta, MV& mv )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); }
 
     /*! \brief Replace \c mv with \f$\alpha A + \beta B\f$.
      */
     static void MvAddMv( const ScalarType alpha, const MV& A, const ScalarType beta, const MV& B, MV& mv )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); }
 
     /*! \brief Scale each element of the vectors in \c mv with \c alpha.
      */
     static void MvScale ( MV& mv, const ScalarType alpha )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); }
 
     /*! \brief Scale each element of the \c i-th vector in \c mv with \c alpha[i].
      */
     static void MvScale ( MV& mv, const std::vector<ScalarType>& alpha )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); }
 
     /*! \brief Compute a dense matrix \c B through the matrix-matrix multiply \f$ \alpha A^Hmv \f$.
+     *  \note Belos solver algorithms are responsible for calling any needed device-to-host syncs after MvTransMv.
+     *  Please do not include extra syncs in the function implementation. 
     */
-    static void MvTransMv( const ScalarType alpha, const MV& A, const MV& mv, Teuchos::SerialDenseMatrix<int,ScalarType>& B)
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); }
+    static void MvTransMv( const ScalarType alpha, const MV& A, const MV& mv, DM& B)
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); }
 
     /*! \brief Compute a vector \c b where the components are the individual dot-products of the \c i-th columns of \c A and \c mv, i.e.\f$b[i] = A[i]^Hmv[i]\f$.
      */
     static void MvDot ( const MV& mv, const MV& A, std::vector<ScalarType> &b)
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); }
 
     //@}
     //! @name Norm method
@@ -260,7 +270,7 @@ namespace Belos {
       @param NormType: norm type (default: two-norm)
     */
     static void MvNorm( const MV& mv, std::vector<typename Teuchos::ScalarTraits<ScalarType>::magnitudeType>& normvec, NormType type = TwoNorm )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); }
 
     //@}
 
@@ -272,7 +282,7 @@ namespace Belos {
     i.e.<tt> mv[index[i]] = A[i]</tt>.
     */
     static void SetBlock( const MV& A, const std::vector<int>& index, MV& mv )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); }
 
     /// \brief Deep copy of A into specified columns of mv
     ///
@@ -287,23 +297,23 @@ namespace Belos {
     ///   index set of the target
     /// \param mv [out] Target multivector
     static void SetBlock( const MV& A, const Teuchos::Range1D& index, MV& mv )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); }
 
     /// \brief mv := A
     ///
     /// Assign (deep copy) A into mv.
     static void Assign( const MV& A, MV& mv )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); }
 
     /*! \brief Replace the vectors in \c mv with random vectors.
      */
     static void MvRandom( MV& mv )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); }
 
     /*! \brief Replace each element of the vectors in \c mv with \c alpha.
      */
     static void MvInit( MV& mv, const ScalarType alpha = Teuchos::ScalarTraits<ScalarType>::zero() )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); }
 
     //@}
 
@@ -313,7 +323,7 @@ namespace Belos {
     /*! \brief Print the \c mv multi-vector to the \c os output stream.
      */
     static void MvPrint( const MV& mv, std::ostream& os )
-    { UndefinedMultiVecTraits<ScalarType, MV>::notDefined(); }
+    { UndefinedMultiVecTraits<ScalarType, MV, DM>::notDefined(); }
 
     //@}
 
@@ -330,7 +340,7 @@ namespace Belos {
     /// adapter.  Please refer to Epetra::TsqrAdapter (for
     /// Epetra_MultiVector) or Tpetra::TsqrAdaptor (for
     /// Tpetra::MultiVector) for examples.
-    typedef Belos::details::StubTsqrAdapter<MV> tsqr_adaptor_type;
+    typedef Belos::details::StubTsqrAdapter<MV, DM> tsqr_adaptor_type;
 #endif // HAVE_BELOS_TSQR
   };
 

--- a/packages/belos/src/BelosOrthoManager.hpp
+++ b/packages/belos/src/BelosOrthoManager.hpp
@@ -36,9 +36,8 @@
 #include "BelosTypes.hpp"
 #include "Teuchos_ScalarTraits.hpp"
 #include "Teuchos_RCP.hpp"
-#include "Teuchos_SerialDenseMatrix.hpp"
 #include "Teuchos_Array.hpp"
-
+#include "BelosTeuchosDenseAdapter.hpp"
 
 namespace Belos {
 
@@ -53,7 +52,7 @@ namespace Belos {
 
   //@}
 
-  template <class ScalarType, class MV>
+  template <class ScalarType, class MV, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
   class OrthoManager : 
     public Teuchos::ParameterListAcceptorDefaultBase 
   {
@@ -78,7 +77,7 @@ namespace Belos {
     if there is a mass matrix \c M, then this might be the \c M inner product (\f$x^HMx\f$).
 
      */
-    virtual void innerProd( const MV &X, const MV &Y, Teuchos::SerialDenseMatrix<int,ScalarType>& Z ) const = 0;
+    virtual void innerProd( const MV &X, const MV &Y, DM & Z ) const = 0;
 
 
     /// \brief Compute the norm(s) of the column(s) of X.
@@ -131,7 +130,7 @@ namespace Belos {
     ///
     virtual void
     project (MV &X,
-             Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+             Teuchos::Array<Teuchos::RCP<DM> > C,
              Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const = 0;
 
     /*! \brief This method takes a multivector \c X and attempts to compute an orthonormal basis for \f$colspan(X)\f$, with respect to innerProd().
@@ -148,13 +147,13 @@ namespace Belos {
 
      @return Rank of the basis computed by this method.
     */
-    virtual int normalize ( MV &X, Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B ) const = 0;
+    virtual int normalize ( MV &X, Teuchos::RCP<DM> B ) const = 0;
 
   protected:
     virtual int
     projectAndNormalizeImpl (MV &X,
-                             Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
-                             Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                             Teuchos::Array<Teuchos::RCP<DM>> C,
+                             Teuchos::RCP<DM> B,
                              Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const = 0;
 
   public:
@@ -215,8 +214,8 @@ namespace Belos {
     ///
     int
     projectAndNormalize (MV &X,
-                         Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
-                         Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                         Teuchos::Array<Teuchos::RCP<DM>> C,
+                         Teuchos::RCP<DM> B,
                          Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const
     {
       return this->projectAndNormalizeImpl (X, C, B, Q);

--- a/packages/belos/src/BelosOrthoManagerFactory.hpp
+++ b/packages/belos/src/BelosOrthoManagerFactory.hpp
@@ -46,7 +46,7 @@ namespace Belos {
   /// multivector), MV is the multivector type, and OP is the operator
   /// type.  For example: Scalar=double, MV=Epetra_MultiVector, and
   /// OP=Epetra_Operator.
-  template<class Scalar, class MV, class OP>
+  template<class Scalar, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int, Scalar>>
   class OrthoManagerFactory {
   private:
     //! List of valid OrthoManager names.
@@ -158,22 +158,22 @@ namespace Belos {
     getDefaultParameters (const std::string& name) const
     {
       if (name == "DGKS") {
-	return Belos::getDGKSDefaultParameters<Scalar, MV, OP> ();
+	return Belos::getDGKSDefaultParameters<Scalar, MV, OP, DM> ();
       }
 #ifdef HAVE_BELOS_TSQR
       else if (name == "TSQR") {
-	TsqrMatOrthoManager<Scalar, MV, OP> orthoMan;
+	TsqrMatOrthoManager<Scalar, MV, OP, DM> orthoMan;
 	return orthoMan.getValidParameters ();
       }
 #endif // HAVE_BELOS_TSQR
       else if (name == "ICGS") {
-	return Belos::getICGSDefaultParameters<Scalar, MV, OP> ();
+	return Belos::getICGSDefaultParameters<Scalar, MV, OP, DM> ();
       }
       else if (name == "IMGS") {
-	return Belos::getIMGSDefaultParameters<Scalar, MV, OP> ();
+	return Belos::getIMGSDefaultParameters<Scalar, MV, OP, DM> ();
       }
       else if (name == "Simple") {
-	SimpleOrthoManager<Scalar, MV> orthoMan;
+	SimpleOrthoManager<Scalar, MV, DM> orthoMan;
 	return orthoMan.getValidParameters ();
       }
       else {
@@ -206,22 +206,22 @@ namespace Belos {
     getFastParameters (const std::string& name) const
     {
       if (name == "DGKS") {
-	return Belos::getDGKSFastParameters<Scalar, MV, OP> ();
+	return Belos::getDGKSFastParameters<Scalar, MV, OP, DM> ();
       }
 #ifdef HAVE_BELOS_TSQR
       else if (name == "TSQR") {
-	TsqrMatOrthoManager<Scalar, MV, OP> orthoMan; 
+	TsqrMatOrthoManager<Scalar, MV, OP, DM> orthoMan; 
 	return orthoMan.getFastParameters ();
       }
 #endif // HAVE_BELOS_TSQR
       else if (name == "ICGS") {
-	return Belos::getICGSFastParameters<Scalar, MV, OP> ();
+	return Belos::getICGSFastParameters<Scalar, MV, OP, DM> ();
       }
       else if (name == "IMGS") {
-	return Belos::getIMGSFastParameters<Scalar, MV, OP> ();
+	return Belos::getIMGSFastParameters<Scalar, MV, OP, DM> ();
       }
       else if (name == "Simple") {
-	SimpleOrthoManager<Scalar, MV> orthoMan;
+	SimpleOrthoManager<Scalar, MV, DM> orthoMan;
 	return orthoMan.getFastParameters ();
       }
       else {
@@ -256,7 +256,7 @@ namespace Belos {
     ///   parameter list with embedded documentation is available for
     ///   each MatOrthoManager subclass that this factory knows how to
     ///   make.
-    Teuchos::RCP<Belos::MatOrthoManager<Scalar, MV, OP> >
+    Teuchos::RCP<Belos::MatOrthoManager<Scalar, MV, OP, DM> >
     makeMatOrthoManager (const std::string& ortho, 
 			 const Teuchos::RCP<const OP>& M,
 			 const Teuchos::RCP<OutputManager<Scalar> >& /* outMan */,
@@ -273,21 +273,21 @@ namespace Belos {
       using Teuchos::rcp;
 
       if (ortho == "DGKS") {
-	typedef DGKSOrthoManager<Scalar, MV, OP> ortho_type;
+	typedef DGKSOrthoManager<Scalar, MV, OP, DM> ortho_type;
 	return rcp (new ortho_type (params, label, M));
       }
 #ifdef HAVE_BELOS_TSQR
       else if (ortho == "TSQR") {
-	typedef TsqrMatOrthoManager<Scalar, MV, OP> ortho_type;
+	typedef TsqrMatOrthoManager<Scalar, MV, OP, DM> ortho_type;
 	return rcp (new ortho_type (params, label, M));
       }
 #endif // HAVE_BELOS_TSQR
       else if (ortho == "ICGS") {
-	typedef ICGSOrthoManager<Scalar, MV, OP> ortho_type;
+	typedef ICGSOrthoManager<Scalar, MV, OP, DM> ortho_type;
 	return rcp (new ortho_type (params, label, M));
       }
       else if (ortho == "IMGS") {
-	typedef IMGSOrthoManager<Scalar, MV, OP> ortho_type;
+	typedef IMGSOrthoManager<Scalar, MV, OP, DM> ortho_type;
 	return rcp (new ortho_type (params, label, M));
       } 
       else if (ortho == "Simple") {
@@ -320,7 +320,7 @@ namespace Belos {
     ///   setting up the specific OrthoManager subclass.
     ///
     /// \return OrthoManager instance.
-    Teuchos::RCP<Belos::OrthoManager<Scalar, MV> >
+    Teuchos::RCP<Belos::OrthoManager<Scalar, MV, DM> >
     makeOrthoManager (const std::string& ortho, 
 		      const Teuchos::RCP<const OP>& M,
 		      const Teuchos::RCP<OutputManager<Scalar> >& outMan,
@@ -337,7 +337,7 @@ namespace Belos {
 				   "SimpleOrthoManager is not yet supported "
 				   "when the operator M is nontrivial (i.e., "
 				   "M != null).");
-	return rcp (new SimpleOrthoManager<Scalar, MV> (outMan, label, params));
+	return rcp (new SimpleOrthoManager<Scalar, MV, DM> (outMan, label, params));
       }
 #ifdef HAVE_BELOS_TSQR
       // TsqrMatOrthoManager has to store more things and do more work
@@ -349,7 +349,7 @@ namespace Belos {
       // TsqrMatOrthoManager would still be correct; this is just an
       // optimization.
       else if (ortho == "TSQR" && M.is_null()) {
-	return rcp (new TsqrOrthoManager<Scalar, MV> (params, label));
+	return rcp (new TsqrOrthoManager<Scalar, MV, DM> (params, label));
       }
 #endif // HAVE_BELOS_TSQR
       else {

--- a/packages/belos/src/BelosPCPGIter.hpp
+++ b/packages/belos/src/BelosPCPGIter.hpp
@@ -18,24 +18,24 @@
 #include "BelosTypes.hpp"
 
 #include "BelosLinearProblem.hpp"
-#include "BelosMatOrthoManager.hpp"
 #include "BelosOutputManager.hpp"
 #include "BelosStatusTest.hpp"
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
+#include "BelosDenseMatTraits.hpp"
 #include "BelosCGIteration.hpp"
 
-#include "Teuchos_SerialDenseMatrix.hpp"
-#include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
+
+#include <vector>
 
 /*!	
   \class Belos::PCPGIter
   
   \brief This class implements the PCPG iteration, where a
-  single-std::vector Krylov subspace is constructed.  The documentation
+  single-vector Krylov subspace is constructed.  The documentation
   refers to blocks, but note that at this point, all blocks have unit
   dimension.
  
@@ -51,7 +51,7 @@ namespace Belos {
    *
    * The structure is utilized by initialize() and getState().
    */
-  template <class ScalarType, class MV>
+  template <class ScalarType, class MV, class DM>
   struct PCPGIterState {
     /*! \brief The current dimension of the reduction.
      *
@@ -80,11 +80,11 @@ namespace Belos {
     /*! \brief C = AU, U spans recycled subspace */
     Teuchos::RCP<MV> C;
 
-    /*! \brief The current Hessenberg matrix.
+    /*! \brief The current diagonal matrix.
      *
      * The \c curDim by \c curDim D = diag(P'*AP) = U' * C
      */
-    Teuchos::RCP<const Teuchos::SerialDenseMatrix<int,ScalarType> > D;
+    std::vector<ScalarType> D;
 
     PCPGIterState() : curDim(0), 
                       prevUdim(0), 
@@ -97,16 +97,17 @@ namespace Belos {
   
   //@}
   
-  template<class ScalarType, class MV, class OP>
-  class PCPGIter : virtual public Iteration<ScalarType,MV,OP> {
+  template<class ScalarType, class MV, class OP, class DM>
+  class PCPGIter : virtual public Iteration<ScalarType,MV,OP,DM> {
     
   public:
     
     //
     // Convenience typedefs
     //
-    typedef MultiVecTraits<ScalarType,MV> MVT;
+    typedef MultiVecTraits<ScalarType,MV,DM> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
+    typedef DenseMatTraits<ScalarType,DM>    DMT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename SCT::magnitudeType MagnitudeType;
     
@@ -122,8 +123,7 @@ namespace Belos {
      */
     PCPGIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
 		const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-		const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-		const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > &ortho,
+		const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
 		Teuchos::ParameterList &params );
     
     //! Destructor.
@@ -172,14 +172,14 @@ namespace Belos {
      * \note For any pointer in \c newstate which directly points to the multivectors in 
      * the solver, the data is not (supposed to be) copied.
      */
-    void initialize(PCPGIterState<ScalarType,MV>& newstate);
+    void initialize(PCPGIterState<ScalarType,MV,DM>& newstate);
     
     /*! \brief Initialize the solver with the initial vectors from the linear problem.
      *  An exception is thrown if initialzed is called and newstate.R is null.
      */
     void initialize()
     {
-      PCPGIterState<ScalarType,MV> empty;
+      PCPGIterState<ScalarType,MV,DM> empty;
       initialize(empty);
     }
     
@@ -190,8 +190,8 @@ namespace Belos {
      * \returns A PCPGIterState object containing const pointers to the current
      * solver state.
      */
-    PCPGIterState<ScalarType,MV> getState() const {
-      PCPGIterState<ScalarType,MV> state;
+    PCPGIterState<ScalarType,MV,DM> getState() const {
+      PCPGIterState<ScalarType,MV,DM> state;
       state.Z = Z_;         // CG state
       state.P = P_;
       state.AP = AP_;
@@ -285,8 +285,7 @@ namespace Belos {
     //
     const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
     const Teuchos::RCP<OutputManager<ScalarType> >          om_;
-    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
-    const Teuchos::RCP<OrthoManager<ScalarType,MV> >        ortho_;
+    const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >    stest_;
 
     //
     // Algorithmic parameters
@@ -344,21 +343,19 @@ namespace Belos {
     //
     // Projected matrices
     // D_ : Diagonal matrix of pivots D = P'AP 
-    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > D_;
+    std::vector<ScalarType> D_;
   };
   
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
-  template<class ScalarType, class MV, class OP>
-  PCPGIter<ScalarType,MV,OP>::PCPGIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
+  template<class ScalarType, class MV, class OP, class DM>
+  PCPGIter<ScalarType,MV,OP,DM>::PCPGIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
 					   const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-					   const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-					   const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > &ortho,
+					   const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
 					   Teuchos::ParameterList &params ):
     lp_(problem),
     om_(printer),
     stest_(tester),
-    ortho_(ortho),
     savedBlocks_(0),
     initialized_(false),
     stateStorageInitialized_(false),
@@ -386,8 +383,8 @@ namespace Belos {
   
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Set the block size and adjust as necessary
-  template <class ScalarType, class MV, class OP>
-  void PCPGIter<ScalarType,MV,OP>::setSize( int savedBlocks )
+  template<class ScalarType, class MV, class OP, class DM>
+  void PCPGIter<ScalarType,MV,OP,DM>::setSize( int savedBlocks )
   {
     // allocate space only; perform no computation
     // Any change in size invalidates the state of the solver as implemented here.
@@ -406,8 +403,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Enable the reuse of a single solver object for completely different linear systems
-  template <class ScalarType, class MV, class OP>
-  void PCPGIter<ScalarType,MV,OP>::resetState()
+  template<class ScalarType, class MV, class OP, class DM>
+  void PCPGIter<ScalarType,MV,OP,DM>::resetState()
   {
       stateStorageInitialized_ = false;
       initialized_ = false;
@@ -418,8 +415,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Setup the state storage.  Called by either initialize or, if savedBlocks_ changes, setSize.
-  template <class ScalarType, class MV, class OP>
-  void PCPGIter<ScalarType,MV,OP>::setStateSize ()
+  template<class ScalarType, class MV, class OP, class DM> 
+  void PCPGIter<ScalarType,MV,OP,DM>::setStateSize ()
   {
     if (!stateStorageInitialized_) {
 
@@ -482,16 +479,8 @@ namespace Belos {
 	  }
 	}
         if (keepDiagonal_) {
-          if (D_ == Teuchos::null) {
-            D_ = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>() );
-          }
-          if (initDiagonal_) {
-            D_->shape( newsd, newsd );
-          }
-          else {
-            if (D_->numRows() < newsd || D_->numCols() < newsd) {
-              D_->shapeUninitialized( newsd, newsd );
-            }
+          if (initDiagonal_ || ((int)(D_.size()) < newsd)) {
+            D_.resize( newsd );
           }
         }
 	// State storage has now been initialized.
@@ -502,8 +491,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Initialize the iteration object
-  template <class ScalarType, class MV, class OP>
-  void PCPGIter<ScalarType,MV,OP>::initialize(PCPGIterState<ScalarType,MV>& newstate)
+  template<class ScalarType, class MV, class OP, class DM>
+  void PCPGIter<ScalarType,MV,OP,DM>::initialize(PCPGIterState<ScalarType,MV,DM>& newstate)
   {
 
     TEUCHOS_TEST_FOR_EXCEPTION(!stateStorageInitialized_,std::invalid_argument,
@@ -590,8 +579,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Iterate until the status test informs us we should stop.
-  template <class ScalarType, class MV, class OP>
-  void PCPGIter<ScalarType,MV,OP>::iterate()
+  template<class ScalarType, class MV, class OP, class DM>
+  void PCPGIter<ScalarType,MV,OP,DM>::iterate()
   {
     //
     // Allocate/initialize data structures
@@ -602,10 +591,9 @@ namespace Belos {
     const bool debug = false;
 
     // Allocate memory for scalars.
-    Teuchos::SerialDenseMatrix<int,ScalarType> alpha( 1, 1 );
-    Teuchos::SerialDenseMatrix<int,ScalarType> pAp( 1, 1 );
-    Teuchos::SerialDenseMatrix<int,ScalarType> beta( 1, 1 );
-    Teuchos::SerialDenseMatrix<int,ScalarType> rHz( 1, 1 ), rHz_old( 1, 1 );
+    ScalarType alpha, beta, rHz_old;
+    Teuchos::RCP<DM> pAp = DMT::Create(1,1);
+    Teuchos::RCP<DM> rHz = DMT::Create(1,1);
 
     if( iter_ != 0 )
       std::cout << " Iterate Warning: begin from nonzero iter_ ?" << std::endl;  //DMD
@@ -614,12 +602,12 @@ namespace Belos {
     std::vector<int> prevInd;
     Teuchos::RCP<const MV> Uprev;
     Teuchos::RCP<const MV> Cprev;
-    Teuchos::SerialDenseMatrix<int,ScalarType> CZ;
+    Teuchos::RCP<DM> CZ;
 
     if( prevUdim_ ){
       prevInd.resize( prevUdim_ );
       for( int i=0; i<prevUdim_ ; i++) prevInd[i] = i;
-      CZ.reshape( prevUdim_ , 1 );
+      CZ = DMT::Create( prevUdim_ , 1 );
       Uprev = MVT::CloneView(*U_, prevInd);
       Cprev = MVT::CloneView(*C_, prevInd);
     }
@@ -646,14 +634,9 @@ namespace Belos {
       Teuchos::RCP<MV> P; 
       curind[0] = curDim_ - 1;          // column = dimension - 1 
       P = MVT::CloneViewNonConst(*U_,curind); 
-      MVT::MvTransMv( one, *Cprev, *P, CZ );
-      MVT::MvTimesMatAddMv( -one, *Uprev, CZ, one, *P );       // P -= U*(C'Z)
+      MVT::MvTransMv( one, *Cprev, *P, *CZ );
+      MVT::MvTimesMatAddMv( -one, *Uprev, *CZ, one, *P );       // P -= U*(C'Z)
 
-      if( debug ){
-        MVT::MvTransMv( one, *Cprev, *P, CZ );
-        std::cout << " Input CZ post ortho " << std::endl;
-        CZ.print( std::cout );
-      }
       if( curDim_ == savedBlocks_ ){
         std::vector<int> zero_index(1);
         zero_index[0] = 0;
@@ -663,7 +646,8 @@ namespace Belos {
     }
 
     // Compute first <r,z> a.k.a. rHz
-    MVT::MvTransMv( one, *R_, *Z_, rHz );
+    MVT::MvTransMv( one, *R_, *Z_, *rHz );
+    DMT::SyncDeviceToHost( *rHz );
 
     ////////////////////////////////////////////////////////////////
     // iterate until the status test is satisfied
@@ -682,51 +666,51 @@ namespace Belos {
         P = MVT::CloneView(*U_,curind); 
         AP = MVT::CloneViewNonConst(*C_,curind); 
         lp_->applyOp( *P, *AP );
-        MVT::MvTransMv( one, *P, *AP, pAp );
+        MVT::MvTransMv( one, *P, *AP, *pAp );
       }else{
         if( prevUdim_ + iter_ == savedBlocks_ ){
           AP = MVT::CloneViewNonConst(*C_,curind); 
           lp_->applyOp( *P_, *AP );
-          MVT::MvTransMv( one, *P_, *AP, pAp );
+          MVT::MvTransMv( one, *P_, *AP, *pAp );
         }else{
           lp_->applyOp( *P_, *AP_ );
-          MVT::MvTransMv( one, *P_, *AP_, pAp );
+          MVT::MvTransMv( one, *P_, *AP_, *pAp );
         }
       }
+      DMT::SyncDeviceToHost( *pAp );
 
       if( keepDiagonal_  && prevUdim_ + iter_ <= savedBlocks_ )
-        (*D_)(iter_ -1 ,iter_ -1 ) = pAp(0,0);
+        D_[iter_-1] = DMT::ValueConst(*pAp,0,0);
 
       // positive pAp required 
-      TEUCHOS_TEST_FOR_EXCEPTION( pAp(0,0) <= zero, CGPositiveDefiniteFailure,
+      TEUCHOS_TEST_FOR_EXCEPTION( DMT::ValueConst(*pAp,0,0) <= zero, CGPositiveDefiniteFailure,
                           "Belos::PCPGIter::iterate(): non-positive value for p^H*A*p encountered!" );
 
       // alpha := <R_,Z_> / <P,AP>
-      alpha(0,0) = rHz(0,0) / pAp(0,0);
+      alpha = DMT::ValueConst(*rHz,0,0) / DMT::ValueConst(*pAp,0,0);
 
       // positive alpha required 
-      TEUCHOS_TEST_FOR_EXCEPTION( alpha(0,0) <= zero, CGPositiveDefiniteFailure,
+      TEUCHOS_TEST_FOR_EXCEPTION( alpha <= zero, CGPositiveDefiniteFailure,
                           "Belos::PCPGIter::iterate(): non-positive value for alpha encountered!" );
 
       // solution update  x += alpha * P
       if( curDim_ < savedBlocks_ ){
-         MVT::MvAddMv( one, *cur_soln_vec, alpha(0,0), *P, *cur_soln_vec );
+         MVT::MvAddMv( one, *cur_soln_vec, alpha, *P, *cur_soln_vec );
       }else{
-         MVT::MvAddMv( one, *cur_soln_vec, alpha(0,0), *P_, *cur_soln_vec );
+         MVT::MvAddMv( one, *cur_soln_vec, alpha, *P_, *cur_soln_vec );
       }
-      //lp_->updateSolution(); ... does nothing.
       //
       // The denominator of beta is saved before residual is updated [ old <R_, Z_> ].
       //
-      rHz_old(0,0) = rHz(0,0);
+      rHz_old = DMT::ValueConst(*rHz,0,0);
       //
       // residual update R_ := R_ - alpha * AP
       //
       if( prevUdim_ + iter_ <= savedBlocks_ ){
-         MVT::MvAddMv( one, *R_, -alpha(0,0), *AP, *R_ );
+         MVT::MvAddMv( one, *R_, -alpha, *AP, *R_ );
          AP = Teuchos::null;
       }else{
-         MVT::MvAddMv( one, *R_, -alpha(0,0), *AP_, *R_ );
+         MVT::MvAddMv( one, *R_, -alpha, *AP_, *R_ );
       }
       //
       // update beta := [ new <R_, Z_> ] / [ old <R_, Z_> ] and the search direction p.
@@ -737,23 +721,19 @@ namespace Belos {
         Z_ = R_;
       }
       //
-      MVT::MvTransMv( one, *R_, *Z_, rHz );
+      MVT::MvTransMv( one, *R_, *Z_, *rHz );
+      DMT::SyncDeviceToHost( *rHz );
       //
-      beta(0,0) = rHz(0,0) / rHz_old(0,0);
+      beta = DMT::ValueConst(*rHz,0,0) / rHz_old;
       //
       if( curDim_ < savedBlocks_ ){
          curDim_++;                                                         // update basis dim
          curind[0] = curDim_ - 1;
          Teuchos::RCP<MV> Pnext = MVT::CloneViewNonConst(*U_,curind);
-         MVT::MvAddMv( one, *Z_, beta(0,0), *P, *Pnext );
+         MVT::MvAddMv( one, *Z_, beta, *P, *Pnext );
          if( prevUdim_ ){ // Deflate seed space 
-             MVT::MvTransMv( one, *Cprev, *Z_, CZ );
-             MVT::MvTimesMatAddMv( -one, *Uprev, CZ, one, *Pnext ); // Pnext -= U*(C'Z)
-             if( debug ){
-               std::cout << " Check CZ " << std::endl;
-               MVT::MvTransMv( one, *Cprev, *Pnext, CZ );
-               CZ.print( std::cout );
-             }
+             MVT::MvTransMv( one, *Cprev, *Z_, *CZ );
+             MVT::MvTimesMatAddMv( -one, *Uprev, *CZ, one, *Pnext ); // Pnext -= U*(C'Z)
          }
          P = Teuchos::null;
          if( curDim_ == savedBlocks_ ){
@@ -763,16 +743,10 @@ namespace Belos {
          }
          Pnext = Teuchos::null;
       }else{
-         MVT::MvAddMv( one, *Z_, beta(0,0), *P_, *P_ );
+         MVT::MvAddMv( one, *Z_, beta, *P_, *P_ );
          if( prevUdim_ ){ // Deflate seed space
-             MVT::MvTransMv( one, *Cprev, *Z_, CZ );
-             MVT::MvTimesMatAddMv( -one, *Uprev, CZ, one, *P_ );       // P_ -= U*(C'Z)
-
-             if( debug ){
-               std::cout << " Check CZ " << std::endl;
-               MVT::MvTransMv( one, *Cprev, *P_, CZ );
-               CZ.print( std::cout );
-             }
+             MVT::MvTransMv( one, *Cprev, *Z_, *CZ );
+             MVT::MvTimesMatAddMv( -one, *Uprev, *CZ, one, *P_ );       // P_ -= U*(C'Z)
          }
       }
       // CGB: 5/26/2010

--- a/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
@@ -70,16 +70,16 @@ namespace Belos {
 
   // Partial specialization for unsupported ScalarType types.
   // This contains a stub implementation.
-  template<class ScalarType, class MV, class OP,
+  template<class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>,
            const bool supportsScalarType =
-             Belos::Details::LapackSupportsScalar<ScalarType>::value>
+             Details::LapackSupportsScalar<ScalarType>::value>
   class PseudoBlockCGSolMgr :
-    public Details::SolverManagerRequiresLapack<ScalarType, MV, OP,
-                                                Belos::Details::LapackSupportsScalar<ScalarType>::value>
+    public Details::SolverManagerRequiresLapack<ScalarType, MV, OP, DM,
+                                                Details::LapackSupportsScalar<ScalarType>::value>
   {
     static const bool scalarTypeIsSupported =
-      Belos::Details::LapackSupportsScalar<ScalarType>::value;
-    using base_type = Details::SolverManagerRequiresLapack<ScalarType, MV, OP, scalarTypeIsSupported>;
+      Details::LapackSupportsScalar<ScalarType>::value;
+    using base_type = Details::SolverManagerRequiresLapack<ScalarType, MV, OP, DM, scalarTypeIsSupported>;
 
   public:
     PseudoBlockCGSolMgr () :
@@ -91,17 +91,17 @@ namespace Belos {
     {}
     virtual ~PseudoBlockCGSolMgr () = default;
 
-    Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> >
+    Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP,DM> >
     getResidualStatusTest() const { return Teuchos::null; }
   };
 
 
-  template<class ScalarType, class MV, class OP>
-  class PseudoBlockCGSolMgr<ScalarType, MV, OP, true> :
-    public Details::SolverManagerRequiresLapack<ScalarType, MV, OP, true>
+  template<class ScalarType, class MV, class OP, class DM>
+  class PseudoBlockCGSolMgr<ScalarType, MV, OP, DM, true> :
+    public Details::SolverManagerRequiresLapack<ScalarType, MV, OP, DM, true>
   {
   private:
-    using MVT = MultiVecTraits<ScalarType, MV>;
+    using MVT = MultiVecTraits<ScalarType, MV, DM>;
     using OPT = OperatorTraits<ScalarType, MV, OP>;
     using SCT = Teuchos::ScalarTraits<ScalarType>;
     using MagnitudeType = typename Teuchos::ScalarTraits<ScalarType>::magnitudeType;
@@ -141,8 +141,8 @@ namespace Belos {
     virtual ~PseudoBlockCGSolMgr() = default;
 
     //! clone for Inverted Injection (DII)
-    Teuchos::RCP<SolverManager<ScalarType, MV, OP> > clone () const override {
-      return Teuchos::rcp(new PseudoBlockCGSolMgr<ScalarType,MV,OP>);
+    Teuchos::RCP<SolverManager<ScalarType, MV, OP, DM> > clone () const override {
+      return Teuchos::rcp(new PseudoBlockCGSolMgr<ScalarType,MV,OP,DM>);
     }
     //@}
 
@@ -202,7 +202,7 @@ namespace Belos {
     Teuchos::ArrayRCP<MagnitudeType> getEigenEstimates() const {return eigenEstimates_;}
 
     //! Return the residual status test
-    Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> >
+    Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP,DM> >
     getResidualStatusTest() const { return convTest_; }
 
     //@}
@@ -275,10 +275,10 @@ namespace Belos {
     Teuchos::RCP<std::ostream> outputStream_;
 
     // Status test.
-    Teuchos::RCP<StatusTest<ScalarType,MV,OP> > sTest_;
-    Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP> > maxIterTest_;
-    Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > convTest_;
-    Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP> > outputTest_;
+    Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > sTest_;
+    Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP,DM> > maxIterTest_;
+    Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP,DM> > convTest_;
+    Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP,DM> > outputTest_;
 
     // Current parameter list.
     Teuchos::RCP<Teuchos::ParameterList> params_;
@@ -326,8 +326,8 @@ namespace Belos {
 
 
 // Empty Constructor
-template<class ScalarType, class MV, class OP>
-PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::PseudoBlockCGSolMgr() :
+template<class ScalarType, class MV, class OP, class DM>
+PseudoBlockCGSolMgr<ScalarType,MV,OP,DM,true>::PseudoBlockCGSolMgr() :
   outputStream_(Teuchos::rcpFromRef(std::cout)),
   convtol_(DefaultSolverParameters::convTol),
   maxIters_(maxIters_default_),
@@ -347,8 +347,8 @@ PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::PseudoBlockCGSolMgr() :
 {}
 
 // Basic Constructor
-template<class ScalarType, class MV, class OP>
-PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::
+template<class ScalarType, class MV, class OP, class DM>
+PseudoBlockCGSolMgr<ScalarType,MV,OP,DM,true>::
 PseudoBlockCGSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                      const Teuchos::RCP<Teuchos::ParameterList> &pl ) :
   problem_(problem),
@@ -381,9 +381,8 @@ PseudoBlockCGSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &probl
   }
 }
 
-template<class ScalarType, class MV, class OP>
-void
-PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::
+template<class ScalarType, class MV, class OP, class DM>
+void PseudoBlockCGSolMgr<ScalarType,MV,OP,DM,true>::
 setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
 {
   using Teuchos::ParameterList;
@@ -524,8 +523,8 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
   }
 
   // Convergence
-  using StatusTestCombo_t = Belos::StatusTestCombo<ScalarType, MV, OP>;
-  using StatusTestResNorm_t = Belos::StatusTestGenResNorm<ScalarType, MV, OP>;
+  using StatusTestCombo_t = Belos::StatusTestCombo<ScalarType, MV, OP, DM>;
+  using StatusTestResNorm_t = Belos::StatusTestGenResNorm<ScalarType, MV, OP, DM>;
 
   // Check for convergence tolerance
   if (params->isParameter ("Convergence Tolerance")) {
@@ -610,7 +609,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
 
   // Basic test checks maximum iterations and native residual.
   if (maxIterTest_.is_null ()) {
-    maxIterTest_ = rcp (new StatusTestMaxIters<ScalarType,MV,OP> (maxIters_));
+    maxIterTest_ = rcp (new StatusTestMaxIters<ScalarType,MV,OP,DM> (maxIters_));
   }
 
   // Implicit residual test, using the native residual to determine if convergence was achieved.
@@ -626,7 +625,7 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
   if (outputTest_.is_null () || newResTest) {
     // Create the status test output class.
     // This class manages and formats the output from the status test.
-    StatusTestOutputFactory<ScalarType,MV,OP> stoFactory (outputStyle_);
+    StatusTestOutputFactory<ScalarType,MV,OP,DM> stoFactory (outputStyle_);
     outputTest_ = stoFactory.create (printer_, sTest_, outputFreq_,
                                      Passed+Failed+Undefined);
 
@@ -649,9 +648,9 @@ setParameters (const Teuchos::RCP<Teuchos::ParameterList>& params)
 }
 
 
-template<class ScalarType, class MV, class OP>
+template<class ScalarType, class MV, class OP, class DM>
 Teuchos::RCP<const Teuchos::ParameterList>
-PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
+PseudoBlockCGSolMgr<ScalarType,MV,OP,DM,true>::getValidParameters() const
 {
   using Teuchos::ParameterList;
   using Teuchos::parameterList;
@@ -711,8 +710,8 @@ PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::getValidParameters() const
 
 
 // solve()
-template<class ScalarType, class MV, class OP>
-ReturnType PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::solve ()
+template<class ScalarType, class MV, class OP, class DM>
+ReturnType PseudoBlockCGSolMgr<ScalarType,MV,OP,DM,true>::solve ()
 {
   const char prefix[] = "Belos::PseudoBlockCGSolMgr::solve: ";
 
@@ -756,17 +755,17 @@ ReturnType PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::solve ()
 
   //////////////////////////////////////////////////////////////////////////////////////
   // Pseudo-Block CG solver
-  Teuchos::RCP<CGIteration<ScalarType,MV,OP> > block_cg_iter;
+  Teuchos::RCP<CGIteration<ScalarType,MV,OP,DM> > block_cg_iter;
   if (numRHS2Solve == 1) {
     plist.set("Fold Convergence Detection Into Allreduce",
               foldConvergenceDetectionIntoAllreduce_);
     block_cg_iter =
-      Teuchos::rcp (new CGIter<ScalarType,MV,OP> (problem_, printer_, outputTest_, convTest_, plist));
+      Teuchos::rcp (new CGIter<ScalarType,MV,OP,DM> (problem_, printer_, outputTest_, convTest_, plist));
     if (state_.is_null() || Teuchos::rcp_dynamic_cast<CGIterationState<ScalarType, MV> >(state_).is_null())
       state_ = Teuchos::rcp(new CGIterationState<ScalarType, MV>());
   } else {
     block_cg_iter =
-      Teuchos::rcp (new PseudoBlockCGIter<ScalarType,MV,OP> (problem_, printer_, outputTest_, plist));
+      Teuchos::rcp (new PseudoBlockCGIter<ScalarType,MV,OP,DM> (problem_, printer_, outputTest_, plist));
     if (state_.is_null() || Teuchos::rcp_dynamic_cast<PseudoBlockCGIterationState<ScalarType, MV> >(state_).is_null())
       state_ = Teuchos::rcp(new PseudoBlockCGIterationState<ScalarType, MV>());
   }
@@ -815,8 +814,8 @@ ReturnType PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::solve ()
           if ( convTest_->getStatus() == Passed ) {
 
             // Figure out which linear systems converged.
-            std::vector<int> convIdx = Teuchos::rcp_dynamic_cast<StatusTestGenResNorm<ScalarType,MV,OP> >(convTest_)->convIndices();
-
+            std::vector<int> convIdx = Teuchos::rcp_dynamic_cast<StatusTestGenResNorm<ScalarType,MV,OP,DM> >(convTest_)->convIndices();
+ 
             // If the number of converged linear systems is equal to the
             // number of current linear systems, then we are done with this block.
             if (convIdx.size() == currRHSIdx.size())
@@ -973,8 +972,8 @@ ReturnType PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::solve ()
 }
 
 //  This method requires the solver manager to return a std::string that describes itself.
-template<class ScalarType, class MV, class OP>
-std::string PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::description() const
+template<class ScalarType, class MV, class OP, class DM>
+std::string PseudoBlockCGSolMgr<ScalarType,MV,OP,DM,true>::description() const
 {
   std::ostringstream oss;
   oss << "Belos::PseudoBlockCGSolMgr<...,"<<Teuchos::ScalarTraits<ScalarType>::name()<<">";
@@ -984,9 +983,8 @@ std::string PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::description() const
 }
 
 
-template<class ScalarType, class MV, class OP>
-void
-PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::
+template<class ScalarType, class MV, class OP, class DM>
+void PseudoBlockCGSolMgr<ScalarType,MV,OP,DM,true>::
 compute_condnum_tridiag_sym (Teuchos::ArrayView<MagnitudeType> diag,
                              Teuchos::ArrayView<MagnitudeType> offdiag,
                              Teuchos::ArrayRCP<MagnitudeType>& lambdas,

--- a/packages/belos/src/BelosPseudoBlockGmresIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockGmresIter.hpp
@@ -17,6 +17,7 @@
 #include "BelosConfigDefs.hpp"
 #include "BelosTypes.hpp"
 #include "BelosIteration.hpp"
+#include "BelosGmresIteration.hpp"
 
 #include "BelosLinearProblem.hpp"
 #include "BelosMatOrthoManager.hpp"
@@ -24,10 +25,9 @@
 #include "BelosStatusTest.hpp"
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
+#include "BelosDenseMatTraits.hpp"
 
 #include "Teuchos_BLAS.hpp"
-#include "Teuchos_SerialDenseMatrix.hpp"
-#include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
@@ -46,73 +46,18 @@
 */
 
 namespace Belos {
-  
-  //! @name PseudoBlockGmresIter Structures 
-  //@{ 
-  
-  /** \brief Structure to contain pointers to PseudoBlockGmresIter state variables.
-   *
-   * This struct is utilized by PseudoBlockGmresIter::initialize() and PseudoBlockGmresIter::getState().
-   */
-  template <class ScalarType, class MV>
-  struct PseudoBlockGmresIterState {
 
-    typedef Teuchos::ScalarTraits<ScalarType> SCT;
-    typedef typename SCT::magnitudeType MagnitudeType;
-
-    /*! \brief The current dimension of the reduction.
-     *
-     * This should always be equal to PseudoBlockGmresIter::getCurSubspaceDim()
-     */
-    int curDim;
-    /*! \brief The current Krylov basis. */
-    std::vector<Teuchos::RCP<const MV> > V;
-    /*! \brief The current Hessenberg matrix. 
-     *
-     * The \c curDim by \c curDim leading submatrix of H is the 
-     * projection of problem->getOperator() by the first \c curDim vectors in V. 
-     */
-    std::vector<Teuchos::RCP<const Teuchos::SerialDenseMatrix<int,ScalarType> > > H;
-    /*! \brief The current upper-triangular matrix from the QR reduction of H. */
-    std::vector<Teuchos::RCP<const Teuchos::SerialDenseMatrix<int,ScalarType> > > R;
-    /*! \brief The current right-hand side of the least squares system RY = Z. */
-    std::vector<Teuchos::RCP<const Teuchos::SerialDenseVector<int,ScalarType> > > Z;
-    /*! \brief The current Given's rotation coefficients. */    
-    std::vector<Teuchos::RCP<const Teuchos::SerialDenseVector<int,ScalarType> > > sn;
-    std::vector<Teuchos::RCP<const Teuchos::SerialDenseVector<int,MagnitudeType> > > cs;
-
-    PseudoBlockGmresIterState() : curDim(0), V(0),
-				  H(0), R(0), Z(0),
-                                  sn(0), cs(0)
-    {}
-  };
-  
-  //! @name PseudoBlockGmresIter Exceptions
-  //@{ 
-  
-  /** \brief PseudoBlockGmresIterOrthoFailure is thrown when the orthogonalization manager is
-   * unable to generate orthonormal columns from the new basis vectors.
-   *
-   * This std::exception is thrown from the PseudoBlockGmresIter::iterate() method.
-   *
-   */
-  class PseudoBlockGmresIterOrthoFailure : public BelosError {public:
-    PseudoBlockGmresIterOrthoFailure(const std::string& what_arg) : BelosError(what_arg)
-    {}};
-  
-  //@}
-  
-  
-  template<class ScalarType, class MV, class OP>
-  class PseudoBlockGmresIter : virtual public Iteration<ScalarType,MV,OP> {
+  template<class ScalarType, class MV, class OP, class DM>  
+  class PseudoBlockGmresIter : virtual public Iteration<ScalarType,MV,OP,DM> {
     
   public:
     
     //
     // Convenience typedefs
     //
-    typedef MultiVecTraits<ScalarType,MV> MVT;
+    typedef MultiVecTraits<ScalarType,MV,DM> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
+    typedef DenseMatTraits<ScalarType,DM>    DMT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename SCT::magnitudeType MagnitudeType;
     
@@ -129,8 +74,8 @@ namespace Belos {
      */
     PseudoBlockGmresIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
 			  const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-			  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-			  const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > &ortho,
+			  const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
+			  const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP,DM> > &ortho,
 			  Teuchos::ParameterList &params );
     
     //! Destructor.
@@ -185,14 +130,14 @@ namespace Belos {
      * \note For any pointer in \c newstate which directly points to the multivectors in 
      * the solver, the data is not copied.
      */
-    void initialize(const PseudoBlockGmresIterState<ScalarType,MV> & newstate);
+    void initialize(const PseudoBlockGmresIterState<ScalarType,MV,DM> & newstate);
     
     /*! \brief Initialize the solver with the initial vectors from the linear problem
      *  or random data.
      */
     void initialize()
     {
-      PseudoBlockGmresIterState<ScalarType,MV> empty;
+      PseudoBlockGmresIterState<ScalarType,MV,DM> empty;
       initialize(empty);
     }
     
@@ -203,8 +148,8 @@ namespace Belos {
      * \returns A PseudoBlockGmresIterState object containing const pointers to the current
      * solver state.
      */
-    PseudoBlockGmresIterState<ScalarType,MV> getState() const {
-      PseudoBlockGmresIterState<ScalarType,MV> state;
+    PseudoBlockGmresIterState<ScalarType,MV,DM> getState() const {
+      PseudoBlockGmresIterState<ScalarType,MV,DM> state;
       state.curDim = curDim_;
       state.V.resize(numRHS_);
       state.H.resize(numRHS_);
@@ -309,10 +254,10 @@ namespace Belos {
     //
     // Classes inputed through constructor that define the linear problem to be solved.
     //
-    const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
-    const Teuchos::RCP<OutputManager<ScalarType> >          om_;
-    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
-    const Teuchos::RCP<OrthoManager<ScalarType,MV> >        ortho_;
+    const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >       lp_;
+    const Teuchos::RCP<OutputManager<ScalarType> >             om_;
+    const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >       stest_;
+    const Teuchos::RCP<OrthoManager<ScalarType,MV,DM> >        ortho_;
     
     //
     // Algorithmic parameters
@@ -323,8 +268,8 @@ namespace Belos {
     int numBlocks_; 
     
     // Storage for QR factorization of the least squares system.
-    std::vector<Teuchos::RCP<Teuchos::SerialDenseVector<int,ScalarType> > > sn_;
-    std::vector<Teuchos::RCP<Teuchos::SerialDenseVector<int,MagnitudeType> > > cs_;
+    std::vector<Teuchos::RCP<std::vector<ScalarType> > > sn_;
+    std::vector<Teuchos::RCP<std::vector<MagnitudeType> > > cs_;
     
     // Pointers to a work vector used to improve aggregate performance.
     Teuchos::RCP<MV> U_vec_, AU_vec_;    
@@ -351,22 +296,22 @@ namespace Belos {
     // Projected matrices
     // H_ : Projected matrix from the Krylov factorization AV = VH + FE^T
     //
-    std::vector<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > H_;
+    std::vector<Teuchos::RCP<DM> > H_;
     // 
     // QR decomposition of Projected matrices for solving the least squares system HY = B.
     // R_: Upper triangular reduction of H
     // Z_: Q applied to right-hand side of the least squares system
-    std::vector<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > R_;
-    std::vector<Teuchos::RCP<Teuchos::SerialDenseVector<int,ScalarType> > > Z_;  
+    std::vector<Teuchos::RCP<DM> > R_;
+    std::vector<Teuchos::RCP<DM> > Z_;  
   };
   
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
-  template<class ScalarType, class MV, class OP>
-  PseudoBlockGmresIter<ScalarType,MV,OP>::PseudoBlockGmresIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
+  template<class ScalarType, class MV, class OP, class DM>
+  PseudoBlockGmresIter<ScalarType,MV,OP,DM>::PseudoBlockGmresIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
 							       const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-							       const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-							       const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > &ortho,
+							       const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
+							       const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP,DM> > &ortho,
 							       Teuchos::ParameterList &params ):
     lp_(problem),
     om_(printer),
@@ -388,8 +333,8 @@ namespace Belos {
   
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Set the block size and make necessary adjustments.
-  template <class ScalarType, class MV, class OP>
-  void PseudoBlockGmresIter<ScalarType,MV,OP>::setNumBlocks (int numBlocks)
+  template <class ScalarType, class MV, class OP, class DM>
+  void PseudoBlockGmresIter<ScalarType,MV,OP,DM>::setNumBlocks (int numBlocks)
   {
     // This routine only allocates space; it doesn't not perform any computation
     // any change in size will invalidate the state of the solver.
@@ -404,8 +349,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Get the current update from this subspace.
-  template <class ScalarType, class MV, class OP>
-  Teuchos::RCP<MV> PseudoBlockGmresIter<ScalarType,MV,OP>::getCurrentUpdate() const
+  template <class ScalarType, class MV, class OP, class DM>
+  Teuchos::RCP<MV> PseudoBlockGmresIter<ScalarType,MV,OP,DM>::getCurrentUpdate() const
   {
     //
     // If this is the first iteration of the Arnoldi factorization, 
@@ -430,16 +375,21 @@ namespace Belos {
         //
         //  Make a view and then copy the RHS of the least squares problem.  DON'T OVERWRITE IT!
         //
-        Teuchos::SerialDenseVector<int,ScalarType> y( Teuchos::Copy, Z_[i]->values(), curDim_ );
+        Teuchos::RCP<DM> y = DMT::SubviewCopy(*Z_[i], curDim_, 1);
+        DMT::SyncDeviceToHost( *y );
+        DMT::SyncDeviceToHost( *H_[i] );
         //
         //  Solve the least squares problem and compute current solutions.
         //
         blas.TRSM( Teuchos::LEFT_SIDE, Teuchos::UPPER_TRI, Teuchos::NO_TRANS,
 	           Teuchos::NON_UNIT_DIAG, curDim_, 1, one,  
-		   H_[i]->values(), H_[i]->stride(), y.values(), y.stride() );
-	
+		   DMT::GetConstRawHostPtr(*H_[i]), DMT::GetStride(*H_[i]), 
+                   DMT::GetRawHostPtr(*y), DMT::GetStride(*y) );
+
+        DMT::SyncHostToDevice( *y ); 	
+        DMT::SyncHostToDevice( *H_[i] ); 	
 	Teuchos::RCP<const MV> Vjp1 = MVT::CloneView( *V_[i], index2 );
-	MVT::MvTimesMatAddMv( one, *Vjp1, y, zero, *cur_block_copy_vec );
+	MVT::MvTimesMatAddMv( one, *Vjp1, *y, zero, *cur_block_copy_vec );
       }
     }
     return currentUpdate;
@@ -449,13 +399,11 @@ namespace Belos {
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Get the native residuals stored in this iteration.  
   // Note:  No residual vector will be returned by Gmres.
-  template <class ScalarType, class MV, class OP>
+  template <class ScalarType, class MV, class OP, class DM>
   Teuchos::RCP<const MV> 
-  PseudoBlockGmresIter<ScalarType,MV,OP>::
+  PseudoBlockGmresIter<ScalarType,MV,OP,DM>::
   getNativeResiduals (std::vector<MagnitudeType> *norms) const 
   {
-    typedef typename Teuchos::ScalarTraits<ScalarType> STS;
-
     if (norms)
       { // Resize the incoming std::vector if necessary.  The type
 	// cast avoids the compiler warning resulting from a signed /
@@ -463,21 +411,21 @@ namespace Belos {
 	if (static_cast<int> (norms->size()) < numRHS_)
 	  norms->resize (numRHS_); 
 
-	Teuchos::BLAS<int, ScalarType> blas;
 	for (int j = 0; j < numRHS_; ++j) 
 	  {
-	    const ScalarType curNativeResid = (*Z_[j])(curDim_);
-	    (*norms)[j] = STS::magnitude (curNativeResid);
+            DMT::SyncDeviceToHost( *Z_[j] );
+	    const ScalarType curNativeResid = DMT::ValueConst(*Z_[j],curDim_,0);
+	    (*norms)[j] = SCT::magnitude (curNativeResid);
 	  }
     }
     return Teuchos::null;
   }
 
   
-  template <class ScalarType, class MV, class OP>
+  template <class ScalarType, class MV, class OP, class DM>
   void 
-  PseudoBlockGmresIter<ScalarType,MV,OP>::
-  initialize (const PseudoBlockGmresIterState<ScalarType,MV> & newstate)
+  PseudoBlockGmresIter<ScalarType,MV,OP,DM>::
+  initialize (const PseudoBlockGmresIterState<ScalarType,MV,DM> & newstate)
   {
     using Teuchos::RCP;
 
@@ -572,9 +520,7 @@ namespace Belos {
 
         RCP<const MV> newV = MVT::CloneView (*newstate.V[i], nevind);
         RCP<MV> lclV = MVT::CloneViewNonConst( *V_[i], nevind );
-        const ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
-        const ScalarType zero = Teuchos::ScalarTraits<ScalarType>::zero();
-        MVT::MvAddMv (one, *newV, zero, *newV, *lclV);
+        MVT::Assign(*newV, *lclV);
 
         // Done with local pointers
         lclV = Teuchos::null;
@@ -587,24 +533,23 @@ namespace Belos {
     for (int i=0; i<numRHS_; ++i) {
       // Create a vector if we need to.
       if (Z_[i] == Teuchos::null) {
-	Z_[i] = Teuchos::rcp( new Teuchos::SerialDenseVector<int,ScalarType>() );
+	Z_[i] = DMT::Create();
       }
-      if (Z_[i]->length() < numBlocks_+1) {
-	Z_[i]->shapeUninitialized(numBlocks_+1, 1); 
+      if (DMT::GetNumRows(*Z_[i]) < numBlocks_+1) {
+	DMT::Reshape(*Z_[i], numBlocks_+1, 1, false); 
       }
       
       // Check that the newstate vector is consistent.
-      TEUCHOS_TEST_FOR_EXCEPTION(newstate.Z[i]->numRows() < curDim_, std::invalid_argument, errstr);
+      TEUCHOS_TEST_FOR_EXCEPTION(DMT::GetNumRows(*newstate.Z[i]) < curDim_, std::invalid_argument, errstr);
       
       // Put data into Z_, make sure old information is not still hanging around.
       if (newstate.Z[i] != Z_[i]) {
 	if (curDim_==0)
-	  Z_[i]->putScalar();
+	  DMT::PutScalar(*Z_[i]);
 	
-        Teuchos::SerialDenseVector<int,ScalarType> newZ(Teuchos::View,newstate.Z[i]->values(),curDim_+1);
-        Teuchos::RCP<Teuchos::SerialDenseVector<int,ScalarType> > lclZ;
-        lclZ = Teuchos::rcp( new Teuchos::SerialDenseVector<int,ScalarType>(Teuchos::View,Z_[i]->values(),curDim_+1) );
-        lclZ->assign(newZ);
+        Teuchos::RCP<const DM> newZ = DMT::SubviewConst(*newstate.Z[i],curDim_+1,1);
+        Teuchos::RCP<DM> lclZ = DMT::Subview(*Z_[i],curDim_+1,1);
+        DMT::Assign(*lclZ,*newZ);
 	
         // Done with local pointers
 	lclZ = Teuchos::null;
@@ -617,26 +562,24 @@ namespace Belos {
     for (int i=0; i<numRHS_; ++i) {
       // Create a matrix if we need to.
       if (H_[i] == Teuchos::null) {
-	H_[i] = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>() );
+	H_[i] = DMT::Create();
       }
-      if (H_[i]->numRows() < numBlocks_+1 || H_[i]->numCols() < numBlocks_) {
-	H_[i]->shapeUninitialized(numBlocks_+1, numBlocks_);
+      if (DMT::GetNumRows(*H_[i]) < numBlocks_+1 || DMT::GetNumCols(*H_[i]) < numBlocks_) {
+	DMT::Reshape(*H_[i], numBlocks_+1, numBlocks_, false);
       }
       
       // Put data into H_ if it exists, make sure old information is not still hanging around.
       if ((int)newstate.H.size() == numRHS_) {
 	
 	// Check that the newstate matrix is consistent.
-	TEUCHOS_TEST_FOR_EXCEPTION((newstate.H[i]->numRows() < curDim_ || newstate.H[i]->numCols() < curDim_), std::invalid_argument, 
+	TEUCHOS_TEST_FOR_EXCEPTION((DMT::GetNumRows(*newstate.H[i]) < curDim_ || DMT::GetNumCols(*newstate.H[i]) < curDim_), std::invalid_argument, 
 			   "Belos::PseudoBlockGmresIter::initialize(): Specified Hessenberg matrices must have a consistent size to the current subspace dimension");
 	
 	if (newstate.H[i] != H_[i]) {
-	  // H_[i]->putScalar();
 	  
-	  Teuchos::SerialDenseMatrix<int,ScalarType> newH(Teuchos::View,*newstate.H[i],curDim_+1, curDim_);
-	  Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > lclH;
-	  lclH = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(Teuchos::View,*H_[i],curDim_+1, curDim_) );
-	  lclH->assign(newH);
+	  Teuchos::RCP<const DM> newH = DMT::SubviewConst(*newstate.H[i],curDim_+1, curDim_);
+	  Teuchos::RCP<DM> lclH = DMT::Subview(*H_[i],curDim_+1, curDim_);
+	  DMT::Assign(*lclH,*newH);
 	  
 	  // Done with local pointers
 	  lclH = Teuchos::null;
@@ -654,20 +597,20 @@ namespace Belos {
     if ((int)newstate.cs.size() == numRHS_ && (int)newstate.sn.size() == numRHS_) {
       for (int i=0; i<numRHS_; ++i) {
         if (cs_[i] != newstate.cs[i])
-          cs_[i] = Teuchos::rcp( new Teuchos::SerialDenseVector<int,MagnitudeType>(*newstate.cs[i]) );
+          cs_[i] = Teuchos::rcp( new std::vector<MagnitudeType>(*newstate.cs[i]) );
         if (sn_[i] != newstate.sn[i])
-          sn_[i] = Teuchos::rcp( new Teuchos::SerialDenseVector<int,ScalarType>(*newstate.sn[i]) );
+          sn_[i] = Teuchos::rcp( new std::vector<ScalarType>(*newstate.sn[i]) );
       }
     } 
       
     // Resize or create the vectors as necessary
     for (int i=0; i<numRHS_; ++i) {
       if (cs_[i] == Teuchos::null) 
-        cs_[i] = Teuchos::rcp( new Teuchos::SerialDenseVector<int,MagnitudeType>(numBlocks_+1) );
+        cs_[i] = Teuchos::rcp( new std::vector<MagnitudeType>(numBlocks_+1) );
       else
         cs_[i]->resize(numBlocks_+1);
       if (sn_[i] == Teuchos::null)
-        sn_[i] = Teuchos::rcp( new Teuchos::SerialDenseVector<int,ScalarType>(numBlocks_+1) );
+        sn_[i] = Teuchos::rcp( new std::vector<ScalarType>(numBlocks_+1) );
       else
         sn_[i]->resize(numBlocks_+1);
     }
@@ -680,8 +623,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Iterate until the status test informs us we should stop.
-  template <class ScalarType, class MV, class OP>
-  void PseudoBlockGmresIter<ScalarType,MV,OP>::iterate()
+  template <class ScalarType, class MV, class OP, class DM>
+  void PseudoBlockGmresIter<ScalarType,MV,OP,DM>::iterate()
   {
     //
     // Allocate/initialize data structures
@@ -690,9 +633,6 @@ namespace Belos {
       initialize();
     }
 
-    const ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
-    const ScalarType zero = Teuchos::ScalarTraits<ScalarType>::zero();
-    
     // Compute the current search dimension. 
     int searchDim = numBlocks_;
     //
@@ -711,7 +651,7 @@ namespace Belos {
       index2[0] = i;
       Teuchos::RCP<const MV> tmp_vec = MVT::CloneView( *V_[i], index );
       Teuchos::RCP<MV> U_vec_view = MVT::CloneViewNonConst( *U_vec, index2 );
-      MVT::MvAddMv( one, *tmp_vec, zero, *tmp_vec, *U_vec_view );
+      MVT::Assign( *tmp_vec, *U_vec_view );
     }
     
     ////////////////////////////////////////////////////////////////
@@ -752,14 +692,10 @@ namespace Belos {
 	//
 	// Get a view of the current part of the upper-hessenberg matrix.
 	//
-	Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > h_new 
-	  = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>
-			  ( Teuchos::View, *H_[i], num_prev, 1, 0, curDim_ ) );
-	Teuchos::Array< Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > h_array( 1, h_new );
+	Teuchos::RCP<DM> h_new = DMT::Subview(*H_[i], num_prev, 1, 0, curDim_); 
+	Teuchos::Array< Teuchos::RCP<DM> > h_array( 1, h_new );
 	
-	Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > r_new
-	  = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>
-			  ( Teuchos::View, *H_[i], 1, 1, num_prev, curDim_ ) );
+	Teuchos::RCP<DM> r_new = DMT::Subview(*H_[i], 1, 1, num_prev, curDim_);
 	//
 	// Orthonormalize the new block of the Krylov expansion
 	// NOTE:  Rank deficiencies are not checked because this is a single-std::vector Krylov method.
@@ -771,7 +707,7 @@ namespace Belos {
 	//
 	index2[0] = curDim_+1;
 	Teuchos::RCP<MV> tmp_vec = MVT::CloneViewNonConst( *V_[i], index2 );
-	MVT::MvAddMv( one, *V_new, zero, *V_new, *tmp_vec );
+	MVT::Assign( *V_new, *tmp_vec );
       }
       // 
       // Now _AU_vec is the new _U_vec, so swap these two vectors.
@@ -797,8 +733,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Update the least squares solution for each right-hand side.
-  template<class ScalarType, class MV, class OP>
-  void PseudoBlockGmresIter<ScalarType,MV,OP>::updateLSQR( int dim )
+  template<class ScalarType, class MV, class OP, class DM>
+  void PseudoBlockGmresIter<ScalarType,MV,OP,DM>::updateLSQR( int dim )
   {
     // Get correct dimension based on input "dim"
     // Remember that ortho failures result in an exit before updateLSQR() is called.
@@ -819,21 +755,31 @@ namespace Belos {
       //
       // QR factorization of Least-Squares system with Givens rotations
       //
+      DMT::SyncDeviceToHost(*H_[i]);
+      DMT::SyncDeviceToHost(*Z_[i]);
+      // 
       for (j=0; j<curDim; j++) {
 	//
 	// Apply previous Givens rotations to new column of Hessenberg matrix
 	//
-	blas.ROT( 1, &(*H_[i])(j,curDim), 1, &(*H_[i])(j+1, curDim), 1, &(*cs_[i])[j], &(*sn_[i])[j] );
+	blas.ROT( 1, &(DMT::Value(*H_[i],j,curDim)), 1, &(DMT::Value(*H_[i],j+1, curDim)), 
+                  1, &(*cs_[i])[j], &(*sn_[i])[j] );
       }
       //
       // Calculate new Givens rotation
       //
-      blas.ROTG( &(*H_[i])(curDim,curDim), &(*H_[i])(curDim+1,curDim), &(*cs_[i])[curDim], &(*sn_[i])[curDim] );
-      (*H_[i])(curDim+1,curDim) = zero;
+      blas.ROTG( &(DMT::Value(*H_[i],curDim,curDim)), &(DMT::Value(*H_[i],curDim+1,curDim)), 
+                 &(*cs_[i])[curDim], &(*sn_[i])[curDim] );
+      DMT::Value(*H_[i],curDim+1,curDim) = zero;
       //
       // Update RHS w/ new transformation
       //
-      blas.ROT( 1, &(*Z_[i])(curDim), 1, &(*Z_[i])(curDim+1), 1, &(*cs_[i])[curDim], &(*sn_[i])[curDim] );
+      blas.ROT( 1, &(DMT::Value(*Z_[i],curDim,0)), 1, &(DMT::Value(*Z_[i],curDim+1,0)), 
+                1, &(*cs_[i])[curDim], &(*sn_[i])[curDim] );
+      //
+      DMT::SyncHostToDevice(*H_[i]);
+      DMT::SyncHostToDevice(*Z_[i]);
+      // 
     }
 
   } // end updateLSQR()

--- a/packages/belos/src/BelosPseudoBlockStochasticCGIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockStochasticCGIter.hpp
@@ -25,7 +25,6 @@
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
 
-#include "Teuchos_SerialDenseMatrix.hpp"
 #include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_SerialDenseHelpers.hpp"
 #include "Teuchos_ScalarTraits.hpp"
@@ -49,16 +48,17 @@
 
 namespace Belos {
   
-  template<class ScalarType, class MV, class OP>
-  class PseudoBlockStochasticCGIter : virtual public StochasticCGIteration<ScalarType,MV,OP> {
+  template<class ScalarType, class MV, class OP, class DM>
+  class PseudoBlockStochasticCGIter : virtual public StochasticCGIteration<ScalarType,MV,OP,DM> {
     
   public:
     
     //
     // Convenience typedefs
     //
-    typedef MultiVecTraits<ScalarType,MV> MVT;
+    typedef MultiVecTraits<ScalarType,MV,DM> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
+    typedef DenseMatTraits<ScalarType,DM> DMT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename SCT::magnitudeType MagnitudeType;
     
@@ -72,7 +72,7 @@ namespace Belos {
      */
     PseudoBlockStochasticCGIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
 				 const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-				 const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
+				 const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
 				 Teuchos::ParameterList &params );
     
     //! Destructor.
@@ -240,7 +240,7 @@ namespace Belos {
     //
     const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
     const Teuchos::RCP<OutputManager<ScalarType> >          om_;
-    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
+    const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >       stest_;
     
     //
     // Algorithmic parameters
@@ -287,10 +287,10 @@ namespace Belos {
   
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
-  template<class ScalarType, class MV, class OP>
-  PseudoBlockStochasticCGIter<ScalarType,MV,OP>::PseudoBlockStochasticCGIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
+  template<class ScalarType, class MV, class OP, class DM>
+  PseudoBlockStochasticCGIter<ScalarType,MV,OP,DM>::PseudoBlockStochasticCGIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
 							       const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-							       const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
+							       const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
 							       Teuchos::ParameterList &params ):
     lp_(problem),
     om_(printer),
@@ -305,8 +305,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Initialize this iteration object
-  template <class ScalarType, class MV, class OP>
-  void PseudoBlockStochasticCGIter<ScalarType,MV,OP>::initializeCG(StochasticCGIterationState<ScalarType,MV>& newstate)
+  template<class ScalarType, class MV, class OP, class DM>
+  void PseudoBlockStochasticCGIter<ScalarType,MV,OP,DM>::initializeCG(StochasticCGIterationState<ScalarType,MV>& newstate)
   {
     // Check if there is any multivector to clone from.
     Teuchos::RCP<const MV> lhsMV = lp_->getCurrLHSVec();
@@ -338,10 +338,6 @@ namespace Belos {
     //
     std::string errstr("Belos::BlockPseudoStochasticCGIter::initialize(): Specified multivectors must have a consistent length and width.");
 
-    // Create convenience variables for zero and one.
-    const ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
-    const MagnitudeType zero = Teuchos::ScalarTraits<MagnitudeType>::zero();
-
     if (!Teuchos::is_null(newstate.R)) {
 
       TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetGlobalLength(*newstate.R) != MVT::GetGlobalLength(*R_),
@@ -352,7 +348,7 @@ namespace Belos {
       // Copy basis vectors from newstate into V
       if (newstate.R != R_) {
         // copy over the initial residual (unpreconditioned).
-	MVT::MvAddMv( one, *newstate.R, zero, *newstate.R, *R_ );
+	MVT::Assign( *newstate.R, *R_ );
       }
 
       // Compute initial direction vectors
@@ -372,7 +368,7 @@ namespace Belos {
       else {
 	Z_ = R_;
       }
-      MVT::MvAddMv( one, *Z_, zero, *Z_, *P_ );
+      MVT::Assign( *Z_, *P_ );
     }
     else {
 
@@ -387,8 +383,8 @@ namespace Belos {
 
  //////////////////////////////////////////////////////////////////////////////////////////////////
   // Iterate until the status test informs us we should stop.
-  template <class ScalarType, class MV, class OP>
-  void PseudoBlockStochasticCGIter<ScalarType,MV,OP>::iterate()
+  template<class ScalarType, class MV, class OP, class DM>
+  void PseudoBlockStochasticCGIter<ScalarType,MV,OP,DM>::iterate()
   {
     //
     // Allocate/initialize data structures
@@ -400,8 +396,9 @@ namespace Belos {
     // Allocate memory for scalars.
     int i=0;
     std::vector<int> index(1);
-    std::vector<ScalarType> rHz( numRHS_ ), rHz_old( numRHS_ ), pAp( numRHS_ );
-    Teuchos::SerialDenseMatrix<int, ScalarType> alpha( numRHS_,numRHS_ ), beta( numRHS_,numRHS_ ), zeta(numRHS_,numRHS_);
+    std::vector<ScalarType> rHz( numRHS_ ), rHz_old( numRHS_ ), pAp( numRHS_ ), beta( numRHS_ );
+    Teuchos::RCP<DM> alpha = DMT::Create( numRHS_,numRHS_ );
+    Teuchos::RCP<DM> zeta = DMT::Create( numRHS_,numRHS_ );
 
     // Create convenience variables for zero and one.
     const ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
@@ -442,20 +439,22 @@ namespace Belos {
                                 CGPositiveDefiniteFailure,
                                 "Belos::PseudoBlockStochasticCGIter::iterate(): non-positive value for p^H*A*p encountered!" );
 
-        alpha(i,i) = rHz[i] / pAp[i];
+        DMT::Value(*alpha,i,i) = rHz[i] / pAp[i];
 
 	// Compute the scaling parameter for the stochastic vector
-	zeta(i,i) = z[i] / Teuchos::ScalarTraits<ScalarType>::squareroot(pAp[i]);
+	DMT::Value(*zeta,i,i) = z[i] / Teuchos::ScalarTraits<ScalarType>::squareroot(pAp[i]);
       }
+      DMT::SyncDeviceToHost( *alpha );
+      DMT::SyncDeviceToHost( *zeta );
 
       //
       // Update the solution std::vector x := x + alpha * P_
       //
-      MVT::MvTimesMatAddMv( one, *P_, alpha, one, *cur_soln_vec );
+      MVT::MvTimesMatAddMv( one, *P_, *alpha, one, *cur_soln_vec );
       lp_->updateSolution();
 
       // Updates the stochastic vector y := y + zeta * P_
-      MVT::MvTimesMatAddMv( one, *P_, zeta, one, *Y_);
+      MVT::MvTimesMatAddMv( one, *P_, *zeta, one, *Y_);
 
       //
       // Save the denominator of beta before residual is updated [ old <R_, Z_> ]
@@ -466,7 +465,7 @@ namespace Belos {
       //
       // Compute the new residual R_ := R_ - alpha * AP_
       //
-      MVT::MvTimesMatAddMv( -one, *AP_, alpha, one, *R_ );
+      MVT::MvTimesMatAddMv( -one, *AP_, *alpha, one, *R_ );
       //
       // Compute beta := [ new <R_, Z_> ] / [ old <R_, Z_> ], 
       // and the new direction std::vector p.
@@ -495,11 +494,11 @@ namespace Belos {
       //
       // Update the search directions.
       for (i=0; i<numRHS_; ++i) {
-        beta(i,i) = rHz[i] / rHz_old[i];
+        beta[i] = rHz[i] / rHz_old[i];
 	index[0] = i;
 	Teuchos::RCP<const MV> Z_i = MVT::CloneView( *Z_, index );
 	Teuchos::RCP<MV> P_i = MVT::CloneViewNonConst( *P_, index );
-        MVT::MvAddMv( one, *Z_i, beta(i,i), *P_i, *P_i );
+        MVT::MvAddMv( one, *Z_i, beta[i], *P_i, *P_i );
       }
       //      
     } // end while (sTest_->checkStatus(this) != Passed)

--- a/packages/belos/src/BelosPseudoBlockStochasticCGSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockStochasticCGSolMgr.hpp
@@ -20,12 +20,14 @@
 #include "BelosLinearProblem.hpp"
 #include "BelosSolverManager.hpp"
 
-#include "BelosPseudoBlockStochasticCGIter.hpp"
 #include "BelosStatusTestMaxIters.hpp"
 #include "BelosStatusTestGenResNorm.hpp"
 #include "BelosStatusTestCombo.hpp"
 #include "BelosStatusTestOutputFactory.hpp"
 #include "BelosOutputManager.hpp"
+#include "BelosPseudoBlockStochasticCGIter.hpp"
+#include "BelosTeuchosDenseAdapter.hpp"
+
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
 #include "Teuchos_TimeMonitor.hpp"
 #endif
@@ -54,11 +56,11 @@ namespace Belos {
     PseudoBlockStochasticCGSolMgrLinearProblemFailure(const std::string& what_arg) : BelosError(what_arg)
     {}};
 
-  template<class ScalarType, class MV, class OP>
-  class PseudoBlockStochasticCGSolMgr : public SolverManager<ScalarType,MV,OP> {
+  template<class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
+  class PseudoBlockStochasticCGSolMgr : public SolverManager<ScalarType,MV,OP,DM> {
 
   private:
-    typedef MultiVecTraits<ScalarType,MV> MVT;
+    typedef MultiVecTraits<ScalarType,MV,DM> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
@@ -92,8 +94,8 @@ namespace Belos {
     virtual ~PseudoBlockStochasticCGSolMgr() {};
 
     //! clone for Inverted Injection (DII)
-    Teuchos::RCP<SolverManager<ScalarType, MV, OP> > clone () const override {
-      return Teuchos::rcp(new PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>);
+    Teuchos::RCP<SolverManager<ScalarType, MV, OP, DM> > clone () const override {
+      return Teuchos::rcp(new PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP,DM>);
     }
     //@}
 
@@ -198,10 +200,10 @@ namespace Belos {
     Teuchos::RCP<std::ostream> outputStream_;
 
     // Status test.
-    Teuchos::RCP<StatusTest<ScalarType,MV,OP> > sTest_;
-    Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP> > maxIterTest_;
-    Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP> > convTest_;
-    Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP> > outputTest_;
+    Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > sTest_;
+    Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP,DM> > maxIterTest_;
+    Teuchos::RCP<StatusTestGenResNorm<ScalarType,MV,OP,DM> > convTest_;
+    Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP,DM> > outputTest_;
 
     // Current parameter list.
     Teuchos::RCP<Teuchos::ParameterList> params_;
@@ -245,8 +247,8 @@ namespace Belos {
 
 
 // Empty Constructor
-template<class ScalarType, class MV, class OP>
-PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::PseudoBlockStochasticCGSolMgr() :
+template<class ScalarType, class MV, class OP, class DM>
+PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP,DM>::PseudoBlockStochasticCGSolMgr() :
   outputStream_(Teuchos::rcpFromRef(std::cout)),
   convtol_(DefaultSolverParameters::convTol),
   maxIters_(maxIters_default_),
@@ -263,8 +265,8 @@ PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::PseudoBlockStochasticCGSolMgr()
 {}
 
 // Basic Constructor
-template<class ScalarType, class MV, class OP>
-PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::
+template<class ScalarType, class MV, class OP, class DM>
+PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP,DM>::
 PseudoBlockStochasticCGSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                                const Teuchos::RCP<Teuchos::ParameterList> &pl ) :
   problem_(problem),
@@ -294,8 +296,8 @@ PseudoBlockStochasticCGSolMgr (const Teuchos::RCP<LinearProblem<ScalarType,MV,OP
   }
 }
 
-template<class ScalarType, class MV, class OP>
-void PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params )
+template<class ScalarType, class MV, class OP, class DM>
+void PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP,DM>::setParameters( const Teuchos::RCP<Teuchos::ParameterList> &params )
 {
   using Teuchos::ParameterList;
   using Teuchos::parameterList;
@@ -398,8 +400,8 @@ void PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::setParameters( const Teuch
   }
 
   // Convergence
-  typedef Belos::StatusTestCombo<ScalarType,MV,OP>  StatusTestCombo_t;
-  typedef Belos::StatusTestGenResNorm<ScalarType,MV,OP>  StatusTestResNorm_t;
+  typedef Belos::StatusTestCombo<ScalarType,MV,OP,DM>  StatusTestCombo_t;
+  typedef Belos::StatusTestGenResNorm<ScalarType,MV,OP,DM>  StatusTestResNorm_t;
 
   // Check for convergence tolerance
   if (params->isParameter("Convergence Tolerance")) {
@@ -480,7 +482,7 @@ void PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::setParameters( const Teuch
 
   // Basic test checks maximum iterations and native residual.
   if (maxIterTest_ == Teuchos::null)
-    maxIterTest_ = Teuchos::rcp( new StatusTestMaxIters<ScalarType,MV,OP>( maxIters_ ) );
+    maxIterTest_ = Teuchos::rcp( new StatusTestMaxIters<ScalarType,MV,OP,DM>( maxIters_ ) );
 
   // Implicit residual test, using the native residual to determine if convergence was achieved.
   if (convTest_ == Teuchos::null || newResTest) {
@@ -495,7 +497,7 @@ void PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::setParameters( const Teuch
 
     // Create the status test output class.
     // This class manages and formats the output from the status test.
-    StatusTestOutputFactory<ScalarType,MV,OP> stoFactory( outputStyle_ );
+    StatusTestOutputFactory<ScalarType,MV,OP,DM> stoFactory( outputStyle_ );
     outputTest_ = stoFactory.create( printer_, sTest_, outputFreq_, Passed+Failed+Undefined );
 
     // Set the solver string for the output test
@@ -517,9 +519,9 @@ void PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::setParameters( const Teuch
 }
 
 
-template<class ScalarType, class MV, class OP>
+template<class ScalarType, class MV, class OP, class DM>
 Teuchos::RCP<const Teuchos::ParameterList>
-PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::getValidParameters() const
+PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP,DM>::getValidParameters() const
 {
   using Teuchos::ParameterList;
   using Teuchos::parameterList;
@@ -577,8 +579,8 @@ PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::getValidParameters() const
 
 
 // solve()
-template<class ScalarType, class MV, class OP>
-ReturnType PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::solve() {
+template<class ScalarType, class MV, class OP, class DM>
+ReturnType PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP,DM>::solve() {
 
   // Set the current parameters if they were not set before.
   // NOTE:  This may occur if the user generated the solver manager with the default constructor and
@@ -617,8 +619,8 @@ ReturnType PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::solve() {
   //////////////////////////////////////////////////////////////////////////////////////
   // Pseudo-Block CG solver
 
-  Teuchos::RCP<PseudoBlockStochasticCGIter<ScalarType,MV,OP> > block_cg_iter
-    = Teuchos::rcp( new PseudoBlockStochasticCGIter<ScalarType,MV,OP>(problem_,printer_,outputTest_,plist) );
+  Teuchos::RCP<PseudoBlockStochasticCGIter<ScalarType,MV,OP,DM> > block_cg_iter
+    = Teuchos::rcp( new PseudoBlockStochasticCGIter<ScalarType,MV,OP,DM>(problem_,printer_,outputTest_,plist) );
 
   // Enter solve() iterations
   {
@@ -661,7 +663,7 @@ ReturnType PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::solve() {
           if ( convTest_->getStatus() == Passed ) {
 
             // Figure out which linear systems converged.
-            std::vector<int> convIdx = Teuchos::rcp_dynamic_cast<StatusTestGenResNorm<ScalarType,MV,OP> >(convTest_)->convIndices();
+            std::vector<int> convIdx = Teuchos::rcp_dynamic_cast<StatusTestGenResNorm<ScalarType,MV,OP,DM> >(convTest_)->convIndices();
 
             // If the number of converged linear systems is equal to the
             // number of current linear systems, then we are done with this block.
@@ -787,8 +789,8 @@ ReturnType PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::solve() {
 }
 
 //  This method requires the solver manager to return a std::string that describes itself.
-template<class ScalarType, class MV, class OP>
-std::string PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP>::description() const
+template<class ScalarType, class MV, class OP, class DM>
+std::string PseudoBlockStochasticCGSolMgr<ScalarType,MV,OP,DM>::description() const
 {
   std::ostringstream oss;
   oss << "Belos::PseudoBlockStochasticCGSolMgr<...,"<<Teuchos::ScalarTraits<ScalarType>::name()<<">";

--- a/packages/belos/src/BelosPseudoBlockTFQMRIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockTFQMRIter.hpp
@@ -78,13 +78,13 @@ namespace Belos {
     {}
   };
 
-  template <class ScalarType, class MV, class OP>
-  class PseudoBlockTFQMRIter : public Iteration<ScalarType,MV,OP> { 
+  template<class ScalarType, class MV, class OP, class DM>
+  class PseudoBlockTFQMRIter : public Iteration<ScalarType,MV,OP,DM> { 
   public:
     //
     // Convenience typedefs
     //
-    typedef MultiVecTraits<ScalarType,MV> MVT;
+    typedef MultiVecTraits<ScalarType,MV,DM> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename SCT::magnitudeType MagnitudeType;
@@ -95,7 +95,7 @@ namespace Belos {
     //! %Belos::PseudoBlockTFQMRIter constructor.
     PseudoBlockTFQMRIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
 	       const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-	       const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
+	       const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
 	       Teuchos::ParameterList &params );
     
     //! %Belos::PseudoBlockTFQMRIter destructor.
@@ -231,7 +231,7 @@ namespace Belos {
     //
     const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
     const Teuchos::RCP<OutputManager<ScalarType> >          om_;
-    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
+    const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >       stest_;
     
     //
     // Algorithmic parameters
@@ -274,10 +274,10 @@ namespace Belos {
   
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
-  template <class ScalarType, class MV, class OP>
-  PseudoBlockTFQMRIter<ScalarType,MV,OP>::PseudoBlockTFQMRIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
+  template<class ScalarType, class MV, class OP, class DM>
+  PseudoBlockTFQMRIter<ScalarType,MV,OP,DM>::PseudoBlockTFQMRIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 					 const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-					 const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
+					 const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
 					 Teuchos::ParameterList &/* params */ 
 					 ) : 
     lp_(problem), 
@@ -291,9 +291,9 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Compute native residual from TFQMR recurrence.
-  template <class ScalarType, class MV, class OP>
+  template<class ScalarType, class MV, class OP, class DM>
   Teuchos::RCP<const MV> 
-  PseudoBlockTFQMRIter<ScalarType,MV,OP>::getNativeResiduals( std::vector<MagnitudeType> *normvec ) const 
+  PseudoBlockTFQMRIter<ScalarType,MV,OP,DM>::getNativeResiduals( std::vector<MagnitudeType> *normvec ) const 
   {
     MagnitudeType one = Teuchos::ScalarTraits<MagnitudeType>::one();
     if (normvec) {
@@ -312,8 +312,8 @@ namespace Belos {
 	
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Initialize this iteration object
-  template <class ScalarType, class MV, class OP>
-  void PseudoBlockTFQMRIter<ScalarType,MV,OP>::initializeTFQMR(const PseudoBlockTFQMRIterState<ScalarType,MV> & newstate)
+  template<class ScalarType, class MV, class OP, class DM>
+  void PseudoBlockTFQMRIter<ScalarType,MV,OP,DM>::initializeTFQMR(const PseudoBlockTFQMRIterState<ScalarType,MV> & newstate)
   {
     // Create convenience variables for zero and one.
     const ScalarType STone = Teuchos::ScalarTraits<ScalarType>::one();
@@ -395,8 +395,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Iterate until the status test informs us we should stop.
-  template <class ScalarType, class MV, class OP>
-  void PseudoBlockTFQMRIter<ScalarType,MV,OP>::iterate() 
+  template<class ScalarType, class MV, class OP, class DM>
+  void PseudoBlockTFQMRIter<ScalarType,MV,OP,DM>::iterate() 
   {
     //
     // Allocate/initialize data structures

--- a/packages/belos/src/BelosSolverFactory_Belos.hpp
+++ b/packages/belos/src/BelosSolverFactory_Belos.hpp
@@ -29,7 +29,8 @@ namespace Belos {
     This is an example of how to use the Belos::SolverFactory with Tpetra.
 */
 
-class BelosSolverFactory : public Impl::SolverFactoryParent<double,MultiVec<double>,Operator<double>>
+class BelosSolverFactory : public Impl::SolverFactoryParent<double,MultiVec<double>,Operator<double>,
+                                                          Teuchos::SerialDenseMatrix<int,double>>
 {
   public:
     BelosSolverFactory() {
@@ -37,7 +38,8 @@ class BelosSolverFactory : public Impl::SolverFactoryParent<double,MultiVec<doub
     };
 };
 
-class BelosFloatSolverFactory : public Impl::SolverFactoryParent<float,MultiVec<float>,Operator<float>>
+class BelosFloatSolverFactory : public Impl::SolverFactoryParent<float,MultiVec<float>,Operator<float>,
+                                                          Teuchos::SerialDenseMatrix<int,float>>
 {
   public:
     BelosFloatSolverFactory() {
@@ -48,19 +50,20 @@ class BelosFloatSolverFactory : public Impl::SolverFactoryParent<float,MultiVec<
 namespace Impl {
 
 template<>
-class SolverFactorySelector<double,MultiVec<double>,Operator<double>> {
+class SolverFactorySelector<double,MultiVec<double>,Operator<double>,Teuchos::SerialDenseMatrix<int,double>> {
   public:
     typedef BelosSolverFactory type;
 };
 
 template<>
-class SolverFactorySelector<float,MultiVec<float>,Operator<float>> {
+class SolverFactorySelector<float,MultiVec<float>,Operator<float>,Teuchos::SerialDenseMatrix<int,float>> {
   public:
     typedef BelosFloatSolverFactory type;
 };
 
 #ifdef HAVE_TEUCHOS_COMPLEX
-class BelosComplexSolverFactory : public Impl::SolverFactoryParent<std::complex<double>,MultiVec<std::complex<double>>,Operator<std::complex<double>>>
+class BelosComplexSolverFactory : public Impl::SolverFactoryParent<std::complex<double>,MultiVec<std::complex<double>>,
+                                    Operator<std::complex<double>>, Teuchos::SerialDenseMatrix<int,std::complex<double>>>
 {
   public:
     BelosComplexSolverFactory() {
@@ -69,12 +72,15 @@ class BelosComplexSolverFactory : public Impl::SolverFactoryParent<std::complex<
 };
 
 template<>
-class SolverFactorySelector<std::complex<double>,MultiVec<std::complex<double>>,Operator<std::complex<double>>> {
+class SolverFactorySelector<std::complex<double>,MultiVec<std::complex<double>>,Operator<std::complex<double>>,
+                                    Teuchos::SerialDenseMatrix<int,std::complex<double>>>
+{
   public:
     typedef BelosComplexSolverFactory type;
 };
 
-class BelosFloatComplexSolverFactory : public Impl::SolverFactoryParent<std::complex<float>,MultiVec<std::complex<float>>,Operator<std::complex<float>>>
+class BelosFloatComplexSolverFactory : public Impl::SolverFactoryParent<std::complex<float>,MultiVec<std::complex<float>>,
+                                    Operator<std::complex<float>>, Teuchos::SerialDenseMatrix<int,std::complex<float>>>
 {
   public:
     BelosFloatComplexSolverFactory() {
@@ -83,7 +89,9 @@ class BelosFloatComplexSolverFactory : public Impl::SolverFactoryParent<std::com
 };
 
 template<>
-class SolverFactorySelector<std::complex<float>,MultiVec<std::complex<float>>,Operator<std::complex<float>>> {
+class SolverFactorySelector<std::complex<float>,MultiVec<std::complex<float>>,Operator<std::complex<float>>,
+                                    Teuchos::SerialDenseMatrix<int,std::complex<float>>>
+{
   public:
     typedef BelosFloatComplexSolverFactory type;
 };

--- a/packages/belos/src/BelosSolverFactory_Generic.hpp
+++ b/packages/belos/src/BelosSolverFactory_Generic.hpp
@@ -31,24 +31,24 @@
 
 namespace Belos {
 
-template<class SC, class MV, class OP>
-class GenericSolverFactory : public Impl::SolverFactoryParent<SC, MV, OP>
+template<class SC, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,SC>>
+class GenericSolverFactory : public Impl::SolverFactoryParent<SC, MV, OP, DM>
 {
   public:
     GenericSolverFactory() {
-      Impl::registerSolverSubclassForTypes<BiCGStabSolMgr<SC,MV,OP>, SC, MV, OP> ("BICGSTAB");
-      Impl::registerSolverSubclassForTypes<BlockCGSolMgr<SC,MV,OP>, SC, MV, OP> ("BLOCK CG");
-      Impl::registerSolverSubclassForTypes<BlockGmresSolMgr<SC,MV,OP>, SC, MV, OP> ("BLOCK GMRES");
-      Impl::registerSolverSubclassForTypes<FixedPointSolMgr<SC,MV,OP>, SC, MV, OP> ("FIXED POINT");
-      Impl::registerSolverSubclassForTypes<GCRODRSolMgr<SC,MV,OP>, SC, MV, OP> ("GCRODR");
-      Impl::registerSolverSubclassForTypes<LSQRSolMgr<SC,MV,OP>, SC, MV, OP> ("LSQR");
-      Impl::registerSolverSubclassForTypes<MinresSolMgr<SC,MV,OP>, SC, MV, OP> ("MINRES");
-      Impl::registerSolverSubclassForTypes<PCPGSolMgr<SC,MV,OP>, SC, MV, OP> ("PCPG");
-      Impl::registerSolverSubclassForTypes<PseudoBlockCGSolMgr<SC,MV,OP>, SC, MV, OP> ("PSEUDOBLOCK CG");
-      Impl::registerSolverSubclassForTypes<PseudoBlockGmresSolMgr<SC,MV,OP>, SC, MV, OP> ("PSEUDOBLOCK GMRES");
-      Impl::registerSolverSubclassForTypes<PseudoBlockTFQMRSolMgr<SC,MV,OP>, SC, MV, OP> ("PSEUDOBLOCK TFQMR");
-      Impl::registerSolverSubclassForTypes<RCGSolMgr<SC,MV,OP>, SC, MV, OP> ("RCG");
-      Impl::registerSolverSubclassForTypes<TFQMRSolMgr<SC,MV,OP>, SC, MV, OP> ("TFQMR");
+      Impl::registerSolverSubclassForTypes<BiCGStabSolMgr<SC,MV,OP>, SC, MV, OP, DM> ("BICGSTAB");
+      Impl::registerSolverSubclassForTypes<BlockCGSolMgr<SC,MV,OP>, SC, MV, OP, DM> ("BLOCK CG");
+      Impl::registerSolverSubclassForTypes<BlockGmresSolMgr<SC,MV,OP>, SC, MV, OP, DM> ("BLOCK GMRES");
+      Impl::registerSolverSubclassForTypes<FixedPointSolMgr<SC,MV,OP>, SC, MV, OP, DM> ("FIXED POINT");
+      Impl::registerSolverSubclassForTypes<GCRODRSolMgr<SC,MV,OP>, SC, MV, OP, DM> ("GCRODR");
+      Impl::registerSolverSubclassForTypes<LSQRSolMgr<SC,MV,OP>, SC, MV, OP, DM> ("LSQR");
+      Impl::registerSolverSubclassForTypes<MinresSolMgr<SC,MV,OP>, SC, MV, OP, DM> ("MINRES");
+      Impl::registerSolverSubclassForTypes<PCPGSolMgr<SC,MV,OP>, SC, MV, OP, DM> ("PCPG");
+      Impl::registerSolverSubclassForTypes<PseudoBlockCGSolMgr<SC,MV,OP>, SC, MV, OP, DM> ("PSEUDOBLOCK CG");
+      Impl::registerSolverSubclassForTypes<PseudoBlockGmresSolMgr<SC,MV,OP>, SC, MV, OP, DM> ("PSEUDOBLOCK GMRES");
+      Impl::registerSolverSubclassForTypes<PseudoBlockTFQMRSolMgr<SC,MV,OP>, SC, MV, OP, DM> ("PSEUDOBLOCK TFQMR");
+      Impl::registerSolverSubclassForTypes<RCGSolMgr<SC,MV,OP>, SC, MV, OP, DM> ("RCG");
+      Impl::registerSolverSubclassForTypes<TFQMRSolMgr<SC,MV,OP>, SC, MV, OP, DM> ("TFQMR");
     };
 };
 

--- a/packages/belos/src/BelosStatusTest.hpp
+++ b/packages/belos/src/BelosStatusTest.hpp
@@ -46,7 +46,7 @@ namespace Belos {
 
   //@}
 
-template <class ScalarType, class MV, class OP>
+template <class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
 class StatusTest : public Teuchos::Describable {
 
  public:
@@ -71,7 +71,7 @@ class StatusTest : public Teuchos::Describable {
 
     \return Belos::StatusType: Unconverged, Converged or Failed.
   */
-  virtual StatusType checkStatus( Iteration<ScalarType,MV,OP>* iSolver ) = 0;
+  virtual StatusType checkStatus( Iteration<ScalarType,MV,OP,DM>* iSolver ) = 0;
 
   //! Return the result of the most recent CheckStatus call.
   virtual StatusType getStatus() const = 0;

--- a/packages/belos/src/BelosStatusTestCombo.hpp
+++ b/packages/belos/src/BelosStatusTestCombo.hpp
@@ -55,14 +55,14 @@
 
 namespace Belos {
 
-template <class ScalarType, class MV, class OP>
-class StatusTestCombo: public StatusTest<ScalarType,MV,OP> {
+template <class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
+class StatusTestCombo: public StatusTest<ScalarType,MV,OP,DM> {
 	
  public:
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-  typedef std::vector< Teuchos::RCP<StatusTest<ScalarType,MV,OP> > > st_vector;
+  typedef std::vector< Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > > st_vector;
   typedef typename st_vector::iterator iterator;
   typedef typename st_vector::const_iterator const_iterator;
 
@@ -89,17 +89,17 @@ class StatusTestCombo: public StatusTest<ScalarType,MV,OP> {
 
   //! Single test constructor.
   StatusTestCombo(ComboType t, 
-		  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >& test1);
+		  const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >& test1);
 
   //! Dual test constructor.
   StatusTestCombo(ComboType t, 
-		  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >& test1, 
-		  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >& test2);
+		  const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >& test1, 
+		  const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >& test2);
 
   /// \brief Add another test to this combination.
   ///
   /// Only add the test if doing so would not in infinite recursion.
-  StatusTestCombo<ScalarType,MV,OP>& addStatusTest(const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >& add_test);
+  StatusTestCombo<ScalarType,MV,OP,DM>& addStatusTest(const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >& add_test);
 
   //! Destructor
   virtual ~StatusTestCombo() {};
@@ -113,7 +113,7 @@ class StatusTestCombo: public StatusTest<ScalarType,MV,OP> {
   /// Return one of the following values: Passed (the convergence
   /// criteria are met), Failed (they are not met) or Undefined (we
   /// can't tell).
-  StatusType checkStatus( Iteration<ScalarType,MV,OP>* iSolver );
+  StatusType checkStatus( Iteration<ScalarType,MV,OP,DM>* iSolver );
 
   /// \brief Return the result of the most recent checkStatus call.
   ///
@@ -156,17 +156,17 @@ protected:
   //! @name Internal methods.
   //@{ 
   //! Use this for checkStatus when this is an OR type combo. Updates status.
-  void orOp( Iteration<ScalarType,MV,OP>* iSolver );
+  void orOp( Iteration<ScalarType,MV,OP,DM>* iSolver );
 
   //! Use this for checkStatus when this is an AND type combo. Updates status.
-  void andOp( Iteration<ScalarType,MV,OP>* iSolver );
+  void andOp( Iteration<ScalarType,MV,OP,DM>* iSolver );
 
   //! Use this for checkStatus when this is a sequential AND type combo. Updates status.
-  void seqOp( Iteration<ScalarType,MV,OP>* iSolver );
+  void seqOp( Iteration<ScalarType,MV,OP,DM>* iSolver );
 
   //! Check whether or not it is safe to add a to the list of
   //! tests. This is necessary to avoid any infinite recursions.
-  bool isSafe( const Teuchos:: RCP<StatusTest<ScalarType,MV,OP> >& test1);
+  bool isSafe( const Teuchos:: RCP<StatusTest<ScalarType,MV,OP,DM> >& test1);
   //@}
 
  private:
@@ -185,26 +185,26 @@ protected:
 
 };
 
-template <class ScalarType, class MV, class OP>
-StatusTestCombo<ScalarType,MV,OP>::StatusTestCombo(ComboType t)
+template <class ScalarType, class MV, class OP, class DM>
+StatusTestCombo<ScalarType,MV,OP,DM>::StatusTestCombo(ComboType t)
 {
   type_ = t;
   status_ = Undefined;
 }
 
-template <class ScalarType, class MV, class OP>
-StatusTestCombo<ScalarType,MV,OP>::StatusTestCombo(ComboType t, 
-						   const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >& test1)
+template <class ScalarType, class MV, class OP, class DM>
+StatusTestCombo<ScalarType,MV,OP,DM>::StatusTestCombo(ComboType t, 
+						   const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >& test1)
 {
   type_ = t;
   tests_.push_back(test1);
   status_ = Undefined;
 }
 
-template <class ScalarType, class MV, class OP>
-StatusTestCombo<ScalarType,MV,OP>::StatusTestCombo(ComboType t, 
-						   const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >& test1, 
-						   const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >& test2)
+template <class ScalarType, class MV, class OP, class DM>
+StatusTestCombo<ScalarType,MV,OP,DM>::StatusTestCombo(ComboType t, 
+						   const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >& test1, 
+						   const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >& test2)
 {
   type_ = t;
   tests_.push_back(test1);
@@ -212,8 +212,8 @@ StatusTestCombo<ScalarType,MV,OP>::StatusTestCombo(ComboType t,
   status_ = Undefined;
 }
 
-template <class ScalarType, class MV, class OP>
-StatusTestCombo<ScalarType,MV,OP>& StatusTestCombo<ScalarType,MV,OP>::addStatusTest(const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >& add_test)
+template <class ScalarType, class MV, class OP, class DM>
+StatusTestCombo<ScalarType,MV,OP,DM>& StatusTestCombo<ScalarType,MV,OP,DM>::addStatusTest(const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >& add_test)
 {
   if (isSafe(add_test))
     tests_.push_back(add_test);
@@ -230,8 +230,8 @@ StatusTestCombo<ScalarType,MV,OP>& StatusTestCombo<ScalarType,MV,OP>::addStatusT
   return *this;
 }
 
-template <class ScalarType, class MV, class OP>
-bool StatusTestCombo<ScalarType,MV,OP>::isSafe( const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >& test1)
+template <class ScalarType, class MV, class OP, class DM>
+bool StatusTestCombo<ScalarType,MV,OP,DM>::isSafe( const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >& test1)
 {
   // Are we trying to add "this" to "this"? This would result in an infinite recursion.
   if (test1.get() == this)
@@ -241,7 +241,7 @@ bool StatusTestCombo<ScalarType,MV,OP>::isSafe( const Teuchos::RCP<StatusTest<Sc
   // in the list because that can also lead to infinite recursions.
   for (iterator i = tests_.begin(); i != tests_.end(); ++i) {
     
-    StatusTestCombo<ScalarType,MV,OP>* ptr = dynamic_cast<StatusTestCombo<ScalarType,MV,OP> *>(i->get());
+    StatusTestCombo<ScalarType,MV,OP,DM>* ptr = dynamic_cast<StatusTestCombo<ScalarType,MV,OP,DM> *>(i->get());
     if (ptr != NULL)
       if (!ptr->isSafe(test1))
         return false;
@@ -249,8 +249,8 @@ bool StatusTestCombo<ScalarType,MV,OP>::isSafe( const Teuchos::RCP<StatusTest<Sc
   return true;
 }
 
-template <class ScalarType, class MV, class OP>
-StatusType StatusTestCombo<ScalarType,MV,OP>::checkStatus( Iteration<ScalarType,MV,OP>* iSolver )
+template <class ScalarType, class MV, class OP, class DM>
+StatusType StatusTestCombo<ScalarType,MV,OP,DM>::checkStatus( Iteration<ScalarType,MV,OP,DM>* iSolver )
 {
   status_ = Failed;
 
@@ -264,8 +264,8 @@ StatusType StatusTestCombo<ScalarType,MV,OP>::checkStatus( Iteration<ScalarType,
   return status_;
 }
 
-template <class ScalarType, class MV, class OP>
-void StatusTestCombo<ScalarType,MV,OP>::reset( )
+template <class ScalarType, class MV, class OP, class DM>
+void StatusTestCombo<ScalarType,MV,OP,DM>::reset( )
 {
   // Resets all status tests in my list.
   for (const_iterator i = tests_.begin(); i != tests_.end(); ++i) 
@@ -278,8 +278,8 @@ void StatusTestCombo<ScalarType,MV,OP>::reset( )
   return;
 }
 
-template <class ScalarType, class MV, class OP>
-void StatusTestCombo<ScalarType,MV,OP>::orOp( Iteration<ScalarType,MV,OP>* iSolver )
+template <class ScalarType, class MV, class OP, class DM>
+void StatusTestCombo<ScalarType,MV,OP,DM>::orOp( Iteration<ScalarType,MV,OP,DM>* iSolver )
 {
   status_ = Failed;
 
@@ -294,8 +294,8 @@ void StatusTestCombo<ScalarType,MV,OP>::orOp( Iteration<ScalarType,MV,OP>* iSolv
     }
 }
 
-template <class ScalarType, class MV, class OP>
-void StatusTestCombo<ScalarType,MV,OP>::andOp( Iteration<ScalarType,MV,OP>* iSolver )
+template <class ScalarType, class MV, class OP, class DM>
+void StatusTestCombo<ScalarType,MV,OP,DM>::andOp( Iteration<ScalarType,MV,OP,DM>* iSolver )
 {
   bool isFailed = false;
   
@@ -324,8 +324,8 @@ void StatusTestCombo<ScalarType,MV,OP>::andOp( Iteration<ScalarType,MV,OP>* iSol
   return;
 }
 
-template <class ScalarType, class MV, class OP>
-void StatusTestCombo<ScalarType,MV,OP>::seqOp( Iteration<ScalarType,MV,OP>* iSolver ) 
+template <class ScalarType, class MV, class OP, class DM>
+void StatusTestCombo<ScalarType,MV,OP,DM>::seqOp( Iteration<ScalarType,MV,OP,DM>* iSolver ) 
 {
   for (const_iterator i = tests_.begin(); i != tests_.end(); ++i) {
 
@@ -347,8 +347,8 @@ void StatusTestCombo<ScalarType,MV,OP>::seqOp( Iteration<ScalarType,MV,OP>* iSol
   return;
 }
 
-template <class ScalarType, class MV, class OP>
-void StatusTestCombo<ScalarType,MV,OP>::print(std::ostream& os, int indent) const {
+template <class ScalarType, class MV, class OP, class DM>
+void StatusTestCombo<ScalarType,MV,OP,DM>::print(std::ostream& os, int indent) const {
   for (int j = 0; j < indent; j ++)
     os << ' ';
   this->printStatus(os, status_);

--- a/packages/belos/src/BelosStatusTestFactory.hpp
+++ b/packages/belos/src/BelosStatusTestFactory.hpp
@@ -22,14 +22,14 @@ namespace Belos {
   ///
   /// This factory takes a Teuchos::ParameterList and generates an entire set (a tree)
   /// of status tests for use in Belos.
-  template<class Scalar, class MV, class OP>
+  template<class Scalar, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,Scalar>>
   class StatusTestFactory {
   public:
     typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType magnitude_type;
-    typedef StatusTest<Scalar,MV,OP> base_test;
+    typedef StatusTest<Scalar,MV,OP,DM> base_test;
 
-    typedef StatusTestMaxIters<Scalar,MV,OP> max_iter_test;
-    typedef StatusTestCombo<Scalar,MV,OP> combo_test;
+    typedef StatusTestMaxIters<Scalar,MV,OP,DM> max_iter_test;
+    typedef StatusTestCombo<Scalar,MV,OP,DM> combo_test;
 
     //! Constructor
     StatusTestFactory() {
@@ -74,7 +74,7 @@ namespace Belos {
       return status_test;
     }
 
-    static typename StatusTestCombo<Scalar,MV,OP>::ComboType stringToComboType ( const std::string& comboString ) {
+    static typename StatusTestCombo<Scalar,MV,OP,DM>::ComboType stringToComboType ( const std::string& comboString ) {
       typedef typename combo_test::ComboType comboType;
       comboType userCombo;
       if     (comboString == "AND") userCombo = combo_test::AND;
@@ -120,7 +120,7 @@ namespace Belos {
     }
 
     Teuchos::RCP<base_test> buildResidualNormTest(Teuchos::ParameterList& p) const {
-      typedef StatusTestGenResNorm<Scalar,MV,OP> res_norm_test;
+      typedef StatusTestGenResNorm<Scalar,MV,OP,DM> res_norm_test;
       typename Teuchos::ScalarTraits<Scalar>::magnitudeType tolerance = p.get("Convergence Tolerance", 1.0e-8);
       int quorum = p.get<int>("Deflation Quorum", -1);
       bool showMaxResNormOnly = p.get<bool>("Show Maximum Residual Norm Only",false);
@@ -147,7 +147,7 @@ namespace Belos {
     }
 
     Teuchos::RCP<base_test> buildPartialResidualNormTest(Teuchos::ParameterList& p) const {
-      typedef StatusTestGenResSubNorm<Scalar,MV,OP> res_partialnorm_test;
+      typedef StatusTestGenResSubNorm<Scalar,MV,OP,DM> res_partialnorm_test;
       typename Teuchos::ScalarTraits<Scalar>::magnitudeType tolerance = p.get("Convergence Tolerance", 1.0e-8);
       int quorum = p.get<int>("Deflation Quorum", -1);
       int subIdx = p.get<int>("Block index",-1);

--- a/packages/belos/src/BelosStatusTestGenResNorm.hpp
+++ b/packages/belos/src/BelosStatusTestGenResNorm.hpp
@@ -43,8 +43,8 @@
 
 namespace Belos {
 
-template <class ScalarType, class MV, class OP>
-class StatusTestGenResNorm: public StatusTestResNorm<ScalarType,MV,OP> {
+template <class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
+class StatusTestGenResNorm: public StatusTestResNorm<ScalarType,MV,OP,DM> {
 
  public:
 
@@ -150,7 +150,7 @@ class StatusTestGenResNorm: public StatusTestResNorm<ScalarType,MV,OP> {
 
     \return StatusType: Passed, Failed, or Undefined.
   */
-  StatusType checkStatus(Iteration<ScalarType,MV,OP>* iSolver);
+  StatusType checkStatus(Iteration<ScalarType,MV,OP,DM>* iSolver);
 
   //! Return the result of the most recent CheckStatus call.
   StatusType getStatus() const {return(status_);};
@@ -219,7 +219,7 @@ class StatusTestGenResNorm: public StatusTestResNorm<ScalarType,MV,OP> {
    * After this function is called <tt>getScaledNormValue()</tt> can be called
    * to get the scaling std::vector.
    */
-  StatusType firstCallCheckStatusSetup(Iteration<ScalarType,MV,OP>* iSolver);
+  StatusType firstCallCheckStatusSetup(Iteration<ScalarType,MV,OP,DM>* iSolver);
   //@}
 
   /** \name Overridden from Teuchos::Describable */
@@ -350,8 +350,8 @@ class StatusTestGenResNorm: public StatusTestResNorm<ScalarType,MV,OP> {
 
 };
 
-template <class ScalarType, class MV, class OP>
-StatusTestGenResNorm<ScalarType,MV,OP>::
+template <class ScalarType, class MV, class OP, class DM>
+StatusTestGenResNorm<ScalarType,MV,OP,DM>::
 StatusTestGenResNorm (MagnitudeType Tolerance, int quorum, bool showMaxResNormOnly)
   : tolerance_(Tolerance),
     quorum_(quorum),
@@ -374,12 +374,12 @@ StatusTestGenResNorm (MagnitudeType Tolerance, int quorum, bool showMaxResNormOn
   // the implicit residual std::vector.
 }
 
-template <class ScalarType, class MV, class OP>
-StatusTestGenResNorm<ScalarType,MV,OP>::~StatusTestGenResNorm()
+template <class ScalarType, class MV, class OP, class DM>
+StatusTestGenResNorm<ScalarType,MV,OP,DM>::~StatusTestGenResNorm()
 {}
 
-template <class ScalarType, class MV, class OP>
-void StatusTestGenResNorm<ScalarType,MV,OP>::reset()
+template <class ScalarType, class MV, class OP, class DM>
+void StatusTestGenResNorm<ScalarType,MV,OP,DM>::reset()
 {
   status_ = Undefined;
   curBlksz_ = 0;
@@ -391,8 +391,8 @@ void StatusTestGenResNorm<ScalarType,MV,OP>::reset()
   curSoln_ = Teuchos::null;
 }
 
-template <class ScalarType, class MV, class OP>
-int StatusTestGenResNorm<ScalarType,MV,OP>::defineResForm( ResType TypeOfResidual, NormType TypeOfNorm )
+template <class ScalarType, class MV, class OP, class DM>
+int StatusTestGenResNorm<ScalarType,MV,OP,DM>::defineResForm( ResType TypeOfResidual, NormType TypeOfNorm )
 {
   TEUCHOS_TEST_FOR_EXCEPTION(firstcallDefineResForm_==false,StatusTestError,
         "StatusTestGenResNorm::defineResForm(): The residual form has already been defined.");
@@ -404,8 +404,8 @@ int StatusTestGenResNorm<ScalarType,MV,OP>::defineResForm( ResType TypeOfResidua
   return(0);
 }
 
-template <class ScalarType, class MV, class OP>
-int StatusTestGenResNorm<ScalarType,MV,OP>::defineScaleForm(ScaleType TypeOfScaling, NormType TypeOfNorm,
+template <class ScalarType, class MV, class OP, class DM>
+int StatusTestGenResNorm<ScalarType,MV,OP,DM>::defineScaleForm(ScaleType TypeOfScaling, NormType TypeOfNorm,
                                                          MagnitudeType ScaleValue )
 {
   TEUCHOS_TEST_FOR_EXCEPTION(firstcallDefineScaleForm_==false,StatusTestError,
@@ -419,8 +419,8 @@ int StatusTestGenResNorm<ScalarType,MV,OP>::defineScaleForm(ScaleType TypeOfScal
   return(0);
 }
 
-template <class ScalarType, class MV, class OP>
-StatusType StatusTestGenResNorm<ScalarType,MV,OP>::checkStatus( Iteration<ScalarType,MV,OP>* iSolver )
+template <class ScalarType, class MV, class OP, class DM>
+StatusType StatusTestGenResNorm<ScalarType,MV,OP,DM>::checkStatus( Iteration<ScalarType,MV,OP,DM>* iSolver )
 {
   MagnitudeType zero = Teuchos::ScalarTraits<MagnitudeType>::zero();
   const LinearProblem<ScalarType,MV,OP>& lp = iSolver->getProblem();
@@ -551,8 +551,8 @@ StatusType StatusTestGenResNorm<ScalarType,MV,OP>::checkStatus( Iteration<Scalar
   return status_;
 }
 
-template <class ScalarType, class MV, class OP>
-void StatusTestGenResNorm<ScalarType,MV,OP>::print(std::ostream& os, int indent) const
+template <class ScalarType, class MV, class OP, class DM>
+void StatusTestGenResNorm<ScalarType,MV,OP,DM>::print(std::ostream& os, int indent) const
 {
   for (int j = 0; j < indent; j ++)
     os << ' ';
@@ -583,8 +583,8 @@ void StatusTestGenResNorm<ScalarType,MV,OP>::print(std::ostream& os, int indent)
   os << std::endl;
 }
 
-template <class ScalarType, class MV, class OP>
-void StatusTestGenResNorm<ScalarType,MV,OP>::printStatus(std::ostream& os, StatusType type) const
+template <class ScalarType, class MV, class OP, class DM>
+void StatusTestGenResNorm<ScalarType,MV,OP,DM>::printStatus(std::ostream& os, StatusType type) const
 {
   os << std::left << std::setw(13) << std::setfill('.');
   switch (type) {
@@ -603,8 +603,8 @@ void StatusTestGenResNorm<ScalarType,MV,OP>::printStatus(std::ostream& os, Statu
     return;
 }
 
-template <class ScalarType, class MV, class OP>
-StatusType StatusTestGenResNorm<ScalarType,MV,OP>::firstCallCheckStatusSetup( Iteration<ScalarType,MV,OP>* iSolver )
+template <class ScalarType, class MV, class OP, class DM>
+StatusType StatusTestGenResNorm<ScalarType,MV,OP,DM>::firstCallCheckStatusSetup( Iteration<ScalarType,MV,OP,DM>* iSolver )
 {
   int i;
   MagnitudeType zero = Teuchos::ScalarTraits<MagnitudeType>::zero();

--- a/packages/belos/src/BelosStatusTestGenResSubNorm.hpp
+++ b/packages/belos/src/BelosStatusTestGenResSubNorm.hpp
@@ -36,8 +36,8 @@
 
 namespace Belos {
 
-template <class ScalarType, class MV, class OP>
-class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP> {
+template <class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
+class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP,DM> {
 
  public:
   // Convenience typedefs
@@ -86,7 +86,7 @@ class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP> {
     TEUCHOS_UNREACHABLE_RETURN(0);
   }
 
-  //! Define form of the scaling, its norm, its optional weighting std::vector, or, alternatively, define an explicit value.
+  //! Define form of the scaling, its norm, its optional weighting vector, or, alternatively, define an explicit value.
   /*! This method defines the form of how the residual is scaled (if at all).  It operates in two modes:
     <ol>
     <li> User-provided scaling value:
@@ -100,9 +100,9 @@ class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP> {
 
     <li> Use a supported Scaling Form:
     <ul>
-    <li> Define TypeOfScaling to be the norm of the right hand side, the initial residual std::vector,
+    <li> Define TypeOfScaling to be the norm of the right hand side, the initial residual vector,
     or to none.
-    <li> Define norm to be used on the scaling std::vector (this may be different than the norm used
+    <li> Define norm to be used on the scaling vector (this may be different than the norm used
     in DefineResForm()).
     </ul>
     </ol>
@@ -142,7 +142,7 @@ class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP> {
 
     \return StatusType: Passed, Failed, or Undefined.
   */
-  StatusType checkStatus(Iteration<ScalarType,MV,OP>* /* iSolver */) { return Undefined; }
+  StatusType checkStatus(Iteration<ScalarType,MV,OP,DM>* /* iSolver */) { return Undefined; }
 
   //! Return the result of the most recent CheckStatus call.
   StatusType getStatus() const {return Undefined;}
@@ -209,12 +209,12 @@ class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP> {
   /** @name Misc. */
   //@{
 
-  /** \brief Call to setup initial scaling std::vector.
+  /** \brief Call to setup initial scaling vector.
    *
    * After this function is called <tt>getScaledNormValue()</tt> can be called
-   * to get the scaling std::vector.
+   * to get the scaling vector.
    */
-  StatusType firstCallCheckStatusSetup(Iteration<ScalarType,MV,OP>* iSolver) {
+  StatusType firstCallCheckStatusSetup(Iteration<ScalarType,MV,OP,DM>* iSolver) {
     return Undefined;
   }
   //@}
@@ -232,17 +232,18 @@ class StatusTestGenResSubNorm: public StatusTestResNorm<ScalarType,MV,OP> {
 
 // specialization for Thyra
 template <class ScalarType>
-class StatusTestGenResSubNorm<ScalarType,Thyra::MultiVectorBase<ScalarType>,Thyra::LinearOpBase<ScalarType> >
-   : public StatusTestResNorm<ScalarType,Thyra::MultiVectorBase<ScalarType>,Thyra::LinearOpBase<ScalarType> > {
+class StatusTestGenResSubNorm<ScalarType,Thyra::MultiVectorBase<ScalarType>,Thyra::LinearOpBase<ScalarType>,Teuchos::SerialDenseMatrix<int,ScalarType> >
+   : public StatusTestResNorm<ScalarType,Thyra::MultiVectorBase<ScalarType>,Thyra::LinearOpBase<ScalarType>,Teuchos::SerialDenseMatrix<int,ScalarType> > {
 
  public:
   // Convenience typedefs
   typedef Thyra::MultiVectorBase<ScalarType> MV;
   typedef Thyra::LinearOpBase<ScalarType>    OP;
+  typedef Teuchos::SerialDenseMatrix<int,ScalarType> DM;
 
   typedef Teuchos::ScalarTraits<ScalarType> SCT;
   typedef typename SCT::magnitudeType MagnitudeType;
-  typedef MultiVecTraits<ScalarType,MV>  MVT;
+  typedef MultiVecTraits<ScalarType,MV,DM>  MVT;
   typedef OperatorTraits<ScalarType,MV,OP>  OT;
 
   //! @name Constructors/destructors.
@@ -285,7 +286,7 @@ class StatusTestGenResSubNorm<ScalarType,Thyra::MultiVectorBase<ScalarType>,Thyr
   //! @name Form and parameter definition methods.
   //@{
 
-  //! Define form of the residual, its norm and optional weighting std::vector.
+  //! Define form of the residual, its norm and optional weighting vector.
   /*! This method defines the form of \f$\|r\|\f$.  We specify:
     <ul>
     <li> The norm to be used on the residual (this may be different than the norm used in
@@ -302,7 +303,7 @@ class StatusTestGenResSubNorm<ScalarType,Thyra::MultiVectorBase<ScalarType>,Thyr
     return(0);
   }
 
-  //! Define form of the scaling, its norm, its optional weighting std::vector, or, alternatively, define an explicit value.
+  //! Define form of the scaling, its norm, its optional weighting vector, or, alternatively, define an explicit value.
   /*! This method defines the form of how the residual is scaled (if at all).  It operates in two modes:
     <ol>
     <li> User-provided scaling value:
@@ -316,9 +317,9 @@ class StatusTestGenResSubNorm<ScalarType,Thyra::MultiVectorBase<ScalarType>,Thyr
 
     <li> Use a supported Scaling Form:
     <ul>
-    <li> Define TypeOfScaling to be the norm of the right hand side, the initial residual std::vector,
+    <li> Define TypeOfScaling to be the norm of the right hand side, the initial residual vector,
     or to none.
-    <li> Define norm to be used on the scaling std::vector (this may be different than the norm used
+    <li> Define norm to be used on the scaling vector (this may be different than the norm used
     in DefineResForm()).
     </ul>
     </ol>
@@ -364,7 +365,7 @@ class StatusTestGenResSubNorm<ScalarType,Thyra::MultiVectorBase<ScalarType>,Thyr
 
     \return StatusType: Passed, Failed, or Undefined.
   */
-  StatusType checkStatus(Iteration<ScalarType,MV,OP>* iSolver) {
+  StatusType checkStatus(Iteration<ScalarType,MV,OP,DM>* iSolver) {
     MagnitudeType zero = Teuchos::ScalarTraits<MagnitudeType>::zero();
     const LinearProblem<ScalarType,MV,OP>& lp = iSolver->getProblem();
     // Compute scaling term (done once for each block that's being solved)
@@ -377,7 +378,7 @@ class StatusTestGenResSubNorm<ScalarType,Thyra::MultiVectorBase<ScalarType>,Thyr
     }
 
     //
-    // This section computes the norm of the residual std::vector
+    // This section computes the norm of the residual vector
     //
     if ( curLSNum_ != lp.getLSNumber() ) {
       //
@@ -589,12 +590,12 @@ class StatusTestGenResSubNorm<ScalarType,Thyra::MultiVectorBase<ScalarType>,Thyr
   /** @name Misc. */
   //@{
 
-  /** \brief Call to setup initial scaling std::vector.
+  /** \brief Call to setup initial scaling vector.
    *
    * After this function is called <tt>getScaledNormValue()</tt> can be called
-   * to get the scaling std::vector.
+   * to get the scaling vector.
    */
-  StatusType firstCallCheckStatusSetup(Iteration<ScalarType,MV,OP>* iSolver) {
+  StatusType firstCallCheckStatusSetup(Iteration<ScalarType,MV,OP,DM>* iSolver) {
     int i;
     MagnitudeType zero = Teuchos::ScalarTraits<MagnitudeType>::zero();
     MagnitudeType one = Teuchos::ScalarTraits<MagnitudeType>::one();

--- a/packages/belos/src/BelosStatusTestGeneralOutput.hpp
+++ b/packages/belos/src/BelosStatusTestGeneralOutput.hpp
@@ -36,8 +36,8 @@ namespace Belos {
     The frequency and occasion of the printing can be dictated according to some parameters passed to 
     StatusTestGeneralOutput::StatusTestGeneralOutput().
   */
-template <class ScalarType, class MV, class OP>
-class StatusTestGeneralOutput : public StatusTestOutput<ScalarType,MV,OP> {
+template <class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
+class StatusTestGeneralOutput : public StatusTestOutput<ScalarType,MV,OP,DM> {
 
  public:
   //! @name Constructors/destructors
@@ -58,7 +58,7 @@ class StatusTestGeneralOutput : public StatusTestOutput<ScalarType,MV,OP> {
    *
    */
   StatusTestGeneralOutput(const Teuchos::RCP<OutputManager<ScalarType> > &printer, 
-			  Teuchos::RCP<StatusTest<ScalarType,MV,OP> > test,
+			  Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > test,
 			  int mod = 1,
 			  int printStates = Passed)
     : printer_(printer), 
@@ -92,7 +92,7 @@ class StatusTestGeneralOutput : public StatusTestOutput<ScalarType,MV,OP> {
     
     \return ::StatusType indicating whether the underlying test passed or failed.
   */
-  StatusType checkStatus( Iteration<ScalarType,MV,OP>* solver ) {
+  StatusType checkStatus( Iteration<ScalarType,MV,OP,DM>* solver ) {
     TEUCHOS_TEST_FOR_EXCEPTION(test_ == Teuchos::null,StatusTestError,"StatusTestGeneralOutput::checkStatus(): child pointer is null.");
     state_ = test_->checkStatus(solver);
 
@@ -132,13 +132,13 @@ class StatusTestGeneralOutput : public StatusTestOutput<ScalarType,MV,OP> {
    *
    *  \note This also resets the test status to ::Undefined.
    */
-  void setChild(Teuchos::RCP<StatusTest<ScalarType,MV,OP> > test) {
+  void setChild(Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > test) {
     test_ = test;
     state_ = Undefined;
   }
 
   //! \brief Get child test.
-  Teuchos::RCP<StatusTest<ScalarType,MV,OP> > getChild() const {
+  Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > getChild() const {
     return test_;
   }
 
@@ -207,7 +207,7 @@ class StatusTestGeneralOutput : public StatusTestOutput<ScalarType,MV,OP> {
 
   private:
     Teuchos::RCP<OutputManager<ScalarType> > printer_;
-    Teuchos::RCP<StatusTest<ScalarType,MV,OP> > test_;
+    Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > test_;
     std::string solverDesc_;
     std::string precondDesc_;
     StatusType state_;

--- a/packages/belos/src/BelosStatusTestImpResNorm.hpp
+++ b/packages/belos/src/BelosStatusTestImpResNorm.hpp
@@ -68,8 +68,8 @@
 
 namespace Belos {
 
-template <class ScalarType, class MV, class OP>
-class StatusTestImpResNorm: public StatusTestResNorm<ScalarType,MV,OP> {
+template <class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
+class StatusTestImpResNorm: public StatusTestResNorm<ScalarType,MV,OP,DM> {
 public:
   //! The type of the magnitude (absolute value) of a ScalarType.
   typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
@@ -173,7 +173,7 @@ public:
 
     \return StatusType: Passed, Failed, or Undefined.
   */
-  StatusType checkStatus(Iteration<ScalarType,MV,OP>* iSolver);
+  StatusType checkStatus(Iteration<ScalarType,MV,OP,DM>* iSolver);
 
   //! Return the result of the most recent CheckStatus call.
   StatusType getStatus() const {return(status_);};
@@ -257,7 +257,7 @@ public:
    * After this function is called <tt>getScaledNormValue()</tt> can be called
    * to get the scaling vector.
    */
-  StatusType firstCallCheckStatusSetup(Iteration<ScalarType,MV,OP>* iSolver);
+  StatusType firstCallCheckStatusSetup(Iteration<ScalarType,MV,OP,DM>* iSolver);
   //@}
 
   /** \name Overridden from Teuchos::Describable */
@@ -384,8 +384,8 @@ public:
 
 };
 
-template <class ScalarType, class MV, class OP>
-StatusTestImpResNorm<ScalarType,MV,OP>::
+template <class ScalarType, class MV, class OP, class DM>
+StatusTestImpResNorm<ScalarType,MV,OP,DM>::
 StatusTestImpResNorm (MagnitudeType Tolerance, int quorum, bool showMaxResNormOnly)
   : tolerance_(Tolerance),
     currTolerance_(Tolerance),
@@ -409,12 +409,12 @@ StatusTestImpResNorm (MagnitudeType Tolerance, int quorum, bool showMaxResNormOn
   // the implicit residual vector.
 }
 
-template <class ScalarType, class MV, class OP>
-StatusTestImpResNorm<ScalarType,MV,OP>::~StatusTestImpResNorm()
+template <class ScalarType, class MV, class OP, class DM>
+StatusTestImpResNorm<ScalarType,MV,OP,DM>::~StatusTestImpResNorm()
 {}
 
-template <class ScalarType, class MV, class OP>
-void StatusTestImpResNorm<ScalarType,MV,OP>::reset()
+template <class ScalarType, class MV, class OP, class DM>
+void StatusTestImpResNorm<ScalarType,MV,OP,DM>::reset()
 {
   status_ = Undefined;
   curBlksz_ = 0;
@@ -428,8 +428,8 @@ void StatusTestImpResNorm<ScalarType,MV,OP>::reset()
   curSoln_ = Teuchos::null;
 }
 
-template <class ScalarType, class MV, class OP>
-int StatusTestImpResNorm<ScalarType,MV,OP>::defineResForm( NormType TypeOfNorm )
+template <class ScalarType, class MV, class OP, class DM>
+int StatusTestImpResNorm<ScalarType,MV,OP,DM>::defineResForm( NormType TypeOfNorm )
 {
   TEUCHOS_TEST_FOR_EXCEPTION(firstcallDefineResForm_==false,StatusTestError,
         "StatusTestResNorm::defineResForm(): The residual form has already been defined.");
@@ -440,8 +440,8 @@ int StatusTestImpResNorm<ScalarType,MV,OP>::defineResForm( NormType TypeOfNorm )
   return(0);
 }
 
-template <class ScalarType, class MV, class OP>
-int StatusTestImpResNorm<ScalarType,MV,OP>::defineScaleForm(ScaleType TypeOfScaling, NormType TypeOfNorm,
+template <class ScalarType, class MV, class OP, class DM>
+int StatusTestImpResNorm<ScalarType,MV,OP,DM>::defineScaleForm(ScaleType TypeOfScaling, NormType TypeOfNorm,
                                                          MagnitudeType ScaleValue )
 {
   TEUCHOS_TEST_FOR_EXCEPTION(firstcallDefineScaleForm_==false,StatusTestError,
@@ -455,9 +455,9 @@ int StatusTestImpResNorm<ScalarType,MV,OP>::defineScaleForm(ScaleType TypeOfScal
   return(0);
 }
 
-template <class ScalarType, class MV, class OP>
-StatusType StatusTestImpResNorm<ScalarType,MV,OP>::
-checkStatus (Iteration<ScalarType,MV,OP>* iSolver)
+template <class ScalarType, class MV, class OP, class DM>
+StatusType StatusTestImpResNorm<ScalarType,MV,OP,DM>::
+checkStatus (Iteration<ScalarType,MV,OP,DM>* iSolver)
 {
   using Teuchos::as;
   using Teuchos::RCP;
@@ -716,8 +716,8 @@ checkStatus (Iteration<ScalarType,MV,OP>* iSolver)
   return status_;
 }
 
-template <class ScalarType, class MV, class OP>
-void StatusTestImpResNorm<ScalarType,MV,OP>::print(std::ostream& os, int indent) const
+template <class ScalarType, class MV, class OP, class DM>
+void StatusTestImpResNorm<ScalarType,MV,OP,DM>::print(std::ostream& os, int indent) const
 {
   for (int j = 0; j < indent; j ++)
     os << ' ';
@@ -748,8 +748,8 @@ void StatusTestImpResNorm<ScalarType,MV,OP>::print(std::ostream& os, int indent)
   os << std::endl;
 }
 
-template <class ScalarType, class MV, class OP>
-void StatusTestImpResNorm<ScalarType,MV,OP>::printStatus(std::ostream& os, StatusType type) const
+template <class ScalarType, class MV, class OP, class DM>
+void StatusTestImpResNorm<ScalarType,MV,OP,DM>::printStatus(std::ostream& os, StatusType type) const
 {
   os << std::left << std::setw(13) << std::setfill('.');
   switch (type) {
@@ -771,9 +771,9 @@ void StatusTestImpResNorm<ScalarType,MV,OP>::printStatus(std::ostream& os, Statu
     return;
 }
 
-template <class ScalarType, class MV, class OP>
-StatusType StatusTestImpResNorm<ScalarType,MV,OP>::
-firstCallCheckStatusSetup (Iteration<ScalarType,MV,OP>* iSolver)
+template <class ScalarType, class MV, class OP, class DM>
+StatusType StatusTestImpResNorm<ScalarType,MV,OP,DM>::
+firstCallCheckStatusSetup (Iteration<ScalarType,MV,OP,DM>* iSolver)
 {
   int i;
   const MagnitudeType zero = STM::zero ();

--- a/packages/belos/src/BelosStatusTestLogResNorm.hpp
+++ b/packages/belos/src/BelosStatusTestLogResNorm.hpp
@@ -31,8 +31,8 @@
 
 namespace Belos {
 
-template <class ScalarType, class MV, class OP>
-class StatusTestLogResNorm: public StatusTest<ScalarType,MV,OP> {
+template <class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
+class StatusTestLogResNorm: public StatusTest<ScalarType,MV,OP,DM> {
 
 public:
   //! The type of the magnitude (absolute value) of a ScalarType.
@@ -63,7 +63,7 @@ private:
   /*! This method checks to see if the convergence criteria are met using the current information from the 
     iterative solver.
   */
-  StatusType checkStatus(Iteration<ScalarType,MV,OP> *iSolver );
+  StatusType checkStatus(Iteration<ScalarType,MV,OP,DM> *iSolver );
 
   //! Return the result of the most recent CheckStatus call.
   StatusType getStatus() const {return(Undefined);}
@@ -136,8 +136,8 @@ private:
 
 };
 
-  template <class ScalarType, class MV, class OP> 
-  StatusTestLogResNorm<ScalarType,MV,OP>::StatusTestLogResNorm(int maxIters)
+  template <class ScalarType, class MV, class OP, class DM> 
+  StatusTestLogResNorm<ScalarType,MV,OP,DM>::StatusTestLogResNorm(int maxIters)
   {
     if (maxIters < 1)
       maxIters_ = 1;
@@ -149,8 +149,8 @@ private:
     nIters_ = 0;
   }
   
-  template <class ScalarType, class MV, class OP>
-  StatusType StatusTestLogResNorm<ScalarType,MV,OP>::checkStatus(Iteration<ScalarType,MV,OP> *iSolver )
+  template <class ScalarType, class MV, class OP, class DM>
+  StatusType StatusTestLogResNorm<ScalarType,MV,OP,DM>::checkStatus(Iteration<ScalarType,MV,OP,DM> *iSolver )
   {
     // Check that this solve is a single-vector, single-block.
     const LinearProblem<ScalarType,MV,OP>& lp = iSolver->getProblem ();
@@ -176,16 +176,16 @@ private:
     return Undefined;
   }
   
-  template <class ScalarType, class MV, class OP>
-  void StatusTestLogResNorm<ScalarType,MV,OP>::reset()
+  template <class ScalarType, class MV, class OP, class DM>
+  void StatusTestLogResNorm<ScalarType,MV,OP,DM>::reset()
   {
     nIters_ = 0;
     logResNorm_.clear();
     logResNorm_.reserve( maxIters_ );
   }    
     
-  template <class ScalarType, class MV, class OP>
-  void StatusTestLogResNorm<ScalarType,MV,OP>::print(std::ostream& os, int indent) const
+  template <class ScalarType, class MV, class OP, class DM>
+  void StatusTestLogResNorm<ScalarType,MV,OP,DM>::print(std::ostream& os, int indent) const
   {
     for (int j = 0; j < indent; j ++)
       os << ' ';
@@ -193,8 +193,8 @@ private:
     os << "Logging Absolute Residual 2-Norm" << std::endl;
   }
  
-  template <class ScalarType, class MV, class OP>
-  void StatusTestLogResNorm<ScalarType,MV,OP>::printStatus(std::ostream& os, StatusType type) const 
+  template <class ScalarType, class MV, class OP, class DM>
+  void StatusTestLogResNorm<ScalarType,MV,OP,DM>::printStatus(std::ostream& os, StatusType type) const 
   {
     os << std::left << std::setw(13) << std::setfill('.');
     os << "**";

--- a/packages/belos/src/BelosStatusTestMaxIters.hpp
+++ b/packages/belos/src/BelosStatusTestMaxIters.hpp
@@ -27,8 +27,8 @@
 
 namespace Belos {
 
-template <class ScalarType, class MV, class OP>
-class StatusTestMaxIters: public StatusTest<ScalarType,MV,OP> {
+template <class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
+class StatusTestMaxIters: public StatusTest<ScalarType,MV,OP,DM> {
 
  public:
 
@@ -49,7 +49,7 @@ class StatusTestMaxIters: public StatusTest<ScalarType,MV,OP> {
   /*! This method checks to see if the convergence criteria are met using the current information from the 
     iterative solver.
   */
-  StatusType checkStatus(Iteration<ScalarType,MV,OP> *iSolver );
+  StatusType checkStatus(Iteration<ScalarType,MV,OP,DM> *iSolver );
 
   //! Return the result of the most recent CheckStatus call.
   StatusType getStatus() const {return(status_);}
@@ -117,8 +117,8 @@ private:
 
 };
 
-  template <class ScalarType, class MV, class OP> 
-  StatusTestMaxIters<ScalarType,MV,OP>::StatusTestMaxIters(int maxIters)
+  template <class ScalarType, class MV, class OP, class DM> 
+  StatusTestMaxIters<ScalarType,MV,OP,DM>::StatusTestMaxIters(int maxIters)
   {
     if (maxIters < 1)
       maxIters_ = 1;
@@ -129,8 +129,8 @@ private:
     status_ = Undefined;
   }
   
-  template <class ScalarType, class MV, class OP>
-  StatusType StatusTestMaxIters<ScalarType,MV,OP>::checkStatus(Iteration<ScalarType,MV,OP> *iSolver )
+  template <class ScalarType, class MV, class OP, class DM>
+  StatusType StatusTestMaxIters<ScalarType,MV,OP,DM>::checkStatus(Iteration<ScalarType,MV,OP,DM> *iSolver )
   {
     status_ = Failed;
     nIters_ = iSolver->getNumIters();
@@ -139,15 +139,15 @@ private:
     return status_;
   }
   
-  template <class ScalarType, class MV, class OP>
-  void StatusTestMaxIters<ScalarType,MV,OP>::reset()
+  template <class ScalarType, class MV, class OP, class DM>
+  void StatusTestMaxIters<ScalarType,MV,OP,DM>::reset()
   {
     nIters_ = 0;
     status_ = Undefined;
   }    
     
-  template <class ScalarType, class MV, class OP>
-  void StatusTestMaxIters<ScalarType,MV,OP>::print(std::ostream& os, int indent) const
+  template <class ScalarType, class MV, class OP, class DM>
+  void StatusTestMaxIters<ScalarType,MV,OP,DM>::print(std::ostream& os, int indent) const
   {
     for (int j = 0; j < indent; j ++)
       os << ' ';
@@ -159,8 +159,8 @@ private:
     os << std::endl;
   }
  
-  template <class ScalarType, class MV, class OP>
-  void StatusTestMaxIters<ScalarType,MV,OP>::printStatus(std::ostream& os, StatusType type) const 
+  template <class ScalarType, class MV, class OP, class DM>
+  void StatusTestMaxIters<ScalarType,MV,OP,DM>::printStatus(std::ostream& os, StatusType type) const 
   {
     os << std::left << std::setw(13) << std::setfill('.');
     switch (type) {

--- a/packages/belos/src/BelosStatusTestOutput.hpp
+++ b/packages/belos/src/BelosStatusTestOutput.hpp
@@ -36,8 +36,8 @@ namespace Belos {
     of the printing can be dictated according to some parameters passed to 
     StatusTestOutput::StatusTestOutput().
   */
-template <class ScalarType, class MV, class OP>
-class StatusTestOutput : public virtual StatusTest<ScalarType,MV,OP> {
+template <class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
+class StatusTestOutput : public virtual StatusTest<ScalarType,MV,OP,DM> {
 
  public:
   //! @name Constructors/destructors
@@ -61,7 +61,7 @@ class StatusTestOutput : public virtual StatusTest<ScalarType,MV,OP> {
    *
    */
   StatusTestOutput(const Teuchos::RCP<OutputManager<ScalarType> > &printer, 
-                   Teuchos::RCP<StatusTest<ScalarType,MV,OP> > test,
+                   Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > test,
                    int mod = 1,
                    int printStates = Passed)
     {}   
@@ -85,10 +85,10 @@ class StatusTestOutput : public virtual StatusTest<ScalarType,MV,OP> {
    *
    *  \note This also resets the test status to ::Undefined.
    */
-  virtual void setChild(Teuchos::RCP<StatusTest<ScalarType,MV,OP> > test) = 0;
+  virtual void setChild(Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > test) = 0;
 
   //! \brief Get child test.
-  virtual Teuchos::RCP<StatusTest<ScalarType,MV,OP> > getChild() const = 0;
+  virtual Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > getChild() const = 0;
 
   /*! \brief Set a short solver description for output clarity.
    */

--- a/packages/belos/src/BelosStatusTestOutputFactory.hpp
+++ b/packages/belos/src/BelosStatusTestOutputFactory.hpp
@@ -22,7 +22,6 @@
 #include "BelosStatusTestUserOutput.hpp"
 #include "BelosStatusTestGeneralOutput.hpp"
 
-
 namespace Belos {
 
   /*!
@@ -34,7 +33,7 @@ namespace Belos {
     class needs to be used from the solver managers. It also hides the generation of new StatusTestOutput
     classes from the solver managers.
   */
-template <class ScalarType, class MV, class OP>
+template <class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
 class StatusTestOutputFactory {
 
  public:
@@ -49,7 +48,7 @@ class StatusTestOutputFactory {
    * @param[in] outputStyle A ::OutputType value which defines the style of output requested by the user.
    * @param[in] taggedTests: map tag names of status tests to status tests (optional, default = Teuchos::null)
    */
-  StatusTestOutputFactory( int outputStyle, Teuchos::RCP<std::map<std::string,Teuchos::RCP<StatusTest<ScalarType,MV,OP> > > > taggedTests = Teuchos::null )
+  StatusTestOutputFactory( int outputStyle, Teuchos::RCP<std::map<std::string,Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > > > taggedTests = Teuchos::null )
     : outputStyle_(outputStyle),
       taggedTests_(taggedTests)
   {}
@@ -76,45 +75,45 @@ class StatusTestOutputFactory {
    * @param[in] printStates A combination of ::StatusType values for which the output may be printed. Default: ::Passed (attempt to print whenever checkStatus() will return ::Passed)
    *
    */
-   Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP> > create(const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-                                                            Teuchos::RCP<StatusTest<ScalarType,MV,OP> > test,
+   Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP,DM> > create(const Teuchos::RCP<OutputManager<ScalarType> > &printer,
+                                                            Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > test,
                                                             int mod,
                                                             int printStates)
     {
-      Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP> > outputTest;
+      Teuchos::RCP<StatusTestOutput<ScalarType,MV,OP,DM> > outputTest;
 
       switch( outputStyle_ ) {
 
       case General:
         if (mod > 0) {
-          outputTest = Teuchos::rcp( new StatusTestGeneralOutput<ScalarType,MV,OP>( printer, test, mod, printStates ) );
+          outputTest = Teuchos::rcp( new StatusTestGeneralOutput<ScalarType,MV,OP,DM>( printer, test, mod, printStates ) );
         }
         else {
-          outputTest = Teuchos::rcp( new StatusTestGeneralOutput<ScalarType,MV,OP>( printer, test, 1 ) );
+          outputTest = Teuchos::rcp( new StatusTestGeneralOutput<ScalarType,MV,OP,DM>( printer, test, 1 ) );
         }
         break;
       case Brief:
         if (mod > 0) {
-          outputTest = Teuchos::rcp( new StatusTestResNormOutput<ScalarType,MV,OP>( printer, test, mod, printStates ) );
+          outputTest = Teuchos::rcp( new StatusTestResNormOutput<ScalarType,MV,OP,DM>( printer, test, mod, printStates ) );
         }
         else {
-          outputTest = Teuchos::rcp( new StatusTestResNormOutput<ScalarType,MV,OP>( printer, test, 1 ) );
+          outputTest = Teuchos::rcp( new StatusTestResNormOutput<ScalarType,MV,OP,DM>( printer, test, 1 ) );
         }
         break;
       case User:
         if (mod > 0) {
-          outputTest = Teuchos::rcp( new StatusTestUserOutput<ScalarType,MV,OP>( printer, test, taggedTests_, mod, printStates ) );
+          outputTest = Teuchos::rcp( new StatusTestUserOutput<ScalarType,MV,OP,DM>( printer, test, taggedTests_, mod, printStates ) );
         }
         else {
-          outputTest = Teuchos::rcp( new StatusTestUserOutput<ScalarType,MV,OP>( printer, test, taggedTests_, 1 ) );
+          outputTest = Teuchos::rcp( new StatusTestUserOutput<ScalarType,MV,OP,DM>( printer, test, taggedTests_, 1 ) );
         }
         break;
       default: //Default to General if invalid outputStyle_ given.
         if (mod > 0) {
-          outputTest = Teuchos::rcp( new StatusTestGeneralOutput<ScalarType,MV,OP>( printer, test, mod, printStates ) );
+          outputTest = Teuchos::rcp( new StatusTestGeneralOutput<ScalarType,MV,OP,DM>( printer, test, mod, printStates ) );
         }
         else {
-          outputTest = Teuchos::rcp( new StatusTestGeneralOutput<ScalarType,MV,OP>( printer, test, 1 ) );
+          outputTest = Teuchos::rcp( new StatusTestGeneralOutput<ScalarType,MV,OP,DM>( printer, test, 1 ) );
         }
         break;
       }
@@ -130,11 +129,11 @@ class StatusTestOutputFactory {
   // Which type of StatusTestOutput class
   int outputStyle_;
 
-  Teuchos::RCP<std::map<std::string,Teuchos::RCP<StatusTest<ScalarType,MV,OP> > > > taggedTests_;
+  Teuchos::RCP<std::map<std::string,Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > > > taggedTests_;
 
   // Hide the default constructor and copy constructor
   StatusTestOutputFactory( void ) {}
-  StatusTestOutputFactory( const StatusTestOutputFactory<ScalarType,MV,OP>& ) {}
+  StatusTestOutputFactory( const StatusTestOutputFactory<ScalarType,MV,OP,DM>& ) {}
 
 };
 

--- a/packages/belos/src/BelosStatusTestResNorm.hpp
+++ b/packages/belos/src/BelosStatusTestResNorm.hpp
@@ -26,15 +26,15 @@
 
 namespace Belos {
 
-template <class ScalarType, class MV, class OP>
-class StatusTestResNorm: public StatusTest<ScalarType,MV,OP> {
+template <class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
+class StatusTestResNorm: public StatusTest<ScalarType,MV,OP,DM> {
 
  public:
 
   // Convenience typedefs
   typedef Teuchos::ScalarTraits<ScalarType> SCT;
   typedef typename SCT::magnitudeType MagnitudeType;
-  typedef MultiVecTraits<ScalarType,MV>  MVT;
+  typedef MultiVecTraits<ScalarType,MV,DM>  MVT;
 
   //! @name Form and parameter definition methods.
   //@{ 

--- a/packages/belos/src/BelosStatusTestResNormOutput.hpp
+++ b/packages/belos/src/BelosStatusTestResNormOutput.hpp
@@ -38,13 +38,13 @@ namespace Belos {
     The frequency and occasion of the printing can be dictated according to some parameters passed to 
     StatusTestResNormOutput::StatusTestResNormOutput().
   */
-template <class ScalarType, class MV, class OP>
-class StatusTestResNormOutput : public StatusTestOutput<ScalarType,MV,OP> {
+template <class ScalarType, class MV, class OP, class DM = Teuchos::SerialDenseMatrix<int,ScalarType>>
+class StatusTestResNormOutput : public StatusTestOutput<ScalarType,MV,OP,DM> {
 
-  typedef MultiVecTraits<ScalarType,MV> MVT;
-  typedef Belos::StatusTestCombo<ScalarType,MV,OP>  StatusTestCombo_t;
-  typedef Belos::StatusTestResNorm<ScalarType,MV,OP>  StatusTestResNorm_t;
-  typedef Belos::StatusTestMaxIters<ScalarType,MV,OP>  StatusTestMaxIters_t;
+  typedef MultiVecTraits<ScalarType,MV,DM> MVT;
+  typedef Belos::StatusTestCombo<ScalarType,MV,OP,DM>  StatusTestCombo_t;
+  typedef Belos::StatusTestResNorm<ScalarType,MV,OP,DM>  StatusTestResNorm_t;
+  typedef Belos::StatusTestMaxIters<ScalarType,MV,OP,DM>  StatusTestMaxIters_t;
 
  public:
   //! @name Constructors/destructors
@@ -66,7 +66,7 @@ class StatusTestResNormOutput : public StatusTestOutput<ScalarType,MV,OP> {
    *
    */
   StatusTestResNormOutput(const Teuchos::RCP<OutputManager<ScalarType> > &printer, 
-			Teuchos::RCP<StatusTest<ScalarType,MV,OP> > test,
+			Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > test,
 			int mod = 1,
 			int printStates = Passed)
     : printer_(printer), 
@@ -110,7 +110,7 @@ class StatusTestResNormOutput : public StatusTestOutput<ScalarType,MV,OP> {
     
     \return ::StatusType indicating whether the underlying test passed or failed.
   */
-  StatusType checkStatus( Iteration<ScalarType,MV,OP>* solver ) 
+  StatusType checkStatus( Iteration<ScalarType,MV,OP,DM>* solver ) 
   {
     TEUCHOS_TEST_FOR_EXCEPTION(iterTest_ == Teuchos::null,StatusTestError,"StatusTestResNormOutput::checkStatus():  iteration test pointer is null.");
     TEUCHOS_TEST_FOR_EXCEPTION(resTestVec_.size() == 0,StatusTestError,"StatusTestResNormOutput::checkStatus():  residual test pointer is null.");
@@ -165,12 +165,12 @@ class StatusTestResNormOutput : public StatusTestOutput<ScalarType,MV,OP> {
    *
    *  \note This also resets the test status to ::Undefined.
    */
-  void setChild(Teuchos::RCP<StatusTest<ScalarType,MV,OP> > test) {
+  void setChild(Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > test) {
 
     // First check to see if this test is a combination test
     Teuchos::RCP<StatusTestCombo_t> comboTest = Teuchos::rcp_dynamic_cast<StatusTestCombo_t>(test);
     TEUCHOS_TEST_FOR_EXCEPTION(comboTest == Teuchos::null,StatusTestError,"StatusTestResNormOutput():  test must be a Belos::StatusTestCombo.");
-    std::vector<Teuchos::RCP<StatusTest<ScalarType,MV,OP> > > tmpVec = comboTest->getStatusTests();
+    std::vector<Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > > tmpVec = comboTest->getStatusTests();
     
     // Get the number of tests.
     int numTests = tmpVec.size();
@@ -216,7 +216,7 @@ class StatusTestResNormOutput : public StatusTestOutput<ScalarType,MV,OP> {
   }
  
   //! \brief Get child test.
-  Teuchos::RCP<StatusTest<ScalarType,MV,OP> > getChild() const {
+  Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > getChild() const {
     return test_;
   }
 
@@ -318,13 +318,13 @@ class StatusTestResNormOutput : public StatusTestOutput<ScalarType,MV,OP> {
     Teuchos::RCP<OutputManager<ScalarType> > printer_;
 
     // Overall status test.
-    Teuchos::RCP<StatusTest<ScalarType,MV,OP> > test_;
+    Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > test_;
 
     // Iteration test (as passed in).
-    Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP> > iterTest_;
+    Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP,DM> > iterTest_;
 
     //! Vector of residual status tests
-    std::vector<Teuchos::RCP<StatusTestResNorm<ScalarType,MV,OP> > > resTestVec_;
+    std::vector<Teuchos::RCP<StatusTestResNorm<ScalarType,MV,OP,DM> > > resTestVec_;
 
     std::string solverDesc_;
     std::string precondDesc_;

--- a/packages/belos/src/BelosStatusTestUserOutput.hpp
+++ b/packages/belos/src/BelosStatusTestUserOutput.hpp
@@ -34,13 +34,13 @@ namespace Belos {
     \brief A special StatusTest for printing other status tests in a simple format.
 
   */
-template <class ScalarType, class MV, class OP>
-class StatusTestUserOutput : public StatusTestOutput<ScalarType,MV,OP> {
+template <class ScalarType, class MV, class OP, class DM>
+class StatusTestUserOutput : public StatusTestOutput<ScalarType,MV,OP,DM> {
 
-  typedef MultiVecTraits<ScalarType,MV> MVT;
-  typedef Belos::StatusTestCombo<ScalarType,MV,OP>  StatusTestCombo_t;
-  typedef Belos::StatusTestResNorm<ScalarType,MV,OP>  StatusTestResNorm_t;
-  typedef Belos::StatusTestMaxIters<ScalarType,MV,OP>  StatusTestMaxIters_t;
+  typedef MultiVecTraits<ScalarType,MV,DM> MVT;
+  typedef Belos::StatusTestCombo<ScalarType,MV,OP,DM>  StatusTestCombo_t;
+  typedef Belos::StatusTestResNorm<ScalarType,MV,OP,DM>  StatusTestResNorm_t;
+  typedef Belos::StatusTestMaxIters<ScalarType,MV,OP,DM>  StatusTestMaxIters_t;
 
  public:
   //! @name Constructors/destructors
@@ -62,8 +62,8 @@ class StatusTestUserOutput : public StatusTestOutput<ScalarType,MV,OP> {
    *
    */
   StatusTestUserOutput(const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-      Teuchos::RCP<StatusTest<ScalarType,MV,OP> > test,
-      Teuchos::RCP<std::map<std::string,Teuchos::RCP<StatusTest<ScalarType,MV,OP> > > > taggedTests,
+      Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > test,
+      Teuchos::RCP<std::map<std::string,Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > > > taggedTests,
       int mod = 1,
       int printStates = Passed)
     : printer_(printer),
@@ -107,7 +107,7 @@ class StatusTestUserOutput : public StatusTestOutput<ScalarType,MV,OP> {
 
     \return ::StatusType indicating whether the underlying test passed or failed.
   */
-  StatusType checkStatus( Iteration<ScalarType,MV,OP>* solver )
+  StatusType checkStatus( Iteration<ScalarType,MV,OP,DM>* solver )
   {
     TEUCHOS_TEST_FOR_EXCEPTION(iterTest_ == Teuchos::null,StatusTestError,"StatusTestUserOutput::checkStatus():  iteration test pointer is null.");
     TEUCHOS_TEST_FOR_EXCEPTION(resTestVec_.size() == 0,StatusTestError,"StatusTestUserOutput::checkStatus():  residual test pointer is null.");
@@ -162,12 +162,12 @@ class StatusTestUserOutput : public StatusTestOutput<ScalarType,MV,OP> {
    *
    *  \note This also resets the test status to ::Undefined.
    */
-  void setChild(Teuchos::RCP<StatusTest<ScalarType,MV,OP> > test) {
+  void setChild(Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > test) {
 
     // First check to see if this test is a combination test
     Teuchos::RCP<StatusTestCombo_t> comboTest = Teuchos::rcp_dynamic_cast<StatusTestCombo_t>(test);
     TEUCHOS_TEST_FOR_EXCEPTION(comboTest == Teuchos::null,StatusTestError,"StatusTestUserOutput::setChild: The parameter \"test\" must be a Belos::StatusTestCombo.");
-    std::vector<Teuchos::RCP<StatusTest<ScalarType,MV,OP> > > tmpVec = comboTest->getStatusTests();
+    std::vector<Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > > tmpVec = comboTest->getStatusTests();
 
     // Get the number of tests.
     int numTests = tmpVec.size();
@@ -205,7 +205,7 @@ class StatusTestUserOutput : public StatusTestOutput<ScalarType,MV,OP> {
 
       // Add only status tests which are not in the user-specified list of tagged status tests
       // More specifically: we want to add the implicit residual test
-      typename std::map<std::string,Teuchos::RCP<StatusTest<ScalarType,MV,OP> > >::iterator it;
+      typename std::map<std::string,Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > >::iterator it;
       for (size_t j=0; j<tmpVec.size(); ++j) {
         tmpResTest = Teuchos::rcp_dynamic_cast<StatusTestResNorm_t>(tmpVec[j]);
 
@@ -235,7 +235,7 @@ class StatusTestUserOutput : public StatusTestOutput<ScalarType,MV,OP> {
   }
 
   //! \brief Get child test.
-  Teuchos::RCP<StatusTest<ScalarType,MV,OP> > getChild() const {
+  Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > getChild() const {
     return test_;
   }
 
@@ -353,16 +353,16 @@ class StatusTestUserOutput : public StatusTestOutput<ScalarType,MV,OP> {
     Teuchos::RCP<OutputManager<ScalarType> > printer_;
 
     // Overall status test.
-    Teuchos::RCP<StatusTest<ScalarType,MV,OP> > test_;
+    Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > test_;
 
     // tagged tests
-    Teuchos::RCP<std::map<std::string,Teuchos::RCP<StatusTest<ScalarType,MV,OP> > > > taggedTests_;
+    Teuchos::RCP<std::map<std::string,Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > > > taggedTests_;
 
     // Iteration test (as passed in).
-    Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP> > iterTest_;
+    Teuchos::RCP<StatusTestMaxIters<ScalarType,MV,OP,DM> > iterTest_;
 
     //! Vector of residual status tests
-    std::vector<Teuchos::RCP<StatusTest<ScalarType,MV,OP> > > resTestVec_;
+    std::vector<Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > > resTestVec_;
 
     //! Name tags for status tests
     std::vector<std::string> resTestNamesVec_;

--- a/packages/belos/src/BelosStochasticCGIteration.hpp
+++ b/packages/belos/src/BelosStochasticCGIteration.hpp
@@ -51,8 +51,8 @@ namespace Belos {
     {}
   };
 
-template<class ScalarType, class MV, class OP>
-class StochasticCGIteration : virtual public Iteration<ScalarType,MV,OP> {
+template<class ScalarType, class MV, class OP, class DM>
+class StochasticCGIteration : virtual public Iteration<ScalarType,MV,OP,DM> {
 
   public:
 

--- a/packages/belos/src/BelosStubTsqrAdapter.hpp
+++ b/packages/belos/src/BelosStubTsqrAdapter.hpp
@@ -48,14 +48,13 @@ namespace details {
   /// TsqrOrthoManagerImpl to compile successfully for unsupported MV
   /// types.  This in turn allows OrthoManagerFactory to be templated
   /// on the MV type.
-  template<class MultiVectorType>
+  template<class MultiVectorType, class DM = Teuchos::SerialDenseMatrix<int,double>>
   class StubTsqrAdapter : public Teuchos::ParameterListAcceptorDefaultBase {
   public:
     typedef MultiVectorType MV;
     typedef double scalar_type; // This doesn't really matter
     typedef int ordinal_type; // This doesn't matter either
     typedef int node_type; // Nor does this
-    typedef Teuchos::SerialDenseMatrix<ordinal_type, scalar_type> dense_matrix_type;
     typedef typename Teuchos::ScalarTraits<scalar_type>::magnitudeType magnitude_type;
 
     /// \brief Constructor (that accepts a parameter list).
@@ -110,7 +109,7 @@ namespace details {
     void
     factorExplicit (MV& A,
 		    MV& Q,
-		    dense_matrix_type& R,
+		    DM& R,
 		    const bool forceNonnegativeDiagonal=false)
     {
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "TSQR adapter for "
@@ -121,7 +120,7 @@ namespace details {
     //! Rank-revealing decomposition (stub; does nothing).
     int
     revealRank (MV& Q,
-		dense_matrix_type& R,
+		DM& R,
 		const magnitude_type& tol)
     {
       // mfh 07 Sep 2012: In order to prevent compiler warnings on

--- a/packages/belos/src/BelosTFQMRIter.hpp
+++ b/packages/belos/src/BelosTFQMRIter.hpp
@@ -35,8 +35,6 @@
 #include "BelosOperatorTraits.hpp"
 #include "BelosMultiVecTraits.hpp"
 
-#include "Teuchos_SerialDenseMatrix.hpp"
-#include "Teuchos_SerialDenseVector.hpp"
 #include "Teuchos_ScalarTraits.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TimeMonitor.hpp"
@@ -90,14 +88,13 @@ namespace Belos {
   
   //@}
 
-
-  template <class ScalarType, class MV, class OP>
-  class TFQMRIter : public Iteration<ScalarType,MV,OP> { 
+  template<class ScalarType, class MV, class OP, class DM>
+  class TFQMRIter : public Iteration<ScalarType,MV,OP,DM> { 
   public:
     //
     // Convenience typedefs
     //
-    typedef MultiVecTraits<ScalarType,MV> MVT;
+    typedef MultiVecTraits<ScalarType,MV,DM> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename SCT::magnitudeType MagnitudeType;
@@ -108,7 +105,7 @@ namespace Belos {
     //! %Belos::TFQMRIter constructor.
     TFQMRIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
 	       const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-	       const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
+	       const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
 	       Teuchos::ParameterList &params );
     
     //! %Belos::TFQMRIter destructor.
@@ -241,14 +238,13 @@ namespace Belos {
     //
     const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
     const Teuchos::RCP<OutputManager<ScalarType> >          om_;
-    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
+    const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> >       stest_;
     
     //
     // Algorithmic parameters
     //      
 
     // Storage for QR factorization of the least squares system.
-    // Teuchos::SerialDenseMatrix<int,ScalarType> alpha_, rho_, rho_old_;
     std::vector<ScalarType> alpha_, rho_, rho_old_;
     std::vector<MagnitudeType> tau_, cs_, theta_;
     
@@ -287,10 +283,10 @@ namespace Belos {
   
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
-  template <class ScalarType, class MV, class OP>
-  TFQMRIter<ScalarType,MV,OP>::TFQMRIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
+  template <class ScalarType, class MV, class OP, class DM>
+  TFQMRIter<ScalarType,MV,OP,DM>::TFQMRIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 					 const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-					 const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
+					 const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DM> > &tester,
 					 Teuchos::ParameterList &/* params */ 
 					 ) : 
     lp_(problem), 
@@ -310,9 +306,9 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Compute native residual from TFQMR recurrence.
-  template <class ScalarType, class MV, class OP>
+  template <class ScalarType, class MV, class OP, class DM>
   Teuchos::RCP<const MV> 
-  TFQMRIter<ScalarType,MV,OP>::getNativeResiduals( std::vector<MagnitudeType> *normvec ) const 
+  TFQMRIter<ScalarType,MV,OP,DM>::getNativeResiduals( std::vector<MagnitudeType> *normvec ) const 
   {
     MagnitudeType one = Teuchos::ScalarTraits<MagnitudeType>::one();
     if (normvec)
@@ -324,8 +320,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Setup the state storage.
-  template <class ScalarType, class MV, class OP>
-  void TFQMRIter<ScalarType,MV,OP>::setStateSize ()
+  template <class ScalarType, class MV, class OP, class DM>
+  void TFQMRIter<ScalarType,MV,OP,DM>::setStateSize ()
   {
     if (!stateStorageInitialized_) {
 
@@ -359,8 +355,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Initialize this iteration object
-  template <class ScalarType, class MV, class OP>
-  void TFQMRIter<ScalarType,MV,OP>::initializeTFQMR(const TFQMRIterState<ScalarType,MV> & newstate)
+  template <class ScalarType, class MV, class OP, class DM>
+  void TFQMRIter<ScalarType,MV,OP,DM>::initializeTFQMR(const TFQMRIterState<ScalarType,MV> & newstate)
   {
     // Initialize the state storage if it isn't already.
     if (!stateStorageInitialized_)
@@ -422,8 +418,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Iterate until the status test informs us we should stop.
-  template <class ScalarType, class MV, class OP>
-  void TFQMRIter<ScalarType,MV,OP>::iterate() 
+  template <class ScalarType, class MV, class OP, class DM>
+  void TFQMRIter<ScalarType,MV,OP,DM>::iterate() 
   {
     //
     // Allocate/initialize data structures

--- a/packages/belos/src/BelosTeuchosDenseAdapter.hpp
+++ b/packages/belos/src/BelosTeuchosDenseAdapter.hpp
@@ -1,0 +1,348 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+#ifndef BELOS_TEUCHOS_DENSE_MAT_TRAITS_HPP
+#define BELOS_TEUCHOS_DENSE_MAT_TRAITS_HPP
+
+/*! \file BelosTeuchosDenseAdapter.hpp
+  \brief Full specialization of Belos::DenseMatTraits for Teuchos::SerialDenseMatrix
+  with ordinal type int and arbitrary scalar type.
+*/
+
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_ScalarTraits.hpp"
+#include "Teuchos_SerialDenseMatrix.hpp"
+#include "Teuchos_SerialDenseSolver.hpp"
+#include "Teuchos_SerialSpdDenseSolver.hpp"
+
+#include "BelosDenseMatTraits.hpp" 
+#include "BelosDenseSolver.hpp"
+
+namespace Belos {
+
+  //! Full specialization of Belos::DenseSolver for Teuchos::SerialDenseMatrix<int,ST>.
+  template<class ScalarType>
+  class TeuchosDenseSolver : public DenseSolver<ScalarType,Teuchos::SerialDenseMatrix<int,ScalarType> >
+  {
+  public:
+
+    //! @name Constructor/Destructor Methods
+    //@{
+    //! Default constructor; matrix should be set using setMatrix(), LHS and RHS set with setVectors().
+    TeuchosDenseSolver() {}
+
+    //! TeuchosDenseSolver destructor.
+    virtual ~TeuchosDenseSolver() {}
+    //@}
+
+    //! @name Set Methods
+    //@{
+    //! Sets the pointers for coefficient matrix
+    using DenseSolver<ScalarType,Teuchos::SerialDenseMatrix<int,ScalarType>>::setMatrix;
+
+    //! Sets the pointers for left and right hand side vector(s).
+    using DenseSolver<ScalarType,Teuchos::SerialDenseMatrix<int,ScalarType>>::setVectors;
+    //@}
+
+    //! @name Strategy Modifying Methods
+    //@{
+
+    //! Set if dense matrix is symmetric positive definite
+    //! \note This method must be called before the factorization is performed, otherwise it will have no effect.
+    using DenseSolver<ScalarType,Teuchos::SerialDenseMatrix<int,ScalarType>>::setSPD;
+
+    //! Causes equilibration to be called just before the matrix factorization as part of the call to \c factor.
+    /*! \note This method must be called before the factorization is performed, otherwise it will have no effect.
+    */
+    using DenseSolver<ScalarType,Teuchos::SerialDenseMatrix<int,ScalarType>>::factorWithEquilibration;
+
+    //! All subsequent function calls will work with the transpose-type set by this method (\c Teuchos::NO_TRANS, \c Teuchos::TRANS, and \c Teuchos::CONJ_TRANS).
+    /*! \note This interface will set correct transpose flag for matrix, including complex-valued linear systems.
+    */
+    using DenseSolver<ScalarType,Teuchos::SerialDenseMatrix<int,ScalarType>>::solveWithTransposeFlag;
+    //@}
+
+    //! @name Factor/Solve Methods
+    //@{
+
+    //! Computes the in-place LU factorization of the matrix.
+    /*!
+      \return Integer error code, set to 0 if successful.
+    */
+    int factor() 
+    {
+       //std::cout << "Calling DenseMatrix<Teuchos> factor!" << std::endl;
+       // Create solver object if one doesn't exist.
+       if ( (dSolver_==Teuchos::null) && (spdSolver_==Teuchos::null) )
+       {
+         if (spd_)
+           spdSolver_ = Teuchos::rcp( new Teuchos::SerialSpdDenseSolver<int,ScalarType>() );
+         else
+           dSolver_ = Teuchos::rcp( new Teuchos::SerialDenseSolver<int,ScalarType>() );
+      }
+
+      int info = 0;
+
+      // Set the matrix and factor
+      if (spd_)
+      {
+        if (newMatrix_)
+        {
+          spdMatrix_ = Teuchos::rcp( new Teuchos::SerialSymDenseMatrix<int,ScalarType>(Teuchos::View, true, A_->values(),
+                                                                                       A_->numRows(), A_->numCols()) );
+        } 
+        spdSolver_->setMatrix( spdMatrix_ );
+        spdSolver_->factorWithEquilibration( equilibrate_ );
+        info = spdSolver_->factor();
+      }
+      else
+      {
+        dSolver_->setMatrix( A_ );
+        dSolver_->solveWithTransposeFlag( TRANS_ );
+        dSolver_->factorWithEquilibration( equilibrate_ );
+        info = dSolver_->factor();
+      }     
+
+      if (!info) 
+        newMatrix_ = false;
+      return info;
+    }
+
+    //! Computes the solution X to AX = B for the \e this matrix and the B provided.
+    /*!
+      \return Integer error code, set to 0 if successful.
+    */
+    int solve() 
+    {
+      //std::cout << "Calling DenseMatrix<Teuchos> solve!" << std::endl;
+      // Check if this is a new matrix that has not been factored.
+      if (newMatrix_)
+        factor();
+
+      int info = 0;
+
+      if (spd_)
+      {
+        spdSolver_->setVectors( X_, B_ );
+        info = spdSolver_->solve();
+      }
+      else
+      {
+        dSolver_->setVectors( X_, B_ );
+        info = dSolver_->solve();
+      }
+
+      return info;
+    }
+
+    //@}
+
+  private:
+
+    using DenseSolver<ScalarType,Teuchos::SerialDenseMatrix<int,ScalarType>>::newMatrix_;
+    using DenseSolver<ScalarType,Teuchos::SerialDenseMatrix<int,ScalarType>>::equilibrate_;
+    using DenseSolver<ScalarType,Teuchos::SerialDenseMatrix<int,ScalarType>>::TRANS_;
+    using DenseSolver<ScalarType,Teuchos::SerialDenseMatrix<int,ScalarType>>::spd_;
+
+    using DenseSolver<ScalarType,Teuchos::SerialDenseMatrix<int,ScalarType>>::A_;
+    using DenseSolver<ScalarType,Teuchos::SerialDenseMatrix<int,ScalarType>>::X_;
+    using DenseSolver<ScalarType,Teuchos::SerialDenseMatrix<int,ScalarType>>::B_;
+
+    // Pointer to dense solver for general linear systems
+    Teuchos::RCP<Teuchos::SerialDenseSolver<int,ScalarType>> dSolver_;
+
+    // Pointer to dense solver for SPD linear systems
+    Teuchos::RCP<Teuchos::SerialSymDenseMatrix<int,ScalarType>> spdMatrix_;
+    Teuchos::RCP<Teuchos::SerialSpdDenseSolver<int,ScalarType>> spdSolver_;
+
+  };
+
+
+  //! Full specialization of Belos::DenseMatTraits for Teuchos::SerialDenseMatrix<int,ST>.
+  template<class ScalarType>
+  class DenseMatTraits<ScalarType, Teuchos::SerialDenseMatrix<int,ScalarType>>{
+  public:
+    
+    //@{ \name Creation methods
+
+    /*! \brief Creates a new empty \c Teuchos::SerialDenseMatrix<int,ScalarType> with no dimension.
+
+    \return Reference-counted pointer to a new dense matrix of type \c Teuchos::SerialDenseMatrix<int,ScalarType>.
+    */
+    static Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType>> Create() { 
+      return Teuchos::rcp(new Teuchos::SerialDenseMatrix<int,ScalarType>());
+    }     
+
+    /*! \brief Creates a new empty \c Teuchos::SerialDenseMatrix<int,ScalarType> containing \c numvecs columns.
+     *         Will be initialized to zeros if last parameter is true.
+
+    \return Reference-counted pointer to a new dense matrix of type \c Teuchos::SerialDenseMatrix<int,ScalarType>.
+    */
+    static Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType>> Create( const int numrows, const int numcols, bool initZero = true) { 
+      return Teuchos::rcp(new Teuchos::SerialDenseMatrix<int,ScalarType>(numrows,numcols,initZero));
+    }     
+
+    /*! \brief Create a new copy \c Teuchos::SerialDenseMatrix<int,ScalarType>, possibly transposed.
+   
+       \return Reference-counted pointer to a new dense matrix of type \c Teuchos::SerialDenseMatrix<int,ScalarType>.
+    */
+    static Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType>> CreateCopy(const Teuchos::SerialDenseMatrix<int,ScalarType> & dm, bool transpose=false) {
+      if (transpose)    
+        return Teuchos::rcp(new Teuchos::SerialDenseMatrix<int,ScalarType>(dm, Teuchos::CONJ_TRANS));
+      else 
+        return Teuchos::rcp(new Teuchos::SerialDenseMatrix<int,ScalarType>(Teuchos::Copy, dm));
+    }
+
+    //! \brief Returns a raw pointer to the (non-const) data on the host.
+    static ScalarType* GetRawHostPtr( Teuchos::SerialDenseMatrix<int,ScalarType> & dm )
+    { return dm.values(); }     
+
+    //! \brief Returns a raw pointer to const data on the host.
+    static ScalarType const * GetConstRawHostPtr(const Teuchos::SerialDenseMatrix<int,ScalarType> & dm )  
+    { return const_cast<ScalarType const *>(dm.values()); }     
+
+    //! \brief Marks host data modified to avoid device sync errors. 
+    /// \note Belos developers must call this function after EVERY
+    ///   call to LAPACK!!!
+    //static void RawPtrDataModified(Teuchos::SerialDenseMatrix<int,ScalarType> & dm ) { }
+
+    //! \brief Returns an RCP to a DM which has a subview of the given DM.
+    //        Row and column indexing is zero-based.
+    //        Source  - Reference to another dense matrix from which values are to be copied.
+    //        numRows - The number of rows in this matrix.
+    //        numCols - The number of columns in this matrix.
+    //        startRow  - The row of Source from which the submatrix copy should start.
+    //        startCol  - The column of Source from which the submatrix copy should start.
+    //  
+    //        Should ints be const? Should they be ints or some other ordinal type?
+    static Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType>> Subview(Teuchos::SerialDenseMatrix<int,ScalarType> & source, int numRows, int numCols, int startRow=0, int startCol=0)
+    { return Teuchos::rcp(new Teuchos::SerialDenseMatrix<int,ScalarType>(Teuchos::View, source, numRows, numCols, startRow, startCol)); }    
+
+    static Teuchos::RCP<const Teuchos::SerialDenseMatrix<int,ScalarType>> SubviewConst( 
+                              const Teuchos::SerialDenseMatrix<int,ScalarType> & source, int numRows, int numCols, int startRow=0, int startCol=0)
+    { return Teuchos::rcp(new const Teuchos::SerialDenseMatrix<int,ScalarType>(Teuchos::View, source, numRows, numCols, startRow, startCol)); }    
+
+    //! \brief Returns a deep copy of the requested subview.
+    static Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType>> SubviewCopy( const Teuchos::SerialDenseMatrix<int,ScalarType>& source, int numRows, int numCols, int startRow=0, int startCol=0)
+    { return Teuchos::rcp(new Teuchos::SerialDenseMatrix<int,ScalarType>(Teuchos::Copy, source, numRows, numCols, startRow, startCol)); }    
+    //@}
+
+    //@{ \name Attribute methods
+
+    //! \brief Obtain the number of rows of \c dm.
+    static int GetNumRows( const Teuchos::SerialDenseMatrix<int,ScalarType>& dm )
+    { return dm.numRows(); }     
+
+    //! \brief Obtain the number of columns of \c dm.
+    static int GetNumCols( const Teuchos::SerialDenseMatrix<int,ScalarType>& dm )
+    { return dm.numCols(); }     
+
+    //! \brief Obtain the stride between the columns of \c dm.
+    static int GetStride( const Teuchos::SerialDenseMatrix<int,ScalarType>& dm )
+    { return dm.stride(); }    
+
+    //@}
+
+    //@{ \name Shaping methods
+
+    /* \brief Reshaping method for changing the size of \c dm to have \c numrows rows and \c numcols columns.
+     *        All values will be initialized to zero if the final argument is true. 
+     *        If the final argument is fale, the previous entries in 
+     *        the matrix will be maintained. For new entries that did not exist in the previous matrix, values will
+     *        contain noise from memory. 
+    */
+    static void Reshape( Teuchos::SerialDenseMatrix<int,ScalarType>& dm, const int numrows, const int numcols, bool initZero = false) { 
+      if(initZero){
+        int err =  dm.shape(numrows,numcols); 
+        if(err != 0){throw std::runtime_error ("Error in DenseMatrixTraits::shape. Teuchos::SerialDenseMatrix.shape failed.");}
+      }
+      else{
+        int err =  dm.reshape(numrows,numcols); 
+        if(err != 0){throw std::runtime_error ("Error in DenseMatrixTraits::reshape. Teuchos::SerialDenseMatrix.reshape failed.");}
+      }
+    }     
+
+    //@}
+
+    //@{ \name Data access methods
+
+    //! \brief Access a reference to the (i,j) entry of \c dm, \c e_i^T dm e_j.
+    static ScalarType & Value( Teuchos::SerialDenseMatrix<int,ScalarType>& dm, const int i, const int j )
+    { 
+      return dm(i,j);
+    }
+
+    //! \brief Access a const reference to the (i,j) entry of \c dm, \c e_i^T dm e_j.
+    static const ScalarType & ValueConst( const Teuchos::SerialDenseMatrix<int,ScalarType>& dm, const int i, const int j ) 
+    { 
+      return dm(i,j);
+    }
+
+    static void SyncDeviceToHost(Teuchos::SerialDenseMatrix<int,ScalarType> &){ }
+
+    static void SyncHostToDevice(Teuchos::SerialDenseMatrix<int,ScalarType> &){ }
+    //@}
+
+    //@{ \name Operator methods
+    
+    //!  \brief Adds sourceDM to thisDM and returns answer in thisDM.
+    static void Add( Teuchos::SerialDenseMatrix<int,ScalarType>& thisDM, const Teuchos::SerialDenseMatrix<int,ScalarType>& sourceDM){ 
+      thisDM += sourceDM; 
+    }
+
+    //!  \brief Fill all entries with \c value. Value is zero if not specified.
+    static void PutScalar( Teuchos::SerialDenseMatrix<int,ScalarType> & dm, ScalarType value = Teuchos::ScalarTraits<ScalarType>::zero()){ 
+      dm.putScalar(value);
+    }
+
+    //!  \brief Multiply all entries by a scalar. DM = value.*DM
+    static void Scale( Teuchos::SerialDenseMatrix<int,ScalarType>& dm, ScalarType value){
+      dm.scale(value);
+    }
+
+    //!  \brief Fill the DM with random entries.
+    //!   Entries are assumed to be the same on each MPI rank (each matrix copy). 
+    //TODO What to do here? Kinda needs random synced version??
+    static void Randomize( Teuchos::SerialDenseMatrix<int,ScalarType>& dm){ 
+      dm.random();
+    }
+
+    //!  \brief Copies entries of source to dest (deep copy). 
+    static void Assign( Teuchos::SerialDenseMatrix<int,ScalarType>& dest, const Teuchos::SerialDenseMatrix<int,ScalarType>& source){ 
+      dest.assign(source);
+    }
+
+    //!  \brief Returns the Frobenius norm of the dense matrix.
+    static typename Teuchos::ScalarTraits<ScalarType>::magnitudeType NormFrobenius(Teuchos::SerialDenseMatrix<int,ScalarType>& dm) { 
+      return dm.normFrobenius(); 
+    }
+
+    //!  \brief Returns the one-norm of the dense matrix.
+    static typename Teuchos::ScalarTraits<ScalarType>::magnitudeType NormOne( Teuchos::SerialDenseMatrix<int,ScalarType>& dm) { 
+      return dm.normOne();
+    }
+    //@}
+
+    //@{ \name Solver methods 
+    
+    //!  \brief Returns a dense solver object for the dense matrix.
+    static Teuchos::RCP<DenseSolver<ScalarType, Teuchos::SerialDenseMatrix<int,ScalarType>>> 
+      createDenseSolver() { 
+   
+      Teuchos::RCP<DenseSolver<ScalarType, Teuchos::SerialDenseMatrix<int,ScalarType>>> newSolver
+        = Teuchos::rcp( new TeuchosDenseSolver<ScalarType>() );
+      return newSolver;
+    }
+    //@}
+
+  };
+ 
+} // namespace Belos
+
+#endif // end file BELOS_TEUCHOS_DENSE_MAT_TRAITS_HPP

--- a/packages/belos/src/CMakeLists.txt
+++ b/packages/belos/src/CMakeLists.txt
@@ -35,6 +35,7 @@ APPEND_SET(HEADERS
   BelosCGIter.hpp
   BelosCGSingleRedIter.hpp
   BelosConfigDefs.hpp
+  BelosDenseMatTraits.hpp
   BelosDGKSOrthoManager.hpp
   BelosFixedPointIter.hpp
   BelosFixedPointIteration.hpp

--- a/packages/belos/test/BiCGStab/CMakeLists.txt
+++ b/packages/belos/test/BiCGStab/CMakeLists.txt
@@ -1,0 +1,23 @@
+
+
+TRIBITS_INCLUDE_DIRECTORIES(REQUIRED_DURING_INSTALLATION_TESTING ${CMAKE_CURRENT_SOURCE_DIR}/../MVOPTester)
+
+ASSERT_DEFINED(Teuchos_ENABLE_COMPLEX)
+IF(Teuchos_ENABLE_COMPLEX)
+
+  TRIBITS_INCLUDE_DIRECTORIES(../MVOPTester)
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    bicgstab_complex_hb
+    SOURCES test_bicgstab_complex_hb.cpp 
+    ARGS
+      "--verbose --filename=mhd1280b.cua"
+    )
+
+  TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyTestBiCGStabComplexFiles
+    SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
+    SOURCE_FILES mhd1280b.cua
+    EXEDEPS bicgstab_complex_hb
+  )
+
+ENDIF(Teuchos_ENABLE_COMPLEX)

--- a/packages/belos/test/BiCGStab/test_bicgstab_complex_hb.cpp
+++ b/packages/belos/test/BiCGStab/test_bicgstab_complex_hb.cpp
@@ -1,0 +1,202 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side from the HB file is used instead of random vectors.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosBiCGStabSolMgr.hpp"
+#include "Teuchos_CommandLineProcessor.hpp"
+#include "Teuchos_ParameterList.hpp"
+#include "Teuchos_StandardCatchMacros.hpp"
+#include "Tpetra_Util_iohb.h"
+
+#ifdef HAVE_MPI
+#include <mpi.h>
+#endif
+
+#include "MyMultiVec.hpp"
+#include "MyBetterOperator.hpp"
+#include "MyOperator.hpp"
+
+using namespace Teuchos;
+
+int main(int argc, char *argv[]) {
+  //
+  typedef std::complex<double>              ST;
+  typedef ScalarTraits<ST>                 SCT;
+  typedef SCT::magnitudeType                MT;
+  typedef Belos::MultiVec<ST>               MV;
+  typedef Belos::Operator<ST>               OP;
+  typedef Belos::MultiVecTraits<ST,MV>     MVT;
+  typedef Belos::OperatorTraits<ST,MV,OP>  OPT;
+  ST one  = SCT::one();
+  ST zero = SCT::zero();
+
+  int info = 0;
+  int MyPID = 0;
+  bool norm_failure = false;
+
+  Teuchos::GlobalMPISession session(&argc, &argv, NULL);
+  //
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+bool success = false;
+bool verbose = false;
+try {
+bool proc_verbose = false;
+  int frequency = -1;  // how often residuals are printed by solver
+  int blocksize = 1;
+  int numrhs = 1;
+  std::string filename("mhd1280b.cua");
+  MT tol = 1.0e-5;  // relative residual tolerance
+
+  CommandLineProcessor cmdp(false,true);
+  cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+  cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+  cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+  cmdp.setOption("tol",&tol,"Relative residual tolerance used by BiCGStab solver.");
+  cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+  if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
+    return -1;
+  }
+
+  proc_verbose = verbose && (MyPID==0);  /* Only print on the zero processor */
+  if (proc_verbose) {
+    std::cout << Belos::Belos_Version() << std::endl << std::endl;
+  }
+  if (!verbose)
+    frequency = -1;  // reset frequency if test is not verbose
+
+  // Get the data from the HB file
+  int dim,dim2,nnz;
+  MT *dvals;
+  int *colptr,*rowind;
+  ST *cvals;
+  nnz = -1;
+  info = Tpetra::HB::readHB_newmat_double(filename.c_str(),&dim,&dim2,&nnz,
+        &colptr,&rowind,&dvals);
+  if (info == 0 || nnz < 0) {
+    if (MyPID==0) {
+      std::cout << "Error reading '" << filename << "'" << std::endl;
+      std::cout << "End Result: TEST FAILED" << std::endl;
+    }
+    return -1;
+  }
+  // Convert interleaved doubles to std::complex values
+  cvals = new ST[nnz];
+  for (int ii=0; ii<nnz; ii++) {
+    cvals[ii] = ST(dvals[ii*2],dvals[ii*2+1]);
+  }
+  // Build the problem matrix
+  RCP< MyBetterOperator<ST> > A
+    = rcp( new MyBetterOperator<ST>(dim,colptr,nnz,rowind,cvals) );
+  //
+  // ********Other information used by block solver***********
+  // *****************(can be user specified)******************
+  //
+  int maxits = dim/blocksize; // maximum number of iterations to run
+  //
+  ParameterList belosList;
+  belosList.set( "Maximum Iterations", maxits );         // Maximum number of iterations allowed
+  belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+  if (verbose) {
+    belosList.set( "Verbosity", Belos::Errors + Belos::Warnings +
+		   Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails );
+    if (frequency > 0)
+      belosList.set( "Output Frequency", frequency );
+  }
+  else
+    belosList.set( "Verbosity", Belos::Errors + Belos::Warnings );
+  //
+  // Construct the right-hand side and solution multivectors.
+  // NOTE:  The right-hand side will be constructed such that the solution is
+  // a vectors of one.
+  //
+  RCP<MyMultiVec<ST> > soln = rcp( new MyMultiVec<ST>(dim,numrhs) );
+  RCP<MyMultiVec<ST> > rhs = rcp( new MyMultiVec<ST>(dim,numrhs) );
+  MVT::MvRandom( *soln );
+  OPT::Apply( *A, *soln, *rhs );
+  MVT::MvInit( *soln, zero );
+  //
+  //  Construct an unpreconditioned linear problem instance.
+  //
+  RCP<Belos::LinearProblem<ST,MV,OP> > problem =
+    rcp( new Belos::LinearProblem<ST,MV,OP>( A, soln, rhs ) );
+  bool set = problem->setProblem();
+  if (set == false) {
+    if (proc_verbose)
+      std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+    return -1;
+  }
+  //
+  // *******************************************************************
+  // *************Start the BiCGStab iteration***********************
+  // *******************************************************************
+  //
+  Belos::BiCGStabSolMgr<ST,MV,OP> solver( problem, rcp(&belosList,false) );
+
+  //
+  // **********Print out information about problem*******************
+  //
+  if (proc_verbose) {
+    std::cout << std::endl << std::endl;
+    std::cout << "Dimension of matrix: " << dim << std::endl;
+    std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+    std::cout << "Block size used by solver: " << blocksize << std::endl;
+    std::cout << "Max number of BiCGStab iterations: " << maxits << std::endl;
+    std::cout << "Relative residual tolerance: " << tol << std::endl;
+    std::cout << std::endl;
+  }
+  //
+  // Perform solve
+  //
+  Belos::ReturnType ret = solver.solve();
+  //
+  // Compute actual residuals.
+  //
+  RCP<MyMultiVec<ST> > temp = rcp( new MyMultiVec<ST>(dim,numrhs) );
+  OPT::Apply( *A, *soln, *temp );
+  MVT::MvAddMv( one, *rhs, -one, *temp, *temp );
+  std::vector<MT> norm_num(numrhs), norm_denom(numrhs);
+  MVT::MvNorm( *temp, norm_num );
+  MVT::MvNorm( *rhs, norm_denom );
+  for (int i=0; i<numrhs; ++i) {
+    if (proc_verbose)
+      std::cout << "Relative residual "<<i<<" : " << norm_num[i] / norm_denom[i] << std::endl;
+    if ( norm_num[i] / norm_denom[i] > tol ) {
+      norm_failure = true;
+    }
+  }
+
+  // Clean up.
+  delete [] dvals;
+  delete [] colptr;
+  delete [] rowind;
+  delete [] cvals;
+
+success = ret==Belos::Converged && !norm_failure;
+
+if (success) {
+  if (proc_verbose)
+    std::cout << "End Result: TEST PASSED" << std::endl;
+} else {
+if (proc_verbose)
+  std::cout << "End Result: TEST FAILED" << std::endl;
+}
+}
+TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
+} // end test_minres_complex_hb.cpp

--- a/packages/belos/test/BlockCG/CMakeLists.txt
+++ b/packages/belos/test/BlockCG/CMakeLists.txt
@@ -14,16 +14,13 @@ IF(Teuchos_ENABLE_COMPLEX)
     "--verbose --filename=mhd1280b.cua"
     "--verbose --filename=mhd1280b.cua --pseudo"
     "--verbose --filename=mhd1280b.cua --use-single-red"
-    XHOST KALLIKRATES
   )
 
-  IF(NOT ${${PROJECT_NAME}_HOSTNAME} STREQUAL "KALLIKRATES")
-    TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyTestBlockCGComplexFiles
-      SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
-      SOURCE_FILES mhd1280b.cua
-      EXEDEPS bl_cg_complex_hb
-    )
-  ENDIF()
+  TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyTestBlockCGComplexFiles
+    SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
+    SOURCE_FILES mhd1280b.cua
+    EXEDEPS bl_cg_complex_hb
+  )
 
 ENDIF(Teuchos_ENABLE_COMPLEX)
 

--- a/packages/belos/test/BlockGmres/CMakeLists.txt
+++ b/packages/belos/test/BlockGmres/CMakeLists.txt
@@ -16,7 +16,6 @@ IF(Teuchos_ENABLE_COMPLEX)
       "--verbose --ortho-type=ICGS"
       "--verbose --ortho-type=IMGS"
     STANDARD_PASS_OUTPUT
-    XHOST KALLIKRATES
     )
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
@@ -29,7 +28,6 @@ IF(Teuchos_ENABLE_COMPLEX)
       "--verbose --filename=mhd1280b.cua --pseudo"
       "--verbose --filename=mhd1280a.cua --subspace-length=200 --tol=1e-4"
     STANDARD_PASS_OUTPUT
-    XHOST KALLIKRATES
     )
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
@@ -40,15 +38,12 @@ IF(Teuchos_ENABLE_COMPLEX)
       "--verbose --filename=mhd1280b.cua --max-degree=10"
       "--verbose --filename=mhd1280b.cua --max-degree=10 --poly-type=Roots"
     STANDARD_PASS_OUTPUT
-    XHOST KALLIKRATES
     )
 
-  IF(NOT ${${PROJECT_NAME}_HOSTNAME} STREQUAL "KALLIKRATES")
-    TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyTestBlockGmresComplexFiles
-      SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
-      SOURCE_FILES mhd1280b.cua mhd1280a.cua cg05.cua
-      EXEDEPS bl_gmres_complex_hb
-    )
-  ENDIF()
+  TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyTestBlockGmresComplexFiles
+    SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
+    SOURCE_FILES mhd1280b.cua mhd1280a.cua cg05.cua
+    EXEDEPS bl_gmres_complex_hb
+  )
 
 ENDIF(Teuchos_ENABLE_COMPLEX)

--- a/packages/belos/test/CMakeLists.txt
+++ b/packages/belos/test/CMakeLists.txt
@@ -7,7 +7,8 @@ ADD_SUBDIRECTORY(GCRODR)
 # mfh 10 Jan 2013: MINRES test is taking a long time and causing test timeouts.
 # It's not obviously broken, so I'm disabling the test for now until we can find
 # a different test problem that doesn't take so long.
-#ADD_SUBDIRECTORY(MINRES)
+ADD_SUBDIRECTORY(MINRES)
+ADD_SUBDIRECTORY(BiCGStab)
 ADD_SUBDIRECTORY(MVOPTester)
 
 IF(${PACKAGE_NAME}_ENABLE_Experimental)

--- a/packages/belos/test/GCRODR/test_gcrodr_complex_hb.cpp
+++ b/packages/belos/test/GCRODR/test_gcrodr_complex_hb.cpp
@@ -55,6 +55,7 @@ int main(int argc, char *argv[]) {
 
   bool success = false;
   bool verbose = false;
+  bool debug = false;
   try {
     bool proc_verbose = false;
     int frequency = -1;  // how often residuals are printed by solver
@@ -65,6 +66,7 @@ int main(int argc, char *argv[]) {
 
     CommandLineProcessor cmdp(false,true);
     cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+    cmdp.setOption("debug","no-debug",&debug,"Print debug messages.");
     cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
     cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
     cmdp.setOption("tol",&tol,"Relative residual tolerance used by GCRODR solver.");
@@ -112,9 +114,20 @@ int main(int argc, char *argv[]) {
     ParameterList belosList;
     belosList.set( "Maximum Iterations", maxits );         // Maximum number of iterations allowed
     belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
-    belosList.set( "Verbosity", Belos::Errors + Belos::Warnings + Belos::StatusTestDetails + Belos::TimingDetails);
     belosList.set( "Num Blocks", numBlocks );
     belosList.set( "Num Recycled Blocks", numRecycledBlocks );
+    if (verbose) {
+      int verbosity = Belos::Errors + Belos::Warnings +
+          Belos::TimingDetails + Belos::StatusTestDetails;
+      if (debug)
+        verbosity += Belos::OrthoDetails + Belos::Debug;
+      belosList.set( "Verbosity", verbosity );
+      if (frequency > 0)
+        belosList.set( "Output Frequency", frequency );
+    }
+    else
+      belosList.set( "Verbosity", Belos::Errors + Belos::Warnings );
+
     // Construct the right-hand side and solution multivectors.
     // NOTE:  The right-hand side will be constructed such that the solution is
     // a vectors of one.

--- a/packages/belos/test/MINRES/CMakeLists.txt
+++ b/packages/belos/test/MINRES/CMakeLists.txt
@@ -14,7 +14,7 @@ IF(Teuchos_ENABLE_COMPLEX)
         "--verbose --filename=mhd1280b.cua"
       )
 
-    TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyTestBlockCGComplexFiles
+    TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyTestMinresComplexFiles
       SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
       SOURCE_FILES mhd1280b.cua 
       EXEDEPS minres_complex_hb

--- a/packages/belos/test/MINRES/test_minres_complex_hb.cpp
+++ b/packages/belos/test/MINRES/test_minres_complex_hb.cpp
@@ -18,6 +18,7 @@
 #include "BelosMinresSolMgr.hpp"
 #include "Teuchos_CommandLineProcessor.hpp"
 #include "Teuchos_ParameterList.hpp"
+#include "Teuchos_StandardCatchMacros.hpp"
 
 #ifdef HAVE_MPI
 #include <mpi.h>

--- a/packages/belos/test/MVOPTester/CMakeLists.txt
+++ b/packages/belos/test/MVOPTester/CMakeLists.txt
@@ -19,3 +19,11 @@ IF(Teuchos_ENABLE_COMPLEX)
     )
 
 ENDIF(Teuchos_ENABLE_COMPLEX)
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  TeuchosSDMTester
+  SOURCES cxx_main_dense.cpp
+  ARGS "-v"
+  COMM serial 
+  STANDARD_PASS_OUTPUT
+)

--- a/packages/belos/test/MVOPTester/cxx_main_complex.cpp
+++ b/packages/belos/test/MVOPTester/cxx_main_complex.cpp
@@ -27,6 +27,7 @@
 #include "MyMultiVec.hpp"
 #include "MyOperator.hpp"
 #include "MyBetterOperator.hpp"
+#include "BelosTeuchosDenseAdapter.hpp"
 
 using namespace Teuchos;
 
@@ -73,7 +74,7 @@ int main(int argc, char *argv[])
     typedef Belos::MultiVec<ST> MV;
     typedef Belos::Operator<ST> OP;
     typedef Belos::MultiVecTraits<ST,MV> MVT;
-    //typedef Belos::OperatorTraits<ST,MV,OP> OPT;
+    typedef Teuchos::SerialDenseMatrix<int,ST> TDM;
 
     // Create an output manager to handle the I/O from the solver
     RCP<Belos::OutputManager<ST> > MyOM
@@ -117,7 +118,7 @@ int main(int argc, char *argv[])
     RCP<MyOperator<ST> > A2 = rcp( new MyOperator<ST>(dim) );
 
     // test the multivector and its adapter
-    ierr = Belos::TestMultiVecTraits<ST,MV>(MyOM,ivec);
+    ierr = Belos::TestMultiVecTraits<ST,MV,TDM>(MyOM,ivec);
     gerr &= ierr;
     if (ierr) {
       MyOM->print(Belos::Warnings, "*** MyMultiVec<std::complex> PASSED TestMultiVecTraits()\n");

--- a/packages/belos/test/MVOPTester/cxx_main_dense.cpp
+++ b/packages/belos/test/MVOPTester/cxx_main_dense.cpp
@@ -1,0 +1,537 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+#include "BelosDenseMatTraits.hpp"
+#include "BelosTeuchosDenseAdapter.hpp"
+#include "BelosDenseMatTester.hpp"
+#include "BelosOutputManager.hpp"
+
+#include "Teuchos_SerialDenseMatrix.hpp"
+#include "Teuchos_SerialDenseVector.hpp"
+#include "Teuchos_Version.hpp"
+#include "Teuchos_RCP.hpp"
+
+#include "Teuchos_StandardCatchMacros.hpp"
+
+#define OTYPE int
+
+#if defined(HAVE_TEUCHOS_COMPLEX)
+#define STYPE std::complex<double>
+#else
+#define STYPE double
+#endif
+
+template<typename TYPE>
+int PrintTestResults(std::string, Teuchos::RCP<TYPE>, Teuchos::RCP<TYPE>, bool);
+
+template<typename TYPE>
+int PrintTestResults2(std::string, TYPE, TYPE, bool);
+
+int main(int argc, char* argv[])
+{
+  typedef Teuchos::SerialDenseMatrix<int, STYPE> DMatrix;
+  typedef Belos::DenseMatTraits<STYPE, Teuchos::SerialDenseMatrix<int,STYPE> > DMT;
+
+  int i;
+  bool verbose = 0;
+  if (argc>1) if (argv[1][0]=='-' && argv[1][1]=='v') verbose = true;
+
+  if (verbose)
+    std::cout << Teuchos::Teuchos_Version() << std::endl << std::endl;
+
+  bool success = true;
+  try {
+    bool ierr=false;
+    int numberFailedTests = 0;
+    std::string testName = "";
+    STYPE zero = Teuchos::ScalarTraits<STYPE>::zero();
+    STYPE one = Teuchos::ScalarTraits<STYPE>::one();
+
+    // Create an output manager to handle the I/O from the solver
+    Teuchos::RCP<Belos::OutputManager<double> > MyOM = Teuchos::rcp( new Belos::OutputManager<double>() );
+    Teuchos::RCP<Belos::OutputManager<float> > MyOMFloat = Teuchos::rcp( new Belos::OutputManager<float>() );
+#if defined(HAVE_TEUCHOS_COMPLEX)
+    Teuchos::RCP<Belos::OutputManager<std::complex<double>> > MyOMCplxDouble = Teuchos::rcp( new Belos::OutputManager<std::complex<double>>() );
+    Teuchos::RCP<Belos::OutputManager<std::complex<float>> > MyOMCplxFloat = Teuchos::rcp( new Belos::OutputManager<std::complex<float>>() );
+#endif
+    if (verbose) {
+      MyOM->setVerbosity( Belos::Warnings );
+      MyOMFloat->setVerbosity( Belos::Warnings );
+#if defined(HAVE_TEUCHOS_COMPLEX)
+      MyOMCplxDouble->setVerbosity( Belos::Warnings );
+      MyOMCplxFloat->setVerbosity( Belos::Warnings );
+#endif
+    }
+
+    //*********************************************************************
+    // Teuchos SerialDense MatrixTraits impl testing.
+    //*********************************************************************
+    ierr = Belos::TestDenseMatTraits<double,Teuchos::SerialDenseMatrix<int,double>>(MyOM);
+    if (ierr) {
+      MyOM->print(Belos::Warnings,"*** TeuchosAdapter PASSED TestDenseMatTraits() scalar double \n");
+    }
+    else {
+      MyOM->print(Belos::Warnings,"*** TeuchosAdapter FAILED TestDenseMatTraits() scalar double ***\n\n");
+      numberFailedTests++;
+    }
+
+    //*********************************************************************
+    // Teuchos SerialDense MatrixTraits impl testing.
+    //*********************************************************************
+    ierr = Belos::TestDenseMatTraits<float,Teuchos::SerialDenseMatrix<int,float>>(MyOMFloat);
+    if (ierr) {
+      MyOMFloat->print(Belos::Warnings,"*** TeuchosAdapter PASSED TestDenseMatTraits() scalar float \n");
+    }
+    else {
+      MyOMFloat->print(Belos::Warnings,"*** TeuchosAdapter FAILED TestDenseMatTraits() scalar float ***\n\n");
+      numberFailedTests++;
+    }
+
+#if defined(HAVE_TEUCHOS_COMPLEX)
+    //*********************************************************************
+    // Teuchos SerialDense MatrixTraits impl testing.
+    //*********************************************************************
+    ierr = Belos::TestDenseMatTraits<std::complex<double>,Teuchos::SerialDenseMatrix<int,std::complex<double>>>(MyOMCplxDouble);
+    if (ierr) {
+      MyOMCplxDouble->print(Belos::Warnings,"*** TeuchosAdapter PASSED TestDenseMatTraits() scalar complex double \n");
+    }
+    else {
+      MyOMCplxDouble->print(Belos::Warnings,"*** TeuchosAdapter FAILED TestDenseMatTraits() scalar complex double ***\n\n");
+      numberFailedTests++;
+    }
+
+    //*********************************************************************
+    // Teuchos SerialDense MatrixTraits impl testing.
+    //*********************************************************************
+    ierr = Belos::TestDenseMatTraits<std::complex<float>,Teuchos::SerialDenseMatrix<int,std::complex<float>>>(MyOMCplxFloat);
+    if (ierr) {
+      MyOMCplxFloat->print(Belos::Warnings,"*** TeuchosAdapter PASSED TestDenseMatTraits() complex float\n");
+    }
+    else {
+      MyOMCplxFloat->print(Belos::Warnings,"*** TeuchosAdapter FAILED TestDenseMatTraits() complex float ***\n\n");
+      numberFailedTests++;
+    }
+#endif
+
+    if (verbose) std::cout<<std::endl<<"********** CHECKING TEUCHOS SERIAL DENSE MATRIX **********"<<std::endl<<std::endl;
+
+    // default constructor test
+    Teuchos::RCP<DMatrix> DefConTest = DMT::Create();
+    if (verbose) std::cout <<"default constructor -- construct empty matrix ";
+    if ( DMT::GetRawHostPtr( *DefConTest )!=NULL || DMT::GetNumRows(*DefConTest)!=0 || DMT::GetNumCols(*DefConTest)!=0 || DMT::GetStride(*DefConTest)!=0 ) {
+	if (verbose) std::cout << "[ unsuccessful ]"<<std::endl;
+	numberFailedTests++;
+    } else {
+	if (verbose) std::cout << "[ successful ]"<<std::endl;
+    }
+
+    // constructor 1 (matrix w/ dimension but empty)
+
+    Teuchos::RCP<DMatrix> Con1Test = DMT::Create( 3, 4 );
+    if (verbose) std::cout <<"constructor 1 -- empty matrix with given dimensions ";
+    if ( DMT::GetNumRows(*Con1Test)!=3 || DMT::GetNumCols(*Con1Test)!=4 || DMT::Value(*Con1Test, 1, 2 )!=zero || DMT::ValueConst(*Con1Test, 1, 2 )!=zero ) {
+	if (verbose) std::cout << "[ unsuccessful ]"<<std::endl;
+        numberFailedTests++;
+    } else {
+        if (verbose) std::cout << "[ successful ]"<<std::endl;
+    }
+	
+    // constructor 2 (from array) tests
+
+    Teuchos::RCP<DMatrix> A33 = DMT::Create(3, 3);
+    STYPE* A33data = DMT::GetRawHostPtr(*A33);
+    for(i = 0; i < 9; i++)
+    {
+      A33data[i] = i;
+    }
+    DMT::SyncHostToDevice(*A33);
+
+    Teuchos::RCP<DMatrix> Con2Test1ExpRes = DMT::Create();
+    DMT::Reshape(*Con2Test1ExpRes, 2, 3);
+    DMT::Value(*Con2Test1ExpRes, 0, 0) = 0;  
+    DMT::Value(*Con2Test1ExpRes, 0, 1) = 3; 
+    DMT::Value(*Con2Test1ExpRes, 0, 2) = 6;
+    DMT::Value(*Con2Test1ExpRes, 1, 0) = 1;  
+    DMT::Value(*Con2Test1ExpRes, 1, 1) = 4; 
+    DMT::Value(*Con2Test1ExpRes, 1, 2) = 7;
+    DMT::SyncHostToDevice(*Con2Test1ExpRes);
+
+    Teuchos::RCP<DMatrix> Con2Test1 = DMT::SubviewCopy(*A33, 2, 3);
+    numberFailedTests += PrintTestResults("constructor 2 -- construct matrix from array subrange", Con2Test1, Con2Test1ExpRes, verbose);
+
+    // constructor 3 (submatrix)
+
+    Teuchos::RCP<DMatrix> Con4TestOrig = DMT::SubviewCopy(*A33, 3, 3);
+    Teuchos::RCP<DMatrix> Con4TestSubmatrix = DMT::Create(2, 2);
+    DMT::Value(*Con4TestSubmatrix, 0, 0) = 4;
+    DMT::Value(*Con4TestSubmatrix, 0, 1) = 7;
+    DMT::Value(*Con4TestSubmatrix, 1, 0) = 5;
+    DMT::Value(*Con4TestSubmatrix, 1, 1) = 8;
+    DMT::SyncHostToDevice(*Con4TestSubmatrix);
+    Teuchos::RCP<DMatrix> Con4TestCopy1 = DMT::SubviewCopy(*Con4TestOrig, 2, 2, 1, 1);
+    numberFailedTests += PrintTestResults("constructor 4 -- submatrix copy", Con4TestCopy1, Con4TestSubmatrix, verbose);
+    Teuchos::RCP<DMatrix> Con4TestCopy2 = DMT::SubviewCopy(*Con4TestOrig, 3, 3, 0, 0);
+    numberFailedTests += PrintTestResults("constructor 4 -- full matrix copy", Con4TestCopy2, Con4TestOrig, verbose);
+    Teuchos::RCP<DMatrix> Con4TestView1 = DMT::Subview(*Con4TestOrig, 2, 2, 1, 1);
+    numberFailedTests += PrintTestResults("constructor 4 -- full matrix view", Con4TestView1, Con4TestSubmatrix, verbose);
+    Teuchos::RCP<DMatrix> Con4TestView2 = DMT::Subview(*Con4TestOrig, 3, 3, 0, 0);
+    numberFailedTests += PrintTestResults("constructor 4 -- submatrix view", Con4TestView2, Con4TestOrig, verbose);
+
+    // Norm Tests
+
+    Teuchos::RCP<DMatrix> AAA = DMT::Create(3, 3);
+    DMT::Value(*AAA, 0, 0) = 1; 
+    DMT::Value(*AAA, 0, 1) = 2; 
+    DMT::Value(*AAA, 0, 2) = 3;
+    DMT::Value(*AAA, 1, 0) = 4; 
+    DMT::Value(*AAA, 1, 1) = 5; 
+    DMT::Value(*AAA, 1, 2) = 6;
+    DMT::Value(*AAA, 2, 0) = 7; 
+    DMT::Value(*AAA, 2, 1) = 8; 
+    DMT::Value(*AAA, 2, 2) = 9;
+    DMT::SyncHostToDevice(*AAA);
+
+    Teuchos::RCP<DMatrix> BBB = DMT::Create();
+    numberFailedTests += PrintTestResults2("normOne of a 3x3", DMT::NormOne(*AAA), 18.0, verbose);
+    DMT::PutScalar(*AAA, one);
+    numberFailedTests += PrintTestResults2("normOne of a 3x3 (ones)", DMT::NormOne(*AAA), 3.0, verbose);
+    numberFailedTests += PrintTestResults2("normFrobenius of a 3x3", DMT::NormFrobenius(*AAA), 3.0, verbose);
+    numberFailedTests += PrintTestResults2("normOne of a 0x0", DMT::NormOne(*BBB), 0.0, verbose);
+    numberFailedTests += PrintTestResults2("normFrobenius of a 0x0", DMT::NormFrobenius(*BBB), 0.0, verbose);
+
+    //  Check scale methods.
+  
+    Teuchos::RCP<DMatrix> ScalTest = DMT::Create( 8, 8 );
+    DMT::PutScalar(*ScalTest, one);
+
+    //  Scale the entries by 8, it should be 8.
+    if (verbose) std::cout << "scale() -- scale matrix by some number ";
+    DMT::Scale(*ScalTest, 8.0);
+    if (DMT::Value(*ScalTest, 2, 3) == 8.0) {
+	if (verbose) std::cout<< "[ successful ]" <<std::endl;
+    } else {
+	if (verbose) std::cout<< "[ unsuccessful ]" <<std::endl;
+	numberFailedTests++;
+    }
+    //  Pointwise scale the entries by zero, they all should be zero.
+    if (verbose) std::cout << "scale() -- scale matrix by zero ";
+    DMT::Scale(*ScalTest, zero);
+    if (DMT::NormOne(*ScalTest) == 0.0) {
+	if (verbose) std::cout<< "[ successful ]" <<std::endl;
+    } else {
+	if (verbose) std::cout<< "[ unsuccessful ]" <<std::endl;
+	numberFailedTests++;
+    }
+    //
+    //  Check set methods.
+    //
+    Teuchos::RCP<DMatrix> CCC = DMT::Create( 5, 5 );
+    //  Randomize the entries in CCC.
+    if (verbose) std::cout << "random() -- enter random entries into matrix ";
+    DMT::Randomize(*CCC);
+    if (DMT::NormOne(*CCC) != 0.0) {
+	if (verbose) std::cout<< "[ successful ]" <<std::endl;
+    } else {
+	if (verbose) std::cout<< "[ unsuccessful ]" <<std::endl;
+	numberFailedTests++;
+    }
+    //  Set the entries of CCC to 1.0.
+    if (verbose) std::cout << "putScalar() -- set every entry of this matrix to 1.0 ";
+    DMT::PutScalar(*CCC, one);
+    if ( DMT::Value(*CCC, 3, 4) == one ) {
+      if (verbose) std::cout<< "[ successful ]" <<std::endl;
+    } else {
+      if (verbose) std::cout<< "[ unsuccessful ]" <<std::endl;
+      numberFailedTests++;
+    }
+    //  Check assignment operator.
+    Teuchos::RCP<DMatrix> CCC2 = DMT::Create( 5, 5 );
+    DMT::Assign(*CCC2, *CCC);
+    if (verbose) std::cout <<  "assign() -- copy the values of an input matrix ";
+    if ( DMT::Value(*CCC2, 3, 4) == one ) {
+      if (verbose) std::cout<< "[ successful ]" <<std::endl;
+    } else {
+      if (verbose) std::cout<< "[ unsuccessful ]" <<std::endl;
+      numberFailedTests++;
+    }
+    //  Create a view into a submatrix of CCC, add them together
+    Teuchos::RCP<DMatrix> CCCview = DMT::Subview( *CCC, 3, 3 );
+    Teuchos::RCP<DMatrix> CCCview2 = DMT::Subview( *CCC, 3, 3, 1, 1 );
+
+    if (verbose) std::cout << "view copy large(orig) -> small(view) ";
+    if (DMT::GetNumRows(*CCCview)==3 && (DMT::GetRawHostPtr(*CCCview)==DMT::GetRawHostPtr(*CCC))) {
+      if (verbose) std::cout<< "[ successful ]" <<std::endl;
+    } else {
+      if (verbose) std::cout<< "[ unsuccessful ]" <<std::endl;
+      numberFailedTests++;
+    }
+    if (verbose) std::cout << "view copy addition ";
+    STYPE sum = DMT::Value(*CCCview, 2, 2) + DMT::Value(*CCCview2, 2, 2);
+    DMT::Add(*CCCview, *CCCview2);
+    if ((DMT::Value(*CCCview, 2, 2) == DMT::Value(*CCC, 2, 2)) && (DMT::Value(*CCC, 2, 2) == sum)) {
+      if (verbose) std::cout<< "[ successful ]"<<std::endl;
+    } else {
+      if (verbose) std::cout<< "[ unsuccessful ]"<<std::endl;
+      numberFailedTests++;
+    }
+
+/*  Commenting out here!
+  DMatrix CCCtest2( 2, 2 );
+  CCCtest2 = 3.0;
+  CCCtest1 = CCCtest2;
+  if (verbose) std::cout << "operator= -- large(copy) = small(copy) ";
+  if (CCCtest1.numRows()==2 ) {
+    if (verbose) std::cout<< "[ successful ]"<<std::endl;
+  } else {
+    if (verbose) std::cout<< "[ unsuccessful ]"<<std::endl;
+    numberFailedTests++;
+  }
+  CCCtest1 = CCCview;
+  if (verbose) std::cout << "operator= -- large(copy) = small(view) ";
+  if (CCCtest1.numRows()==3 && CCCtest1.stride()==5) {
+    if(verbose) std::cout<<"[ successful ]" <<std::endl;
+  } else {
+    if (verbose) std::cout<<"[ unsuccessful ]"<<std::endl;
+    numberFailedTests++;
+  }
+
+  DMatrix CCCtest3( CCCview );
+  CCCtest1 += CCCtest3;
+  if (verbose) std::cout << "operator+= -- add two matrices of the same size, but different leading dimension ";
+  if (CCCtest1(1,1)==2.0) {
+    if(verbose) std::cout<<"[ successful ]" <<std::endl;
+  } else {
+    if (verbose) std::cout<<"[ unsuccessful ]"<<std::endl;
+    numberFailedTests++;
+  }
+  if (verbose) std::cout << "operator+= -- add two matrices of different size (nothing should change) ";
+  CCCtest1 += CCC;
+  if (CCCtest1(1,1)==2.0) {
+    if(verbose) std::cout<<"[ successful ]" <<std::endl;
+  } else {
+    if (verbose) std::cout<<"[ unsuccessful ]"<<std::endl;
+    numberFailedTests++;
+  }
+
+  if (verbose) std::cout<<std::endl<<"********** CHECKING TEUCHOS SERIAL DENSE VECTOR **********"<<std::endl<<std::endl;
+
+  DVector DefConTestV;
+  if (verbose) std::cout <<"default constructor -- construct empty std::vector ";
+  if ( DefConTestV.values()!=NULL || DefConTestV.length()!=0 || DefConTestV.numRows()!=0 ||DefConTestV.stride()!=0 ) {
+        if (verbose) std::cout << "[ unsuccessful ]"<<std::endl;
+        numberFailedTests++;
+  } else {
+        if (verbose) std::cout << "[ successful ]"<<std::endl;
+  }
+
+  // constructor 1 (matrix w/ dimension but empty)
+
+  DVector Con1TestV( 3 );
+  if (verbose) std::cout <<"constructor 1 -- empty std::vector with given dimensions ";
+  if ( Con1TestV.length()!=3 || Con1TestV.numCols()!=1 || Con1TestV( 1 )!=0.0 ) {
+	if (verbose) std::cout << "[ unsuccessful ]"<<std::endl;
+        numberFailedTests++;
+  } else {
+      	if (verbose) std::cout << "[ successful ]"<<std::endl;
+  }
+	
+  // constructor 2 (from array) tests
+
+  DVector Con2Test1V(Teuchos::Copy, a, 4);
+  if (verbose) std::cout <<"constructor 2 -- construct std::vector from array subrange ";
+  if ( Con2Test1V.numRows()!=4 || Con2Test1V.numCols()!=1 || Con2Test1V[ 2 ]!=2.0 ) {
+        if (verbose) std::cout << "[ unsuccessful ]"<<std::endl;
+        numberFailedTests++;
+  } else {
+        if (verbose) std::cout << "[ successful ]"<<std::endl;
+  }
+
+  // constructor 3 (copy constructor)
+
+  DVector Con3TestCopyV( Con2Test1V );
+  if(verbose) std::cout <<"constructor 3 -- copy constructor ";
+  if ( Con3TestCopyV != Con2Test1V ) {
+        if (verbose) std::cout << "[ unsuccessful ]"<<std::endl;
+        numberFailedTests++;
+  } else {
+        if (verbose) std::cout << "[ successful ]"<<std::endl;
+  }
+
+  // non-member helper function (construct vector view of matrix column)
+
+  OTYPE col = Teuchos::OrdinalTraits<OTYPE>::one();
+  DVector ColViewTestV = Teuchos::getCol<OTYPE,STYPE>( Teuchos::View, AAA, col );
+  if (verbose) std::cout <<"non-method helper function -- construct vector view of second column of matrix ";
+  if ( ColViewTestV.normInf() != 1.0 || ColViewTestV.normOne() != 3.0 ) {
+        if (verbose) std::cout << "[ unsuccessful ]"<<std::endl;
+        numberFailedTests++;
+  } else {
+        if (verbose) std::cout << "[ successful ]"<<std::endl;
+  }
+
+  // checking norms
+
+  numberFailedTests += PrintTestResults("normOne of a 3x1 std::vector", Con2Test1V.normOne(), 6.0, verbose);
+  numberFailedTests += PrintTestResults("normInf of a 3x1 std::vector", Con2Test1V.normInf(), 3.0, verbose);
+  Con2Test1V = Teuchos::ScalarTraits<STYPE>::one();
+  numberFailedTests += PrintTestResults("normFrobenius of a 3x1 std::vector", Con2Test1V.normFrobenius(), 2.0, verbose);
+
+  // check size/resize
+
+  DVector SizeTestV1;
+  SizeTestV1.size( 5 );
+  if(verbose) std::cout <<"size() -- test ";
+  if (SizeTestV1( 4 )!= 0.0) {
+    if (verbose) std::cout << "[ unsuccessful ]"<<std::endl;
+    numberFailedTests++;
+  } else {
+    if (verbose) std::cout << "[ successful ]"<<std::endl;
+  }
+  SizeTestV1 = 2.0*Teuchos::ScalarTraits<STYPE>::one();
+  SizeTestV1.resize( 10 );
+  if(verbose) std::cout <<"resize() -- test small --> large ";
+  if (SizeTestV1[ 4 ]!= 2.0 || SizeTestV1[ 8 ]!=0.0 ) {
+    if (verbose) std::cout << "[ unsuccessful ]"<<std::endl;
+    numberFailedTests++;
+  } else {
+    if (verbose) std::cout << "[ successful ]"<<std::endl;
+  }
+  SizeTestV1.resize( 3 );
+  if(verbose) std::cout <<"resize() -- test large --> small ";
+  if (SizeTestV1( 2 )!= 2.0) {
+    if (verbose) std::cout << "[ unsuccessful ]"<<std::endl;
+    numberFailedTests++;
+  } else {
+    if (verbose) std::cout << "[ successful ]"<<std::endl;
+  }
+
+  DVector OpEqTestV1( 10 ); OpEqTestV1 = 3.0*Teuchos::ScalarTraits<STYPE>::one();
+  DVector OpEqTestV2( Teuchos::View, OpEqTestV1.values(), 3 );
+  DVector OpEqTestV3( 2 );
+  OpEqTestV3 = OpEqTestV2;
+  if (verbose) std::cout << "operator= -- small(empty) = large(view) ";
+  if (OpEqTestV3.length()==3 && OpEqTestV3.values()==OpEqTestV2.values()) {
+    if (verbose) std::cout<< "successful"<<std::endl;
+  } else {
+    if (verbose) std::cout<< "unsuccessful"<<std::endl;
+    numberFailedTests++;
+  }
+  OpEqTestV3 = OpEqTestV1;
+  if (verbose) std::cout << "operator= -- small(view) = large(copy) ";
+  if (OpEqTestV3.length()==10 && OpEqTestV3.values()!=OpEqTestV1.values()) {
+    if (verbose) std::cout<< "successful"<<std::endl;
+  } else {
+    if (verbose) std::cout<< "unsuccessful"<<std::endl;
+    numberFailedTests++;
+  }
+  OpEqTestV3.size(5);
+  OpEqTestV3 = OpEqTestV1;
+  if (verbose) std::cout << "operator= -- small(copy) = large(copy) ";
+  if (OpEqTestV3.length()==10 && OpEqTestV3.values()!=OpEqTestV1.values() && OpEqTestV3[ 9 ]==3.0) {
+    if (verbose) std::cout<< "successful"<<std::endl;
+  } else {
+    if (verbose) std::cout<< "unsuccessful"<<std::endl;
+    numberFailedTests++;
+  }
+
+  DVector OpSumTestV1( OpEqTestV2 );
+  OpSumTestV1 += OpEqTestV2;
+  if (verbose) std::cout << "operator+= -- add two vectors of the same size, but different leading dimension ";
+  if (OpSumTestV1( 1 )==6.0) {
+    if (verbose) std::cout<<"successful" <<std::endl;
+  } else {
+    if (verbose) std::cout<<"unsuccessful"<<std::endl;
+    numberFailedTests++;
+  }
+  if (verbose) std::cout << "operator+= -- add two vectors of different size (nothing should change) ";
+  OpSumTestV1 += OpEqTestV1;
+  if (OpSumTestV1( 1 )==6.0) {
+    if (verbose) std::cout<<"successful" <<std::endl;
+  } else {
+    if (verbose) std::cout<<"unsuccessful"<<std::endl;
+    numberFailedTests++;
+  }
+
+  DVector OpCompTestV1( 5 );
+  OpCompTestV1 = 2.0*Teuchos::ScalarTraits<STYPE>::one();
+  if(verbose) std::cout <<"operator== -- test large == small ";
+  if (OpCompTestV1 == SizeTestV1) {
+    if (verbose) std::cout << "[ unsuccessful ]"<<std::endl;
+    numberFailedTests++;
+  } else {
+    if (verbose) std::cout << "[ successful ]"<<std::endl;
+  }
+  if(verbose) std::cout <<"operator!= -- test large != small ";
+  if (OpCompTestV1 != SizeTestV1) {
+    if (verbose) std::cout << "[ successful ]"<<std::endl;
+  } else {
+    if (verbose) std::cout << "[ successful ]"<<std::endl;
+    numberFailedTests++;
+  }
+
+  DVector ColSetTestV( AAA.numRows() );
+  ColSetTestV.putScalar( 2.0 );
+  bool ret = Teuchos::setCol<OTYPE,STYPE>( ColSetTestV, col, AAA );
+  if (verbose) std::cout <<"non-method helper function -- set second column of matrix with vector ";
+  if ( ColViewTestV.normInf() != 2.0 || ColViewTestV.normOne() != 6.0 || ret == false ) {
+        if (verbose) std::cout << "[ unsuccessful ]"<<std::endl;
+        numberFailedTests++;
+  } else {
+        if (verbose) std::cout << "[ successful ]"<<std::endl;
+  }
+*/
+    //
+    // If a test failed output the number of failed tests.
+    //
+    if (numberFailedTests>0) {
+      success = false;
+      MyOM->print(Belos::Warnings,"End Result: TEST FAILED\n");
+    } else {
+      success = true;
+      MyOM->print(Belos::Warnings,"End Result: TEST PASSED\n");
+    }
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose,std::cerr,success);
+  return success ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+template<typename TYPE>
+int PrintTestResults(std::string testName, Teuchos::RCP<TYPE> calculatedResult, Teuchos::RCP<TYPE> expectedResult, bool verbose)
+{
+  int result;
+  if((*calculatedResult) == (*expectedResult))
+    {
+      if(verbose) std::cout << testName << " [ successful ]" << std::endl;
+      result = 0;
+    }
+  else
+    {
+      if(verbose) std::cout << testName << " [ unsuccessful ]" << std::endl;
+      result = 1;
+    }
+  return result;
+}
+
+template<typename TYPE>
+int PrintTestResults2(std::string testName, TYPE calculatedResult, TYPE expectedResult, bool verbose)
+{
+  int result;
+  if( calculatedResult == expectedResult )
+    {
+      if(verbose) std::cout << testName << " [ successful ]" << std::endl;
+      result = 0;
+    }
+  else
+    {
+      if(verbose) std::cout << testName << " [ unsuccessful ]" << std::endl;
+      result = 1;
+    }
+  return result;
+}
+

--- a/packages/belos/tpetra/example/BlockCG/BlockCGTpetraExFile.cpp
+++ b/packages/belos/tpetra/example/BlockCG/BlockCGTpetraExFile.cpp
@@ -21,8 +21,6 @@
 #include <Tpetra_Core.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Tpetra_CrsMatrix.hpp>
-// I/O for Harwell-Boeing files
-#define HIDE_TPETRA_INOUT_IMPLEMENTATIONS
 #include <Tpetra_MatrixIO.hpp>
 
 // Teuchos

--- a/packages/belos/tpetra/example/BlockCG/PseudoBlockCGTpetraExFile.cpp
+++ b/packages/belos/tpetra/example/BlockCG/PseudoBlockCGTpetraExFile.cpp
@@ -22,8 +22,6 @@
 #include <Tpetra_Core.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Tpetra_CrsMatrix.hpp>
-// I/O for Harwell-Boeing files
-#define HIDE_TPETRA_INOUT_IMPLEMENTATIONS
 #include <Tpetra_MatrixIO.hpp>
 
 // Teuchos

--- a/packages/belos/tpetra/example/PCPG/CMakeLists.txt
+++ b/packages/belos/tpetra/example/PCPG/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 
 ASSERT_DEFINED(${PACKAGE_NAME}_ENABLE_Tpetra)
+
 IF (${PACKAGE_NAME}_ENABLE_Tpetra)
   TRIBITS_ADD_EXECUTABLE(
     PCPG_Tpetra_File_Ex
@@ -8,4 +9,12 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra)
     COMM serial mpi
     # ARGS --verbose
     )
+
+  TRIBITS_ADD_EXECUTABLE(
+    PCPG_DenseKokkos_Tpetra_File_Ex
+    SOURCES PCPGTpetraDenseKokkosExFile.cpp
+    COMM serial mpi
+    # ARGS --verbose
+    )
+
 ENDIF()

--- a/packages/belos/tpetra/example/PCPG/PCPGTpetraDenseKokkosExFile.cpp
+++ b/packages/belos/tpetra/example/PCPG/PCPGTpetraDenseKokkosExFile.cpp
@@ -1,0 +1,401 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+// Purpose
+// The example tests the successive right-hand sides capabilities of ML
+// and Belos on a heat flow u_t = u_xx problem.
+//
+// A sequence of linear systems with the same coefficient matrix and
+// different right-hand sides is solved.  A seed space is generated dynamically,
+// and a deflated linear system is solved.  After each solves, the first
+// few Krylov vectors are saved, and used to reduce the number of iterations
+// for later solves.
+// The optimal numbers of vectors to deflate and save are not known.
+// Presently, the maximum number of vectors to deflate (seed space dimension)
+// and to save are user paraemters.
+// The seed space dimension is less than or equal to total number of vectors
+// saved. The difference between the seed space dimension and the total number
+// of vectors, is the number of vectors used to update the seed space after each
+// solve. I guess that a seed space whose dimension is a small fraction of the
+// total space will be best.
+//
+// maxSave=1 and maxDeflate=0 uses no recycling (not tested ).
+//
+// TODO: Instrument with timers, so that we can tell what is going on besides
+//       by counting the numbers of iterations.
+//
+//
+// Adapted from PCPGEpetraExFile.cpp by David M. Day (with original comments)
+
+// All preconditioning has been commented out
+
+// Tpetra
+#include <TpetraExt_MatrixMatrix.hpp>
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix_fwd.hpp>
+#include <Tpetra_Map_fwd.hpp>
+#include <Tpetra_Vector_fwd.hpp>
+
+// MueLu
+// #include <MueLu_TpetraOperator.hpp>
+// #include <MueLu_CreateTpetraPreconditioner.hpp>
+
+// Teuchos
+#include <Teuchos_Comm.hpp>
+#include <Teuchos_CommHelpers.hpp>
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_DefaultComm.hpp>
+#include <Teuchos_FancyOStream.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_RCP.hpp>
+#include <Teuchos_StandardCatchMacros.hpp>
+#include <Teuchos_Tuple.hpp>
+#include <Teuchos_VerboseObject.hpp>
+
+// Belos
+#include "BelosLinearProblem.hpp"
+#include "BelosPCPGSolMgr.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+
+template <typename ScalarType>
+int run(int argc, char *argv[]) {
+  //
+  // Laplace's equation, homogeneous Dirichlet boundary conditions, [0,1]^2
+  // regular mesh, Q1 finite elements
+  //
+
+  using Teuchos::ParameterList;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::tuple;
+
+  using ST = typename Tpetra::MultiVector<ScalarType>::scalar_type;
+  using LO = typename Tpetra::Vector<>::local_ordinal_type;
+  using GO = typename Tpetra::Vector<>::global_ordinal_type;
+  using NT = typename Tpetra::Vector<>::node_type;
+
+  using IST = Tpetra::MultiVector<>::impl_scalar_type;
+  using DM  = Kokkos::DualView<IST**,Kokkos::LayoutLeft>;
+
+  using V = typename Tpetra::Vector<ST, LO, GO, NT>;
+  using MV = typename Tpetra::MultiVector<ST, LO, GO, NT>;
+  using OP = typename Tpetra::Operator<ST, LO, GO, NT>;
+  using MVT = typename Belos::MultiVecTraits<ST, MV, DM>;
+  using OPT = typename Belos::OperatorTraits<ST, MV, OP>;
+  using MAP = typename Tpetra::Map<LO, GO, NT>;
+  using MAT = typename Tpetra::CrsMatrix<ST, LO, GO, NT>;
+  using SCT = typename Teuchos::ScalarTraits<ST>;
+  using MT = typename SCT::magnitudeType;
+
+  using LinearProblem = typename Belos::LinearProblem<ST, MV, OP>;
+  using PCPGSolMgr = ::Belos::PCPGSolMgr<ST, MV, OP, DM>;
+
+  Teuchos::GlobalMPISession session(&argc, &argv, NULL);
+  RCP<const Teuchos::Comm<int>> comm = Tpetra::getDefaultComm();
+
+  bool verbose = false;
+  bool success = true;
+
+  try {
+    bool procVerbose = false;
+    int frequency = -1;  // frequency of status test output.
+    int blocksize = 1;   // blocksize, PCPGIter
+    int numRhs = 1;      // number of right-hand sides to solve for
+    int maxIters = 30;   // maximum number of iterations allowed per linear system
+
+    int maxDeflate = 4;  // maximum number of vectors deflated from the linear system;
+    // There is no overhead cost assoc with changing maxDeflate between solves
+    int maxSave = 8;  // maximum number of vectors saved from current and previous .");
+    // If maxSave changes between solves, then re-initialize (setSize).
+
+    // Hypothesis: seed vectors are conjugate.
+    // Initial versions allowed users to supply a seed space et cetera, but no
+    // longer.
+
+    // The documentation it suitable for certain tasks, like defining a modules
+    // grammar,
+    std::string ortho("ICGS");  // The Belos documentation obscures the fact that
+    // IMGS is Iterated Modified Gram Schmidt,
+    // ICGS is Iterated Classical Gram Schmidt, and
+    // DKGS is another Iterated Classical Gram Schmidt.
+    // Mathematical issues, such as the difference between ICGS and DKGS, are
+    // not documented at all. UH tells me that Anasazi::SVQBOrthoManager is
+    // available;  I need it for Belos
+    MT tol = sqrt(std::numeric_limits<ST>::epsilon());  // relative residual tolerance
+
+    // How do command line parsers work?
+    Teuchos::CommandLineProcessor cmdp(false, true);
+    cmdp.setOption("verbose", "quiet", &verbose, "Print messages and results");
+    cmdp.setOption("frequency", &frequency, "Solvers frequency for printing residuals (#iters)");
+    cmdp.setOption("tol", &tol, "Relative residual tolerance used by PCPG solver");
+    cmdp.setOption("num-rhs", &numRhs, "Number of right-hand sides to be solved for");
+    cmdp.setOption("max-iters", &maxIters,
+                   "Maximum number of iterations per linear system (-1 = "
+                   "adapted to problem/block size)");
+    cmdp.setOption("num-deflate", &maxDeflate, "Number of vectors deflated from the linear system");
+    cmdp.setOption("num-save", &maxSave, "Number of vectors saved from old Krylov subspaces");
+    cmdp.setOption("ortho-type", &ortho, "Orthogonalization type, either DGKS, ICGS or IMGS");
+    if (cmdp.parse(argc, argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+      return -1;
+    }
+    if (!verbose)
+      frequency = -1;  // reset frequency if test is not verbose
+
+    //
+    // *************Form the problem****************
+    //
+    int numTimeStep = 4;
+    GO numElePerDirection = 14 * comm->getSize();  // 5 -> 20
+    size_t numNodes = (numElePerDirection - 1) * (numElePerDirection - 1);
+
+    // By the way, either matrix has (3*numElePerDirection - 2)^2 nonzeros.
+    RCP<MAP> map = rcp(new MAP(numNodes, 0, comm));
+    RCP<MAT> stiff = rcp(new MAT(map, numNodes));
+    RCP<MAT> mass = rcp(new MAT(map, numNodes));
+    RCP<V> vecLHS = rcp(new V(map));
+    RCP<V> vecRHS = rcp(new V(map));
+    RCP<MV> LHS, RHS;
+
+    ST ko = 8.0 / 3.0, k1 = -1.0 / 3.0;
+
+    ST h = 1.0 / static_cast<ST>(numElePerDirection);  // x=(iX,iY)h
+    ST mo = h * h * 4.0 / 9.0, m1 = h * h / 9.0, m2 = h * h / 36.0;
+
+    ST pi = 4.0 * atan(1.0), valueLHS;
+    GO node, iX, iY;
+
+    for (LO lid = map->getMinLocalIndex(); lid <= map->getMaxLocalIndex(); lid++) {
+      node = map->getGlobalElement(lid);
+      iX = node % (numElePerDirection - 1);
+      iY = (node - iX) / (numElePerDirection - 1);
+      GO pos = node;
+      stiff->insertGlobalValues(node, tuple(pos), tuple(ko));
+      mass->insertGlobalValues(node, tuple(pos),
+                               tuple(mo));  // init guess violates hom Dir bc
+      valueLHS = sin(pi * h * ((ST)iX + 1)) * cos(2.0 * pi * h * ((ST)iY + 1));
+      vecLHS->replaceGlobalValue(1, valueLHS);
+
+      if (iY > 0) {
+        pos = iX + (iY - 1) * (numElePerDirection - 1);
+        stiff->insertGlobalValues(node, tuple(pos), tuple(k1));  // North
+        mass->insertGlobalValues(node, tuple(pos), tuple(m1));
+      }
+      if (iY < numElePerDirection - 2) {
+        pos = iX + (iY + 1) * (numElePerDirection - 1);
+        stiff->insertGlobalValues(node, tuple(pos), tuple(k1));  // South
+        mass->insertGlobalValues(node, tuple(pos), tuple(m1));
+      }
+
+      if (iX > 0) {
+        pos = iX - 1 + iY * (numElePerDirection - 1);
+        stiff->insertGlobalValues(node, tuple(pos), tuple(k1));  // West
+        mass->insertGlobalValues(node, tuple(pos), tuple(m1));
+        if (iY > 0) {
+          pos = iX - 1 + (iY - 1) * (numElePerDirection - 1);
+          stiff->insertGlobalValues(node, tuple(pos), tuple(k1));  // North West
+          mass->insertGlobalValues(node, tuple(pos), tuple(m2));
+        }
+        if (iY < numElePerDirection - 2) {
+          pos = iX - 1 + (iY + 1) * (numElePerDirection - 1);
+          stiff->insertGlobalValues(node, tuple(pos), tuple(k1));  // South West
+          mass->insertGlobalValues(node, tuple(pos), tuple(m2));
+        }
+      }
+
+      if (iX < numElePerDirection - 2) {
+        pos = iX + 1 + iY * (numElePerDirection - 1);
+        stiff->insertGlobalValues(node, tuple(pos), tuple(k1));  // East
+        mass->insertGlobalValues(node, tuple(pos), tuple(m1));
+        if (iY > 0) {
+          pos = iX + 1 + (iY - 1) * (numElePerDirection - 1);
+          stiff->insertGlobalValues(node, tuple(pos), tuple(k1));  // North East
+          mass->insertGlobalValues(node, tuple(pos), tuple(m2));
+        }
+        if (iY < numElePerDirection - 2) {
+          pos = iX + 1 + (iY + 1) * (numElePerDirection - 1);
+          stiff->insertGlobalValues(node, tuple(pos), tuple(k1));  // South East
+          mass->insertGlobalValues(node, tuple(pos), tuple(m2));
+        }
+      }
+    }
+
+    stiff->fillComplete();
+    mass->fillComplete();
+
+    const ST one = SCT::one();
+    ST hdt = .00005;  // half time step
+
+    // A = Mass+Stiff*dt/2
+    RCP<MAT> A = Tpetra::MatrixMatrix::add(one, false, *mass, hdt, false, *stiff);
+
+    // B = Mass-Stiff*dt/2
+    hdt = -hdt;
+    RCP<MAT> B = Tpetra::MatrixMatrix::add(one, false, *mass, hdt, false, *stiff);
+
+    B->apply(*vecLHS, *vecRHS);
+
+    procVerbose = verbose && (comm->getRank() == 0);  // Only print on the zero processor
+
+    LHS = Teuchos::rcp_implicit_cast<MV>(vecLHS);
+    RHS = Teuchos::rcp_implicit_cast<MV>(vecRHS);
+
+    //
+    // **********Construct preconditioner***********
+    //
+
+    // Teuchos::ParameterList MLList; // Set MLList for Smoothed Aggregation
+    // ML_Tpetra::SetDefaults("SA",MLList); // reset parameters ML User's Guide
+    // MLList.set("smoother: type","CHEBYSHEV"); // Chebyshev smoother  ... aztec??
+    // MLList.set("smoother: sweeps",3);
+    // MLList.set("smoother: pre or post", "both"); // both pre- and post-smoothing
+
+    // #ifdef HAVE_MUELU_AMESOS2
+    //     MueLuList.set("coarse: type", "KLU2"); // solve with serial direct
+    //     solver KLU
+    // #else
+    //     MLList.set("coarse: type", "Jacobi");     // not recommended
+    //     puts("Warning: Iterative coarse grid solve");
+    // #endif
+
+    //
+    // RCP<OP> prec = MueLu::CreateTpetraPreconditioner(A, MLList );
+    // assert(prec != Teuchos::null);
+
+    // Create the Belos preconditioned operator from the preconditioner.
+    // NOTE:  This is necessary because Belos expects an operator to apply the
+    //        preconditioner with Apply() NOT ApplyInverse().
+    // RCP<Belos::EpetraPrecOp> belosPrec = rcp( new Belos::EpetraPrecOp( Prec )
+    // );
+
+    // Create parameter list for the PCPG solver manager
+    const int numGlobalElements = RHS->getGlobalLength();
+    if (maxIters == -1)
+      maxIters = numGlobalElements / blocksize - 1;  // maximum number of iterations to run
+
+    RCP<ParameterList> belosList = rcp(new ParameterList());
+    belosList->set("Block Size",
+                   blocksize);  // Blocksize to be used by iterative solver
+    belosList->set("Maximum Iterations",
+                   maxIters);  // Maximum number of iterations allowed
+    belosList->set("Convergence Tolerance",
+                   tol);  // Relative convergence tolerance requested
+    belosList->set("Num Deflated Blocks",
+                   maxDeflate);  // Number of vectors in seed space
+    belosList->set("Num Saved Blocks",
+                   maxSave);                     // Number of vectors saved from old spaces
+    belosList->set("Orthogonalization", ortho);  // Orthogonalization type
+
+    if (numRhs > 1) {
+      belosList->set("Show Maximum Residual Norm Only",
+                     true);  // although numRhs = 1.
+    }
+    if (verbose) {
+      belosList->set("Verbosity", Belos::Errors + Belos::Warnings + Belos::TimingDetails +
+                                      Belos::FinalSummary + Belos::StatusTestDetails);
+      if (frequency > 0)
+        belosList->set("Output Frequency", frequency);
+    } else
+      belosList->set("Verbosity", Belos::Errors + Belos::Warnings + Belos::FinalSummary);
+
+    // Construct a preconditioned linear problem
+    RCP<LinearProblem> problem = rcp(new LinearProblem(A, LHS, RHS));
+
+    // problem->setLeftPrec( prec );
+
+    bool set = problem->setProblem();
+    if (set == false) {
+      if (procVerbose)
+        std::cout << std::endl
+                  << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+
+    // Create an iterative solver manager.
+    RCP<PCPGSolMgr> solver = rcp(new PCPGSolMgr(problem, belosList));
+
+    //
+    // *******************************************************************
+    // ************************* Iterate PCPG ****************************
+    // *******************************************************************
+    //
+    if (procVerbose) {
+      std::cout << std::endl << std::endl;
+      std::cout << "Dimension of matrix: " << numGlobalElements << std::endl;
+      std::cout << "Number of right-hand sides: " << numRhs << std::endl;
+      std::cout << "Block size used by solver: " << blocksize << std::endl;
+      std::cout << "Maximum number of iterations allowed: " << maxIters << std::endl;
+      std::cout << "Relative residual tolerance: " << tol << std::endl;
+      std::cout << std::endl;
+    }
+    bool badRes;
+    for (int timeStep = 0; timeStep < numTimeStep; timeStep++) {
+      if (timeStep) {
+        // old epetra B->multiply(false, *vecLHS, *vecRHS); // rhs_new :=
+        // B*lhs_old,
+        B->apply(*LHS, *RHS);  // rhs_new := B*lhs_old,
+        set = problem->setProblem(LHS, RHS);
+        if (set == false) {
+          if (procVerbose)
+            std::cout << std::endl
+                      << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+          return -1;
+        }
+      }  // if timeStep
+      std::vector<ST> rhs_norm(numRhs);
+      MVT::MvNorm(*RHS, rhs_norm);
+      std::cout << "                  RHS norm is ... " << rhs_norm[0] << std::endl;
+
+      // Perform solve
+      Belos::ReturnType ret = solver->solve();
+
+      // Compute actual residuals.
+      badRes = false;
+      std::vector<ST> actual_resids(numRhs);
+      MV resid(map, numRhs);
+      OPT::Apply(*A, *LHS, resid);
+      MVT::MvAddMv(-1.0, resid, 1.0, *RHS, resid);
+      MVT::MvNorm(resid, actual_resids);
+      MVT::MvNorm(*RHS, rhs_norm);
+      std::cout << "                    RHS norm is ... " << rhs_norm[0] << std::endl;
+
+      if (procVerbose) {
+        std::cout << "---------- Actual Residuals (normalized) ----------" << std::endl
+                  << std::endl;
+        for (int i = 0; i < numRhs; i++) {
+          double actRes = actual_resids[i] / rhs_norm[i];
+          std::cout << "Problem " << i << " : \t" << actRes << std::endl;
+          if (actRes > tol)
+            badRes = true;
+        }
+      }
+      if (ret != Belos::Converged || badRes) {
+        success = false;
+        break;
+      }
+    }  // for timeStep
+
+    if (procVerbose) {
+      if (success)
+        std::cout << std::endl << "SUCCESS:  Belos converged!" << std::endl;
+      else
+        std::cout << std::endl << "ERROR:  Belos did not converge!" << std::endl;
+    }
+  }  // end try
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return success ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+int main(int argc, char *argv[]) { 
+  return run<double>(argc, argv);
+  // return run<float>(argc, argv); }
+}
+
+// end PCPGTpetraExFile.cpp

--- a/packages/belos/tpetra/src/BelosMultiVecTraits_Tpetra.hpp
+++ b/packages/belos/tpetra/src/BelosMultiVecTraits_Tpetra.hpp
@@ -27,6 +27,7 @@
 #include <utility>
 #include <vector>
 
+
 #ifdef HAVE_BELOS_TSQR
 #  include "Tpetra_TsqrAdaptor.hpp"
 #endif // HAVE_BELOS_TSQR
@@ -73,8 +74,8 @@ makeStaticLocalMultiVector (const MultiVectorType& gblMv,
                             const size_t numCols)
 {
   using Tpetra::Details::getStatic2dDualView;
-  using IST = typename MultiVectorType::impl_scalar_type;
-  using DT = typename MultiVectorType::device_type;
+  using IST = typename MultiVectorType::impl_scalar_type; 
+  using DT = typename MultiVectorType::device_type; 
 
   auto lclMap = makeLocalMap (* (gblMv.getMap ()), lclNumRows);
   auto dv = getStatic2dDualView<IST, DT> (lclNumRows, numCols);
@@ -89,6 +90,21 @@ makeStaticLocalMultiVector (const MultiVectorType& gblMv,
     Kokkos::deep_copy (dv.view_device(), nan);
     Kokkos::deep_copy (dv.view_host(), nan);
   }
+  return MultiVectorType (lclMap, dv);
+}
+
+// Return a Tpetra::MultiVector with static storage and a local Map,
+// as above, but this time, instead of pointing the multivector to 
+// uninitialized data, the multivector points to the data of the 
+// Kokkos::DualView provided, allowing us to avoid extra deep copies.
+template<class MultiVectorType, class DualViewType>
+MultiVectorType
+makeStaticLocalMultiVector (const MultiVectorType& gblMv,
+                            DualViewType & dv) //TODO Should this be const?
+{
+  const size_t lclNumRows = dv.extent(0);
+
+  auto lclMap = makeLocalMap (* (gblMv.getMap ()), lclNumRows);
   return MultiVectorType (lclMap, dv);
 }
 
@@ -220,7 +236,7 @@ namespace Belos {
   /// \tparam GO Same as template parameter 3 of Tpetra::MultiVector.
   /// \tparam Node Same as template parameter 4 of Tpetra::MultiVector.
   template<class Scalar, class LO, class GO, class Node>
-  class MultiVecTraits<Scalar, ::Tpetra::MultiVector<Scalar,LO,GO,Node> > {
+  class TpetraMVGeneralTraits {
     typedef ::Tpetra::MultiVector<Scalar, LO, GO, Node> MV;
   public:
     /// \brief Create a new MultiVector with \c numVecs columns.
@@ -467,39 +483,6 @@ namespace Belos {
       return mv.isConstantStride ();
     }
 
-    static void
-    MvTimesMatAddMv (Scalar alpha,
-                     const MV& A,
-                     const Teuchos::SerialDenseMatrix<int, Scalar>& B,
-                     Scalar beta,
-                     MV& mv)
-    {
-#ifdef HAVE_BELOS_TPETRA_TIMERS
-      const std::string timerName ("Belos::MVT::MvTimesMatAddMv");
-      auto timer = Teuchos::TimeMonitor::getNewCounter (timerName);
-      Teuchos::TimeMonitor timeMon (*timer);
-#endif // HAVE_BELOS_TPETRA_TIMERS
-
-      const size_t B_numRows = static_cast<size_t> (B.numRows ());
-      const size_t B_numCols = static_cast<size_t> (B.numCols ());
-
-      // Check if B is 1-by-1, in which case we can just call update()
-      if (B_numRows == size_t (1) && B_numCols == size_t (1)) {
-        mv.update (alpha*B(0,0), A, beta);
-      }
-      else {
-        MV B_mv = impl::makeStaticLocalMultiVector (A, B_numRows, B_numCols);
-        Tpetra::deep_copy (B_mv, B);
-        mv.multiply (Teuchos::NO_TRANS, Teuchos::NO_TRANS,
-                     alpha, A, B_mv, beta);
-      }
-      Kokkos::fence();  // Belos with Thyra's MvTimesMatAddMv allowed failures
-                        // when fence was not applied after mv.multiply; 
-                        // adding the fence fixed the tests in Thyra.  
-                        // Out of an abundance of caution (and with blessing 
-                        // from @hkthorn), we add the fence here as well.  
-                        // #8821 KDD
-    }
 
     /// \brief <tt>mv := alpha*A + beta*B</tt>
     ///
@@ -526,43 +509,6 @@ namespace Belos {
       mv.scale (alphas);
     }
 
-    static void
-    MvTransMv (const Scalar alpha,
-               const MV& A,
-               const MV& B,
-               Teuchos::SerialDenseMatrix<int,Scalar>& C)
-    {
-#ifdef HAVE_BELOS_TPETRA_TIMERS
-      const std::string timerName ("Belos::MVT::MvTransMv");
-      auto timer = Teuchos::TimeMonitor::getNewCounter (timerName);
-      Teuchos::TimeMonitor timeMon (*timer);
-#endif // HAVE_BELOS_TPETRA_TIMERS
-
-      const Scalar ZERO = Teuchos::ScalarTraits<Scalar>::zero ();
-      const int numRowsC = C.numRows ();
-      const int numColsC = C.numCols ();
-
-      // If numRowsC == numColsC == 1, then we can call dot().
-      if (numRowsC == 1 && numColsC == 1) {
-        if (alpha == ZERO) {
-          // Short-circuit, as required by BLAS semantics.
-          C(0,0) = alpha;
-          return;
-        }
-        A.dot (B, Teuchos::ArrayView<Scalar> (C.values (), 1));
-        if (alpha != Teuchos::ScalarTraits<Scalar>::one ()) {
-          C(0,0) *= alpha;
-        }
-        return;
-      }
-
-      MV C_mv = impl::makeStaticLocalMultiVector (A, numRowsC, numColsC);
-      // Filling with zero should be unnecessary, in theory, but not
-      // in practice, alas (Issue_3235 test fails).
-      C_mv.putScalar (ZERO);
-      C_mv.multiply (Teuchos::CONJ_TRANS, Teuchos::NO_TRANS, alpha, A, B, ZERO);
-      Tpetra::deep_copy (C, C_mv);
-    }
 
     //! For all columns j of A, set <tt>dots[j] := A[j]^T * B[j]</tt>.
     static void
@@ -790,12 +736,472 @@ namespace Belos {
       mv.describe (fos, Teuchos::VERB_EXTREME);
     }
 
+  };
+
+  //==============================================================
+  //Specialize multivec traits for Teuchos Serial Dense
+  //==============================================================
+  template<class Scalar, class LO, class GO, class Node >
+  class MultiVecTraits<Scalar, ::Tpetra::MultiVector<Scalar,LO,GO,Node>, Teuchos::SerialDenseMatrix<int,Scalar>> {
+
+    typedef ::Tpetra::MultiVector<Scalar, LO, GO, Node> MV;
+    typedef TpetraMVGeneralTraits<Scalar,LO,GO,Node> MVGen;
+
+  public:
+    //==============================================================
+    //Two functions here specialized for Teuchos::SerialDense
+    //==============================================================
+    static void
+    MvTimesMatAddMv (Scalar alpha,
+                     const MV& A,
+                     const Teuchos::SerialDenseMatrix<int, Scalar>& B,
+                     Scalar beta,
+                     MV& mv)
+    {
+#ifdef HAVE_BELOS_TPETRA_TIMERS
+      const std::string timerName ("Belos::MVT::MvTimesMatAddMv");
+      auto timer = Teuchos::TimeMonitor::getNewCounter (timerName);
+      Teuchos::TimeMonitor timeMon (*timer);
+#endif // HAVE_BELOS_TPETRA_TIMERS
+
+      const size_t B_numRows = static_cast<size_t> (B.numRows ());
+      const size_t B_numCols = static_cast<size_t> (B.numCols ());
+
+      // Check if B is 1-by-1, in which case we can just call update()
+      if (B_numRows == size_t (1) && B_numCols == size_t (1)) {
+        mv.update (alpha*B(0,0), A, beta);
+      }
+      else {
+        MV B_mv = impl::makeStaticLocalMultiVector (A, B_numRows, B_numCols);
+        Tpetra::deep_copy (B_mv, B);
+        mv.multiply (Teuchos::NO_TRANS, Teuchos::NO_TRANS,
+                     alpha, A, B_mv, beta);
+      }
+      Kokkos::fence();  // Belos with Thyra's MvTimesMatAddMv allowed failures
+                        // when fence was not applied after mv.multiply;
+                        // adding the fence fixed the tests in Thyra.
+                        // Out of an abundance of caution (and with blessing
+                        // from @hkthorn), we add the fence here as well.
+                        // #8821 KDD
+    }
+
+    static void
+    MvTransMv (const Scalar alpha,
+               const MV& A,
+               const MV& B,
+               Teuchos::SerialDenseMatrix<int,Scalar>& C)
+    {
+#ifdef HAVE_BELOS_TPETRA_TIMERS
+      const std::string timerName ("Belos::MVT::MvTransMv");
+      auto timer = Teuchos::TimeMonitor::getNewCounter (timerName);
+      Teuchos::TimeMonitor timeMon (*timer);
+#endif // HAVE_BELOS_TPETRA_TIMERS
+
+      const Scalar ZERO = Teuchos::ScalarTraits<Scalar>::zero ();
+      const int numRowsC = C.numRows ();
+      const int numColsC = C.numCols ();
+
+      // If numRowsC == numColsC == 1, then we can call dot().
+      if (numRowsC == 1 && numColsC == 1) {
+        if (alpha == ZERO) {
+          // Short-circuit, as required by BLAS semantics.
+          C(0,0) = alpha;
+          return;
+        }
+        A.dot (B, Teuchos::ArrayView<Scalar> (C.values (), 1));
+        if (alpha != Teuchos::ScalarTraits<Scalar>::one ()) {
+          C(0,0) *= alpha;
+        }
+        return;
+      }
+
+      MV C_mv = impl::makeStaticLocalMultiVector (A, numRowsC, numColsC);
+      // Filling with zero should be unnecessary, in theory, but not
+      // in practice, alas (Issue_3235 test fails).
+      C_mv.putScalar (ZERO);
+      C_mv.multiply (Teuchos::CONJ_TRANS, Teuchos::NO_TRANS, alpha, A, B, ZERO);
+      Tpetra::deep_copy (C, C_mv);
+    }
+    
+    //==============================================================
+    //Remaining functions can be called from the generic versions:
+    //==============================================================
+
+    /// \brief Create a new MultiVector with \c numVecs columns.
+    static Teuchos::RCP<MV> Clone (const MV& X, const int numVecs) {
+      return MVGen::Clone(X,numVecs);
+    }
+
+    //! Create and return a deep copy of X.
+    static Teuchos::RCP<MV> CloneCopy (const MV& X) {
+      return MVGen::CloneCopy(X);
+    }
+
+    /// \brief Create and return a deep copy of the given columns of mv.
+    static Teuchos::RCP<MV>
+    CloneCopy (const MV& mv, const std::vector<int>& index) {
+      return MVGen::CloneCopy(mv,index);
+    }
+
+    /// \brief Create and return a deep copy of the given columns of mv.
+    static Teuchos::RCP<MV>
+    CloneCopy (const MV& mv, const Teuchos::Range1D& index) {
+      return MVGen::CloneCopy(mv,index);
+    }
+
+    static Teuchos::RCP<MV>
+    CloneViewNonConst (MV& mv, const std::vector<int>& index) {
+      return MVGen::CloneViewNonConst(mv, index);
+    }
+
+    static Teuchos::RCP<MV>
+    CloneViewNonConst (MV& mv, const Teuchos::Range1D& index) {
+      return MVGen::CloneViewNonConst(mv, index);
+    }
+
+    static Teuchos::RCP<const MV>
+    CloneView (const MV& mv, const std::vector<int>& index) {
+      return MVGen::CloneView(mv,index);
+    }
+
+    static Teuchos::RCP<const MV>
+    CloneView (const MV& mv, const Teuchos::Range1D& index) {
+      return MVGen::CloneView(mv,index);
+    }
+
+    static ptrdiff_t GetGlobalLength (const MV& mv) {
+      return MVGen::GetGlobalLength(mv);
+    }
+
+    static int GetNumberVecs (const MV& mv) {
+      return MVGen::GetNumberVecs(mv);
+    }
+
+    static bool HasConstantStride (const MV& mv) {
+      return MVGen::HasConstantStride(mv);
+    }
+
+    /// \brief <tt>mv := alpha*A + beta*B</tt>
+    static void MvAddMv (Scalar alpha, const MV& A,
+             Scalar beta, const MV& B, MV& mv) {
+      MVGen::MvAddMv(alpha,A,beta,B,mv);
+    }
+
+    static void MvScale (MV& mv, Scalar alpha) {
+      MVGen::MvScale(mv,alpha);
+    }
+
+    static void MvScale (MV& mv, const std::vector<Scalar>& alphas) {
+      MVGen::MvScale(mv,alphas);
+    }
+
+    //! For all columns j of A, set <tt>dots[j] := A[j]^T * B[j]</tt>.
+    static void
+    MvDot (const MV& A, const MV& B, std::vector<Scalar> &dots) {
+      MVGen::MvDot(A,B,dots);
+    }
+
+    //! For all columns j of mv, set <tt>normvec[j] = norm(mv[j])</tt>.
+    static void
+    MvNorm (const MV& mv,
+            std::vector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType>& normvec,
+            NormType type=TwoNorm) {
+      MVGen::MvNorm(mv, normvec, type);
+    }
+
+    static void
+    SetBlock (const MV& A, const std::vector<int>& index, MV& mv) {
+      MVGen::SetBlock(A,index,mv);
+    }
+
+    static void
+    SetBlock (const MV& A, const Teuchos::Range1D& index, MV& mv) {
+      MVGen::SetBlock(A,index,mv);
+    }
+
+    static void Assign (const MV& A, MV& mv) {
+      MVGen::Assign(A,mv);
+    }
+
+    static void MvRandom (MV& mv) {
+      MVGen::MvRandom(mv);
+    }
+
+    static void
+    MvInit (MV& mv, const Scalar alpha = Teuchos::ScalarTraits<Scalar>::zero ()) {
+      MVGen::MvInit(mv,alpha);
+    }
+
+    static void MvPrint (const MV& mv, std::ostream& os) {
+      MVGen::MvPrint(mv,os);
+    }
+
+// This will not work until the TsqrAdaptor has been changed to include a dense matrix template argument
 #ifdef HAVE_BELOS_TSQR
     /// \typedef tsqr_adaptor_type
     /// \brief TsqrAdaptor specialization for Tpetra::MultiVector
-    typedef ::Tpetra::TsqrAdaptor< ::Tpetra::MultiVector<Scalar, LO, GO, Node> > tsqr_adaptor_type;
+    typedef ::Tpetra::TsqrAdaptor< ::Tpetra::MultiVector<Scalar, LO, GO, Node>,
+                                   Teuchos::SerialDenseMatrix<int,Scalar> > tsqr_adaptor_type;
 #endif // HAVE_BELOS_TSQR
-  };
+
+  };//end Teuchos serial dense specialized. 
+
+
+  //==============================================================
+  //Specialize multivec traits for  Kokkos::DualView
+  //==============================================================
+  template<class Scalar, class LO, class GO, class Node >
+  class MultiVecTraits<Scalar, ::Tpetra::MultiVector<Scalar,LO,GO,Node>, 
+        Kokkos::DualView<typename ::Tpetra::MultiVector<Scalar,LO,GO,Node>::impl_scalar_type**,Kokkos::LayoutLeft>> {
+
+    typedef ::Tpetra::MultiVector<Scalar, LO, GO, Node> MV;
+    typedef typename MV::impl_scalar_type IST;
+    typedef TpetraMVGeneralTraits<Scalar,LO,GO,Node> MVGen;
+
+  public:
+    //==============================================================
+    //Two functions here specialized for Kokkos::DualView
+    //==============================================================
+
+    // NOTE: Must call SyncHostToDevice if B has new information and is bigger than 1x1. 
+    static void
+    MvTimesMatAddMv (Scalar alpha,
+                     const MV& A,
+                     const Kokkos::DualView<IST**,Kokkos::LayoutLeft>& B,
+                     Scalar beta,
+                     MV& mv)
+    {
+#ifdef HAVE_BELOS_TPETRA_TIMERS
+      const std::string timerName ("Belos::MVT::MvTimesMatAddMv");
+      auto timer = Teuchos::TimeMonitor::getNewCounter (timerName);
+      Teuchos::TimeMonitor timeMon (*timer);
+#endif // HAVE_BELOS_TPETRA_TIMERS
+
+      // Give mv = alpha * A * B + beta * mv. 
+    /*  const size_t B_numRows = B.extent(0);
+      const size_t B_numCols = B.extent(1);
+
+      // Check if B is 1-by-1, in which case we can just call update()
+      if (B_numRows == size_t (1) && B_numCols == size_t (1)) {
+        // We have to call B.sync_host() here in case this is run
+        // after a call to MvTransMv. 
+        //
+        // Belos solver developer isn't responsible for syncing before 
+        // this case because
+        // a) This would cost a lot of extra syncs.
+        // b) solver developer only has to worry about syncing before
+        // calling other DenseMatTraits functions. 
+        mv.update (alpha*B.view_host()(0,0), A, beta); 
+        if(dm.need_sync_host()){
+          dm.sync_host();
+        } 
+        //TODO: Later can evaluate if it would be cheaper
+        // to throw this directly to Tpetra multiply (would need
+        // to investigate how KK handles the gemm call underneath)
+        // to see if we could avoid the host sync. But just because
+        // we avoid the host sync doesn't necessarily mean that will
+        // be cheaper, so that would need detailed testing. 
+      }
+      else {*/
+        // Note: This is ONLY moment in all of Belos where 
+        // the dense matrix needs to be synced to device. :) 
+        //
+        // Note: No need to explicitly call sync to device here because 
+        // Tpetra multiply takes care of this with the wrapped
+        // dualView-multivector. 
+        MV B_mv = impl::makeStaticLocalMultiVector (A, B);
+        mv.multiply (Teuchos::NO_TRANS, Teuchos::NO_TRANS,
+                     alpha, A, B_mv, beta);
+      //}
+      // Note: B is const here, never modified, so no need to sync
+      // back to host. 
+    }
+
+    // NOTE: This is the ONLY function in all of Belos that will
+    // ever modify a Kokkos::DualView on device. 
+    static void
+    MvTransMv (const Scalar alpha,
+               const MV& A,
+               const MV& B,
+               Kokkos::DualView<IST**,Kokkos::LayoutLeft>& C)
+    {
+#ifdef HAVE_BELOS_TPETRA_TIMERS 
+      const std::string timerName ("Belos::MVT::MvTransMv");
+      auto timer = Teuchos::TimeMonitor::getNewCounter (timerName);
+      Teuchos::TimeMonitor timeMon (*timer);
+#endif // HAVE_BELOS_TPETRA_TIMERS
+
+      const Scalar ZERO = Teuchos::ScalarTraits<Scalar>::zero();
+      const size_t numRowsC = C.extent(0);
+      const size_t numColsC = C.extent(1);
+
+      // Return C = alpha * A^(conj trans) * B
+
+      // If numRowsC == numColsC == 1, then we can call dot().
+      if (numRowsC == size_t (1) && numColsC == size_t (1)) {
+        if (alpha == ZERO) {
+          // Short-circuit, as required by BLAS semantics.
+          C.view_host()(0,0) = IST(alpha);
+          C.modify_host();
+          C.sync_device(); //TODO should this be counted somehow? Not in a DMT interface.
+          return;
+        }
+        //TODO This case has build problems. Pushing to multiply for now.
+        //LATER: Check performance. Should we be calling do instead? 
+        //
+        /*auto subview1d = Kokkos::subview(C.view_host(),Kokkos::ALL,1);
+        A.dot (B, subview1d);
+        C.modify_host();
+        if (alpha != Teuchos::ScalarTraits<Scalar>::one()) {
+          C.view_host()(0,0) *= alpha;
+        }
+        return;*/
+      }
+      MV C_mv = impl::makeStaticLocalMultiVector(A,C);
+      // Filling with zero should be unnecessary, in theory, but not
+      // in practice, alas (Issue_3235 test fails).
+      // TODO: double-check what was going on here in that issue.
+      // TODO: Is the put zero still necessary?
+      C_mv.putScalar(ZERO);
+
+      //C_mv = ZERO*C_mv + alpha*A(conjtrans)*B
+      //Data in C is overwritten, so there is no need to sync to device before this call.
+      //
+      //  TODO: 
+      // NOTE: Need to make special case in Tpetra multiply for scalar=Zero to get read-only access.
+      // Line 4192 of Tpetra_MultiVector_def.hpp 
+      // There exists a Tpetra unit test that counts number of syncs... Can use this to verify
+      // improvements in code!
+      // Use ascicgpu30 31 32 33 quad V100s
+      // SEMS build modules probably best. Copy ones from PR testing??
+      //
+      // Note: Multiply does all the right things, syncing data if it needs to.
+      C_mv.multiply(Teuchos::CONJ_TRANS, Teuchos::NO_TRANS, alpha, A, B, ZERO);
+      C.modify_device();
+    }
+    
+    //==============================================================
+    //Remaining functions can be called from the generic versions:
+    //==============================================================
+
+    /// \brief Create a new MultiVector with \c numVecs columns.
+    static Teuchos::RCP<MV> Clone (const MV& X, const int numVecs) {
+      return MVGen::Clone(X,numVecs);
+    }
+
+    //! Create and return a deep copy of X.
+    static Teuchos::RCP<MV> CloneCopy (const MV& X) {
+      return MVGen::CloneCopy(X);
+    }
+
+    /// \brief Create and return a deep copy of the given columns of mv.
+    static Teuchos::RCP<MV>
+    CloneCopy (const MV& mv, const std::vector<int>& index) {
+      return MVGen::CloneCopy(mv,index);
+    }
+
+    /// \brief Create and return a deep copy of the given columns of mv.
+    static Teuchos::RCP<MV>
+    CloneCopy (const MV& mv, const Teuchos::Range1D& index) {
+      return MVGen::CloneCopy(mv,index);
+    }
+
+    static Teuchos::RCP<MV>
+    CloneViewNonConst (MV& mv, const std::vector<int>& index) {
+      return MVGen::CloneViewNonConst(mv, index);
+    }
+
+    static Teuchos::RCP<MV>
+    CloneViewNonConst (MV& mv, const Teuchos::Range1D& index) {
+      return MVGen::CloneViewNonConst(mv, index);
+    }
+
+    static Teuchos::RCP<const MV>
+    CloneView (const MV& mv, const std::vector<int>& index) {
+      return MVGen::CloneView(mv,index);
+    }
+
+    static Teuchos::RCP<const MV>
+    CloneView (const MV& mv, const Teuchos::Range1D& index) {
+      return MVGen::CloneView(mv,index);
+    }
+
+    static ptrdiff_t GetGlobalLength (const MV& mv) {
+      return MVGen::GetGlobalLength(mv);
+    }
+
+    static int GetNumberVecs (const MV& mv) {
+      return MVGen::GetNumberVecs(mv);
+    }
+
+    static bool HasConstantStride (const MV& mv) {
+      return MVGen::HasConstantStride(mv);
+    }
+
+    /// \brief <tt>mv := alpha*A + beta*B</tt>
+    static void MvAddMv (Scalar alpha, const MV& A,
+             Scalar beta, const MV& B, MV& mv) {
+      MVGen::MvAddMv(alpha,A,beta,B,mv);
+    }
+
+    static void MvScale (MV& mv, Scalar alpha) {
+      MVGen::MvScale(mv,alpha);
+    }
+
+    static void MvScale (MV& mv, const std::vector<Scalar>& alphas) {
+      MVGen::MvScale(mv,alphas);
+    }
+
+    //! For all columns j of A, set <tt>dots[j] := A[j]^T * B[j]</tt>.
+    static void
+    MvDot (const MV& A, const MV& B, std::vector<Scalar> &dots) {
+      MVGen::MvDot(A,B,dots);
+    }
+
+    //! For all columns j of mv, set <tt>normvec[j] = norm(mv[j])</tt>.
+    static void
+    MvNorm (const MV& mv,
+            std::vector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType>& normvec,
+            NormType type=TwoNorm) {
+      MVGen::MvNorm(mv, normvec, type);
+    }
+
+    static void
+    SetBlock (const MV& A, const std::vector<int>& index, MV& mv) {
+      MVGen::SetBlock(A,index,mv);
+    }
+
+    static void
+    SetBlock (const MV& A, const Teuchos::Range1D& index, MV& mv) {
+      MVGen::SetBlock(A,index,mv);
+    }
+
+    static void Assign (const MV& A, MV& mv) {
+      MVGen::Assign(A,mv);
+    }
+
+    static void MvRandom (MV& mv) {
+      MVGen::MvRandom(mv);
+    }
+
+    static void
+    MvInit (MV& mv, const Scalar alpha = Teuchos::ScalarTraits<Scalar>::zero ()) {
+      MVGen::MvInit(mv,alpha);
+    }
+
+    static void MvPrint (const MV& mv, std::ostream& os) {
+      MVGen::MvPrint(mv,os);
+    }
+
+// This will not work until the TsqrAdaptor has been changed to include a dense matrix template argument
+#ifdef HAVE_BELOS_TSQR
+    /// \typedef tsqr_adaptor_type
+    /// \brief TsqrAdaptor specialization for Tpetra::MultiVector
+   typedef ::Tpetra::TsqrAdaptor< ::Tpetra::MultiVector<Scalar, LO, GO, Node>, 
+                                  Kokkos::DualView<IST**,Kokkos::LayoutLeft> > tsqr_adaptor_type;
+#endif // HAVE_BELOS_TSQR
+
+  };//end Kokkos dense specialized. 
 
 } // namespace Belos
 

--- a/packages/belos/tpetra/test/BiCGStab/CMakeLists.txt
+++ b/packages/belos/tpetra/test/BiCGStab/CMakeLists.txt
@@ -6,8 +6,18 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
-  Tpetra_BiCGStab_hb
+  Tpetra_BiCGStab_hb_test
   SOURCES test_bicgstab_hb.cpp
+  COMM serial mpi
+  ARGS "--verbose --max-iters=10"
+       "--verbose --max-iters=10 --tol=1e-10"
+       "--verbose --max-iters=10 --num-rhs=2"
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_KokkosDense_BiCGStab_hb_test
+  SOURCES test_kokkos_bicgstab_hb.cpp
   COMM serial mpi
   ARGS "--verbose --max-iters=10"
        "--verbose --max-iters=10 --tol=1e-10"
@@ -18,5 +28,5 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Tpetra_CopyTestBiCGSTABFiles
   SOURCE_DIR ${${PACKAGE_NAME}_SOURCE_DIR}/testmatrices
   SOURCE_FILES cage4.hb
-  EXEDEPS Tpetra_BiCGStab_hb
+  EXEDEPS Tpetra_BiCGStab_hb_test Tpetra_KokkosDense_BiCGStab_hb_test
   )

--- a/packages/belos/tpetra/test/BiCGStab/test_bicgstab_complex_hb.cpp
+++ b/packages/belos/tpetra/test/BiCGStab/test_bicgstab_complex_hb.cpp
@@ -1,0 +1,208 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosBiCGStabSolMgr.hpp"
+#include "BelosTpetraTestFramework.hpp"
+
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+
+template <typename ScalarType>
+int run(int argc, char *argv[])
+{ 
+  using Teuchos::Comm;
+  using Teuchos::RCP;
+  using Teuchos::rcpFromRef;
+  using Teuchos::tuple;  
+  
+  using BST = typename Tpetra::MultiVector<ScalarType>::scalar_type;
+  using ST = typename std::complex<BST>;
+
+  using SCT = typename Teuchos::ScalarTraits<ST>;
+  using MT = typename SCT::magnitudeType;
+
+  using OP = typename Tpetra::Operator<ST>;
+  using MV = typename Tpetra::MultiVector<ST>;
+  using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+  using MVT = typename Belos::MultiVecTraits<ST,MV>;
+
+  using tcrsmatrix_t = Tpetra::CrsMatrix<ST>;
+
+  Teuchos::GlobalMPISession mpisess(&argc, &argv, &std::cout);
+
+  const ST one = SCT::one();
+  const ST zero = SCT::zero();
+
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+  int MyPID = rank(*comm);
+
+  // Get test parameters from command-line processor
+  bool verbose = false, proc_verbose = false, debug = false;
+  int frequency = -1;  // how often residuals are printed by solver
+  int numrhs = 1;      // total number of right-hand sides to solve for
+  std::string filename("mhd1280b.cua");
+  MT tol = 1.0e-5;     // relative residual tolerance
+
+  Teuchos::CommandLineProcessor cmdp(false,true);
+  cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+  cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+  cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+  cmdp.setOption("tol",&tol,"Relative residual tolerance used by BiCGStab solver.");
+  cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+  cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+  if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+    return -1;
+  }
+  if (debug) {
+    verbose = true;
+  }
+  if (!verbose) {
+    frequency = -1;  // reset frequency if test is not verbose
+  }
+
+  proc_verbose = ( verbose && (MyPID==0) );
+
+  if (proc_verbose) {
+    std::cout << Belos::Belos_Version() << std::endl << std::endl;
+  }
+
+  Belos::Tpetra::HarwellBoeingReader<tcrsmatrix_t> reader( comm );
+  RCP<tcrsmatrix_t> A = reader.readFromFile( filename );
+  RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+  // Create initial vectors
+  RCP<MV> B, X;
+  X = rcp( new MV(map,numrhs) );
+  //MVT::MvRandom( *X );
+  MVT::MvInit( *X, one );
+  B = rcp( new MV(map,numrhs) );
+  OPT::Apply( *A, *X, *B );
+  MVT::MvInit( *X, 0.0 );
+
+  // ********Other information used by block solver***********
+  // *****************(can be user specified)******************
+  const int NumGlobalElements = B->getGlobalLength();
+  int numIters1, numIters2, numIters3;
+  int maxits = NumGlobalElements; // maximum number of iterations to run
+  Teuchos::ParameterList belosList;
+  belosList.set( "Maximum Iterations", maxits );         // Maximum number of iterations allowed
+  belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+
+  int verbLevel = Belos::Errors + Belos::Warnings;
+  if (debug) {
+    verbLevel += Belos::Debug;
+  }
+  if (verbose) {
+    verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
+  }
+  belosList.set( "Verbosity", verbLevel );
+  if (verbose) {
+    if (frequency > 0) {
+      belosList.set( "Output Frequency", frequency );
+    }
+  }
+  
+  // Construct an unpreconditioned linear problem instance.
+  Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+  bool set = problem.setProblem();
+  if (set == false) {
+    if (proc_verbose)
+      std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+    return -1;
+  }
+
+  // Start the BiCGStab iteration
+  Belos::BiCGStabSolMgr<ST,MV,OP> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+
+  // Print out information about problem
+  if (proc_verbose) {
+    std::cout << std::endl << std::endl;
+    std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+    std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+    std::cout << "Max number of BiCGStab iterations: " << maxits << std::endl;
+    std::cout << "Relative residual tolerance: " << tol << std::endl;
+    std::cout << std::endl;
+  }
+  
+  // Perform solve
+  Belos::ReturnType ret = solver.solve();
+  numIters1=solver.getNumIters();
+  
+  // Compute actual residuals.
+  bool badRes = false;
+  std::vector<MT> actual_resids( numrhs );
+  std::vector<MT> rhs_norm( numrhs );
+  MV resid(map, numrhs);
+  OPT::Apply( *A, *X, resid );
+  MVT::MvAddMv( -one, resid, one, *B, resid );
+  MVT::MvNorm( resid, actual_resids );
+  MVT::MvNorm( *B, rhs_norm );
+  if (proc_verbose) {
+    std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+  }
+  for ( int i=0; i<numrhs; i++) {
+    MT actRes = actual_resids[i]/rhs_norm[i];
+    if (proc_verbose) {
+      std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+    }
+    if (actRes > tol) badRes = true;
+  }
+
+  if (proc_verbose) { std::cout << "First solve took " << numIters1 << " iterations." << std::endl; }
+
+  // Resolve linear system with same rhs and recycled space
+  MVT::MvInit( *X, zero );
+  solver.reset(Belos::Problem);
+  ret = solver.solve();
+  numIters2=solver.getNumIters();
+
+  if (proc_verbose) { std::cout << "Second solve took " << numIters2 << " iterations." << std::endl; }
+
+  // Resolve linear system (again) with same rhs and recycled space
+  MVT::MvInit( *X, zero );
+  solver.reset(Belos::Problem);
+  ret = solver.solve();
+  numIters3=solver.getNumIters();
+
+  if (proc_verbose) { std::cout << "Third solve took " << numIters3 << " iterations." << std::endl; }
+
+  if ( ret!=Belos::Converged || badRes || numIters1 < numIters2 || numIters2 < numIters3 ) {
+    if (proc_verbose) {
+      std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+    return -1;
+  }
+  
+  // Default return value
+  if (proc_verbose) {
+    std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+  }
+  return 0;
+
+} // end test_gcrodr_complex_hb.cpp
+
+int main(int argc, char *argv[]) {
+  return run<double>(argc, argv);
+  // return run<float>(argc, argv);
+}
+

--- a/packages/belos/tpetra/test/BiCGStab/test_kokkos_bicgstab_hb.cpp
+++ b/packages/belos/tpetra/test/BiCGStab/test_kokkos_bicgstab_hb.cpp
@@ -1,0 +1,189 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a file, which can only be a Harwell-Boeing (*.hb)
+// matrix.  The right-hand side is generated using a random solution vector that has
+// the matrix applied to it.  The initial guesses are all set to zero.  
+//
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosBiCGStabSolMgr.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+#include "BelosTpetraTestFramework.hpp"
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+#include "Teuchos_StandardCatchMacros.hpp"
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+int main (int argc, char *argv[])
+{
+  using Teuchos::ParameterList;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using std::cout;
+  using std::endl;
+
+  typedef Tpetra::MultiVector<>::scalar_type ST;
+  typedef Tpetra::MultiVector<>::impl_scalar_type IST;
+  typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+  typedef Teuchos::ScalarTraits<ST>       SCT;
+  typedef SCT::magnitudeType               MT;
+  typedef Tpetra::Operator<ST>             OP;
+  typedef Tpetra::MultiVector<ST>          MV;
+  typedef Belos::OperatorTraits<ST,MV,OP> OPT;
+  typedef Belos::MultiVecTraits<ST,MV,DM> MVT;
+
+  Teuchos::GlobalMPISession mpisess(&argc,&argv,&cout);
+
+  const ST one  = SCT::one();
+
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
+  int MyPID = rank(*comm);
+
+  bool verbose = false;
+  bool success = true;
+
+  // This "try" relates to TEUCHOS_STANDARD_CATCH_STATEMENTS near the
+  // bottom of main().  That macro has the corresponding "catch".
+  try {
+    bool proc_verbose = false;
+    int frequency = -1;        // frequency of status test output.
+    int numrhs = 1;            // number of right-hand sides to solve for
+    int maxiters = -1;         // maximum number of iterations allowed per linear system
+    std::string filename ("cage4.hb");
+    MT tol = 1.0e-5;           // relative residual tolerance
+
+    Teuchos::CommandLineProcessor cmdp(false,true);
+    cmdp.setOption ("verbose", "quiet", &verbose, "Whether to print messages "
+                    "and results.");
+    cmdp.setOption ("frequency", &frequency, "Frequency of solver output "
+                    "(1 means every iteration; -1 means never).");
+    cmdp.setOption ("filename", &filename, "Test matrix filename.  "
+                    "Allowed file extensions: *.hb, *.mtx, *.triU, *.triS");
+    cmdp.setOption ("tol", &tol, "Relative residual tolerance for solver.");
+    cmdp.setOption ("num-rhs", &numrhs, "Number of right-hand sides to solve.");
+    cmdp.setOption ("max-iters", &maxiters, "Maximum number of iterations per "
+                    "linear system (-1 = adapted to problem/block size).");
+    if (cmdp.parse (argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+      return -1;
+    }
+    if (! verbose) {
+      frequency = -1;  // reset frequency if test is not verbose
+    }
+
+    proc_verbose = ( verbose && (MyPID==0) );
+
+    //
+    // *************Get the problem*********************
+    //
+    Belos::Tpetra::HarwellBoeingReader<Tpetra::CrsMatrix<ST> > reader( comm );
+    RCP<Tpetra::CrsMatrix<ST> > A = reader.readFromFile( filename );
+    RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+    // Create initial vectors
+    RCP<MV> B, X;
+    X = rcp( new MV(map,numrhs) );
+    MVT::MvRandom( *X );
+    B = rcp( new MV(map,numrhs) );
+    OPT::Apply( *A, *X, *B );
+    MVT::MvInit( *X, 0.0 );
+
+    //
+    // Create parameter list for the Belos solver
+    //
+    const int NumGlobalElements = B->getGlobalLength ();
+    if (maxiters == -1) {
+      maxiters = NumGlobalElements - 1; // maximum number of iterations to run
+    }
+    RCP<ParameterList> belosList (new ParameterList ("Belos"));
+    belosList->set ("Maximum Iterations", maxiters);
+    belosList->set ("Convergence Tolerance", tol);
+    if (verbose) {
+      belosList->set ("Verbosity", Belos::Errors + Belos::Warnings +
+                     Belos::TimingDetails + Belos::StatusTestDetails);
+      if (frequency > 0) {
+        belosList->set ("Output Frequency", frequency);
+      }
+    }
+    else {
+      belosList->set ("Verbosity", Belos::Errors + Belos::Warnings +
+                      Belos::FinalSummary);
+    }
+    //
+    // Construct a preconditioned linear problem
+    //
+    RCP<Belos::LinearProblem<ST,MV,OP> > problem
+      = rcp (new Belos::LinearProblem<ST,MV,OP> (A, X, B));
+    bool set = problem->setProblem ();
+    if (! set) {
+      if (proc_verbose) {
+        cout << endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << endl;
+      }
+      return -1;
+    }
+
+    // Create a Belos solver.
+    Belos::BiCGStabSolMgr<ST,MV,OP,DM> solver( problem, belosList );
+
+    if (proc_verbose) {
+      cout << endl << endl;
+      cout << "Dimension of matrix: " << NumGlobalElements << endl;
+      cout << "Number of right-hand sides: " << numrhs << endl;
+      cout << "Max number of BiCGStab iterations: " << maxiters << endl;
+      cout << "Relative residual tolerance: " << tol << endl;
+      cout << endl;
+    }
+
+    // Ask Belos to solve the linear system.
+    Belos::ReturnType ret = solver.solve();
+
+    //
+    // Compute actual residuals.
+    //
+    bool badRes = false;
+    std::vector<MT> actual_resids( numrhs );
+    std::vector<MT> rhs_norm( numrhs );
+    MV resid(map, numrhs);
+    OPT::Apply( *A, *X, resid );
+    MVT::MvAddMv( -one, resid, one, *B, resid );
+    MVT::MvNorm( resid, actual_resids );
+    MVT::MvNorm( *B, rhs_norm );
+    if (proc_verbose) {
+      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+    }
+    for ( int i=0; i<numrhs; i++) {
+      MT actRes = actual_resids[i]/rhs_norm[i];
+      if (proc_verbose) {
+        std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+      }
+      if (actRes > tol) badRes = true;
+    }
+
+    if ( ret!=Belos::Converged || badRes) {
+      if (proc_verbose) {
+        std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+      }
+      return -1;
+    }
+    //
+    // Default return value
+    //
+    if (proc_verbose) {
+      std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+    }
+
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return success ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/packages/belos/tpetra/test/BlockCG/CMakeLists.txt
+++ b/packages/belos/tpetra/test/BlockCG/CMakeLists.txt
@@ -11,6 +11,18 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Tpetra_BlockCG_hb_test
   SOURCES test_bl_cg_hb.cpp
+  ARGS "--verbose"
+       "--verbose --use-single-red"
+       "--verbose --num-rhs=2 --block-size=2"
+  COMM serial mpi
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_KokkosDense_BlockCG_hb_test
+  SOURCES test_kokkos_bl_cg_hb.cpp
+  ARGS "--verbose"
+       "--verbose --use-single-red"
+       "--verbose --num-rhs=2 --block-size=2"
   COMM serial mpi
   ARGS
     "--verbose"
@@ -25,8 +37,22 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_KokkosDense_PseudoBlockCG_hb_test
+  SOURCES test_kokkos_pseudo_bl_cg_hb.cpp
+  ARGS "--verbose"
+  COMM serial mpi
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Tpetra_PseudoBlockStochasticCG_hb_test
   SOURCES test_pseudo_stochastic_cg_hb.cpp
+  ARGS
+  COMM serial mpi
+)
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_KokkosDense_StochasticCG_hb_test
+  SOURCES test_kokkos_stochastic_cg_hb.cpp
   ARGS
   COMM serial mpi
 )
@@ -52,8 +78,19 @@ IF (Tpetra_INST_COMPLEX_DOUBLE)
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     Tpetra_BlockCG_complex_hb_test
-    SOURCES test_bl_cg_complex_hb.cpp
-    ARGS "--verbose"
+    SOURCES test_cg_complex_hb.cpp
+    ARGS
+      "--verbose"
+      "--verbose --pseudo"
+    COMM serial mpi
+  )
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    Tpetra_KokkosDense_BlockCG_complex_hb_test
+    SOURCES test_kokkos_cg_complex_hb.cpp
+    ARGS
+      "--verbose"
+      "--verbose --pseudo"
     COMM serial mpi
   )
 
@@ -61,7 +98,7 @@ IF (Tpetra_INST_COMPLEX_DOUBLE)
     Tpetra_BlockCG_complex_hb_CopyFiles
     SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
     SOURCE_FILES mhd1280b.cua
-    EXEDEPS Tpetra_BlockCG_complex_hb_test
+    EXEDEPS Tpetra_BlockCG_complex_hb_test Tpetra_KokkosDense_BlockCG_complex_hb_test
   )
 
 ENDIF()

--- a/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb.cpp
@@ -21,8 +21,6 @@
 
 #include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
-// I/O for Harwell-Boeing files
-#define HIDE_TPETRA_INOUT_IMPLEMENTATIONS
 #include <Tpetra_MatrixIO.hpp>
 
 #include <Teuchos_CommandLineProcessor.hpp>
@@ -60,6 +58,7 @@ int run(int argc, char *argv[])
     
     // Get test parameters from command-line processor
     bool proc_verbose = false;
+    bool use_single_red = false;
     bool debug = false;
     int frequency = -1;  // how often residuals are printed by solver
     int numrhs = 1;      // total number of right-hand sides to solve for
@@ -77,6 +76,7 @@ int run(int argc, char *argv[])
     cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
     cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
     cmdp.setOption("block-size",&blocksize,"Block size to be used by the CG solver.");
+    cmdp.setOption("use-single-red","use-standard-red",&use_single_red,"Use single-reduction CG iteration.");
     if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
       return -1;
     }
@@ -108,7 +108,7 @@ int run(int argc, char *argv[])
     // Other information used by block solver (can be user specified)
     const int NumGlobalElements = B->getGlobalLength();
     if (maxiters == -1) {
-      maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
+      maxiters = NumGlobalElements - 1; // maximum number of iterations to run
     }
 
     //
@@ -116,6 +116,8 @@ int run(int argc, char *argv[])
     belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
     belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
     belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    if ((blocksize==1) && use_single_red)
+      belosList.set( "Use Single Reduction", use_single_red ); // Use single reduction CG iteration
     int verbLevel = Belos::Errors + Belos::Warnings;
     if (debug) {
       verbLevel += Belos::Debug;

--- a/packages/belos/tpetra/test/BlockCG/test_cg_complex_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_cg_complex_hb.cpp
@@ -1,0 +1,206 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosBlockCGSolMgr.hpp"
+#include "BelosPseudoBlockCGSolMgr.hpp"
+#include "BelosTpetraTestFramework.hpp"
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+// I/O for Harwell-Boeing files
+#include <Tpetra_Util_iohb.h>
+
+template <typename ScalarType>
+int run(int argc, char *argv[])
+{
+  using BSC = typename Tpetra::MultiVector<ScalarType>::scalar_type;
+  using ST  = typename std::complex<BSC>;
+  
+  using OP = typename Tpetra::Operator<ST>;
+  using MV = typename Tpetra::MultiVector<ST>;
+  using tcrsmatrix_t = Tpetra::CrsMatrix<ST>;
+  
+  using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+  using MVT = typename Belos::MultiVecTraits<ST,MV>;
+
+  using SCT = typename Teuchos::ScalarTraits<ST>;
+  using MT  = typename SCT::magnitudeType;
+
+  using Tpetra::Operator;
+  using Tpetra::CrsMatrix;
+  using Tpetra::MultiVector;
+
+  using Teuchos::GlobalMPISession;
+  using Teuchos::Comm;
+  using Teuchos::RCP;
+  using Teuchos::CommandLineProcessor;
+  using Teuchos::ParameterList;
+
+  const ST one = SCT::one();
+
+  GlobalMPISession mpisess(&argc,&argv,&std::cout);
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+  int MyPID = rank(*comm);
+
+  // Get test parameters from command-line processor
+  bool verbose = false, proc_verbose = false, debug = false;
+  bool pseudo = false; // block or pseudo block
+  int frequency = -1;  // how often residuals are printed by solver
+  int numrhs = 1;      // total number of right-hand sides to solve for
+  int blocksize = 1;   // blocksize used by solver
+  int maxiters = -1;   // maximum number of iterations for solver to use
+  std::string filename("mhd1280b.cua");
+  MT tol = 1.0e-5;     // relative residual tolerance
+
+  CommandLineProcessor cmdp(false,true);
+  cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+  cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+  cmdp.setOption("pseudo","not-pseudo",&pseudo,"Use pseudo-block CG solver.");
+  cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+  cmdp.setOption("tol",&tol,"Relative residual tolerance used by CG solver.");
+  cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+  cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+  cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
+  cmdp.setOption("block-size",&blocksize,"Block size to be used by the CG solver.");
+  if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
+    return -1;
+  }
+  if (debug) {
+    verbose = true;
+  }
+  if (!verbose) {
+    frequency = -1;  // reset frequency if test is not verbose
+  }
+
+  proc_verbose = ( verbose && (MyPID==0) );
+  if (proc_verbose) {
+    std::cout << Belos::Belos_Version() << std::endl << std::endl;
+  }
+
+  Belos::Tpetra::HarwellBoeingReader<tcrsmatrix_t> reader( comm );
+  RCP<tcrsmatrix_t> A = reader.readFromFile( filename );
+  RCP<const Tpetra::Map<> > map = A->getMap();
+
+  // Create initial vectors
+  RCP<MV> B, X;
+  X = rcp( new MV(map,numrhs) );
+  MVT::MvRandom( *X );
+  B = rcp( new MV(map,numrhs) );
+  OPT::Apply( *A, *X, *B );
+  MVT::MvInit( *X, 0.0 );
+
+  // Other information used by block solver (can be user specified)
+  const int NumGlobalElements = B->getGlobalLength();
+  if (maxiters == -1) {
+    maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
+  }
+
+  ParameterList belosList;
+  belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+  belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+  belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+  int verbLevel = Belos::Errors + Belos::Warnings;
+  if (debug) {
+    verbLevel += Belos::Debug;
+  }
+  if (verbose) {
+    verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
+  }
+  belosList.set( "Verbosity", verbLevel );
+  if (verbose) {
+    if (frequency > 0) {
+      belosList.set( "Output Frequency", frequency );
+    }
+  }
+  
+  // Construct an unpreconditioned linear problem instance.
+  Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+  bool set = problem.setProblem();
+  if (set == false) {
+    if (proc_verbose)
+      std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+    return -1;
+  }
+
+  RCP<Belos::SolverManager<ST,MV,OP> > solver;
+  if (pseudo)
+    solver = Teuchos::rcp( new Belos::PseudoBlockCGSolMgr<ST,MV,OP>( rcpFromRef(problem), rcpFromRef(belosList) ) );
+  else
+    solver = Teuchos::rcp( new Belos::BlockCGSolMgr<ST,MV,OP>( rcpFromRef(problem), rcpFromRef(belosList) ) );
+
+  // Print out information about problem
+  if (proc_verbose) {
+    std::cout << std::endl << std::endl;
+    std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+    std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+    std::cout << "Block size used by solver: " << blocksize << std::endl;
+    std::cout << "Max number of CG iterations: " << maxiters << std::endl;
+    std::cout << "Relative residual tolerance: " << tol << std::endl;
+    std::cout << std::endl;
+  }
+  
+  // Perform solve
+  Belos::ReturnType ret = solver->solve();
+
+  // Compute actual residuals.
+  bool badRes = false;
+  std::vector<MT> actual_resids( numrhs );
+  std::vector<MT> rhs_norm( numrhs );
+  MV resid(map, numrhs);
+  OPT::Apply( *A, *X, resid );
+  MVT::MvAddMv( -one, resid, one, *B, resid );
+  MVT::MvNorm( resid, actual_resids );
+  MVT::MvNorm( *B, rhs_norm );
+  if (proc_verbose) {
+    std::cout << "---------- Actual Residuals (normalized) ----------" << std::endl<<std::endl;
+  }
+  for ( int i=0; i<numrhs; i++) {
+    MT actRes = actual_resids[i]/rhs_norm[i];
+    if (proc_verbose) {
+      std::cout << "Problem "<<i<<" : \t"<< actRes << std::endl;
+    }
+    if (actRes > tol) badRes = true;
+  }
+
+  if (ret!=Belos::Converged || badRes) {
+    if (proc_verbose) {
+      std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+    return -1;
+  }
+  
+  // Default return value
+  if (proc_verbose) {
+    std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+  }
+
+  return 0;
+} // end test_bl_cg_complex_hb.cpp
+
+int main(int argc, char *argv[]) {
+  return run<double>(argc,argv);
+
+  // wrapped with a check: CMake option Trilinos_ENABLE_FLOAT=ON
+  // return run<float>(argc,argv);
+}
+

--- a/packages/belos/tpetra/test/BlockCG/test_kokkos_bl_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_kokkos_bl_cg_hb.cpp
@@ -1,0 +1,212 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+#include "BelosBlockCGSolMgr.hpp"
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+#include <Teuchos_StandardCatchMacros.hpp>
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_MatrixIO.hpp>
+
+using namespace Teuchos;
+using Tpetra::Operator;
+using Tpetra::CrsMatrix;
+using Tpetra::MultiVector;
+using std::endl;
+using std::cout;
+using std::vector;
+using Teuchos::tuple;
+
+int main(int argc, char *argv[]) {
+  typedef Tpetra::MultiVector<>::scalar_type ST;
+  typedef ScalarTraits<ST>                SCT;
+  typedef Tpetra::MultiVector<>::impl_scalar_type IST;
+  typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+  typedef SCT::magnitudeType               MT;
+  typedef Tpetra::Operator<ST>             OP;
+  typedef Tpetra::MultiVector<ST>          MV;
+  typedef Belos::OperatorTraits<ST,MV,OP> OPT;
+  typedef Belos::MultiVecTraits<ST,MV>    MVT;
+
+  GlobalMPISession mpisess(&argc,&argv,&cout);
+
+  bool success = false;
+  bool verbose = false;
+  try {
+    const ST one  = SCT::one();
+
+    int MyPID = 0;
+
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+
+    //
+    // Get test parameters from command-line processor
+    //
+    bool proc_verbose = false;
+    bool debug = false;
+    bool use_single_red = false;
+    int frequency = -1;  // how often residuals are printed by solver
+    int numrhs = 1;      // total number of right-hand sides to solve for
+    int blocksize = 1;   // blocksize used by solver
+    int maxiters = -1;   // maximum number of iterations for solver to use
+    std::string filename("bcsstk14.hb");
+    MT tol = 1.0e-5;     // relative residual tolerance
+
+    CommandLineProcessor cmdp(false,true);
+    cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+    cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+    cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+    cmdp.setOption("tol",&tol,"Relative residual tolerance used by CG solver.");
+    cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+    cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+    cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
+    cmdp.setOption("block-size",&blocksize,"Block size to be used by the CG solver.");
+    cmdp.setOption("use-single-red","use-standard-red",&use_single_red,"Use single-reduction CG iteration.");
+    if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
+      return -1;
+    }
+    if (debug) {
+      verbose = true;
+    }
+    if (!verbose) {
+      frequency = -1;  // reset frequency if test is not verbose
+    }
+
+    MyPID = rank(*comm);
+    proc_verbose = ( verbose && (MyPID==0) );
+
+    if (proc_verbose) {
+      std::cout << Belos::Belos_Version() << std::endl << std::endl;
+    }
+    //
+    // Get the data from the HB file and build the Map,Matrix
+    //
+    RCP<CrsMatrix<ST> > A;
+    Tpetra::Utils::readHBMatrix(filename,comm,A);
+    RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+    // Create initial vectors
+    RCP<MV> B, X;
+    X = rcp( new MV(map,numrhs) );
+    MVT::MvRandom( *X );
+    B = rcp( new MV(map,numrhs) );
+    OPT::Apply( *A, *X, *B );
+    MVT::MvInit( *X, 0.0 );
+
+    //
+    // ********Other information used by block solver***********
+    // *****************(can be user specified)******************
+    //
+    const int NumGlobalElements = B->getGlobalLength();
+    if (maxiters == -1) {
+      maxiters = NumGlobalElements - 1; // maximum number of iterations to run
+    }
+    //
+    ParameterList belosList;
+    belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+    belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+    belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    if ((blocksize==1) && use_single_red)
+      belosList.set( "Use Single Reduction", use_single_red ); // Use single reduction CG iteration
+
+    int verbLevel = Belos::Errors + Belos::Warnings;
+    if (debug) {
+      verbLevel += Belos::Debug;
+    }
+    if (verbose) {
+      verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
+    }
+    belosList.set( "Verbosity", verbLevel );
+    if (verbose) {
+      if (frequency > 0) {
+        belosList.set( "Output Frequency", frequency );
+      }
+    }
+    //
+    // Construct an unpreconditioned linear problem instance.
+    //
+    Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+    bool set = problem.setProblem();
+    if (set == false) {
+      if (proc_verbose)
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+    //
+    // *******************************************************************
+    // *************Start the block CG iteration***********************
+    // *******************************************************************
+    //
+    Belos::BlockCGSolMgr<ST,MV,OP,DM> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+
+    //
+    // **********Print out information about problem*******************
+    //
+    if (proc_verbose) {
+      std::cout << std::endl << std::endl;
+      std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+      std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+      std::cout << "Block size used by solver: " << blocksize << std::endl;
+      std::cout << "Max number of CG iterations: " << maxiters << std::endl;
+      std::cout << "Relative residual tolerance: " << tol << std::endl;
+      std::cout << std::endl;
+    }
+    //
+    // Perform solve
+    //
+    Belos::ReturnType ret = solver.solve();
+    //
+    // Compute actual residuals.
+    //
+    bool badRes = false;
+    std::vector<MT> actual_resids( numrhs );
+    std::vector<MT> rhs_norm( numrhs );
+    MV resid(map, numrhs);
+    OPT::Apply( *A, *X, resid );
+    MVT::MvAddMv( -one, resid, one, *B, resid );
+    MVT::MvNorm( resid, actual_resids );
+    MVT::MvNorm( *B, rhs_norm );
+    if (proc_verbose) {
+      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+    }
+    for ( int i=0; i<numrhs; i++) {
+      MT actRes = actual_resids[i]/rhs_norm[i];
+      if (proc_verbose) {
+        std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+      }
+      if (actRes > tol) badRes = true;
+    }
+
+    success = (ret==Belos::Converged && !badRes);
+
+    if (success) {
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+    } else {
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
+} // end test_bl_cg_hb.cpp

--- a/packages/belos/tpetra/test/BlockCG/test_kokkos_cg_complex_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_kokkos_cg_complex_hb.cpp
@@ -16,7 +16,9 @@
 #include "BelosConfigDefs.hpp"
 #include "BelosLinearProblem.hpp"
 #include "BelosTpetraAdapter.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
 #include "BelosBlockCGSolMgr.hpp"
+#include "BelosPseudoBlockCGSolMgr.hpp"
 #include "BelosTpetraTestFramework.hpp"
 
 #include <Teuchos_CommandLineProcessor.hpp>
@@ -26,21 +28,19 @@
 #include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 
-// I/O for Harwell-Boeing files
-#include <Tpetra_Util_iohb.h>
-
 template <typename ScalarType>
 int run(int argc, char *argv[])
 {
-  using BSC = typename Tpetra::MultiVector<ScalarType>::scalar_type;
-  using ST  = typename std::complex<BSC>;
+  using ST = std::complex<ScalarType>;
+  using IST = typename Tpetra::MultiVector<ST>::impl_scalar_type;
+  using DM = typename Kokkos::DualView<IST**,Kokkos::LayoutLeft>;
   
   using OP = typename Tpetra::Operator<ST>;
   using MV = typename Tpetra::MultiVector<ST>;
   using tcrsmatrix_t = Tpetra::CrsMatrix<ST>;
-  
+
   using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
-  using MVT = typename Belos::MultiVecTraits<ST,MV>;
+  using MVT = typename Belos::MultiVecTraits<ST,MV,DM>;
 
   using SCT = typename Teuchos::ScalarTraits<ST>;
   using MT  = typename SCT::magnitudeType;
@@ -63,6 +63,7 @@ int run(int argc, char *argv[])
 
   // Get test parameters from command-line processor
   bool verbose = false, proc_verbose = false, debug = false;
+  bool pseudo = false; // block or pseudo block
   int frequency = -1;  // how often residuals are printed by solver
   int numrhs = 1;      // total number of right-hand sides to solve for
   int blocksize = 1;   // blocksize used by solver
@@ -73,6 +74,7 @@ int run(int argc, char *argv[])
   CommandLineProcessor cmdp(false,true);
   cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
   cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+  cmdp.setOption("pseudo","not-pseudo",&pseudo,"Use pseudo-block CG solver.");
   cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
   cmdp.setOption("tol",&tol,"Relative residual tolerance used by CG solver.");
   cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
@@ -139,8 +141,11 @@ int run(int argc, char *argv[])
     return -1;
   }
 
-  // Start the block CG iteration
-  Belos::BlockCGSolMgr<ST,MV,OP> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+  RCP<Belos::SolverManager<ST,MV,OP,DM> > solver;
+  if (pseudo)
+    solver = Teuchos::rcp( new Belos::PseudoBlockCGSolMgr<ST,MV,OP,DM>( rcpFromRef(problem), rcpFromRef(belosList) ) );
+  else
+    solver = Teuchos::rcp( new Belos::BlockCGSolMgr<ST,MV,OP,DM>( rcpFromRef(problem), rcpFromRef(belosList) ) );
 
   // Print out information about problem
   if (proc_verbose) {
@@ -154,7 +159,7 @@ int run(int argc, char *argv[])
   }
   
   // Perform solve
-  Belos::ReturnType ret = solver.solve();
+  Belos::ReturnType ret = solver->solve();
 
   // Compute actual residuals.
   bool badRes = false;

--- a/packages/belos/tpetra/test/BlockCG/test_kokkos_pseudo_bl_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_kokkos_pseudo_bl_cg_hb.cpp
@@ -1,0 +1,218 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+#include "BelosPseudoBlockCGSolMgr.hpp"
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+#include <Teuchos_StandardCatchMacros.hpp>
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_MatrixIO.hpp>
+
+using namespace Teuchos;
+using Tpetra::Operator;
+using Tpetra::CrsMatrix;
+using Tpetra::MultiVector;
+using std::endl;
+using std::cout;
+using std::vector;
+using Teuchos::tuple;
+
+int main(int argc, char *argv[]) {
+  typedef Tpetra::MultiVector<>::scalar_type ST;
+  typedef ScalarTraits<ST>                SCT;
+  typedef Tpetra::MultiVector<>::impl_scalar_type IST;
+  typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+  typedef SCT::magnitudeType               MT;
+  typedef Tpetra::Operator<ST>             OP;
+  typedef Tpetra::MultiVector<ST>          MV;
+  typedef Belos::OperatorTraits<ST,MV,OP> OPT;
+  typedef Belos::MultiVecTraits<ST,MV>    MVT;
+
+  GlobalMPISession mpisess(&argc,&argv,&cout);
+
+  bool success = false;
+  bool verbose = false;
+  try {
+    const ST one  = SCT::one();
+
+    int MyPID = 0;
+
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+
+    //
+    // Get test parameters from command-line processor
+    //
+    bool proc_verbose = false;
+    bool debug = false;
+    int frequency = -1;  // how often residuals are printed by solver
+    int numrhs = 1;      // total number of right-hand sides to solve for
+    int blocksize = 1;   // blocksize used by solver
+    int maxiters = -1;   // maximum number of iterations for solver to use
+    std::string filename("bcsstk14.hb");
+    MT tol = 1.0e-5;     // relative residual tolerance
+
+    CommandLineProcessor cmdp(false,true);
+    cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+    cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+    cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+    cmdp.setOption("tol",&tol,"Relative residual tolerance used by CG solver.");
+    cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+    cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+    cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
+    cmdp.setOption("block-size",&blocksize,"Block size to be used by the CG solver.");
+    if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
+      return -1;
+    }
+    if (debug) {
+      verbose = true;
+    }
+    if (!verbose) {
+      frequency = -1;  // reset frequency if test is not verbose
+    }
+
+    MyPID = rank(*comm);
+    proc_verbose = ( verbose && (MyPID==0) );
+
+    if (proc_verbose) {
+      std::cout << Belos::Belos_Version() << std::endl << std::endl;
+    }
+    //
+    // Get the data from the HB file and build the Map,Matrix
+    //
+    RCP<CrsMatrix<ST> > A;
+    Tpetra::Utils::readHBMatrix(filename,comm,A);
+    RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+    // Create initial vectors
+    RCP<MV> B, X;
+    X = rcp( new MV(map,numrhs) );
+    MVT::MvRandom( *X );
+    B = rcp( new MV(map,numrhs) );
+    OPT::Apply( *A, *X, *B );
+    MVT::MvInit( *X, 0.0 );
+
+    //
+    // ********Other information used by block solver***********
+    // *****************(can be user specified)******************
+    //
+    const int NumGlobalElements = B->getGlobalLength();
+    if (maxiters == -1) {
+      maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
+    }
+    //
+    ParameterList belosList;
+    belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+    belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+    belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    belosList.set( "Estimate Condition Number", true );
+    int verbLevel = Belos::Errors + Belos::Warnings;
+    if (debug) {
+      verbLevel += Belos::Debug;
+    }
+    if (verbose) {
+      verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
+    }
+    belosList.set( "Verbosity", verbLevel );
+    if (verbose) {
+      if (frequency > 0) {
+        belosList.set( "Output Frequency", frequency );
+      }
+    }
+    //
+    // Construct an unpreconditioned linear problem instance.
+    //
+    Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+    bool set = problem.setProblem();
+    if (set == false) {
+      if (proc_verbose)
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+    //
+    // *******************************************************************
+    // *************Start the block CG iteration***********************
+    // *******************************************************************
+    //
+    Belos::PseudoBlockCGSolMgr<ST,MV,OP,DM> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+
+    //
+    // **********Print out information about problem*******************
+    //
+    if (proc_verbose) {
+      std::cout << std::endl << std::endl;
+      std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+      std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+      std::cout << "Block size used by solver: " << blocksize << std::endl;
+      std::cout << "Max number of CG iterations: " << maxiters << std::endl;
+      std::cout << "Relative residual tolerance: " << tol << std::endl;
+      std::cout << std::endl;
+    }
+    //
+    // Perform solve
+    //
+    Belos::ReturnType ret = solver.solve();
+    //
+    // Compute actual residuals.
+    //
+    bool badRes = false;
+    std::vector<MT> actual_resids( numrhs );
+    std::vector<MT> rhs_norm( numrhs );
+    MV resid(map, numrhs);
+    OPT::Apply( *A, *X, resid );
+    MVT::MvAddMv( -one, resid, one, *B, resid );
+    MVT::MvNorm( resid, actual_resids );
+    MVT::MvNorm( *B, rhs_norm );
+    if (proc_verbose) {
+      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+    }
+    for ( int i=0; i<numrhs; i++) {
+      MT actRes = actual_resids[i]/rhs_norm[i];
+      if (proc_verbose) {
+        std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+      }
+      if (actRes > tol) badRes = true;
+    }
+
+    if (proc_verbose) {
+      std::cout<<std::endl<<"Condition Estimate: " << SCT::real(solver.getConditionEstimate()) << std::endl;
+      auto ee = solver.getEigenEstimates();
+      std::cout << std::endl << "Eigen estimates:\n" << ee.size() << " " << ee << std::endl;
+      for (int i=0; i < ee.size(); i++) {
+        std::cout << " " << ee[i];
+        if (i > 0 && (i % 10 == 0)) std::cout << std::endl;
+      }
+    }
+
+    success = (ret==Belos::Converged && !badRes);
+
+    if (success) {
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+    } else {
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
+} // end test_bl_cg_hb.cpp

--- a/packages/belos/tpetra/test/BlockCG/test_kokkos_stochastic_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_kokkos_stochastic_cg_hb.cpp
@@ -1,0 +1,215 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+#include "BelosPseudoBlockStochasticCGSolMgr.hpp"
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_StandardCatchMacros.hpp>
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_MatrixIO.hpp>
+
+int
+main (int argc, char *argv[])
+{
+  using Teuchos::Comm;
+  using Teuchos::ParameterList;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::rcpFromRef;
+  using std::endl;
+  using std::cout;
+  typedef Tpetra::MultiVector<>::scalar_type ST;
+  typedef Tpetra::MultiVector<>::impl_scalar_type IST;
+  typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+  typedef Teuchos::ScalarTraits<ST>       STS;
+  typedef STS::magnitudeType               MT;
+  typedef Tpetra::Operator<ST>             OP;
+  typedef Tpetra::MultiVector<ST>          MV;
+  typedef Belos::OperatorTraits<ST,MV,OP> OPT;
+  typedef Belos::MultiVecTraits<ST,MV>    MVT;
+
+  typedef Teuchos::CommandLineProcessor   CLP;
+
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+
+  bool success = false;
+  bool verbose = false;
+  try {
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
+
+    //
+    // Get test parameters from command-line processor
+    //
+    bool proc_verbose = false;
+    bool debug = false;
+    int frequency = -1;
+    int numrhs = 1;
+    int blocksize = 1;
+    int maxiters = -1;
+    std::string filename ("bcsstk14.hb");
+    MT tol = 1.0e-5;
+
+    CLP cmdp (false, true);
+    cmdp.setOption ("verbose", "quiet", &verbose, "Print messages and "
+                    "results.");
+    cmdp.setOption ("debug", "nodebug", &debug, "Run debugging checks.");
+    cmdp.setOption ("frequency", &frequency, "Solver's frequency for printing "
+                    "residuals (#iters).  -1 means \"never\"; 1 means \"every "
+                    "iteration.\"");
+    cmdp.setOption ("tol", &tol, "Relative residual tolerance used by solver.");
+    cmdp.setOption ("filename", &filename, "Filename for Harwell-Boeing test "
+                    "matrix.");
+    cmdp.setOption ("num-rhs", &numrhs, "Number of right-hand sides for which "
+                    "to solve.");
+    cmdp.setOption ("max-iters", &maxiters, "Maximum number of iterations per "
+                    "linear system (-1 := adapted to problem/block size).");
+    cmdp.setOption ("block-size", &blocksize, "Block size to be used by the "
+                    "solver.");
+    if (cmdp.parse (argc, argv) != CLP::PARSE_SUCCESSFUL) {
+      return -1;
+    }
+    if (debug) {
+      verbose = true;
+    }
+    if (!verbose) {
+      frequency = -1;  // reset frequency if test is not verbose
+    }
+
+    const int MyPID = comm->getRank ();
+    proc_verbose = verbose && MyPID == 0;
+
+    if (proc_verbose) {
+      cout << Belos::Belos_Version () << endl << endl;
+    }
+
+    //
+    // Get the data from the HB file and build the Map,Matrix
+    //
+    RCP<Tpetra::CrsMatrix<ST> > A;
+    Tpetra::Utils::readHBMatrix (filename, comm, A);
+    RCP<const Tpetra::Map<> > map = A->getDomainMap ();
+
+    // Create initial vectors
+    RCP<MV> B, X;
+    X = rcp (new MV (map, numrhs));
+    MVT::MvRandom (*X);
+    B = rcp (new MV (map, numrhs));
+    OPT::Apply (*A, *X, *B);
+    MVT::MvInit (*X, STS::zero ());
+
+    //
+    // ********Other information used by block solver***********
+    // *****************(can be user specified)******************
+    //
+    const int NumGlobalElements = B->getGlobalLength();
+    if (maxiters == -1) {
+      maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
+    }
+    //
+    ParameterList belosList;
+    belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+    belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+    belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    int verbLevel = Belos::Errors + Belos::Warnings;
+    if (debug) {
+      verbLevel += Belos::Debug;
+    }
+    if (verbose) {
+      verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
+    }
+    belosList.set( "Verbosity", verbLevel );
+    if (verbose) {
+      if (frequency > 0) {
+        belosList.set( "Output Frequency", frequency );
+      }
+    }
+    //
+    // Construct an unpreconditioned linear problem instance.
+    //
+    Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+    bool set = problem.setProblem ();
+    if (! set) {
+      if (proc_verbose) {
+        cout << endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << endl;
+      }
+      return EXIT_FAILURE;
+    }
+    //
+    // *******************************************************************
+    // *************Start the block CG iteration***********************
+    // *******************************************************************
+    //
+    typedef Belos::PseudoBlockStochasticCGSolMgr<ST,MV,OP,DM> solver_type;
+    solver_type solver (rcpFromRef (problem), rcpFromRef (belosList));
+
+    //
+    // **********Print out information about problem*******************
+    //
+    if (proc_verbose) {
+      cout << endl << endl;
+      cout << "Dimension of matrix: " << NumGlobalElements << endl;
+      cout << "Number of right-hand sides: " << numrhs << endl;
+      cout << "Block size used by solver: " << blocksize << endl;
+      cout << "Max number of CG iterations: " << maxiters << endl;
+      cout << "Relative residual tolerance: " << tol << endl;
+      cout << endl;
+    }
+    //
+    // Perform solve
+    //
+    Belos::ReturnType ret = solver.solve();
+    //
+    // Compute actual residuals.
+    //
+    bool badRes = false;
+    std::vector<MT> actual_resids (numrhs);
+    std::vector<MT> rhs_norm (numrhs);
+    MV resid (map, numrhs);
+    OPT::Apply (*A, *X, resid);
+    MVT::MvAddMv (-STS::one (), resid, STS::one (), *B, resid);
+    MVT::MvNorm (resid, actual_resids);
+    MVT::MvNorm (*B, rhs_norm);
+    if (proc_verbose) {
+      cout << "---------- Actual Residuals (normalized) ----------" << endl << endl;
+    }
+    for (int i=0; i<numrhs; i++) {
+      MT actRes = actual_resids[i]/rhs_norm[i];
+      if (proc_verbose) {
+        cout << "Problem " << i << " : \t" << actRes << endl;
+      }
+      if (actRes > tol) badRes = true;
+    }
+
+    success = ret == Belos::Converged && ! badRes;
+    if (success) {
+      if (proc_verbose) {
+        cout << "\nEnd Result: TEST PASSED" << endl;
+      }
+    } else {
+      if (proc_verbose) {
+        cout << "\nEnd Result: TEST FAILED" << endl;
+      }
+    }
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return success ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/packages/belos/tpetra/test/BlockCG/test_pseudo_bl_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_pseudo_bl_cg_hb.cpp
@@ -20,8 +20,6 @@
 
 #include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
-// I/O for Harwell-Boeing files
-#define HIDE_TPETRA_INOUT_IMPLEMENTATIONS
 #include <Tpetra_MatrixIO.hpp>
 
 #include <Teuchos_CommandLineProcessor.hpp>

--- a/packages/belos/tpetra/test/BlockCG/test_pseudo_stochastic_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_pseudo_stochastic_cg_hb.cpp
@@ -20,8 +20,6 @@
 
 #include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
-// I/O for Harwell-Boeing files
-#define HIDE_TPETRA_INOUT_IMPLEMENTATIONS
 #include <Tpetra_MatrixIO.hpp>
 
 #include <Teuchos_CommandLineProcessor.hpp>

--- a/packages/belos/tpetra/test/BlockGmres/CMakeLists.txt
+++ b/packages/belos/tpetra/test/BlockGmres/CMakeLists.txt
@@ -30,8 +30,26 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_KokkosDense_resolve_gmres_hb
+  SOURCES test_kokkos_resolve_gmres_hb.cpp
+  COMM serial mpi
+  ARGS
+    "--verbose --filename=orsirr1.hb"
+    "--verbose --filename=orsirr1.hb --pseudo"
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Tpetra_pseudo_gmres_hb
   SOURCES test_pseudo_gmres_hb.cpp
+  COMM serial mpi
+  ARGS "--verbose --filename=orsirr1.hb"
+  STANDARD_PASS_OUTPUT
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_KokkosDense_pseudo_gmres_hb
+  SOURCES test_kokkos_pseudo_gmres_hb.cpp
   COMM serial mpi
   ARGS "--verbose --filename=orsirr1.hb"
   STANDARD_PASS_OUTPUT
@@ -44,6 +62,13 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
     "--verbose --ortho-type=DGKS"
     "--verbose --ortho-type=ICGS"
     "--verbose --ortho-type=IMGS"
+  COMM serial mpi
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_KokkosDense_BlockGMRES_hb_test
+  SOURCES test_kokkos_bl_gmres_hb.cpp
+  ARGS "--verbose"
   COMM serial mpi
   )
 
@@ -74,8 +99,24 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_KokkosDense_BlockFGMRES_hb_test
+  SOURCES test_kokkos_bl_fgmres_hb.cpp
+  ARGS "--verbose"
+  COMM serial mpi
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Tpetra_HybridGMRES_hb_test
   SOURCES test_hybrid_gmres_hb.cpp
+  ARGS "--verbose --max-degree=10 --poly-type=Arnoldi"
+       "--verbose --max-degree=10 --poly-type=Gmres"
+       "--verbose --max-degree=10 --poly-type=Roots"
+  COMM serial mpi
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_KokkosDense_HybridGMRES_hb_test
+  SOURCES test_kokkos_hybrid_gmres_hb.cpp
   ARGS "--verbose --max-degree=10 --poly-type=Arnoldi"
        "--verbose --max-degree=10 --poly-type=Gmres"
        "--verbose --max-degree=10 --poly-type=Roots"

--- a/packages/belos/tpetra/test/BlockGmres/test_bl_fgmres_keep_hessenberg.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_bl_fgmres_keep_hessenberg.cpp
@@ -47,27 +47,28 @@ using Teuchos::rcp;
 // StatusTest that snapshots H and R from BlockFGmresIter after each
 // iteration.  Returns Undefined so it never affects convergence decisions.
 // -----------------------------------------------------------------------
-template <class SC, class MV, class OP>
-class HessenbergCapture : public Belos::StatusTest<SC, MV, OP> {
+template <class SC, class MV, class OP, class DM>
+class HessenbergCapture : public Belos::StatusTest<SC, MV, OP, DM> {
  public:
-  using State = Belos::GmresIterationState<SC, MV>;
+  using DMT   = Belos::DenseMatTraits<SC,DM>;
+  using State = Belos::GmresIterationState<SC, MV, DM>;
 
-  int                                     curDim = 0;
-  bool                                    sawFGmresIter = false;
-  RCP<Teuchos::SerialDenseMatrix<int,SC>> H;   // deep copy of raw Hessenberg
-  RCP<Teuchos::SerialDenseMatrix<int,SC>> R;   // deep copy of QR-rotated R
+  int     curDim = 0;
+  bool    sawFGmresIter = false;
+  RCP<DM> H;   // deep copy of raw Hessenberg
+  RCP<DM> R;   // deep copy of QR-rotated R
 
-  Belos::StatusType checkStatus(Belos::Iteration<SC, MV, OP>* it) override {
-    auto* fg = dynamic_cast<Belos::BlockFGmresIter<SC, MV, OP>*>(it);
+  Belos::StatusType checkStatus(Belos::Iteration<SC, MV, OP, DM>* it) override {
+    auto* fg = dynamic_cast<Belos::BlockFGmresIter<SC, MV, OP, DM>*>(it);
     if (fg) {
       sawFGmresIter = true;
       State s = fg->getState();
       if (s.curDim > 0) {
         curDim = s.curDim;
         if (s.H)
-          H = rcp(new Teuchos::SerialDenseMatrix<int,SC>(*s.H));
+          H = DMT::CreateCopy( *s.H );
         if (s.R)
-          R = rcp(new Teuchos::SerialDenseMatrix<int,SC>(*s.R));
+          R = DMT::CreateCopy( *s.R );
       }
     }
     return Belos::Undefined;
@@ -158,8 +159,8 @@ bool runCase(bool keepHessenberg, int numBlocks, bool verbose)
   params->set("Keep Hessenberg",       keepHessenberg);
   params->set("Verbosity",             Belos::Errors);
 
-  auto capture = rcp(new HessenbergCapture<SC,MV,OP>());
-  Belos::BlockGmresSolMgr<SC,MV,OP> solver(problem, params);
+  auto capture = rcp(new HessenbergCapture<SC,MV,OP,SDM>());
+  Belos::BlockGmresSolMgr<SC,MV,OP,SDM> solver(problem, params);
   solver.setDebugStatusTest(capture);
 
   Belos::ReturnType ret = solver.solve();

--- a/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb_df.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb_df.cpp
@@ -88,7 +88,7 @@ RCP<LinearProblem<Scalar,Tpetra::MultiVector<Scalar>,Tpetra::Operator<Scalar> > 
   MVT::MvRandom( *X );
   B = rcp( new MV(vmap,numrhs) );
   OPT::Apply( *A, *X, *B );
-  MVT::MvInit( *X, 0.0 );
+  MVT::MvInit( *X, SCT::zero() );
   // Construct a linear problem instance with zero initial MV
   RCP<LinearProblem<Scalar,MV,OP> > problem = rcp( new LinearProblem<Scalar,MV,OP>(A,X,B) );
   problem->setLabel(Teuchos::typeName(SCT::one()));
@@ -186,7 +186,7 @@ int main(int argc, char *argv[])
   //
   // Get test parameters from command-line processor
   //
-  bool verbose = false, debug = false;
+  bool verbose = true, debug = true;
   int frequency = -1;  // how often residuals are printed by solver
   int maxiters = -1;   // maximum number of iterations for solver to use
   numrhs = 1;      // total number of right-hand sides to solve for

--- a/packages/belos/tpetra/test/BlockGmres/test_hybrid_gmres_hb.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_hybrid_gmres_hb.cpp
@@ -27,15 +27,12 @@
 #include "BelosTpetraAdapter.hpp"
 #include "BelosGmresPolySolMgr.hpp"
 
-// I/O for Harwell-Boeing files
-#define HIDE_TPETRA_INOUT_IMPLEMENTATIONS
-#include <Tpetra_MatrixIO.hpp>
-
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_ParameterList.hpp>
 #include <Teuchos_StandardCatchMacros.hpp>
 #include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_MatrixIO.hpp>
 
 using namespace Teuchos;
 using Tpetra::Operator;

--- a/packages/belos/tpetra/test/BlockGmres/test_kokkos_bl_fgmres_hb.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_kokkos_bl_fgmres_hb.cpp
@@ -1,0 +1,241 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosTpetraOperator.hpp"
+#include "BelosBlockGmresSolMgr.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+
+// I/O for Harwell-Boeing files
+#include "Tpetra_MatrixIO.hpp"
+
+#include "Teuchos_CommandLineProcessor.hpp"
+#include "Teuchos_ParameterList.hpp"
+#include "Teuchos_StandardCatchMacros.hpp"
+#include "Tpetra_Core.hpp"
+#include "Tpetra_CrsMatrix.hpp"
+
+using Tpetra::Operator;
+using Tpetra::CrsMatrix;
+using Tpetra::MultiVector;
+using std::endl;
+using std::cout;
+using std::vector;
+using Teuchos::tuple;
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::ParameterList;
+
+int main(int argc, char *argv[]) {
+  typedef Tpetra::MultiVector<>::scalar_type ST;
+  typedef Tpetra::MultiVector<>::impl_scalar_type IST;
+  typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+  typedef Teuchos::ScalarTraits<ST>       SCT;
+  typedef SCT::magnitudeType               MT;
+  typedef Tpetra::Operator<ST>             OP;
+  typedef Tpetra::MultiVector<ST>          MV;
+  typedef Belos::OperatorTraits<ST,MV,OP> OPT;
+  typedef Belos::MultiVecTraits<ST,MV,DM> MVT;
+
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
+
+  bool success = false;
+  bool verbose = false;
+  try {
+    const ST one  = SCT::one();
+
+    int MyPID = 0;
+
+    RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
+    //
+    // Get test parameters from command-line processor
+    //
+    bool proc_verbose = false;
+    bool debug = false;
+    int frequency = -1;  // how often residuals are printed by solver
+    int numrhs = 1;      // total number of right-hand sides to solve for
+    int blocksize = 1;   // blocksize used by solver
+    int maxiters = -1;   // maximum number of iterations for solver to use
+    int length = 100;    // max subspace size
+    std::string filename("bcsstk14.hb");
+    MT tol = 1.0e-5;     // relative residual tolerance
+
+    Teuchos::CommandLineProcessor cmdp(false,true);
+    cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+    cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+    cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+    cmdp.setOption("tol",&tol,"Relative residual tolerance used by Gmres solver.");
+    cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+    cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+    cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
+    cmdp.setOption("max-subspace",&length,"Maximum number of blocks the solver can use for the subspace.");
+    cmdp.setOption("block-size",&blocksize,"Block size to be used by the Gmres solver.");
+    if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+      return -1;
+    }
+    if (debug) {
+      verbose = true;
+    }
+    if (!verbose) {
+      frequency = -1;  // reset frequency if test is not verbose
+    }
+
+    MyPID = rank(*comm);
+    proc_verbose = ( verbose && (MyPID==0) );
+
+    if (proc_verbose) {
+      std::cout << Belos::Belos_Version() << std::endl << std::endl;
+    }
+
+    //
+    // Get the data from the HB file and build the Map,Matrix
+    //
+    RCP<CrsMatrix<ST> > A;
+    Tpetra::Utils::readHBMatrix(filename,comm,A);
+    RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+    // Create initial vectors
+    RCP<MV> B, X;
+    X = rcp( new MV(map,numrhs) );
+    MVT::MvRandom( *X );
+    B = rcp( new MV(map,numrhs) );
+    OPT::Apply( *A, *X, *B );
+    MVT::MvInit( *X, 0.0 );
+
+    //
+    // ********Other information used by block solver***********
+    // *****************(can be user specified)******************
+    //
+    const int NumGlobalElements = B->getGlobalLength();
+    if (maxiters == -1) {
+      maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
+    }
+    //
+    ParameterList belosList;
+    belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+    belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+    belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    belosList.set( "Num Blocks", length );                 // Maximum number of blocks in Krylov subspace (max subspace size)
+    belosList.set( "Flexible Gmres", true );               // use FGMRES
+                                                           
+    int verbLevel = Belos::Errors + Belos::Warnings;
+    if (debug) {
+      verbLevel += Belos::Debug;
+    }
+    if (verbose) {
+      verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
+    }
+    belosList.set( "Verbosity", verbLevel );
+    if (verbose) {
+      if (frequency > 0) {
+        belosList.set( "Output Frequency", frequency );
+      }
+    }
+
+    // Set parameters for the inner GMRES (preconditioning) iteration.
+    ParameterList innerBelosList;
+    innerBelosList.set( "Num Blocks", length );                 // Maximum number of blocks in Krylov subspace (max subspace size)
+    innerBelosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+    innerBelosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+    innerBelosList.set( "Convergence Tolerance", 1.0e-2 );       // Relative convergence tolerance requested
+    innerBelosList.set( "Verbosity", Belos::Errors + Belos::Warnings );
+    innerBelosList.set( "Timer Label", "Belos Preconditioner Solve" );// Choose a different label for the inner solve
+
+    // *****Construct linear problem for the inner iteration using A *****
+    Belos::LinearProblem<ST,MV,OP> innerProblem;
+    innerProblem.setOperator( A );
+    innerProblem.setLabel( "Belos Preconditioner Solve" );
+
+    //  
+    // *****Create the inner block Gmres iteration********
+    //  
+    RCP<Belos::TpetraOperator<ST>> innerSolver;
+    innerSolver = rcp( new Belos::TpetraOperator<ST>( rcpFromRef(innerProblem), rcpFromRef(innerBelosList), "Block Gmres", true ) );
+    //  
+
+    //
+    // Construct a linear problem instance with GMRES as preconditoner.
+    //
+    Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+    problem.setInitResVec( B );
+    problem.setRightPrec( innerSolver );
+    problem.setLabel( "Belos Flexible Gmres Solve" );
+    bool set = problem.setProblem();
+    if (set == false) {
+      if (proc_verbose)
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+    //
+    // *******************************************************************
+    // *************Start the block Gmres iteration***********************
+    // *******************************************************************
+    //
+    Belos::BlockGmresSolMgr<ST,MV,OP,DM> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+
+    //
+    // **********Print out information about problem*******************
+    //
+    if (proc_verbose) {
+      std::cout << std::endl << std::endl;
+      std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+      std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+      std::cout << "Block size used by solver: " << blocksize << std::endl;
+      std::cout << "Max number of Gmres iterations: " << maxiters << std::endl;
+      std::cout << "Relative residual tolerance: " << tol << std::endl;
+      std::cout << std::endl;
+    }
+    //
+    // Perform solve
+    //
+    Belos::ReturnType ret = solver.solve();
+    //
+    // Compute actual residuals.
+    //
+    bool badRes = false;
+    std::vector<MT> actual_resids( numrhs );
+    std::vector<MT> rhs_norm( numrhs );
+    MV resid(map, numrhs);
+    OPT::Apply( *A, *X, resid );
+    MVT::MvAddMv( -one, resid, one, *B, resid );
+    MVT::MvNorm( resid, actual_resids );
+    MVT::MvNorm( *B, rhs_norm );
+    if (proc_verbose) {
+      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+    }
+    for ( int i=0; i<numrhs; i++) {
+      MT actRes = actual_resids[i]/rhs_norm[i];
+      if (proc_verbose) {
+        std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+      }
+      if (actRes > tol) badRes = true;
+    }
+
+    success = (ret==Belos::Converged && !badRes);
+
+    if (success) {
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+    } else {
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
+} // end test_kokkos_bl_fgmres_hb.cpp

--- a/packages/belos/tpetra/test/BlockGmres/test_kokkos_bl_gmres_hb.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_kokkos_bl_gmres_hb.cpp
@@ -1,0 +1,213 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+#include "BelosBlockGmresSolMgr.hpp"
+
+// I/O for Harwell-Boeing files
+#include <Tpetra_MatrixIO.hpp>
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_StandardCatchMacros.hpp>
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+using namespace Teuchos;
+using Tpetra::Operator;
+using Tpetra::CrsMatrix;
+using Tpetra::MultiVector;
+using std::endl;
+using std::cout;
+using std::vector;
+using Teuchos::tuple;
+
+int main(int argc, char *argv[]) {
+  typedef Tpetra::MultiVector<>::scalar_type ST;
+  typedef Tpetra::MultiVector<>::impl_scalar_type IST;
+  typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+  typedef ScalarTraits<ST>                SCT;
+  typedef SCT::magnitudeType               MT;
+  typedef Tpetra::Operator<ST>             OP;
+  typedef Tpetra::MultiVector<ST>          MV;
+  typedef Belos::OperatorTraits<ST,MV,OP> OPT;
+  typedef Belos::MultiVecTraits<ST,MV,DM>    MVT;
+
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
+
+  bool success = false;
+  bool verbose = false;
+  try {
+    const ST one  = SCT::one();
+
+    int MyPID = 0;
+
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+    //
+    // Get test parameters from command-line processor
+    //
+    bool proc_verbose = false;
+    bool debug = false;
+    int frequency = -1;  // how often residuals are printed by solver
+    int numrhs = 1;      // total number of right-hand sides to solve for
+    int blocksize = 1;   // blocksize used by solver
+    int maxiters = -1;   // maximum number of iterations for solver to use
+    std::string ortho("DGKS"); // orthogonalization type
+    std::string filename("bcsstk14.hb");
+    MT tol = 1.0e-5;     // relative residual tolerance
+
+    CommandLineProcessor cmdp(false,true);
+    cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+    cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+    cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+    cmdp.setOption("tol",&tol,"Relative residual tolerance used by Gmres solver.");
+    cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+    cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+    cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
+    cmdp.setOption("block-size",&blocksize,"Block size to be used by the Gmres solver.");
+    cmdp.setOption("ortho-type",&ortho,"Orthogonalization type, either DGKS, ICGS or IMGS (or TSQR if enabled)");
+    if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
+      return -1;
+    }
+    if (debug) {
+      verbose = true;
+    }
+    if (!verbose) {
+      frequency = -1;  // reset frequency if test is not verbose
+    }
+
+    MyPID = rank(*comm);
+    proc_verbose = ( verbose && (MyPID==0) );
+
+    if (proc_verbose) {
+      std::cout << Belos::Belos_Version() << std::endl << std::endl;
+    }
+
+    //
+    // Get the data from the HB file and build the Map,Matrix
+    //
+    RCP<CrsMatrix<ST> > A;
+    Tpetra::Utils::readHBMatrix(filename,comm,A);
+    RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+    // Create initial vectors
+    RCP<MV> B, X;
+    X = rcp( new MV(map,numrhs) );
+    MVT::MvRandom( *X );
+    B = rcp( new MV(map,numrhs) );
+    OPT::Apply( *A, *X, *B );
+    MVT::MvInit( *X, 0.0 );
+
+    //
+    // ********Other information used by block solver***********
+    // *****************(can be user specified)******************
+    //
+    const int NumGlobalElements = B->getGlobalLength();
+    if (maxiters == -1) {
+      maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
+    }
+    //
+    ParameterList belosList;
+    belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+    belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+    belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    belosList.set( "Orthogonalization", ortho );           // Orthogonalization type
+
+    int verbLevel = Belos::Errors + Belos::Warnings;
+    if (debug) {
+      verbLevel += Belos::Debug;
+    }
+    if (verbose) {
+      verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
+    }
+    belosList.set( "Verbosity", verbLevel );
+    if (verbose) {
+      if (frequency > 0) {
+        belosList.set( "Output Frequency", frequency );
+      }
+    }
+    //
+    // Construct an unpreconditioned linear problem instance.
+    //
+    Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+    problem.setInitResVec( B );
+    bool set = problem.setProblem();
+    if (set == false) {
+      if (proc_verbose)
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+    //
+    // *******************************************************************
+    // *************Start the block Gmres iteration***********************
+    // *******************************************************************
+    //
+    Belos::BlockGmresSolMgr<ST,MV,OP,DM> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+
+    //
+    // **********Print out information about problem*******************
+    //
+    if (proc_verbose) {
+      std::cout << std::endl << std::endl;
+      std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+      std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+      std::cout << "Block size used by solver: " << blocksize << std::endl;
+      std::cout << "Max number of Gmres iterations: " << maxiters << std::endl;
+      std::cout << "Relative residual tolerance: " << tol << std::endl;
+      std::cout << std::endl;
+    }
+    //
+    // Perform solve
+    //
+    Belos::ReturnType ret = solver.solve();
+    //
+    // Compute actual residuals.
+    //
+    bool badRes = false;
+    std::vector<MT> actual_resids( numrhs );
+    std::vector<MT> rhs_norm( numrhs );
+    MV resid(map, numrhs);
+    OPT::Apply( *A, *X, resid );
+    MVT::MvAddMv( -one, resid, one, *B, resid );
+    MVT::MvNorm( resid, actual_resids );
+    MVT::MvNorm( *B, rhs_norm );
+    if (proc_verbose) {
+      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+    }
+    for ( int i=0; i<numrhs; i++) {
+      MT actRes = actual_resids[i]/rhs_norm[i];
+      if (proc_verbose) {
+        std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+      }
+      if (actRes > tol) badRes = true;
+    }
+
+    success = (ret==Belos::Converged && !badRes);
+
+    if (success) {
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+    } else {
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
+} // end test_bl_cg_hb.cpp

--- a/packages/belos/tpetra/test/BlockGmres/test_kokkos_hybrid_gmres_hb.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_kokkos_hybrid_gmres_hb.cpp
@@ -1,0 +1,248 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver tests variations of Hybrid GMRES using the Belos GMRES 
+// Polynomial solver manager.  One can specify an 'outer solver'
+// to which the GMRES Polynomial is applied as a preconditioner.  
+// If the 'outer solver' string is empty, the polynomial will be applied
+// alone.
+//
+// Alternately, one can apply the GMRES polynomial without the 'outer
+// solver' functionality by using the BelosTpetraOperator interface.
+// See the FGMRES test driver for an example of its use.  
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+//
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+#include "BelosGmresPolySolMgr.hpp"
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_StandardCatchMacros.hpp>
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_MatrixIO.hpp>
+
+using namespace Teuchos;
+using Tpetra::Operator;
+using Tpetra::CrsMatrix;
+using Tpetra::MultiVector;
+using std::endl;
+using std::cout;
+using std::vector;
+using Teuchos::tuple;
+
+int main(int argc, char *argv[]) {
+  typedef Tpetra::MultiVector<>::scalar_type ST;
+  typedef Tpetra::MultiVector<>::impl_scalar_type IST;
+  typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+  typedef ScalarTraits<ST>                SCT;
+  typedef SCT::magnitudeType               MT;
+  typedef Tpetra::Operator<ST>             OP;
+  typedef Tpetra::MultiVector<ST>          MV;
+  typedef Belos::OperatorTraits<ST,MV,OP> OPT;
+  typedef Belos::MultiVecTraits<ST,MV,DM> MVT;
+
+  Tpetra::ScopeGuard tpetraScope(&argc,&argv);
+
+  bool success = false;
+  bool verbose = false;
+  try {
+    const ST one  = SCT::one();
+
+    int MyPID = 0;
+
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+    //
+    // Get test parameters from command-line processor
+    //
+    bool proc_verbose = false;
+    bool userandomrhs = false;                // use linear problem RHS or random RHS to generate poly
+    int frequency = -1;                       // frequency of status test output.
+    int blocksize = 1;                        // blocksize
+    int numrhs = 1;                           // number of right-hand sides to solve for
+    int maxiters = -1;                        // maximum number of iterations allowed per linear system
+    int maxdegree = 25;                       // maximum degree of polynomial
+    int maxsubspace = 50;                     // maximum number of blocks the solver can use for the subspace
+    int maxrestarts = 15;                     // number of restarts allowed
+    std::string outersolver("Block Gmres");   // name of outer solver
+    std::string polytype("Roots");            // polynomial configuration.  
+    std::string filename("bcsstk14.hb");      // name of matrix file
+    MT tol = 1.0e-5;                          // relative residual tolerance
+    MT polytol = tol/10;                      // relative residual tolerance for polynomial construction
+
+    Teuchos::CommandLineProcessor cmdp(false,true);
+    cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+    cmdp.setOption("use-random-rhs","use-rhs",&userandomrhs,"Use linear system RHS or random RHS to generate polynomial.");
+    cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+    cmdp.setOption("filename",&filename,"Filename for test matrix.  Acceptable file extensions: *.hb,*.mtx,*.triU,*.triS");
+    cmdp.setOption("outersolver",&outersolver,"Name of outer solver to be used with GMRES poly");
+    cmdp.setOption("poly-type",&polytype,"Name of the polynomial to be generated. Arnoldi, Gmres, or Roots.");
+    cmdp.setOption("tol",&tol,"Relative residual tolerance used by GMRES solver.");
+    cmdp.setOption("poly-tol",&polytol,"Relative residual tolerance used to construct the GMRES polynomial.");
+    cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+    cmdp.setOption("block-size",&blocksize,"Block size used by GMRES.");
+    cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 = adapted to problem/block size).");
+    cmdp.setOption("max-degree",&maxdegree,"Maximum degree of the GMRES polynomial.");
+    cmdp.setOption("max-subspace",&maxsubspace,"Maximum number of blocks the solver can use for the subspace.");
+    cmdp.setOption("max-restarts",&maxrestarts,"Maximum number of restarts allowed for GMRES solver.");
+    if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
+      return EXIT_FAILURE;
+    }
+    if (!verbose) {
+      frequency = -1;  // reset frequency if test is not verbose
+    }
+
+    MyPID = rank(*comm);
+    proc_verbose = ( verbose && (MyPID==0) );
+
+    if (proc_verbose) {
+      std::cout << Belos::Belos_Version() << std::endl << std::endl;
+    }
+
+    //
+    // Get the data from the HB file and build the Map,Matrix
+    //
+    RCP<CrsMatrix<ST> > A;
+    Tpetra::Utils::readHBMatrix(filename,comm,A);
+    RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+    // Create initial vectors
+    RCP<MV> B, X;
+    X = rcp( new MV(map,numrhs) );
+    MVT::MvRandom( *X );
+    B = rcp( new MV(map,numrhs) );
+    OPT::Apply( *A, *X, *B );
+    MVT::MvInit( *X, 0.0 );
+
+    //
+    // ********Other information used by block solver***********
+    // *****************(can be user specified)******************
+    //
+    const int NumGlobalElements = B->getGlobalLength();
+    if (maxiters == -1) {
+      maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
+    }
+    //
+    //
+    //Parameter list used by the outer solver:
+    ParameterList belosList;
+    belosList.set( "Num Blocks", maxsubspace);             // Maximum number of blocks in Krylov factorization
+    belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+    belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+    belosList.set( "Maximum Restarts", maxrestarts );      // Maximum number of restarts allowed
+    belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    int verbosity = Belos::Errors + Belos::Warnings;
+    if (verbose) {
+      verbosity += Belos::FinalSummary + Belos::TimingDetails + Belos::StatusTestDetails;
+      if (frequency > 0)
+        belosList.set( "Output Frequency", frequency );
+    }
+    belosList.set( "Verbosity", verbosity );
+
+    // Parameter list used by the GMRES Polynomial (inner) solver
+    ParameterList polyList;
+    polyList.set( "Polynomial Type", polytype );          // Type of polynomial to be generated
+    polyList.set( "Maximum Degree", maxdegree );          // Maximum degree of the GMRES polynomial
+    polyList.set( "Polynomial Tolerance", polytol );      // Polynomial convergence tolerance requested
+    polyList.set( "Verbosity", verbosity );               // Verbosity for polynomial construction
+    polyList.set( "Random RHS", userandomrhs );           // Use RHS from linear system or random vector
+                                                          // to generate the polynomial.
+                                                          
+    //
+    // Pass the outer solver name and parameters to the polynomial solver manager.
+    //
+    if ( outersolver != "" ) {
+      polyList.set( "Outer Solver", outersolver );
+      polyList.set( "Outer Solver Params", belosList );
+    }
+
+    //
+    // Construct an unpreconditioned linear problem instance. 
+    //
+    // The polynomial preconditioning will be handled by the solver manager.
+    // One could pass another preconditioner such as ILU to the linear problem
+    // to be used in combination with the polynomial preconditioner.
+    //
+    Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+    problem.setInitResVec( B );
+    bool set = problem.setProblem();
+    if (set == false) {
+      if (proc_verbose)
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return EXIT_FAILURE;
+    }
+    //
+    // *******************************************************************
+    // *************Start the Hybrid Gmres iteration***********************
+    // ********* Using the GMRES Poly Solver Manager *********************
+    // *******************************************************************
+    //
+    Belos::GmresPolySolMgr<ST,MV,OP,DM> solver( rcpFromRef(problem), rcpFromRef(polyList) );
+
+    //
+    // **********Print out information about problem*******************
+    //
+    if (proc_verbose) {
+      std::cout << std::endl << std::endl;
+      std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+      std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+      std::cout << "Block size used by solver: " << blocksize << std::endl;
+      std::cout << "Max number of Gmres iterations: " << maxiters << std::endl;
+      std::cout << "Relative residual tolerance: " << tol << std::endl;
+      std::cout << std::endl;
+    }
+
+    //
+    // Perform solve
+    //
+    Belos::ReturnType ret = solver.solve();
+
+    //
+    // Compute actual residuals.
+    //
+    bool badRes = false;
+    std::vector<MT> actual_resids( numrhs );
+    std::vector<MT> rhs_norm( numrhs );
+    MV resid(map, numrhs);
+    OPT::Apply( *A, *X, resid );
+    MVT::MvAddMv( -one, resid, one, *B, resid );
+    MVT::MvNorm( resid, actual_resids );
+    MVT::MvNorm( *B, rhs_norm );
+    if (proc_verbose) {
+      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+    }
+    for ( int i=0; i<numrhs; i++) {
+      MT actRes = actual_resids[i]/rhs_norm[i];
+      if (proc_verbose) {
+        std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+      }
+      if (actRes > tol) badRes = true;
+    }
+
+    success = (ret==Belos::Converged && !badRes);
+
+    if (success) {
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+    } else {
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
+} // end test_hybrid_gmres_hb.cpp

--- a/packages/belos/tpetra/test/BlockGmres/test_kokkos_pseudo_gmres_hb.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_kokkos_pseudo_gmres_hb.cpp
@@ -1,0 +1,286 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// Multiple right-hand-sides are created randomly.
+// The initial guesses are all set to zero.
+//
+// This test is for testing the deflation in the pseudo-block Gmres solver.
+// One set of linear systems is solved and then augmented with additional
+// linear systems and resolved.  The already solved linear systems should be
+// deflated immediately, leaving only the augmented systems to be solved.
+//
+//
+
+// Tpetra
+#include <Tpetra_Map.hpp>
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_MultiVector.hpp>
+
+// Belos
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraTestFramework.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+#include "BelosPseudoBlockGmresSolMgr.hpp"
+
+
+template <typename ScalarType>
+int run(int argc, char *argv[]) {
+
+  using ST = typename Tpetra::CrsMatrix<ScalarType>::scalar_type;
+  using LO = typename Tpetra::CrsMatrix<>::local_ordinal_type;
+  using GO = typename Tpetra::CrsMatrix<>::global_ordinal_type;
+  using NT = typename Tpetra::CrsMatrix<>::node_type;
+
+  using OP  = typename Tpetra::Operator<ST,LO,GO,NT>;
+  using MV  = typename Tpetra::MultiVector<ST,LO,GO,NT>;
+  using MT = typename Teuchos::ScalarTraits<ST>::magnitudeType;
+
+  using IST = typename Tpetra::MultiVector<>::impl_scalar_type;
+  using DM = typename Kokkos::DualView<IST**,Kokkos::LayoutLeft>;
+
+  using tmap_t       = Tpetra::Map<LO,GO,NT>;
+  using tcrsmatrix_t = Tpetra::CrsMatrix<ST,LO,GO,NT>;
+
+  using MVT = typename Belos::MultiVecTraits<ST,MV,DM>;
+  using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::ParameterList;
+
+  Teuchos::GlobalMPISession session(&argc, &argv, nullptr);
+
+  bool verbose = false;
+  bool success = true;
+
+  try {
+
+    const auto comm = Tpetra::getDefaultComm();
+    const int myPID = comm->getRank();
+
+    bool procVerbose = false;
+    int frequency = -1;    // how often residuals are printed by solver
+    int initNumRHS = 5;   // how many right-hand sides get solved first
+    int augNumRHS = 10;   // how many right-hand sides are augmented to the first group
+    int maxRestarts = 15;  // number of restarts allowed
+    int length = 100;
+    int initBlockSize = 5;// blocksize used for the initial pseudo-block GMRES solve
+    int augBlockSize = 3; // blocksize used for the augmented pseudo-block GMRES solve
+    int maxIters = -1;     // maximum iterations allowed
+    std::string filename("orsirr1.hb");
+    MT tol = 1.0e-5;       // relative residual tolerance
+    MT aug_tol = 1.0e-5;   // relative residual tolerance for augmented system
+
+    Teuchos::CommandLineProcessor cmdp(false,true);
+    cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+    cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+    cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+    cmdp.setOption("tol",&tol,"Relative residual tolerance used by GMRES solver.");
+    cmdp.setOption("aug-tol",&aug_tol,"Relative residual tolerance used by GMRES solver for augmented systems.");
+    cmdp.setOption("init-num-rhs",&initNumRHS,"Number of right-hand sides to be initially solved for.");
+    cmdp.setOption("aug-num-rhs",&augNumRHS,"Number of right-hand sides augmenting the initial solve.");
+    cmdp.setOption("max-restarts",&maxRestarts,"Maximum number of restarts allowed for GMRES solver.");
+    cmdp.setOption("block-size",&initBlockSize,"Block size used by GMRES for the initial solve.");
+    cmdp.setOption("aug-block-size",&augBlockSize,"Block size used by GMRES for the augmented solve.");
+    cmdp.setOption("max-iters",&maxIters,"Maximum number of iterations per linear system (-1 = adapted to problem/block size).");
+    cmdp.setOption("subspace-size",&length,"Dimension of Krylov subspace used by GMRES.");
+    if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+      return -1;
+    }
+    if (!verbose)
+      frequency = -1;  // reset frequency if test is not verbose
+
+    procVerbose = verbose && (myPID==0); /* Only print on zero processor */
+
+    // Get the problem
+    Belos::Tpetra::HarwellBoeingReader<tcrsmatrix_t> reader( comm );
+    RCP<tcrsmatrix_t> A = reader.readFromFile( filename );
+    RCP<const tmap_t> Map = A->getDomainMap();
+
+    // ********Other information used by block solver***********
+    // *****************(can be user specified)******************
+
+    const int numGlobalElements = Map->getGlobalNumElements();
+    if (maxIters == -1)
+      maxIters = numGlobalElements - 1; // maximum number of iterations to run
+
+    ParameterList belosList;
+    belosList.set( "Num Blocks", length );                 // Maximum number of blocks in Krylov factorization
+    belosList.set( "Block Size", initBlockSize );         // Blocksize to be used by iterative solver
+    belosList.set( "Maximum Iterations", maxIters );       // Maximum number of iterations allowed
+    belosList.set( "Maximum Restarts", maxRestarts );      // Maximum number of restarts allowed
+    belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    belosList.set( "Deflation Quorum", initBlockSize  );  // Number of converged linear systems before deflation
+    belosList.set( "Timer Label", "Belos Init" );          // Label used by the timers in this solver
+    if (verbose) {
+      belosList.set( "Verbosity", Belos::Errors + Belos::Warnings +
+          Belos::TimingDetails + Belos::StatusTestDetails );
+      if (frequency > 0)
+        belosList.set( "Output Frequency", frequency );
+    }
+    else
+      belosList.set( "Verbosity", Belos::Errors + Belos::Warnings );
+
+    // *****Construct solution std::vector and random right-hand-sides *****
+
+    RCP<MV> initX = rcp( new MV(Map, initNumRHS) );
+    RCP<MV> initB = rcp( new MV(Map, initNumRHS) );
+    MVT::MvRandom( *initX );
+    OPT::Apply( *A, *initX, *initB );
+    initX->putScalar( 0.0 );
+    Belos::LinearProblem<ST,MV,OP> initProblem( A, initX, initB );
+    initProblem.setLabel("Belos Init");
+
+    bool set = initProblem.setProblem();
+
+    if (set == false) {
+      if (procVerbose)
+        std::cout << std::endl << "ERROR:  Initial Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+
+    // *******************************************************************
+    // *********************Perform initial solve*************************
+    // *******************************************************************
+
+    RCP< Belos::SolverManager<ST,MV,OP,DM> > initSolver
+      = rcp( new Belos::PseudoBlockGmresSolMgr<ST,MV,OP,DM>( rcp(&initProblem,false), rcp(&belosList,false) ) );
+
+    // Perform solve
+    Belos::ReturnType ret = initSolver->solve();
+
+    // Compute actual residuals
+    bool badRes = false;
+    std::vector<ST> actualResids( initNumRHS );
+    std::vector<ST> rhsNorm( initNumRHS );
+    MV initR( Map, initNumRHS );
+    OPT::Apply( *A, *initX, initR );
+    MVT::MvAddMv( -1.0, initR, 1.0, *initB, initR );
+    MVT::MvNorm( initR, actualResids );
+    MVT::MvNorm( *initB, rhsNorm );
+    if (procVerbose) {
+      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+      for (int i=0; i<initNumRHS; i++) {
+        ST actRes = actualResids[i]/rhsNorm[i];
+        std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+        if (actRes > tol) badRes = true;
+      }
+    }
+
+    if (ret != Belos::Converged || badRes==true) {
+      if (procVerbose)
+        std::cout << std::endl << "ERROR:  Initial solve did not converge to solution!" << std::endl;
+      return -1;
+    }
+
+    // ***************Construct augmented linear system****************
+
+    RCP<MV> augX = rcp( new MV(Map, initNumRHS+augNumRHS) );
+    RCP<MV> augB = rcp( new MV(Map, initNumRHS+augNumRHS) );
+    if (augNumRHS) {
+      MVT::MvRandom( *augX );
+      OPT::Apply( *A, *augX, *augB );
+      augX->putScalar( 0.0 );
+    }
+
+    // Copy previous linear system into
+    RCP<MV> tmpX = rcp( new MV( *augX ) );
+    RCP<MV> tmpB = rcp( new MV( *augB ) );
+    tmpX->scale( 1.0, *augX );
+    tmpB->scale( 1.0, *augB );
+
+    Belos::LinearProblem<ST,MV,OP> augProblem( A, augX, augB );
+    augProblem.setLabel("Belos Aug");
+
+    set = augProblem.setProblem();
+    if (set == false) {
+      if (procVerbose)
+        std::cout << std::endl << "ERROR:  Augmented Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+
+    // *******************************************************************
+    // *******************Perform augmented solve*************************
+    // *******************************************************************
+
+    belosList.set( "Block Size", augBlockSize );                // Blocksize to be used by iterative solver
+    belosList.set( "Convergence Tolerance", aug_tol );           // Relative convergence tolerance requested
+    belosList.set( "Deflation Quorum", augBlockSize );          // Number of converged linear systems before deflation
+    belosList.set( "Timer Label", "Belos Aug" );          // Label used by the timers in this solver
+    belosList.set( "Implicit Residual Scaling", "Norm of RHS" ); // Implicit residual scaling for convergence
+    belosList.set( "Explicit Residual Scaling", "Norm of RHS" ); // Explicit residual scaling for convergence
+    RCP< Belos::SolverManager<ST,MV,OP> > augSolver
+      = rcp( new Belos::PseudoBlockGmresSolMgr<ST,MV,OP>( rcp(&augProblem,false), rcp(&belosList,false) ) );
+
+    // Perform solve
+    ret = augSolver->solve();
+
+    if (ret != Belos::Converged) {
+      if (procVerbose)
+        std::cout << std::endl << "ERROR: Augmented solver did not converge to solution!" << std::endl;
+      return -1;
+    }
+
+    // **********Print out information about problem*******************
+
+    if (procVerbose) {
+      std::cout << std::endl << std::endl;
+      std::cout << "Dimension of matrix: " << numGlobalElements << std::endl;
+      std::cout << "Number of initial right-hand sides: " << initNumRHS << std::endl;
+      std::cout << "Number of augmented right-hand sides: " << augNumRHS << std::endl;
+      std::cout << "Number of restarts allowed: " << maxRestarts << std::endl;
+      std::cout << "Length of block Arnoldi factorization: " << length <<std::endl;
+      std::cout << "Max number of Gmres iterations: " << maxIters << std::endl;
+      std::cout << "Relative residual tolerance: " << tol << std::endl;
+      if (aug_tol != tol)
+        std::cout << "Relative residual tolerance for augmented systems: " << aug_tol << std::endl;
+      std::cout << std::endl;
+    }
+
+    // Compute actual residuals.
+    badRes = false;
+    int total_numrhs = initNumRHS + augNumRHS;
+    actualResids.resize( total_numrhs );
+    rhsNorm.resize( total_numrhs );
+    MV augR( Map, total_numrhs );
+    OPT::Apply( *A, *augX, augR );
+    MVT::MvAddMv( -1.0, augR, 1.0, *augB, augR );
+    MVT::MvNorm( augR, actualResids );
+    MVT::MvNorm( *augB, rhsNorm );
+    if (procVerbose) {
+      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+      for ( int i=0; i<total_numrhs; i++) {
+        ST actRes = actualResids[i]/rhsNorm[i];
+        std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+        if (actRes > tol ) badRes = true;
+      }
+    }
+    if (ret!=Belos::Converged || badRes==true) {
+      success = false;
+      if (procVerbose)
+        std::cout << "End Result: TEST FAILED" << std::endl;
+    } else {
+      success = true;
+      if (procVerbose)
+        std::cout << "End Result: TEST PASSED" << std::endl;
+    }
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose,std::cerr,success);
+
+  return success ? EXIT_SUCCESS : EXIT_FAILURE;
+} // run
+
+int main(int argc, char *argv[]) {
+  // run with different ST
+  return run<double>(argc,argv);
+  // run<float>(argc,argv); // FAILS
+}

--- a/packages/belos/tpetra/test/BlockGmres/test_kokkos_resolve_gmres_hb.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_kokkos_resolve_gmres_hb.cpp
@@ -1,0 +1,404 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side from the problem is being used instead of multiple
+// random right-hand-sides.  The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+
+// Tpetra
+#include <Tpetra_Map.hpp>
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+// Belos
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosBlockGmresSolMgr.hpp"
+#include "BelosTpetraTestFramework.hpp"
+#include "BelosPseudoBlockGmresSolMgr.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+
+template <typename ScalarType>
+int run(int argc, char *argv[]) {
+  //
+  Teuchos::GlobalMPISession session(&argc, &argv, nullptr);
+  //
+  using ST = typename Tpetra::Vector<ScalarType>::scalar_type;
+  using LO = typename Tpetra::Vector<>::local_ordinal_type;
+  using GO = typename Tpetra::Vector<>::global_ordinal_type;
+  using NT = typename Tpetra::Vector<>::node_type;
+
+  using OP  = typename Tpetra::Operator<ST,LO,GO,NT>;
+  using MV  = typename Tpetra::MultiVector<ST,LO,GO,NT>;
+  using SCT = typename Teuchos::ScalarTraits<ST>;
+  using MT  = typename SCT::magnitudeType;
+
+  using IST = typename Tpetra::MultiVector<>::impl_scalar_type;
+  using DM = typename Kokkos::DualView<IST**,Kokkos::LayoutLeft>;
+
+  using tmap_t       = Tpetra::Map<LO,GO,NT>;
+  using tcrsmatrix_t = Tpetra::CrsMatrix<ST,LO,GO,NT>;
+
+  using MVT = typename Belos::MultiVecTraits<ST,MV,DM>;
+  using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::ParameterList;
+
+  bool success = false;
+  bool verbose = false;
+
+  try {
+
+    const auto comm = Tpetra::getDefaultComm();
+    const int myPID = comm->getRank();
+
+    bool badRes = false;
+    bool procVerbose = false;
+    bool pseudo = false;   // use pseudo block Gmres to solve this linear system.
+    int frequency = -1;
+    int blockSize = 1;
+    int numrhs = 1;
+    int maxRestarts = 15; // number of restarts allowed
+    int maxIters = -1;    // maximum number of iterations allowed per linear system
+    std::string filename("orsirr1.hb");
+    std::string ortho("DGKS");
+    MT tol = 1.0e-5;  // relative residual tolerance
+
+    Teuchos::CommandLineProcessor cmdp(false,true);
+    cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+    cmdp.setOption("pseudo","regular",&pseudo,"Use pseudo-block Gmres to solve the linear systems.");
+    cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+    cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+    cmdp.setOption("ortho",&ortho,"Orthogonalization routine used by Gmres solver.");
+    cmdp.setOption("tol",&tol,"Relative residual tolerance used by Gmres solver.");
+    cmdp.setOption("max-restarts",&maxRestarts,"Maximum number of restarts allowed for Gmres solver.");
+    cmdp.setOption("blockSize",&blockSize,"Block size used by Gmres.");
+    cmdp.setOption("maxIters",&maxIters,"Maximum number of iterations per linear system (-1 = adapted to problem/block size).");
+    if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+      return -1;
+    }
+    if (!verbose)
+      frequency = -1;  // reset frequency if test is not verbose
+
+    procVerbose = ( verbose && (myPID==0) );
+
+    // Get the problem
+    Belos::Tpetra::HarwellBoeingReader<tcrsmatrix_t> reader( comm );
+    RCP<tcrsmatrix_t> A = reader.readFromFile( filename );
+    RCP<const tmap_t> Map = A->getDomainMap();
+
+    // Create initial vectors
+    RCP<MV> B, X;
+    X = rcp( new MV(Map,numrhs) );
+    MVT::MvRandom( *X );
+    B = rcp( new MV(Map,numrhs) );
+    OPT::Apply( *A, *X, *B );
+    MVT::MvInit( *X, 0.0 );
+
+    // ********Other information used by block solver***********
+    // *****************(can be user specified)******************
+
+    const int NumGlobalElements = B->getGlobalLength();
+    if (maxIters == -1)
+      maxIters = NumGlobalElements/blockSize - 1; // maximum number of iterations to run
+
+    ParameterList belosList;
+    belosList.set( "Num Blocks", maxIters );               // Maximum number of blocks in Krylov factorization
+    belosList.set( "Block Size", blockSize );              // Blocksize to be used by iterative solver
+    belosList.set( "Maximum Iterations", maxIters );       // Maximum number of iterations allowed
+    belosList.set( "Maximum Restarts", maxRestarts );      // Maximum number of restarts allowed
+    belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    belosList.set( "Orthogonalization", ortho );           // Orthogonalization routine
+    if (verbose) {
+      belosList.set( "Verbosity", Belos::Errors + Belos::Warnings +
+          Belos::TimingDetails + Belos::StatusTestDetails );
+      if (frequency > 0)
+        belosList.set( "Output Frequency", frequency );
+    }
+    else
+      belosList.set( "Verbosity", Belos::Errors + Belos::Warnings );
+
+    // Construct an unpreconditioned linear problem instance.
+    Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+    bool set = problem.setProblem();
+    if (set == false) {
+      if (procVerbose)
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+
+    // *******************************************************************
+    // *************Start the block Gmres iteration*************************
+    // *******************************************************************
+
+    RCP< Belos::SolverManager<ST,MV,OP,DM> > solver;
+    if (pseudo)
+      solver = rcp( new Belos::PseudoBlockGmresSolMgr<ST,MV,OP,DM>( rcp(&problem,false), rcp(&belosList,false) ) );
+    else
+      solver = rcp( new Belos::BlockGmresSolMgr<ST,MV,OP,DM>( rcp(&problem,false), rcp(&belosList,false) ) );
+
+    // Perform solve
+    Belos::ReturnType ret = solver->solve();
+
+    if (ret!=Belos::Converged) {
+      if (procVerbose)
+        std::cout << "End Result: TEST FAILED" << std::endl;
+      return -1;
+    }
+
+    // Get the number of iterations for this solve.
+    int numIters = solver->getNumIters();
+    std::cout << "Number of iterations performed for this solve: " << numIters << std::endl;
+
+    // Compute actual residuals.
+    std::vector<ST> actual_resids( numrhs );
+    std::vector<ST> rhs_norm( numrhs );
+    MV resid(Map, numrhs);
+    OPT::Apply( *A, *X, resid );
+    MVT::MvAddMv( -1.0, resid, 1.0, *B, resid );
+    MVT::MvNorm( resid, actual_resids );
+    MVT::MvNorm( *B, rhs_norm );
+    if (procVerbose) {
+      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+      for ( int i=0; i<numrhs; i++) {
+        std::cout<<"Problem "<<i<<" : \t"<< actual_resids[i]/rhs_norm[i] <<std::endl;
+      }
+    }
+
+    // -----------------------------------------------------------------
+    // Resolve the first problem by just resetting the solver manager.
+    // -----------------------------------------------------------------
+
+    X->putScalar( 0.0 );
+    solver->reset( Belos::Problem );
+
+    // Perform solve (again)
+    ret = solver->solve();
+
+    // Get the number of iterations for this solve.
+    numIters = solver->getNumIters();
+    std::cout << "Number of iterations performed for this solve (manager reset): " << numIters << std::endl;
+
+    if (ret!=Belos::Converged) {
+      if (procVerbose)
+        std::cout << "End Result: TEST FAILED" << std::endl;
+      return -1;
+    }
+
+    // Compute actual residuals.
+    std::vector<ST> actual_resids2( numrhs );
+    MV resid2(Map, numrhs);
+    OPT::Apply( *A, *X, resid2 );
+    MVT::MvAddMv( -1.0, resid2, 1.0, *B, resid2 );
+    MVT::MvNorm( resid2, actual_resids );
+    MVT::MvAddMv( -1.0, resid2, 1.0, resid, resid2 );
+    MVT::MvNorm( resid2, actual_resids2 );
+    MVT::MvNorm( *B, rhs_norm );
+    if (procVerbose) {
+      std::cout<< "---------- Actual Residuals (manager reset) ----------"<<std::endl<<std::endl;
+      for ( int i=0; i<numrhs; i++) {
+        std::cout<<"Problem "<<i<<" : \t"<< actual_resids[i]/rhs_norm[i] <<std::endl;
+        if ( actual_resids2[i] > SCT::prec() ) {
+          badRes = true;
+          std::cout << "Resolve residual vector is too different from first solve residual vector: " << actual_resids2[i] << std::endl;
+        }
+      }
+    }
+
+    // -----------------------------------------------------------------
+    // Resolve the first problem by resetting the linear problem.
+    // -----------------------------------------------------------------
+
+    X->putScalar( 0.0 );
+    set = problem.setProblem();
+    if (set == false) {
+      if (procVerbose)
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+    solver->setProblem( rcp(&problem,false) );
+
+    // Perform solve (again)
+    ret = solver->solve();
+
+    // Get the number of iterations for this solve.
+    numIters = solver->getNumIters();
+    std::cout << "Number of iterations performed for this solve (manager setProblem()): " << numIters << std::endl;
+
+    if (ret!=Belos::Converged) {
+      if (procVerbose)
+        std::cout << "End Result: TEST FAILED" << std::endl;
+      return -1;
+    }
+
+    // Compute actual residuals.
+    OPT::Apply( *A, *X, resid2 );
+    MVT::MvAddMv( -1.0, resid2, 1.0, *B, resid2 );
+    MVT::MvNorm( resid2, actual_resids );
+    MVT::MvAddMv( -1.0, resid2, 1.0, resid, resid2 );
+    MVT::MvNorm( resid2, actual_resids2 );
+    MVT::MvNorm( *B, rhs_norm );
+    if (procVerbose) {
+      std::cout<< "---------- Actual Residuals (manager setProblem()) ----------"<<std::endl<<std::endl;
+      for ( int i=0; i<numrhs; i++) {
+        std::cout<<"Problem "<<i<<" : \t"<< actual_resids[i]/rhs_norm[i] <<std::endl;
+        if ( actual_resids2[i] > SCT::prec() ) {
+          badRes = true;
+          std::cout << "Resolve residual vector is too different from first solve residual vector: " << actual_resids2[i] << std::endl;
+        }
+      }
+    }
+
+    // ----------------------------------------------------------------------------------
+    // Resolve the first problem by resetting the solver manager and changing the labels.
+    // ----------------------------------------------------------------------------------
+
+    ParameterList belosList2;
+    belosList2.set( "Timer Label", "Belos Resolve w/ New Label" );   // Change timer labels.
+    solver->setParameters( rcp( &belosList2, false ) );
+
+    problem.setLabel( "Belos Resolve w/ New Label" );
+    X->putScalar( 0.0 );
+    solver->reset( Belos::Problem );
+
+    // Perform solve (again)
+    ret = solver->solve();
+
+    // Get the number of iterations for this solve.
+    numIters = solver->getNumIters();
+    std::cout << "Number of iterations performed for this solve (label reset): " << numIters << std::endl;
+
+    if (ret!=Belos::Converged) {
+      if (procVerbose)
+        std::cout << "End Result: TEST FAILED" << std::endl;
+      return -1;
+    }
+
+    // Compute actual residuals.
+    OPT::Apply( *A, *X, resid2 );
+    MVT::MvAddMv( -1.0, resid2, 1.0, *B, resid2 );
+    MVT::MvNorm( resid2, actual_resids );
+    MVT::MvAddMv( -1.0, resid2, 1.0, resid, resid2 );
+    MVT::MvNorm( resid2, actual_resids2 );
+    MVT::MvNorm( *B, rhs_norm );
+    if (procVerbose) {
+      std::cout<< "---------- Actual Residuals (label reset) ----------"<<std::endl<<std::endl;
+      for ( int i=0; i<numrhs; i++) {
+        std::cout<<"Problem "<<i<<" : \t"<< actual_resids[i]/rhs_norm[i] <<std::endl;
+        if ( actual_resids2[i] > SCT::prec() ) {
+          badRes = true;
+          std::cout << "Resolve residual vector is too different from first solve residual vector: " << actual_resids2[i] << std::endl;
+        }
+      }
+    }
+
+    // -------------------------------------------------------------
+    // Construct a second unpreconditioned linear problem instance.
+    // -------------------------------------------------------------
+
+    RCP<MV> X2 = MVT::Clone(*X, numrhs);
+    MVT::MvInit( *X2, 0.0 );
+    Belos::LinearProblem<ST,MV,OP> problem2( A, X2, B );
+    problem2.setLabel("Belos Resolve");
+    set = problem2.setProblem();
+    if (set == false) {
+      if (procVerbose)
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+
+    // *******************************************************************
+    // *************Start the block Gmres iteration*************************
+    // *******************************************************************
+
+    // Create the solver without either the problem or parameter list.
+    if (pseudo)
+      solver = rcp( new Belos::PseudoBlockGmresSolMgr<ST,MV,OP,DM>() );
+    else
+      solver = rcp( new Belos::BlockGmresSolMgr<ST,MV,OP,DM>() );
+
+    // Set the problem after the solver construction.
+    solver->setProblem( rcp( &problem2, false ) );
+
+    // Get the valid list of parameters from the solver and print it.
+    RCP<const ParameterList> validList = solver->getValidParameters();
+    if (procVerbose) {
+      if (pseudo)
+        std::cout << std::endl << "Valid parameters from the pseudo-block Gmres solver manager:" << std::endl;
+      else
+        std::cout << std::endl << "Valid parameters from the block Gmres solver manager:" << std::endl;
+
+      std::cout << *validList << std::endl;
+    }
+
+    // Set the parameter list after the solver construction.
+    belosList.set( "Timer Label", "Belos Resolve" );         // Set timer label to discern between the two solvers.
+    solver->setParameters( rcp( &belosList, false ) );
+
+    // Perform solve
+    ret = solver->solve();
+
+    // Get the number of iterations for this solve.
+    numIters = solver->getNumIters();
+    std::cout << "Number of iterations performed for this solve (new solver): " << numIters << std::endl;
+
+    // Compute actual residuals.
+    OPT::Apply( *A, *X2, resid2 );
+    MVT::MvAddMv( -1.0, resid2, 1.0, *B, resid2 );
+    MVT::MvNorm( resid2, actual_resids );
+    MVT::MvAddMv( -1.0, resid2, 1.0, resid, resid2 );
+    MVT::MvNorm( resid2, actual_resids2 );
+    MVT::MvNorm( *B, rhs_norm );
+    if (procVerbose) {
+      std::cout<< "---------- Actual Residuals (new solver) ----------"<<std::endl<<std::endl;
+      for ( int i=0; i<numrhs; i++) {
+        std::cout<<"Problem "<<i<<" : \t"<< actual_resids[i]/rhs_norm[i] <<std::endl;
+        if ( actual_resids2[i] > SCT::prec() ) {
+          badRes = true;
+          std::cout << "Resolve residual vector is too different from first solve residual vector: " << actual_resids2[i] << std::endl;
+        }
+      }
+    }
+
+    // **********Print out information about problem*******************
+    if (procVerbose) {
+      std::cout << std::endl << std::endl;
+      std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+      std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+      std::cout << "Block size used by solver: " << blockSize << std::endl;
+      std::cout << "Max number of Gmres iterations: " << maxIters << std::endl;
+      std::cout << "Relative residual tolerance: " << tol << std::endl;
+      std::cout << std::endl;
+    }
+
+    success = ret==Belos::Converged && !badRes;
+
+    if (success) {
+      if (procVerbose)
+        std::cout << "End Result: TEST PASSED" << std::endl;
+    } else {
+      if (procVerbose)
+        std::cout << "End Result: TEST FAILED" << std::endl;
+    }
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
+} // run
+
+int main(int argc, char *argv[]) {
+  // run with different ST
+  return run<double>(argc,argv);
+  // run<float>(argc,argv); // FAILS
+}

--- a/packages/belos/tpetra/test/FixedPoint/CMakeLists.txt
+++ b/packages/belos/tpetra/test/FixedPoint/CMakeLists.txt
@@ -5,11 +5,21 @@ TRIBITS_ADD_EXECUTABLE(
   SOURCES test_fp_hb.cpp
   )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_KokkosDense_FixedPoint_hb_test
+  SOURCES test_kokkos_fp_hb.cpp
+  ARGS
+     "--verbose --no-precond"
+     "--verbose --use-precond --left"
+     "--verbose --use-precond --right"
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )
 
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Tpetra_FixedPoint_hb_CopyFiles1
   SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
   SOURCE_FILES bcsstk14.hb
-  EXEDEPS Tpetra_FixedPoint_hb_test
+  EXEDEPS Tpetra_FixedPoint_hb_test Tpetra_KokkosDense_FixedPoint_hb_test
   )
 
 
@@ -18,6 +28,7 @@ TRIBITS_ADD_TEST(
   NAME "FixedPoint_tpetra_hb_test_no_precond"
   ARGS "--verbose --no-precond"
   COMM serial mpi
+  STANDARD_PASS_OUTPUT
   )
 
 TRIBITS_ADD_TEST(
@@ -25,6 +36,7 @@ TRIBITS_ADD_TEST(
   NAME "FixedPoint_tpetra_hb_test_left_precond"
   ARGS "--verbose --use-precond --left"
   COMM serial mpi
+  STANDARD_PASS_OUTPUT
   )
 
 TRIBITS_ADD_TEST(
@@ -32,4 +44,5 @@ TRIBITS_ADD_TEST(
   NAME "FixedPoint_tpetra_hb_test_right_precond"
   ARGS "--verbose --use-precond --right"
   COMM serial mpi
+  STANDARD_PASS_OUTPUT
   )

--- a/packages/belos/tpetra/test/FixedPoint/test_fp_hb.cpp
+++ b/packages/belos/tpetra/test/FixedPoint/test_fp_hb.cpp
@@ -18,16 +18,13 @@
 #include "BelosTpetraAdapter.hpp"
 #include "BelosFixedPointSolMgr.hpp"
 
-// I/O for Harwell-Boeing files
-#define HIDE_TPETRA_INOUT_IMPLEMENTATIONS
-#include <Tpetra_MatrixIO.hpp>
-
 #include <Teuchos_CommandLineProcessor.hpp>
 #include <Teuchos_ParameterList.hpp>
 #include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_StandardCatchMacros.hpp>
 #include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_MatrixIO.hpp>
 
 using namespace Teuchos;
 using Tpetra::Operator;

--- a/packages/belos/tpetra/test/FixedPoint/test_kokkos_fp_hb.cpp
+++ b/packages/belos/tpetra/test/FixedPoint/test_kokkos_fp_hb.cpp
@@ -1,0 +1,264 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+#include "BelosFixedPointSolMgr.hpp"
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+#include <Teuchos_StandardCatchMacros.hpp>
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_MatrixIO.hpp>
+
+using namespace Teuchos;
+using Tpetra::Operator;
+using Tpetra::CrsMatrix;
+using Tpetra::MultiVector;
+using std::endl;
+using std::cout;
+using std::vector;
+using Teuchos::tuple;
+
+int main(int argc, char *argv[]) {
+  typedef Tpetra::MultiVector<>::scalar_type ST;
+  typedef Tpetra::MultiVector<>::impl_scalar_type IST;
+  typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+  typedef ScalarTraits<ST>                SCT;
+  typedef SCT::magnitudeType               MT;
+  typedef Tpetra::Operator<ST>             OP;
+  typedef Tpetra::MultiVector<ST>          MV;
+  typedef Tpetra::Vector<ST>               VV;
+  typedef Belos::OperatorTraits<ST,MV,OP> OPT;
+  typedef Belos::MultiVecTraits<ST,MV,DM> MVT;
+  using GO = MV::global_ordinal_type;
+
+  GlobalMPISession mpisess(&argc,&argv,&cout);
+
+  bool success = false;
+  bool verbose = false;
+  try {
+    const ST one  = SCT::one();
+
+    int MyPID = 0;
+
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+
+    //
+    // Get test parameters from command-line processor
+    //
+    bool proc_verbose = false;
+    bool debug = false;
+    int frequency = -1;  // how often residuals are printed by solver
+    int numrhs = 1;      // total number of right-hand sides to solve for
+    int maxiters = -1;   // maximum number of iterations for solver to use
+    std::string filename("bcsstk14.hb");
+    MT tol = 1.0e-5;     // relative residual tolerance
+    bool precond = false; // use diagonal preconditioner
+    bool leftPrecond = false; // if preconditioner is used, left or right?
+
+    CommandLineProcessor cmdp(false,true);
+    cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+    cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+    cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+    cmdp.setOption("tol",&tol,"Relative residual tolerance used by fixed point solver.");
+    cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+    cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+    cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
+    cmdp.setOption("use-precond","no-precond",&precond,"Use a diagonal preconditioner.");
+    cmdp.setOption("left","right",&leftPrecond,"Use a left/right preconditioner.");
+    if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
+      return -1;
+    }
+    if (debug) {
+      verbose = true;
+    }
+    if (!verbose) {
+      frequency = -1;  // reset frequency if test is not verbose
+    }
+
+    MyPID = rank(*comm);
+    proc_verbose = ( verbose && (MyPID==0) );
+
+    if (proc_verbose) {
+      std::cout << Belos::Belos_Version() << std::endl << std::endl;
+    }
+
+    //
+    // Get the data from the HB file and build the Map,Matrix
+    //
+    RCP<CrsMatrix<ST> > A;
+    Tpetra::Utils::readHBMatrix(filename,comm,A);
+    RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+    // Create initial vectors
+    RCP<MV> B, X;
+    X = rcp( new MV(map,numrhs) );
+    MVT::MvRandom( *X );
+    B = rcp( new MV(map,numrhs) );
+    OPT::Apply( *A, *X, *B );
+    MVT::MvInit( *X, 0.0 );
+
+
+    // Scale down the rhs
+    std::vector<ST> norm( MVT::GetNumberVecs(*B));
+    MVT::MvNorm(*B,norm);
+    for(int i=0; i< MVT::GetNumberVecs(*B); i++)
+      norm[i] = 1.0 / norm[i];
+    MVT::MvScale(*B,norm);
+
+    // Drastically bump the diagonal and then rescale so FP can converge
+    {
+      VV diag(A->getRowMap());
+      A->getLocalDiagCopy(diag);
+      {
+        Teuchos::ArrayRCP<ST> dd=diag.getDataNonConst();
+
+        auto GlobalElements = A->getRowMap()->getLocalElementList();
+        A->resumeFill();
+        for(int i=0; i<(int)dd.size(); i++) {
+          dd[i]=dd[i]*1e4;
+          A->replaceGlobalValues(GlobalElements[i],
+                                 Teuchos::tuple<GO>(GlobalElements[i]),
+                                 Teuchos::tuple<ST>(dd[i]) );
+        }
+        A->fillComplete();
+
+        for(int i=0; i<(int)dd.size(); i++)
+          dd[i] = 1.0/sqrt(dd[i]);
+      }
+      A->leftScale(diag);
+      A->rightScale(diag);
+    }
+
+    //
+    // ********Other information used by block solver***********
+    // *****************(can be user specified)******************
+    //
+    const int NumGlobalElements = B->getGlobalLength();
+    if (maxiters == -1) {
+      maxiters = NumGlobalElements- 1; // maximum number of iterations to run
+    }
+    //
+    ParameterList belosList;
+    belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+    belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    int verbLevel = Belos::Errors + Belos::Warnings;
+    if (debug) {
+      verbLevel += Belos::Debug;
+    }
+    if (verbose) {
+      verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
+    }
+    belosList.set( "Verbosity", verbLevel );
+    if (verbose) {
+      if (frequency > 0) {
+        belosList.set( "Output Frequency", frequency );
+      }
+    }
+    //
+    // Construct an linear problem instance.
+    //
+    Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+    // diagonal preconditioner
+    if (precond) {
+      VV diagonal(A->getRowMap());
+      A->getLocalDiagCopy(diagonal);
+
+      int NumMyElements    = diagonal.getMap()->getLocalNumElements();
+      auto MyGlobalElements = diagonal.getMap()->getLocalElementList();
+      Teuchos::ArrayRCP<ST> dd=diagonal.getDataNonConst();
+      RCP<CrsMatrix<ST> > invDiagMatrix = Teuchos::rcp(new CrsMatrix<ST>(A->getRowMap(), 1));
+
+      for (Teuchos_Ordinal i=0; i<NumMyElements; ++i) {
+        invDiagMatrix->insertGlobalValues(MyGlobalElements[i],
+                                          Teuchos::tuple<GO>(MyGlobalElements[i]),
+                                          Teuchos::tuple<ST>(SCT::one() / dd[i]) );
+      }
+      invDiagMatrix->fillComplete();
+
+      if (leftPrecond)
+        problem.setLeftPrec(invDiagMatrix);
+      else
+        problem.setRightPrec(invDiagMatrix);
+    }
+    bool set = problem.setProblem();
+    if (set == false) {
+      if (proc_verbose)
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+    //
+    // *******************************************************************
+    // *************Start the fixed point iteration***********************
+    // *******************************************************************
+    //
+    Belos::FixedPointSolMgr<ST,MV,OP,DM> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+
+    //
+    // **********Print out information about problem*******************
+    //
+    if (proc_verbose) {
+      std::cout << std::endl << std::endl;
+      std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+      std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+      std::cout << "Max number of fixed point iterations: " << maxiters << std::endl;
+      std::cout << "Relative residual tolerance: " << tol << std::endl;
+      std::cout << std::endl;
+    }
+    //
+    // Perform solve
+    //
+    Belos::ReturnType ret = solver.solve();
+    //
+    // Compute actual residuals.
+    //
+    bool badRes = false;
+    std::vector<MT> actual_resids( numrhs );
+    std::vector<MT> rhs_norm( numrhs );
+    MV resid(map, numrhs);
+    OPT::Apply( *A, *X, resid );
+    MVT::MvAddMv( -one, resid, one, *B, resid );
+    MVT::MvNorm( resid, actual_resids );
+    MVT::MvNorm( *B, rhs_norm );
+    if (proc_verbose) {
+      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+    }
+    for ( int i=0; i<numrhs; i++) {
+      MT actRes = actual_resids[i]/rhs_norm[i];
+      if (proc_verbose) {
+        std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+      }
+      if (actRes > tol) badRes = true;
+    }
+
+    success = (ret==Belos::Converged && !badRes);
+
+    if (success) {
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+    } else {
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
+} // end test_fp_hb.cpp

--- a/packages/belos/tpetra/test/GCRODR/CMakeLists.txt
+++ b/packages/belos/tpetra/test/GCRODR/CMakeLists.txt
@@ -5,14 +5,27 @@ ASSERT_DEFINED(Tpetra_INST_COMPLEX_DOUBLE)
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Tpetra_gcrodr_hb_test
   SOURCES test_gcrodr_hb.cpp
-  ARGS "--verbose --filename=sherman5.hb --tol=1e-4 --num-rhs=2 --max-subspace=61 --recycle=23 --max-cycles=75"
+  ARGS
+  "--verbose --filename=sherman5.hb --tol=1e-4 --num-rhs=2 --max-subspace=61 --recycle=23 --max-cycles=75 --ortho-type=ICGS"
+  "--verbose --filename=sherman5.hb --tol=1e-4 --num-rhs=2 --max-subspace=61 --recycle=23 --max-cycles=75 --ortho-type=IMGS"
+  "--verbose --filename=sherman5.hb --tol=1e-4 --num-rhs=2 --max-subspace=61 --recycle=23 --max-cycles=75 --ortho-type=DGKS"
+  COMM serial mpi
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_KokkosDense_gcrodr_hb_test
+  SOURCES test_kokkos_gcrodr_hb.cpp
+  ARGS 
+  "--verbose --filename=sherman5.hb --tol=1e-4 --num-rhs=2 --max-subspace=61 --recycle=23 --max-cycles=75 --ortho-type=ICGS"
+  "--verbose --filename=sherman5.hb --tol=1e-4 --num-rhs=2 --max-subspace=61 --recycle=23 --max-cycles=75 --ortho-type=IMGS"
+  "--verbose --filename=sherman5.hb --tol=1e-4 --num-rhs=2 --max-subspace=61 --recycle=23 --max-cycles=75 --ortho-type=DGKS"
   COMM serial mpi
   )
 
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Tpetra_CopyTestGCRODRFiles
     SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
     SOURCE_FILES sherman5.hb
-    EXEDEPS Tpetra_gcrodr_hb_test
+    EXEDEPS Tpetra_gcrodr_hb_test Tpetra_KokkosDense_gcrodr_hb_test
     )
 
 IF (Tpetra_INST_COMPLEX_DOUBLE)
@@ -24,10 +37,15 @@ IF (Tpetra_INST_COMPLEX_DOUBLE)
         "--verbose --filename=mhd1280b.cua"
       )
 
+    TRIBITS_ADD_EXECUTABLE(
+      Tpetra_KokkosDense_gcrodr_complex_hb
+      SOURCES test_kokkos_gcrodr_complex_hb.cpp
+      )
+
     TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyTpetraGCRODRComplexFiles
       SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
       SOURCE_FILES mhd1280b.cua 
-      EXEDEPS Tpetra_gcrodr_complex_hb
+      EXEDEPS Tpetra_gcrodr_complex_hb Tpetra_KokkosDense_gcrodr_complex_hb
     )
 
 ENDIF()

--- a/packages/belos/tpetra/test/GCRODR/test_block_gcrodr.cpp
+++ b/packages/belos/tpetra/test/GCRODR/test_block_gcrodr.cpp
@@ -109,8 +109,7 @@ int run (int argc, char *argv[])
   RCP<tcrsmatrix_t> A;
   RCP<MV> X_guess, X_exact, B;
   {
-    Teuchos::RCP<NT> node; // can be null; only for type deduction
-    Belos::Tpetra::ProblemMaker<tcrsmatrix_t> factory (comm, node, out, tolerant, debug);
+    Belos::Tpetra::ProblemMaker<tcrsmatrix_t> factory (comm, out, tolerant, debug);
 
     RCP<ParameterList> problemParams = parameterList ();
     problemParams->set ("Global number of rows",

--- a/packages/belos/tpetra/test/GCRODR/test_kokkos_gcrodr_complex_hb.cpp
+++ b/packages/belos/tpetra/test/GCRODR/test_kokkos_gcrodr_complex_hb.cpp
@@ -1,0 +1,214 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+#include "BelosGCRODRSolMgr.hpp"
+#include "BelosTpetraTestFramework.hpp"
+
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+
+template <typename ScalarType>
+int run(int argc, char *argv[])
+{ 
+  using Teuchos::Comm;
+  using Teuchos::RCP;
+  using Teuchos::rcpFromRef;
+  using Teuchos::tuple;  
+  
+  using BST = typename Tpetra::MultiVector<ScalarType>::scalar_type;
+  using ST = typename std::complex<BST>;
+
+  using SCT = typename Teuchos::ScalarTraits<ST>;
+  using MT = typename SCT::magnitudeType;
+
+  using IST = typename Tpetra::MultiVector<ST>::impl_scalar_type;
+  using DM = typename Kokkos::DualView<IST**,Kokkos::LayoutLeft>;
+
+  using OP = typename Tpetra::Operator<ST>;
+  using MV = typename Tpetra::MultiVector<ST>;
+  using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+  using MVT = typename Belos::MultiVecTraits<ST,MV,DM>;
+
+  using tcrsmatrix_t = Tpetra::CrsMatrix<ST>;
+
+  Teuchos::GlobalMPISession mpisess(&argc, &argv, &std::cout);
+
+  const ST one  = SCT::one();
+
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+  int MyPID = rank(*comm);
+
+  // Get test parameters from command-line processor
+  bool verbose = false, proc_verbose = false, debug = false;
+  int frequency = -1;  // how often residuals are printed by solver
+  int numrhs = 1;      // total number of right-hand sides to solve for
+  std::string filename("mhd1280b.cua");
+  MT tol = 1.0e-5;     // relative residual tolerance
+
+  Teuchos::CommandLineProcessor cmdp(false,true);
+  cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+  cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+  cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+  cmdp.setOption("tol",&tol,"Relative residual tolerance used by GCRODR solver.");
+  cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+  cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+  if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+    return -1;
+  }
+  if (debug) {
+    verbose = true;
+  }
+  if (!verbose) {
+    frequency = -1;  // reset frequency if test is not verbose
+  }
+
+  proc_verbose = ( verbose && (MyPID==0) );
+
+  if (proc_verbose) {
+    std::cout << Belos::Belos_Version() << std::endl << std::endl;
+  }
+
+  Belos::Tpetra::HarwellBoeingReader<tcrsmatrix_t> reader( comm );
+  RCP<tcrsmatrix_t> A = reader.readFromFile( filename );
+  RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+  // Create initial vectors
+  RCP<MV> B, X;
+  X = rcp( new MV(map,numrhs) );
+  MVT::MvRandom( *X );
+  B = rcp( new MV(map,numrhs) );
+  OPT::Apply( *A, *X, *B );
+  MVT::MvInit( *X, 0.0 );
+
+  // ********Other information used by block solver***********
+  // *****************(can be user specified)******************
+  const int NumGlobalElements = B->getGlobalLength();
+  int numIters1, numIters2, numIters3;
+  int maxits = NumGlobalElements; // maximum number of iterations to run
+  int numBlocks = 100;
+  int numRecycledBlocks = 20;
+  Teuchos::ParameterList belosList;
+  belosList.set( "Maximum Iterations", maxits );         // Maximum number of iterations allowed
+  belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+  belosList.set( "Num Blocks", numBlocks );
+  belosList.set( "Num Recycled Blocks", numRecycledBlocks );
+
+  int verbLevel = Belos::Errors + Belos::Warnings;
+  if (debug) {
+    verbLevel += Belos::Debug;
+  }
+  if (verbose) {
+    verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
+  }
+  belosList.set( "Verbosity", verbLevel );
+  if (verbose) {
+    if (frequency > 0) {
+      belosList.set( "Output Frequency", frequency );
+    }
+  }
+  
+  // Construct an unpreconditioned linear problem instance.
+  Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+  bool set = problem.setProblem();
+  if (set == false) {
+    if (proc_verbose)
+      std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+    return -1;
+  }
+
+  // Start the GCRODR iteration
+  Belos::GCRODRSolMgr<ST,MV,OP,DM> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+
+  // Print out information about problem
+  if (proc_verbose) {
+    std::cout << std::endl << std::endl;
+    std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+    std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+    std::cout << "Max number of GCRODR iterations: " << maxits << std::endl;
+    std::cout << "Relative residual tolerance: " << tol << std::endl;
+    std::cout << std::endl;
+  }
+  
+  // Perform solve
+  Belos::ReturnType ret = solver.solve();
+  numIters1=solver.getNumIters();
+  
+  // Compute actual residuals.
+  bool badRes = false;
+  std::vector<MT> actual_resids( numrhs );
+  std::vector<MT> rhs_norm( numrhs );
+  MV resid(map, numrhs);
+  OPT::Apply( *A, *X, resid );
+  MVT::MvAddMv( -one, resid, one, *B, resid );
+  MVT::MvNorm( resid, actual_resids );
+  MVT::MvNorm( *B, rhs_norm );
+  if (proc_verbose) {
+    std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+  }
+  for ( int i=0; i<numrhs; i++) {
+    MT actRes = actual_resids[i]/rhs_norm[i];
+    if (proc_verbose) {
+      std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+    }
+    if (actRes > tol) badRes = true;
+  }
+
+  if (proc_verbose) { std::cout << "First solve took " << numIters1 << " iterations." << std::endl; }
+
+  // Resolve linear system with same rhs and recycled space
+  MVT::MvInit( *X, SCT::zero() );
+  solver.reset(Belos::Problem);
+  ret = solver.solve();
+  numIters2=solver.getNumIters();
+
+  if (proc_verbose) { std::cout << "Second solve took " << numIters2 << " iterations." << std::endl; }
+
+  // Resolve linear system (again) with same rhs and recycled space
+  MVT::MvInit( *X, SCT::zero() );
+  solver.reset(Belos::Problem);
+  ret = solver.solve();
+  numIters3=solver.getNumIters();
+
+  if (proc_verbose) { std::cout << "Third solve took " << numIters3 << " iterations." << std::endl; }
+
+  if ( ret!=Belos::Converged || badRes || numIters1 < numIters2 || numIters2 < numIters3 ) {
+    if (proc_verbose) {
+      std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+    return -1;
+  }
+  
+  // Default return value
+  if (proc_verbose) {
+    std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+  }
+  return 0;
+
+} // end test_gcrodr_complex_hb.cpp
+
+int main(int argc, char *argv[]) {
+  return run<double>(argc, argv);
+  // return run<float>(argc, argv);
+}
+

--- a/packages/belos/tpetra/test/GCRODR/test_kokkos_gcrodr_hb.cpp
+++ b/packages/belos/tpetra/test/GCRODR/test_kokkos_gcrodr_hb.cpp
@@ -1,0 +1,198 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosGCRODRSolMgr.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+#include "BelosTpetraTestFramework.hpp"
+
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+
+template<typename ScalarType>
+int run(int argc, char *argv[])
+{
+  using Teuchos::Comm;
+  using Teuchos::RCP;
+
+  using ST = typename Tpetra::MultiVector<ScalarType>::scalar_type;
+  
+  using SCT = typename Teuchos::ScalarTraits<ST>;
+  using MT = typename SCT::magnitudeType;
+
+  using IST = typename Tpetra::MultiVector<>::impl_scalar_type;
+  using DM = typename Kokkos::DualView<IST**,Kokkos::LayoutLeft>;
+
+  using OP = typename Tpetra::Operator<ST>;
+  using MV = typename Tpetra::MultiVector<ST>;
+  using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+  using MVT = typename Belos::MultiVecTraits<ST,MV,DM>;
+
+  using tcrsmatrix_t = Tpetra::CrsMatrix<ST>;
+
+  Teuchos::GlobalMPISession mpisess(&argc,&argv,&std::cout);
+
+  const ST one  = SCT::one();
+
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+  int MyPID = rank(*comm);
+
+  // Get test parameters from command-line processor
+  bool verbose = false, debug = false, proc_verbose = false;
+  int frequency = -1;        // frequency of status test output.
+  int numrhs = 1;            // number of right-hand sides to solve for
+  int maxiters = -1;         // maximum number of iterations allowed per linear system
+  int maxsubspace = 250;      // maximum number of blocks the solver can use for the subspace
+  int recycle = 50;      // maximum number of blocks the solver can use for the subspace
+  int maxrestarts = 15;      // number of restarts allowed
+  std::string filename("orsirr1.hb");
+  std::string ortho("IMGS");
+  MT tol = 1.0e-10;           // relative residual tolerance
+
+  Teuchos::CommandLineProcessor cmdp(false,true);
+  cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+  cmdp.setOption("debug","nodebug",&debug,"Print debugging information from the solver.");
+  cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+  cmdp.setOption("filename",&filename,"Filename for test matrix.  Acceptable file extensions: *.hb,*.mtx,*.triU,*.triS");
+  cmdp.setOption("tol",&tol,"Relative residual tolerance used by GMRES solver.");
+  cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+  cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 = adapted to problem/block size).");
+  cmdp.setOption("max-subspace",&maxsubspace,"Maximum number of vectors in search space (including recycle space).");
+  cmdp.setOption("recycle",&recycle,"Number of vectors in recycle space.");
+  cmdp.setOption("max-cycles",&maxrestarts,"Maximum number of cycles allowed for GCRO-DR solver.");
+  cmdp.setOption("ortho-type",&ortho,"Orthogonalization type. Must be one of DGKS, ICGS, IMGS.");
+  if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+    return -1;
+  }
+  if (debug) {
+    verbose = true;
+  }
+  if (!verbose)
+    frequency = -1;  // reset frequency if test is not verbose
+
+  proc_verbose = ( verbose && (MyPID==0) );
+
+  if (proc_verbose) {
+    std::cout << Belos::Belos_Version() << std::endl << std::endl;
+  }
+
+  Belos::Tpetra::HarwellBoeingReader<tcrsmatrix_t> reader( comm );
+  RCP<tcrsmatrix_t> A = reader.readFromFile( filename );
+  RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+  // Create initial vectors
+  RCP<MV> B, X;
+  X = rcp( new MV(map,numrhs) );
+  MVT::MvRandom( *X );
+  B = rcp( new MV(map,numrhs) );
+  OPT::Apply( *A, *X, *B );
+  MVT::MvInit( *X, 0.0 );
+
+  // Other information used by block solver (can be user specified)
+  const int NumGlobalElements = B->getGlobalLength();
+  if (maxiters == -1)
+    maxiters = NumGlobalElements - 1; // maximum number of iterations to run
+  //
+  Teuchos::ParameterList belosList;
+  belosList.set( "Num Blocks", maxsubspace);             // Maximum number of blocks in Krylov factorization
+  belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+  belosList.set( "Maximum Restarts", maxrestarts );      // Maximum number of restarts allowed
+  belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+  belosList.set( "Num Recycled Blocks", recycle );       // Number of vectors in recycle space
+  belosList.set( "Orthogonalization", ortho );           // Orthogonalization type
+
+  int verbosity = Belos::Errors + Belos::Warnings;
+  if (verbose) {
+    verbosity += Belos::TimingDetails + Belos::StatusTestDetails;
+    if (frequency > 0)
+      belosList.set( "Output Frequency", frequency );
+  }
+  if (debug) {
+    verbosity += Belos::Debug;
+  }
+  belosList.set( "Verbosity", verbosity );
+  
+  // Construct an unpreconditioned linear problem instance.
+  Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+  bool set = problem.setProblem();
+  if (set == false) {
+    if (proc_verbose)
+      std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+    return -1;
+  }
+
+  // Start the GCRODR iteration
+  Belos::GCRODRSolMgr<ST,MV,OP,DM> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+
+  // Print out information about problem
+  if (proc_verbose) {
+    std::cout << std::endl << std::endl;
+    std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+    std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+    std::cout << "Max number of GCRODR iterations: " << maxiters << std::endl;
+    std::cout << "Relative residual tolerance: " << tol << std::endl;
+    std::cout << std::endl;
+  }
+  
+  // Perform solve
+  Belos::ReturnType ret = solver.solve();
+  
+  // Compute actual residuals.
+  bool badRes = false;
+  std::vector<MT> actual_resids( numrhs );
+  std::vector<MT> rhs_norm( numrhs );
+  MV resid(map, numrhs);
+  OPT::Apply( *A, *X, resid );
+  MVT::MvAddMv( -one, resid, one, *B, resid );
+  MVT::MvNorm( resid, actual_resids );
+  MVT::MvNorm( *B, rhs_norm );
+  if (proc_verbose) {
+    std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+  }
+  for ( int i=0; i<numrhs; i++) {
+    MT actRes = actual_resids[i]/rhs_norm[i];
+    if (proc_verbose) {
+      std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+    }
+    if (actRes > tol) badRes = true;
+  }
+
+  if ( ret!=Belos::Converged || badRes) {
+    if (proc_verbose) {
+      std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+    return -1;
+  }
+  
+  // Default return value
+  if (proc_verbose) {
+    std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+  }
+  return 0;
+  //
+} // end test_gcrodr_hb.cpp
+
+int main(int argc, char *argv[]) {
+  return run<double>(argc, argv);
+  // return run<float>(argc, argv);
+}
+

--- a/packages/belos/tpetra/test/MINRES/CMakeLists.txt
+++ b/packages/belos/tpetra/test/MINRES/CMakeLists.txt
@@ -15,8 +15,8 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
 )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
-  Tpetra_minres_hb
-  SOURCES test_minres_hb.cpp 
+  Tpetra_KokkosDense_minres_hb_test
+  SOURCES test_kokkos_minres_hb.cpp
   COMM serial mpi
   ARGS
     "--verbose --filename=bcsstk14.hb --tol=1e-5"
@@ -24,8 +24,35 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT 
 )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_minres_hb_test
+  SOURCES test_minres_hb.cpp
+  COMM serial mpi
+  ARGS
+    "--verbose --filename=bcsstk14.hb --tol=1e-5"
+    "--verbose --filename=bcsstk14.hb --num-rhs=2 --tol=1e-5"
+  STANDARD_PASS_OUTPUT
+)
+
+IF (Tpetra_INST_COMPLEX_DOUBLE)
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      Tpetra_minres_complex_hb
+      SOURCES test_minres_complex_hb.cpp
+      ARGS
+        "--verbose --filename=mhd1280b.cua"
+      )
+
+    TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyTpetraMinresComplexFiles
+      SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
+      SOURCE_FILES mhd1280b.cua
+      EXEDEPS Tpetra_minres_complex_hb
+    )
+
+ENDIF()
+
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Tpetra_CopyTestMinresFiles
   SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
   SOURCE_FILES bcsstk14.hb
-  EXEDEPS Tpetra_minres_hb
-)
+  EXEDEPS Tpetra_minres_hb_test Tpetra_KokkosDense_minres_hb_test
+  )

--- a/packages/belos/tpetra/test/MINRES/test_kokkos_minres_hb.cpp
+++ b/packages/belos/tpetra/test/MINRES/test_kokkos_minres_hb.cpp
@@ -1,0 +1,208 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+#include "BelosMinresSolMgr.hpp"
+
+#include <Tpetra_MatrixIO.hpp> // I/O for Harwell-Boeing files
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+#include <Teuchos_StandardCatchMacros.hpp>
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+using namespace Teuchos;
+using Tpetra::Operator;
+using Tpetra::CrsMatrix;
+using Tpetra::MultiVector;
+using std::endl;
+using std::cout;
+using std::vector;
+using Teuchos::tuple;
+
+int main(int argc, char *argv[]) {
+  typedef Tpetra::MultiVector<>::scalar_type ST;
+  typedef Tpetra::MultiVector<>::impl_scalar_type IST;
+  typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+  typedef ScalarTraits<ST>                SCT;
+  typedef SCT::magnitudeType               MT;
+  typedef Tpetra::Operator<ST>             OP;
+  typedef Tpetra::MultiVector<ST>          MV;
+  typedef Belos::OperatorTraits<ST,MV,OP> OPT;
+  typedef Belos::MultiVecTraits<ST,MV,DM>    MVT;
+
+  GlobalMPISession mpisess(&argc,&argv,&cout);
+
+  bool success = false;
+  bool verbose = false;
+  try {
+    const ST one  = SCT::one();
+
+    int MyPID = 0;
+
+    RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+
+    //
+    // Get test parameters from command-line processor
+    //
+    bool proc_verbose = false;
+    bool debug = false;
+    int frequency = -1;  // how often residuals are printed by solver
+    int numrhs = 1;      // total number of right-hand sides to solve for
+    int blocksize = 1;   // blocksize used by solver
+    int maxiters = -1;   // maximum number of iterations for solver to use
+    std::string filename("bcsstk14.hb");
+    MT tol = 1.0e-5;     // relative residual tolerance
+
+    CommandLineProcessor cmdp(false,true);
+    cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+    cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+    cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+    cmdp.setOption("tol",&tol,"Relative residual tolerance used by CG solver.");
+    cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+    cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+    cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
+    cmdp.setOption("block-size",&blocksize,"Block size to be used by the CG solver.");
+    if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
+      return -1;
+    }
+    if (debug) {
+      verbose = true;
+    }
+    if (!verbose) {
+      frequency = -1;  // reset frequency if test is not verbose
+    }
+
+    MyPID = rank(*comm);
+    proc_verbose = ( verbose && (MyPID==0) );
+
+    if (proc_verbose) {
+      std::cout << Belos::Belos_Version() << std::endl << std::endl;
+    }
+    //
+    // Get the data from the HB file and build the Map,Matrix
+    //
+    RCP<CrsMatrix<ST> > A;
+    Tpetra::Utils::readHBMatrix(filename,comm,A);
+    RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+    // Create initial vectors
+    RCP<MV> B, X;
+    X = rcp( new MV(map,numrhs) );
+    MVT::MvRandom( *X );
+    B = rcp( new MV(map,numrhs) );
+    OPT::Apply( *A, *X, *B );
+    MVT::MvInit( *X, 0.0 );
+
+    //
+    // ********Other information used by block solver***********
+    // *****************(can be user specified)******************
+    //
+    const int NumGlobalElements = B->getGlobalLength();
+    if (maxiters == -1) {
+      maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
+    }
+    //
+    ParameterList belosList;
+    belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+    belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+    belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    int verbLevel = Belos::Errors + Belos::Warnings;
+    if (debug) {
+      verbLevel += Belos::Debug;
+    }
+    if (verbose) {
+      verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
+    }
+    belosList.set( "Verbosity", verbLevel );
+    if (verbose) {
+      if (frequency > 0) {
+        belosList.set( "Output Frequency", frequency );
+      }
+    }
+    //
+    // Construct an unpreconditioned linear problem instance.
+    //
+    Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+    bool set = problem.setProblem();
+    if (set == false) {
+      if (proc_verbose)
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+    //
+    // *******************************************************************
+    // *************Start the block CG iteration***********************
+    // *******************************************************************
+    //
+    Belos::MinresSolMgr<ST,MV,OP,DM> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+
+    //
+    // **********Print out information about problem*******************
+    //
+    if (proc_verbose) {
+      std::cout << std::endl << std::endl;
+      std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+      std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+      std::cout << "Block size used by solver: " << blocksize << std::endl;
+      std::cout << "Max number of CG iterations: " << maxiters << std::endl;
+      std::cout << "Relative residual tolerance: " << tol << std::endl;
+      std::cout << std::endl;
+    }
+    //
+    // Perform solve
+    //
+    Belos::ReturnType ret = solver.solve();
+    //
+    // Compute actual residuals.
+    //
+    bool badRes = false;
+    std::vector<MT> actual_resids( numrhs );
+    std::vector<MT> rhs_norm( numrhs );
+    MV resid(map, numrhs);
+    OPT::Apply( *A, *X, resid );
+    MVT::MvAddMv( -one, resid, one, *B, resid );
+    MVT::MvNorm( resid, actual_resids );
+    MVT::MvNorm( *B, rhs_norm );
+    if (proc_verbose) {
+      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+    }
+    for ( int i=0; i<numrhs; i++) {
+      MT actRes = actual_resids[i]/rhs_norm[i];
+      if (proc_verbose) {
+        std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+      }
+      if (actRes > tol) badRes = true;
+    }
+
+    success = (ret==Belos::Converged && !badRes);
+
+    if (success) {
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+    } else {
+      if (proc_verbose)
+        std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
+} // end test_bl_cg_hb.cpp

--- a/packages/belos/tpetra/test/MINRES/test_minres_complex_hb.cpp
+++ b/packages/belos/tpetra/test/MINRES/test_minres_complex_hb.cpp
@@ -1,0 +1,192 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosMinresSolMgr.hpp"
+#include "BelosTpetraTestFramework.hpp"
+
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+
+template <typename ScalarType>
+int run(int argc, char *argv[])
+{ 
+  using Teuchos::Comm;
+  using Teuchos::RCP;
+  using Teuchos::rcpFromRef;
+  using Teuchos::tuple;  
+  
+  using BST = typename Tpetra::MultiVector<ScalarType>::scalar_type;
+  using ST = typename std::complex<BST>;
+
+  using SCT = typename Teuchos::ScalarTraits<ST>;
+  using MT = typename SCT::magnitudeType;
+
+  using OP = typename Tpetra::Operator<ST>;
+  using MV = typename Tpetra::MultiVector<ST>;
+  using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+  using MVT = typename Belos::MultiVecTraits<ST,MV>;
+
+  using tcrsmatrix_t = Tpetra::CrsMatrix<ST>;
+
+  Teuchos::GlobalMPISession mpisess(&argc, &argv, &std::cout);
+
+  const ST one  = SCT::one();
+  const ST zero  = SCT::zero();
+
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+  int MyPID = rank(*comm);
+
+  // Get test parameters from command-line processor
+  bool verbose = false, proc_verbose = false, debug = false;
+  int frequency = -1;  // how often residuals are printed by solver
+  int numrhs = 1;      // total number of right-hand sides to solve for
+  std::string filename("mhd1280b.cua");
+  MT tol = 1.0e-5;     // relative residual tolerance
+
+  Teuchos::CommandLineProcessor cmdp(false,true);
+  cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+  cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+  cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+  cmdp.setOption("tol",&tol,"Relative residual tolerance used by Minres solver.");
+  cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+  cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+  if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+    return -1;
+  }
+  if (debug) {
+    verbose = true;
+  }
+  if (!verbose) {
+    frequency = -1;  // reset frequency if test is not verbose
+  }
+
+  proc_verbose = ( verbose && (MyPID==0) );
+
+  if (proc_verbose) {
+    std::cout << Belos::Belos_Version() << std::endl << std::endl;
+  }
+
+  Belos::Tpetra::HarwellBoeingReader<tcrsmatrix_t> reader( comm );
+  RCP<tcrsmatrix_t> A = reader.readFromFile( filename );
+  RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+  // Create initial vectors
+  RCP<MV> B, X;
+  X = rcp( new MV(map,numrhs) );
+  //MVT::MvRandom( *X );
+  MVT::MvInit( *X, one );
+  B = rcp( new MV(map,numrhs) );
+  OPT::Apply( *A, *X, *B );
+  MVT::MvInit( *X, zero );
+
+  // ********Other information used by block solver***********
+  // *****************(can be user specified)******************
+  const int NumGlobalElements = B->getGlobalLength();
+  int numIters1;
+  int maxits = NumGlobalElements; // maximum number of iterations to run
+  Teuchos::ParameterList belosList;
+  belosList.set( "Maximum Iterations", maxits );         // Maximum number of iterations allowed
+  belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+
+  int verbLevel = Belos::Errors + Belos::Warnings;
+  if (debug) {
+    verbLevel += Belos::Debug;
+  }
+  if (verbose) {
+    verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
+  }
+  belosList.set( "Verbosity", verbLevel );
+  if (verbose) {
+    if (frequency > 0) {
+      belosList.set( "Output Frequency", frequency );
+    }
+  }
+  
+  // Construct an unpreconditioned linear problem instance.
+  Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+  bool set = problem.setProblem();
+  if (set == false) {
+    if (proc_verbose)
+      std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+    return -1;
+  }
+
+  // Start the Minres iteration
+  Belos::MinresSolMgr<ST,MV,OP> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+
+  // Print out information about problem
+  if (proc_verbose) {
+    std::cout << std::endl << std::endl;
+    std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+    std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+    std::cout << "Max number of Minres iterations: " << maxits << std::endl;
+    std::cout << "Relative residual tolerance: " << tol << std::endl;
+    std::cout << std::endl;
+  }
+  
+  // Perform solve
+  Belos::ReturnType ret = solver.solve();
+  numIters1=solver.getNumIters();
+  
+  // Compute actual residuals.
+  bool badRes = false;
+  std::vector<MT> actual_resids( numrhs );
+  std::vector<MT> rhs_norm( numrhs );
+  MV resid(map, numrhs);
+  OPT::Apply( *A, *X, resid );
+  MVT::MvAddMv( -one, resid, one, *B, resid );
+  MVT::MvNorm( resid, actual_resids );
+  MVT::MvNorm( *B, rhs_norm );
+  if (proc_verbose) {
+    std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+  }
+  for ( int i=0; i<numrhs; i++) {
+    MT actRes = actual_resids[i]/rhs_norm[i];
+    if (proc_verbose) {
+      std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+    }
+    if (actRes > tol) badRes = true;
+  }
+
+  if (proc_verbose) { std::cout << "Solve took " << numIters1 << " iterations." << std::endl; }
+
+  if ( ret!=Belos::Converged || badRes ) {
+    if (proc_verbose) {
+      std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+    return -1;
+  }
+  
+  // Default return value
+  if (proc_verbose) {
+    std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+  }
+  return 0;
+
+} // end test_gcrodr_complex_hb.cpp
+
+int main(int argc, char *argv[]) {
+  return run<double>(argc, argv);
+  // return run<float>(argc, argv);
+}
+

--- a/packages/belos/tpetra/test/MVOPTester/cxx_main_complex.cpp
+++ b/packages/belos/tpetra/test/MVOPTester/cxx_main_complex.cpp
@@ -14,8 +14,11 @@
 #include <Tpetra_CrsMatrix.hpp>
 
 #include "BelosConfigDefs.hpp"
+#include "BelosDenseMatTester.hpp"
 #include "BelosMVOPTester.hpp"
 #include "BelosTpetraAdapter.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+#include "BelosTeuchosDenseAdapter.hpp"
 #include "BelosOutputManager.hpp"
 
 namespace {
@@ -89,6 +92,7 @@ namespace {
   TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( MultiVector, MVTestDist, O1, O2, Scalar )
   {
     typedef Tpetra::MultiVector<Scalar,O1,O2> MV;
+    typedef Teuchos::SerialDenseMatrix<int,Scalar> DM;
     const O2 dim = 500;
     const Teuchos_Ordinal numVecs = 5;
     // Create an output manager to handle the I/O from the solver
@@ -98,7 +102,7 @@ namespace {
     // create a uniform contiguous map
     RCP<Map<O1,O2,Node> > map = rcp( new Map<O1,O2,Node>(dim,0,comm) );
     RCP<MV> mvec = rcp( new MV(map,numVecs,true) );
-    bool res = Belos::TestMultiVecTraits<Scalar,MV>(MyOM,mvec);
+    bool res = Belos::TestMultiVecTraits<Scalar,MV,DM>(MyOM,mvec);
     TEST_EQUALITY_CONST(res,true);
     // All procs fail if any proc fails
     int globalSuccess_int = -1;
@@ -110,6 +114,7 @@ namespace {
   TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( MultiVector, MVTestLocal, O1, O2, Scalar )
   {
     typedef Tpetra::MultiVector<Scalar,O1,O2> MV;
+    typedef Teuchos::SerialDenseMatrix<int,Scalar> DM;
     const O2 dim = 500;
     const Teuchos_Ordinal numVecs = 5;
     // Create an output manager to handle the I/O from the solver
@@ -119,7 +124,53 @@ namespace {
     // create a uniform contiguous map
     RCP<Map<O1,O2,Node> > map = rcp(new Map<O1,O2,Node>(dim,0,comm,Tpetra::LocallyReplicated) );
     RCP<MV> mvec = rcp( new MV(map,numVecs,true) );
-    bool res = Belos::TestMultiVecTraits<Scalar,MV>(MyOM,mvec);
+    bool res = Belos::TestMultiVecTraits<Scalar,MV,DM>(MyOM,mvec);
+    TEST_EQUALITY_CONST(res,true);
+    // All procs fail if any proc fails
+    int globalSuccess_int = -1;
+    reduceAll( *comm, Teuchos::REDUCE_SUM, success ? 0 : 1, Teuchos::outArg(globalSuccess_int) );
+    TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+  }
+
+  ////
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( MultiVector, MVTestDistKokkos, O1, O2, Scalar )
+  {
+    typedef Tpetra::MultiVector<Scalar,O1,O2> MV;
+    typedef typename MV::impl_scalar_type IST;
+    typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+    const O2 dim = 500;
+    const Teuchos_Ordinal numVecs = 5;
+    // Create an output manager to handle the I/O from the solver
+    RCP<OutputManager<Scalar> > MyOM = rcp( new OutputManager<Scalar>(Warnings,rcp(&out,false)) );
+    // get a comm
+    RCP<const Comm<int> > comm = getDefaultComm();
+    // create a uniform contiguous map
+    RCP<Map<O1,O2,Node> > map = rcp( new Map<O1,O2,Node>(dim,0,comm) );
+    RCP<MV> mvec = rcp( new MV(map,numVecs,true) );
+    bool res = Belos::TestMultiVecTraits<Scalar,MV,DM>(MyOM,mvec);
+    TEST_EQUALITY_CONST(res,true);
+    // All procs fail if any proc fails
+    int globalSuccess_int = -1;
+    reduceAll( *comm, Teuchos::REDUCE_SUM, success ? 0 : 1, Teuchos::outArg(globalSuccess_int) );
+    TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+  }
+
+  ////
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( MultiVector, MVTestLocalKokkos, O1, O2, Scalar )
+  {
+    typedef Tpetra::MultiVector<Scalar,O1,O2> MV;
+    typedef typename MV::impl_scalar_type IST;
+    typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+    const O2 dim = 500;
+    const Teuchos_Ordinal numVecs = 5;
+    // Create an output manager to handle the I/O from the solver
+    RCP<OutputManager<Scalar> > MyOM = rcp( new OutputManager<Scalar>(Warnings,rcp(&out,false)) );
+    // get a comm
+    RCP<const Comm<int> > comm = getDefaultComm();
+    // create a uniform contiguous map
+    RCP<Map<O1,O2,Node> > map = rcp(new Map<O1,O2,Node>(dim,0,comm,Tpetra::LocallyReplicated) );
+    RCP<MV> mvec = rcp( new MV(map,numVecs,true) );
+    bool res = Belos::TestMultiVecTraits<Scalar,MV,DM>(MyOM,mvec);
     TEST_EQUALITY_CONST(res,true);
     // All procs fail if any proc fails
     int globalSuccess_int = -1;
@@ -177,6 +228,41 @@ namespace {
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
   }
 
+  ////
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( MultiVector, DenseTest, O1, O2, Scalar )
+  {
+    typedef Teuchos::SerialDenseMatrix<int,Scalar> DM;
+    // Create an output manager to handle the I/O from the solver
+    RCP<OutputManager<Scalar> > MyOM = rcp( new OutputManager<Scalar>(Warnings,rcp(&out,false)) );
+    // get a comm
+    RCP<const Comm<int> > comm = getDefaultComm();
+    // Test Dense Traits:
+    bool res = Belos::TestDenseMatTraits<Scalar,DM>(MyOM);
+    TEST_EQUALITY_CONST(res,true);
+    // All procs fail if any proc fails
+    int globalSuccess_int = -1;
+    reduceAll( *comm, Teuchos::REDUCE_SUM, success ? 0 : 1, Teuchos::outArg(globalSuccess_int) );
+    TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+  } 
+
+  ////
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( MultiVector, DenseTestKokkos, O1, O2, Scalar )
+  {
+    typedef Tpetra::MultiVector<Scalar,O1,O2> MV;
+    typedef typename MV::impl_scalar_type IST;
+    typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+    // Create an output manager to handle the I/O from the solver
+    RCP<OutputManager<Scalar> > MyOM = rcp( new OutputManager<Scalar>(Warnings,rcp(&out,false)) );
+    // get a comm
+    RCP<const Comm<int> > comm = getDefaultComm();
+    // Test Dense Traits:
+    bool res = Belos::TestDenseMatTraits<Scalar,DM>(MyOM);
+    TEST_EQUALITY_CONST(res,true);
+    // All procs fail if any proc fails
+    int globalSuccess_int = -1;
+    reduceAll( *comm, Teuchos::REDUCE_SUM, success ? 0 : 1, Teuchos::outArg(globalSuccess_int) );
+    TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+  } 
   //
   // INSTANTIATIONS
   //
@@ -184,8 +270,12 @@ namespace {
 #define UNIT_TEST_GROUP( SCALAR, LO, GO ) \
     TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( MultiVector, MVTestDist, LO, GO, SCALAR ) \
     TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( MultiVector, MVTestLocal, LO, GO, SCALAR ) \
+    TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( MultiVector, MVTestDistKokkos, LO, GO, SCALAR ) \
+    TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( MultiVector, MVTestLocalKokkos, LO, GO, SCALAR ) \
     TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( MultiVector, OPTestDist, LO, GO, SCALAR ) \
-    TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( MultiVector, OPTestLocal, LO, GO, SCALAR )
+    TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( MultiVector, OPTestLocal, LO, GO, SCALAR ) \
+    TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( MultiVector, DenseTest, LO, GO, SCALAR ) \
+    TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( MultiVector, DenseTestKokkos, LO, GO, SCALAR ) 
 
 #include "TpetraCore_ETIHelperMacros.h"
 

--- a/packages/belos/tpetra/test/OrthoManager/CMakeLists.txt
+++ b/packages/belos/tpetra/test/OrthoManager/CMakeLists.txt
@@ -18,6 +18,15 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   COMM serial mpi
   )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_KokkosDense_OrthoManager_test
+  SOURCES belos_orthomanager_kokkosdense_tpetra.cpp
+  ARGS "--ortho=ICGS --verbose"
+  ARGS "--ortho=IMGS --verbose"
+  ARGS "--ortho=DGKS --verbose"
+  COMM serial mpi
+  )
+
 IF (${PACKAGE_NAME}_ENABLE_TSQR)
   TRIBITS_ADD_TEST(
     Tpetra_OrthoManager_test

--- a/packages/belos/tpetra/test/OrthoManager/belos_orthomanager_kokkosdense_tpetra.cpp
+++ b/packages/belos/tpetra/test/OrthoManager/belos_orthomanager_kokkosdense_tpetra.cpp
@@ -1,0 +1,422 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+/// \file belos_orthomanager_tpetra.cpp
+/// \brief Test (Mat)OrthoManager subclass(es) with Tpetra
+///
+/// Test various subclasses of (Mat)OrthoManager, using
+/// Tpetra::MultiVector as the multivector implementation,
+/// and Tpetra::Operator as the operator implementation.
+///
+#include "belos_orthomanager_tpetra_util.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+
+#include "Teuchos_CommandLineProcessor.hpp"
+#include "Tpetra_Core.hpp"
+
+using std::endl;
+
+//////////////////////////////////////////////////////////////////////
+// Command-line arguments
+//////////////////////////////////////////////////////////////////////
+
+// The name of the (Mat)OrthoManager subclass to instantiate.
+std::string orthoManName ("DGKS");
+
+// For SimpleOrthoManager: the normalization method to use.
+std::string normalization ("CGS");
+
+// Name of the Harwell-Boeing sparse matrix file from which to read
+// the inner product operator matrix.  If name is "" or not provided
+// at the command line, use the standard Euclidean inner product.
+std::string filename;
+
+bool verbose = false;
+bool debug = false;
+
+// The OrthoManager is tested with three different multivectors: S
+// (sizeS columns), X1 (sizeX1 columns), and X2 (sizeX2 columns).  The
+// values below are defaults and may be changed by the corresponding
+// command-line arguments.
+int sizeS  = 5;
+int sizeX1 = 11;
+int sizeX2 = 13;
+
+// Default _global_ number of rows.  The number of rows per MPI
+// process must be no less than max(sizeS, sizeX1, sizeX2).  To ensure
+// that the test always passes with default parameters, we must scale
+// below by the number of processes.  The default value below may be
+// changed by a command-line parameter with a corresponding name.
+int numRows = 100;
+
+// Set default values of command-line arguments,
+// and get their actual values from the command line.
+static void
+getCmdLineArgs (const Teuchos::Comm<int>& comm, int argc, char* argv[])
+{
+  using Teuchos::CommandLineProcessor;
+  typedef Tpetra::MultiVector<>::scalar_type ST;
+
+  // Define a OrthoManagerFactory to use to get the names of valid
+  // orthogonalization manager types.  We won't use this factory to
+  // create them, so we should be able to pick the Scalar, MV, and
+  // OP template parameters as we wish.
+  typedef Belos::OrthoManagerFactory<double,
+    Tpetra::MultiVector<ST>, Tpetra::Operator<ST> > factory_type;
+  factory_type factory;
+
+  ////////////////////////////////////////////////////////////////////
+  // Set default values of command-line arguments.
+  ////////////////////////////////////////////////////////////////////
+
+  // The name of the (Mat)OrthoManager subclass to instantiate.
+  orthoManName = factory.defaultName ();
+
+  // For SimpleOrthoManager: the normalization method to use.  Valid
+  // values: "MGS", "CGS".
+  normalization = "CGS";
+
+  // Name of the Harwell-Boeing sparse matrix file from which to read
+  // the inner product operator matrix.  If name is "" or not provided
+  // at the command line, use the standard Euclidean inner product.
+  filename = "";
+
+  verbose = false;
+  debug = false;
+
+  // The OrthoManager is tested with three different multivectors: S
+  // (sizeS columns), X1 (sizeX1 columns), and X2 (sizeX2 columns).
+  // The values below are defaults and may be changed by the
+  // corresponding command-line arguments.
+  sizeS  = 5;
+  sizeX1 = 11;
+  sizeX2 = 13;
+
+  // Default _global_ number of rows.  The number of rows per MPI
+  // process must be no less than max(sizeS, sizeX1, sizeX2).  To
+  // ensure that the test always passes with default parameters, we
+  // scale by the number of processes.  The default value below may be
+  // changed by a command-line parameter with a corresponding name.
+  numRows = 100 * comm.getSize ();
+
+  ////////////////////////////////////////////////////////////////////
+  // Define command-line arguments and parse them.
+  ////////////////////////////////////////////////////////////////////
+
+  CommandLineProcessor cmdp (false, true);
+  cmdp.setOption ("verbose", "quiet", &verbose, "Print messages and results.");
+  cmdp.setOption ("debug", "nodebug", &debug, "Print debugging information.");
+  cmdp.setOption ("filename", &filename,
+                  "Filename of a Harwell-Boeing sparse matrix, used as the "
+                  "inner product operator by the orthogonalization manager."
+                  "  If not provided, no matrix is read and the Euclidean "
+                  "inner product is used.  This is only valid for Scalar="
+                  "double.");
+  {
+    std::ostringstream os;
+    const int numValid = factory.numOrthoManagers ();
+    const bool plural = numValid > 1 || numValid == 0;
+
+    os << "OrthoManager subclass to test.  There ";
+    os << (plural ? "are " : "is ") << numValid << (plural ? "s: " : ": ");
+    factory.printValidNames (os);
+    os << ".";
+    cmdp.setOption ("ortho", &orthoManName, os.str ().c_str ());
+  }
+  cmdp.setOption ("normalization", &normalization,
+                  "For SimpleOrthoManager (--ortho=Simple): the normalization "
+                  "method to use.  Valid values: \"MGS\", \"CGS\".");
+  cmdp.setOption ("numRows", &numRows,
+                  "Controls the number of rows of the test "
+                  "multivectors.  If an input matrix is given, this "
+                  "parameter\'s value is ignored, since the vectors must "
+                  "be commensurate with the dimensions of the matrix.");
+  cmdp.setOption ("sizeS", &sizeS, "Controls the number of columns of the "
+                  "input multivector.");
+  cmdp.setOption ("sizeX1", &sizeX1, "Controls the number of columns of the "
+                  "first basis.");
+  cmdp.setOption ("sizeX2", &sizeX2, "Controls the number of columns of the "
+                  "second basis.  We require for simplicity of testing (the "
+                  "routines do not require it) that sizeX1 >= sizeX2.");
+  // Parse the command-line arguments.
+  {
+    const CommandLineProcessor::EParseCommandLineReturn parseResult =
+      cmdp.parse (argc, argv);
+    // If the caller asks us to print the documentation, or does not
+    // provide the name of an OrthoManager subclass, we just keep
+    // going.  Otherwise, we throw an exception.
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      parseResult != CommandLineProcessor::PARSE_SUCCESSFUL,
+      std::invalid_argument,
+      "Failed to parse command-line arguments");
+  }
+  //
+  // Validate command-line arguments
+  //
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    numRows <= 0, std::invalid_argument, "numRows <= 0 is not allowed");
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    numRows <= sizeS + sizeX1 + sizeX2, std::invalid_argument,
+    "numRows <= sizeS + sizeX1 + sizeX2 is not allowed");
+}
+
+// C++03 does not allow partial specialization of a template function,
+// so we have to declare a class to load the sparse matrix and create
+// the Map.
+
+// We don't have a generic Harwell-Boeing sparse file reader yet.  If
+// filename == "", then the user doesn't want to read in a sparse
+// matrix, so we can just create the appropriate Map and be done with
+// it.  Otherwise, raise an exception at run time.
+template<class ScalarType, class LocalOrdinalType, class GlobalOrdinalType, class NodeType>
+class SparseMatrixLoader {
+public:
+  typedef Tpetra::Map<LocalOrdinalType, GlobalOrdinalType, NodeType> map_type;
+  typedef Tpetra::CrsMatrix<ScalarType, LocalOrdinalType, GlobalOrdinalType, NodeType> matrix_type;
+
+  static void
+  load (Teuchos::RCP<map_type>& map,
+        Teuchos::RCP<matrix_type>& M,
+        const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+        std::ostream& debugOut)
+  {
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      filename != "", std::logic_error, "Sorry, reading in a Harwell-Boeing "
+      "sparse matrix file for ScalarType="
+      << Teuchos::TypeNameTraits<ScalarType>::name () << " is not yet "
+      "implemented.  This currently only works for ScalarType=double.");
+    const GlobalOrdinalType indexBase = 0;
+    map = Teuchos::rcp (new map_type (numRows, indexBase, comm, Tpetra::GloballyDistributed));
+    M = Teuchos::null;
+  }
+};
+
+// We _do_ know how to read a Harwell-Boeing sparse matrix file with Scalar=double.
+template<class LocalOrdinalType, class GlobalOrdinalType, class NodeType>
+class SparseMatrixLoader<double, LocalOrdinalType, GlobalOrdinalType, NodeType> {
+public:
+  typedef Tpetra::Map<LocalOrdinalType, GlobalOrdinalType, NodeType> map_type;
+  typedef Tpetra::CrsMatrix<double, LocalOrdinalType, GlobalOrdinalType, NodeType> matrix_type;
+
+  static void
+  load (Teuchos::RCP<map_type>& map,
+        Teuchos::RCP<matrix_type>& M,
+        const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+        std::ostream& debugOut)
+  {
+    // If the sparse matrix is loaded successfully, this call will
+    // modify numRows to be the number of rows in the sparse matrix.
+    // Otherwise, it will leave numRows alone.
+    std::pair<Teuchos::RCP<map_type>, Teuchos::RCP<matrix_type> > results =
+      Belos::Test::loadSparseMatrix<typename matrix_type::scalar_type,LocalOrdinalType,
+      GlobalOrdinalType,
+      NodeType> (comm, filename, numRows, debugOut);
+    map = results.first;
+    M = results.second;
+  }
+};
+
+
+// Run the actual test.  The test has the same template parameters as
+// MultiVector.  The most interesting template parameters for this
+// test are ScalarType and NodeType.
+//
+// Return true if test passed, else return false.
+template<class ScalarType, class LocalOrdinalType, class GlobalOrdinalType, class NodeType>
+bool runTest (const Teuchos::RCP<const Teuchos::Comm<int> >& comm)
+{
+  using Teuchos::ParameterList;
+  using Teuchos::parameterList;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  typedef ScalarType scalar_type;
+  typedef LocalOrdinalType local_ordinal_type;
+  typedef GlobalOrdinalType global_ordinal_type;
+  typedef NodeType node_type;
+
+  typedef Tpetra::MultiVector<>::impl_scalar_type IST;
+  typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+
+  typedef Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal_type, node_type> MV;
+  typedef Tpetra::Operator<scalar_type, local_ordinal_type, global_ordinal_type, node_type> OP;
+  typedef Tpetra::Map<local_ordinal_type, global_ordinal_type, node_type> map_type;
+  typedef Tpetra::CrsMatrix<scalar_type, local_ordinal_type, global_ordinal_type, node_type> crs_matrix_type;
+
+  // Declare an output manager for handling local output.  Initialize,
+  // using the caller's desired verbosity level.
+  //
+  // NOTE In Anasazi, this class is called BasicOutputManager.  In
+  // Belos, this class is called OutputManager.  We should eventually
+  // resolve the difference.
+  RCP<Belos::OutputManager<scalar_type> > outMan =
+    Belos::Test::makeOutputManager<scalar_type> (verbose, debug);
+
+  // Stream for debug output.  If debug output is not enabled, then
+  // this stream doesn't print anything sent to it (it's a "black
+  // hole" stream).
+  std::ostream& debugOut = outMan->stream (Belos::Debug);
+  Belos::Test::printVersionInfo (debugOut);
+
+  // Load the inner product operator matrix from the given filename.
+  // If filename == "", use the identity matrix as the inner product
+  // operator (the Euclidean inner product), and leave M as
+  // Teuchos::null.  Also return an appropriate Map (which will always
+  // be initialized, even if filename == ""; it should never be
+  // Teuchos::null).
+  RCP<map_type> map;
+  RCP<crs_matrix_type> M;
+  {
+    typedef SparseMatrixLoader<scalar_type, local_ordinal_type,
+      global_ordinal_type, node_type> loader_type;
+    loader_type::load (map, M, comm, debugOut);
+  }
+  TEUCHOS_TEST_FOR_EXCEPTION(map.is_null (), std::runtime_error,
+    "(Mat)OrthoManager test code failed to initialize the Map.");
+  {
+    // The maximum number of columns that will be passed to a
+    // MatOrthoManager's normalize() routine.  Some MatOrthoManager
+    // subclasses (e.g., Tsqr(Mat)OrthoManager) need to have the
+    // number of columns no larger than the number of rows on any
+    // process.  We check this _after_ attempting to load any sparse
+    // matrix to be used as the inner product matrix, because if a
+    // sparse matrix is successfully loaded, its number of rows will
+    // override the number of rows specified on the command line (if
+    // specified), and will also override the default number of rows.
+    const size_t maxNormalizeNumCols = std::max (sizeS, std::max (sizeX1, sizeX2));
+    // getLocalNumElements() returns a size_t, which is unsigned, and
+    // you shouldn't compare signed and unsigned values.  This is why
+    // we make maxNormalizeNumCols a size_t as well.
+    if (map->getLocalNumElements () < maxNormalizeNumCols) {
+      std::ostringstream os;
+      os << "The number of elements on this process " << comm->getRank()
+         << " is too small for the number of columns that you want to test."
+         << "  There are " << map->getLocalNumElements() << " elements on "
+        "this process, but the normalize() method of the MatOrthoManager "
+        "subclass will need to process a multivector with "
+         << maxNormalizeNumCols << " columns.  Not all MatOrthoManager "
+        "subclasses can handle a local row block with fewer rows than "
+        "columns.";
+      TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, os.str ());
+    }
+  }
+
+  // This factory object knows how to make a (Mat)OrthoManager
+  // subclass, given a name for the subclass and its parameters.
+  Belos::OrthoManagerFactory<scalar_type, MV, OP, DM> factory;
+
+  // Using the factory object, instantiate the specified OrthoManager
+  // subclass to be tested.  Specify "default" parameters (which
+  // should favor accuracy over performance), but override the default
+  // parameters to get the desired normalization method for
+  // SimpleOrthoManaager.
+  RCP<Belos::OrthoManager<scalar_type, MV, DM> > orthoMan;
+  {
+    std::string label (orthoManName);
+    RCP<ParameterList> params =
+      parameterList (*(factory.getDefaultParameters (orthoManName)));
+    if (orthoManName == "Simple") {
+      params->set ("Normalization", normalization);
+      label = label + " (" + normalization + " normalization)";
+    } else if (orthoManName == "TSQR") {
+      params->set ("randomizeNullSpace", false); // for testing the norm of zero-vector is zero
+    }
+    orthoMan = factory.makeOrthoManager (orthoManName, M, outMan, label, params);
+  }
+
+  // Whether the specific OrthoManager subclass promises to compute
+  // rank-revealing orthogonalizations.  If yes, then test it on
+  // rank-deficient multivectors, otherwise only test it on full-rank
+  // multivectors.
+  const bool isRankRevealing = factory.isRankRevealing (orthoManName);
+
+  // "Prototype" multivector.  The test code will use this (via
+  // Belos::MultiVecTraits) to clone other multivectors as
+  // necessary.  (This means the test code doesn't need the Map, and
+  // it also makes the test code independent of the idea of a Map.)
+  RCP<MV> S = rcp (new MV (map, sizeS));
+
+  // Test the OrthoManager subclass.  Return the number of tests
+  // that failed.  None of the tests should fail (this function
+  // should return zero).
+  int numFailed = 0;
+  {
+    typedef Belos::Test::OrthoManagerTester<scalar_type, MV, DM> tester_type;
+    numFailed = tester_type::runTests (orthoMan, isRankRevealing, S,
+                                       sizeX1, sizeX2, outMan);
+  }
+
+  if (numFailed != 0) {
+    outMan->stream (Belos::Errors) << numFailed << " errors." << endl;
+    return false;
+  } else {
+    return true;
+  }
+}
+
+int
+main (int argc, char *argv[])
+{
+  using Teuchos::ParameterList;
+  using Teuchos::parameterList;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  bool success = false;
+
+  Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+  try {
+    RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm ();
+
+    // Get values of command-line arguments.
+    getCmdLineArgs (*comm, argc, argv);
+
+    typedef Tpetra::Map<>::local_ordinal_type local_ordinal_type;
+    typedef Tpetra::Map<>::global_ordinal_type global_ordinal_type;
+    typedef Tpetra::Map<>::node_type node_type;
+
+    {
+      typedef Tpetra::MultiVector<>::scalar_type scalar_type;
+      success = runTest<scalar_type, local_ordinal_type,
+              global_ordinal_type, node_type> (comm);
+      if (success) {
+        // The Trilinos test framework depends on seeing this message,
+        // so don't rely on the OutputManager to report it correctly.
+        if (comm->getRank () == 0) {
+          std::cout << "End Result: TEST PASSED" << endl;
+        }
+      }
+      else {
+        if (comm->getRank () == 0) {
+          std::cout << "End Result: TEST FAILED" << endl;
+        }
+      }
+    }
+#if defined(HAVE_TEUCHOS_COMPLEX) && defined(HAVE_TPETRA_COMPLEX)
+    {
+      typedef std::complex<Tpetra::MultiVector<>::scalar_type> scalar_type;
+      success = runTest<scalar_type, local_ordinal_type,
+              global_ordinal_type, node_type> (comm);
+      if (success) {
+        // The Trilinos test framework depends on seeing this message,
+        // so don't rely on the OutputManager to report it correctly.
+        if (comm->getRank () == 0) {
+          std::cout << "End Result: TEST PASSED" << endl;
+        }
+      } else {
+        if (comm->getRank () == 0) {
+          std::cout << "End Result: TEST FAILED" << endl;
+        }
+      }
+    }
+#endif // defined(HAVE_TEUCHOS_COMPLEX) && defined(HAVE_TPETRA_COMPLEX)
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
+}

--- a/packages/belos/tpetra/test/OrthoManager/belos_orthomanager_tpetra_benchmark.cpp
+++ b/packages/belos/tpetra/test/OrthoManager/belos_orthomanager_tpetra_benchmark.cpp
@@ -34,9 +34,9 @@ typedef Teuchos::ScalarTraits<scalar_type> SCT;
 typedef SCT::magnitudeType magnitude_type;
 typedef Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal_type, node_type> MV;
 typedef Tpetra::Operator<scalar_type, local_ordinal_type, global_ordinal_type, node_type> OP;
-typedef Belos::MultiVecTraits<scalar_type, MV> MVT;
-typedef Belos::OperatorTraits<scalar_type, MV, OP> OPT;
 typedef Teuchos::SerialDenseMatrix<int, scalar_type> serial_matrix_type;
+typedef Belos::MultiVecTraits<scalar_type, MV, serial_matrix_type> MVT;
+typedef Belos::OperatorTraits<scalar_type, MV, OP> OPT;
 typedef Tpetra::Map<local_ordinal_type, global_ordinal_type, node_type> map_type;
 typedef Tpetra::CrsMatrix<scalar_type, local_ordinal_type, global_ordinal_type, node_type> sparse_matrix_type;
 
@@ -66,7 +66,7 @@ main (int argc, char *argv[])
     // subclass, given a name for the subclass.  The name is not the
     // same as the class' syntactic name: e.g., "TSQR" is the name of
     // TsqrOrthoManager.
-    OrthoManagerFactory<scalar_type, MV, OP> factory;
+    OrthoManagerFactory<scalar_type, MV, OP, serial_matrix_type> factory;
 
     // The name of the (Mat)OrthoManager subclass to instantiate.
     std::string orthoManName (factory.defaultName());
@@ -240,7 +240,7 @@ main (int argc, char *argv[])
     // subclass to be tested.  Specify "fast" parameters for a fair
     // benchmark comparison, but override the fast parameters to get the
     // desired normalization method for SimpleOrthoManaager.
-    RCP<OrthoManager<scalar_type, MV> > orthoMan;
+    RCP<OrthoManager<scalar_type, MV, serial_matrix_type> > orthoMan;
     {
       std::string label (orthoManName);
       RCP<ParameterList> params =
@@ -273,7 +273,7 @@ main (int argc, char *argv[])
       (displayResultsCompactly && Teuchos::rank(*pComm) != 0) ? bitBucket : std::cout;
 
     // Benchmark the OrthoManager subclass.
-    typedef Belos::Test::OrthoManagerBenchmarker<scalar_type, MV> benchmarker_type;
+    typedef Belos::Test::OrthoManagerBenchmarker<scalar_type, MV, serial_matrix_type> benchmarker_type;
     benchmarker_type::benchmark (orthoMan, orthoManName, normalization, X,
         numCols, numBlocks, numTrials,
         outMan, resultStream, displayResultsCompactly);

--- a/packages/belos/tpetra/test/PCPG/CMakeLists.txt
+++ b/packages/belos/tpetra/test/PCPG/CMakeLists.txt
@@ -4,3 +4,10 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   COMM mpi
   NUM_MPI_PROCS 4
   )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  pcpg_densekokkos_tpetraex
+  SOURCES test_kokkos_pcpg_tpetraex.cpp
+  COMM mpi
+  NUM_MPI_PROCS 4
+  )

--- a/packages/belos/tpetra/test/PCPG/test_kokkos_pcpg_tpetraex.cpp
+++ b/packages/belos/tpetra/test/PCPG/test_kokkos_pcpg_tpetraex.cpp
@@ -1,0 +1,374 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+// Purpose
+// The example tests the successive right-hand sides capabilities of Belos 
+// on a heat flow u_t = u_xx problem.
+//
+// A sequence of linear systems with the same coefficient matrix and
+// different right-hand sides is solved.  A seed space is generated dynamically,
+// and a deflated linear system is solved.  After each solves, the first
+// few Krylov vectors are saved, and used to reduce the number of iterations
+// for later solves.
+// The optimal numbers of vectors to deflate and save are not known.
+// Presently, the maximum number of vectors to deflate (seed space dimension)
+// and to save are user paraemters.
+// The seed space dimension is less than or equal to total number of vectors saved.
+// The difference between the seed space dimension and the total number of vectors,
+// is the number of vectors used to update the seed space after each solve.
+// I guess that a seed space whose dimension is a small fraction of the total space
+// will be best.
+//
+// maxSave=1 and maxDeflate=0 uses no recycling (not tested ).
+//
+// TODO: Instrument with timers, so that we can tell what is going on besides
+//       by counting the numbers of iterations.
+
+// Adapted from test_pcpg_epetraex.cpp by David M. Day (with original comments)
+
+// Belos
+#include <BelosPCPGSolMgr.hpp>
+#include <BelosLinearProblem.hpp>
+#include <BelosTpetraAdapter.hpp>
+#include <BelosKokkosDenseAdapter.hpp>
+
+// Tpetra
+#include <Tpetra_Core.hpp>
+#include <Tpetra_Map_fwd.hpp>
+#include <Tpetra_Vector_fwd.hpp>
+#include <Tpetra_CrsMatrix_fwd.hpp>
+#include <TpetraExt_MatrixMatrix.hpp>
+
+// Teuchos
+#include <Teuchos_RCP.hpp>
+#include <Teuchos_Comm.hpp>
+#include <Teuchos_Tuple.hpp>
+#include <Teuchos_VerboseObject.hpp>
+#include <Teuchos_FancyOStream.hpp>
+#include <Teuchos_CommHelpers.hpp>
+#include <Teuchos_DefaultComm.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_StandardCatchMacros.hpp>
+#include <Teuchos_CommandLineProcessor.hpp>
+
+
+template<typename ScalarType>
+int run(int argc, char *argv[]) {
+    using ST = typename Tpetra::Vector<ScalarType>::scalar_type;
+    using LO = typename Tpetra::Vector<>::local_ordinal_type;
+    using GO = typename Tpetra::Vector<>::global_ordinal_type;
+    using NT = typename Tpetra::Vector<>::node_type;
+
+    using SCT = typename Teuchos::ScalarTraits<ST>;
+    using MT  = typename SCT::magnitudeType;
+    using MV  = typename Tpetra::MultiVector<ST,LO,GO,NT>;
+    using OP  = typename Tpetra::Operator<ST,LO,GO,NT>;
+    using MVT = typename Belos::MultiVecTraits<ST,MV>;
+    using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+
+    using IST = typename Tpetra::MultiVector<>::impl_scalar_type;
+    using DM  = typename Kokkos::DualView<IST**,Kokkos::LayoutLeft>; 
+
+    using tcrsmatrix_t   = Tpetra::CrsMatrix<ST,LO,GO,NT>;
+    using tmap_t         = Tpetra::Map<LO,GO,NT>;
+    using tvector_t      = Tpetra::Vector<ST,LO,GO,NT>;
+    using tmultivector_t = Tpetra::MultiVector<ST,LO,GO,NT>;
+
+    using starray_t = Teuchos::Array<ST>;
+    using goarray_t = Teuchos::Array<GO>;
+
+    using Teuchos::ParameterList; // all of this may look fine but do not be fooled ...
+    using Teuchos::RCP;           // it is not so clear what any of this does
+    using Teuchos::rcp;
+    using Teuchos::Comm;
+    using Teuchos::rcp_dynamic_cast;
+
+    Teuchos::GlobalMPISession mpiSession (&argc, &argv, &std::cout);
+    const auto comm = Tpetra::getDefaultComm();
+    const int MyPID = comm->getRank();
+    const int numProc = comm->getSize();
+
+    // Laplace's equation, homogenous Dirichlet boundary counditions, [0,1]^2
+    // regular mesh, Q1 finite elements
+    bool success = false;
+    bool verbose = false;
+
+    try {
+        bool proc_verbose = false;
+        int frequency = -1;        // frequency of status test output.
+        int blocksize = 1;         // blocksize, PCPGIter
+        int numrhs = 1;            // number of right-hand sides to solve for
+        int maxiters = 30;         // maximum number of iterations allowed per linear system
+
+        int maxDeflate = 4; // maximum number of vectors deflated from the linear system;
+        // There is no overhead cost assoc with changing maxDeflate between solves
+        int maxSave = 8;    // maximum number of vectors saved from current and previous .");
+        // If maxSave changes between solves, then re-initialize (setSize).
+
+        // Hypothesis: seed vectors are conjugate.
+        // Initial versions allowed users to supply a seed space et cetera, but no longer.
+
+        // The documentation is suitable for certain tasks, like defining a modules grammar,
+        std::string ortho("ICGS"); // The Belos documentation obscures the fact that
+        // IMGS is Iterated Modified Gram Schmidt,
+        // ICGS is Iterated Classical Gram Schmidt, and
+        // DKGS is another Iterated Classical Gram Schmidt.
+        // Mathematical issues, such as the difference between ICGS and DKGS, are not documented at all.
+        // UH tells me that Anasazi::SVQBOrthoManager is available;  I need it for Belos
+        MT tol = 1.0e-8;           // relative residual tolerance
+        // How do command line parsers work?
+        Teuchos::CommandLineProcessor cmdp(false,true);
+
+        cmdp.setOption("verbose","quiet",&verbose,"Print messages and results");
+        cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters)");
+        cmdp.setOption("tol",&tol,"Relative residual tolerance used by PCPG solver");
+        cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for");
+        cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 = adapted to problem/block size)");
+        cmdp.setOption("num-deflate",&maxDeflate,"Number of vectors deflated from the linear system");
+        cmdp.setOption("num-save",&maxSave,"Number of vectors saved from old Krylov subspaces");
+        cmdp.setOption("ortho-type",&ortho,"Orthogonalization type, either DGKS, ICGS or IMGS");
+
+        if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+            return -1;
+        }
+        if (!verbose)
+            frequency = -1;  // reset frequency if test is not verbose
+
+        ////////////////////////////////////////////////////
+        //                Form the problem                //
+        ////////////////////////////////////////////////////
+
+        int num_time_step = 4;
+        GO numElePerDirection = 14 * numProc;
+        size_t numNodes = (numElePerDirection - 1)*(numElePerDirection - 1);
+        GO base = 0;
+
+        //By the way, either matrix has (3*numElePerDirection - 2)^2 nonzeros.
+        RCP<tmap_t> Map         = rcp(new tmap_t(numNodes, base, comm));
+        RCP<tcrsmatrix_t> Stiff = rcp(new tcrsmatrix_t(Map, numNodes));
+        RCP<tcrsmatrix_t> Mass  = rcp(new tcrsmatrix_t(Map, numNodes));
+        RCP<tvector_t> vecLHS   = rcp(new tvector_t(Map));
+        RCP<tvector_t> vecRHS   = rcp(new tvector_t(Map));
+        RCP<tmultivector_t> LHS, RHS;
+
+        ST ko = 8.0 / 3.0, k1 = -1.0 / 3.0;
+        starray_t k_arr(2);
+        k_arr[0] = ko;
+        k_arr[1] = k1;
+
+        ST h = 1.0 / static_cast<ST>(numElePerDirection);  // x=(iX,iY)h
+
+        ST mo = h*h*4.0/9.0, m1 = h*h/9.0, m2 = h*h/36.0;
+        starray_t m_arr(3);
+        m_arr[0] = mo;
+        m_arr[1] = m1;
+        m_arr[2] = m2;
+
+        ST pi = 4.0*atan(1.0), valueLHS;
+        GO lid, node, iX, iY;
+
+        goarray_t pos_arr(1);
+
+        for (lid = Map->getMinLocalIndex(); lid <= Map->getMaxLocalIndex(); lid++) {
+
+            node = Map->getGlobalElement(lid);
+            iX  = node  % (numElePerDirection-1);
+            iY  = ( node - iX )/(numElePerDirection-1);
+            pos_arr[0] = node;
+            Stiff->insertGlobalValues(node, pos_arr.view(0,1), k_arr.view(0,1)); // global row ID, global col ID, value
+            Mass->insertGlobalValues(node, pos_arr.view(0,1), m_arr.view(0,1)); // init guess violates hom Dir bc
+            valueLHS = sin( pi*h*((ST) iX+1) )*cos( 2.0 * pi*h*((ST) iY+1) );
+            vecLHS->replaceGlobalValue(node, valueLHS);
+
+            if (iY > 0) {
+                pos_arr[0] = iX + (iY-1)*(numElePerDirection-1);
+                Stiff->insertGlobalValues(node, pos_arr.view(0,1), k_arr.view(1,1)); //North
+                Mass->insertGlobalValues(node, pos_arr.view(0,1), m_arr.view(1,1));
+            }
+
+            if (iY < numElePerDirection-2) {
+                pos_arr[0] = iX + (iY+1)*(numElePerDirection-1);
+                Stiff->insertGlobalValues(node, pos_arr.view(0,1), k_arr.view(1,1)); //South
+                Mass->insertGlobalValues(node, pos_arr.view(0,1), m_arr.view(1,1));
+            }
+
+            if (iX > 0) {
+                pos_arr[0] = iX-1 + iY*(numElePerDirection-1);
+                Stiff->insertGlobalValues(node, pos_arr.view(0,1), k_arr.view(1,1)); // West
+                Mass->insertGlobalValues(node, pos_arr.view(0,1), m_arr.view(1,1));
+                if (iY > 0) {
+                    pos_arr[0] = iX-1 + (iY-1)*(numElePerDirection-1);
+                    Stiff->insertGlobalValues(node, pos_arr.view(0,1), k_arr.view(1,1)); // North West
+                    Mass->insertGlobalValues(node, pos_arr.view(0,1), m_arr.view(2,1));
+                }
+                if (iY < numElePerDirection-2) {
+                    pos_arr[0] = iX-1 + (iY+1)*(numElePerDirection-1);
+                    Stiff->insertGlobalValues(node, pos_arr.view(0,1), k_arr.view(1,1)); // South West
+                    Mass->insertGlobalValues(node, pos_arr.view(0,1), m_arr.view(2,1));
+                }
+            }
+
+            if (iX < numElePerDirection - 2) {
+                pos_arr[0] = iX+1 + iY*(numElePerDirection-1);
+                Stiff->insertGlobalValues(node, pos_arr.view(0,1), k_arr.view(1,1)); // East
+                Mass->insertGlobalValues(node, pos_arr.view(0,1), m_arr.view(1,1));
+                if (iY > 0) {
+                    pos_arr[0] = iX+1 + (iY-1)*(numElePerDirection-1);
+                    Stiff->insertGlobalValues(node, pos_arr.view(0,1), k_arr.view(1,1)); // North East
+                    Mass->insertGlobalValues(node, pos_arr.view(0,1), m_arr.view(2,1));
+                }
+                if (iY < numElePerDirection-2) {
+                    pos_arr[0] = iX+1 + (iY+1)*(numElePerDirection-1);
+                    Stiff->insertGlobalValues(node, pos_arr.view(0,1), k_arr.view(1,1)); // South East
+                    Mass->insertGlobalValues(node, pos_arr.view(0,1), m_arr.view(2,1));
+                }
+            }
+        }
+
+        Stiff->fillComplete();
+        Mass->fillComplete();
+
+        ST one = 1.0, hdt = .00005; // A = Mass+Stiff*dt/2
+        RCP<tcrsmatrix_t> A = Tpetra::MatrixMatrix::add(one, false, *Mass, hdt, false, *Stiff);
+
+        hdt = -hdt; // B = Mass-Stiff*dt/2
+        RCP<tcrsmatrix_t> B = Tpetra::MatrixMatrix::add(one, false, *Mass, hdt, false, *Stiff);
+
+        B->apply(*vecLHS, *vecRHS); // rhs_new := B*lhs_old,
+
+        proc_verbose = verbose && (MyPID==0);  /* Only print on the zero processor */
+
+        LHS = Teuchos::rcp_implicit_cast<tmultivector_t>(vecLHS);
+        RHS = Teuchos::rcp_implicit_cast<tmultivector_t>(vecRHS);
+
+        ///////////////////////////////////////////////////
+        //             Create Parameter List             //
+        ///////////////////////////////////////////////////
+
+        const size_t NumGlobalElements = RHS->getGlobalLength();
+
+        if (maxiters == -1)
+            maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
+
+        ParameterList belosList;
+        belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+        belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+        belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+        belosList.set( "Num Deflated Blocks", maxDeflate );    // Number of vectors in seed space
+        belosList.set( "Num Saved Blocks", maxSave );          // Number of vectors saved from old spaces
+        belosList.set( "Orthogonalization", ortho );           // Orthogonalization type
+
+        if (numrhs > 1) {
+        belosList.set( "Show Maximum Residual Norm Only", true );  // although numrhs = 1.
+        }
+        if (verbose) {
+            belosList.set( "Verbosity", Belos::Errors + Belos::Warnings +
+            Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails );
+            if (frequency > 0)
+                belosList.set( "Output Frequency", frequency );
+        }
+        else
+            belosList.set( "Verbosity", Belos::Errors + Belos::Warnings + Belos::FinalSummary );
+
+        ///////////////////////////////////////////////////
+        //  Construct /*Preconditioned*/ Linear Problem  //
+        ///////////////////////////////////////////////////
+
+        RCP<Belos::LinearProblem<ST,MV,OP> > problem
+            = rcp( new Belos::LinearProblem<ST,MV,OP>( A, LHS, RHS ) );
+
+        // problem->setLeftPrec( Prec ); // for Preconditioned Problem
+
+        bool set = problem->setProblem();
+        if (set == false) {
+            if (proc_verbose) {
+                std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+            }
+            return -1;
+        }
+
+        // Create an iterative solver manager.
+        RCP< Belos::SolverManager<ST,MV,OP,DM> > solver
+        = rcp( new Belos::PCPGSolMgr<ST,MV,OP,DM>(problem, rcp(&belosList,false)) );
+
+        ////////////////////////////////////////////////////
+        //                  Iterate PCPG                  //
+        ////////////////////////////////////////////////////
+
+        if (proc_verbose) {
+            std::cout << std::endl << std::endl;
+            std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+            std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+            std::cout << "Block size used by solver: " << blocksize << std::endl;
+            std::cout << "Maximum number of iterations allowed: " << maxiters << std::endl;
+            std::cout << "Relative residual tolerance: " << tol << std::endl;
+            std::cout << std::endl;
+        }
+        bool badRes;
+        for( int time_step = 0; time_step < num_time_step; time_step++){
+        if (time_step) {
+            B->apply(*LHS, *RHS); // rhs_new := B*lhs_old,
+            set = problem->setProblem(LHS, RHS);
+            if (set == false) {
+                if (proc_verbose)
+                    std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+                return -1;
+            }
+        } // if time_step
+        std::vector<ST> rhs_norm(numrhs);
+        MVT::MvNorm(*RHS, rhs_norm);
+        std::cout << "\t\t\t\tRHS norm is ... " << rhs_norm[0] << std::endl;
+
+        // Perform solve
+
+        Belos::ReturnType ret = solver->solve();
+
+        // Compute actual residuals.
+
+        badRes = false;
+        std::vector<ST> actual_resids(numrhs);
+        tmultivector_t resid(Map, numrhs);
+        OPT::Apply( *A, *LHS, resid );
+        MVT::MvAddMv( -1.0, resid, 1.0, *RHS, resid );
+        MVT::MvNorm( resid, actual_resids );
+        MVT::MvNorm( *RHS, rhs_norm );
+        std::cout << "\t\t\t\tRHS norm is ... " << rhs_norm[0] << std::endl;
+
+        if (proc_verbose) {
+            std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+            for ( int i=0; i<numrhs; i++) {
+                ST actRes = actual_resids[i]/rhs_norm[i];
+                std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+                if (actRes > tol) badRes = true;
+            }
+        }
+
+        success = ret==Belos::Converged && !badRes;
+        if (!success)
+            break;
+        } // for time_step
+
+        if (success) {
+            if (proc_verbose)
+                std::cout << "End Result: TEST PASSED" << std::endl;
+        } else {
+            if (proc_verbose)
+                std::cout << "End Result: TEST FAILED" << std::endl;
+        }
+    } // try block
+    TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+    return (success ? EXIT_SUCCESS : EXIT_FAILURE);
+} // run
+
+int main(int argc, char *argv[]) {
+    // run with different ST
+    run<double>(argc, argv);
+    // run<float>(argc, argv); // FAILS -- will need to change tolerance
+}

--- a/packages/belos/tpetra/test/PCPG/test_pcpg_tpetraex.cpp
+++ b/packages/belos/tpetra/test/PCPG/test_pcpg_tpetraex.cpp
@@ -8,8 +8,8 @@
 // @HEADER
 
 // Purpose
-// The example tests the successive right-hand sides capabilities of MueLu
-// and Belos on a heat flow u_t = u_xx problem.
+// The example tests the successive right-hand sides capabilities of Belos
+// on a heat flow u_t = u_xx problem.
 //
 // A sequence of linear systems with the same coefficient matrix and
 // different right-hand sides is solved.  A seed space is generated dynamically,
@@ -32,8 +32,6 @@
 
 // Adapted from test_pcpg_epetraex.cpp by David M. Day (with original comments)
 
-// All preconditioning has been commented out
-
 // Belos
 #include <BelosPCPGSolMgr.hpp>
 #include <BelosLinearProblem.hpp>
@@ -45,10 +43,6 @@
 #include <Tpetra_Vector_fwd.hpp>
 #include <Tpetra_CrsMatrix_fwd.hpp>
 #include <TpetraExt_MatrixMatrix.hpp>
-
-// MueLu
-// #include <MueLu_TpetraOperator.hpp>
-// #include <MueLu_CreateTpetraPreconditioner.hpp>
 
 // Teuchos
 #include <Teuchos_RCP.hpp>
@@ -81,8 +75,6 @@ int run(int argc, char *argv[]) {
     using tmap_t         = Tpetra::Map<LO,GO,NT>;
     using tvector_t      = Tpetra::Vector<ST,LO,GO,NT>;
     using tmultivector_t = Tpetra::MultiVector<ST,LO,GO,NT>;
-
-    // using mtoperator_t = MueLu::TpetraOperator<ST,LO,GO,NT>;
 
     using starray_t = Teuchos::Array<ST>;
     using goarray_t = Teuchos::Array<GO>;
@@ -250,23 +242,6 @@ int run(int argc, char *argv[]) {
 
         LHS = Teuchos::rcp_implicit_cast<tmultivector_t>(vecLHS);
         RHS = Teuchos::rcp_implicit_cast<tmultivector_t>(vecRHS);
-
-        ////////////////////////////////////////////////////
-        //            Construct Preconditioner            //
-        ////////////////////////////////////////////////////
-
-//         ParameterList MueLuList; // Set MueLuList for Smoothed Aggregation
-
-//         MueLuList.set("smoother: type", "CHEBYSHEV");
-//         MueLuList.set("smoother: pre or post", "both"); // both pre- and post-smoothing
-
-// #ifdef HAVE_MUELU_AMESOS2
-//         MueLuList.set("coarse: type", "KLU2");
-// #else
-//         MueLuList.set("coarse: type", "none")
-// #endif
-//         RCP<toperator_t> A_op = A;
-//         RCP<mtoperator_t> Prec = MueLu::CreateTpetraPreconditioner(A_op, MueLuList);
 
         ///////////////////////////////////////////////////
         //             Create Parameter List             //

--- a/packages/belos/tpetra/test/RCG/CMakeLists.txt
+++ b/packages/belos/tpetra/test/RCG/CMakeLists.txt
@@ -6,8 +6,16 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   COMM serial mpi
   )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_DenseKokkos_rcg_hb_test
+  SOURCES test_kokkos_rcg_hb.cpp
+  ARGS
+      "--verbose --tol=1e-6 --filename=bcsstk14.hb --num-rhs=3 --max-subspace=100 --recycle=10 --max-iters=4000"
+  COMM serial mpi
+  )
+
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Tpetra_CopyTestRCGFiles
   SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
   SOURCE_FILES bcsstk14.hb
-  EXEDEPS Tpetra_rcg_hb_test
+  EXEDEPS Tpetra_rcg_hb_test Tpetra_DenseKokkos_rcg_hb_test
   )

--- a/packages/belos/tpetra/test/RCG/test_kokkos_rcg_hb.cpp
+++ b/packages/belos/tpetra/test/RCG/test_kokkos_rcg_hb.cpp
@@ -1,0 +1,200 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+#include "BelosRCGSolMgr.hpp"
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_MatrixIO.hpp>
+
+using namespace Teuchos;
+using Tpetra::Operator;
+using Tpetra::CrsMatrix;
+using Tpetra::MultiVector;
+using std::endl;
+using std::cout;
+using std::vector;
+using Teuchos::tuple;
+
+int main(int argc, char *argv[]) {
+
+  typedef Tpetra::MultiVector<>::scalar_type ST;
+  typedef Tpetra::MultiVector<>::impl_scalar_type IST;
+  typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+  typedef ScalarTraits<ST>                SCT;
+  typedef SCT::magnitudeType               MT;
+  typedef Tpetra::Operator<ST>             OP;
+  typedef Tpetra::MultiVector<ST>          MV;
+  typedef Belos::OperatorTraits<ST,MV,OP> OPT;
+  typedef Belos::MultiVecTraits<ST,MV,DM> MVT;
+
+  GlobalMPISession mpisess(&argc,&argv,&cout);
+
+  const ST one  = SCT::one();
+
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+  int MyPID = rank(*comm);
+
+  //
+  // Get test parameters from command-line processor
+  //
+  bool verbose = false, proc_verbose = false, debug = false;
+  int frequency = -1;  // how often residuals are printed by solver
+  std::string filename("bcsstk14.hb");
+  int numBlocks = 30;                  // maximum number of blocks the solver can use for the Krylov subspace
+  int recycleBlocks = 3;               // maximum number of blocks the solver can use for the recycle space
+  int numrhs = 1;                      // number of right-hand sides to solve for
+  int maxiters = -1;                   // maximum number of iterations allowed per linear system
+  MT tol = 1.0e-5;     // relative residual tolerance
+
+  CommandLineProcessor cmdp(false,true);
+  cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+  cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+  cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+  cmdp.setOption("tol",&tol,"Relative residual tolerance used by the RCG solver.");
+  cmdp.setOption("max-subspace",&numBlocks,"Maximum number of vectors in search space (not including recycle space).");
+  cmdp.setOption("recycle",&recycleBlocks,"Number of vectors in recycle space.");
+  cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+  cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 = adapted to problem/block size).");
+  cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+  if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
+    return -1;
+  }
+  if (debug) {
+    verbose = true;
+  }
+  if (!verbose) {
+    frequency = -1;  // reset frequency if test is not verbose
+  }
+
+  proc_verbose = ( verbose && (MyPID==0) );
+
+  if (proc_verbose) {
+    std::cout << Belos::Belos_Version() << std::endl << std::endl;
+  }
+
+  RCP<CrsMatrix<ST> > A;
+  Tpetra::Utils::readHBMatrix(filename,comm,A);
+  RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+  // Create initial vectors
+  RCP<MV> B, X;
+  X = rcp( new MV(map,numrhs) );
+  MVT::MvRandom( *X );
+  B = rcp( new MV(map,numrhs) );
+  OPT::Apply( *A, *X, *B );
+  MVT::MvInit( *X, 0.0 );
+
+  //
+  // ********Other information used by block solver***********
+  // *****************(can be user specified)******************
+  //
+  int numIters1;
+  const int NumGlobalElements = B->getGlobalLength();
+  if (maxiters == -1)
+    maxiters = NumGlobalElements - 1; // maximum number of iterations to run
+  //
+  ParameterList belosList;
+  belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+  belosList.set( "Num Blocks", numBlocks);               // Maximum number of blocks in Krylov space
+  belosList.set( "Num Recycled Blocks", recycleBlocks ); // Number of vectors in recycle space
+  belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+  if (verbose) {
+    belosList.set( "Verbosity", Belos::Errors + Belos::Warnings +
+      Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails );
+    if (frequency > 0)
+      belosList.set( "Output Frequency", frequency );
+  }
+  else
+    belosList.set( "Verbosity", Belos::Errors + Belos::Warnings );
+  //
+  // Construct an unpreconditioned linear problem instance.
+  //
+  Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+  bool set = problem.setProblem();
+  if (set == false) {
+    if (proc_verbose)
+      std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+    return -1;
+  }
+  //
+  // *******************************************************************
+  // *********************Start the RCG iteration***********************
+  // *******************************************************************
+  //
+  Belos::RCGSolMgr<ST,MV,OP,DM> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+
+  //
+  // **********Print out information about problem*******************
+  //
+  if (proc_verbose) {
+    std::cout << std::endl << std::endl;
+    std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+    std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+    std::cout << "Max number of RCG iterations: " << maxiters << std::endl;
+    std::cout << "Relative residual tolerance: " << tol << std::endl;
+    std::cout << std::endl;
+  }
+  //
+  // Perform solve
+  //
+  Belos::ReturnType ret = solver.solve();
+  numIters1=solver.getNumIters();
+  //
+  // Compute actual residuals.
+  //
+  bool badRes = false;
+  std::vector<MT> actual_resids( numrhs );
+  std::vector<MT> rhs_norm( numrhs );
+  MV resid(map, numrhs);
+  OPT::Apply( *A, *X, resid );
+  MVT::MvAddMv( -one, resid, one, *B, resid );
+  MVT::MvNorm( resid, actual_resids );
+  MVT::MvNorm( *B, rhs_norm );
+  if (proc_verbose) {
+    std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+  }
+  for ( int i=0; i<numrhs; i++) {
+    MT actRes = actual_resids[i]/rhs_norm[i];
+    if (proc_verbose) {
+      std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+    }
+    if (actRes > tol) badRes = true;
+  }
+
+  if (proc_verbose) { std::cout << "Solve took " << numIters1 << " iterations." << std::endl; }
+
+  if ( ret!=Belos::Converged || badRes ) {
+    if (proc_verbose) {
+      std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+    return -1;
+  }
+  //
+  // Default return value
+  //
+  if (proc_verbose) {
+    std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+  }
+  return 0;
+  //
+} // end test_rcg_hb.cpp

--- a/packages/belos/tpetra/test/RCG/test_rcg_hb.cpp
+++ b/packages/belos/tpetra/test/RCG/test_rcg_hb.cpp
@@ -23,9 +23,6 @@
 #include <Teuchos_GlobalMPISession.hpp>
 #include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
-
-// I/O for Harwell-Boeing files
-#define HIDE_TPETRA_INOUT_IMPLEMENTATIONS
 #include <Tpetra_MatrixIO.hpp>
 
 using namespace Teuchos;

--- a/packages/belos/tpetra/test/TFQMR/CMakeLists.txt
+++ b/packages/belos/tpetra/test/TFQMR/CMakeLists.txt
@@ -26,8 +26,20 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT
 )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_KokkosDense_tfqmr_hb
+  SOURCES test_kokkos_tfqmr_hb.cpp 
+  COMM serial mpi
+  ARGS
+    "--verbose --filename=orsirr1_scaled.hb"
+    "--verbose --pseudo --filename=orsirr1_scaled.hb"
+    "--verbose --explicit --filename=orsirr1_scaled.hb"
+    "--verbose --recursive --filename=orsirr1_scaled.hb"
+  STANDARD_PASS_OUTPUT 
+)
+
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Tpetra_CopyTestTFQMRFiles
   SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
   SOURCE_FILES orsirr1.hb orsirr1_scaled.hb
-  EXEDEPS Tpetra_tfqmr_hb
+  EXEDEPS Tpetra_tfqmr_hb Tpetra_KokkosDense_tfqmr_hb
   )

--- a/packages/belos/tpetra/test/TFQMR/test_kokkos_tfqmr_hb.cpp
+++ b/packages/belos/tpetra/test/TFQMR/test_kokkos_tfqmr_hb.cpp
@@ -1,0 +1,203 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+//
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosTFQMRSolMgr.hpp"
+#include "BelosPseudoBlockTFQMRSolMgr.hpp"
+#include "BelosTpetraTestFramework.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_StandardCatchMacros.hpp>
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+
+int main(int argc, char *argv[]) {
+  //
+  typedef Tpetra::MultiVector<>::scalar_type ST;
+  typedef Tpetra::MultiVector<>::impl_scalar_type IST;
+  typedef Kokkos::DualView<IST**,Kokkos::LayoutLeft> DM;
+  typedef Teuchos::ScalarTraits<ST>       SCT;
+  typedef SCT::magnitudeType               MT;
+  typedef Tpetra::Operator<ST>             OP;
+  typedef Tpetra::MultiVector<ST>          MV;
+  typedef Belos::OperatorTraits<ST,MV,OP> OPT;
+  typedef Belos::MultiVecTraits<ST,MV,DM> MVT;
+
+  using Teuchos::ParameterList;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  const ST one  = SCT::one();
+
+  Teuchos::GlobalMPISession session(&argc, &argv, NULL);
+
+  RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
+  int MyPID = rank(*comm);
+
+  //
+  bool success = false;
+  bool verbose = false;
+  try {
+    //
+    // Get test parameters from command-line processor
+    //
+    bool proc_verbose = false;
+    bool explicit_test = false;
+    bool comp_recursive = false;
+    bool pseudo = false;
+    int frequency = -1;  // how often residuals are printed by solver
+    int numrhs = 1;  // total number of right-hand sides to solve for
+    int maxiters = -1;  // maximum number of iterations for solver to use
+    std::string filename("orsirr1.hb");
+    double tol = 1.0e-5;  // relative residual tolerance
+
+    Teuchos::CommandLineProcessor cmdp(false,true);
+    cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+
+    cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+    cmdp.setOption("explicit","implicit-only",&explicit_test,"Compute explicit residuals.");
+    cmdp.setOption("recursive","native",&comp_recursive,"Compute recursive residuals.");
+    cmdp.setOption("pseudo","not-pseudo",&pseudo,"Use pseudo-block TFQMR solver.");
+    cmdp.setOption("tol",&tol,"Relative residual tolerance used by TFQMR solver.");
+    cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+    cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+    cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem size).");
+    if (cmdp.parse(argc,argv) != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL) {
+      return -1;
+    }
+    if (!verbose)
+      frequency = -1;  // reset frequency if test is not verbose
+    //
+    // Get the problem
+    //
+    Belos::Tpetra::HarwellBoeingReader<Tpetra::CrsMatrix<ST> > reader( comm );
+    RCP<Tpetra::CrsMatrix<ST> > A = reader.readFromFile( filename );
+    RCP<const Tpetra::Map<> > map = A->getDomainMap();
+
+    // Create initial vectors
+    RCP<MV> B, X;
+    X = rcp( new MV(map,numrhs) );
+    MVT::MvRandom( *X );
+    B = rcp( new MV(map,numrhs) );
+    OPT::Apply( *A, *X, *B );
+    MVT::MvInit( *X, 0.0 );
+
+    proc_verbose = ( verbose && (MyPID==0) );
+    //
+    // Solve using Belos
+    //
+    const int NumGlobalElements = B->getGlobalLength();
+    if (maxiters == -1)
+      maxiters = NumGlobalElements; // maximum number of iterations to run
+    //
+    ParameterList belosList;
+    belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+    belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    if (explicit_test)
+    {
+      belosList.set( "Explicit Residual Test", true );       // Scale by norm of right-hand side vector."
+      belosList.set( "Explicit Residual Scaling", "Norm of RHS" ); // Scale by norm of right-hand side vector."
+    }
+    if (comp_recursive)
+    {
+      belosList.set( "Compute Recursive Residuals", true );
+    }
+    if (verbose) {
+      belosList.set( "Verbosity", Belos::Errors + Belos::Warnings +
+          Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails );
+      if (frequency > 0)
+        belosList.set( "Output Frequency", frequency );
+    }
+    else
+      belosList.set( "Verbosity", Belos::Errors + Belos::Warnings );
+    //
+    // Construct an unpreconditioned linear problem instance.
+    //
+    Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+    bool set = problem.setProblem();
+    if (set == false) {
+      if (proc_verbose)
+        std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+      return -1;
+    }
+    //
+    // Create an iterative solver manager.
+    //
+    RCP< Belos::SolverManager<ST,MV,OP,DM> > solver;
+
+    if (pseudo)
+      solver = rcp( new Belos::PseudoBlockTFQMRSolMgr<ST,MV,OP,DM>(rcp(&problem,false), rcp(&belosList,false)) );
+    else
+      solver = rcp( new Belos::TFQMRSolMgr<ST,MV,OP,DM>(rcp(&problem,false), rcp(&belosList,false)) );
+    //
+    // **********Print out information about problem*******************
+    //
+    if (proc_verbose) {
+      std::cout << std::endl << std::endl;
+      std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+      std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+      std::cout << "Max number of TFQMR iterations: " << maxiters << std::endl;
+      std::cout << "Relative residual tolerance: " << tol << std::endl;
+      std::cout << std::endl;
+    }
+    //
+    // Perform solve
+    //
+    Belos::ReturnType ret = solver->solve();
+    //
+    // Compute actual residuals.
+    //
+    bool badRes = false;
+    std::vector<MT> actual_resids( numrhs );
+    std::vector<MT> rhs_norm( numrhs );
+    MV resid(map, numrhs);
+    OPT::Apply( *A, *X, resid );
+    MVT::MvAddMv( -one, resid, one, *B, resid );
+    MVT::MvNorm( resid, actual_resids );
+    MVT::MvNorm( *B, rhs_norm );
+    if (proc_verbose) {
+      std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
+    }
+    for ( int i=0; i<numrhs; i++) {
+      MT actRes = actual_resids[i]/rhs_norm[i];
+      if (proc_verbose) {
+        std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+      }
+      if (actRes > tol) badRes = true;
+    }
+
+    if ( ret!=Belos::Converged || badRes) {
+      if (proc_verbose) {
+        std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+      }
+      return -1;
+    }
+    //
+    // Default return value
+    //
+    if (proc_verbose) {
+      std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+    }
+    success = true;
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return ( success ? EXIT_SUCCESS : EXIT_FAILURE );
+
+} // end test_tfqmr_hb.cpp

--- a/packages/muelu/adapters/belos/BelosXpetraStatusTestGenResSubNorm.hpp
+++ b/packages/muelu/adapters/belos/BelosXpetraStatusTestGenResSubNorm.hpp
@@ -28,18 +28,19 @@ namespace Belos {
  * Xpetra::MultiVector and Belos::OperatorT MueLu adapter class.
  */
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-class StatusTestGenResSubNorm<Scalar, Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>, Belos::OperatorT<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >
-  : public StatusTestResNorm<Scalar, Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>, Belos::OperatorT<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > {
+class StatusTestGenResSubNorm<Scalar, Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>, Belos::OperatorT<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >, Teuchos::SerialDenseMatrix<LocalOrdinal, Scalar> >
+  : public StatusTestResNorm<Scalar, Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>, Belos::OperatorT<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >, Teuchos::SerialDenseMatrix<LocalOrdinal, Scalar> > {
  public:
   // Convenience typedefs
   typedef Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
   typedef Xpetra::BlockedCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> BCRS;
   typedef Xpetra::MapExtractor<Scalar, LocalOrdinal, GlobalOrdinal, Node> ME;
+  typedef Teuchos::SerialDenseMatrix<LocalOrdinal, Scalar> DM;
   typedef Belos::OperatorT<MV> OP;
 
   typedef Teuchos::ScalarTraits<Scalar> SCT;
   typedef typename SCT::magnitudeType MagnitudeType;
-  typedef MultiVecTraits<Scalar, MV> MVT;
+  typedef MultiVecTraits<Scalar, MV, DM> MVT;
   typedef OperatorTraits<Scalar, MV, OP> OT;
 
   //! @name Constructors/destructors.
@@ -174,7 +175,7 @@ class StatusTestGenResSubNorm<Scalar, Xpetra::MultiVector<Scalar, LocalOrdinal, 
 
     \return StatusType: Passed, Failed, or Undefined.
   */
-  StatusType checkStatus(Iteration<Scalar, MV, OP>* iSolver) {
+  StatusType checkStatus(Iteration<Scalar, MV, OP, DM>* iSolver) {
     MagnitudeType zero                      = Teuchos::ScalarTraits<MagnitudeType>::zero();
     const LinearProblem<Scalar, MV, OP>& lp = iSolver->getProblem();
     // Compute scaling term (done once for each block that's being solved)

--- a/packages/stokhos/example/cijk/cijk_simple_tile.cpp
+++ b/packages/stokhos/example/cijk/cijk_simple_tile.cpp
@@ -11,9 +11,11 @@
 #include "Teuchos_CommandLineProcessor.hpp"
 #include "Teuchos_ParameterList.hpp"
 
+#include <random>
 #include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <ctime>
 
 // sparsity_example
 //
@@ -347,7 +349,9 @@ int main(int argc, char **argv)
     Teuchos::Array<int> part_IDs(num_parts);
     for (int i=0; i<num_parts; ++i)
       part_IDs[i] = i;
-    std::random_shuffle(part_IDs.begin(), part_IDs.end());
+
+    std::mt19937 rng(std::time(nullptr));
+    std::shuffle(part_IDs.begin(), part_IDs.end(), rng);
 
     // Assign part IDs
     int pp = 0;

--- a/packages/stokhos/src/sacado/kokkos/Stokhos_Tpetra_Utilities.hpp
+++ b/packages/stokhos/src/sacado/kokkos/Stokhos_Tpetra_Utilities.hpp
@@ -214,7 +214,6 @@ namespace Stokhos {
 
     KokkosMatrixType kokkos_matrix = A.getLocalMatrixDevice();
     KokkosMatrixValuesType matrix_values = kokkos_matrix.values;
-    const size_t ncols = kokkos_matrix.numCols();
     typedef GetMeanValsFunc <KokkosMatrixValuesType > MeanFunc;
     typedef typename MeanFunc::MeanViewType KokkosMeanMatrixValuesType;
     MeanFunc meanfunc(matrix_values);

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_DGKS_OrthoManager_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_DGKS_OrthoManager_MP_Vector.hpp
@@ -20,6 +20,7 @@
 
 #include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
 #include "BelosDGKSOrthoManager.hpp"
+#include "Teuchos_SerialDenseMatrix.hpp"
 
 namespace Belos {
 

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_ICGS_OrthoManager_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_ICGS_OrthoManager_MP_Vector.hpp
@@ -20,6 +20,7 @@
 
 #include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
 #include "BelosICGSOrthoManager.hpp"
+#include "Teuchos_SerialDenseMatrix.hpp"
 
 namespace Belos {
 

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_IMGS_OrthoManager_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_IMGS_OrthoManager_MP_Vector.hpp
@@ -20,6 +20,8 @@
 
 #include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
 #include "BelosIMGSOrthoManager.hpp"
+#include "Teuchos_SerialDenseMatrix.hpp"
+#include "Teuchos_SerialDenseVector.hpp"
 
 namespace Belos {
 

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_PseudoBlockCGIter_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_PseudoBlockCGIter_MP_Vector.hpp
@@ -20,6 +20,7 @@
 
 #include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
 #include "BelosPseudoBlockCGIter.hpp"
+#include "Teuchos_SerialDenseMatrix.hpp"
 
 /*!
   \class Belos::PseudoBlockCGIter
@@ -38,9 +39,9 @@
 
 namespace Belos {
 
-  template<class Storage, class MV, class OP>
-  class PseudoBlockCGIter<Sacado::MP::Vector<Storage>, MV, OP> :
-    virtual public CGIteration<Sacado::MP::Vector<Storage>, MV, OP> {
+  template<class Storage, class MV, class OP, class DM>
+  class PseudoBlockCGIter<Sacado::MP::Vector<Storage>, MV, OP, DM> :
+    virtual public CGIteration<Sacado::MP::Vector<Storage>, MV, OP, Teuchos::SerialDenseMatrix<int, Sacado::MP::Vector<Storage> > > {
 
   public:
 
@@ -48,7 +49,8 @@ namespace Belos {
     // Convenience typedefs
     //
     typedef Sacado::MP::Vector<Storage> ScalarType;
-    typedef MultiVecTraits<ScalarType,MV> MVT;
+    typedef Teuchos::SerialDenseMatrix<int, ScalarType> DMType;
+    typedef MultiVecTraits<ScalarType,MV,DM> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename SCT::magnitudeType MagnitudeType;
@@ -64,7 +66,7 @@ namespace Belos {
      */
     PseudoBlockCGIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                           const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-                          const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
+                          const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DMType> > &tester,
                           Teuchos::ParameterList &params );
 
     //! Destructor.
@@ -223,9 +225,9 @@ namespace Belos {
     //
     // Classes inputed through constructor that define the linear problem to be solved.
     //
-    const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
-    const Teuchos::RCP<OutputManager<ScalarType> >          om_;
-    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
+    const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >        lp_;
+    const Teuchos::RCP<OutputManager<ScalarType> >              om_;
+    const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DMType> >    stest_;
 
     //
     // Algorithmic parameters
@@ -274,11 +276,11 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
-  template<class StorageType, class MV, class OP>
-  PseudoBlockCGIter<Sacado::MP::Vector<StorageType>,MV,OP>::
+  template<class StorageType, class MV, class OP, class DM>
+  PseudoBlockCGIter<Sacado::MP::Vector<StorageType>,MV,OP,DM>::
   PseudoBlockCGIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
                                                                const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-                                                               const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
+                                                               const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DMType> > &tester,
                                                                Teuchos::ParameterList &params ):
     lp_(problem),
     om_(printer),
@@ -295,8 +297,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Initialize this iteration object
-  template <class StorageType, class MV, class OP>
-  void PseudoBlockCGIter<Sacado::MP::Vector<StorageType>,MV,OP>::
+  template <class StorageType, class MV, class OP, class DM>
+  void PseudoBlockCGIter<Sacado::MP::Vector<StorageType>,MV,OP,DM>::
   initializeCG(Teuchos::RCP<CGIterationStateBase<ScalarType,MV> >  newstate, Teuchos::RCP<MV> R_0) {
 
     // Check if there is any mltivector to clone from.
@@ -365,8 +367,8 @@ namespace Belos {
 
  //////////////////////////////////////////////////////////////////////////////////////////////////
   // Iterate until the status test informs us we should stop.
-  template <class StorageType, class MV, class OP>
-  void PseudoBlockCGIter<Sacado::MP::Vector<StorageType>,MV,OP>::
+  template <class StorageType, class MV, class OP, class DM>
+  void PseudoBlockCGIter<Sacado::MP::Vector<StorageType>,MV,OP,DM>::
   iterate()
   {
     //

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_PseudoBlockGmresIter_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_PseudoBlockGmresIter_MP_Vector.hpp
@@ -20,6 +20,8 @@
 
 #include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
 #include "BelosPseudoBlockGmresIter.hpp"
+#include "Teuchos_SerialDenseMatrix.hpp"
+#include "Teuchos_SerialDenseVector.hpp"
 
 /*!
   \class Belos::PseudoBlockGmresIter
@@ -36,9 +38,9 @@
 
 namespace Belos {
     
-  template<class Storage, class MV, class OP>
-  class PseudoBlockGmresIter<Sacado::MP::Vector<Storage>, MV, OP> : 
-    virtual public Iteration<Sacado::MP::Vector<Storage>, MV, OP> {
+  template<class Storage, class MV, class OP, class DM>
+  class PseudoBlockGmresIter<Sacado::MP::Vector<Storage>, MV, OP, DM> : 
+    virtual public Iteration<Sacado::MP::Vector<Storage>, MV, OP, Teuchos::SerialDenseMatrix<int, Sacado::MP::Vector<Storage> > > {
     
   public:
     
@@ -46,7 +48,8 @@ namespace Belos {
     // Convenience typedefs
     //
     typedef Sacado::MP::Vector<Storage> ScalarType;
-    typedef MultiVecTraits<ScalarType,MV> MVT;
+    typedef Teuchos::SerialDenseMatrix<int, ScalarType> DMType;
+    typedef MultiVecTraits<ScalarType,MV,DMType> MVT;
     typedef OperatorTraits<ScalarType,MV,OP> OPT;
     typedef Teuchos::ScalarTraits<ScalarType> SCT;
     typedef typename SCT::magnitudeType MagnitudeType;
@@ -65,8 +68,8 @@ namespace Belos {
      */  
     PseudoBlockGmresIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
 			  const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-			  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-			  const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > &ortho,
+			  const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DMType> > &tester,
+			  const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP,DMType> > &ortho,
 			  Teuchos::ParameterList &params );
     
     //! Destructor.
@@ -121,14 +124,14 @@ namespace Belos {
      * \note For any pointer in \c newstate which directly points to the multivectors in 
      * the solver, the data is not copied.
      */
-    void initialize(const PseudoBlockGmresIterState<ScalarType,MV> & newstate);
+    void initialize(const PseudoBlockGmresIterState<ScalarType,MV,DMType> & newstate);
 
     /*! \brief Initialize the solver with the initial vectors from the linear problem
      *  or random data.
      */
     void initialize()
     {
-      PseudoBlockGmresIterState<ScalarType,MV> empty;
+      PseudoBlockGmresIterState<ScalarType,MV,DMType> empty;
       initialize(empty);
     }
     
@@ -139,8 +142,8 @@ namespace Belos {
      * \returns A PseudoBlockGmresIterState object containing const pointers to the current
      * solver state.
      */
-    PseudoBlockGmresIterState<ScalarType,MV> getState() const {
-      PseudoBlockGmresIterState<ScalarType,MV> state;
+    PseudoBlockGmresIterState<ScalarType,MV,DMType> getState() const {
+      PseudoBlockGmresIterState<ScalarType,MV,DMType> state;
       state.curDim = curDim_;
       state.V.resize(numRHS_);
       state.H.resize(numRHS_);
@@ -245,10 +248,10 @@ namespace Belos {
     //
     // Classes inputed through constructor that define the linear problem to be solved.
     //
-    const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
-    const Teuchos::RCP<OutputManager<ScalarType> >          om_;
-    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
-    const Teuchos::RCP<OrthoManager<ScalarType,MV> >        ortho_;
+    const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >      lp_;
+    const Teuchos::RCP<OutputManager<ScalarType> >            om_;
+    const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DMType> >  stest_;
+    const Teuchos::RCP<OrthoManager<ScalarType,MV,DMType> >   ortho_;
     
     //
     // Algorithmic parameters
@@ -260,11 +263,11 @@ namespace Belos {
 
     // Mask used to store whether the ensemble GMRES has faced lucky breakdown or not.
     Mask<MagnitudeType> lucky_breakdown_;
-    
+   
     // Storage for QR factorization of the least squares system.
-    std::vector<Teuchos::RCP<Teuchos::SerialDenseVector<int,ScalarType> > > sn_;
-    std::vector<Teuchos::RCP<Teuchos::SerialDenseVector<int,MagnitudeType> > > cs_;
-    
+    std::vector<Teuchos::RCP<std::vector<ScalarType> > > sn_;
+    std::vector<Teuchos::RCP<std::vector<MagnitudeType> > > cs_;
+ 
     // Pointers to a work vector used to improve aggregate performance.
     Teuchos::RCP<MV> U_vec_, AU_vec_;    
 
@@ -308,12 +311,12 @@ namespace Belos {
      
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Constructor.
-  template<class StorageType, class MV, class OP>
-  PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP>::
+  template<class StorageType, class MV, class OP, class DM>
+  PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP,DM>::
   PseudoBlockGmresIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
 							       const Teuchos::RCP<OutputManager<ScalarType> > &printer,
-							       const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
-							       const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > &ortho,
+							       const Teuchos::RCP<StatusTest<ScalarType,MV,OP,DMType> > &tester,
+							       const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP,DMType> > &ortho,
 							       Teuchos::ParameterList &params ):
     lp_(problem),
     om_(printer),
@@ -336,8 +339,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Set the block size and make necessary adjustments.
-  template <class StorageType, class MV, class OP>
-  void PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP>::setNumBlocks (int numBlocks)
+  template <class StorageType, class MV, class OP, class DM>
+  void PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP,DM>::setNumBlocks (int numBlocks)
   {
     // This routine only allocates space; it doesn't not perform any computation
     // any change in size will invalidate the state of the solver.
@@ -352,8 +355,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Get the current update from this subspace.
-  template <class StorageType, class MV, class OP>
-  Teuchos::RCP<MV> PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP>::getCurrentUpdate() const
+  template <class StorageType, class MV, class OP, class DM>
+  Teuchos::RCP<MV> PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP,DM>::getCurrentUpdate() const
   {
 #ifdef BELOS_TEUCHOS_TIME_MONITOR
       Teuchos::TimeMonitor updateTimer( *timerSolveLSQR_ );
@@ -401,9 +404,9 @@ namespace Belos {
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Get the native residuals stored in this iteration.
   // Note:  No residual vector will be returned by Gmres.
-  template <class StorageType, class MV, class OP>
+  template <class StorageType, class MV, class OP, class DM>
   Teuchos::RCP<const MV>
-  PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP>::
+  PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP,DM>::
   getNativeResiduals (std::vector<MagnitudeType> *norms) const
   {
     typedef typename Teuchos::ScalarTraits<ScalarType> STS;
@@ -426,10 +429,10 @@ namespace Belos {
   }
 
 
-  template <class StorageType, class MV, class OP>
+  template <class StorageType, class MV, class OP, class DM>
   void
-  PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP>::
-  initialize (const PseudoBlockGmresIterState<ScalarType,MV> & newstate)
+  PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP,DM>::
+  initialize (const PseudoBlockGmresIterState<ScalarType,MV,DMType> & newstate)
   {
     using Teuchos::RCP;
 
@@ -617,20 +620,20 @@ namespace Belos {
     if ((int)newstate.cs.size() == numRHS_ && (int)newstate.sn.size() == numRHS_) {
       for (int i=0; i<numRHS_; ++i) {
         if (cs_[i] != newstate.cs[i])
-          cs_[i] = Teuchos::rcp( new Teuchos::SerialDenseVector<int,MagnitudeType>(*newstate.cs[i]) );
+          cs_[i] = Teuchos::rcp( new std::vector<MagnitudeType>(*newstate.cs[i]) );
         if (sn_[i] != newstate.sn[i])
-          sn_[i] = Teuchos::rcp( new Teuchos::SerialDenseVector<int,ScalarType>(*newstate.sn[i]) );
+          sn_[i] = Teuchos::rcp( new std::vector<ScalarType>(*newstate.sn[i]) );
       }
     }
 
     // Resize or create the vectors as necessary
     for (int i=0; i<numRHS_; ++i) {
       if (cs_[i] == Teuchos::null)
-        cs_[i] = Teuchos::rcp( new Teuchos::SerialDenseVector<int,MagnitudeType>(numBlocks_+1) );
+        cs_[i] = Teuchos::rcp( new std::vector<MagnitudeType>(numBlocks_+1) );
       else
         cs_[i]->resize(numBlocks_+1);
       if (sn_[i] == Teuchos::null)
-        sn_[i] = Teuchos::rcp( new Teuchos::SerialDenseVector<int,ScalarType>(numBlocks_+1) );
+        sn_[i] = Teuchos::rcp( new std::vector<ScalarType>(numBlocks_+1) );
       else
         sn_[i]->resize(numBlocks_+1);
     }
@@ -654,8 +657,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Iterate until the status test informs us we should stop.
-  template <class StorageType, class MV, class OP>
-  void PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP>::iterate()
+  template <class StorageType, class MV, class OP, class DM>
+  void PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP,DM>::iterate()
   {
     //
     // Allocate/initialize data structures
@@ -796,8 +799,8 @@ namespace Belos {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Update the least squares solution for each right-hand side.
-  template<class StorageType, class MV, class OP>
-  void PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP>::updateLSQR( int dim )
+  template<class StorageType, class MV, class OP, class DM>
+  void PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP,DM>::updateLSQR( int dim )
   {
     // Get correct dimension based on input "dim"
     // Remember that ortho failures result in an exit before updateLSQR() is called.

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_StatusTest_ImpResNorm_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_StatusTest_ImpResNorm_MP_Vector.hpp
@@ -482,7 +482,6 @@ checkStatus (Iteration<ScalarType,MV,OP>* iSolver)
   using Teuchos::RCP;
 
   const MagnitudeType zero = STM::zero ();
-  const MagnitudeType one  = STM::one ();
   const LinearProblem<ScalarType,MV,OP>& lp = iSolver->getProblem ();
 
   // Compute scaling term (done once for each block that's being solved)

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_TpetraAdapter_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_TpetraAdapter_MP_Vector.hpp
@@ -14,6 +14,7 @@
 #include "Belos_Tpetra_MP_Vector.hpp"
 #include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
 #include "KokkosBlas.hpp"
+#include "Teuchos_SerialDenseMatrix.hpp"
 
 #ifdef HAVE_BELOS_TSQR
 #  include <Tpetra_TsqrAdaptor_MP_Vector.hpp>

--- a/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
@@ -2253,8 +2253,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // of iterations across the ensemble when not doing ensemble reductions
   belosParams->set("Implicit Residual Scaling", "None");
 
-  RCP<Belos::PseudoBlockCGSolMgr<BelosScalar,MV,OP,true> > solver =
-    rcp(new Belos::PseudoBlockCGSolMgr<BelosScalar,MV,OP,true>(problem, belosParams));
+  RCP<Belos::PseudoBlockCGSolMgr<BelosScalar,MV,OP> > solver =
+    rcp(new Belos::PseudoBlockCGSolMgr<BelosScalar,MV,OP>(problem, belosParams));
   Belos::ReturnType ret = solver->solve();
   TEST_EQUALITY_CONST( ret, Belos::Converged );
 


### PR DESCRIPTION
<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.
-->
@trilinos/belos 

## Motivation
 * The Belos solvers are hard-coded to use the Teuchos::SerialDenseMatrix object to store the projection matrices internal to the iterative solvers.  To improve performance on advanced architectures, the Kokkos::DualView object may serve as a better object to store the projection matrices.  The addition of a template argument for the DenseMatrix object will allow for an architecture-dependent choice of the internal dense matrix representation.

## Testing
 * Additional tests have been added to replicate current tests, but use the Kokkos::DualView object as the dense matrix type.
 * Testing has been performed on OSX Clang 16.x serial and parallel and GCC 14.x serial and parallel. 

## Additional Information
  * This commit includes the infrastructure for extending necessary template arguments where dense matrix types are relevant, integrating the dense matrix type into all Belos solvers, and adding thorough testing of the dense matrix templates for Kokkos::DualView.
  * What is not in this commit is the internal mechanism to leverage KokkosKernels for performing operations on the dense matrices, which will further improve performance on GPUs.

