### PR TITLE
PR reproducer script, GitHub actions on forks, RAMSES job

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -137,7 +137,7 @@ jobs:
       skip-create-packageenables: true
 
   ramses-openmp:
-    needs: [pre-checks, gcc12-openmpi4, openmp]
+    needs: pre-checks
     if: ${{ !cancelled() && needs.pre-checks.outputs.should_skip != 'true' }}
     uses: ./.github/workflows/ci.yml
     with:

--- a/.github/workflows/cdash_urls.yml
+++ b/.github/workflows/cdash_urls.yml
@@ -29,7 +29,7 @@ jobs:
 
               CI builds can be reproduced locally in a container.
 
-              Requirements: Python 3.9+, [Podman](https://podman.io/docs/installation), CMake
+              Requirements: Python 3.9+, [Podman](https://podman.io/docs/installation)
 
               Steps:
               - Check out the branch of the PR locally.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    if: ${{ github.repository == 'trilinos/Trilinos' }}
     runs-on: [self-hosted, gcc-12.3.0-openmpi-4.1.6]
 
     permissions:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   cuda-kokkos-bounds-check:
+    if: ${{ github.repository == 'trilinos/Trilinos' }}
     uses: ./.github/workflows/ci.yml
     with:
       target-runner-labels: "['self-hosted', 'cuda-12.4.1-gcc-12.3.0-openmpi-4.1.6', '20260507', 'gpu:A100']"
@@ -32,6 +33,7 @@ jobs:
       slots-per-gpu: 8
 
   address-sanitizer:
+    if: ${{ github.repository == 'trilinos/Trilinos' }}
     uses: ./.github/workflows/ci.yml
     with:
       target-runner-labels: "['self-hosted', 'clang-19.1.7-openmpi-4.1.6', '20260507']"
@@ -44,6 +46,7 @@ jobs:
       num-concurrent-tests: 16
 
   coverage-check:
+    if: ${{ github.repository == 'trilinos/Trilinos' }}
     uses: ./.github/workflows/ci.yml
     with:
       target-runner-labels: "['self-hosted', 'gcc-12.3.0-openmpi-4.1.6']"

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -20,6 +20,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
+    if: ${{ github.repository == 'trilinos/Trilinos' }}
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.

--- a/.github/workflows/snapshot-kokkos.yml
+++ b/.github/workflows/snapshot-kokkos.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    if: ${{ github.repository == 'trilinos/Trilinos' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/snapshot-kokkos.yml
+++ b/.github/workflows/snapshot-kokkos.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.SNAPSHOT_APP_ID }}
+          client-id: ${{ secrets.SNAPSHOT_APP_ID }}
           private-key: ${{ secrets.SNAPSHOT_APP_PRIVATE_KEY }}
 
       - name: Clone Trilinos

--- a/.github/workflows/snapshot-rol.yml
+++ b/.github/workflows/snapshot-rol.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    if: ${{ github.repository == 'trilinos/Trilinos' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/snapshot-rol.yml
+++ b/.github/workflows/snapshot-rol.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.SNAPSHOT_APP_ID }}
+          client-id: ${{ secrets.SNAPSHOT_APP_ID }}
           private-key: ${{ secrets.SNAPSHOT_APP_PRIVATE_KEY }}
 
       - name: Clone Trilinos

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs
+    if: ${{ github.repository == 'trilinos/Trilinos' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0

--- a/commonTools/pr_reproducer/requirements.txt
+++ b/commonTools/pr_reproducer/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML==6.0.2
 questionary==2.1.1
 PyGithub==2.6.1
+cmake==4.4.0


### PR DESCRIPTION
@trilinos/framework 

## Motivation
- PR reproducer script: Add CMake to the virtual env instead of relying on a system install.
- Make all scheduled GitHub actions run only in the Trilinos repo itself, not in forks.
- Remove dependency of RAMSES job on gcc12 and openmp jobs. The build now passes and we might want to make it required soon.