### PR TITLE
Belos complex GCRORDR test: Change problem init

### DIFF
--- a/packages/belos/tpetra/test/GCRODR/test_gcrodr_complex_hb.cpp
+++ b/packages/belos/tpetra/test/GCRODR/test_gcrodr_complex_hb.cpp
@@ -92,7 +92,7 @@ int run(int argc, char *argv[])
   // Create initial vectors
   RCP<MV> B, X;
   X = rcp( new MV(map,numrhs) );
-  MVT::MvRandom( *X );
+  MVT::MvInit( *X, one );
   B = rcp( new MV(map,numrhs) );
   OPT::Apply( *A, *X, *B );
   MVT::MvInit( *X, 0.0 );


### PR DESCRIPTION
@trilinos/belos

## Motivation
Attempt to fix failing test [Belos_Tpetra_gcrodr_complex_hb_MPI_4](https://my.cdash.org/queryTests.php?project=Trilinos&date=2026-07-28&filtercount=1&showfilters=1&field1=testname&compare1=61&value1=Belos_Tpetra_gcrodr_complex_hb_MPI_4). The problem matches the problem in the GCRODR Kokkos test.
