### PR TITLE
ShyLU (FROSch): Allow tolerance to be zero to detect Dirichlet boundary nodes

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp
@@ -1339,11 +1339,12 @@ namespace FROSch {
             repeatedMatrix->getGlobalRowView(row,indices,values);
             nnz = indices.size();
             if (indices.size()==1) {
+                // Values might be zero and still be stored explicitly, so this case does not numerically determine the number of zeros.
                 oneEntryOnlyRows[tmp] = row;
                 tmp++;
-            } else if (tol > zero) {
+            } else if (tol >= zero) {
                 for (LO j=0; j<values.size(); j++) {
-                    if (fabs(values[j])<tol) {
+                    if (fabs(values[j])<=tol) {
                         nnz--;
                     }
                 }


### PR DESCRIPTION
@iyamazaki @searhein 
@trilinos/shylu 

## Motivation
The number of indices of a row in a sparse matrix may not be equal to the number of nonzero values if (some) zero values are stored explicitly. In that case, detecting a row with only a single value cannot be done by counting the stored indices for that row, but the values must be inspected.

## Related Issues
No issues are related. The code section was last touched in PR #15080 to avoid ignoring small nonzero values by default.

## Testing
@iyamazaki Please test if it still works for your case.