### PR TITLE
Ifpack2: Use 'trisolver:type = Internal' in MDF unit tests

### DIFF
--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestMDF.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestMDF.cpp
@@ -51,6 +51,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2MDF, Test0, Scalar, LocalOrdinal, Globa
   Teuchos::ParameterList params;
   params.set("fact: mdf level-of-fill", 0.0);
   params.set("Verbosity", 0);
+  params.set("trisolver: type", "Internal");
   TEST_NOTHROW(prec.setParameters(params));
 
   prec.initialize();


### PR DESCRIPTION
@trilinos/ifpack2

Likely fix for https://github.com/trilinos/Trilinos/issues/15497

