### PR TITLE
minitensor: make 2x2 eig/sqrt scaling FAD-safe

### DIFF
--- a/packages/minitensor/src/MiniTensor_LinearAlgebra.t.h
+++ b/packages/minitensor/src/MiniTensor_LinearAlgebra.t.h
@@ -3550,7 +3550,8 @@ sqrt_dbp(Tensor<T, N> const & A, int& k)
       // (or overflow), which would make g non-finite and flood the iteration
       // with Inf/NaN. The scaling only accelerates convergence, so it is
       // safe to skip it in that case.
-      if (d > 0.0 && std::isfinite(g)) {
+      if (Sacado::ScalarValue<T>::eval(d) > 0.0 &&
+          std::isfinite(Sacado::ScalarValue<T>::eval(g))) {
         X *= g;
         M *= g * g;
       }
@@ -3678,7 +3679,7 @@ schur_standardize_2x2(Tensor<T, N> & S, Tensor<T, N> & Q, Index const p)
     // onto the first coordinate axis.
     T const root = std::sqrt(disc);
     T const z = Sacado::ScalarValue<T>::eval(half_diff) >= 0.0 ?
-        half_diff + root : half_diff - root;
+        T(half_diff + root) : T(half_diff - root);
     std::tie(cs, sn) = givens_zero(z, c);
     givens_left(cs, sn, p, q, S);
     givens_right(cs, sn, p, q, S);


### PR DESCRIPTION
## Summary

`minitensor::sqrt`/`log` and `log_schur` (via `sqrt_dbp` and
`schur_standardize_2x2` in `MiniTensor_LinearAlgebra.t.h`) compile for real
scalars but fail to compile when instantiated with a **Sacado FAD** scalar,
because two spots operate on *unevaluated* FAD expression templates:

- **`sqrt_dbp`** (`:3553`): `std::isfinite(g)` is called on `g = 1.0/d6`, a
  `Sacado::Fad::Exp` expression (`DivisionOp<...>`), for which no `isfinite`
  overload exists → *no matching function for call to `isfinite(...)`*.
- **`schur_standardize_2x2`** (`:3680`): the ternary
  `... ? half_diff + root : half_diff - root` has branches of different Sacado
  expression types (`AdditionOp` vs `SubtractionOp`), so `?:` has no common
  type → *operands to `?:` have different types*.

Both functions are reached from public entry points (`sqrt`/`log` and
`log_schur`), so any downstream code instantiating them with a FAD scalar
fails to build. This surfaced as a hard build break in a downstream
application (Albany/LCM) that instantiates `minitensor::log()` on a
`Tensor<FAD>`; MiniTensor's own tests only exercise `double`, so they stayed
green.

## Fix

- Wrap the finiteness test in `Sacado::ScalarValue<T>::eval(...)`.
- Force both ternary branches to `T`.

Both mirror the `Sacado::ScalarValue<T>::eval(...)` idiom already used on the
guard conditions in the very same routines. **No behavioral change for real
scalars** (`ScalarValue<double>::eval(x) == x`, `T(x) == x`).

## Testing

Compiled a minimal FAD instantiation (`minitensor::log` and
`minitensor::log_schur` on a `Tensor<Sacado::Fad::DFad<double>>`) with
gcc-toolset-15:

- **without this change:** the two errors above (`:3680` and `:3553`);
- **with this change:** compiles clean (exit 0).

Real-scalar behavior is unchanged; the arithmetic path is identical.
