### PR TITLE
Ifpack2: Use 'trisolver: type = Internal' for all MDF unit tests

### DIFF
--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestMDF.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestMDF.cpp
@@ -119,6 +119,7 @@ void test_mdf_reference_problem(
     Teuchos::ParameterList params;
     params.set("fact: mdf level-of-fill", 0.0);
     params.set("Verbosity", 0);
+    params.set("trisolver: type", "Internal");
     TEST_NOTHROW(prec.setParameters(params));
   }
 


### PR DESCRIPTION
May fix https://github.com/trilinos/Trilinos/issues/15497

@trilinos/ifpack2 