### PR TITLE
Belos: Fix  Belos_Kokkos_GCRODRComplexEx_MPI_4 test

### DIFF
--- a/packages/belos/kokkos/example/CMakeLists.txt
+++ b/packages/belos/kokkos/example/CMakeLists.txt
@@ -6,6 +6,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   ARGS "--verbose"
        "--verbose --num-rhs=4"
   COMM serial mpi
+  NUM_MPI_PROCS 1
   )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
@@ -14,6 +15,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   ARGS "--verbose"
        "--verbose --num-rhs=4"
   COMM serial mpi
+  NUM_MPI_PROCS 1
   )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
@@ -21,6 +23,7 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   SOURCES GCRODRKokkosExFile.cpp
   ARGS "--verbose"
   COMM serial mpi
+  NUM_MPI_PROCS 1
   )
 
 TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyExampleMtxFiles
@@ -36,6 +39,7 @@ IF(Teuchos_ENABLE_COMPLEX)
     SOURCES GCRODRComplexKokkosExFile.cpp
     ARGS "--verbose"
     COMM serial mpi
+    NUM_MPI_PROCS 1
     )
 
   TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyExampleComplexMtxFiles

--- a/packages/belos/kokkos/example/GCRODRComplexKokkosExFile.cpp
+++ b/packages/belos/kokkos/example/GCRODRComplexKokkosExFile.cpp
@@ -54,9 +54,12 @@ bool success = true;
   using Teuchos::rcp;
   using Teuchos::rcpFromRef;
 
+  const ST one  = SCT::one();
+  const ST zero = SCT::zero();
+
 bool verbose = true;
 try {
-  int frequency = 25;        // frequency of status test output.
+  int frequency = -1;        // frequency of status test output.
   int numrhs = 1;            // number of right-hand sides to solve for
   int maxiters = -1;         // maximum number of iterations allowed per linear system
   int maxsubspace = 300;     // maximum number of blocks the solver can use for the subspace
@@ -93,10 +96,10 @@ try {
   OT numRows = crsMat.numRows();
 
   Teuchos::RCP<MV> X = Teuchos::rcp( new MV(numRows, numrhs) );
-  X->MvRandom();
+  X->MvInit( one );
   Teuchos::RCP<MV> B = Teuchos::rcp( new MV(numRows, numrhs) );
   OPT::Apply(*A,*X,*B);
-  X->MvInit(0.0);
+  X->MvInit( zero );
 
   //
   // ********Other information used by block solver***********
@@ -171,21 +174,28 @@ try {
   std::cout<< "---------- Actual Residuals (normalized) ----------"<<std::endl<<std::endl;
   for ( int i=0; i<numrhs; i++) {
     MT actRes = actual_resids[i]/rhs_norm[i];
-    std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
+    if (verbose)
+      std::cout<<"Problem "<<i<<" : \t"<< actRes <<std::endl;
     if (actRes > tol) badRes = true;
   }
 
+  if (verbose) { std::cout << "First solve took " << numIters1 << " iterations." << std::endl; }
+
   // Resolve linear system with same rhs and recycled space
-  X->MvInit(0.0);
+  X->MvInit( zero );
   newSolver->reset(Belos::Problem);
   ret = newSolver->solve();
   int numIters2 = newSolver->getNumIters();
 
+  if (verbose) { std::cout << "Second solve took " << numIters2 << " iterations." << std::endl; }
+
   // Resolve linear system (again) with same rhs and recycled space
-  X->MvInit(0.0);
+  X->MvInit( zero );
   newSolver->reset(Belos::Problem);
   ret = newSolver->solve();
   int numIters3 = newSolver->getNumIters();
+
+  if (verbose) { std::cout << "Third solve took " << numIters3 << " iterations." << std::endl; }
 
   //
   if (ret!=Belos::Converged || badRes || numIters1 < numIters2 || numIters2 < numIters3) {
@@ -193,7 +203,7 @@ try {
     std::cout << std::endl << "ERROR: Belos GCRODR TEST FAILED!" << std::endl;
   } else {
     success = true;
-    std::cout << std::endl << "SUCCESS: Belos GCRRODRR TEST PASSED!" << std::endl;
+    std::cout << std::endl << "SUCCESS: Belos GCRODR TEST PASSED!" << std::endl;
   }
 
   }

--- a/packages/belos/kokkos/test/CMakeLists.txt
+++ b/packages/belos/kokkos/test/CMakeLists.txt
@@ -4,5 +4,6 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   KokkosMVOPTest
   SOURCES KokkosMVOPTest.cpp
   COMM serial mpi
+  NUM_MPI_PROCS 1
   )
 

--- a/packages/belos/tpetra/test/GCRODR/test_gcrodr_complex_hb.cpp
+++ b/packages/belos/tpetra/test/GCRODR/test_gcrodr_complex_hb.cpp
@@ -102,7 +102,7 @@ int run(int argc, char *argv[])
   const int NumGlobalElements = B->getGlobalLength();
   int numIters1, numIters2, numIters3;
   int maxits = NumGlobalElements; // maximum number of iterations to run
-  int numBlocks = 100;
+  int numBlocks = 300;
   int numRecycledBlocks = 20;
   Teuchos::ParameterList belosList;
   belosList.set( "Maximum Iterations", maxits );         // Maximum number of iterations allowed


### PR DESCRIPTION

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.
--->
@trilinos/belos

## Motivation
The `Belos_Kokkos_GCRODRComplexEx` test performs repeated solves with the GCRODR solver on a complex-valued matrix using a Kokkos implementation of the Belos MultiVector/Operator interfaces.  The success of the test appears to be susceptible to the random solution vector that generates the right-hand side used in the test.  If a constant valued solution vector is used, the test is stable and passing.  Further investigation needs to be made to see if there is a numerical issue in the solver or linear algebra interface contributing to this, but for now this change will help the autotester stability.

The Tpetra-based GCRODR test that also performs repeated solves has been changed to solve the same problem, with a constant solution vector, so the performance can be compared between the two linear algebra backends.

## Testing
 * Tested on OSX Clang 16.x OMPI / CEE GCC 14.x OMPI
 
## Additional Information
The Kokkos examples were changed to run on one MPI processor because they don't really use more than one processor. 
