### PR TITLE
Thyra, Tempus, NOX: Silence warnings

### DIFF
--- a/packages/nox/src-loca/src-tpetra/LOCA_BorderedSolver_TpetraHouseholder.cpp
+++ b/packages/nox/src-loca/src-tpetra/LOCA_BorderedSolver_TpetraHouseholder.cpp
@@ -838,11 +838,11 @@ LOCA::BorderedSolver::TpetraHouseholder::solve(
 
 NOX::Abstract::Group::ReturnType
 LOCA::BorderedSolver::TpetraHouseholder::solveTranspose(
-                  Teuchos::ParameterList& params,
-                  const NOX::Abstract::MultiVector* F,
-                  const NOX::Abstract::MultiVector::DenseMatrix* G,
-                  NOX::Abstract::MultiVector& X,
-                  NOX::Abstract::MultiVector::DenseMatrix& Y) const
+                  Teuchos::ParameterList&  /*params*/,
+                  const NOX::Abstract::MultiVector*  /*F*/,
+                  const NOX::Abstract::MultiVector::DenseMatrix*  /*G*/,
+                  NOX::Abstract::MultiVector&  /*X*/,
+                  NOX::Abstract::MultiVector::DenseMatrix&  /*Y*/) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                              "ERROR - LOCA::BorderedSolver::TpetraHouseholder::solveTranspose(): TRANSPOSE SOLVE NOT SUPPORTED YET!");
@@ -1174,7 +1174,7 @@ updateCrsMatrixForPreconditioner(const NOX::Abstract::MultiVector& UU,
 
 Teuchos::RCP<NOX::Abstract::MultiVector>
 LOCA::BorderedSolver::TpetraHouseholder::createBlockMV(
-                    const NOX::Abstract::MultiVector& v) const
+                    const NOX::Abstract::MultiVector&  /*v*/) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                              "ERROR: LOCA::BorderedSolver::TpetraHouseholder::createBlockMV - Support for COMPLEX systems not supported!");
@@ -1214,8 +1214,8 @@ LOCA::BorderedSolver::TpetraHouseholder::createBlockMV(
 
 void
 LOCA::BorderedSolver::TpetraHouseholder::setBlockMV(
-                       const NOX::Abstract::MultiVector& bv,
-                       NOX::Abstract::MultiVector& v) const
+                       const NOX::Abstract::MultiVector&  /*bv*/,
+                       NOX::Abstract::MultiVector&  /*v*/) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                              "ERROR: LOCA::BorderedSolver::TpetraHouseholder::setBlockMV - Support for COMPLEX systems not supported!");

--- a/packages/nox/src-loca/src-tpetra/LOCA_Tpetra_LowRankUpdateRowMatrix.cpp
+++ b/packages/nox/src-loca/src-tpetra/LOCA_Tpetra_LowRankUpdateRowMatrix.cpp
@@ -24,11 +24,11 @@ namespace LOCA {
   namespace Tpetra {
 
     LowRankUpdateRowMatrix::
-    LowRankUpdateRowMatrix(const Teuchos::RCP<LOCA::GlobalData>& global_data,
+    LowRankUpdateRowMatrix(const Teuchos::RCP<LOCA::GlobalData>&  /*global_data*/,
                            const Teuchos::RCP<NOX::TRowMatrix>& jacRowMatrix,
                            const Teuchos::RCP<NOX::TMultiVector>& U_multiVec,
                            const Teuchos::RCP<NOX::TMultiVector>& V_multiVec,
-                           bool setup_for_solve,
+                           bool  /*setup_for_solve*/,
                            bool include_UV_terms) :
       J_rowMatrix(jacRowMatrix),
       nonconst_U(U_multiVec),
@@ -111,38 +111,38 @@ namespace LOCA {
     {return J_rowMatrix->supportsRowViews();}
 
     void
-    LowRankUpdateRowMatrix::getGlobalRowCopy(NOX::GlobalOrdinal GlobalRow,
-                                             NOX::TRowMatrix::nonconst_global_inds_host_view_type &Indices,
-                                             NOX::TRowMatrix::nonconst_values_host_view_type &Values,
-                                             size_t &NumEntries) const
+    LowRankUpdateRowMatrix::getGlobalRowCopy(NOX::GlobalOrdinal  /*GlobalRow*/,
+                                             NOX::TRowMatrix::nonconst_global_inds_host_view_type & /*Indices*/,
+                                             NOX::TRowMatrix::nonconst_values_host_view_type & /*Values*/,
+                                             size_t & /*NumEntries*/) const
     {
       TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                                  "ERROR - LOCA::LowRankRowMatrix::getGlobalRowCopy() - NOT implemented yet!");
     }
 
     void
-    LowRankUpdateRowMatrix::getLocalRowCopy (NOX::LocalOrdinal LocalRow,
-                                             NOX::TRowMatrix::nonconst_local_inds_host_view_type &Indices,
-                                             NOX::TRowMatrix::nonconst_values_host_view_type &Values,
-                                             size_t &NumEntries) const
+    LowRankUpdateRowMatrix::getLocalRowCopy (NOX::LocalOrdinal  /*LocalRow*/,
+                                             NOX::TRowMatrix::nonconst_local_inds_host_view_type & /*Indices*/,
+                                             NOX::TRowMatrix::nonconst_values_host_view_type & /*Values*/,
+                                             size_t & /*NumEntries*/) const
     {
       TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                                  "ERROR - LOCA::LowRankRowMatrix::getLocalRowCopy() - NOT implemented yet!");
     }
 
     void
-    LowRankUpdateRowMatrix::getGlobalRowView (NOX::GlobalOrdinal GlobalRow,
-                                              NOX::TRowMatrix::global_inds_host_view_type &indices,
-                                              NOX::TRowMatrix::values_host_view_type &values) const
+    LowRankUpdateRowMatrix::getGlobalRowView (NOX::GlobalOrdinal  /*GlobalRow*/,
+                                              NOX::TRowMatrix::global_inds_host_view_type & /*indices*/,
+                                              NOX::TRowMatrix::values_host_view_type & /*values*/) const
     {
       TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                                  "ERROR - LOCA::LowRankRowMatrix::getGlobalRowView() - NOT implemented yet!");
     }
 
     void
-    LowRankUpdateRowMatrix::getLocalRowView(NOX::LocalOrdinal LocalRow,
-                                            NOX::TRowMatrix::local_inds_host_view_type &indices,
-                                            NOX::TRowMatrix::values_host_view_type &values) const
+    LowRankUpdateRowMatrix::getLocalRowView(NOX::LocalOrdinal  /*LocalRow*/,
+                                            NOX::TRowMatrix::local_inds_host_view_type & /*indices*/,
+                                            NOX::TRowMatrix::values_host_view_type & /*values*/) const
     {
       TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                                  "ERROR - LOCA::LowRankRowMatrix::getLocalRowView() - NOT implemented yet!");
@@ -156,19 +156,19 @@ namespace LOCA {
     //                                            const NOX::Scalar*& vals) const
     // {}
 
-    void LowRankUpdateRowMatrix::getLocalDiagCopy(NOX::TVector& diag) const
+    void LowRankUpdateRowMatrix::getLocalDiagCopy(NOX::TVector&  /*diag*/) const
     {
       TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                                  "ERROR - LOCA::LowRankRowMatrix::getLocalDiagCopy() - NOT implemented yet!");
     }
 
-    void LowRankUpdateRowMatrix::leftScale(const NOX::TVector& x)
+    void LowRankUpdateRowMatrix::leftScale(const NOX::TVector&  /*x*/)
     {
       TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                                  "ERROR - LOCA::LowRankRowMatrix::leftScale() - NOT implemented yet!");
     }
 
