### PR TITLE
MiniTensor: fix log() failure on ill-conditioned SPD tensors

### DIFF
--- a/packages/minitensor/src/MiniTensor_LinearAlgebra.t.h
+++ b/packages/minitensor/src/MiniTensor_LinearAlgebra.t.h
@@ -181,14 +181,16 @@ solve_full_pivot(Tensor<T, N> const & A, RHS const & b)
 
     }
 
-    assert(pivot_row < dimension);
-    assert(pivot_col < dimension);
+    // The search finds no pivot if all remaining entries are zero or NaN
+    // (NaN compares false against the running maximum). Indexing with
+    // pivot_row == dimension would write out of bounds, so fail explicitly.
+    if (pivot_row >= dimension || pivot_col >= dimension) {
+      MT_ERROR_EXIT("Full-pivot solve failed: singular or non-finite matrix.");
+    }
 
     // Gauss-Jordan elimination
     T const
     t{S(pivot_row, pivot_col)};
-
-    assert(t != 0.0);
 
     for (Index j{0}; j < dimension; ++j) {
       S(pivot_row, j) /= t;
@@ -3398,8 +3400,14 @@ sqrt_dbp(Tensor<T, N> const & A, int& k)
       auto const d2 = std::sqrt(d);
       auto const d6 = cbrt(d2);
       auto const g  = 1.0 / d6;
-      X *= g;
-      M *= g * g;
+      // For ill-conditioned M the expanded determinant can cancel to zero
+      // (or overflow), which would make g non-finite and flood the iteration
+      // with Inf/NaN. The scaling only accelerates convergence, so it is
+      // safe to skip it in that case.
+      if (d > 0.0 && std::isfinite(g)) {
+        X *= g;
+        M *= g * g;
+      }
     }
     auto const Y = X;
     auto const L = inverse_full_pivot(M);

--- a/packages/minitensor/test/test_01.cc
+++ b/packages/minitensor/test/test_01.cc
@@ -975,6 +975,38 @@ TEST(MiniTensor, ExpSym)
   ASSERT_LE(error_rt, 16 * machine_epsilon<Real>());
 }
 
+TEST(MiniTensor, LogIllConditioned)
+{
+  // SPD tensor with eigenvalues (1e6, 1, 1e-6) and unit determinant. The
+  // expanded 3x3 determinant of this tensor cancels catastrophically to
+  // exactly zero in double precision, which used to make the determinant
+  // scaling in sqrt_dbp non-finite and abort (or corrupt memory in release
+  // builds) inside log().
+  Tensor<Real>
+  A(3.05423526260858198e+04, 1.44662229379329743e+05, 9.31790062083673984e+04,
+    1.44662229379329743e+05, 6.85186842144699185e+05, 4.41337014755186858e+05,
+    9.31790062083673984e+04, 4.41337014755186858e+05, 2.84271805230215017e+05);
+
+  Tensor<Real> const
+  L = log(A);
+
+  for (Index i = 0; i < 3; ++i) {
+    for (Index j = 0; j < 3; ++j) {
+      ASSERT_TRUE(std::isfinite(L(i, j)));
+    }
+  }
+
+  // The eigendecomposition path is independent of the scaling-and-squaring
+  // path; at this conditioning both are accurate to ~1e-5 relative.
+  Tensor<Real> const
+  L_sym = log_sym(A);
+
+  Real const
+  error_log = norm(L - L_sym) / norm(L_sym);
+
+  ASSERT_LE(error_log, 1.0e-4);
+}
+
 TEST(MiniTensor, LogRotation)
 {
   // Identity rotation


### PR DESCRIPTION
@trilinos/minitensor

## Motivation

For SPD tensors with condition number above ~1e10, `minitensor::log()` (inverse scaling and squaring) can abort in debug builds and write out of bounds in release builds. Root cause chain, verified with a debugger on a captured input:

1. The fully expanded 3x3 determinant used by the Denman–Beavers scaling in `sqrt_dbp` cancels catastrophically: for the tensor in the added regression test (eigenvalues 1e6, 1, 1e-6; unit determinant) the six terms are of order 1e15 and the computed determinant is exactly 0.0.
2. The scaling factor `g = 1/det^(1/6)` becomes Inf and floods the iterates `X` and `M` with Inf.
3. `inverse_full_pivot` → `solve_full_pivot`: elimination produces Inf/Inf = NaN, and the next pivot search finds no pivot because NaN comparisons are false.
4. With asserts enabled, the run aborts at the `pivot_row < dimension` assert; with `-DNDEBUG` the subsequent `S(pivot_row, j) /= t` with `pivot_row == dimension` is an out-of-bounds write.

In a 500-sample sweep per condition number, `log()` aborted on 22% of random SPD tensors at condition 1e12 and 39% at 1e14.

## Changes

- `sqrt_dbp`: skip the determinant scaling when the computed determinant is zero or the scaling factor is non-finite. The scaling only accelerates convergence, so skipping it affects iteration count, not correctness.
- `solve_full_pivot`: replace the pivot-search asserts with `MT_ERROR_EXIT` so a singular or non-finite matrix produces a clean failure instead of memory corruption in release builds.
- New regression test `MiniTensor.LogIllConditioned` with the captured tensor whose expanded determinant cancels to exactly zero.

## Related Issues

None filed; found during an accuracy/performance study of `log()` vs `log_sym()` on SPD tensors.

## Testing

- Full `test_01.cc` gtest suite (33 tests including the new one) passes on Linux x86-64, GCC 16, serial Kokkos.
- With the fix, 500-sample sweeps at conditions 1e12 and 1e14 complete 500/500 (previously 391/500 and 307/500), with relative errors identical to the unpatched code on the samples that previously succeeded (median ~1e-6 at 1e12 against an independent 80-bit eigendecomposition reference).
- The alternative of switching the ISS pipeline to `inverse_fast23` was also evaluated and rejected: it divides by the same cancellation-prone determinant, and NaN passes its `assert(det != 0)`, turning the failure into an infinite loop.