### PR TITLE
Teko: Convert tStridedTpetraOperator and tBlockedTpetraOperator tests to use Galeri instead of Epetra

### DIFF
--- a/packages/teko/tests/CMakeLists.txt
+++ b/packages/teko/tests/CMakeLists.txt
@@ -35,8 +35,6 @@ ELSE()
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tGraphLaplacian.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tBlockUpperTriInverseOp.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tDiagonalPreconditionerFactory.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/Tpetra/tBlockedTpetraOperator.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/Tpetra/tStridedTpetraOperator.cpp
   )
 ENDIF()
 

--- a/packages/teko/tests/src/Tpetra/tBlockedTpetraOperator.cpp
+++ b/packages/teko/tests/src/Tpetra/tBlockedTpetraOperator.cpp
@@ -39,7 +39,8 @@
 #include "Teko_BlockedTpetraOperator.hpp"
 #include "Teko_TpetraHelpers.hpp"
 
-#include <random>
+#include <string>
+#include <vector>
 
 namespace Teko {
 namespace Test {
@@ -78,6 +79,123 @@ RCP<crs_t> buildRecirc2DMatrix(const RCP<const Teuchos::Comm<int>>& comm, GO nx,
       Galeri::Xpetra::BuildProblem<ST, LO, GO, map_t, crs_t, mv_t>("Recirc2D", tMap, galeriList);
 
   return problem->BuildMatrix();
+}
+
+GO gcd_go(GO a, GO b) {
+  if (a < 0) a = -a;
+  if (b < 0) b = -b;
+
+  while (b != 0) {
+    const GO t = a % b;
+    a          = b;
+    b          = t;
+  }
+
+  return a;
+}
+
+GO chooseCoprimeMultiplier(GO n) {
+  if (n <= 2) return 1;
+
+  for (GO a = 3; a < n; a += 2) {
+    if (gcd_go(a, n) == 1) return a;
+  }
+
+  return 1;
+}
+
+// Deterministic global permutation.
+//
+// This is used to create a globally noncontiguous map without assuming that
+// each MPI rank owns a contiguous range of GIDs.  The permutation is bijective
+// as long as the multiplier is coprime with numGlobalElements.
+GO permute_gid(GO gid, GO numGlobalElements, GO indexBase) {
+  if (numGlobalElements <= 1) return gid;
+
+  const GO zeroBasedGid = gid - indexBase;
+
+  const GO multiplier = chooseCoprimeMultiplier(numGlobalElements);
+  const GO shift      = 1 % numGlobalElements;
+
+  const GO permutedZeroBasedGid = (multiplier * zeroBasedGid + shift) % numGlobalElements;
+
+  return indexBase + permutedZeroBasedGid;
+}
+
+std::vector<GO> permuted_local_gids(const RCP<const map_t>& contigRowMap) {
+  const auto numLocalElements  = contigRowMap->getLocalNumElements();
+  const auto numGlobalElements = contigRowMap->getGlobalNumElements();
+  const auto indexBase         = contigRowMap->getIndexBase();
+
+  std::vector<GO> localPermutedGids(numLocalElements);
+
+  for (size_t localRow = 0; localRow < numLocalElements; ++localRow) {
+    const GO oldGid             = contigRowMap->getGlobalElement(static_cast<LO>(localRow));
+    localPermutedGids[localRow] = permute_gid(oldGid, numGlobalElements, indexBase);
+  }
+
+  return localPermutedGids;
+}
+
+RCP<Tpetra::CrsMatrix<ST, LO, GO, NT>> assemble_noncontig_matrix(
+    const RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT>>& contigMat) {
+  const auto contigRowMap      = contigMat->getRowMap();
+  const auto comm              = contigRowMap->getComm();
+  const auto numGlobalElements = contigRowMap->getGlobalNumElements();
+  const auto indexBase         = contigRowMap->getIndexBase();
+  const auto invalid           = Teuchos::OrdinalTraits<GO>::invalid();
+
+  // Build the new local GID list by applying a deterministic global
+  // permutation to exactly the GIDs owned by this rank.  Do not assume that
+  // minGID:maxGID is a contiguous local interval.
+  auto localPermutedGids = permuted_local_gids(contigRowMap);
+
+  const auto noncontigRowMap = Teuchos::make_rcp<Tpetra::Map<LO, GO, NT>>(
+      invalid, Teuchos::ArrayView<const GO>(localPermutedGids.data(), localPermutedGids.size()),
+      indexBase, comm);
+
+  const auto nrowsLocal = contigRowMap->getLocalNumElements();
+
+  std::vector<size_t> numEntPerRow(nrowsLocal);
+  for (size_t localRow = 0; localRow < nrowsLocal; ++localRow) {
+    numEntPerRow[localRow] = contigMat->getNumEntriesInLocalRow(localRow);
+  }
+
+  auto noncontigMat = Teuchos::make_rcp<Tpetra::CrsMatrix<ST, LO, GO, NT>>(
+      noncontigRowMap, Teuchos::ArrayView<const size_t>(numEntPerRow));
+
+  noncontigMat->resumeFill();
+
+  const auto globalMaxNumRowEntries = contigMat->getGlobalMaxNumRowEntries();
+
+  crs_t::nonconst_global_inds_host_view_type contigColumnIndices("contigColumnIndices",
+                                                                 globalMaxNumRowEntries);
+  crs_t::nonconst_global_inds_host_view_type noncontigColumnIndices("noncontigColumnIndices",
+                                                                    globalMaxNumRowEntries);
+  crs_t::nonconst_values_host_view_type columnValues("columnValues", globalMaxNumRowEntries);
+
+  for (size_t localRow = 0; localRow < nrowsLocal; ++localRow) {
+    const GO contigGlobalRow = contigRowMap->getGlobalElement(static_cast<LO>(localRow));
+
+    size_t numEntries = Teuchos::OrdinalTraits<size_t>::invalid();
+
+    contigMat->getGlobalRowCopy(contigGlobalRow, contigColumnIndices, columnValues, numEntries);
+
+    for (size_t entry = 0; entry < numEntries; ++entry) {
+      const GO contigGlobalCol      = contigColumnIndices(entry);
+      noncontigColumnIndices(entry) = permute_gid(contigGlobalCol, numGlobalElements, indexBase);
+    }
+
+    const GO noncontigGlobalRow = permute_gid(contigGlobalRow, numGlobalElements, indexBase);
+
+    noncontigMat->insertGlobalValues(
+        noncontigGlobalRow, Teuchos::ArrayView<const GO>(noncontigColumnIndices.data(), numEntries),
+        Teuchos::ArrayView<const ST>(columnValues.data(), numEntries));
+  }
+
+  noncontigMat->fillComplete(noncontigRowMap, noncontigRowMap);
+
+  return noncontigMat;
 }
 
 }  // namespace
@@ -283,92 +401,6 @@ bool tBlockedTpetraOperator::test_vector_constr(int verbosity, std::ostream& os)
                                      << max << " <= " << tolerance_ << " )");
 
   return allPassed;