-    void LowRankUpdateRowMatrix::rightScale(const NOX::TVector& x)
+    void LowRankUpdateRowMatrix::rightScale(const NOX::TVector&  /*x*/)
     {
       TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,
                                  "ERROR - LOCA::LowRankRowMatrix::rightScale() - NOT implemented yet!");

--- a/packages/nox/src-thyra/NOX_Observer_ReusePreconditioner.cpp
+++ b/packages/nox/src-thyra/NOX_Observer_ReusePreconditioner.cpp
@@ -154,7 +154,7 @@ void NOX::ObserverReusePreconditioner::runPreIterate(const NOX::Solver::Generic&
   }
 }
 
-void NOX::ObserverReusePreconditioner::runPostIterate(const NOX::Solver::Generic& solver)
+void NOX::ObserverReusePreconditioner::runPostIterate(const NOX::Solver::Generic&  /*solver*/)
 {++iterations_since_last_update_;}
 
 void NOX::ObserverReusePreconditioner::runPostSolve(const NOX::Solver::Generic& solver)

--- a/packages/nox/src-thyra/NOX_Thyra_MatrixFreeJacobianOperator_impl.hpp
+++ b/packages/nox/src-thyra/NOX_Thyra_MatrixFreeJacobianOperator_impl.hpp
@@ -163,11 +163,11 @@ MatrixFreeJacobianOperator<Scalar>::opSupportedImpl (::Thyra::EOpTransp M_trans)
 
 template<typename Scalar>
 void
