### PR TITLE
Ifpack2: Use KSPTRSV as default triangular solver on GPU platforms

### DIFF
--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -351,7 +351,7 @@ void LocalSparseTriangularSolver<MatrixType>::
   using Teuchos::ParameterList;
   using Teuchos::RCP;
 
-  Details::TrisolverType::Enum trisolverType = Details::TrisolverType::Internal;
+  Details::TrisolverType::Enum trisolverType = node_type::is_gpu ? Details::TrisolverType::KSPTRSV : Details::TrisolverType::Internal;
   do {
     static const char typeName[] = "trisolver: type";
 

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -351,7 +351,7 @@ void LocalSparseTriangularSolver<MatrixType>::
   using Teuchos::ParameterList;
   using Teuchos::RCP;
 
-  Details::TrisolverType::Enum trisolverType = typename node_type::execution_space().concurrency() > 1 ? Details::TrisolverType::KSPTRSV : Details::TrisolverType::Internal;
+  Details::TrisolverType::Enum trisolverType = std::is_same_v<typename node_type::execution_space, Kokkos::Serial> ? Details::TrisolverType::Internal : Details::TrisolverType::KSPTRSV;
   do {
     static const char typeName[] = "trisolver: type";
 

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -351,7 +351,7 @@ void LocalSparseTriangularSolver<MatrixType>::
   using Teuchos::ParameterList;
   using Teuchos::RCP;
 
-  Details::TrisolverType::Enum trisolverType = node_type::is_gpu ? Details::TrisolverType::KSPTRSV : Details::TrisolverType::Internal;
+  Details::TrisolverType::Enum trisolverType = typename node_type::execution_space().concurrency() > 1 ? Details::TrisolverType::KSPTRSV : Details::TrisolverType::Internal;
   do {
     static const char typeName[] = "trisolver: type";
 

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -344,22 +344,20 @@ LocalSparseTriangularSolver<MatrixType>::
   }
 }
 
-namespace
-{
-template<typename MatrixType>
-constexpr bool is_host_type()
-{
+namespace {
+template <typename MatrixType>
+constexpr bool is_host_type() {
   using node_type = typename MatrixType::node_type;
   return std::is_same_v<typename node_type::execution_space, Kokkos::Serial>
 #ifdef KOKKOS_ENABLE_THREADS
-    || std::is_same_v<typename node_type::execution_space, Kokkos::Threads>
+         || std::is_same_v<typename node_type::execution_space, Kokkos::Threads>
 #endif
 #ifdef KOKKOS_ENABLE_OPENMP
-    || std::is_same_v<typename node_type::execution_space, Kokkos::OpenMP>
+         || std::is_same_v<typename node_type::execution_space, Kokkos::OpenMP>
 #endif
-  ;
+      ;
 }
-}
+}  // namespace
 
 template <class MatrixType>
 void LocalSparseTriangularSolver<MatrixType>::

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -344,6 +344,23 @@ LocalSparseTriangularSolver<MatrixType>::
   }
 }
 
+namespace
+{
+template<typename MatrixType>
+constexpr bool is_host_type()
+{
+  using node_type = typename MatrixType::node_type;
+  return std::is_same_v<typename node_type::execution_space, Kokkos::Serial>
+#ifdef KOKKOS_ENABLE_THREADS
+    || std::is_same_v<typename node_type::execution_space, Kokkos::Threads>
+#endif
+#ifdef KOKKOS_ENABLE_OPENMP
+    || std::is_same_v<typename node_type::execution_space, Kokkos::OpenMP>
+#endif
+  ;
+}
+}
+
 template <class MatrixType>
 void LocalSparseTriangularSolver<MatrixType>::
     setParameters(const Teuchos::ParameterList& pl) {
@@ -351,7 +368,7 @@ void LocalSparseTriangularSolver<MatrixType>::
   using Teuchos::ParameterList;
   using Teuchos::RCP;
 
-  Details::TrisolverType::Enum trisolverType = std::is_same_v<typename node_type::execution_space, Kokkos::Serial> ? Details::TrisolverType::Internal : Details::TrisolverType::KSPTRSV;
+  Details::TrisolverType::Enum trisolverType = is_host_type<MatrixType>() ? Details::TrisolverType::Internal : Details::TrisolverType::KSPTRSV;
   do {
     static const char typeName[] = "trisolver: type";
 

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -10,6 +10,7 @@
 #ifndef IFPACK2_LOCALSPARSETRIANGULARSOLVER_DEF_HPP
 #define IFPACK2_LOCALSPARSETRIANGULARSOLVER_DEF_HPP
 
+#include "Kokkos_Macros.hpp"
 #include <sstream>    // ostringstream
 #include <stdexcept>  // runtime_error
 


### PR DESCRIPTION
@trilinos/ifpack2

Motivation: provide more reasonable defaults on GPU platforms. Otherwise, a user may forget to set `trisolver: type` and end up routing through host-execution for the triangular solves for RILUK/ILUT. See: https://github.com/kokkos/kokkos-kernels/issues/48.