### PR TITLE
MiniTensor: add exp_sym/exp_eig_sym, eigendecomposition exponential for symmetric tensors

### DIFF
--- a/packages/minitensor/src/MiniTensor_LinearAlgebra.h
+++ b/packages/minitensor/src/MiniTensor_LinearAlgebra.h
@@ -170,6 +170,24 @@ exp_taylor(Tensor<T, N> const & A);
 template <typename T, Index N> Tensor<T, N> exp_pade(Tensor<T, N> const &A);
 
 ///
+/// Exponential map for symmetric tensor
+/// \return \f$ \exp A \f$
+///
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Tensor<T, N>
+exp_sym(Tensor<T, N> const & A);
+
+///
+/// Exponential map for symmetric tensor using eigenvalue decomposition
+/// \return \f$ \exp A \f$
+///
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Tensor<T, N>
+exp_eig_sym(Tensor<T, N> const & A);
+
+///
 /// Logarithmic map.
 /// \return \f$ \log A \f$
 ///

--- a/packages/minitensor/src/MiniTensor_LinearAlgebra.t.h
+++ b/packages/minitensor/src/MiniTensor_LinearAlgebra.t.h
@@ -3536,6 +3536,46 @@ log_eig_sym(Tensor<T, N> const & A)
 }
 
 //
+// Exponential map for symmetric tensor.
+//
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Tensor<T, N>
+exp_sym(Tensor<T, N> const & A)
+{
+  return exp_eig_sym(A);
+}
+
+//
+// Exponential map for symmetric tensor using eigenvalue decomposition.
+//
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Tensor<T, N>
+exp_eig_sym(Tensor<T, N> const & A)
+{
+  Index const
+  dimension = A.get_dimension();
+
+  Tensor<T, N>
+  V(dimension);
+
+  Tensor<T, N>
+  D(dimension);
+
+  std::tie(V, D) = eig_sym(A);
+
+  for (Index i = 0; i < dimension; ++i) {
+    D(i, i) = std::exp(D(i, i));
+  }
+
+  Tensor<T, N> const
+  B = dot_t(dot(V, D), V);
+
+  return B;
+}
+
+//
 // R^N logarithmic map of a rotation.
 // \param R with \f$ R \in SO(N) \f$
 // \return \f$ r = \log R \f$ with \f$ r \in so(N) \f$

--- a/packages/minitensor/test/test_01.cc
+++ b/packages/minitensor/test/test_01.cc
@@ -936,6 +936,45 @@ TEST(MiniTensor, Log)
   ASSERT_LE(error_F, 8 * machine_epsilon<Real>());
 }
 
+TEST(MiniTensor, ExpSym)
+{
+  Tensor<Real> const
+  O(3, Filler::ZEROS);
+
+  // exp of the zero tensor is the identity
+  Tensor<Real> const
+  I = exp_sym(O);
+
+  Real const
+  error_I = norm(I - identity<Real>(3));
+
+  ASSERT_LE(error_I, machine_epsilon<Real>());
+
+  // symmetric tensor with eigenvalues of both signs
+  Tensor<Real> const
+  A(0.7, -0.3,  0.2,
+   -0.3,  0.1, -0.5,
+    0.2, -0.5, -0.9);
+
+  // agree with the general scaling-and-squaring exponential
+  Tensor<Real> const
+  E = exp_sym(A);
+
+  Real const
+  error_exp = norm(E - exp(A)) / norm(E);
+
+  ASSERT_LE(error_exp, 16 * machine_epsilon<Real>());
+
+  // round trip through the symmetric logarithm recovers the argument
+  Tensor<Real> const
+  R = log_sym(E);
+
+  Real const
+  error_rt = norm(R - A) / norm(A);
+
+  ASSERT_LE(error_rt, 16 * machine_epsilon<Real>());
+}
+
 TEST(MiniTensor, LogRotation)
 {
   // Identity rotation


### PR DESCRIPTION
@trilinos/minitensor

## Motivation

MiniTensor provides `log_sym()`/`log_eig_sym()` for the logarithm of a symmetric tensor via eigendecomposition, but no exponential counterpart. Applications that work with logarithms of SPD tensors (logarithmic strain measures, metric-tensor interpolation via log/exp maps) currently pair `log_sym()` with the general `exp()`. This PR adds `exp_sym()`/`exp_eig_sym()` as the exact mirror: eigendecomposition via `eig_sym`, exponential of the eigenvalues, recomposition. The addition is for API completeness and symmetry.

## Changes

- `exp_sym()` and `exp_eig_sym()` in `MiniTensor_LinearAlgebra.h`/`.t.h`, mirroring the structure and placement of `log_sym()`/`log_eig_sym()`.
- Unit test `MiniTensor.ExpSym`: exponential of the zero tensor is the identity; agreement with the scaling-and-squaring `exp()` on a symmetric tensor with eigenvalues of both signs; round trip through `log_sym()` recovers the argument.

## Related Issues

Complements #15513 (robustness fix for `log()` on ill-conditioned SPD tensors).

## Testing

- Full MiniTensor gtest suite (33 tests including the new one) passes on Linux x86-64, GCC 16, serial Kokkos.
- Benchmarked against `exp()` on six suites of random symmetric tensors (near zero, mixed stretch/contraction, contraction only, stretch only, norm sweep to ‖L‖ ≈ 16, nearly repeated eigenvalues; 500 samples per point, 80-bit eigendecomposition reference): both are at machine precision on every suite with no failures; the existing scaling-and-squaring `exp()` remains 2–5× faster. `exp_sym` is therefore offered for API completeness and consistency with `log_sym`, not as a performance improvement; the data is available on request.

## Additional Information

None.