### PR TITLE
MueLu: Accept a skipped test as an OK state for MultiphysicsTestMonolithicSmoother

### DIFF
--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -334,7 +334,7 @@ TRIBITS_ADD_TEST(
   ARGS "--xml=multiphys_monolithic_smoother.xml --expected-iters=5 --path=monolithic"
   NUM_MPI_PROCS 4
   COMM mpi
-  PASS_REGULAR_EXPRESSION "Belos converged"
+  PASS_REGULAR_EXPRESSION "Belos converged|Skipping test"
 )
 
 TRIBITS_ADD_TEST(


### PR DESCRIPTION
This closes issue: https://github.com/trilinos/Trilinos/issues/15480.

@trilinos/muelu 
