### PR TITLE
Framework: change gcc 14 PR build to use SLFad in Panzer

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1136,6 +1136,9 @@ opt-set-cmake-var TPL_ENABLE_Pnetcdf        BOOL FORCE   : OFF
 opt-set-cmake-var Trilinos_ENABLE_TrilinosFrameworkTests BOOL FORCE : OFF
 opt-set-cmake-var Trilinos_ENABLE_TrilinosBuildStats     BOOL FORCE : OFF
 
+# One build with SLFad testing of Panzer (all other builds default to DFad)
+opt-set-cmake-var Panzer_FADTYPE STRING FORCE : "Sacado::Fad::SLFad<double,256>"
+
 [rhel_gcc_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel_gcc_release-debug_shared_no-kokkos-arch_no-asan_no-complex_no-fpic_no-mpi_no-pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use PACKAGE-ENABLES|ALL


### PR DESCRIPTION
@trilinos/panzer

## Motivation
Panzer builds default to DFad automatic differentiation type in
Sacado. Applications are starting to use SFad and SLFad. This commit
changes the gcc 14 build to use SLFad. Note that SFad testing is not
really feasible at this time since it hard codes the number of
derivative components at compile time and each Panzer test requires
different derivative sizes based on the physics and algorithms
in the particular test.

## Stakeholder Feedback
 * Test coverage requested by ASINA.

## Testing
 * All tests will now use SLFad in assembly