-}
-
-std::vector<GO> random_gids(const RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT>>& contigMat) {
-  std::random_device rd;
-  std::mt19937 g(rd());
-
-  const auto contigRowMap          = contigMat->getRowMap();
-  const auto numGlobalElements     = contigRowMap->getGlobalNumElements();
-  const auto numLargestPossibleGid = 10 * numGlobalElements;
-  std::vector<GO> randomGids(numLargestPossibleGid);
-  std::iota(randomGids.begin(), randomGids.end(), 0);
-  std::shuffle(randomGids.begin(), randomGids.end(), g);
-
-  const auto numLocalGids = contigRowMap->getLocalNumElements();
-  const auto gidStart     = contigRowMap->getMinGlobalIndex();
-  const auto gidEnd       = contigRowMap->getMaxGlobalIndex();
-
-  size_t numGids = gidEnd - gidStart + 1;
-  TEUCHOS_ASSERT(numGids == numLocalGids);
-
-  std::vector<GO> localRandomGids(numLocalGids);
-  std::copy(randomGids.begin() + gidStart, randomGids.begin() + gidStart + numGids,
-            localRandomGids.begin());
-
-  return localRandomGids;
-}
-
-RCP<Tpetra::CrsMatrix<ST, LO, GO, NT>> assemble_noncontig_matrix(
-    const RCP<const Tpetra::CrsMatrix<ST, LO, GO, NT>>& contigMat) {
-  const auto contigRowMap        = contigMat->getRowMap();
-  const auto comm                = contigRowMap->getComm();
-  const auto contigGlobalIndices = contigRowMap->getMyGlobalIndices();
-
-  auto randomGlobalGids = random_gids(contigMat);
-
-  decltype(contigGlobalIndices)::non_const_type noncontigGlobalIndices(
-      "noncontig", contigGlobalIndices.extent(0));
-  for (auto i = 0U; i < contigGlobalIndices.extent(0); ++i) {
-    noncontigGlobalIndices(i) = randomGlobalGids[i];
-  }
-
-  const auto indexBase       = 0;
-  const auto invalid         = Teuchos::OrdinalTraits<GO>::invalid();
-  const auto noncontigRowMap = Teuchos::make_rcp<Tpetra::Map<LO, GO, NT>>(
-      invalid,
-      Teuchos::ArrayView<const GO>(noncontigGlobalIndices.data(), noncontigGlobalIndices.extent(0)),
-      indexBase, comm);
-
-  auto nrowsLocal = contigRowMap->getLocalNumElements();
-  std::vector<size_t> numEntPerRow(nrowsLocal);
-  for (size_t row = 0; row < nrowsLocal; ++row) {
-    numEntPerRow[row] = contigMat->getNumEntriesInLocalRow(row);
-  }
-
-  auto noncontigMat = Teuchos::make_rcp<Tpetra::CrsMatrix<ST, LO, GO, NT>>(
-      noncontigRowMap, Teuchos::ArrayView<const size_t>(numEntPerRow));
-
-  noncontigMat->resumeFill();
-
-  const auto globalMaxNumRowEntries = contigMat->getGlobalMaxNumRowEntries();
-  Tpetra::CrsMatrix<ST, LO, GO, NT>::nonconst_global_inds_host_view_type contigColumnIndices(
-      "contigColumnIndices", globalMaxNumRowEntries);
-  Tpetra::CrsMatrix<ST, LO, GO, NT>::nonconst_global_inds_host_view_type noncontigColumnIndices(
-      "noncontigColumnIndices", globalMaxNumRowEntries);
-  Tpetra::CrsMatrix<ST, LO, GO, NT>::nonconst_values_host_view_type columnValues(
-      "columnValues", globalMaxNumRowEntries);
-
-  for (size_t row = 0; row < nrowsLocal; ++row) {
-    const auto contigGlobalRow = contigRowMap->getGlobalElement(row);
-    size_t numEntries          = Teuchos::OrdinalTraits<size_t>::invalid();
-    contigMat->getGlobalRowCopy(contigGlobalRow, contigColumnIndices, columnValues, numEntries);
-
-    for (auto index = 0U; index < numEntries; ++index) {
-      auto localCol                 = contigRowMap->getLocalElement(contigGlobalIndices(index));
-      noncontigColumnIndices(index) = noncontigRowMap->getGlobalElement(localCol);
-    }
-
-    const auto noncontigGlobalRow = noncontigRowMap->getGlobalElement(row);
-    noncontigMat->insertGlobalValues(
-        noncontigGlobalRow, Teuchos::ArrayView<const GO>(noncontigColumnIndices.data(), numEntries),
-        Teuchos::ArrayView<ST>(columnValues.data(), numEntries));
-  }
-
-  noncontigMat->fillComplete(noncontigRowMap, noncontigRowMap);
-
-  return noncontigMat;
 }
 
 bool tBlockedTpetraOperator::test_single_block(int verbosity, std::ostream& os) {

--- a/packages/teko/tests/src/Tpetra/tBlockedTpetraOperator.cpp
+++ b/packages/teko/tests/src/Tpetra/tBlockedTpetraOperator.cpp
@@ -32,7 +32,9 @@
 
 #include "tBlockedTpetraOperator.hpp"
 
-#include "Trilinos_Util_CrsMatrixGallery.h"
+#include "Galeri_XpetraMaps.hpp"
+#include "Galeri_XpetraProblemFactory.hpp"
+#include "Galeri_XpetraParameters.hpp"
 
 #include "Teko_BlockedTpetraOperator.hpp"
 #include "Teko_TpetraHelpers.hpp"
@@ -50,6 +52,35 @@ using Thyra::createMember;
 using Thyra::LinearOpBase;
 using Thyra::LinearOpTester;
 using Thyra::VectorBase;
+
+namespace {
+
+using ST = Teko::ST;
+using LO = Teko::LO;
+using GO = Teko::GO;
+using NT = Teko::NT;
+
+using map_t = Tpetra::Map<LO, GO, NT>;
+using crs_t = Tpetra::CrsMatrix<ST, LO, GO, NT>;
+using vec_t = Tpetra::Vector<ST, LO, GO, NT>;
+using mv_t  = Tpetra::MultiVector<ST, LO, GO, NT>;
+
+RCP<crs_t> buildRecirc2DMatrix(const RCP<const Teuchos::Comm<int>>& comm, GO nx, GO ny) {
+  Teuchos::ParameterList galeriList;
+  galeriList.set("nx", nx);
+  galeriList.set("ny", ny);
+  galeriList.set("mx", comm->getSize());
+  galeriList.set("my", 1);
+
+  auto tMap = Galeri::Xpetra::CreateMap<LO, GO, map_t>("Cartesian2D", comm, galeriList);
+
+  auto problem =
+      Galeri::Xpetra::BuildProblem<ST, LO, GO, map_t, crs_t, mv_t>("Recirc2D", tMap, galeriList);
+
+  return problem->BuildMatrix();
+}
+
+}  // namespace
 
 void tBlockedTpetraOperator::buildBlockGIDs(std::vector<std::vector<GO>>& gids,
                                             const Tpetra::Map<LO, GO, NT>& map,
@@ -96,51 +127,53 @@ int tBlockedTpetraOperator::runTest(int verbosity, std::ostream& stdstrm, std::o
   failstrm << "tBlockedTpetraOperator";
 
   status = test_vector_constr(verbosity, failstrm);
-  Teko_TEST_MSG(stdstrm, 1, "   \"vector_constr\" ... PASSED", "   \"vector_constr\" ... FAILED");
+  Teko_TEST_MSG_tpetra(stdstrm, 1, "   \"vector_constr\" ... PASSED",
+                       "   \"vector_constr\" ... FAILED");
   allTests &= status;
   failcount += status ? 0 : 1;
   totalrun++;
 
   status = test_single_block(verbosity, failstrm);
-  Teko_TEST_MSG(stdstrm, 1, "   \"test_single_block\" ... PASSED",
-                "   \"test_single_block\" ... FAILED");
+  Teko_TEST_MSG_tpetra(stdstrm, 1, "   \"test_single_block\" ... PASSED",
+                       "   \"test_single_block\" ... FAILED");
   allTests &= status;
   failcount += status ? 0 : 1;
   totalrun++;
 
   status = test_noncontig(verbosity, failstrm);
-  Teko_TEST_MSG(stdstrm, 1, "   \"test_noncontig\" ... PASSED", "   \"test_noncontig\" ... FAILED");
+  Teko_TEST_MSG_tpetra(stdstrm, 1, "   \"test_noncontig\" ... PASSED",
+                       "   \"test_noncontig\" ... FAILED");
   allTests &= status;
   failcount += status ? 0 : 1;
   totalrun++;
 
   status = test_reorder(verbosity, failstrm, 0);
-  Teko_TEST_MSG(stdstrm, 1, "   \"reorder(flat reorder)\" ... PASSED",
-                "   \"reorder(flat reorder)\" ... FAILED");
+  Teko_TEST_MSG_tpetra(stdstrm, 1, "   \"reorder(flat reorder)\" ... PASSED",
+                       "   \"reorder(flat reorder)\" ... FAILED");
   allTests &= status;
   failcount += status ? 0 : 1;
   totalrun++;
 
   status = test_reorder(verbosity, failstrm, 1);
-  Teko_TEST_MSG(stdstrm, 1, "   \"reorder(composite reorder = " << 1 << ")\" ... PASSED",
-                "   \"reorder(composite reorder)\" ... FAILED");
+  Teko_TEST_MSG_tpetra(stdstrm, 1, "   \"reorder(composite reorder = " << 1 << ")\" ... PASSED",
+                       "   \"reorder(composite reorder)\" ... FAILED");
   allTests &= status;
   failcount += status ? 0 : 1;
   totalrun++;
 
   status = test_reorder(verbosity, failstrm, 2);
-  Teko_TEST_MSG(stdstrm, 1, "   \"reorder(composite reorder = " << 2 << ")\" ... PASSED",
-                "   \"reorder(composite reorder)\" ... FAILED");
+  Teko_TEST_MSG_tpetra(stdstrm, 1, "   \"reorder(composite reorder = " << 2 << ")\" ... PASSED",
+                       "   \"reorder(composite reorder)\" ... FAILED");
   allTests &= status;
   failcount += status ? 0 : 1;
   totalrun++;
 
   status = allTests;
   if (verbosity >= 10) {
-    Teko_TEST_MSG(failstrm, 0, "tBlockedTpetraOperator...PASSED",
-                  "tBlockedTpetraOperator...FAILED");
+    Teko_TEST_MSG_tpetra(failstrm, 0, "tBlockedTpetraOperator...PASSED",
+                         "tBlockedTpetraOperator...FAILED");
   } else {  // Normal Operating Procedures (NOP)
-    Teko_TEST_MSG(failstrm, 0, "...PASSED", "tBlockedTpetraOperator...FAILED");
+    Teko_TEST_MSG_tpetra(failstrm, 0, "...PASSED", "tBlockedTpetraOperator...FAILED");
   }
 
   return failcount;
@@ -150,26 +183,20 @@ bool tBlockedTpetraOperator::test_vector_constr(int verbosity, std::ostream& os)
   bool status    = false;
   bool allPassed = true;
 
-  const Epetra_Comm& comm_epetra            = *GetComm();
   RCP<const Teuchos::Comm<int>> comm_tpetra = GetComm_tpetra();
 
   TEST_MSG("\n   tBlockedTpetraOperator::test_vector_constr: "
-           << "Running on " << comm_epetra.NumProc() << " processors");
+           << "Running on " << comm_tpetra->getSize() << " processors");
 
   // pick
-  int nx = 5;  // * comm_epetra.NumProc();
-  int ny = 5;  // * comm_epetra.NumProc();
+  GO nx = 5;  // * comm_epetra.NumProc();
+  GO ny = 5;  // * comm_epetra.NumProc();
 
   // create a big matrix to play with
   // note: this matrix is not really strided
   //       however, I just need a nontrivial
   //       matrix to play with
-  Trilinos_Util::CrsMatrixGallery FGallery("recirc_2d", comm_epetra, false);
-  FGallery.Set("nx", nx);
-  FGallery.Set("ny", ny);
-  RCP<Epetra_CrsMatrix> epetraA = rcp(FGallery.GetMatrix(), false);
-  RCP<Tpetra::CrsMatrix<ST, LO, GO, NT>> A =
-      Teko::TpetraHelpers::nonConstEpetraCrsMatrixToTpetra(epetraA, comm_tpetra);
+  auto A        = buildRecirc2DMatrix(comm_tpetra, nx, ny);
   ST beforeNorm = A->getFrobeniusNorm();
 
   int width = 3;
@@ -348,26 +375,20 @@ bool tBlockedTpetraOperator::test_single_block(int verbosity, std::ostream& os) 
   bool status    = false;
   bool allPassed = true;
 
-  const Epetra_Comm& comm_epetra            = *GetComm();
   RCP<const Teuchos::Comm<int>> comm_tpetra = GetComm_tpetra();
 
   TEST_MSG("\n   tBlockedTpetraOperator::test_single_block: "
-           << "Running on " << comm_epetra.NumProc() << " processors");
+           << "Running on " << comm_tpetra->getSize() << " processors");
 
   // pick
-  int nx = 5;  // * comm_epetra.NumProc();
-  int ny = 5;  // * comm_epetra.NumProc();
+  GO nx = 5;  // * comm_epetra.NumProc();
+  GO ny = 5;  // * comm_epetra.NumProc();
 
   // create a big matrix to play with
   // note: this matrix is not really strided
   //       however, I just need a nontrivial
   //       matrix to play with
-  Trilinos_Util::CrsMatrixGallery FGallery("recirc_2d", comm_epetra, false);
-  FGallery.Set("nx", nx);
-  FGallery.Set("ny", ny);
-  RCP<Epetra_CrsMatrix> epetraA = rcp(FGallery.GetMatrix(), false);
-  RCP<Tpetra::CrsMatrix<ST, LO, GO, NT>> contigA =
-      Teko::TpetraHelpers::nonConstEpetraCrsMatrixToTpetra(epetraA, comm_tpetra);
+  auto contigA = buildRecirc2DMatrix(comm_tpetra, nx, ny);
 
   auto A = assemble_noncontig_matrix(contigA);
 
@@ -463,26 +484,20 @@ bool tBlockedTpetraOperator::test_noncontig(int verbosity, std::ostream& os) {
   bool status    = false;
   bool allPassed = true;
 
-  const Epetra_Comm& comm_epetra            = *GetComm();
   RCP<const Teuchos::Comm<int>> comm_tpetra = GetComm_tpetra();
 
   TEST_MSG("\n   tBlockedTpetraOperator::test_noncontig: "
-           << "Running on " << comm_epetra.NumProc() << " processors");
+           << "Running on " << comm_tpetra->getSize() << " processors");
 
   // pick
-  int nx = 15;  // * comm_epetra.NumProc();
-  int ny = 15;  // * comm_epetra.NumProc();
+  GO nx = 15;  // * comm_epetra.NumProc();
+  GO ny = 15;  // * comm_epetra.NumProc();
 
   // create a big matrix to play with
   // note: this matrix is not really strided
   //       however, I just need a nontrivial
   //       matrix to play with
-  Trilinos_Util::CrsMatrixGallery FGallery("recirc_2d", comm_epetra, false);
-  FGallery.Set("nx", nx);
-  FGallery.Set("ny", ny);
-  RCP<Epetra_CrsMatrix> epetraA = rcp(FGallery.GetMatrix(), false);
-  RCP<Tpetra::CrsMatrix<ST, LO, GO, NT>> contigA =
-      Teko::TpetraHelpers::nonConstEpetraCrsMatrixToTpetra(epetraA, comm_tpetra);
+  auto contigA = buildRecirc2DMatrix(comm_tpetra, nx, ny);
 
   auto A = assemble_noncontig_matrix(contigA);
 
@@ -578,29 +593,23 @@ bool tBlockedTpetraOperator::test_reorder(int verbosity, std::ostream& os, int t
   bool status    = false;
   bool allPassed = true;
 
-  const Epetra_Comm& comm_epetra            = *GetComm();
   RCP<const Teuchos::Comm<int>> comm_tpetra = GetComm_tpetra();
 
   std::string tstr = total ? "(composite reorder)" : "(flat reorder)";
 
   TEST_MSG("\n   tBlockedTpetraOperator::test_reorder" << tstr << ": "
-                                                       << "Running on " << comm_epetra.NumProc()
+                                                       << "Running on " << comm_tpetra->getSize()
                                                        << " processors");
 
   // pick
-  int nx = 5;  // 3 * 25 * comm_epetra.NumProc();
-  int ny = 5;  // 3 * 50 * comm_epetra.NumProc();
+  GO nx = 5;  // 3 * 25 * comm_epetra.NumProc();
+  GO ny = 5;  // 3 * 50 * comm_epetra.NumProc();
 
   // create a big matrix to play with
   // note: this matrix is not really strided
   //       however, I just need a nontrivial
   //       matrix to play with
-  Trilinos_Util::CrsMatrixGallery FGallery("recirc_2d", comm_epetra, false);
-  FGallery.Set("nx", nx);
-  FGallery.Set("ny", ny);
-  RCP<Epetra_CrsMatrix> epetraA = rcp(FGallery.GetMatrix(), false);
-  RCP<Tpetra::CrsMatrix<ST, LO, GO, NT>> A =
-      Teko::TpetraHelpers::nonConstEpetraCrsMatrixToTpetra(epetraA, comm_tpetra);
+  auto A = buildRecirc2DMatrix(comm_tpetra, nx, ny);
 
   int width = 3;
   Tpetra::MultiVector<ST, LO, GO, NT> x(A->getDomainMap(), width);

--- a/packages/teko/tests/src/Tpetra/tStridedTpetraOperator.cpp
+++ b/packages/teko/tests/src/Tpetra/tStridedTpetraOperator.cpp
@@ -40,6 +40,9 @@
 #include "Teko_TpetraHelpers.hpp"
 #include "Teko_ConfigDefs.hpp"
 
+#include <string>
+#include <vector>
+
 namespace Teko {
 namespace Test {
 
@@ -68,8 +71,21 @@ RCP<crs_t> buildRecirc2DMatrix(const RCP<const Teuchos::Comm<int>>& comm, GO nx,
   Teuchos::ParameterList galeriList;
   galeriList.set("nx", nx);
   galeriList.set("ny", ny);
-  galeriList.set("mx", comm->getSize());
-  galeriList.set("my", 1);
+
+  // Important for the strided-operator tests:
+  //
+  // These tests assume that the local map ordering is compatible with a simple
+  // interleaved striding pattern.  With the usual Galeri Cartesian2D numbering,
+  // decomposing in the x-direction can give each rank locally noncontiguous GID
+  // sequences such as:
+  //
+  //   9, 10, 11, 21, 22, 23, ...
+  //
+  // That layout can break the local striding assumptions in parallel.  A
+  // y-direction decomposition gives each rank a contiguous slab of rows, which
+  // keeps the local GID ordering compatible with the intended striding pattern.
+  galeriList.set("mx", 1);
+  galeriList.set("my", comm->getSize());
 
   auto tMap = Galeri::Xpetra::CreateMap<LO, GO, map_t>("Cartesian2D", comm, galeriList);
 
@@ -310,7 +326,6 @@ bool tStridedTpetraOperator::test_vector_constr(int verbosity, std::ostream& os)
   shell.RebuildOps();
 
   // test the operator against a lot of random vectors
-
   numtests = 10;
   max      = 0.0;
   min      = 1.0;
@@ -322,7 +337,10 @@ bool tStridedTpetraOperator::test_vector_constr(int verbosity, std::ostream& os)
     shell.apply(x, y);
     A->apply(x, ys);
 
-    Tpetra::MultiVector<ST, LO, GO, NT> e(y);
+    // This must be a deep copy of y before subtracting ys.  The single-arg
+    // MultiVector constructor can alias/copy-view behavior depending on the
+    // overload, which is not what this error-vector computation wants.
+    Tpetra::MultiVector<ST, LO, GO, NT> e(y, Teuchos::Copy);
     e.update(-1.0, ys, 1.0);
     e.norm2(Teuchos::ArrayView<ST>(norm));
 

--- a/packages/teko/tests/src/Tpetra/tStridedTpetraOperator.cpp
+++ b/packages/teko/tests/src/Tpetra/tStridedTpetraOperator.cpp
@@ -32,7 +32,9 @@
 
 #include "tStridedTpetraOperator.hpp"
 
-#include "Trilinos_Util_CrsMatrixGallery.h"
+#include "Galeri_XpetraMaps.hpp"
+#include "Galeri_XpetraProblemFactory.hpp"
+#include "Galeri_XpetraParameters.hpp"
 
 #include "Teko_StridedTpetraOperator.hpp"
 #include "Teko_TpetraHelpers.hpp"
@@ -50,6 +52,35 @@ using Thyra::LinearOpBase;
 using Thyra::LinearOpTester;
 using Thyra::VectorBase;
 
+namespace {
+
+using ST = Teko::ST;
+using LO = Teko::LO;
+using GO = Teko::GO;
+using NT = Teko::NT;
+
+using map_t = Tpetra::Map<LO, GO, NT>;
+using crs_t = Tpetra::CrsMatrix<ST, LO, GO, NT>;
+using vec_t = Tpetra::Vector<ST, LO, GO, NT>;
+using mv_t  = Tpetra::MultiVector<ST, LO, GO, NT>;
+
+RCP<crs_t> buildRecirc2DMatrix(const RCP<const Teuchos::Comm<int>>& comm, GO nx, GO ny) {
+  Teuchos::ParameterList galeriList;
+  galeriList.set("nx", nx);
+  galeriList.set("ny", ny);
+  galeriList.set("mx", comm->getSize());
+  galeriList.set("my", 1);
+
+  auto tMap = Galeri::Xpetra::CreateMap<LO, GO, map_t>("Cartesian2D", comm, galeriList);
+
+  auto problem =
+      Galeri::Xpetra::BuildProblem<ST, LO, GO, map_t, crs_t, mv_t>("Recirc2D", tMap, galeriList);
+
+  return problem->BuildMatrix();
+}
+
+}  // namespace
+
 void tStridedTpetraOperator::initializeTest() { tolerance_ = 1e-14; }
 
 int tStridedTpetraOperator::runTest(int verbosity, std::ostream& stdstrm, std::ostream& failstrm,
@@ -61,44 +92,46 @@ int tStridedTpetraOperator::runTest(int verbosity, std::ostream& stdstrm, std::o
   failstrm << "tStridedTpetraOperator";
 
   status = test_numvars_constr(verbosity, failstrm);
-  Teko_TEST_MSG(stdstrm, 1, "   \"numvars_constr\" ... PASSED", "   \"numvars_constr\" ... FAILED");
+  Teko_TEST_MSG_tpetra(stdstrm, 1, "   \"numvars_constr\" ... PASSED",
+                       "   \"numvars_constr\" ... FAILED");
   allTests &= status;
   failcount += status ? 0 : 1;
   totalrun++;
 
   status = test_vector_constr(verbosity, failstrm);
-  Teko_TEST_MSG(stdstrm, 1, "   \"vector_constr\" ... PASSED", "   \"vector_constr\" ... FAILED");
+  Teko_TEST_MSG_tpetra(stdstrm, 1, "   \"vector_constr\" ... PASSED",
+                       "   \"vector_constr\" ... FAILED");
   allTests &= status;
   failcount += status ? 0 : 1;
   totalrun++;
 
   status = test_reorder(verbosity, failstrm, 0);
-  Teko_TEST_MSG(stdstrm, 1, "   \"reorder(flat reorder)\" ... PASSED",
-                "   \"reorder(flat reorder)\" ... FAILED");
+  Teko_TEST_MSG_tpetra(stdstrm, 1, "   \"reorder(flat reorder)\" ... PASSED",
+                       "   \"reorder(flat reorder)\" ... FAILED");
   allTests &= status;
   failcount += status ? 0 : 1;
   totalrun++;
 
   status = test_reorder(verbosity, failstrm, 1);
-  Teko_TEST_MSG(stdstrm, 1, "   \"reorder(composite reorder = " << 1 << ")\" ... PASSED",
-                "   \"reorder(composite reorder)\" ... FAILED");
+  Teko_TEST_MSG_tpetra(stdstrm, 1, "   \"reorder(composite reorder = " << 1 << ")\" ... PASSED",
+                       "   \"reorder(composite reorder)\" ... FAILED");
   allTests &= status;
   failcount += status ? 0 : 1;
   totalrun++;
 
   status = test_reorder(verbosity, failstrm, 2);
-  Teko_TEST_MSG(stdstrm, 1, "   \"reorder(composite reorder = " << 2 << ")\" ... PASSED",
-                "   \"reorder(composite reorder)\" ... FAILED");
+  Teko_TEST_MSG_tpetra(stdstrm, 1, "   \"reorder(composite reorder = " << 2 << ")\" ... PASSED",
+                       "   \"reorder(composite reorder)\" ... FAILED");
   allTests &= status;
   failcount += status ? 0 : 1;
   totalrun++;
 
   status = allTests;
   if (verbosity >= 10) {
-    Teko_TEST_MSG(failstrm, 0, "tStridedTpetraOperator...PASSED",
-                  "tStridedTpetraOperator...FAILED");
+    Teko_TEST_MSG_tpetra(failstrm, 0, "tStridedTpetraOperator...PASSED",
+                         "tStridedTpetraOperator...FAILED");
   } else {  // Normal Operating Procedures (NOP)
-    Teko_TEST_MSG(failstrm, 0, "...PASSED", "tStridedTpetraOperator...FAILED");
+    Teko_TEST_MSG_tpetra(failstrm, 0, "...PASSED", "tStridedTpetraOperator...FAILED");
   }
 
   return failcount;
@@ -108,26 +141,20 @@ bool tStridedTpetraOperator::test_numvars_constr(int verbosity, std::ostream& os
   bool status    = false;
   bool allPassed = true;
 
-  const Epetra_Comm& comm_epetra             = *GetComm();
-  RCP<const Teuchos::Comm<int> > comm_tpetra = GetComm_tpetra();
+  RCP<const Teuchos::Comm<int>> comm_tpetra = GetComm_tpetra();
 
   TEST_MSG("\n   tStridedTpetraOperator::test_numvars: "
-           << "Running on " << comm_epetra.NumProc() << " processors");
+           << "Running on " << comm_tpetra->getSize() << " processors");
 
   // pick
-  int nx = 3 * comm_epetra.NumProc();  // 3 * 25 * comm_epetra.NumProc();
-  int ny = 3 * comm_epetra.NumProc();  // 3 * 50 * comm_epetra.NumProc();
+  GO nx = 3 * comm_tpetra->getSize();  // 3 * 25 * comm_epetra.NumProc();
+  GO ny = 3 * comm_tpetra->getSize();  // 3 * 50 * comm_epetra.NumProc();
 
   // create a big matrix to play with
   // note: this matrix is not really strided
   //       however, I just need a nontrivial
   //       matrix to play with
-  Trilinos_Util::CrsMatrixGallery FGallery("recirc_2d", comm_epetra, false);
-  FGallery.Set("nx", nx);
-  FGallery.Set("ny", ny);
-  RCP<Epetra_CrsMatrix> epetraA = rcp(FGallery.GetMatrix(), false);
-  RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > A =
-      Teko::TpetraHelpers::nonConstEpetraCrsMatrixToTpetra(epetraA, comm_tpetra);
+  auto A        = buildRecirc2DMatrix(comm_tpetra, nx, ny);
   ST beforeNorm = A->getFrobeniusNorm();
 
   int vars  = 3;
@@ -216,26 +243,20 @@ bool tStridedTpetraOperator::test_vector_constr(int verbosity, std::ostream& os)
   bool status    = false;
   bool allPassed = true;
 
-  const Epetra_Comm& comm_epetra             = *GetComm();
-  RCP<const Teuchos::Comm<int> > comm_tpetra = GetComm_tpetra();
+  RCP<const Teuchos::Comm<int>> comm_tpetra = GetComm_tpetra();
 
   TEST_MSG("\n   tStridedTpetraOperator::test_vector_constr: "
-           << "Running on " << comm_epetra.NumProc() << " processors");
+           << "Running on " << comm_tpetra->getSize() << " processors");
 
   // pick
-  int nx = 3 * comm_epetra.NumProc();  // 3 * 25 * comm_epetra.NumProc();
-  int ny = 3 * comm_epetra.NumProc();  // 3 * 50 * comm_epetra.NumProc();
+  GO nx = 3 * comm_tpetra->getSize();  // 3 * 25 * comm_epetra.NumProc();
+  GO ny = 3 * comm_tpetra->getSize();  // 3 * 50 * comm_epetra.NumProc();
 
   // create a big matrix to play with
   // note: this matrix is not really strided
   //       however, I just need a nontrivial
   //       matrix to play with
-  Trilinos_Util::CrsMatrixGallery FGallery("recirc_2d", comm_epetra, false);
-  FGallery.Set("nx", nx);
-  FGallery.Set("ny", ny);
-  RCP<Epetra_CrsMatrix> epetraA = rcp(FGallery.GetMatrix(), false);
-  RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > A =
-      Teko::TpetraHelpers::nonConstEpetraCrsMatrixToTpetra(epetraA, comm_tpetra);
+  auto A        = buildRecirc2DMatrix(comm_tpetra, nx, ny);
   ST beforeNorm = A->getFrobeniusNorm();
 
   int width = 3;
@@ -327,29 +348,23 @@ bool tStridedTpetraOperator::test_reorder(int verbosity, std::ostream& os, int t
   bool status    = false;
   bool allPassed = true;
 
-  const Epetra_Comm& comm_epetra             = *GetComm();
-  RCP<const Teuchos::Comm<int> > comm_tpetra = GetComm_tpetra();
+  RCP<const Teuchos::Comm<int>> comm_tpetra = GetComm_tpetra();
 
   std::string tstr = total ? "(composite reorder)" : "(flat reorder)";
 
   TEST_MSG("\n   tStridedTpetraOperator::test_reorder" << tstr << ": "
-                                                       << "Running on " << comm_epetra.NumProc()
+                                                       << "Running on " << comm_tpetra->getSize()
                                                        << " processors");
 
   // pick
-  int nx = 3 * comm_epetra.NumProc();  // 3 * 25 * comm_epetra.NumProc();
-  int ny = 3 * comm_epetra.NumProc();  // 3 * 50 * comm_epetra.NumProc();
+  GO nx = 3 * comm_tpetra->getSize();  // 3 * 25 * comm_epetra.NumProc();
+  GO ny = 3 * comm_tpetra->getSize();  // 3 * 50 * comm_epetra.NumProc();
 
   // create a big matrix to play with
   // note: this matrix is not really strided
   //       however, I just need a nontrivial
   //       matrix to play with
-  Trilinos_Util::CrsMatrixGallery FGallery("recirc_2d", comm_epetra, false);
-  FGallery.Set("nx", nx);
-  FGallery.Set("ny", ny);
-  RCP<Epetra_CrsMatrix> epetraA = rcp(FGallery.GetMatrix(), false);
-  RCP<Tpetra::CrsMatrix<ST, LO, GO, NT> > A =
-      Teko::TpetraHelpers::nonConstEpetraCrsMatrixToTpetra(epetraA, comm_tpetra);
+  auto A = buildRecirc2DMatrix(comm_tpetra, nx, ny);
 
   int width = 3;
   Tpetra::MultiVector<ST, LO, GO, NT> x(A->getDomainMap(), width);

--- a/packages/teko/tests/testdriver_tpetra.cpp
+++ b/packages/teko/tests/testdriver_tpetra.cpp
@@ -43,16 +43,8 @@
 #include "src/tExplicitOps_tpetra.hpp"
 #include "src/tBlockJacobiPreconditionerFactory_tpetra.hpp"
 #include "src/Tpetra/tTpetraOperatorWrapper.hpp"
-
-#ifdef TEKO_HAVE_EPETRA
 #include "src/Tpetra/tStridedTpetraOperator.hpp"
 #include "src/Tpetra/tBlockedTpetraOperator.hpp"
-#ifdef HAVE_MPI
-#include "Epetra_MpiComm.h"
-#else
-#include "Epetra_SerialComm.h"
-#endif
-#endif
 
 #include "src/Tpetra/tInterlacedTpetra.hpp"
 #include "src/Tpetra/tBlockingTpetra.hpp"
@@ -152,10 +144,8 @@ int main(int argc, char* argv[]) {
     Teko_ADD_UNIT_TEST(Teko::Test::tPCDStrategy_tpetra, PCDStrategy_tpetra);
     if (not isfast) {
       Teko_ADD_UNIT_TEST(Teko::Test::tLSCIntegrationTest_tpetra, LSCIntegrationTest_tpetra);
-#ifdef TEKO_HAVE_EPETRA
       Teko_ADD_UNIT_TEST(Teko::Test::tStridedTpetraOperator, tStridedTpetraOperator);
       Teko_ADD_UNIT_TEST(Teko::Test::tBlockedTpetraOperator, tBlockedTpetraOperator);
-#endif
     }
 
     status = Teko::Test::UnitTest::RunTests_tpetra(verbosity, *termout, *failout);


### PR DESCRIPTION
Assisted-by: Opencode:devstra
@trilinos/teko 