### PR TITLE
Panzer MixedPoissonExample: Switch preconditioner back to Jacobi

### DIFF
--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/main.cpp
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/main.cpp
@@ -435,11 +435,12 @@ int main(int argc,char * argv[])
 
      // solve linear system
      /////////////////////////////////////////////////////////////
-
+     stackedTimer->start("Solve system");
      if(useTpetra)
         solveTpetraSystem(*container);
      else
         solveEpetraSystem(*container);
+     stackedTimer->stop("Solve system");
 
      // output data (optional)
      /////////////////////////////////////////////////////////////
@@ -569,9 +570,9 @@ void solveTpetraSystem(panzer::LinearObjContainer & container)
   typedef Tpetra::Operator<double,int,panzer::GlobalOrdinal> OP;
   typedef Belos::LinearProblem<double,MV, OP> ProblemType;
   Teuchos::RCP<ProblemType> problem(new ProblemType(tp_container.get_A(), tp_container.get_x(), tp_container.get_f()));
-  auto prec = Ifpack2::Factory::create<Tpetra::RowMatrix<double,int,panzer::GlobalOrdinal>>("RELAXATION",tp_container.get_A(),4);
+  auto prec = Ifpack2::Factory::create<Tpetra::RowMatrix<double,int,panzer::GlobalOrdinal>>("RELAXATION",tp_container.get_A());
   Teuchos::ParameterList precParams;
-  precParams.set("relaxation: type", "Gauss-Seidel");
+  precParams.set("relaxation: type", "Jacobi");
   prec->setParameters(precParams);
   prec->initialize();
   prec->compute();


### PR DESCRIPTION
@trilinos/panzer 

## Motivation
The test `PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3` is kinda slow in the debug CI builds:
https://my.cdash.org/queryTests.php?project=Trilinos&begin=2026-07-01&end=2026-07-10&filtercount=3&showfilters=1&filtercombine=and&field1=testname&compare1=63&value1=PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3&field2=buildname&compare2=63&value2=ubi8-gcc-12.3.0-openmpi-4.1.6_debug_shared&field3=site&compare3=61&value3=trilo002

The preconditioner is using 4 levels of overlap and Gauss-Seidel. The Epetra code path used Jacobi with no overlap. Switching back worked in local testing, but I want to see if this is truly the cause for the slow runs.