-MatrixFreeJacobianOperator<Scalar>::applyImpl(const ::Thyra::EOpTransp M_trans,
+MatrixFreeJacobianOperator<Scalar>::applyImpl(const ::Thyra::EOpTransp  /*M_trans*/,
                           const ::Thyra::MultiVectorBase< Scalar > &thyra_mv_y,
                           const Teuchos::Ptr< ::Thyra::MultiVectorBase< Scalar > > &thyra_mv_u,
-                          const Scalar alpha,
-                          const Scalar beta) const
+                          const Scalar  /*alpha*/,
+                          const Scalar  /*beta*/) const
 {
   TEUCHOS_ASSERT(setup_called_);
 

--- a/packages/nox/src-tpetra/NOX_Tpetra_MultiVector_def.hpp
+++ b/packages/nox/src-tpetra/NOX_Tpetra_MultiVector_def.hpp
@@ -106,7 +106,7 @@ init(double gamma)
 
 template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
 Abstract::MultiVector& MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-random(bool useSeed, int seed)
+random(bool  /*useSeed*/, int  /*seed*/)
 {
     if (!tpetraMultiVec->isDistributed())
     {

--- a/packages/nox/src-tpetra/NOX_Tpetra_Vector_def.hpp
+++ b/packages/nox/src-tpetra/NOX_Tpetra_Vector_def.hpp
@@ -112,7 +112,7 @@ abs(const Abstract::Vector& source) {
 
 template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
 Abstract::Vector& Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-random(bool useSeed, int seed)
+random(bool  /*useSeed*/, int  /*seed*/)
 {
     if (!tpetraVec->isDistributed())
     {

--- a/packages/nox/src/NOX_Solver_SingleStep.C
+++ b/packages/nox/src/NOX_Solver_SingleStep.C
@@ -10,7 +10,6 @@
 #include "NOX_Solver_SingleStep.H"    // class definition
 #include "NOX_GlobalData.H"    // class definition
 #include "NOX_Abstract_Group.H"    // class definition
-#include "NOX_Abstract_Group.H"    // class definition
 #include "NOX_Solver_SolverUtils.H"
 #include "Teuchos_ParameterList.hpp"  // class data element
 #include "NOX_Observer.hpp"

--- a/packages/nox/test/basic/NOXObserverTests.C
+++ b/packages/nox/test/basic/NOXObserverTests.C
@@ -61,7 +61,7 @@ namespace NOX_UNIT_TEST {
     clone(NOX::CopyType ) const {return Teuchos::null;}
     double norm(NOX::Abstract::Vector::NormType ) const {return 0.0;}
     double norm(const NOX::Abstract::Vector& ) const {return 0.0;}
-    double innerProduct(const NOX::Abstract::Vector& y) const {return 0.0;}
+    double innerProduct(const NOX::Abstract::Vector&  /*y*/) const {return 0.0;}
     NOX::size_type length() const {return 0;}
   };
 

--- a/packages/nox/test/lapack/StatusTests/StatusTests.C
+++ b/packages/nox/test/lapack/StatusTests/StatusTests.C
@@ -206,7 +206,7 @@ private:
 };
 
 
-int main(int argc, char *argv[])
+int main(int  /*argc*/, char * /*argv*/[])
 {
   using Teuchos::RCP;
   using Teuchos::rcp;

--- a/packages/nox/test/lapack/UserDefinedObjects/UserDefinedObjects.C
+++ b/packages/nox/test/lapack/UserDefinedObjects/UserDefinedObjects.C
@@ -144,7 +144,7 @@ private:
 };
 
 //! Main subroutine of Broyden.C
-int main(int argc, char *argv[])
+int main(int  /*argc*/, char * /*argv*/[])
 {
   // Basic declarations to clean up the code
   using Teuchos::RCP;

--- a/packages/nox/test/thyra-tpetra/ME_Tpetra_1DFEM.hpp
+++ b/packages/nox/test/thyra-tpetra/ME_Tpetra_1DFEM.hpp
@@ -142,16 +142,16 @@ public:
 
   // Dummy
   Teuchos::RCP<const thyra_vec_space> get_f_multiplier_space() const{return Teuchos::null;}
-  Teuchos::RCP<const thyra_vec_space> get_g_multiplier_space(int j) const{return Teuchos::null;}
+  Teuchos::RCP<const thyra_vec_space> get_g_multiplier_space(int  /*j*/) const{return Teuchos::null;}
   ::Thyra::ModelEvaluatorBase::InArgs<Scalar> getLowerBounds() const{return prototypeInArgs_;}
   ::Thyra::ModelEvaluatorBase::InArgs<Scalar> getUpperBounds() const{return prototypeInArgs_;}
   Teuchos::RCP<::Thyra::LinearOpWithSolveBase<Scalar>> create_W() const{return Teuchos::null;}
   Teuchos::RCP<::Thyra::LinearOpBase<Scalar>> create_hess_f_xx() const{return Teuchos::null;}
-  Teuchos::RCP<::Thyra::LinearOpBase<Scalar>> create_hess_f_xp(int l) const{return Teuchos::null;}
-  Teuchos::RCP<::Thyra::LinearOpBase<Scalar>> create_hess_f_pp( int l1, int l2 ) const{return Teuchos::null;}
-  Teuchos::RCP<::Thyra::LinearOpBase<Scalar>> create_hess_g_xx(int j) const{return Teuchos::null;}
-  Teuchos::RCP<::Thyra::LinearOpBase<Scalar>> create_hess_g_xp( int j, int l ) const{return Teuchos::null;}
-  Teuchos::RCP<::Thyra::LinearOpBase<Scalar>> create_hess_g_pp( int j, int l1, int l2 ) const{return Teuchos::null;}
+  Teuchos::RCP<::Thyra::LinearOpBase<Scalar>> create_hess_f_xp(int  /*l*/) const{return Teuchos::null;}
+  Teuchos::RCP<::Thyra::LinearOpBase<Scalar>> create_hess_f_pp( int  /*l1*/, int  /*l2*/ ) const{return Teuchos::null;}
+  Teuchos::RCP<::Thyra::LinearOpBase<Scalar>> create_hess_g_xx(int  /*j*/) const{return Teuchos::null;}
+  Teuchos::RCP<::Thyra::LinearOpBase<Scalar>> create_hess_g_xp( int  /*j*/, int  /*l*/ ) const{return Teuchos::null;}
+  Teuchos::RCP<::Thyra::LinearOpBase<Scalar>> create_hess_g_pp( int  /*j*/, int  /*l1*/, int  /*l2*/ ) const{return Teuchos::null;}
   void reportFinalPoint (const ::Thyra::ModelEvaluatorBase::InArgs<Scalar> &finalPoint, const bool wasSolved);
   //@}
 

--- a/packages/nox/test/thyra-tpetra/Tpetra_OperatorTests.cpp
+++ b/packages/nox/test/thyra-tpetra/Tpetra_OperatorTests.cpp
@@ -89,7 +89,7 @@ public:
 private:
   Thyra::ModelEvaluatorBase::OutArgs<Scalar> createOutArgsImpl() const { return outArgs_; }
   void evalModelImpl(
-    const Thyra::ModelEvaluatorBase::InArgs<Scalar> &inArgs,
+    const Thyra::ModelEvaluatorBase::InArgs<Scalar> & /*inArgs*/,
     const Thyra::ModelEvaluatorBase::OutArgs<Scalar> &outArgs
     ) const
   { if (nonnull(outArgs.get_W_op())) outArgs.get_W_op() = lop_; }

--- a/packages/nox/test/thyra-tpetra/tTpetra_HouseholderBorderedSolve_Continuation.cpp
+++ b/packages/nox/test/thyra-tpetra/tTpetra_HouseholderBorderedSolve_Continuation.cpp
@@ -143,7 +143,7 @@ public:
 
   ~WriteParametersObserver() { file_.close(); }
 
-  void runPreSolve(const NOX::Solver::Generic& solver)
+  void runPreSolve(const NOX::Solver::Generic&  /*solver*/)
   {
     if (first_ && on_print_rank_) {
       file_.open(file_name_,std::ios::trunc);

--- a/packages/tempus/examples/00_Basic_Problem/00_Basic_Problem.cpp
+++ b/packages/tempus/examples/00_Basic_Problem/00_Basic_Problem.cpp
@@ -72,7 +72,7 @@ using namespace std;
  *  </div>
  *  \endhtmlonly
  */
-int main(int argc, char *argv[])
+int main(int  /*argc*/, char * /*argv*/[])
 {
   bool verbose = true;
   bool success = false;

--- a/packages/tempus/examples/01_Utilize_Thyra/01_Utilize_Thyra.cpp
+++ b/packages/tempus/examples/01_Utilize_Thyra/01_Utilize_Thyra.cpp
@@ -56,7 +56,7 @@ using Teuchos::RCP;
  *  </div>
  *  \endhtmlonly
  */
-int main(int argc, char *argv[])
+int main(int  /*argc*/, char * /*argv*/[])
 {
   bool verbose = true;
   bool success = false;

--- a/packages/tempus/examples/02_Use_ModelEvaluator/02_Use_ModelEvaluator.cpp
+++ b/packages/tempus/examples/02_Use_ModelEvaluator/02_Use_ModelEvaluator.cpp
@@ -63,7 +63,7 @@ using Teuchos::RCP;
  *  </div>
  *  \endhtmlonly
  */
-int main(int argc, char *argv[])
+int main(int  /*argc*/, char * /*argv*/[])
 {
   bool verbose = true;
   bool success = false;

--- a/packages/tempus/examples/03_Intro_SolutionState/03_Intro_SolutionState.cpp
+++ b/packages/tempus/examples/03_Intro_SolutionState/03_Intro_SolutionState.cpp
@@ -70,7 +70,7 @@ using Teuchos::RCP;
  *  </div>
  *  \endhtmlonly
  */
-int main(int argc, char *argv[])
+int main(int  /*argc*/, char * /*argv*/[])
 {
   bool verbose = true;
   bool success = false;

--- a/packages/tempus/examples/04_Adding_SolutionHistory/04_Adding_SolutionHistory.cpp
+++ b/packages/tempus/examples/04_Adding_SolutionHistory/04_Adding_SolutionHistory.cpp
@@ -76,7 +76,7 @@ using Teuchos::RCP;
  *  </div>
  *  \endhtmlonly
  */
-int main(int argc, char *argv[])
+int main(int  /*argc*/, char * /*argv*/[])
 {
   bool verbose = true;
   bool success = false;

--- a/packages/tempus/examples/05_Intro_Stepper/05_Intro_Stepper.cpp
+++ b/packages/tempus/examples/05_Intro_Stepper/05_Intro_Stepper.cpp
@@ -74,7 +74,7 @@ using Teuchos::RCP;
  *  </div>
  *  \endhtmlonly
  */
-int main(int argc, char *argv[])
+int main(int  /*argc*/, char * /*argv*/[])
 {
   bool verbose = true;
   bool success = false;

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
@@ -46,7 +46,7 @@ IntegratorForwardSensitivity<Scalar>::IntegratorForwardSensitivity()
 
 template <class Scalar>
 void IntegratorForwardSensitivity<Scalar>::setStepper(
-    Teuchos::RCP<Thyra::ModelEvaluator<Scalar>> model)
+    Teuchos::RCP<Thyra::ModelEvaluator<Scalar>> /*model*/)
 {
   if (use_combined_method_)
     integrator_->setModel(sens_model_);

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
@@ -530,7 +530,7 @@ Teuchos::RCP<AdjointSensitivityModelEvaluator<Scalar>>
 IntegratorPseudoTransientAdjointSensitivity<Scalar>::createSensitivityModel(
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar>>& model,
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar>>& adjoint_residual_model,
-    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar>>& adjoint_solve_model,
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar>>& /*adjoint_solve_model*/,
     const Teuchos::RCP<Teuchos::ParameterList>& inputPL)
 {
   using Teuchos::rcp;

--- a/packages/tempus/src/Tempus_StepperBDF2ModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2ModifierXBase.hpp
@@ -53,7 +53,7 @@ class StepperBDF2ModifierXBase
    */
   void execute(
       Teuchos::RCP<SolutionHistory<Scalar> > sh,
-      Teuchos::RCP<StepperBDF2<Scalar> > stepper,
+      Teuchos::RCP<StepperBDF2<Scalar> > /*stepper*/,
       const typename StepperBDF2AppAction<Scalar>::ACTION_LOCATION actLoc)
   {
     using Teuchos::RCP;

--- a/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
@@ -334,7 +334,7 @@ void StepperExplicit<Scalar>::evaluateExplicitODE(
 
 template <class Scalar>
 void StepperExplicit<Scalar>::describe(
-    Teuchos::FancyOStream& out, const Teuchos::EVerbosityLevel verbLevel) const
+    Teuchos::FancyOStream& out, const Teuchos::EVerbosityLevel /*verbLevel*/) const
 {
   auto l_out = Teuchos::fancyOStream(out.getOStream());
   Teuchos::OSTab ostab(*l_out, 2, this->description());

--- a/packages/tempus/src/Tempus_StepperImplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_impl.hpp
@@ -305,7 +305,7 @@ void StepperImplicit<Scalar>::evaluateImplicitODE(
 
 template <class Scalar>
 void StepperImplicit<Scalar>::describe(
-    Teuchos::FancyOStream& out, const Teuchos::EVerbosityLevel verbLevel) const
+    Teuchos::FancyOStream& out, const Teuchos::EVerbosityLevel /*verbLevel*/) const
 {
   out.setOutputToRootOnly(0);
   out << "--- StepperImplicit ---\n";

--- a/packages/tempus/src/Tempus_StepperLeapfrogModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrogModifierXBase.hpp
@@ -53,7 +53,7 @@ class StepperLeapfrogModifierXBase
    */
   void execute(
       Teuchos::RCP<SolutionHistory<Scalar> > sh,
-      Teuchos::RCP<StepperLeapfrog<Scalar> > stepper,
+      Teuchos::RCP<StepperLeapfrog<Scalar> > /*stepper*/,
       const typename StepperLeapfrogAppAction<Scalar>::ACTION_LOCATION actLoc)
   {
     using Teuchos::RCP;

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAFormModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAFormModifierXBase.hpp
@@ -52,7 +52,7 @@ class StepperNewmarkExplicitAFormModifierXBase
    *  function.
    */
   void execute(Teuchos::RCP<SolutionHistory<Scalar> > sh,
-               Teuchos::RCP<StepperNewmarkExplicitAForm<Scalar> > stepper,
+               Teuchos::RCP<StepperNewmarkExplicitAForm<Scalar> > /*stepper*/,
                const typename StepperNewmarkExplicitAFormAppAction<
                    Scalar>::ACTION_LOCATION actLoc)
   {

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAFormModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAFormModifierXBase.hpp
@@ -52,7 +52,7 @@ class StepperNewmarkImplicitAFormModifierXBase
    *  function.
    */
   void execute(Teuchos::RCP<SolutionHistory<Scalar> > sh,
-               Teuchos::RCP<StepperNewmarkImplicitAForm<Scalar> > stepper,
+               Teuchos::RCP<StepperNewmarkImplicitAForm<Scalar> > /*stepper*/,
                const typename StepperNewmarkImplicitAFormAppAction<
                    Scalar>::ACTION_LOCATION actLoc)
   {

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDFormModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDFormModifierXBase.hpp
@@ -52,7 +52,7 @@ class StepperNewmarkImplicitDFormModifierXBase
    *  function.
    */
   void execute(Teuchos::RCP<SolutionHistory<Scalar> > sh,
-               Teuchos::RCP<StepperNewmarkImplicitDForm<Scalar> > stepper,
+               Teuchos::RCP<StepperNewmarkImplicitDForm<Scalar> > /*stepper*/,
                const typename StepperNewmarkImplicitDFormAppAction<
                    Scalar>::ACTION_LOCATION actLoc)
   {

--- a/packages/tempus/src/Tempus_Stepper_impl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_impl.hpp
@@ -117,7 +117,7 @@ Teuchos::RCP<Thyra::VectorBase<Scalar> > Stepper<Scalar>::getStepperXDotDot(
 
 template <class Scalar>
 void Stepper<Scalar>::describe(Teuchos::FancyOStream& out,
-                               const Teuchos::EVerbosityLevel verbLevel) const
+                               const Teuchos::EVerbosityLevel /*verbLevel*/) const
 {
   auto l_out = Teuchos::fancyOStream(out.getOStream());
   Teuchos::OSTab ostab(*l_out, 2, this->description());

--- a/packages/tempus/src/Tempus_TimeEventBase.hpp
+++ b/packages/tempus/src/Tempus_TimeEventBase.hpp
@@ -60,7 +60,7 @@ class TimeEventBase {
    *  \param time [in] The input time.
    *  \return True if time is near an event (within absolute tolerance).
    */
-  virtual bool isTime(Scalar time) const { return false; }
+  virtual bool isTime(Scalar /*time*/) const { return false; }
 
   /** \brief How much time until the next event.
    *
@@ -72,7 +72,7 @@ class TimeEventBase {
    *
    *  \return The time to the next event.
    */
-  virtual Scalar timeToNextEvent(Scalar time) const { return defaultTime_; }
+  virtual Scalar timeToNextEvent(Scalar /*time*/) const { return defaultTime_; }
 
   /** \brief Return the time of the next event following the input time.
    *
@@ -90,7 +90,7 @@ class TimeEventBase {
    *  \param time [in] Input time.
    *  \return Time of the next event.
    */
-  virtual Scalar timeOfNextEvent(Scalar time) const { return defaultTime_; }
+  virtual Scalar timeOfNextEvent(Scalar /*time*/) const { return defaultTime_; }
 
   /** \brief Test if an event occurs within the time range.
    *
@@ -109,7 +109,7 @@ class TimeEventBase {
    *
    *  \return True if a time event is within the range.
    */
-  virtual bool eventInRange(Scalar time1, Scalar time2) const { return false; }
+  virtual bool eventInRange(Scalar /*time1*/, Scalar /*time2*/) const { return false; }
 
   /** \brief Test if index is an event.
    *
@@ -121,7 +121,7 @@ class TimeEventBase {
    *  \param index [in] The input index.
    *  \return True if index is an event.
    */
-  virtual bool isIndex(int index) const { return false; }
+  virtual bool isIndex(int /*index*/) const { return false; }
 
   /** \brief How many indices until the next event.
    *
@@ -132,7 +132,7 @@ class TimeEventBase {
    *
    *  \return The index to the next event.
    */
-  virtual int indexToNextEvent(int index) const { return defaultIndex_; }
+  virtual int indexToNextEvent(int /*index*/) const { return defaultIndex_; }
 
   /** \brief Return the index of the next event following the input index.
    *
@@ -150,7 +150,7 @@ class TimeEventBase {
    *  \param index [in] Input index.
    *  \return Index of the next event.
    */
-  virtual int indexOfNextEvent(int index) const { return defaultIndex_; }
+  virtual int indexOfNextEvent(int /*index*/) const { return defaultIndex_; }
 
   /** \brief Test if an event occurs within the index range.
    *
@@ -167,11 +167,11 @@ class TimeEventBase {
    *
    *  \return True if a index event is within the range.
    */
-  virtual bool eventInRangeIndex(int index1, int index2) const { return false; }
+  virtual bool eventInRangeIndex(int /*index1*/, int /*index2*/) const { return false; }
 
   /// Describe member data.
   virtual void describe(Teuchos::FancyOStream &out,
-                        const Teuchos::EVerbosityLevel verbLevel) const
+                        const Teuchos::EVerbosityLevel /*verbLevel*/) const
   {
     auto l_out = Teuchos::fancyOStream(out.getOStream());
     Teuchos::OSTab ostab(*l_out, 2, "TimeEventBase");

--- a/packages/tempus/src/Tempus_TimeEventListIndex_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventListIndex_impl.hpp
@@ -123,7 +123,7 @@ bool TimeEventListIndex<Scalar>::eventInRangeIndex(int index1, int index2) const
 
 template <class Scalar>
 void TimeEventListIndex<Scalar>::describe(
-    Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel) const
+    Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel /*verbLevel*/) const
 {
   auto l_out = Teuchos::fancyOStream(out.getOStream());
   Teuchos::OSTab ostab(*l_out, 2, "TimeEventListIndex");

--- a/packages/tempus/src/Tempus_TimeEventList_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventList_impl.hpp
@@ -173,7 +173,7 @@ bool TimeEventList<Scalar>::eventInRange(Scalar time1, Scalar time2) const
 
 template <class Scalar>
 void TimeEventList<Scalar>::describe(
-    Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel) const
+    Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel /*verbLevel*/) const
 {
   auto l_out = Teuchos::fancyOStream(out.getOStream());
   Teuchos::OSTab ostab(*l_out, 2, "TimeEventList");

--- a/packages/tempus/src/Tempus_TimeEventRangeIndex_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRangeIndex_impl.hpp
@@ -150,7 +150,7 @@ bool TimeEventRangeIndex<Scalar>::eventInRangeIndex(int index1,
 
 template <class Scalar>
 void TimeEventRangeIndex<Scalar>::describe(
-    Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel) const
+    Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel /*verbLevel*/) const
 {
   auto l_out = Teuchos::fancyOStream(out.getOStream());
   Teuchos::OSTab ostab(*l_out, 2, "TimeEventRangeIndex");

--- a/packages/tempus/src/Tempus_TimeEventRange_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRange_impl.hpp
@@ -285,7 +285,7 @@ bool TimeEventRange<Scalar>::eventInRange(Scalar time1, Scalar time2) const
 
 template <class Scalar>
 void TimeEventRange<Scalar>::describe(
-    Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel) const
+    Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel /*verbLevel*/) const
 {
   auto l_out = Teuchos::fancyOStream(out.getOStream());
   Teuchos::OSTab ostab(*l_out, 2, "TimeEventRange");

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
@@ -105,7 +105,7 @@ class TimeStepControlStrategyIntegralController
 
   /** \brief Set the time step size.*/
   virtual void setNextTimeStep(
-      const TimeStepControl<Scalar> &tsc,
+      const TimeStepControl<Scalar> & /*tsc*/,
       Teuchos::RCP<SolutionHistory<Scalar> > solutionHistory,
       Status & /* integratorStatus */) override
   {

--- a/packages/tempus/test/PhysicsState/Tempus_PhysicsStateCounter.hpp
+++ b/packages/tempus/test/PhysicsState/Tempus_PhysicsStateCounter.hpp
@@ -62,7 +62,7 @@ class PhysicsStateCounter : virtual public Tempus::PhysicsState<Scalar> {
   /// \name Overridden from Teuchos::Describable
   //@{
   virtual void describe(Teuchos::FancyOStream& out,
-                        const Teuchos::EVerbosityLevel verbLevel) const
+                        const Teuchos::EVerbosityLevel /*verbLevel*/) const
   {
     out << this->description() << "::describe" << std::endl
         << "  physicsName      = " << this->physicsName_ << std::endl

--- a/packages/tempus/test/TestModels/HarmonicOscillatorModel_impl.hpp
+++ b/packages/tempus/test/TestModels/HarmonicOscillatorModel_impl.hpp
@@ -294,7 +294,7 @@ void HarmonicOscillatorModel<Scalar>::evalModelImpl(
 
 template <class Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-HarmonicOscillatorModel<Scalar>::get_p_space(int l) const
+HarmonicOscillatorModel<Scalar>::get_p_space(int /*l*/) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
       true, std::logic_error,
@@ -304,7 +304,7 @@ HarmonicOscillatorModel<Scalar>::get_p_space(int l) const
 
 template <class Scalar>
 Teuchos::RCP<const Teuchos::Array<std::string> >
-HarmonicOscillatorModel<Scalar>::get_p_names(int l) const
+HarmonicOscillatorModel<Scalar>::get_p_names(int /*l*/) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
       true, std::logic_error,

--- a/packages/tempus/test/TestModels/VanDerPolModel_impl.hpp
+++ b/packages/tempus/test/TestModels/VanDerPolModel_impl.hpp
@@ -53,7 +53,7 @@ VanDerPolModel<Scalar>::VanDerPolModel(
 
 template <class Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
-VanDerPolModel<Scalar>::getExactSolution(double t) const
+VanDerPolModel<Scalar>::getExactSolution(double /*t*/) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
       true, std::logic_error,
@@ -63,7 +63,7 @@ VanDerPolModel<Scalar>::getExactSolution(double t) const
 
 template <class Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
-VanDerPolModel<Scalar>::getExactSensSolution(int j, double t) const
+VanDerPolModel<Scalar>::getExactSensSolution(int /*j*/, double /*t*/) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
       !isInitialized_, std::logic_error,

--- a/packages/tempus/unit_test/Tempus_UnitTest_BDF2.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_BDF2.cpp
@@ -276,7 +276,7 @@ class StepperBDF2ModifierTest
   /// Modify BDF2 Stepper at end of takeStep.
   virtual void modify(
       Teuchos::RCP<Tempus::SolutionHistory<double> > sh,
-      Teuchos::RCP<Tempus::StepperBDF2<double> > stepper,
+      Teuchos::RCP<Tempus::StepperBDF2<double> > /*stepper*/,
       const typename Tempus::StepperBDF2AppAction<double>::ACTION_LOCATION
           actLoc)
   {

--- a/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
@@ -288,7 +288,7 @@ class StepperSubcyclingObserverTest
   /// Observe Subcycling Stepper at action location.
   virtual void observe(
       Teuchos::RCP<const Tempus::SolutionHistory<double> > sh,
-      Teuchos::RCP<const Tempus::StepperSubcycling<double> > stepper,
+      Teuchos::RCP<const Tempus::StepperSubcycling<double> > /*stepper*/,
       const typename Tempus::StepperSubcyclingAppAction<double>::ACTION_LOCATION
           actLoc)
   {

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraVectorSpace_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraVectorSpace_def.hpp
@@ -227,7 +227,7 @@ TpetraVectorSpace<Scalar,LocalOrdinal,GlobalOrdinal,Node>::createCachedMembersVi
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 bool TpetraVectorSpace<Scalar,LocalOrdinal,GlobalOrdinal,Node>::hasInCoreView(
-  const Range1D& rng_in, const EViewType viewType, const EStrideType strideType
+  const Range1D& rng_in, const EViewType  /*viewType*/, const EStrideType  /*strideType*/
   ) const
 {
   const Range1D rng = full_range(rng_in,0,this->dim()-1);

--- a/packages/thyra/core/example/operator_vector/ExampleTridiagSerialLinearOp.hpp
+++ b/packages/thyra/core/example/operator_vector/ExampleTridiagSerialLinearOp.hpp
@@ -107,7 +107,7 @@ protected:
     { return space_; }
 
   /** \brief . */
-  bool opSupportedImpl(Thyra::EOpTransp M_trans) const
+  bool opSupportedImpl(Thyra::EOpTransp  /*M_trans*/) const
     { return true; }  // This class supports everything!
 
   /** \brief . */

--- a/packages/thyra/core/example/operator_vector/ExampleTridiagSpmdLinearOp.hpp
+++ b/packages/thyra/core/example/operator_vector/ExampleTridiagSpmdLinearOp.hpp
@@ -286,7 +286,7 @@ void ExampleTridiagSpmdLinearOp<Scalar>::applyImpl(
 
 template<class Scalar>
 void ExampleTridiagSpmdLinearOp<Scalar>::communicate(
-  const bool first, const bool last,
+  const bool  /*first*/, const bool  /*last*/,
   const Teuchos::ArrayView<const Scalar> &x,
     const Teuchos::Ptr<Scalar> &x_km1,
     const Teuchos::Ptr<Scalar> &x_kp1

--- a/packages/thyra/core/src/interfaces/nonlinear/solvers/fundamental/Thyra_NonlinearSolverBase.hpp
+++ b/packages/thyra/core/src/interfaces/nonlinear/solvers/fundamental/Thyra_NonlinearSolverBase.hpp
@@ -232,7 +232,7 @@ bool NonlinearSolverBase<Scalar>::is_W_current() const
 
 template <class Scalar>
 RCP<LinearOpWithSolveBase<Scalar> >
-NonlinearSolverBase<Scalar>::get_nonconst_W(const bool forceUpToDate)
+NonlinearSolverBase<Scalar>::get_nonconst_W(const bool  /*forceUpToDate*/)
 {
   return Teuchos::null;
 }
@@ -245,7 +245,7 @@ NonlinearSolverBase<Scalar>::get_W() const
 }
 
 template <class Scalar>
-void NonlinearSolverBase<Scalar>::set_W_is_current(bool W_is_current)
+void NonlinearSolverBase<Scalar>::set_W_is_current(bool  /*W_is_current*/)
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
     true, std::logic_error,

--- a/packages/thyra/core/src/interfaces/operator_vector/fundamental/Thyra_VectorSpaceBase_decl.hpp
+++ b/packages/thyra/core/src/interfaces/operator_vector/fundamental/Thyra_VectorSpaceBase_decl.hpp
@@ -713,7 +713,7 @@ protected:
    * <tt>MultiVectorBase</tt> object using explicit vector access.
    */
   virtual RCP<MultiVectorBase<Scalar> >
-  createCachedMembersView( const RTOpPack::SubMultiVectorView<Scalar> &raw_mv, bool initialize = true) const { return this->createMembersView(raw_mv); };
+  createCachedMembersView( const RTOpPack::SubMultiVectorView<Scalar> &raw_mv, bool  /*initialize*/ = true) const { return this->createMembersView(raw_mv); };
 
   /** \brief Create a (possibly) cached multi-vector member that is a <tt>const</tt> view of raw
    * multi-vector data. The caching mechanism must be implemented by child classes, by default

--- a/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_DirectionalFiniteDiffCalculator_def.hpp
+++ b/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_DirectionalFiniteDiffCalculator_def.hpp
@@ -52,8 +52,8 @@ public:
   ModelEvaluatorBase::OutArgs<Scalar> createOutArgs() const
     { TEUCHOS_TEST_FOR_EXCEPT(true); TEUCHOS_UNREACHABLE_RETURN(ModelEvaluatorBase::OutArgs<Scalar>()); }
   void evalModel(
-    const ModelEvaluatorBase::InArgs<Scalar> &inArgs,
-    const ModelEvaluatorBase::OutArgs<Scalar> &outArgs
+    const ModelEvaluatorBase::InArgs<Scalar> & /*inArgs*/,
+    const ModelEvaluatorBase::OutArgs<Scalar> & /*outArgs*/
     ) const
     { TEUCHOS_TEST_FOR_EXCEPT(true); }
   // Static function that does the magic!

--- a/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_ModelEvaluatorDefaultBase.hpp
+++ b/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_ModelEvaluatorDefaultBase.hpp
@@ -962,35 +962,35 @@ ModelEvaluatorDefaultBase<Scalar>::create_hess_f_xx() const
 
 template<class Scalar>
 RCP<LinearOpBase<Scalar> >
-ModelEvaluatorDefaultBase<Scalar>::create_hess_f_xp(int l) const
+ModelEvaluatorDefaultBase<Scalar>::create_hess_f_xp(int  /*l*/) const
 {
   return Teuchos::null;
 }
 
 template<class Scalar>
 RCP<LinearOpBase<Scalar> >
-ModelEvaluatorDefaultBase<Scalar>::create_hess_f_pp( int l1, int l2 ) const
+ModelEvaluatorDefaultBase<Scalar>::create_hess_f_pp( int  /*l1*/, int  /*l2*/ ) const
 {
   return Teuchos::null;
 }
 
 template<class Scalar>
 RCP<LinearOpBase<Scalar> >
-ModelEvaluatorDefaultBase<Scalar>::create_hess_g_xx(int j) const
+ModelEvaluatorDefaultBase<Scalar>::create_hess_g_xx(int  /*j*/) const
 {
   return Teuchos::null;
 }
 
 template<class Scalar>
 RCP<LinearOpBase<Scalar> >
-ModelEvaluatorDefaultBase<Scalar>::create_hess_g_xp( int j, int l ) const
+ModelEvaluatorDefaultBase<Scalar>::create_hess_g_xp( int  /*j*/, int  /*l*/ ) const
 {
   return Teuchos::null;
 }
 
 template<class Scalar>
 RCP<LinearOpBase<Scalar> >
-ModelEvaluatorDefaultBase<Scalar>::create_hess_g_pp( int j, int l1, int l2 ) const
+ModelEvaluatorDefaultBase<Scalar>::create_hess_g_pp( int  /*j*/, int  /*l1*/, int  /*l2*/ ) const
 {
   return Teuchos::null;
 }

--- a/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DefaultMultiVectorLinearOpWithSolve_decl.hpp
+++ b/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DefaultMultiVectorLinearOpWithSolve_decl.hpp
@@ -13,7 +13,6 @@
 
 #include "Thyra_LinearOpWithSolveBase.hpp"
 #include "Thyra_DefaultDiagonalLinearOp.hpp"
-#include "Thyra_LinearOpWithSolveBase.hpp"
 #include "Thyra_DefaultMultiVectorProductVectorSpace.hpp"
 #include "Teuchos_ConstNonconstObjectContainer.hpp"
 

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_MultiVectorStdOps_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_MultiVectorStdOps_def.hpp
@@ -13,13 +13,11 @@
 #include "Thyra_MultiVectorStdOps_decl.hpp"
 #include "Thyra_VectorStdOps.hpp"
 #include "Thyra_VectorSpaceBase.hpp"
-#include "Thyra_VectorStdOps.hpp"
 #include "Thyra_MultiVectorBase.hpp"
 #include "Thyra_VectorBase.hpp"
 #include "RTOpPack_ROpSum.hpp"
 #include "RTOpPack_ROpNorm1.hpp"
 #include "RTOpPack_ROpNormInf.hpp"
-#include "Teuchos_Assert.hpp"
 #include "Teuchos_Assert.hpp"
 #include "Teuchos_as.hpp"
 

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_VectorStdOpsTester_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_VectorStdOpsTester_def.hpp
@@ -33,12 +33,12 @@ template <bool isComparable, class Scalar>
 class VectorStdOpsTesterComparable {
 public:
   static bool checkComparableStdOps(
-    const VectorSpaceBase<Scalar> &vecSpc,
-    const Ptr<VectorBase<Scalar> > &z,
-    const typename Teuchos::ScalarTraits<Scalar>::magnitudeType &error_tol,
-    const typename Teuchos::ScalarTraits<Scalar>::magnitudeType &warning_tol,
-    const Ptr<std::ostream> &out,
-    const bool &dumpAll
+    const VectorSpaceBase<Scalar> & /*vecSpc*/,
+    const Ptr<VectorBase<Scalar> > & /*z*/,
+    const typename Teuchos::ScalarTraits<Scalar>::magnitudeType & /*error_tol*/,
+    const typename Teuchos::ScalarTraits<Scalar>::magnitudeType & /*warning_tol*/,
+    const Ptr<std::ostream> & /*out*/,
+    const bool & /*dumpAll*/
     )
     {
       return Teuchos::ScalarTraits<Scalar>::ThisShouldNotCompile();
@@ -50,12 +50,12 @@ template <class Scalar>
 class VectorStdOpsTesterComparable<false,Scalar> {
 public:
   static bool checkComparableStdOps(
-    const VectorSpaceBase<Scalar> &vecSpc,
-    const Ptr<VectorBase<Scalar> > &z,
-    const typename Teuchos::ScalarTraits<Scalar>::magnitudeType &error_tol,
-    const typename Teuchos::ScalarTraits<Scalar>::magnitudeType &warning_tol,
+    const VectorSpaceBase<Scalar> & /*vecSpc*/,
+    const Ptr<VectorBase<Scalar> > & /*z*/,
+    const typename Teuchos::ScalarTraits<Scalar>::magnitudeType & /*error_tol*/,
+    const typename Teuchos::ScalarTraits<Scalar>::magnitudeType & /*warning_tol*/,
     const Ptr<std::ostream> &out,
-    const bool &dumpAll
+    const bool & /*dumpAll*/
     )
     {
       if (nonnull(out)) *out

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_VectorStdOps_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_VectorStdOps_def.hpp
@@ -31,7 +31,6 @@
 #include "RTOpPack_TOpPairWiseMaxUpdate.hpp"
 #include "RTOpPack_TOpRandomize.hpp"
 #include "Teuchos_Assert.hpp"
-#include "Teuchos_Assert.hpp"
 
 
 //

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_describeLinearOp_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_describeLinearOp_def.hpp
@@ -14,7 +14,6 @@
 #include "Thyra_MultiVectorBase.hpp"
 #include "Thyra_VectorStdOps.hpp"
 #include "Thyra_AssertOp.hpp"
-#include "Thyra_AssertOp.hpp"
 
 
 template<class Scalar>


### PR DESCRIPTION
@trilinos/thyra @trilinos/tempus @trilinos/nox 

## Motivation
Silence warnings about unused parameters. Remove duplicate includes. 

I used `clang-tidy` to make the changes. The tool only knows about the build on which it is running. So there could be corner cases where the build configuration determines whether a variable is used or not. I did not spot any such cases in this PR.