### PR TITLE
MiniTensor: add comprehensive Doxygen documentation

### DIFF
--- a/packages/minitensor/README.md
+++ b/packages/minitensor/README.md
@@ -12,6 +12,32 @@ MiniTensor is a library for the use, manipulation, algebra and optimization of s
 *    Emphasis in accurate algorithms.
 *    Fully templated, plays well with Sacado.
 
+## Headers: include what you need
+
+`MiniTensor.h` brings in the containers plus linear algebra, geometry and
+mechanics. Each module header is also self-contained and can be included
+on its own:
+
+| Header | Contents |
+|---|---|
+| `MiniTensor.h` | Umbrella: everything below except the solvers |
+| `MiniTensor_Vector.h` | Vectors |
+| `MiniTensor_Tensor.h` | Second-order tensors and their algebra |
+| `MiniTensor_Tensor3.h`, `MiniTensor_Tensor4.h` | Third- and fourth-order tensors |
+| `MiniTensor_Matrix.h` | General M×N matrices |
+| `MiniTensor_Traits.h` | Scalar/AD type traits (Sacado promotion, index types) |
+| `MiniTensor_Scalar.h` | Scalar helpers: `machine_epsilon`, `not_a_number`, `random`, ... |
+| `MiniTensor_Norms.h` | Norms, determinant, trace, invariants, argmax queries |
+| `MiniTensor_Inverse.h` | Inversion, rank-one updates, preconditioners, linear solves |
+| `MiniTensor_Factorizations.h` | Givens, Cholesky, eigen, SVD, polar, condition numbers |
+| `MiniTensor_MatrixFunctions.h` | `exp`, `log`, `sqrt` families and BCH |
+| `MiniTensor_Rotations.h` | SO(N) logarithmic and exponential maps |
+| `MiniTensor_LinearAlgebra.h` | Umbrella over the five linear-algebra modules |
+| `MiniTensor_Geometry.h` | Element lengths, areas, volumes, centroids |
+| `MiniTensor_Mechanics.h` | Continuum-mechanics operations |
+| `MiniTensor_Solvers.h` | Nonlinear solvers and optimization (opt-in) |
+| `MiniTensor_TestFunctions.h` | Benchmark objectives for the solvers |
+
 ## Documentation
 
 MiniTensor is part of the [Trilinos Project](https://trilinos.github.io), and additional information (e.g., examples, tutorials, and source code documentation) is available through [MiniTensor's Doxygen webpages](https://trilinos.github.io/docs/minitensor/index.html).

--- a/packages/minitensor/doc/Doxyfile.options
+++ b/packages/minitensor/doc/Doxyfile.options
@@ -90,7 +90,7 @@ CITE_BIB_FILES         =
 QUIET                  = YES
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
-WARN_IF_DOC_ERROR      = NO
+WARN_IF_DOC_ERROR      = YES
 WARN_NO_PARAMDOC       = NO
 WARN_FORMAT            = "$file:$line: $text"
 WARN_LOGFILE           =
@@ -106,7 +106,7 @@ EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       = *.x \
                          *.o \
                          *.out
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = minitensor::impl
 EXAMPLE_PATH           = .
 EXAMPLE_PATTERNS       =
 EXAMPLE_RECURSIVE      = YES
@@ -182,7 +182,7 @@ FORMULA_FONTSIZE       = 10
 FORMULA_TRANSPARENT    = YES
 USE_MATHJAX            = YES
 MATHJAX_FORMAT         = HTML-CSS
-MATHJAX_RELPATH        = https://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@2
 MATHJAX_EXTENSIONS     =
 MATHJAX_CODEFILE       =
 SEARCHENGINE           = YES

--- a/packages/minitensor/doc/MiniTensor_DoxygenDocumentation.hpp
+++ b/packages/minitensor/doc/MiniTensor_DoxygenDocumentation.hpp
@@ -17,28 +17,142 @@
 \section minitensor_index Table of Contents
 
 - \ref minitensor_overview
+- \ref minitensor_modules
+- \ref minitensor_usage
 - \ref minitensor_copyright
 - \ref minitensor_questions
 
 \section minitensor_overview MiniTensor Overview
 
-MiniTensor is a library for the use, manipulation, algebra and optimization of small vectors and tensors and problems that depend on them.
-Its purpose is to provide a compact representation of vector and tensor expressions.
-Its emphasis is on ease of use, and accurate algorithms, specifically those used for the development of constitutive models in finite deformation solid mechanics.
-More information can be found at https://trilinos.org/packages/minitensor.
+MiniTensor is a library for the use, manipulation, algebra and optimization
+of small vectors and tensors and problems that depend on them. Its purpose
+is to provide a compact representation of vector and tensor expressions.
+Its emphasis is on ease of use, and accurate algorithms, specifically those
+used for the development of constitutive models in finite deformation solid
+mechanics. It is fully templated, compatible with Sacado automatic
+differentiation types, and usable inside Kokkos device kernels.
+
+MiniTensor is part of the
+<a href="https://trilinos.github.io">Trilinos Project</a>.
+
+\section minitensor_modules Modules
+
+MiniTensor is organized as a collection of module headers. Including
+MiniTensor.h provides the containers plus linear algebra, geometry and
+mechanics; each module header can also be included on its own.
+
+| Header | Contents |
+|---|---|
+| MiniTensor.h | Umbrella: containers, linear algebra, geometry, mechanics |
+| MiniTensor_Vector.h, MiniTensor_Tensor.h, MiniTensor_Tensor3.h, MiniTensor_Tensor4.h, MiniTensor_Matrix.h | \ref minitensor_containers |
+| MiniTensor_Traits.h, MiniTensor_Scalar.h | \ref minitensor_traits |
+| MiniTensor_Norms.h | \ref minitensor_norms |
+| MiniTensor_Inverse.h | \ref minitensor_inverse |
+| MiniTensor_Factorizations.h | \ref minitensor_factorizations |
+| MiniTensor_MatrixFunctions.h | \ref minitensor_matrix_functions |
+| MiniTensor_Rotations.h | \ref minitensor_rotations |
+| MiniTensor_LinearAlgebra.h | Umbrella over the five linear-algebra modules above |
+| MiniTensor_Geometry.h | \ref minitensor_geometry |
+| MiniTensor_Mechanics.h | \ref minitensor_mechanics |
+| MiniTensor_Solvers.h, MiniTensor_TestFunctions.h | \ref minitensor_solvers |
+
+\section minitensor_usage Basic Usage
+
+\code{.cpp}
+#include <MiniTensor.h>
+
+using T = double;
+
+// 3D identity tensor, static storage.
+minitensor::Tensor<T, 3> const I = minitensor::identity<T, 3>(3);
+
+// A deformation-gradient-like tensor; fillers provide zeros, ones,
+// random values, ...
+minitensor::Tensor<T, 3> F(3, minitensor::Filler::RANDOM_UNIFORM);
+F = 0.5 * (F + minitensor::transpose(F)) + I;
+
+// Linear algebra and mechanics operations.
+T const j = minitensor::det(F);
+minitensor::Tensor<T, 3> const C = minitensor::transpose(F) * F;
+minitensor::Tensor<T, 3> const E = 0.5 * (C - I);
+minitensor::Tensor<T, 3> const logC = minitensor::log_sym(C);
+\endcode
+
+Replace \c double with a Sacado forward-AD type to differentiate through
+any of the above.
 
 \section minitensor_copyright Copyright and License
 
-\verbinclude COPYRIGHT_AND_LICENSE
+MiniTensor is distributed under the BSD 3-clause license; see the
+COPYRIGHT and LICENSE files in the package root, and the Trilinos
+<a href="https://trilinos.github.io/about.html#license-and-copyright">
+License and Copyright</a> page.
 
 \section minitensor_questions For All Questions and Comments...
 
    Please contact the authors listed in the License above,
-   or open an issue in the Trilinos GitHub repository (https://github.com/trilinos/Trilinos).
+   or open an issue in the Trilinos GitHub repository
+   (https://github.com/trilinos/Trilinos).
 
 */
 
-/* ************************************************************************ */
-/* ************************************************************************ */
+/*!
+\defgroup minitensor_containers Containers
+\brief Vectors, second- to fourth-order tensors, and general matrices,
+with static (compile-time) or dynamic storage.
+*/
+
+/*!
+\defgroup minitensor_traits Type Traits and Scalar Utilities
+\brief Sacado-aware type promotion machinery, index types, and
+scalar-level helpers such as machine_epsilon and not_a_number.
+*/
+
+/*!
+\defgroup minitensor_norms Norms and Invariants
+\brief Scalar measures of tensors: norms, determinant, trace, principal
+invariants, and argmax queries.
+*/
+
+/*!
+\defgroup minitensor_inverse Inverse and Linear Solves
+\brief Tensor inversion, row/column manipulation, rank-one updates,
+preconditioners and small dense linear solves.
+*/
+
+/*!
+\defgroup minitensor_factorizations Factorizations
+\brief Givens rotations, Cholesky, symmetric eigendecomposition, SVD,
+polar decompositions and condition numbers.
+*/
+
+/*!
+\defgroup minitensor_matrix_functions Matrix Functions
+\brief Tensor exponential, logarithm and square root families, and the
+Baker-Campbell-Hausdorff series.
+*/
+
+/*!
+\defgroup minitensor_rotations Rotations
+\brief Logarithmic and exponential maps on SO(N).
+*/
+
+/*!
+\defgroup minitensor_geometry Geometry
+\brief Lengths, areas, volumes and centroids of finite-element shapes,
+and related parametrization utilities.
+*/
+
+/*!
+\defgroup minitensor_mechanics Mechanics
+\brief Continuum-mechanics operations: deformation and stress measures,
+push-forward and pull-back operations.
+*/
+
+/*!
+\defgroup minitensor_solvers Solvers and Optimization
+\brief Nonlinear system solvers, unconstrained and constrained
+optimization methods, and benchmark test functions.
+*/
 
 #endif //ifndef MINITENSOR_DOXYGEN_DOCUMENTATION_HPP

--- a/packages/minitensor/doc/README.md
+++ b/packages/minitensor/doc/README.md
@@ -6,3 +6,19 @@
 1. In the <buildDirectory>, type `make doc_minitensor`.
 
 The documentation will be placed in `<buildDirectory>/packages/minitensor/doc/html`.
+
+## Publishing to the Trilinos website
+
+The Trilinos website serves package documentation from the
+[trilinos.github.io](https://github.com/trilinos/trilinos.github.io)
+repository: the generated HTML for a package `<pkg>` lives under
+`docs/<pkg>/` there and is served at
+`https://trilinos.github.io/docs/<pkg>/index.html`.
+
+To publish or refresh MiniTensor's pages:
+
+1. Build the documentation as above (`make doc_minitensor`).
+1. Clone `trilinos/trilinos.github.io` and replace the contents of
+   `docs/minitensor/` with the contents of
+   `<buildDirectory>/packages/minitensor/doc/html/`.
+1. Open a pull request against `trilinos/trilinos.github.io`.

--- a/packages/minitensor/src/MiniTensor_Factorizations.h
+++ b/packages/minitensor/src/MiniTensor_Factorizations.h
@@ -16,10 +16,15 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_factorizations
+/// @{
+
 ///
 /// Apply Givens-Jacobi rotation on the left in place.
-/// \param c and s for a rotation G in form [c, s; -s, c]
-/// \param i and k indices for rows and columns where rotation is applied.
+/// \param c cosine defining the rotation G in form [c, s; -s, c]
+/// \param s sine defining the rotation G in form [c, s; -s, c]
+/// \param i row index where the rotation is applied
+/// \param k column index where the rotation is applied
 /// \param A tensor to rotate
 ///
 template<typename T, Index N>
@@ -29,8 +34,10 @@ givens_left(T const & c, T const & s, Index i, Index k, Tensor<T, N> & A);
 
 ///
 /// Apply Givens-Jacobi rotation on the right in place.
-/// \param c and s for a rotation G in form [c, s; -s, c]
-/// \param i and k indices for rows and columns where rotation is applied.
+/// \param c cosine defining the rotation G in form [c, s; -s, c]
+/// \param s sine defining the rotation G in form [c, s; -s, c]
+/// \param i row index where the rotation is applied
+/// \param k column index where the rotation is applied
 /// \param A tensor to rotate
 ///
 template<typename T, Index N>
@@ -125,8 +132,10 @@ polar_left_logV_lame(Tensor<T, N> const &F);
 
 ///
 /// Symmetric Schur algorithm for R^2.
-/// \param \f$ A = [f, g; g, h] \in S(2) \f$
-/// \return \f$ c, s \rightarrow [c, -s; s, c]\f$ diagonalizes A$
+/// \param f component of \f$ A = [f, g; g, h] \in S(2) \f$
+/// \param g component of \f$ A = [f, g; g, h] \in S(2) \f$
+/// \param h component of \f$ A = [f, g; g, h] \in S(2) \f$
+/// \return \f$ c, s \f$ such that \f$ [c, -s; s, c] \f$ diagonalizes A
 ///
 template <typename T>
 std::pair<T, T> schur_sym(const T f, const T g, const T h);
@@ -861,6 +870,10 @@ polar_left_logV(Tensor<T, N> const &F) {
   return std::make_tuple(V, R, v);
 }
 
+///
+/// R^N left polar decomposition with eigenvalue decomposition,
+/// returning also \f$ \log V \f$.
+///
 template <typename T, Index N>
 std::tuple<Tensor<T, N>, Tensor<T, N>, Tensor<T, N>>
 polar_left_logV_eig(Tensor<T, N> const &F) {
@@ -1527,6 +1540,7 @@ std::pair<Tensor<T, N>, bool> cholesky(Tensor<T, N> const &A) {
   return std::make_pair(G, true);
 }
 
+/// @}
 } // namespace minitensor
 
 #endif // MiniTensor_Factorizations_h

--- a/packages/minitensor/src/MiniTensor_Geometry.h
+++ b/packages/minitensor/src/MiniTensor_Geometry.h
@@ -15,11 +15,17 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_geometry
+/// @{
+
 ///
 /// Useful to distinguish among different finite elements.
 ///
 namespace ELEMENT{
 
+///
+/// Finite element types.
+///
 enum Type {
   UNKNOWN,
   SEGMENTAL,
@@ -129,7 +135,8 @@ in_normal_side(
 ///
 /// Given two iterators to a container of points,
 /// find the associated bounding box.
-/// \param start end: define sequence of points
+/// \param start iterator that begins the sequence of points
+/// \param end iterator that ends the sequence of points
 /// \return vectors that define the bounding box
 ///
 template<typename T, typename I, Index N>
@@ -145,7 +152,8 @@ bounding_box(I start, I end);
 ///
 /// Determine if a given point is inside a bounding box.
 /// \param p the point
-/// \param min max points defining the box
+/// \param min lower corner of the box
+/// \param max upper corner of the box
 /// \return whether the point is inside
 ///
 template<typename T, Index N>
@@ -158,7 +166,8 @@ in_box(
 
 ///
 /// Generate random point inside bounding box
-/// \param min max the bounding box
+/// \param min lower corner of the bounding box
+/// \param max upper corner of the bounding box
 /// \return p point inside box
 ///
 template<typename T, Index N>
@@ -217,7 +226,8 @@ closest_point(Vector<T, N> const & p, std::vector<Vector<T, N>> const & n);
 
 /// Median of a sequence defined by random
 /// access iterators. Undefined for empty set.
-/// \param begin end Iterators that define the sequence
+/// \param begin iterator that begins the sequence
+/// \param end iterator that ends the sequence
 /// \return median of sequence
 ///
 template<typename T, typename Iterator>
@@ -229,7 +239,10 @@ median(Iterator begin, Iterator end);
 /// Given quadrilateral nodes and a position
 /// in parametric coordinates, interpolate.
 /// \param xi position in parametric coordinates
-/// \param p0 ... corner nodes
+/// \param p0 corner node
+/// \param p1 corner node
+/// \param p2 corner node
+/// \param p3 corner node
 /// \return interpolated position
 ///
 template<typename T, Index N>
@@ -246,7 +259,9 @@ interpolate_quadrilateral(
 /// Given triangle nodes and a position
 /// in parametric coordinates, interpolate.
 /// \param xi position in parametric coordinates
-/// \param p0 ... corner nodes
+/// \param p0 corner node
+/// \param p1 corner node
+/// \param p2 corner node
 /// \return interpolated position
 ///
 template<typename T, Index N>
@@ -262,7 +277,14 @@ interpolate_triangle(
 /// Given hexahedron nodes and a position
 /// in parametric coordinates, interpolate.
 /// \param xi position in parametric coordinates
-/// \param p0 ... corner nodes
+/// \param p0 corner node
+/// \param p1 corner node
+/// \param p2 corner node
+/// \param p3 corner node
+/// \param p4 corner node
+/// \param p5 corner node
+/// \param p6 corner node
+/// \param p7 corner node
 /// \return interpolated position
 ///
 template<typename T, Index N>
@@ -283,7 +305,10 @@ interpolate_hexahedron(
 /// Given tetrahedron nodes and a position
 /// in parametric coordinates, interpolate.
 /// \param xi position in parametric coordinates
-/// \param p0 ... corner nodes
+/// \param p0 corner node
+/// \param p1 corner node
+/// \param p2 corner node
+/// \param p3 corner node
 /// \return interpolated position
 ///
 template<typename T, Index N>
@@ -348,55 +373,102 @@ class SphericalParametrization
 {
 public:
 
+  ///
+  /// Constructor that takes material tangent
+  /// \param A material tangent (fourth-order tensor)
+  ///
   KOKKOS_INLINE_FUNCTION
   SphericalParametrization(Tensor4<T, N> const & A);
 
+  ///
+  /// Evaluate the localization determinant for the normal defined
+  /// by the spherical angles and update the extrema found so far.
+  /// \param parameters spherical angles (phi, theta)
+  ///
   KOKKOS_INLINE_FUNCTION
   void
   operator()(Vector<T, dimension_const<N, 2>::value> const & parameters);
 
+  ///
+  /// Unit normal for the given spherical angles.
+  /// \param parameters spherical angles (phi, theta)
+  /// \return unit normal on the sphere
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal(Vector<T, dimension_const<N, 2>::value> const & parameters) const;
 
+  ///
+  /// Smallest localization determinant found so far.
+  ///
   KOKKOS_INLINE_FUNCTION
   T
   get_minimum() const {return minimum_;}
 
+  ///
+  /// Largest localization determinant found so far.
+  ///
   KOKKOS_INLINE_FUNCTION
   T
   get_maximum() const {return maximum_;}
 
+  ///
+  /// Parameters at which the minimum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, 2>
   get_arg_minimum() const {return arg_minimum_;}
 
+  ///
+  /// Parameters at which the maximum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, 2>
   get_arg_maximum() const {return arg_maximum_;}
 
+  ///
+  /// Normal at which the minimum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal_minimum() const {return get_normal(arg_minimum_);}
 
+  ///
+  /// Normal at which the maximum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal_maximum() const {return get_normal(arg_maximum_);}
 
 private:
 
+  ///
+  /// Material tangent
+  ///
   Tensor4<T, N> const &
   tangent_;
 
+  ///
+  /// Minimum of the localization determinant
+  ///
   T
   minimum_;
 
+  ///
+  /// Parameters of the minimum
+  ///
   Vector<T, 2>
   arg_minimum_;
 
+  ///
+  /// Maximum of the localization determinant
+  ///
   T
   maximum_;
 
+  ///
+  /// Parameters of the maximum
+  ///
   Vector<T, 2>
   arg_maximum_;
 };
@@ -409,55 +481,102 @@ class StereographicParametrization
 {
 public:
 
+  ///
+  /// Constructor that takes material tangent
+  /// \param A material tangent (fourth-order tensor)
+  ///
   KOKKOS_INLINE_FUNCTION
   StereographicParametrization(Tensor4<T, N> const & A);
 
+  ///
+  /// Unit normal from the inverse stereographic projection.
+  /// \param parameters stereographic projection coordinates (x, y)
+  /// \return unit normal on the sphere
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal(Vector<T, dimension_const<N, 2>::value> const & parameters) const;
 
+  ///
+  /// Evaluate the localization determinant for the normal defined
+  /// by the stereographic coordinates and update the extrema found so far.
+  /// \param parameters stereographic projection coordinates (x, y)
+  ///
   KOKKOS_INLINE_FUNCTION
   void
   operator()(Vector<T, dimension_const<N, 2>::value> const & parameters);
 
+  ///
+  /// Smallest localization determinant found so far.
+  ///
   KOKKOS_INLINE_FUNCTION
   T
   get_minimum() const {return minimum_;}
 
+  ///
+  /// Largest localization determinant found so far.
+  ///
   KOKKOS_INLINE_FUNCTION
   T
   get_maximum() const {return maximum_;}
 
+  ///
+  /// Parameters at which the minimum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, 2>
   get_arg_minimum() const {return arg_minimum_;}
 
+  ///
+  /// Parameters at which the maximum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, 2>
   get_arg_maximum() const {return arg_maximum_;}
 
+  ///
+  /// Normal at which the minimum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal_minimum() const {return get_normal(arg_minimum_);}
 
+  ///
+  /// Normal at which the maximum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal_maximum() const {return get_normal(arg_maximum_);}
 
 private:
 
+  ///
+  /// Material tangent
+  ///
   Tensor4<T, N> const &
   tangent_;
 
+  ///
+  /// Minimum of the localization determinant
+  ///
   T
   minimum_;
 
+  ///
+  /// Parameters of the minimum
+  ///
   Vector<T, 2>
   arg_minimum_;
 
+  ///
+  /// Maximum of the localization determinant
+  ///
   T
   maximum_;
 
+  ///
+  /// Parameters of the maximum
+  ///
   Vector<T, 2>
   arg_maximum_;
 };
@@ -476,52 +595,95 @@ public:
   KOKKOS_INLINE_FUNCTION
   ProjectiveParametrization(Tensor4<T, N> const & A);
 
+  ///
+  /// Evaluate the localization determinant for the normal defined
+  /// by the projective coordinates and update the extrema found so far.
+  /// \param parameters homogeneous (projective) coordinates (x, y, z)
+  ///
   KOKKOS_INLINE_FUNCTION
   void
   operator()(Vector<T, dimension_const<N, 3>::value> const & parameters);
 
+  ///
+  /// Normalized normal for the given homogeneous coordinates.
+  /// \param parameters homogeneous (projective) coordinates (x, y, z)
+  /// \return unit normal, or (1, 1, 1) for the zero vector
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal(Vector<T, dimension_const<N, 3>::value> const & parameters) const;
 
+  ///
+  /// Smallest localization determinant found so far.
+  ///
   KOKKOS_INLINE_FUNCTION
   T
   get_minimum() const {return minimum_;}
 
+  ///
+  /// Largest localization determinant found so far.
+  ///
   KOKKOS_INLINE_FUNCTION
   T
   get_maximum() const {return maximum_;}
 
+  ///
+  /// Parameters at which the minimum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, 3>
   get_arg_minimum() const {return arg_minimum_;}
 
+  ///
+  /// Parameters at which the maximum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, 3>
   get_arg_maximum() const {return arg_maximum_;}
 
+  ///
+  /// Normal at which the minimum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal_minimum() const {return get_normal(arg_minimum_);}
 
+  ///
+  /// Normal at which the maximum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal_maximum() const {return get_normal(arg_maximum_);}
 
 private:
 
+  ///
+  /// Material tangent
+  ///
   Tensor4<T, N> const &
   tangent_;
 
+  ///
+  /// Minimum of the localization determinant
+  ///
   T
   minimum_;
 
+  ///
+  /// Parameters of the minimum
+  ///
   Vector<T, 3>
   arg_minimum_;
 
+  ///
+  /// Maximum of the localization determinant
+  ///
   T
   maximum_;
 
+  ///
+  /// Parameters of the maximum
+  ///
   Vector<T, 3>
   arg_maximum_;
 };
@@ -541,54 +703,95 @@ public:
   TangentParametrization(Tensor4<T, N> const & A);
 
   ///
+  /// Evaluate the localization determinant for the normal defined
+  /// by the tangent coordinates and update the extrema found so far.
+  /// \param parameters tangent coordinates (x, y)
   ///
   ///
   KOKKOS_INLINE_FUNCTION
   void
   operator()(Vector<T, dimension_const<N, 2>::value> const & parameters);
 
+  ///
+  /// Unit normal from the exponential map of the tangent coordinates.
+  /// \param parameters tangent coordinates (x, y)
+  /// \return unit normal on the sphere
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal(Vector<T, dimension_const<N, 2>::value> const & parameters) const;
 
+  ///
+  /// Smallest localization determinant found so far.
+  ///
   KOKKOS_INLINE_FUNCTION
   T
   get_minimum() const {return minimum_;}
 
+  ///
+  /// Largest localization determinant found so far.
+  ///
   KOKKOS_INLINE_FUNCTION
   T
   get_maximum() const {return maximum_;}
 
+  ///
+  /// Parameters at which the minimum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, 2>
   get_arg_minimum() const {return arg_minimum_;}
 
+  ///
+  /// Parameters at which the maximum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, 2>
   get_arg_maximum() const {return arg_maximum_;}
 
+  ///
+  /// Normal at which the minimum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal_minimum() const {return get_normal(arg_minimum_);}
 
+  ///
+  /// Normal at which the maximum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal_maximum() const {return get_normal(arg_maximum_);}
 
 private:
 
+  ///
+  /// Material tangent
+  ///
   Tensor4<T, N> const &
   tangent_;
 
+  ///
+  /// Minimum of the localization determinant
+  ///
   T
   minimum_;
 
+  ///
+  /// Parameters of the minimum
+  ///
   Vector<T, 2>
   arg_minimum_;
 
+  ///
+  /// Maximum of the localization determinant
+  ///
   T
   maximum_;
 
+  ///
+  /// Parameters of the maximum
+  ///
   Vector<T, 2>
   arg_maximum_;
 };
@@ -601,55 +804,103 @@ class CartesianParametrization
 {
 public:
 
+  ///
+  /// Constructor that takes material tangent
+  /// \param A material tangent (fourth-order tensor)
+  ///
   KOKKOS_INLINE_FUNCTION
   CartesianParametrization(Tensor4<T, N> const & A);
 
+  ///
+  /// Evaluate the localization determinant for the normal defined
+  /// by the Cartesian coordinates and update the extrema found so far.
+  /// \param parameters Cartesian components (x, y, z)
+  ///
   KOKKOS_INLINE_FUNCTION
   void
   operator()(Vector<T, dimension_const<N, 3>::value> const & parameters);
 
+  ///
+  /// Normal formed directly from the Cartesian components.
+  /// Note: not normalized.
+  /// \param parameters Cartesian components (x, y, z)
+  /// \return normal vector (x, y, z)
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal(Vector<T, dimension_const<N, 3>::value> const & parameters) const;
 
+  ///
+  /// Smallest localization determinant found so far.
+  ///
   KOKKOS_INLINE_FUNCTION
   T
   get_minimum() const {return minimum_;}
 
+  ///
+  /// Largest localization determinant found so far.
+  ///
   KOKKOS_INLINE_FUNCTION
   T
   get_maximum() const {return maximum_;}
 
+  ///
+  /// Parameters at which the minimum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, 3>
   get_arg_minimum() const {return arg_minimum_;}
 
+  ///
+  /// Parameters at which the maximum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, 3>
   get_arg_maximum() const {return arg_maximum_;}
 
+  ///
+  /// Normal at which the minimum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal_minimum() const {return get_normal(arg_minimum_);}
 
+  ///
+  /// Normal at which the maximum determinant occurs.
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector<T, N>
   get_normal_maximum() const {return get_normal(arg_maximum_);}
 
 private:
 
+  ///
+  /// Material tangent
+  ///
   Tensor4<T, N> const &
   tangent_;
 
+  ///
+  /// Minimum of the localization determinant
+  ///
   T
   minimum_;
 
+  ///
+  /// Parameters of the minimum
+  ///
   Vector<T, 3>
   arg_minimum_;
 
+  ///
+  /// Maximum of the localization determinant
+  ///
   T
   maximum_;
 
+  ///
+  /// Parameters of the maximum
+  ///
   Vector<T, 3>
   arg_maximum_;
 };
@@ -682,6 +933,8 @@ public:
       Vector<Index, N> const & points_per_dimension);
 
   ///
+  /// Traverse the grid, applying the visitor to each grid point.
+  /// \param visitor functor to apply at each grid point
   ///
   template<typename Visitor>
   KOKKOS_INLINE_FUNCTION
@@ -690,12 +943,21 @@ public:
 
 private:
 
+  ///
+  /// Lower limits of the grid
+  ///
   Vector<T, N>
   lower_;
 
+  ///
+  /// Upper limits of the grid
+  ///
   Vector<T, N>
   upper_;
 
+  ///
+  /// Number of grid points in each dimension
+  ///
   Vector<Index, N>
   points_per_dimension_;
 
@@ -1522,6 +1784,9 @@ bounding_box(I start, I end)
   return std::make_pair(min, max);
 }
 
+///
+/// Bounding box of a sequence of points.
+///
 template<typename T, typename I>
 KOKKOS_INLINE_FUNCTION
 std::pair<Vector<T, DYNAMIC>, Vector<T, DYNAMIC>>
@@ -1997,6 +2262,7 @@ minimum_distances(std::vector< std::vector<T>> const & distances)
   return minima;
 }
 
+/// @}
 } // namespace minitensor
 
 #endif // MiniTensor_Geometry_h

--- a/packages/minitensor/src/MiniTensor_Inverse.h
+++ b/packages/minitensor/src/MiniTensor_Inverse.h
@@ -15,6 +15,9 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_inverse
+/// @{
+
 ///
 /// 2nd-order tensor inverse
 /// \param A nonsingular tensor
@@ -47,6 +50,7 @@ inverse_full_pivot(Tensor<T, N> const & A);
 
 ///
 /// Swap row. Echange rows i and j in place
+/// \param A tensor
 /// \param i index
 /// \param j index
 ///
@@ -57,6 +61,7 @@ swap_row(Tensor<T, N> & A, Index const i, Index const j);
 
 ///
 /// Swap column. Echange columns i and j in place
+/// \param A tensor
 /// \param i index
 /// \param j index
 ///
@@ -111,6 +116,7 @@ std::pair<Tensor<T, N>, RHS> precon(PreconditionerType const pt,
 /// conjunction with Kokkos to take advantage of thread parallelism.
 /// \param A assumed non-singular tensor
 /// \param b rhs of the system Ax=b
+/// \param pt preconditioner type
 /// \return x solution(s) to the system Ax=b
 ///
 template <typename T, Index N, typename RHS>
@@ -252,6 +258,10 @@ inverse_fast23(Tensor<T, N> const & A)
 //
 //
 //
+///
+/// Solve linear system A x = b via Gauss-Jordan elimination with full
+/// pivoting.
+///
 template<typename T, Index N, typename RHS>
 KOKKOS_INLINE_FUNCTION
 RHS
@@ -493,6 +503,7 @@ RHS solve(Tensor<T, N> const &A, RHS const &b, PreconditionerType const pt) {
   return solve_full_pivot(PA, Pb);
 }
 
+/// @}
 } // namespace minitensor
 
 #endif // MiniTensor_Inverse_h

--- a/packages/minitensor/src/MiniTensor_Matrix.h
+++ b/packages/minitensor/src/MiniTensor_Matrix.h
@@ -21,6 +21,12 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_containers
+/// @{
+
+///
+/// Storage type alias for Matrix.
+///
 template<typename T, Index M, Index N>
 using matrix_store = Storage<T, dimension_product<M, N>::value>;
 
@@ -64,35 +70,43 @@ public:
 
   ///
   /// Constructor that initializes to NaNs
-  /// \param rows Number of rows
-  /// \param cols Number of columns
   ///
   KOKKOS_INLINE_FUNCTION
   explicit
   Matrix();
 
+  ///
+  /// Constructor that initializes to NaNs.
+  /// \param rows Number of rows
+  /// \param cols Number of columns
+  ///
   KOKKOS_INLINE_FUNCTION
   explicit
   Matrix(Index const rows, Index const cols);
 
   ///
   /// Create tensor from a specified value
-  /// \param rows Number of rows
-  /// \param cols Number of columns
   /// \param value all components are set equal to this
   ///
   KOKKOS_INLINE_FUNCTION
   explicit
   Matrix(Filler const value);
 
+  ///
+  /// Create matrix from a specified value.
+  /// \param rows Number of rows
+  /// \param cols Number of columns
+  /// \param value all components are set equal to this
+  ///
   KOKKOS_INLINE_FUNCTION
   explicit
   Matrix(Index const rows, Index cols, Filler const value);
 
   ///
   /// Create tensor from array
-  /// \param dimension the space dimension
-  /// \param data_ptr pointer into the array
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param data array with source components
+  /// \param index1 first index into the array
   ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
@@ -101,6 +115,13 @@ public:
       ArrayT & data,
       Index index1);
 
+  ///
+  /// Create matrix from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Matrix(
@@ -109,6 +130,14 @@ public:
       Index index1,
       Index index2);
 
+  ///
+  /// Create matrix from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Matrix(
@@ -118,6 +147,15 @@ public:
       Index index2,
       Index index3);
 
+  ///
+  /// Create matrix from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  /// \param index4 fourth index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Matrix(
@@ -128,6 +166,16 @@ public:
       Index index3,
       Index index4);
 
+  ///
+  /// Create matrix from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  /// \param index4 fourth index into the array
+  /// \param index5 fifth index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Matrix(
@@ -139,6 +187,17 @@ public:
       Index index4,
       Index index5);
 
+  ///
+  /// Create matrix from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  /// \param index4 fourth index into the array
+  /// \param index5 fifth index into the array
+  /// \param index6 sixth index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Matrix(
@@ -151,6 +210,14 @@ public:
       Index index5,
       Index index6);
 
+  ///
+  /// Create matrix from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param rows Number of rows
+  /// \param cols Number of columns
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Matrix(
@@ -160,6 +227,15 @@ public:
       ArrayT & data,
       Index index1);
 
+  ///
+  /// Create matrix from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param rows Number of rows
+  /// \param cols Number of columns
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Matrix(
@@ -170,6 +246,16 @@ public:
       Index index1,
       Index index2);
 
+  ///
+  /// Create matrix from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param rows Number of rows
+  /// \param cols Number of columns
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Matrix(
@@ -181,6 +267,17 @@ public:
       Index index2,
       Index index3);
 
+  ///
+  /// Create matrix from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param rows Number of rows
+  /// \param cols Number of columns
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  /// \param index4 fourth index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Matrix(
@@ -193,6 +290,18 @@ public:
       Index index3,
       Index index4);
 
+  ///
+  /// Create matrix from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param rows Number of rows
+  /// \param cols Number of columns
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  /// \param index4 fourth index into the array
+  /// \param index5 fifth index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Matrix(
@@ -206,6 +315,19 @@ public:
       Index index4,
       Index index5);
 
+  ///
+  /// Create matrix from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param rows Number of rows
+  /// \param cols Number of columns
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  /// \param index4 fourth index into the array
+  /// \param index5 fifth index into the array
+  /// \param index6 sixth index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Matrix(
@@ -220,10 +342,20 @@ public:
       Index index5,
       Index index6);
 
+  ///
+  /// Create matrix from array defined by pointer.
+  /// \param data_ptr pointer into the array
+  ///
   KOKKOS_INLINE_FUNCTION
   explicit
   Matrix(T const * data_ptr);
 
+  ///
+  /// Create matrix from array defined by pointer.
+  /// \param rows Number of rows
+  /// \param cols Number of columns
+  /// \param data_ptr pointer into the array
+  ///
   KOKKOS_INLINE_FUNCTION
   explicit
   Matrix(Index const rows, Index cols, T const * data_ptr);
@@ -280,7 +412,8 @@ public:
   get_num_cols() const;
 
   ///
-  /// \param dimension of vector
+  /// \param rows Number of rows
+  /// \param cols Number of columns
   ///
   KOKKOS_INLINE_FUNCTION
   void
@@ -288,9 +421,15 @@ public:
 
 private:
 
+  ///
+  /// Number of rows.
+  ///
   Index
   rows_{M};
 
+  ///
+  /// Number of columns.
+  ///
   Index
   cols_{N};
 
@@ -1730,6 +1869,7 @@ operator<<(std::ostream & os, Matrix<T, M, N> const & A)
   return os;
 }
 
+/// @}
 } // namespace minitensor
 
 #endif //MiniTensor_Matrix_h

--- a/packages/minitensor/src/MiniTensor_MatrixFunctions.h
+++ b/packages/minitensor/src/MiniTensor_MatrixFunctions.h
@@ -17,6 +17,9 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_matrix_functions
+/// @{
+
 ///
 /// Exponential map.
 /// \return \f$ \exp A \f$
@@ -3017,6 +3020,9 @@ binary_powering(Tensor<T, N> const & A, Index const exponent)
 // and Squaring Algorithm for the Matrix Exponential, SIAM J. Matrix Anal.
 // Appl. 31(3), 2009, Table 3.1. The value for order 13 is their revised
 // choice that also accounts for rounding in the squaring phase.
+///
+/// Pade truncation-order thresholds of Al-Mohy and Higham (2009).
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 T
@@ -3037,6 +3043,9 @@ scaling_squaring_theta_ah09(Index const order)
 // number of extra squarings needed so that the truncation bound remains
 // valid when the Padé numerator is evaluated in floating point. Zero for
 // all but the most nonnormal arguments.
+///
+/// Rounding-error correction term of Al-Mohy and Higham (2009), Eq. (5.1).
+///
 template<Index N>
 Index
 expm_ell(Tensor<Real, N> const & A, Index const m)
@@ -3389,6 +3398,12 @@ log_gregory(Tensor<T, N> const & A)
 }
 
 // Matrix square root by product form of Denman-Beavers iteration.
+///
+/// Matrix square root by the product form of the Denman-Beavers
+/// iteration.
+/// \param A tensor
+/// \param k on return, the number of iterations performed
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, N>
@@ -3432,6 +3447,9 @@ sqrt_dbp(Tensor<T, N> const & A, int& k)
 }
 
 // Tensor square root
+///
+/// Matrix square root.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, N>
@@ -3442,6 +3460,9 @@ sqrt(Tensor<T, N> const & A)
 }
 
 // Logarithmic map by Padé approximant and partial fractions
+///
+/// Matrix logarithm via partial-fraction Pade approximant of order n.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, N>
@@ -3460,6 +3481,9 @@ log_pade_pf(Tensor<T, N> const & A, Index const n)
 }
 
 // Logarithmic map by inverse scaling and squaring and Padé approximants
+///
+/// Matrix logarithm by inverse scaling and squaring.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, N>
@@ -3890,6 +3914,10 @@ log_schur(Tensor<T, N> const & A)
 // \param A tensor
 // \return \f$ \log A \f$
 //
+///
+/// Matrix logarithm by inverse scaling and squaring with Pade
+/// approximants.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, N>
@@ -4036,6 +4064,7 @@ bch(Tensor<T, N> const & x, Tensor<T, N> const & y)
       (x*x*y*y - 2.0*x*y*x*y + 2.0*y*x*y*x - y*y*x*x);
 }
 
+/// @}
 } // namespace minitensor
 
 #endif // MiniTensor_MatrixFunctions_h

--- a/packages/minitensor/src/MiniTensor_Mechanics.h
+++ b/packages/minitensor/src/MiniTensor_Mechanics.h
@@ -14,6 +14,9 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_mechanics
+/// @{
+
 ///
 /// Volumetric part of 2nd-order tensor
 /// \param A tensor
@@ -36,7 +39,8 @@ dev(Tensor<T, N> const & A);
 
 ///
 /// Push forward covariant vector
-/// \param \f$ F, u \f$
+/// \param F deformation-gradient-like tensor
+/// \param u vector
 /// \return \f$ F^{-T} u \f$
 ///
 template<typename T, Index N>
@@ -46,7 +50,8 @@ push_forward_covariant(Tensor<T, N> const & F, Vector<T, N> const & u);
 
 ///
 /// Pull back covariant vector
-/// \param \f$ F, u \f$
+/// \param F deformation-gradient-like tensor
+/// \param u vector
 /// \return \f$ F^T u \f$
 ///
 template<typename T, Index N>
@@ -56,7 +61,8 @@ pull_back_covariant(Tensor<T, N> const & F, Vector<T, N> const & u);
 
 ///
 /// Push forward contravariant vector
-/// \param \f$ F, u \f$
+/// \param F deformation-gradient-like tensor
+/// \param u vector
 /// \return \f$ F u \f$
 ///
 template<typename T, Index N>
@@ -66,7 +72,8 @@ push_forward_contravariant(Tensor<T, N> const & F, Vector<T, N> const & u);
 
 ///
 /// Pull back contravariant vector
-/// \param \f$ F, u \f$
+/// \param F deformation-gradient-like tensor
+/// \param u vector
 /// \return \f$ F^{-1} u \f$
 ///
 template<typename T, Index N>
@@ -76,7 +83,8 @@ pull_back_contravariant(Tensor<T, N> const & F, Vector<T, N> const & u);
 
 ///
 /// Push forward covariant tensor
-/// \param \f$ F, A \f$
+/// \param F deformation-gradient-like tensor
+/// \param A tensor
 /// \return \f$ F^{-T} A F^{-1} \f$
 ///
 template<typename T, Index N>
@@ -86,7 +94,8 @@ push_forward_covariant(Tensor<T, N> const & F, Tensor<T, N> const & A);
 
 ///
 /// Pull back covariant tensor
-/// \param \f$ F, A \f$
+/// \param F deformation-gradient-like tensor
+/// \param A tensor
 /// \return \f$ F^T A F\f$
 ///
 template<typename T, Index N>
@@ -96,7 +105,8 @@ pull_back_covariant(Tensor<T, N> const & F, Tensor<T, N> const & A);
 
 ///
 /// Push forward contravariant tensor
-/// \param \f$ F, A \f$
+/// \param F deformation-gradient-like tensor
+/// \param A tensor
 /// \return \f$ F A F^T \f$
 ///
 template<typename T, Index N>
@@ -106,7 +116,8 @@ push_forward_contravariant(Tensor<T, N> const & F, Tensor<T, N> const & A);
 
 ///
 /// Pull back contravariant tensor
-/// \param \f$ F, A \f$
+/// \param F deformation-gradient-like tensor
+/// \param A tensor
 /// \return \f$ F^{-1} A F^{-T} \f$
 ///
 template<typename T, Index N>
@@ -116,7 +127,8 @@ pull_back_contravariant(Tensor<T, N> const & F, Tensor<T, N> const & A);
 
 ///
 /// Piola transformation for vector
-/// \param \f$ F, u \f$
+/// \param F deformation-gradient-like tensor
+/// \param u vector
 /// \return \f$ \det F F^{-1} u \f$
 ///
 template<typename T, Index N>
@@ -126,7 +138,8 @@ piola(Tensor<T, N> const & F, Vector<T, N> const & u);
 
 ///
 /// Inverse Piola transformation for vector
-/// \param \f$ F, u \f$
+/// \param F deformation-gradient-like tensor
+/// \param u vector
 /// \return \f$ (\det F)^{-1} F u \f$
 ///
 template<typename T, Index N>
@@ -137,7 +150,8 @@ piola_inverse(Tensor<T, N> const & F, Vector<T, N> const & u);
 ///
 /// Piola transformation for tensor, applied on second
 /// index. Useful for transforming Cauchy stress to 1PK stress.
-/// \param \f$ F, sigma \f$
+/// \param F deformation-gradient-like tensor
+/// \param sigma Cauchy stress tensor
 /// \return \f$ \det F sigma F^{-T} \f$
 ///
 template<typename T, Index N>
@@ -148,7 +162,8 @@ piola(Tensor<T, N> const & F, Tensor<T, N> const & sigma);
 ///
 /// Inverse Piola transformation for tensor, applied on second
 /// index. Useful for transforming 1PK stress to Cauchy stress.
-/// \param \f$ F, P \f$
+/// \param F deformation-gradient-like tensor
+/// \param P first Piola-Kirchhoff stress tensor
 /// \return \f$ (\det F)^{-1} P F^T \f$
 ///
 template<typename T, Index N>
@@ -863,6 +878,7 @@ check_strong_ellipticity(Tensor4<T, N> const & A)
   return std::make_pair(is_elliptic, eigenvector);
 }
 
+/// @}
 } // namespace minitensor
 
 #endif // MiniTensor_Mechanics_h

--- a/packages/minitensor/src/MiniTensor_Norms.h
+++ b/packages/minitensor/src/MiniTensor_Norms.h
@@ -15,6 +15,9 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_norms
+/// @{
+
 ///
 /// Tensor Frobenius norm
 /// \return \f$ \sqrt{A:A} \f$
@@ -44,6 +47,7 @@ norm_infinity(Tensor<T, N> const & A);
 
 ///
 /// Subtensor
+/// \param A tensor
 /// \param i index
 /// \param j index
 /// \return Subtensor with i-row and j-col deleted.
@@ -620,6 +624,7 @@ std::pair<Index, Index> arg_max_off_diagonal(Tensor<T, N> const &A) {
   return std::make_pair(p,q);
 }
 
+/// @}
 } // namespace minitensor
 
 #endif // MiniTensor_Norms_h

--- a/packages/minitensor/src/MiniTensor_Rotations.h
+++ b/packages/minitensor/src/MiniTensor_Rotations.h
@@ -16,6 +16,9 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_rotations
+/// @{
+
 ///
 /// Logarithmic map of a rotation
 /// \param R with \f$ R \in SO(3) \f$
@@ -269,6 +272,7 @@ exp_skew_symmetric(Tensor<T, N> const & r)
   return R;
 }
 
+/// @}
 } // namespace minitensor
 
 #endif // MiniTensor_Rotations_h

--- a/packages/minitensor/src/MiniTensor_Scalar.h
+++ b/packages/minitensor/src/MiniTensor_Scalar.h
@@ -18,6 +18,9 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_traits
+/// @{
+
 //
 // abs function
 //
@@ -96,11 +99,17 @@ KOKKOS_INLINE_FUNCTION
 Index
 num_digits();
 
+///
+/// Number of binary digits in Index.
+///
 template<>
 KOKKOS_INLINE_FUNCTION
 Index
 num_digits<Index>();
 
+///
+/// Number of binary digits in LongIndex.
+///
 template<>
 KOKKOS_INLINE_FUNCTION
 Index
@@ -226,6 +235,9 @@ namespace minitensor {
 //
 //
 //
+///
+/// Absolute value, usable on host and device.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 T
@@ -237,6 +249,9 @@ abs(T const & a)
 //
 //
 //
+///
+/// Swap two values, usable on host and device.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 void
@@ -253,6 +268,9 @@ swap(T & a, T & b)
 //
 //
 //
+///
+/// Maximum of two values, usable on host and device.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 T
@@ -264,6 +282,9 @@ max(T const & a, T const & b)
 //
 //
 //
+///
+/// Minimum of two values, usable on host and device.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 T
@@ -399,6 +420,9 @@ template <typename T> typename Sacado::ScalarType<T>::type random_normal() {
 //
 // Fill in all levels of AD with specified constant.
 //
+///
+/// Fill a non-AD scalar with a constant.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 void
@@ -410,6 +434,9 @@ fill_AD(
   return;
 }
 
+///
+/// Fill an AD scalar with a constant, handling its derivative components.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 void
@@ -662,6 +689,7 @@ levi_civita(Index const i, Index const j, Index const k, Index const l)
   return T(0);
 }
 
+/// @}
 } // namespace minitensor
 
 #endif // MiniTensor_Scalar_h

--- a/packages/minitensor/src/MiniTensor_Solvers.h
+++ b/packages/minitensor/src/MiniTensor_Solvers.h
@@ -18,6 +18,10 @@
 
 namespace minitensor
 {
+
+/// \addtogroup minitensor_solvers
+/// @{
+
 /// The Fad type to use.
 template<typename T, int N>
 using FAD = Sacado::Fad::SLFad<T, N>;
@@ -32,6 +36,9 @@ template<typename FunctionDerived, typename S, Index M>
 struct Function_Base
 {
 public:
+  ///
+  /// Maximum dimension of the argument vectors.
+  ///
   static constexpr
   Index
   DIMENSION{M};
@@ -69,18 +76,34 @@ public:
   Tensor<T, N>
   hessian(FunctionDerived & f, Vector<T, N> const & x);
 
+  ///
+  /// Mark the function as failed and optionally set a failure
+  /// message.
+  ///
   void
   set_failed(char const * const msg = nullptr);
 
+  ///
+  /// Return whether the function has failed.
+  ///
   bool
   get_failed();
 
+  ///
+  /// Clear the failure flag.
+  ///
   void
   clear_failed();
 
+  ///
+  /// Set the failure message.
+  ///
   void
   set_failure_message(char const * const msg = nullptr);
 
+  ///
+  /// Return the failure message.
+  ///
   char const *
   get_failure_message();
 
@@ -109,6 +132,7 @@ public:
   }
 
   ///
+  /// Return the value of the constraints at point x.
   ///
   template<typename T, Index N>
   Vector<T, NC>
@@ -121,6 +145,9 @@ public:
   Matrix<T, NC, NV>
   gradient(ConstraintDerived & c, Vector<T, N> const & x);
 
+  ///
+  /// This is an equality constraint.
+  ///
   static constexpr
   bool
   IS_EQUALITY{true};
@@ -131,10 +158,16 @@ public:
   bool
   failed{false};
 
+  ///
+  /// Number of constraints.
+  ///
   static constexpr
   Index
   NUM_CONSTR{NC};
 
+  ///
+  /// Number of variables.
+  ///
   static constexpr
   Index
   NUM_VAR{NV};
@@ -147,6 +180,9 @@ template<typename ConstraintDerived, typename S, Index NC, Index NV>
 struct Inequality_Constraint :
     public Equality_Constraint<ConstraintDerived, S, NC, NV>
 {
+  ///
+  /// This is not an equality constraint.
+  ///
   static constexpr
   bool
   IS_EQUALITY{false};
@@ -158,11 +194,20 @@ struct Inequality_Constraint :
 template<typename T, Index N>
 struct Bounds
 {
+  ///
+  /// Construct bounds from lower bound l and upper bound u.
+  ///
   Bounds(Vector<T, N> const & l, Vector<T, N> const & u);
 
+  ///
+  /// Lower bound.
+  ///
   Vector<T, N>
   lower;
 
+  ///
+  /// Upper bound.
+  ///
   Vector<T, N>
   upper;
 };
@@ -176,124 +221,253 @@ struct Minimizer
 public:
   Minimizer();
 
+  ///
+  /// Minimize the function fn starting from x using the given
+  /// step method. On return x contains the solution found.
+  ///
   template<typename STEP, typename FN>
   void
   solve(STEP & step_method, FN & fn, Vector<T, N> & x);
 
+  ///
+  /// Print a summary report of the minimization to the stream
+  /// os.
+  ///
   void
   printReport(std::ostream & os);
 
 private:
+  ///
+  /// Update the absolute and relative errors and the
+  /// convergence status.
+  ///
   void
   updateConvergenceCriterion(T const abs_error);
 
+  ///
+  /// Update the monotonicity, stagnation and boundedness
+  /// status with the latest function value.
+  ///
   void
   updateDivergenceCriterion(T const fn_value);
 
+  ///
+  /// Return whether the iteration loop should continue.
+  ///
   bool
   continueSolve() const;
 
+  ///
+  /// Record the final solution, function value, gradient and
+  /// Hessian.
+  ///
   template<typename FN>
   void
   recordFinals(FN & fn, Vector<T, N> const & x);
 
 public:
+  ///
+  /// Maximum number of iterations allowed.
+  ///
   Index
   max_num_iter{256};
 
+  ///
+  /// Minimum number of iterations to perform.
+  ///
   Index
   min_num_iter{0};
 
+  ///
+  /// Number of iterations taken.
+  ///
   Index
   num_iter{0};
 
+  ///
+  /// Number of consecutive stagnant iterations so far.
+  ///
   Index
   num_stagnation_iter{0};
 
+  ///
+  /// Maximum number of consecutive stagnant iterations
+  /// allowed.
+  ///
   Index
   max_stagnation_iter{0};
 
+  ///
+  /// Norm of the initial residual, \f$ \|R_0\| \f$.
+  ///
   T
   initial_norm{1.0};
 
+  ///
+  /// Relative error tolerance.
+  ///
   T
   rel_tol{1.0e-12};
 
+  ///
+  /// Current relative error, \f$ \|R\| / \|R_0\| \f$.
+  ///
   T
   rel_error{1.0};
 
+  ///
+  /// Absolute error tolerance.
+  ///
   T
   abs_tol{1.0e-12};
 
+  ///
+  /// Acceptable absolute tolerance applied at the last
+  /// iteration.
+  ///
   T
   acc_tol{1.0e-12};  
 
+  ///
+  /// Reduction ratio above which an iteration is considered
+  /// stagnant.
+  ///
   T
   stagnation_tol{1.0};
 
+  ///
+  /// Current absolute error, \f$ \|R\| \f$.
+  ///
   T
   abs_error{1.0};
 
+  ///
+  /// Growth factor over the initial value beyond which the
+  /// objective function is considered unbounded.
+  ///
   T
   growth_limit{1.0};
 
+  ///
+  /// Initial value of the objective function.
+  ///
   T
   initial_value{0.0};
 
+  ///
+  /// Value of the objective function at the previous
+  /// iteration.
+  ///
   T
   previous_value{0.0};
 
+  ///
+  /// Final value of the objective function.
+  ///
   T
   final_value{0.0};
 
+  ///
+  /// Whether the minimization failed.
+  ///
   bool
   failed{false};
 
+  ///
+  /// Whether a warning was issued.
+  ///
   bool
   warning{false};
   
+  ///
+  /// Whether the minimization converged.
+  ///
   bool
   converged{false};
 
+  ///
+  /// Whether the objective function decreased monotonically.
+  ///
   bool
   monotonic{true};
 
+  ///
+  /// Whether the objective function remained bounded.
+  ///
   bool
   bounded{true};
 
+  ///
+  /// Whether the iteration remained non-stagnant.
+  ///
   bool
   non_stagnant{true};
 
+  ///
+  /// If true, fail when the objective function is
+  /// non-monotonic.
+  ///
   bool
   enforce_monotonicity{false};
 
+  ///
+  /// If true, fail when the objective function grows
+  /// unbounded.
+  ///
   bool
   enforce_boundedness{false};
 
+  ///
+  /// If true, warn when the residual stagnates.
+  ///
   bool
   enforce_non_stagnation{false};
 
+  ///
+  /// Initial guess.
+  ///
   Vector<T, N>
   initial_guess;
 
+  ///
+  /// Final solution.
+  ///
   Vector<T, N>
   final_soln;
 
+  ///
+  /// Gradient at the final solution.
+  ///
   Vector<T, N>
   final_gradient;
 
+  ///
+  /// Hessian at the final solution.
+  ///
   Tensor<T, N>
   final_hessian;
 
+  ///
+  /// Name of the step method used.
+  ///
   char const *
   step_method_name{nullptr};
 
+  ///
+  /// Name of the function being minimized.
+  ///
   char const *
   function_name{nullptr};
 
+  ///
+  /// Message describing a failure, if any.
+  ///
   char const *
   failure_message{"No failure detected"};
 
+  ///
+  /// Message describing a warning, if any.
+  ///
   char const *
   warning_message{"No warning detected"};  
 };
@@ -304,13 +478,23 @@ public:
 template<typename T, Index N>
 struct NewtonLineSearch
 {
+  ///
+  /// Perform a Newton line search from soln along direction
+  /// and return the resulting step.
+  ///
   template<typename FN>
   Vector<T, N>
   step(FN & fn, Vector<T, N> const & direction, Vector<T, N> const & soln);
 
+  ///
+  /// Maximum number of line search iterations.
+  ///
   Index
   max_num_iter{16};
 
+  ///
+  /// Convergence tolerance on the step length.
+  ///
   T
   tolerance{1.0e-6};
 };
@@ -321,25 +505,49 @@ struct NewtonLineSearch
 template<typename T, Index N>
 struct BacktrackingLineSearch
 {
+  ///
+  /// Perform a back-tracking line search from soln along
+  /// direction and return the resulting step.
+  ///
   template<typename FN>
   Vector<T, N>
   step(FN & fn, Vector<T, N> const & direction, Vector<T, N> const & soln);
 
+  ///
+  /// Maximum number of iterations.
+  ///
   Index
   max_num_iter{100};
 
+  ///
+  /// Maximum number of line iterations before increasing the
+  /// search parameter.
+  ///
   Index
   max_line_iter{10};
 
+  ///
+  /// Sufficient-decrease parameter for the residual norm.
+  ///
   T
   search_parameter{0.5};
 
+  ///
+  /// Increment applied to the search parameter when the line
+  /// iterations are exhausted.
+  ///
   T
   search_increment{0.1};
 
+  ///
+  /// Line search step length multiplier.
+  ///
   T
   alpha{1.0};
 
+  ///
+  /// Convergence tolerance.
+  ///
   T
   tolerance{1.0e-6};
 };
@@ -350,9 +558,16 @@ struct BacktrackingLineSearch
 template<typename T, Index N>
 struct TrustRegionSubproblemBase
 {
+  ///
+  /// Preconditioner used by the linear solver.
+  ///
   PreconditionerType
   preconditioner_type{PreconditionerType::IDENTITY};
 
+  ///
+  /// Solve the linear system \f$ A x = b \f$ with
+  /// preconditioning.
+  ///
   Vector<T, N>
   lin_solve(Tensor<T, N> const & A, Vector<T, N> const & b);
 };
@@ -364,12 +579,22 @@ struct TrustRegionSubproblemBase
 template<typename T, Index N>
 struct TrustRegionExactValue : public TrustRegionSubproblemBase<T, N>
 {
+  ///
+  /// Compute the trust-region step for the given Hessian and
+  /// gradient.
+  ///
   Vector<T, N>
   step(Tensor<T, N> const & Hessian, Vector<T, N> const & gradient);
 
+  ///
+  /// Maximum number of iterations for the subproblem.
+  ///
   Index
   max_num_iter{4};
 
+  ///
+  /// Trust-region radius \f$ \Delta \f$.
+  ///
   T
   region_size{1.0};
 };
@@ -381,12 +606,22 @@ struct TrustRegionExactValue : public TrustRegionSubproblemBase<T, N>
 template<typename T, Index N>
 struct TrustRegionExactGradient : public TrustRegionSubproblemBase<T, N>
 {
+  ///
+  /// Compute the trust-region step for the given Hessian and
+  /// gradient.
+  ///
   Vector<T, N>
   step(Tensor<T, N> const & Hessian, Vector<T, N> const & gradient);
 
+  ///
+  /// Maximum number of iterations for the subproblem.
+  ///
   Index
   max_num_iter{4};
 
+  ///
+  /// Trust-region radius \f$ \Delta \f$.
+  ///
   T
   region_size{1.0};
 }; 
@@ -398,9 +633,16 @@ struct TrustRegionExactGradient : public TrustRegionSubproblemBase<T, N>
 template<typename T, Index N>
 struct TrustRegionDogLegValue : public TrustRegionSubproblemBase<T, N>
 {
+  ///
+  /// Compute the dog-leg step for the given Hessian and
+  /// gradient.
+  ///
   Vector<T, N>
   step(Tensor<T, N> const & Hessian, Vector<T, N> const & gradient);
 
+  ///
+  /// Trust-region radius \f$ \Delta \f$.
+  ///
   T
   region_size{1.0};
 };
@@ -412,9 +654,16 @@ struct TrustRegionDogLegValue : public TrustRegionSubproblemBase<T, N>
 template<typename T, Index N>
 struct TrustRegionDogLegGradient : public TrustRegionSubproblemBase<T, N>
 {
+  ///
+  /// Compute the dog-leg step for the given Hessian and
+  /// gradient.
+  ///
   Vector<T, N>
   step(Tensor<T, N> const & Hessian, Vector<T, N> const & gradient);
 
+  ///
+  /// Trust-region radius \f$ \Delta \f$.
+  ///
   T
   region_size{1.0};
 }; 
@@ -433,14 +682,25 @@ struct StepBase
     static_assert(is_fad == false, "AD types not allowed for type T");
   }
 
+  ///
+  /// Return the name of the step method.
+  ///
   virtual
   char const *
   name() = 0;
 
+  ///
+  /// Initialize the step method with function fn, initial
+  /// guess x and residual r.
+  ///
   virtual
   void
   initialize(FN & fn, Vector<T, N> const & x, Vector<T, N> const & r) = 0;
 
+  ///
+  /// Compute a step for function fn at point x with residual
+  /// r.
+  ///
   virtual
   Vector<T, N>
   step(FN & fn, Vector<T, N> const & x, Vector<T, N> const & r) = 0;
@@ -448,9 +708,16 @@ struct StepBase
   virtual
   ~StepBase() {}
 
+  ///
+  /// Preconditioner used by the linear solver.
+  ///
   PreconditionerType
   preconditioner_type{PreconditionerType::IDENTITY};
 
+  ///
+  /// Solve the linear system \f$ A x = b \f$ with
+  /// preconditioning.
+  ///
   Vector<T, N>
   lin_solve(Tensor<T, N> const & A, Vector<T, N> const & b);
 };
@@ -481,10 +748,16 @@ stepFactory(StepType step_type);
 template<typename FN, typename T, Index N>
 struct NewtonStep : public StepBase<FN, T, N>
 {
+  ///
+  /// Name of the step method.
+  ///
   static constexpr
   char const * const
   NAME{"Newton"};
 
+  ///
+  /// Return the name of the step method.
+  ///
   virtual
   char const *
   name()
@@ -492,10 +765,16 @@ struct NewtonStep : public StepBase<FN, T, N>
     return NAME;
   }
 
+  ///
+  /// Initialize the step method.
+  ///
   virtual
   void
   initialize(FN & fn, Vector<T, N> const & x, Vector<T, N> const & r);
 
+  ///
+  /// Compute a full Newton step.
+  ///
   virtual
   Vector<T, N>
   step(FN & fn, Vector<T, N> const & x, Vector<T, N> const & r);
@@ -511,10 +790,16 @@ struct NewtonStep : public StepBase<FN, T, N>
 template<typename FN, typename T, Index N>
 struct NewtonWithLineSearchStep : public StepBase<FN, T, N>
 {
+  ///
+  /// Name of the step method.
+  ///
   static constexpr
   char const * const
   NAME{"Newton with Line Search"};
 
+  ///
+  /// Return the name of the step method.
+  ///
   virtual
   char const *
   name()
@@ -522,10 +807,17 @@ struct NewtonWithLineSearchStep : public StepBase<FN, T, N>
     return NAME;
   }
 
+  ///
+  /// Initialize the step method.
+  ///
   virtual
   void
   initialize(FN & fn, Vector<T, N> const & x, Vector<T, N> const & r);
 
+  ///
+  /// Compute a Newton step followed by a back-tracking line
+  /// search.
+  ///
   virtual
   Vector<T, N>
   step(FN & fn, Vector<T, N> const & x, Vector<T, N> const & r);
@@ -540,10 +832,16 @@ struct NewtonWithLineSearchStep : public StepBase<FN, T, N>
 template<typename FN, typename T, Index N>
 struct TrustRegionStep : public StepBase<FN, T, N>
 {
+  ///
+  /// Name of the step method.
+  ///
   static constexpr
   char const * const
   NAME{"Trust Region"};
 
+  ///
+  /// Return the name of the step method.
+  ///
   virtual
   char const *
   name()
@@ -551,10 +849,17 @@ struct TrustRegionStep : public StepBase<FN, T, N>
     return NAME;
   }
 
+  ///
+  /// Initialize the trust-region radius.
+  ///
   virtual
   void
   initialize(FN & fn, Vector<T, N> const & x, Vector<T, N> const & r);
 
+  ///
+  /// Compute a trust-region step. See Nocedal 2nd Ed,
+  /// algorithm 11.5.
+  ///
   virtual
   Vector<T, N>
   step(FN & fn, Vector<T, N> const & x, Vector<T, N> const & r);
@@ -562,16 +867,28 @@ struct TrustRegionStep : public StepBase<FN, T, N>
   virtual
   ~TrustRegionStep() {}
 
+  ///
+  /// Maximum trust-region radius.
+  ///
   T
   max_region_size{10.0};
 
+  ///
+  /// Initial trust-region radius.
+  ///
   T
   initial_region_size{10.0};
 
+  ///
+  /// Minimum reduction ratio to accept a step.
+  ///
   T
   min_reduction{0.0};
 
 private:
+  ///
+  /// Current trust-region radius \f$ \Delta \f$.
+  ///
   T
   region_size{0.0};
 };
@@ -582,10 +899,16 @@ private:
 template<typename FN, typename T, Index N>
 struct ConjugateGradientStep : public StepBase<FN, T, N>
 {
+  ///
+  /// Name of the step method.
+  ///
   static constexpr
   char const * const
   NAME{"Preconditioned Conjugate Gradient"};
 
+  ///
+  /// Return the name of the step method.
+  ///
   virtual
   char const *
   name()
@@ -593,10 +916,18 @@ struct ConjugateGradientStep : public StepBase<FN, T, N>
     return NAME;
   }
 
+  ///
+  /// Initialize the search direction and preconditioned
+  /// residual.
+  ///
   virtual
   void
   initialize(FN & fn, Vector<T, N> const & x, Vector<T, N> const & r);
 
+  ///
+  /// Compute a preconditioned conjugate gradient step
+  /// (Polak-Ribiere).
+  ///
   virtual
   Vector<T, N>
   step(FN & fn, Vector<T, N> const & x, Vector<T, N> const & r);
@@ -604,19 +935,36 @@ struct ConjugateGradientStep : public StepBase<FN, T, N>
   virtual
   ~ConjugateGradientStep() {}
 
+  ///
+  /// Number of iterations between restarts of the search
+  /// directions.
+  ///
   Index
   restart_directions_interval{32};
 
 private:
+  ///
+  /// Current search direction.
+  ///
   Vector<T, N>
   search_direction;
 
+  ///
+  /// Preconditioned residual.
+  ///
   Vector<T, N>
   precon_resi;
 
+  ///
+  /// Latest projection used by the Polak-Ribiere formula.
+  ///
   T
   projection_new{0.0};
 
+  ///
+  /// Iterations since the last restart of the search
+  /// directions.
+  ///
   Index
   restart_directions_counter{0};
 };
@@ -627,10 +975,16 @@ private:
 template<typename FN, typename T, Index N>
 struct LineSearchRegularizedStep : public StepBase<FN, T, N>
 {
+  ///
+  /// Name of the step method.
+  ///
   static constexpr
   char const * const
   NAME{"Line Search Regularized"};
 
+  ///
+  /// Return the name of the step method.
+  ///
   virtual
   char const *
   name()
@@ -638,10 +992,17 @@ struct LineSearchRegularizedStep : public StepBase<FN, T, N>
     return NAME;
   }
 
+  ///
+  /// Initialize the step method.
+  ///
   virtual
   void
   initialize(FN & fn, Vector<T, N> const & x, Vector<T, N> const & r);
 
+  ///
+  /// Compute a regularized Newton step followed by a Newton
+  /// line search. See Nocedal 2nd Ed, algorithm 11.4.
+  ///
   virtual
   Vector<T, N>
   step(FN & fn, Vector<T, N> const & x, Vector<T, N> const & r);
@@ -649,9 +1010,16 @@ struct LineSearchRegularizedStep : public StepBase<FN, T, N>
   virtual
   ~LineSearchRegularizedStep() {}
 
+  ///
+  /// Trust-region size used to regularize a bad Hessian.
+  ///
   T
   step_length{1.0};
 
+  ///
+  /// Hessian condition number above which regularization is
+  /// applied.
+  ///
   T
   hessian_cond_tol{1.0e+08};
 };
@@ -1818,6 +2186,9 @@ step(FN & fn, Vector<T, N> const & soln, Vector<T, N> const & gradient)
 //
 //
 //
+///
+/// Construct the step object for the given step type.
+///
 template<typename FN, typename T, Index N>
 std::unique_ptr<StepBase<FN, T, N>>
 stepFactory(StepType step_type)
@@ -1854,6 +2225,7 @@ stepFactory(StepType step_type)
   return STUP(nullptr);
 }
 
+/// @}
 } // namespace minitensor
 
 #endif // MiniTensor_Solvers_h

--- a/packages/minitensor/src/MiniTensor_Storage.h
+++ b/packages/minitensor/src/MiniTensor_Storage.h
@@ -15,14 +15,26 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_containers
+/// @{
+
 /// Set to constant value if not dynamic
 template<Index N, Index C>
 struct dimension_const {
+  ///
+  /// Resulting dimension: the constant C.
+  ///
   static constexpr Index value = C;
 };
 
+///
+/// Specialization for a dynamic dimension: it remains DYNAMIC.
+///
 template<Index C>
 struct dimension_const<DYNAMIC, C> {
+  ///
+  /// Resulting dimension: DYNAMIC.
+  ///
   static constexpr Index value = DYNAMIC;
 };
 
@@ -33,15 +45,24 @@ struct check_static {
 #if defined(KOKKOS_ENABLE_CUDA)
     // Empty
 #else
+  ///
+  /// Largest dimension allowed for static storage.
+  ///
   static constexpr Index maximum_dimension =
       static_cast<Index>(std::numeric_limits<Index>::digits);
 
   static_assert(D > maximum_dimension, "Dimension is too large");
 #endif
 
+    ///
+    /// The validated dimension D.
+    ///
     static constexpr Index value = D;
 };
 
+///
+/// Validate a run-time dimension for dynamic storage.
+///
 template<typename Store>
 inline
 void
@@ -60,124 +81,277 @@ check_dynamic(Index const dimension)
 /// Integer power template restricted to orders defined below
 template<Index D, Index O>
 struct dimension_power {
+  ///
+  /// Result: 0 for orders without a specialization below.
+  ///
   static constexpr Index value = 0;
 };
 
+///
+/// First power: computes D at compile time.
+///
 template<Index D>
 struct dimension_power<D, 1> {
+  ///
+  /// Result: D.
+  ///
   static constexpr Index value = D;
 };
 
+///
+/// Second power: computes D * D at compile time.
+///
 template<Index D>
 struct dimension_power<D, 2> {
+  ///
+  /// Result: D * D.
+  ///
   static constexpr Index value = D * D;
 };
 
+///
+/// Third power: computes D * D * D at compile time.
+///
 template<Index D>
 struct dimension_power<D, 3> {
+  ///
+  /// Result: D * D * D.
+  ///
   static constexpr Index value = D * D * D;
 };
 
+///
+/// Fourth power: computes D * D * D * D at compile time.
+///
 template<Index D>
 struct dimension_power<D, 4> {
+  ///
+  /// Result: D * D * D * D.
+  ///
   static constexpr Index value = D * D * D * D;
 };
 
 /// Integer square for manipulations between 2nd and 4rd-order tensors.
 template<Index N>
 struct dimension_square {
+  ///
+  /// Result: 0 for dimensions without a specialization below.
+  ///
   static constexpr Index value = 0;
 };
 
+///
+/// Square of a dynamic dimension: it remains DYNAMIC.
+///
 template<>
 struct dimension_square<DYNAMIC> {
+  ///
+  /// Result: DYNAMIC.
+  ///
   static constexpr Index value = DYNAMIC;
 };
 
+///
+/// Compile-time square of 1: value is 1.
+///
 template <> struct dimension_square<1> { static constexpr Index value = 1; };
+/// \var minitensor::dimension_square<1>::value
+/// Result: 1.
 
+///
+/// Compile-time square of 2: value is 4.
+///
 template <> struct dimension_square<2> { static constexpr Index value = 4; };
+/// \var minitensor::dimension_square<2>::value
+/// Result: 4.
 
+///
+/// Compile-time square of 3: value is 9.
+///
 template <> struct dimension_square<3> { static constexpr Index value = 9; };
+/// \var minitensor::dimension_square<3>::value
+/// Result: 9.
 
+///
+/// Compile-time square of 4: value is 16.
+///
 template <> struct dimension_square<4> { static constexpr Index value = 16; };
+/// \var minitensor::dimension_square<4>::value
+/// Result: 16.
 
 /// Integer square root template restricted to dimensions defined below.
 /// Useful for constructing a 2nd-order tensor from a 4th-order
 /// tensor with static storage.
 template <Index N> struct dimension_sqrt { static constexpr Index value = 0; };
+/// \var minitensor::dimension_sqrt::value
+/// Result: 0 for dimensions without a specialization below.
 
+///
+/// Square root of a dynamic dimension: it remains DYNAMIC.
+///
 template<>
 struct dimension_sqrt<DYNAMIC> {
+  ///
+  /// Result: DYNAMIC.
+  ///
   static constexpr Index value = DYNAMIC;
 };
 
+///
+/// Compile-time square root of 1: value is 1.
+///
 template <> struct dimension_sqrt<1> { static constexpr Index value = 1; };
+/// \var minitensor::dimension_sqrt<1>::value
+/// Result: 1.
 
+///
+/// Compile-time square root of 4: value is 2.
+///
 template <> struct dimension_sqrt<4> { static constexpr Index value = 2; };
+/// \var minitensor::dimension_sqrt<4>::value
+/// Result: 2.
 
+///
+/// Compile-time square root of 9: value is 3.
+///
 template <> struct dimension_sqrt<9> { static constexpr Index value = 3; };
+/// \var minitensor::dimension_sqrt<9>::value
+/// Result: 3.
 
+///
+/// Compile-time square root of 16: value is 4.
+///
 template <> struct dimension_sqrt<16> { static constexpr Index value = 4; };
+/// \var minitensor::dimension_sqrt<16>::value
+/// Result: 4.
 
 /// Manipulation of static and dynamic dimensions.
 template<Index N, Index P>
 struct dimension_add {
+  ///
+  /// Result: N + P.
+  ///
   static constexpr Index value = N + P;
 };
 
+///
+/// Adding to a dynamic dimension: the result remains DYNAMIC.
+///
 template<Index P>
 struct dimension_add<DYNAMIC, P> {
+  ///
+  /// Result: DYNAMIC.
+  ///
   static constexpr Index value = DYNAMIC;
 };
 
+///
+/// Compile-time difference of two dimensions.
+///
 template<Index N, Index P>
 struct dimension_subtract {
+  ///
+  /// Result: N - P.
+  ///
   static constexpr Index value = N - P;
 };
 
+///
+/// Subtracting from a dynamic dimension: the result remains DYNAMIC.
+///
 template<Index P>
 struct dimension_subtract<DYNAMIC, P> {
+  ///
+  /// Result: DYNAMIC.
+  ///
   static constexpr Index value = DYNAMIC;
 };
 
+///
+/// Compile-time product of two dimensions.
+///
 template<Index N, Index P>
 struct dimension_product {
+  ///
+  /// Result: N * P.
+  ///
   static constexpr Index value = N * P;
 };
 
+///
+/// Product with a dynamic second factor: the result is DYNAMIC.
+///
 template<Index N>
 struct dimension_product<N, DYNAMIC> {
+  ///
+  /// Result: DYNAMIC.
+  ///
   static constexpr Index value = DYNAMIC;
 };
 
+///
+/// Product with a dynamic first factor: the result is DYNAMIC.
+///
 template<Index P>
 struct dimension_product<DYNAMIC, P> {
+  ///
+  /// Result: DYNAMIC.
+  ///
   static constexpr Index value = DYNAMIC;
 };
 
+///
+/// Product of two dynamic dimensions: the result is DYNAMIC.
+///
 template<>
 struct dimension_product<DYNAMIC, DYNAMIC> {
+  ///
+  /// Result: DYNAMIC.
+  ///
   static constexpr Index value = DYNAMIC;
 };
 
 ///
 /// Base static storage class. Simple linear access memory model.
+/// The capacity N is fixed at compile time and entries live in a
+/// member array, so no heap allocation ever occurs. This policy is
+/// preferred for production runs and GPU (Kokkos) execution.
 ///
 template<typename T, Index N>
 class Storage
 {
 public:
+  ///
+  /// Type of the stored entries.
+  ///
   using value_type = T;
+  ///
+  /// Pointer to an entry.
+  ///
   using pointer_type = T *;
+  ///
+  /// Reference to an entry.
+  ///
   using reference_type = T &;
+  ///
+  /// Pointer to a constant entry.
+  ///
   using const_pointer_type = T const *;
+  ///
+  /// Reference to a constant entry.
+  ///
   using const_reference_type = T const &;
 
+  ///
+  /// Storage policy flag: this is static storage.
+  ///
   static constexpr
   bool
   IS_STATIC = true;
 
+  ///
+  /// Storage policy flag: this is not dynamic storage.
+  ///
   static constexpr
   bool
   IS_DYNAMIC = false;
@@ -187,6 +361,9 @@ public:
   {
   }
 
+  ///
+  /// Create storage with the given number of entries (at most N).
+  ///
   explicit KOKKOS_INLINE_FUNCTION Storage(Index const number_entries) {
     resize(number_entries);
   }
@@ -201,6 +378,9 @@ public:
   {
   }
 
+  ///
+  /// Constant read access to entry i.
+  ///
   KOKKOS_INLINE_FUNCTION
   T const &
   operator[](Index const i) const
@@ -212,6 +392,9 @@ public:
 #pragma GCC diagnostic pop
   }
 
+  ///
+  /// Read-write access to entry i.
+  ///
   KOKKOS_INLINE_FUNCTION
   T &
   operator[](Index const i)
@@ -223,6 +406,9 @@ public:
 #pragma GCC diagnostic pop
   }
 
+  ///
+  /// Number of entries currently in use.
+  ///
   KOKKOS_INLINE_FUNCTION
   Index
   size() const
@@ -230,6 +416,9 @@ public:
     return size_;
   }
 
+  ///
+  /// Set the number of entries in use; must not exceed N.
+  ///
   KOKKOS_INLINE_FUNCTION
   void
   resize(Index const number_entries)
@@ -238,12 +427,18 @@ public:
     size_ = number_entries;
   }
 
+  ///
+  /// No-op: static storage cannot be deallocated.
+  ///
   KOKKOS_INLINE_FUNCTION
   void
   clear()
   {
   }
 
+  ///
+  /// Raw pointer to the underlying array.
+  ///
   KOKKOS_INLINE_FUNCTION
   pointer_type
   get_pointer()
@@ -251,6 +446,9 @@ public:
     return &storage_[0];
   }
 
+  ///
+  /// Raw pointer to the constant underlying array.
+  ///
   KOKKOS_INLINE_FUNCTION
   const_pointer_type
   get_const_pointer() const
@@ -258,34 +456,67 @@ public:
     return &storage_[0];
   }
 
+  ///
+  /// Compile-time capacity N of the storage.
+  ///
   static KOKKOS_INLINE_FUNCTION constexpr Index static_size() { return N; }
 
 private:
 
+  ///
+  /// Fixed-size array that holds the entries.
+  ///
   T
   storage_[N];
 
+  ///
+  /// Number of entries in use; defaults to the capacity N.
+  ///
   Index
   size_{N};
 };
 
 ///
 /// Base dynamic storage class. Simple linear access memory model.
+/// The number of entries is determined at run time and entries are
+/// heap-allocated, allowing resizing. This policy is preferred for
+/// research flexibility when sizes are not known at compile time.
 ///
 template<typename T>
 class Storage<T, DYNAMIC>
 {
 public:
+  ///
+  /// Type of the stored entries.
+  ///
   using value_type = T;
+  ///
+  /// Pointer to an entry.
+  ///
   using pointer_type = T *;
+  ///
+  /// Reference to an entry.
+  ///
   using reference_type = T &;
+  ///
+  /// Pointer to a constant entry.
+  ///
   using const_pointer_type = T const *;
+  ///
+  /// Reference to a constant entry.
+  ///
   using const_reference_type = T const &;
 
+  ///
+  /// Storage policy flag: this is dynamic storage.
+  ///
   static constexpr
   bool
   IS_DYNAMIC = true;
 
+  ///
+  /// Storage policy flag: this is not static storage.
+  ///
   static constexpr
   bool
   IS_STATIC = false;
@@ -295,6 +526,9 @@ public:
   {
   }
 
+  ///
+  /// Create heap-allocated storage with the given number of entries.
+  ///
   explicit KOKKOS_INLINE_FUNCTION Storage(Index const number_entries) {
     resize(number_entries);
   }
@@ -310,6 +544,9 @@ public:
     clear();
   }
 
+  ///
+  /// Constant read access to entry i.
+  ///
   KOKKOS_INLINE_FUNCTION
   T const &
   operator[](Index const i) const
@@ -318,6 +555,9 @@ public:
     return storage_[i];
   }
 
+  ///
+  /// Read-write access to entry i.
+  ///
   KOKKOS_INLINE_FUNCTION
   T &
   operator[](Index const i)
@@ -326,6 +566,9 @@ public:
     return storage_[i];
   }
 
+  ///
+  /// Number of entries currently allocated.
+  ///
   KOKKOS_INLINE_FUNCTION
   Index
   size() const
@@ -333,6 +576,9 @@ public:
     return size_;
   }
 
+  ///
+  /// Reallocate to hold number_entries entries; prior data are lost.
+  ///
   KOKKOS_INLINE_FUNCTION
   void
   resize(Index const number_entries)
@@ -344,6 +590,9 @@ public:
     }
   }
 
+  ///
+  /// Free the heap storage and reset the size to zero.
+  ///
   KOKKOS_INLINE_FUNCTION
   void
   clear()
@@ -355,6 +604,9 @@ public:
     }
   }
 
+  ///
+  /// Raw pointer to the underlying array.
+  ///
   KOKKOS_INLINE_FUNCTION
   pointer_type
   get_pointer()
@@ -362,6 +614,9 @@ public:
     return storage_;
   }
 
+  ///
+  /// Raw pointer to the constant underlying array.
+  ///
   KOKKOS_INLINE_FUNCTION
   const_pointer_type
   get_const_pointer() const
@@ -369,13 +624,22 @@ public:
     return storage_;
   }
 
+  ///
+  /// Compile-time size: 0, since the size is set at run time.
+  ///
   static KOKKOS_INLINE_FUNCTION constexpr Index static_size() { return 0; }
 
 private:
 
+  ///
+  /// Pointer to the heap-allocated entries.
+  ///
   T *
   storage_{nullptr};
 
+  ///
+  /// Number of entries currently allocated.
+  ///
   Index
   size_{0};
 };
@@ -386,6 +650,7 @@ namespace minitensor {
 
 // Place holder for now.
 
+/// @}
 } // namespace minitensor
 
 #endif // MiniTensor_Storage_h

--- a/packages/minitensor/src/MiniTensor_Tensor.h
+++ b/packages/minitensor/src/MiniTensor_Tensor.h
@@ -21,6 +21,12 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_containers
+/// @{
+
+///
+/// Storage type alias for Tensor.
+///
 template<typename T, Index N>
 using tensor_store = Storage<T, dimension_power<N, 2>::value>;
 
@@ -64,15 +70,26 @@ public:
 
   ///
   /// Constructor that initializes to NaNs
-  /// \param dimension the space dimension
   ///
   explicit
   KOKKOS_INLINE_FUNCTION
   Tensor();
 
+  ///
+  /// Constructor that initializes to NaNs
+  /// \param dimension the space dimension
+  ///
   explicit
   KOKKOS_INLINE_FUNCTION
   Tensor(Index const dimension);
+
+  ///
+  /// Create tensor from a specified value
+  /// \param value all components are set equal to this
+  ///
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor(Filler const value);
 
   ///
   /// Create tensor from a specified value
@@ -81,153 +98,261 @@ public:
   ///
   explicit
   KOKKOS_INLINE_FUNCTION
-  Tensor(Filler const value);
+  Tensor(Index const dimension, Filler const value);
 
+  ///
+  /// Create tensor from array
+  /// \param source the array source (Source::ARRAY)
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  ///
+  template<class ArrayT>
   explicit
   KOKKOS_INLINE_FUNCTION
-  Tensor(Index const dimension, Filler const value);
+  Tensor(
+      Source const source,
+      ArrayT & data,
+      Index index1);
+
+  ///
+  /// Create tensor from array
+  /// \param source the array source (Source::ARRAY)
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  ///
+  template<class ArrayT>
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor(
+      Source const source,
+      ArrayT & data,
+      Index index1,
+      Index index2);
+
+  ///
+  /// Create tensor from array
+  /// \param source the array source (Source::ARRAY)
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  ///
+  template<class ArrayT>
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor(
+      Source const source,
+      ArrayT & data,
+      Index index1,
+      Index index2,
+      Index index3);
+
+  ///
+  /// Create tensor from array
+  /// \param source the array source (Source::ARRAY)
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  /// \param index4 fourth fixed index into the array
+  ///
+  template<class ArrayT>
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor(
+      Source const source,
+      ArrayT & data,
+      Index index1,
+      Index index2,
+      Index index3,
+      Index index4);
+
+  ///
+  /// Create tensor from array
+  /// \param source the array source (Source::ARRAY)
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  /// \param index4 fourth fixed index into the array
+  /// \param index5 fifth fixed index into the array
+  ///
+  template<class ArrayT>
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor(
+      Source const source,
+      ArrayT & data,
+      Index index1,
+      Index index2,
+      Index index3,
+      Index index4,
+      Index index5);
+
+  ///
+  /// Create tensor from array
+  /// \param source the array source (Source::ARRAY)
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  /// \param index4 fourth fixed index into the array
+  /// \param index5 fifth fixed index into the array
+  /// \param index6 sixth fixed index into the array
+  ///
+  template<class ArrayT>
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor(
+      Source const source,
+      ArrayT & data,
+      Index index1,
+      Index index2,
+      Index index3,
+      Index index4,
+      Index index5,
+      Index index6);
+
+  ///
+  /// Create tensor from array
+  /// \param source the array source (Source::ARRAY)
+  /// \param dimension the space dimension
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  ///
+  template<class ArrayT>
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor(
+      Source const source,
+      Index const dimension,
+      ArrayT & data,
+      Index index1);
+
+  ///
+  /// Create tensor from array
+  /// \param source the array source (Source::ARRAY)
+  /// \param dimension the space dimension
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  ///
+  template<class ArrayT>
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor(
+      Source const source,
+      Index const dimension,
+      ArrayT & data,
+      Index index1,
+      Index index2);
+
+  ///
+  /// Create tensor from array
+  /// \param source the array source (Source::ARRAY)
+  /// \param dimension the space dimension
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  ///
+  template<class ArrayT>
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor(
+      Source const source,
+      Index const dimension,
+      ArrayT & data,
+      Index index1,
+      Index index2,
+      Index index3);
+
+  ///
+  /// Create tensor from array
+  /// \param source the array source (Source::ARRAY)
+  /// \param dimension the space dimension
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  /// \param index4 fourth fixed index into the array
+  ///
+  template<class ArrayT>
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor(
+      Source const source,
+      Index const dimension,
+      ArrayT & data,
+      Index index1,
+      Index index2,
+      Index index3,
+      Index index4);
+
+  ///
+  /// Create tensor from array
+  /// \param source the array source (Source::ARRAY)
+  /// \param dimension the space dimension
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  /// \param index4 fourth fixed index into the array
+  /// \param index5 fifth fixed index into the array
+  ///
+  template<class ArrayT>
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor(
+      Source const source,
+      Index const dimension,
+      ArrayT & data,
+      Index index1,
+      Index index2,
+      Index index3,
+      Index index4,
+      Index index5);
+
+  ///
+  /// Create tensor from array
+  /// \param source the array source (Source::ARRAY)
+  /// \param dimension the space dimension
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  /// \param index4 fourth fixed index into the array
+  /// \param index5 fifth fixed index into the array
+  /// \param index6 sixth fixed index into the array
+  ///
+  template<class ArrayT>
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor(
+      Source const source,
+      Index const dimension,
+      ArrayT & data,
+      Index index1,
+      Index index2,
+      Index index3,
+      Index index4,
+      Index index5,
+      Index index6);
+
+  ///
+  /// Create tensor from array
+  /// \param data_ptr pointer into the array
+  ///
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor(T const * data_ptr);
 
   ///
   /// Create tensor from array
   /// \param dimension the space dimension
   /// \param data_ptr pointer into the array
   ///
-  template<class ArrayT>
-  explicit
-  KOKKOS_INLINE_FUNCTION
-  Tensor(
-      Source const source,
-      ArrayT & data,
-      Index index1);
-
-  template<class ArrayT>
-  explicit
-  KOKKOS_INLINE_FUNCTION
-  Tensor(
-      Source const source,
-      ArrayT & data,
-      Index index1,
-      Index index2);
-
-  template<class ArrayT>
-  explicit
-  KOKKOS_INLINE_FUNCTION
-  Tensor(
-      Source const source,
-      ArrayT & data,
-      Index index1,
-      Index index2,
-      Index index3);
-
-  template<class ArrayT>
-  explicit
-  KOKKOS_INLINE_FUNCTION
-  Tensor(
-      Source const source,
-      ArrayT & data,
-      Index index1,
-      Index index2,
-      Index index3,
-      Index index4);
-
-  template<class ArrayT>
-  explicit
-  KOKKOS_INLINE_FUNCTION
-  Tensor(
-      Source const source,
-      ArrayT & data,
-      Index index1,
-      Index index2,
-      Index index3,
-      Index index4,
-      Index index5);
-
-  template<class ArrayT>
-  explicit
-  KOKKOS_INLINE_FUNCTION
-  Tensor(
-      Source const source,
-      ArrayT & data,
-      Index index1,
-      Index index2,
-      Index index3,
-      Index index4,
-      Index index5,
-      Index index6);
-
-  template<class ArrayT>
-  explicit
-  KOKKOS_INLINE_FUNCTION
-  Tensor(
-      Source const source,
-      Index const dimension,
-      ArrayT & data,
-      Index index1);
-
-  template<class ArrayT>
-  explicit
-  KOKKOS_INLINE_FUNCTION
-  Tensor(
-      Source const source,
-      Index const dimension,
-      ArrayT & data,
-      Index index1,
-      Index index2);
-
-  template<class ArrayT>
-  explicit
-  KOKKOS_INLINE_FUNCTION
-  Tensor(
-      Source const source,
-      Index const dimension,
-      ArrayT & data,
-      Index index1,
-      Index index2,
-      Index index3);
-
-  template<class ArrayT>
-  explicit
-  KOKKOS_INLINE_FUNCTION
-  Tensor(
-      Source const source,
-      Index const dimension,
-      ArrayT & data,
-      Index index1,
-      Index index2,
-      Index index3,
-      Index index4);
-
-  template<class ArrayT>
-  explicit
-  KOKKOS_INLINE_FUNCTION
-  Tensor(
-      Source const source,
-      Index const dimension,
-      ArrayT & data,
-      Index index1,
-      Index index2,
-      Index index3,
-      Index index4,
-      Index index5);
-
-  template<class ArrayT>
-  explicit
-  KOKKOS_INLINE_FUNCTION
-  Tensor(
-      Source const source,
-      Index const dimension,
-      ArrayT & data,
-      Index index1,
-      Index index2,
-      Index index3,
-      Index index4,
-      Index index5,
-      Index index6);
-
-  explicit
-  KOKKOS_INLINE_FUNCTION
-  Tensor(T const * data_ptr);
-
   explicit
   KOKKOS_INLINE_FUNCTION
   Tensor(Index const dimension, T const * data_ptr);
@@ -247,6 +372,9 @@ public:
   ///
   /// Create tensor specifying components
   /// \param  s00 s01 ... components in the R^2 canonical basis
+  /// \param s01 component in the R^2 canonical basis
+  /// \param s10 component in the R^2 canonical basis
+  /// \param s11 component in the R^2 canonical basis
   ///
   //
   explicit
@@ -256,6 +384,14 @@ public:
   ///
   /// Create tensor specifying components
   /// \param  s00 s01 ... components in the R^3 canonical basis
+  /// \param s01 component in the R^3 canonical basis
+  /// \param s02 component in the R^3 canonical basis
+  /// \param s10 component in the R^3 canonical basis
+  /// \param s11 component in the R^3 canonical basis
+  /// \param s12 component in the R^3 canonical basis
+  /// \param s20 component in the R^3 canonical basis
+  /// \param s21 component in the R^3 canonical basis
+  /// \param s22 component in the R^3 canonical basis
   ///
   explicit
   KOKKOS_INLINE_FUNCTION
@@ -273,6 +409,12 @@ public:
   KOKKOS_INLINE_FUNCTION
   Tensor(T const * data_ptr, ComponentOrder const component_order);
 
+  ///
+  /// Create tensor from array
+  /// \param dimension the space dimension
+  /// \param data_ptr pointer into the array
+  /// \param component_order component convention (3D only)
+  ///
   explicit
   KOKKOS_INLINE_FUNCTION
   Tensor(
@@ -2160,6 +2302,9 @@ zero()
   return Tensor<T, N>(N, Filler::ZEROS);
 }
 
+///
+/// Zero 2nd-order tensor.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, DYNAMIC> const
@@ -2168,6 +2313,9 @@ zero(Index const dimension)
   return Tensor<T, DYNAMIC>(dimension, Filler::ZEROS);
 }
 
+///
+/// Zero 2nd-order tensor.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, N> const
@@ -2244,6 +2392,9 @@ identity()
   return A;
 }
 
+///
+/// Identity 2nd-order tensor.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, DYNAMIC> const
@@ -2257,6 +2408,9 @@ identity(Index const dimension)
   return A;
 }
 
+///
+/// Identity 2nd-order tensor.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, N> const
@@ -2282,6 +2436,9 @@ eye()
   return identity<T, N>();
 }
 
+///
+/// Identity 2nd-order tensor; alias of identity.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, DYNAMIC> const
@@ -2290,6 +2447,9 @@ eye(Index const dimension)
   return identity<T, DYNAMIC>(dimension);
 }
 
+///
+/// Identity 2nd-order tensor; alias of identity.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, N> const
@@ -2314,6 +2474,9 @@ levi_civita_2()
   return A;
 }
 
+///
+/// Levi-Civita symbol as a 2nd-order tensor.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, DYNAMIC> const
@@ -2327,6 +2490,9 @@ levi_civita_2(Index const dimension)
   return A;
 }
 
+///
+/// Levi-Civita symbol as a 2nd-order tensor.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, N> const
@@ -2352,6 +2518,9 @@ permutation_2()
   return levi_civita_2<T, N>();
 }
 
+///
+/// Permutation symbol as a 2nd-order tensor; alias of levi_civita_2.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, DYNAMIC> const
@@ -2361,6 +2530,9 @@ permutation_2(Index const dimension)
 }
 
 
+///
+/// Permutation symbol as a 2nd-order tensor; alias of levi_civita_2.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, N> const
@@ -2380,6 +2552,9 @@ alternator_2()
   return levi_civita_2<T, N>();
 }
 
+///
+/// Alternator as a 2nd-order tensor; alias of levi_civita_2.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, DYNAMIC> const
@@ -2388,6 +2563,9 @@ alternator_2(Index const dimension)
   return levi_civita_2<T, DYNAMIC>(dimension);
 }
 
+///
+/// Alternator as a 2nd-order tensor; alias of levi_civita_2.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor<T, N> const
@@ -2649,6 +2827,7 @@ operator<<(std::ostream & os, Tensor<T, N> const & A)
   return os;
 }
 
+/// @}
 } // namespace minitensor
 
 #endif //MiniTensor_Tensor_h

--- a/packages/minitensor/src/MiniTensor_Tensor3.h
+++ b/packages/minitensor/src/MiniTensor_Tensor3.h
@@ -16,6 +16,12 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_containers
+/// @{
+
+///
+/// Storage type alias for Tensor3.
+///
 template<typename T, Index N>
 using tensor3_store = Storage<T, dimension_power<N, 3>::value>;
 
@@ -59,15 +65,26 @@ public:
 
   ///
   /// 3rd-order tensor constructor with NaNs
-  /// \param dimension the space dimension
   ///
   KOKKOS_INLINE_FUNCTION
   explicit
   Tensor3();
 
+  ///
+  /// 3rd-order tensor constructor with NaNs
+  /// \param dimension the space dimension
+  ///
   explicit
   KOKKOS_INLINE_FUNCTION
   Tensor3(Index const dimension);
+
+  ///
+  /// Create 3rd-order tensor from a specified value
+  /// \param value all components are set equal to this
+  ///
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor3(Filler const value);
 
   ///
   /// Create 3rd-order tensor from a specified value
@@ -76,21 +93,21 @@ public:
   ///
   explicit
   KOKKOS_INLINE_FUNCTION
-  Tensor3(Filler const value);
-
-  explicit
-  KOKKOS_INLINE_FUNCTION
   Tensor3(Index const dimension, Filler const value);
 
   ///
   /// Create 3rd-order tensor from array
-  /// \param dimension the space dimension
   /// \param data_ptr pointer into the array
   ///
   explicit
   KOKKOS_INLINE_FUNCTION
   Tensor3(T const * data_ptr);
 
+  ///
+  /// Create 3rd-order tensor from array
+  /// \param dimension the space dimension
+  /// \param data_ptr pointer into the array
+  ///
   explicit
   KOKKOS_INLINE_FUNCTION
   Tensor3(Index const dimension, T const * data_ptr);
@@ -755,6 +772,9 @@ levi_civita_3()
   return A;
 }
 
+///
+/// Levi-Civita symbol as a 3rd-order tensor.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor3<T, DYNAMIC> const
@@ -768,6 +788,9 @@ levi_civita_3(Index const dimension)
   return A;
 }
 
+///
+/// Levi-Civita symbol as a 3rd-order tensor.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor3<T, N> const
@@ -792,6 +815,9 @@ permutation_3()
   return levi_civita_3<T, N>();
 }
 
+///
+/// Permutation symbol as a 3rd-order tensor; alias of levi_civita_3.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor3<T, DYNAMIC> const
@@ -800,6 +826,9 @@ permutation_3(Index const dimension)
   return levi_civita_3<T>(dimension);
 }
 
+///
+/// Permutation symbol as a 3rd-order tensor; alias of levi_civita_3.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor3<T, N> const
@@ -819,6 +848,9 @@ alternator_3()
   return levi_civita_3<T, N>();
 }
 
+///
+/// Alternator as a 3rd-order tensor; alias of levi_civita_3.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor3<T, DYNAMIC> const
@@ -827,6 +859,9 @@ alternator_3(Index const dimension)
   return levi_civita_3<T>(dimension);
 }
 
+///
+/// Alternator as a 3rd-order tensor; alias of levi_civita_3.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor3<T, N> const
@@ -938,6 +973,10 @@ dot(Vector<S, N> const & u, Tensor3<T, N> const & A)
 //
 // \return \f$ B = A \cdot u := B_{ij} = A_{ipj} u_p \f$
 //
+///
+/// Contraction of a vector with the middle index of a 3rd-order tensor.
+/// \return \f$ B_{ij} = A_{ipj} u_p \f$
+///
 template<typename S, typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor<typename Promote<S, T>::type, N>
@@ -1181,6 +1220,7 @@ operator<<(std::ostream & os, Tensor3<T, N> const & A)
   return os;
 }
 
+/// @}
 } // namespace minitensor
 
 #endif //MiniTensor_Tensor3_h

--- a/packages/minitensor/src/MiniTensor_Tensor4.h
+++ b/packages/minitensor/src/MiniTensor_Tensor4.h
@@ -16,6 +16,12 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_containers
+/// @{
+
+///
+/// Storage type alias for Tensor4.
+///
 template<typename T, Index N>
 using tensor4_store = Storage<T, dimension_power<N, 4>::value>;
 
@@ -59,15 +65,26 @@ public:
 
   ///
   /// 4th-order tensor constructor with NaNs
-  /// \param dimension the space dimension
   ///
   explicit
   KOKKOS_INLINE_FUNCTION
   Tensor4();
 
+  ///
+  /// 4th-order tensor constructor with NaNs
+  /// \param dimension the space dimension
+  ///
   explicit
   KOKKOS_INLINE_FUNCTION
   Tensor4(Index const dimension);
+
+  ///
+  /// Create 4th-order tensor from a specified value
+  /// \param value all components are set equal to this
+  ///
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Tensor4(Filler const value);
 
   ///
   /// Create 4th-order tensor from a specified value
@@ -76,21 +93,21 @@ public:
   ///
   explicit
   KOKKOS_INLINE_FUNCTION
-  Tensor4(Filler const value);
-
-  explicit
-  KOKKOS_INLINE_FUNCTION
   Tensor4(Index const dimension, Filler const value);
 
   ///
   /// Create 4th-order tensor from array
-  /// \param dimension the space dimension
   /// \param data_ptr pointer into the array
   ///
   explicit
   KOKKOS_INLINE_FUNCTION
   Tensor4(T const * data_ptr);
 
+  ///
+  /// Create 4th-order tensor from array
+  /// \param dimension the space dimension
+  /// \param data_ptr pointer into the array
+  ///
   explicit
   KOKKOS_INLINE_FUNCTION
   Tensor4(Index const dimension, T const * data_ptr);
@@ -271,6 +288,9 @@ KOKKOS_INLINE_FUNCTION
 Tensor4<T, N> const
 identity_1();
 
+///
+/// 4th-order identity I1: \f$ \delta_{ik} \delta_{jl} \f$ such that \f$ A = I_1 A \f$.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor4<T, DYNAMIC> const
@@ -290,6 +310,9 @@ KOKKOS_INLINE_FUNCTION
 Tensor4<T, N> const
 identity_2();
 
+///
+/// 4th-order identity I2: \f$ \delta_{il} \delta_{jk} \f$ such that \f$ A^T = I_2 A \f$.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor4<T, DYNAMIC> const
@@ -309,6 +332,9 @@ KOKKOS_INLINE_FUNCTION
 Tensor4<T, N> const
 identity_3();
 
+///
+/// 4th-order identity I3: \f$ \delta_{ij} \delta_{kl} \f$ such that \f$ I_A I = I_3 A \f$.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor4<T, DYNAMIC> const
@@ -1106,6 +1132,9 @@ identity_1(Index const dimension)
   return I;
 }
 
+///
+/// 4th-order identity I1: \f$ \delta_{ik} \delta_{jl} \f$ such that \f$ A = I_1 A \f$.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor4<T, N> const
@@ -1142,6 +1171,9 @@ identity_2(Index const dimension)
   return I;
 }
 
+///
+/// 4th-order identity I2: \f$ \delta_{il} \delta_{jk} \f$ such that \f$ A^T = I_2 A \f$.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor4<T, N> const
@@ -1178,6 +1210,9 @@ identity_3(Index const dimension)
   return I;
 }
 
+///
+/// 4th-order identity I3: \f$ \delta_{ij} \delta_{kl} \f$ such that \f$ I_A I = I_3 A \f$.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor4<T, N> const
@@ -1204,6 +1239,9 @@ levi_civita_4()
   return A;
 }
 
+///
+/// Levi-Civita symbol as a 4th-order tensor.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor4<T, DYNAMIC> const
@@ -1217,6 +1255,9 @@ levi_civita_4(Index const dimension)
   return A;
 }
 
+///
+/// Levi-Civita symbol as a 4th-order tensor.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor4<T, N> const
@@ -1243,6 +1284,9 @@ permutation_4()
   return levi_civita_4<T, N>();
 }
 
+///
+/// Permutation symbol as a 4th-order tensor; alias of levi_civita_4.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor4<T, DYNAMIC> const
@@ -1251,6 +1295,9 @@ permutation_4(Index const dimension)
   return levi_civita_4<T>(dimension);
 }
 
+///
+/// Permutation symbol as a 4th-order tensor; alias of levi_civita_4.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor4<T, N> const
@@ -1270,6 +1317,9 @@ alternator_4()
   return levi_civita_4<T, N>();
 }
 
+///
+/// Alternator as a 4th-order tensor; alias of levi_civita_4.
+///
 template<typename T>
 KOKKOS_INLINE_FUNCTION
 Tensor4<T, DYNAMIC> const
@@ -1279,6 +1329,9 @@ alternator_4(Index const dimension)
 }
 
 
+///
+/// Alternator as a 4th-order tensor; alias of levi_civita_4.
+///
 template<typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor4<T, N> const
@@ -1731,6 +1784,10 @@ dot_t(Tensor4<T, N> const & A, Tensor<S, N> const & B)
 //
 // \return \f$ C = A \cdot B := C_{ijkl} = A_{ip} B_{pjkl} \f$
 //
+///
+/// 2nd-order by 4th-order dot product.
+/// \return \f$ C_{ijkl} = A_{ip} B_{pjkl} \f$
+///
 template<typename S, typename T, Index N>
 KOKKOS_INLINE_FUNCTION
 Tensor4<typename Promote<S, T>::type, N>
@@ -2097,6 +2154,7 @@ operator<<(std::ostream & os, Tensor4<T, N> const & A)
   return os;
 }
 
+/// @}
 } // namespace minitensor
 
 #endif //MiniTensor_Tensor4_h

--- a/packages/minitensor/src/MiniTensor_TensorBase.h
+++ b/packages/minitensor/src/MiniTensor_TensorBase.h
@@ -20,6 +20,9 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_containers
+/// @{
+
 ///
 /// Type for setting components all at once
 ///
@@ -78,6 +81,7 @@ public:
   ///
   /// Constructor that initializes to NaNs
   /// \param dimension the space dimension
+  /// \param order the tensor order
   ///
   explicit
   KOKKOS_INLINE_FUNCTION
@@ -86,6 +90,7 @@ public:
   ///
   /// Create with specified value
   /// \param dimension the space dimension
+  /// \param order the tensor order
   /// \param value all components are set equal to this
   ///
   KOKKOS_INLINE_FUNCTION
@@ -94,6 +99,7 @@ public:
   ///
   /// Create from a scalar
   /// \param dimension the space dimension
+  /// \param order the tensor order
   /// \param s all components are set equal to this value
   ///
   KOKKOS_INLINE_FUNCTION
@@ -102,7 +108,9 @@ public:
   ///
   /// Create from array
   /// \param dimension the space dimension
-  /// \param data_ptr pointer into the array
+  /// \param order the tensor order
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
   ///
   // TensorBase for Kokkos Data Types (we can 't use pointers with Kokkos::View)
   template<class ArrayT>
@@ -113,6 +121,14 @@ public:
       ArrayT & data,
       Index index1);
 
+  ///
+  /// Create from array
+  /// \param dimension the space dimension
+  /// \param order the tensor order
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   TensorBase(
@@ -122,6 +138,15 @@ public:
       Index index1,
       Index index2);
 
+  ///
+  /// Create from array
+  /// \param dimension the space dimension
+  /// \param order the tensor order
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   TensorBase(
@@ -132,6 +157,16 @@ public:
       Index index2,
       Index index3);
 
+  ///
+  /// Create from array
+  /// \param dimension the space dimension
+  /// \param order the tensor order
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  /// \param index4 fourth fixed index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   TensorBase(
@@ -143,6 +178,17 @@ public:
       Index index3,
       Index index4);
 
+  ///
+  /// Create from array
+  /// \param dimension the space dimension
+  /// \param order the tensor order
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  /// \param index4 fourth fixed index into the array
+  /// \param index5 fifth fixed index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   TensorBase(
@@ -155,6 +201,18 @@ public:
       Index index4,
       Index index5);
 
+  ///
+  /// Create from array
+  /// \param dimension the space dimension
+  /// \param order the tensor order
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  /// \param index4 fourth fixed index into the array
+  /// \param index5 fifth fixed index into the array
+  /// \param index6 sixth fixed index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   TensorBase(
@@ -169,6 +227,12 @@ public:
       Index index6);
 
   //TensorBase for Shards and other data Types
+  ///
+  /// Create from array defined by pointer.
+  /// \param dimension the space dimension
+  /// \param order the tensor order
+  /// \param data_ptr pointer into the array
+  ///
   KOKKOS_INLINE_FUNCTION
   TensorBase(Index const dimension, Index const order, T const * data_ptr);
   ///
@@ -219,7 +283,7 @@ public:
 
   ///
   /// Fill components with value
-  /// \param value all components are set equal to this parameter
+  /// \param s all components are set equal to this value
   ///
   KOKKOS_INLINE_FUNCTION
   void
@@ -227,7 +291,8 @@ public:
 
   ///
   /// Fill components from array defined by pointer.
-  /// \param data_ptr pointer into array for filling components
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
   ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
@@ -236,6 +301,12 @@ public:
       ArrayT & data,
       Index index1);
 
+  ///
+  /// Fill components from array.
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   void
@@ -244,6 +315,13 @@ public:
       Index index1,
       Index index2);
 
+  ///
+  /// Fill components from array.
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   void
@@ -253,6 +331,14 @@ public:
       Index index2,
       Index index3);
 
+  ///
+  /// Fill components from array.
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  /// \param index4 fourth fixed index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   void
@@ -263,6 +349,15 @@ public:
       Index index3,
       Index index4);
 
+  ///
+  /// Fill components from array.
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  /// \param index4 fourth fixed index into the array
+  /// \param index5 fifth fixed index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   void
@@ -274,6 +369,16 @@ public:
       Index index4,
       Index index5);
 
+  ///
+  /// Fill components from array.
+  /// \param data array to copy components from
+  /// \param index1 first fixed index into the array
+  /// \param index2 second fixed index into the array
+  /// \param index3 third fixed index into the array
+  /// \param index4 fourth fixed index into the array
+  /// \param index5 fifth fixed index into the array
+  /// \param index6 sixth fixed index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   void
@@ -286,6 +391,10 @@ public:
       Index index5,
       Index index6);
 
+  ///
+  /// Fill components from array defined by pointer.
+  /// \param data_ptr pointer into array for filling components
+  ///
   KOKKOS_INLINE_FUNCTION
   void fill(T const * data_ptr);
 
@@ -1738,6 +1847,7 @@ namespace minitensor {
 
 // Placeholder for now.
 
+/// @}
 } // namespace minitensor
 
 #endif //MiniTensor_TensorBase_h

--- a/packages/minitensor/src/MiniTensor_TestFunctions.h
+++ b/packages/minitensor/src/MiniTensor_TestFunctions.h
@@ -14,6 +14,9 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_solvers
+/// @{
+
 //
 // Define some nonlinear systems (NLS) to test nonlinear solution methods.
 //
@@ -21,22 +24,40 @@ namespace minitensor {
 //
 //
 //
+///
+/// Square root NLS: the residual is \f$ r(x) = x^2 - c \f$,
+/// whose root is \f$ x = \sqrt{c} \f$. One-dimensional test
+/// for nonlinear system solvers.
+///
 template<typename S, Index M = 1>
 class SquareRoot : public Function_Base<SquareRoot<S, M>, S, M>
 {
 public:
 
+  ///
+  /// Constructor.
+  /// \param c Value whose square root is sought.
+  ///
   SquareRoot(S const c) : c_(c)
   {
   }
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Square Root"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<SquareRoot<S, M>, S, M>;
 
   // Default value.
+  ///
+  /// Objective value.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & x)
@@ -45,6 +66,9 @@ public:
   }
 
   // Explicit gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x) const
@@ -63,6 +87,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -71,6 +98,9 @@ public:
   }
 
 private:
+  ///
+  /// Value whose square root is sought.
+  ///
   S const
   c_{0.0};
 };
@@ -78,21 +108,41 @@ private:
 //
 //
 //
+///
+/// Quadratic NLS: the residual is the gradient of
+/// \f$ c((x_1-a)^2 + (x_2-b)^2) \f$. Two-dimensional, convex,
+/// single minimum at \f$ (a, b) \f$.
+///
 template<typename S, Index M = 2>
 class Quadratic : public Function_Base<Quadratic<S, M>, S, M>
 {
 public:
+  ///
+  /// Constructor.
+  /// \param a First coordinate of the minimizer.
+  /// \param b Second coordinate of the minimizer.
+  /// \param c Curvature scale factor.
+  ///
   Quadratic(S const a, S const b, S const c) :  a_(a), b_(b), c_(c)
   {
   }
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Quadratic"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<Quadratic<S, M>, S, M>;
 
   // Default value.
+  ///
+  /// Objective value.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & x)
@@ -101,6 +151,9 @@ public:
   }
 
   // Explicit gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x) const
@@ -120,6 +173,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -128,12 +184,21 @@ public:
   }
 
 private:
+  ///
+  /// First coordinate of the minimizer.
+  ///
   S const
   a_{0.0};
 
+  ///
+  /// Second coordinate of the minimizer.
+  ///
   S const
   b_{0.0};
 
+  ///
+  /// Curvature scale factor.
+  ///
   S const
   c_{0.0};
 };
@@ -141,21 +206,42 @@ private:
 //
 //
 //
+///
+/// Inverted Gaussian NLS: the residual is the gradient of
+/// \f$ -e^{-c^2((x_1-a)^2+(x_2-b)^2)} \f$ scaled by
+/// \f$ c \f$. Two-dimensional; minimum at \f$ (a, b) \f$,
+/// nearly flat away from it, stressing globalization.
+///
 template<typename S, Index M = 2>
 class Gaussian : public Function_Base<Gaussian<S, M>, S, M>
 {
 public:
+  ///
+  /// Constructor.
+  /// \param a First coordinate of the center (minimizer).
+  /// \param b Second coordinate of the center (minimizer).
+  /// \param c Inverse width of the Gaussian.
+  ///
   Gaussian(S const a, S const b, S const c) : a_(a), b_(b), c_(c)
   {
   }
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Inverted Gaussian"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<Gaussian<S, M>, S, M>;
 
   // Default value.
+  ///
+  /// Objective value.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & x)
@@ -164,6 +250,9 @@ public:
   }
 
   // Explicit gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x) const
@@ -192,6 +281,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -200,12 +292,21 @@ public:
   }
 
 private:
+  ///
+  /// First coordinate of the center.
+  ///
   S const
   a_{0.0};
 
+  ///
+  /// Second coordinate of the center.
+  ///
   S const
   b_{0.0};
 
+  ///
+  /// Inverse width of the Gaussian.
+  ///
   S const
   c_{0.0};
 };
@@ -213,22 +314,40 @@ private:
 //
 //
 //
+///
+/// Rosenbrock's banana function as an NLS: the residual is
+/// the gradient of \f$ (1-x_1)^2 + 100(x_2-x_1^2)^2 \f$.
+/// Two-dimensional; its curved, flat-bottomed valley stresses
+/// step control. Minimum at \f$ (1, 1) \f$.
+///
 template<typename S, Index M = 2>
 class Banana : public Function_Base<Banana<S, M>, S, M>
 {
 public:
 
+  ///
+  /// Constructor.
+  ///
   Banana()
   {
   }
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Rosenbrock's Banana"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<Banana<S, M>, S, M>;
 
   // Default value.
+  ///
+  /// Objective value.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & x)
@@ -237,6 +356,9 @@ public:
   }
 
   // Explicit gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x) const
@@ -256,6 +378,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -268,20 +393,38 @@ public:
 //
 //
 //
+///
+/// Matyas function NLS: the residual is the gradient of
+/// \f$ 0.26(x_1^2+x_2^2) - 0.48 x_1 x_2 \f$.
+/// Two-dimensional, convex but ill-conditioned; minimum at
+/// the origin.
+///
 template<typename S, Index M = 2>
 class Matyas : public Function_Base<Matyas<S, M>, S, M>
 {
 public:
 
+  ///
+  /// Constructor.
+  ///
   Matyas() {}
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Matyas"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<Matyas<S, M>, S, M>;
 
   // Default value.
+  ///
+  /// Objective value.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & x)
@@ -290,6 +433,9 @@ public:
   }
 
   // Explicit gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x) const
@@ -309,6 +455,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -321,20 +470,38 @@ public:
 //
 //
 //
+///
+/// McCormick function NLS: the residual is the gradient of
+/// \f$ \sin(x_1+x_2) + (x_1-x_2)^2 - 1.5 x_1
+/// + 2.5 x_2 + 1 \f$. Two-dimensional with multiple minima;
+/// global minimum near \f$ (-0.547, -1.547) \f$.
+///
 template<typename S, Index M = 2>
 class McCormick : public Function_Base<McCormick<S, M>, S, M>
 {
 public:
 
+  ///
+  /// Constructor.
+  ///
   McCormick() {}
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"McCormick"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<McCormick<S, M>, S, M>;
 
   // Default value.
+  ///
+  /// Objective value.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & x)
@@ -343,6 +510,9 @@ public:
   }
 
   // Explicit gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x) const
@@ -362,6 +532,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -374,20 +547,40 @@ public:
 //
 //
 //
+///
+/// Styblinski-Tang function NLS: the residual is the
+/// gradient of
+/// \f$ \frac{1}{2}\sum_{i=1}^{2}
+/// (x_i^4 - 16 x_i^2 + 5 x_i) \f$.
+/// Two-dimensional with multiple local minima; global
+/// minimum at \f$ x_i \approx -2.9035 \f$.
+///
 template<typename S, Index M = 2>
 class StyblinskiTang : public Function_Base<StyblinskiTang<S, M>, S, M>
 {
 public:
 
+  ///
+  /// Constructor.
+  ///
   StyblinskiTang() {}
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Styblinski-Tang"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<StyblinskiTang<S, M>, S, M>;
 
   // Default value.
+  ///
+  /// Objective value.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & x)
@@ -396,6 +589,9 @@ public:
   }
 
   // Explicit gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x) const
@@ -415,6 +611,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -431,22 +630,41 @@ public:
 //
 // Paraboloid of revolution
 //
+///
+/// Paraboloid of revolution
+/// \f$ (x_1-x_c)^2 + (x_2-y_c)^2 \f$. Two-dimensional,
+/// convex, single minimum at \f$ (x_c, y_c) \f$.
+///
 template<typename S, Index M = 2>
 class Paraboloid : public Function_Base<Paraboloid<S, M>, S, M>
 {
 public:
 
+  ///
+  /// Constructor.
+  /// \param xc First coordinate of the minimizer.
+  /// \param yc Second coordinate of the minimizer.
+  ///
   Paraboloid(S xc = 0.0, S yc = 0.0) : xc_(xc), yc_(yc)
   {
   }
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Paraboloid"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<Paraboloid<S, M>, S, M>;
 
   // Explicit value.
+  ///
+  /// Objective value.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & x)
@@ -466,6 +684,9 @@ public:
   }
 
   // Default AD gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x)
@@ -474,6 +695,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -482,9 +706,15 @@ public:
   }
 
 private:
+  ///
+  /// First coordinate of the minimizer.
+  ///
   S
   xc_{0.0};
 
+  ///
+  /// Second coordinate of the minimizer.
+  ///
   S
   yc_{0.0};
 };
@@ -492,22 +722,43 @@ private:
 //
 //
 //
+///
+/// Rosenbrock's function \f$ (a-x_1)^2 + b(x_2-x_1^2)^2 \f$
+/// with defaults \f$ a=1, b=100 \f$. Two-dimensional; its
+/// curved banana valley stresses line search and step
+/// control. Minimum at \f$ (a, a^2) \f$.
+///
 template<typename S, Index M = 2>
 class Rosenbrock : public Function_Base<Rosenbrock<S, M>, S, M>
 {
 public:
 
+  ///
+  /// Constructor.
+  /// \param a Location parameter; the minimizer is
+  /// \f$ (a, a^2) \f$.
+  /// \param b Weight of the valley (coupling) term.
+  ///
   Rosenbrock(S a = 1.0, S b = 100.0) : a_(a), b_(b)
   {
   }
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Rosenbrock's Function 2D"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<Rosenbrock<S, M>, S, M>;
 
   // Explicit value.
+  ///
+  /// Objective value.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & x)
@@ -522,6 +773,9 @@ public:
   }
 
   // Default AD gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x)
@@ -530,6 +784,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -538,9 +795,15 @@ public:
   }
 
 private:
+  ///
+  /// Location parameter.
+  ///
   S
   a_{1.0};
 
+  ///
+  /// Weight of the valley (coupling) term.
+  ///
   S
   b_{100.0};
 };
@@ -548,20 +811,37 @@ private:
 //
 // Beale's function
 //
+///
+/// Beale's function \f$ (1.5-x+xy)^2 + (2.25-x+xy^2)^2
+/// + (2.625-x+xy^3)^2 \f$. Two-dimensional with sharp
+/// curved valleys; minimum at \f$ (3, 0.5) \f$.
+///
 template<typename S, Index M = 2>
 class Beale : public Function_Base<Beale<S, M>, S, M>
 {
 public:
 
+  ///
+  /// Constructor.
+  ///
   Beale() {}
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Beale"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<Beale<S, M>, S, M>;
 
   // Explicit value.
+  ///
+  /// Objective value.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & X)
@@ -590,6 +870,9 @@ public:
   }
 
   // Default AD gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x)
@@ -598,6 +881,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -610,20 +896,37 @@ public:
 //
 // Booth's function
 //
+///
+/// Booth's function \f$ (x+2y-7)^2 + (2x+y-5)^2 \f$.
+/// Two-dimensional, convex quadratic; minimum at
+/// \f$ (1, 3) \f$.
+///
 template<typename S, Index M = 2>
 class Booth : public Function_Base<Booth<S, M>, S, M>
 {
 public:
 
+  ///
+  /// Constructor.
+  ///
   Booth() {}
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Booth"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<Booth<S, M>, S, M>;
 
   // Explicit value.
+  ///
+  /// Objective value.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & X)
@@ -649,6 +952,9 @@ public:
   }
 
   // Default AD gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x)
@@ -657,6 +963,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -669,20 +978,39 @@ public:
 //
 // Goldstein-Price function
 //
+///
+/// Goldstein-Price function
+/// \f$ [1+(x+y+1)^2(19-14x+3x^2-14y+6xy+3y^2)] \f$
+/// \f$ [30+(2x-3y)^2(18-32x+12x^2+48y-36xy+27y^2)] \f$.
+/// Two-dimensional with several local minima; global
+/// minimum of 3 at \f$ (0, -1) \f$.
+///
 template<typename S, Index M = 2>
 class GoldsteinPrice : public Function_Base<GoldsteinPrice<S, M>, S, M>
 {
 public:
 
+  ///
+  /// Constructor.
+  ///
   GoldsteinPrice() {}
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Goldstein-Price"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<GoldsteinPrice<S, M>, S, M>;
 
   // Explicit value.
+  ///
+  /// Objective value.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & X)
@@ -720,6 +1048,9 @@ public:
   }
 
   // Default AD gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x)
@@ -728,6 +1059,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -740,20 +1074,38 @@ public:
 //
 // Failure function to test failed mechanism
 //
+///
+/// Function that always reports failure: value() sets the
+/// failed flag and returns zero. One-dimensional; exercises
+/// the solvers' failure detection mechanism.
+///
 template<typename S, Index M = 1>
 class Failure : public Function_Base<Failure<S, M>, S, M>
 {
 public:
 
+  ///
+  /// Constructor.
+  ///
   Failure() {}
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Failure"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<Failure<S, M>, S, M>;
 
   // Explicit value.
+  ///
+  /// Objective value; flags an unrecoverable failure and
+  /// returns zero.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & X)
@@ -768,6 +1120,9 @@ public:
   }
 
   // Default AD gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x)
@@ -776,6 +1131,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -788,20 +1146,38 @@ public:
 //
 // Non-monotonic function to test monotonicity enforcement.
 //
+///
+/// Mesa function: \f$ x^2 \f$ plus a plateau of height 100
+/// on \f$ [-1, 1] \f$. One-dimensional, discontinuous and
+/// non-monotonic near the origin; tests monotonicity
+/// enforcement.
+///
 template<typename S, Index M = 1>
 class Mesa : public Function_Base<Mesa<S, M>, S, M>
 {
 public:
 
+  ///
+  /// Constructor.
+  ///
   Mesa() {}
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Mesa"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<Mesa<S, M>, S, M>;
 
   // Explicit value.
+  ///
+  /// Objective value.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & X)
@@ -820,6 +1196,9 @@ public:
   }
 
   // Default AD gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x)
@@ -828,6 +1207,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -840,20 +1222,38 @@ public:
 //
 // Function to test boundedness or residual enforcement.
 //
+///
+/// Steep sigmoid-like monomial \f$ x^{33} \f$.
+/// One-dimensional, extremely flat near the origin and steep
+/// beyond \f$ |x| = 1 \f$; tests boundedness and residual
+/// enforcement.
+///
 template<typename S, Index M = 1>
 class Sigmoid : public Function_Base<Sigmoid<S, M>, S, M>
 {
 public:
 
+  ///
+  /// Constructor.
+  ///
   Sigmoid() {}
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Sigmoid"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Function_Base<Sigmoid<S, M>, S, M>;
 
   // Explicit value.
+  ///
+  /// Objective value.
+  ///
   template<typename T, Index N>
   T
   value(Vector<T, N> const & X)
@@ -883,6 +1283,9 @@ public:
   }
 
   // Default AD gradient.
+  ///
+  /// Gradient of the objective.
+  ///
   template<typename T, Index N>
   Vector<T, N>
   gradient(Vector<T, N> const & x)
@@ -891,6 +1294,9 @@ public:
   }
 
   // Default AD hessian.
+  ///
+  /// Hessian of the objective.
+  ///
   template<typename T, Index N>
   Tensor<T, N>
   hessian(Vector<T, N> const & x)
@@ -907,20 +1313,36 @@ public:
 //
 // Identity
 //
+///
+/// Identity map equality constraint \f$ c(x) = x \f$ with
+/// NC constraints in NV variables.
+///
 template<typename S, Index NC, Index NV>
 class Identity : public Equality_Constraint<Identity<S, NC, NV>, S, NC, NV>
 {
 public:
 
+  ///
+  /// Constructor.
+  ///
   Identity() {}
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Identity Map"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Equality_Constraint<Identity<S, NC, NV>, S, NC, NV>;
 
   // Explicit value.
+  ///
+  /// Constraint value.
+  ///
   template<typename T, Index N>
   Vector<T, NC>
   value(Vector<T, N> const & x)
@@ -930,6 +1352,9 @@ public:
   }
 
   // Default AD gradient.
+  ///
+  /// Gradient (Jacobian) of the constraint.
+  ///
   template<typename T, Index N>
   Matrix<T, NC, NV>
   gradient(Vector<T, N> const & x)
@@ -941,20 +1366,38 @@ public:
 //
 // A nonlinear function
 //
+///
+/// Nonlinear equality constraints, 3 equations in 5
+/// variables: \f$ x \cdot x - 10 \f$,
+/// \f$ x_2 x_3 - 5 x_4 x_5 \f$,
+/// \f$ x_1^3 + x_2^3 + 1 \f$.
+///
 template<typename S, Index NC = 3, Index NV = 5>
 class Nonlinear01 : public Equality_Constraint<Nonlinear01<S, NC, NV>, S, NC, NV>
 {
 public:
 
+  ///
+  /// Constructor.
+  ///
   Nonlinear01() {}
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Nonlinear 01"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Equality_Constraint<Nonlinear01<S, NC, NV>, S, NC, NV>;
 
   // Explicit value.
+  ///
+  /// Constraint value.
+  ///
   template<typename T, Index N = 5>
   Vector<T, NC>
   value(Vector<T, N> const & x)
@@ -974,6 +1417,9 @@ public:
   }
 
   // Default AD gradient.
+  ///
+  /// Gradient (Jacobian) of the constraint.
+  ///
   template<typename T, Index N = 5>
   Matrix<T, NC, NV>
   gradient(Vector<T, N> const & x)
@@ -985,24 +1431,45 @@ public:
 //
 // Circumference feasible region
 //
+///
+/// Circumference equality constraint
+/// \f$ r^2 - \|x - c\|^2 = 0 \f$: the feasible set is
+/// the circle of radius \f$ r \f$ centered at
+/// \f$ c = (x_c, y_c) \f$.
+///
 template<typename S, Index NC = 1, Index NV = 2>
 class Circumference : public Equality_Constraint<Circumference<S, NC, NV>, S, NC, NV>
 {
 public:
 
+  ///
+  /// Constructor.
+  /// \param r Radius of the circumference.
+  /// \param xc First coordinate of the center.
+  /// \param yc Second coordinate of the center.
+  ///
   Circumference(S const r, S const xc = S(0.0), S const yc = S(0.0)) : r_(r)
   {
     c_(0) = xc;
     c_(1) = yc;
   }
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Circumference"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Equality_Constraint<Circumference<S, NC, NV>, S, NC, NV>;
 
   // Explicit value.
+  ///
+  /// Constraint value.
+  ///
   template<typename T, Index N = 2>
   Vector<T, NC>
   value(Vector<T, N> const & x)
@@ -1018,6 +1485,9 @@ public:
   }
 
   // Default AD gradient.
+  ///
+  /// Gradient (Jacobian) of the constraint.
+  ///
   template<typename T, Index N = 2>
   Matrix<T, NC, NV>
   gradient(Vector<T, N> const & x)
@@ -1026,9 +1496,15 @@ public:
   }
 
 private:
+  ///
+  /// Radius of the circumference.
+  ///
   S
   r_{0.0};
 
+  ///
+  /// Center of the circumference.
+  ///
   Vector<S, NV>
   c_;
 };
@@ -1036,24 +1512,45 @@ private:
 //
 // Circle feasible region
 //
+///
+/// Circle (disk) inequality constraint
+/// \f$ r^2 - \|x - c\|^2 \geq 0 \f$: the feasible set
+/// is the closed disk of radius \f$ r \f$ centered at
+/// \f$ c = (x_c, y_c) \f$.
+///
 template<typename S, Index NC = 1, Index NV = 2>
 class Circle : public Inequality_Constraint<Circle<S, NC, NV>, S, NC, NV>
 {
 public:
 
+  ///
+  /// Constructor.
+  /// \param r Radius of the disk.
+  /// \param xc First coordinate of the center.
+  /// \param yc Second coordinate of the center.
+  ///
   Circle(S const r, S const xc = S(0.0), S const yc = S(0.0)) : r_(r)
   {
     c_(0) = xc;
     c_(1) = yc;
   }
 
+  ///
+  /// Function name.
+  ///
   static constexpr
   char const * const
   NAME{"Circle constraint"};
 
+  ///
+  /// Base class type.
+  ///
   using Base = Inequality_Constraint<Circle<S, NC, NV>, S, NC, NV>;
 
   // Explicit value.
+  ///
+  /// Constraint value.
+  ///
   template<typename T, Index N = 2>
   Vector<T, NC>
   value(Vector<T, N> const & x)
@@ -1069,6 +1566,9 @@ public:
   }
 
   // Default AD gradient.
+  ///
+  /// Gradient (Jacobian) of the constraint.
+  ///
   template<typename T, Index N = 2>
   Matrix<T, NC, NV>
   gradient(Vector<T, N> const & x)
@@ -1077,13 +1577,20 @@ public:
   }
 
 private:
+  ///
+  /// Radius of the disk.
+  ///
   S
   r_{0.0};
 
+  ///
+  /// Center of the disk.
+  ///
   Vector<S, NV>
   c_;
 };
 
+/// @}
 } // namespace minitensor
 
 #endif // MiniTensor_TestFunctions_h

--- a/packages/minitensor/src/MiniTensor_Traits.h
+++ b/packages/minitensor/src/MiniTensor_Traits.h
@@ -43,15 +43,24 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_traits
+/// @{
+
 /// Indexing type
 using Index = uint32_t;
 
+///
+/// Number of bits in Index.
+///
 constexpr Index
 INDEX_SIZE{32};
 
 /// High count type
 using LongIndex = uint64_t;
 
+///
+/// Number of bits in LongIndex.
+///
 constexpr Index
 LONG_INDEX_SIZE{64};
 
@@ -80,111 +89,162 @@ using Sacado::mpl::disable_if_c;
 /// Vector
 template <typename T>
 struct is_vector {
+  /// Whether T is a Vector.
   static bool const value = false;
 };
 
+/// is_vector specialization: T is a Vector.
 template <typename T, Index N>
 struct is_vector<Vector<T, N>> {
+  /// Whether T is a Vector.
   static bool const value = true;
 };
 
+///
+/// Metafunction that forms a Vector of dimension N whose element
+/// type is the nested type of the metafunction T.
+///
 template <typename T, Index N>
 struct apply_vector {
+  /// Vector with element type T::type.
   typedef Vector<typename T::type, N> type;
 };
 
 /// 2nd-order tensor
 template <typename T>
 struct is_tensor {
+  /// Whether T is a Tensor.
   static bool const value = false;
 };
 
+/// is_tensor specialization: T is a Tensor.
 template <typename T, Index N>
 struct is_tensor<Tensor<T, N>> {
+  /// Whether T is a Tensor.
   static bool const value = true;
 };
 
+///
+/// Metafunction that forms a Tensor of dimension N whose element
+/// type is the nested type of the metafunction T.
+///
 template <typename T, Index N>
 struct apply_tensor {
+  /// Tensor with element type T::type.
   typedef Tensor<typename T::type, N> type;
 };
 
 /// 3rd-order tensor
 template <typename T>
 struct is_tensor3 {
+  /// Whether T is a Tensor3.
   static bool const value = false;
 };
 
+/// is_tensor3 specialization: T is a Tensor3.
 template <typename T, Index N>
 struct is_tensor3<Tensor3<T, N>> {
+  /// Whether T is a Tensor3.
   static bool const value = true;
 };
 
+///
+/// Metafunction that forms a Tensor3 of dimension N whose element
+/// type is the nested type of the metafunction T.
+///
 template <typename T, Index N>
 struct apply_tensor3 {
+  /// Tensor3 with element type T::type.
   typedef Tensor3<typename T::type, N> type;
 };
 
 /// 4th-order tensor
 template <typename T>
 struct is_tensor4 {
+  /// Whether T is a Tensor4.
   static bool const value = false;
 };
 
+/// is_tensor4 specialization: T is a Tensor4.
 template <typename T, Index N>
 struct is_tensor4<Tensor4<T, N>> {
+  /// Whether T is a Tensor4.
   static bool const value = true;
 };
 
+///
+/// Metafunction that forms a Tensor4 of dimension N whose element
+/// type is the nested type of the metafunction T.
+///
 template <typename T, Index N>
 struct apply_tensor4 {
+  /// Tensor4 with element type T::type.
   typedef Tensor4<typename T::type, N> type;
 };
 
 /// Matrix
 template <typename T>
 struct is_matrix {
+  /// Whether T is a Matrix.
   static bool const value = false;
 };
 
+/// is_matrix specialization: T is a Matrix.
 template <typename T, Index M, Index N>
 struct is_matrix<Matrix<T, M, N>> {
+  /// Whether T is a Matrix.
   static bool const value = true;
 };
 
+///
+/// Metafunction that forms an M by N Matrix whose element type
+/// is the nested type of the metafunction T.
+///
 template <typename T, Index M, Index N>
 struct apply_matrix {
+  /// Matrix with element type T::type.
   typedef Matrix<typename T::type, M, N> type;
 };
 
 /// Tensors from 1st to 4th order and matrix
 template <typename T>
 struct order_1234 {
+  /// Whether T is a tensor of order 1 to 4 or a matrix.
   static bool const value = false;
 };
 
+/// order_1234 specialization for Vector.
 template <typename T, Index N>
 struct order_1234<Vector<T, N>> {
+  /// Whether T is a tensor of order 1 to 4 or a matrix.
   static bool const value = true;
 };
 
+/// order_1234 specialization for Tensor.
 template <typename T, Index N>
 struct order_1234<Tensor<T, N>> {
+  /// Whether T is a tensor of order 1 to 4 or a matrix.
   static bool const value = true;
 };
 
+/// order_1234 specialization for Tensor3.
 template <typename T, Index N>
 struct order_1234<Tensor3<T, N>> {
+  /// Whether T is a tensor of order 1 to 4 or a matrix.
   static bool const value = true;
 };
 
+/// order_1234 specialization for Tensor4.
 template <typename T, Index N>
 struct order_1234<Tensor4<T, N>> {
+ /// Whether T is a tensor of order 1 to 4 or a matrix.
  static bool const value = true;
   };                        
 
+/// order_1234 specialization for Matrix.
 template<typename T, Index M, Index N>
 struct order_1234<Matrix<T, M, N>>{
+  /// Whether T is a tensor of order 1 to 4 or a matrix.
   static bool const value = true;
 };
 
@@ -192,36 +252,52 @@ struct order_1234<Matrix<T, M, N>>{
 
 using std::string;
 
+///
+/// Compile-time conversion of a dimension N to a string, used by
+/// the Sacado StringName specializations below.
+///
 template<Index N>
 struct dimension_string {
+  /// Return "INVALID" for dimensions without a specialization.
   static string eval() {return string("INVALID");}
 };
 
+/// dimension_string specialization for DYNAMIC.
 template<>
 struct dimension_string<DYNAMIC> {
+  /// Return "DYNAMIC".
   static string eval() {return string("DYNAMIC");}
 };
 
+/// dimension_string specialization for dimension 1.
 template<>
 struct dimension_string<1> {
+  /// Return "1".
   static string eval() {return string("1");}
 };
 
+/// dimension_string specialization for dimension 2.
 template<>
 struct dimension_string<2> {
+  /// Return "2".
   static string eval() {return string("2");}
 };
 
+/// dimension_string specialization for dimension 3.
 template<>
 struct dimension_string<3> {
+  /// Return "3".
   static string eval() {return string("3");}
 };
 
+/// dimension_string specialization for dimension 4.
 template<>
 struct dimension_string<4> {
+  /// Return "4".
   static string eval() {return string("4");}
 };
 
+/// @}
 } // namespace minitensor
 
 namespace Sacado {
@@ -240,68 +316,93 @@ using std::string;
 /// Specialization of Promote for Index
 template<>
 struct Promote<double, Index> {
+  /// Promoted type.
   typedef double type;
 };
 
+/// Promote specialization for Index and double.
 template<>
 struct Promote<Index, double> {
+  /// Promoted type.
   typedef double type;
 };
 
+/// Promote specialization for float and Index.
 template<>
 struct Promote<float, Index> {
+  /// Promoted type.
   typedef float type;
 };
 
+/// Promote specialization for Index and float.
 template<>
 struct Promote<Index, float> {
+  /// Promoted type.
   typedef float type;
 };
 
+/// Promote specialization for complex<double> and Index.
 template<>
 struct Promote<complex<double>, Index> {
+  /// Promoted type.
   typedef complex<double> type;
 };
 
+/// Promote specialization for Index and complex<double>.
 template<>
 struct Promote<Index, complex<double>> {
+  /// Promoted type.
   typedef complex<double> type;
 };
 
+/// Promote specialization for complex<float> and Index.
 template<>
 struct Promote<complex<float>, Index> {
+  /// Promoted type.
   typedef complex<float> type;
 };
 
+/// Promote specialization for Index and complex<float>.
 template<>
 struct Promote<Index, complex<float>> {
+  /// Promoted type.
   typedef complex<float> type;
 };
 
 /// Sacado traits specializations for Vector
 template <typename T, Index N>
 struct ScalarType<Vector<T, N>> {
+  /// Underlying scalar type of the Vector components.
   typedef typename ScalarType<T>::type type;
 };
 
+/// Sacado ValueType specialization for Vector.
 template <typename T, Index N>
 struct ValueType<Vector<T, N>> {
+  /// Value type of the Vector components.
   typedef typename ValueType<T>::type type;
 };
 
+/// Sacado IsADType specialization for Vector.
 template <typename T, Index N>
 struct IsADType<Vector<T, N>> {
+  /// Whether the component type is an AD type.
   static bool const value = IsADType<T>::value;
 };
 
+/// Sacado IsScalarType specialization for Vector.
 template <typename T, Index N>
 struct IsScalarType<Vector<T, N>> {
+  /// Whether the component type is a scalar type.
   static bool const value = IsScalarType<T>::value;
 };
 
+/// Sacado Value specialization for Vector.
 template <typename T, Index N>
 struct Value<Vector<T, N>> {
+  /// Value type of the Vector components.
   typedef typename ValueType<Vector<T, N>>::type value_type;
+  /// Extract a Vector of the values of the components of x.
   static const Vector<value_type, N>
   eval(Vector<T, N> const & x)
   {
@@ -315,9 +416,13 @@ struct Value<Vector<T, N>> {
   }
 };
 
+/// Sacado ScalarValue specialization for Vector.
 template <typename T, Index N>
 struct ScalarValue<Vector<T, N>> {
+  /// Scalar type of the Vector components.
   typedef typename ScalarType<Vector<T, N>>::type scalar_type;
+  /// Extract a Vector of the scalar values of the components
+  /// of x.
   static const Vector<scalar_type, N>
   eval(Vector<T, N> const & x)
   {
@@ -330,8 +435,10 @@ struct ScalarValue<Vector<T, N>> {
   }
 };
 
+/// Sacado StringName specialization for Vector.
 template <typename T, Index N>
 struct StringName<Vector<T, N>> {
+  /// Return the name of the Vector type as a string.
   static string
   eval()
   {
@@ -340,46 +447,62 @@ struct StringName<Vector<T, N>> {
   }
 };
 
+/// Sacado IsEqual specialization for Vector.
 template <typename T, Index N>
 struct IsEqual<Vector<T, N>> {
+  /// Compare two components for equality.
   static bool eval(T const & x, T const & y) { return x == y; }
 };
 
+/// Sacado IsStaticallySized specialization for Vector.
 template <typename T, Index N>
 struct IsStaticallySized<Vector<T, N>> {
+  /// True: the dimension is fixed at compile time.
   static bool const value = true;
 };
 
+/// Sacado IsStaticallySized specialization for dynamic Vector.
 template <typename T>
 struct IsStaticallySized<Vector<T, DYNAMIC>>
 {
+  /// False: the dimension is determined at run time.
   static bool const value = false;
 };
 
 /// Sacado traits specializations for Tensor
 template <typename T, Index N>
 struct ScalarType<Tensor<T, N>> {
+  /// Underlying scalar type of the Tensor components.
   typedef typename ScalarType<T>::type type;
 };
 
+/// Sacado ValueType specialization for Tensor.
 template <typename T, Index N>
 struct ValueType<Tensor<T, N>> {
+  /// Value type of the Tensor components.
   typedef typename ValueType<T>::type type;
 };
 
+/// Sacado IsADType specialization for Tensor.
 template <typename T, Index N>
 struct IsADType<Tensor<T, N>> {
+  /// Whether the component type is an AD type.
   static bool const value = IsADType<T>::value;
 };
 
+/// Sacado IsScalarType specialization for Tensor.
 template <typename T, Index N>
 struct IsScalarType<Tensor<T, N>> {
+  /// Whether the component type is a scalar type.
   static bool const value = IsScalarType<T>::value;
 };
 
+/// Sacado Value specialization for Tensor.
 template <typename T, Index N>
 struct Value<Tensor<T, N>> {
+  /// Value type of the Tensor components.
   typedef typename ValueType<Tensor<T, N>>::type value_type;
+  /// Extract a Tensor of the values of the components of x.
   static const Tensor<value_type, N>
   eval(Tensor<T, N> const & x)
   {
@@ -393,9 +516,13 @@ struct Value<Tensor<T, N>> {
   }
 };
 
+/// Sacado ScalarValue specialization for Tensor.
 template <typename T, Index N>
 struct ScalarValue<Tensor<T, N>> {
+  /// Scalar type of the Tensor components.
   typedef typename ScalarType<Tensor<T, N>>::type scalar_type;
+  /// Extract a Tensor of the scalar values of the components
+  /// of x.
   static const Tensor<scalar_type, N>
   eval(Tensor<T, N> const & x)
   {
@@ -409,8 +536,10 @@ struct ScalarValue<Tensor<T, N>> {
   }
 };
 
+/// Sacado StringName specialization for Tensor.
 template <typename T, Index N>
 struct StringName<Tensor<T, N>> {
+  /// Return the name of the Tensor type as a string.
   static string
   eval()
   {
@@ -419,46 +548,62 @@ struct StringName<Tensor<T, N>> {
   }
 };
 
+/// Sacado IsEqual specialization for Tensor.
 template <typename T, Index N>
 struct IsEqual<Tensor<T, N>> {
+  /// Compare two components for equality.
   static bool eval(T const & x, T const & y) { return x == y; }
 };
 
+/// Sacado IsStaticallySized specialization for Tensor.
 template <typename T, Index N>
 struct IsStaticallySized<Tensor<T, N>> {
+  /// True: the dimension is fixed at compile time.
   static bool const value = true;
 };
 
+/// Sacado IsStaticallySized specialization for dynamic Tensor.
 template <typename T>
 struct IsStaticallySized<Tensor<T, DYNAMIC>>
 {
+  /// False: the dimension is determined at run time.
   static bool const value = false;
 };
 
 /// Sacado traits specializations for Tensor3
 template <typename T, Index N>
 struct ScalarType<Tensor3<T, N>> {
+  /// Underlying scalar type of the Tensor3 components.
   typedef typename ScalarType<T>::type type;
 };
 
+/// Sacado ValueType specialization for Tensor3.
 template <typename T, Index N>
 struct ValueType<Tensor3<T, N>> {
+  /// Value type of the Tensor3 components.
   typedef typename ValueType<T>::type type;
 };
 
+/// Sacado IsADType specialization for Tensor3.
 template <typename T, Index N>
 struct IsADType<Tensor3<T, N>> {
+  /// Whether the component type is an AD type.
   static bool const value = IsADType<T>::value;
 };
 
+/// Sacado IsScalarType specialization for Tensor3.
 template <typename T, Index N>
 struct IsScalarType<Tensor3<T, N>> {
+  /// Whether the component type is a scalar type.
   static bool const value = IsScalarType<T>::value;
 };
 
+/// Sacado Value specialization for Tensor3.
 template <typename T, Index N>
 struct Value<Tensor3<T, N>> {
+  /// Value type of the Tensor3 components.
   typedef typename ValueType<Tensor3<T, N>>::type value_type;
+  /// Extract a Tensor3 of the values of the components of x.
   static const Tensor3<value_type, N>
   eval(Tensor3<T, N> const & x)
   {
@@ -472,9 +617,13 @@ struct Value<Tensor3<T, N>> {
   }
 };
 
+/// Sacado ScalarValue specialization for Tensor3.
 template <typename T, Index N>
 struct ScalarValue<Tensor3<T, N>> {
+  /// Scalar type of the Tensor3 components.
   typedef typename ScalarType<Tensor3<T, N>>::type scalar_type;
+  /// Extract a Tensor3 of the scalar values of the components
+  /// of x.
   static const Tensor3<scalar_type, N>
   eval(Tensor3<T, N> const & x)
   {
@@ -488,8 +637,10 @@ struct ScalarValue<Tensor3<T, N>> {
   }
 };
 
+/// Sacado StringName specialization for Tensor3.
 template <typename T, Index N>
 struct StringName<Tensor3<T, N>> {
+  /// Return the name of the Tensor3 type as a string.
   static string
   eval()
   {
@@ -498,47 +649,63 @@ struct StringName<Tensor3<T, N>> {
   }
 };
 
+/// Sacado IsEqual specialization for Tensor3.
 template <typename T, Index N>
 struct IsEqual<Tensor3<T, N>> {
+  /// Compare two components for equality.
   static bool eval(T const & x, T const & y) { return x == y; }
 };
 
+/// Sacado IsStaticallySized specialization for Tensor3.
 template <typename T, Index N>
 struct IsStaticallySized<Tensor3<T, N>>
 {
+  /// True: the dimension is fixed at compile time.
   static bool const value = true;
 };
 
+/// Sacado IsStaticallySized specialization for dynamic Tensor3.
 template <typename T>
 struct IsStaticallySized<Tensor3<T, DYNAMIC>>
 {
+  /// False: the dimension is determined at run time.
   static bool const value = false;
 };
 
 /// Sacado traits specializations for Tensor4
 template <typename T, Index N>
 struct ScalarType<Tensor4<T, N>> {
+  /// Underlying scalar type of the Tensor4 components.
   typedef typename ScalarType<T>::type type;
 };
 
+/// Sacado ValueType specialization for Tensor4.
 template <typename T, Index N>
 struct ValueType<Tensor4<T, N>> {
+  /// Value type of the Tensor4 components.
   typedef typename ValueType<T>::type type;
 };
 
+/// Sacado IsADType specialization for Tensor4.
 template <typename T, Index N>
 struct IsADType<Tensor4<T, N>> {
+  /// Whether the component type is an AD type.
   static bool const value = IsADType<T>::value;
 };
 
+/// Sacado IsScalarType specialization for Tensor4.
 template <typename T, Index N>
 struct IsScalarType<Tensor4<T, N>> {
+  /// Whether the component type is a scalar type.
   static bool const value = IsScalarType<T>::value;
 };
 
+/// Sacado Value specialization for Tensor4.
 template <typename T, Index N>
 struct Value<Tensor4<T, N>> {
+  /// Value type of the Tensor4 components.
   typedef typename ValueType<Tensor4<T, N>>::type value_type;
+  /// Extract a Tensor4 of the values of the components of x.
   static const Tensor4<value_type, N>
   eval(Tensor4<T, N> const & x)
   {
@@ -552,9 +719,13 @@ struct Value<Tensor4<T, N>> {
   }
 };
 
+/// Sacado ScalarValue specialization for Tensor4.
 template <typename T, Index N>
 struct ScalarValue<Tensor4<T, N>> {
+  /// Scalar type of the Tensor4 components.
   typedef typename ScalarType<Tensor4<T, N>>::type scalar_type;
+  /// Extract a Tensor4 of the scalar values of the components
+  /// of x.
   static const Tensor4<scalar_type, N>
   eval(Tensor4<T, N> const & x)
   {
@@ -568,8 +739,10 @@ struct ScalarValue<Tensor4<T, N>> {
   }
 };
 
+/// Sacado StringName specialization for Tensor4.
 template <typename T, Index N>
 struct StringName<Tensor4<T, N>> {
+  /// Return the name of the Tensor4 type as a string.
   static string
   eval()
   {
@@ -578,47 +751,63 @@ struct StringName<Tensor4<T, N>> {
   }
 };
 
+/// Sacado IsEqual specialization for Tensor4.
 template <typename T, Index N>
 struct IsEqual<Tensor4<T, N>> {
+  /// Compare two components for equality.
   static bool eval(T const & x, T const & y) { return x == y; }
 };
 
+/// Sacado IsStaticallySized specialization for Tensor4.
 template <typename T, Index N>
 struct IsStaticallySized<Tensor4<T, N>>
 {
+  /// True: the dimension is fixed at compile time.
   static bool const value = true;
 };
 
+/// Sacado IsStaticallySized specialization for dynamic Tensor4.
 template <typename T>
 struct IsStaticallySized<Tensor4<T, DYNAMIC>>
 {
+ /// False: the dimension is determined at run time.
  static bool const value= false;
 };
 
 /// Sacado traits specializations for Matrix
 template <typename T, Index M, Index N>
 struct ScalarType<Matrix<T, M, N>> {
+  /// Underlying scalar type of the Matrix components.
   typedef typename ScalarType<T>::type type;
 };
 
+/// Sacado ValueType specialization for Matrix.
 template <typename T, Index M, Index N>
 struct ValueType<Matrix<T, M, N>> {
+  /// Value type of the Matrix components.
   typedef typename ValueType<T>::type type;
 };
 
+/// Sacado IsADType specialization for Matrix.
 template <typename T, Index M, Index N>
 struct IsADType<Matrix<T, M, N>> {
+  /// Whether the component type is an AD type.
   static bool const value = IsADType<T>::value;
 };
 
+/// Sacado IsScalarType specialization for Matrix.
 template <typename T, Index M, Index N>
 struct IsScalarType<Matrix<T, M, N>> {
+  /// Whether the component type is a scalar type.
   static bool const value = IsScalarType<T>::value;
 };
 
+/// Sacado Value specialization for Matrix.
 template <typename T, Index M, Index N>
 struct Value<Matrix<T, M, N>> {
+  /// Value type of the Matrix components.
   typedef typename ValueType<Matrix<T, M, N>>::type value_type;
+  /// Extract a Matrix of the values of the components of x.
   static const Matrix<value_type, M, N>
   eval(Matrix<T, M, N> const & x)
   {
@@ -632,9 +821,13 @@ struct Value<Matrix<T, M, N>> {
   }
 };
 
+/// Sacado ScalarValue specialization for Matrix.
 template <typename T, Index M, Index N>
 struct ScalarValue<Matrix<T, M, N>> {
+  /// Scalar type of the Matrix components.
   typedef typename ScalarType<Matrix<T, M, N>>::type scalar_type;
+  /// Extract a Matrix of the scalar values of the components
+  /// of x.
   static const Matrix<scalar_type, M, N>
   eval(Matrix<T, M, N> const & x)
   {
@@ -648,8 +841,10 @@ struct ScalarValue<Matrix<T, M, N>> {
   }
 };
 
+/// Sacado StringName specialization for Matrix.
 template <typename T, Index M, Index N>
 struct StringName<Matrix<T, M, N>> {
+  /// Return the name of the Matrix type as a string.
   static string
   eval()
   {
@@ -659,31 +854,44 @@ struct StringName<Matrix<T, M, N>> {
   }
 };
 
+/// Sacado IsEqual specialization for Matrix.
 template <typename T, Index M, Index N>
 struct IsEqual<Matrix<T, M, N>> {
+  /// Compare two components for equality.
   static bool eval(T const & x, T const & y) { return x == y; }
 };
 
+/// Sacado IsStaticallySized specialization for Matrix.
 template <typename T, Index M, Index N>
 struct IsStaticallySized<Matrix<T, M, N>> {
+  /// True: the dimensions are fixed at compile time.
   static bool const value = true;
 };
 
+/// Sacado IsStaticallySized specialization for Matrix with a
+/// dynamic number of columns.
 template <typename T, Index M>
 struct IsStaticallySized<Matrix<T, M, DYNAMIC>>
 {
+  /// False: the number of columns is determined at run time.
   static bool const value = false;
 };
 
+/// Sacado IsStaticallySized specialization for Matrix with a
+/// dynamic number of rows.
 template <typename T, Index N>
 struct IsStaticallySized<Matrix<T, DYNAMIC, N>>
 {
+  /// False: the number of rows is determined at run time.
   static bool const value = false;
 };
 
+/// Sacado IsStaticallySized specialization for Matrix with
+/// dynamic numbers of rows and columns.
 template <typename T>
 struct IsStaticallySized<Matrix<T, DYNAMIC, DYNAMIC>>
 {
+  /// False: the dimensions are determined at run time.
   static bool const value = false;
 };
 

--- a/packages/minitensor/src/MiniTensor_Vector.h
+++ b/packages/minitensor/src/MiniTensor_Vector.h
@@ -20,6 +20,12 @@
 
 namespace minitensor {
 
+/// \addtogroup minitensor_containers
+/// @{
+
+///
+/// Storage type alias for Vector.
+///
 template<typename T, Index N>
 using vector_store = Storage<T, dimension_power<N, 1>::value>;
 
@@ -63,33 +69,41 @@ public:
 
   ///
   /// Construction that initializes to NaNs
-  /// \param dimension the space dimension
   ///
   explicit
   KOKKOS_INLINE_FUNCTION
   Vector();
 
+  ///
+  /// Construction that initializes to NaNs.
+  /// \param dimension the space dimension
+  ///
   explicit
   KOKKOS_INLINE_FUNCTION
   Vector(Index const dimension);
 
   ///
   /// Create vector from a specified value
-  /// \param dimension the space dimension
   /// \param value all components are set equal to this
   ///
   explicit
   KOKKOS_INLINE_FUNCTION
   Vector(Filler const value);
 
+  ///
+  /// Create vector from a specified value.
+  /// \param dimension the space dimension
+  /// \param value all components are set equal to this
+  ///
   explicit
   KOKKOS_INLINE_FUNCTION
   Vector(Index const dimension, Filler const value);
 
   ///
   /// Create vector from array.
-  /// \param dimension the space dimension
-  /// \param data_ptr pointer into the array
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param data array with source components
+  /// \param index1 first index into the array
   ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
@@ -98,6 +112,13 @@ public:
       ArrayT & data,
       Index index1);
 
+  ///
+  /// Create vector from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Vector(
@@ -106,6 +127,14 @@ public:
       Index index1,
       Index index2);
 
+  ///
+  /// Create vector from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Vector(
@@ -115,6 +144,15 @@ public:
       Index index2,
       Index index3);
 
+  ///
+  /// Create vector from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  /// \param index4 fourth index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Vector(
@@ -125,6 +163,16 @@ public:
       Index index3,
       Index index4);
 
+  ///
+  /// Create vector from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  /// \param index4 fourth index into the array
+  /// \param index5 fifth index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Vector(
@@ -136,6 +184,17 @@ public:
       Index index4,
       Index index5);
 
+  ///
+  /// Create vector from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  /// \param index4 fourth index into the array
+  /// \param index5 fifth index into the array
+  /// \param index6 sixth index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Vector(
@@ -148,6 +207,13 @@ public:
       Index index5,
       Index index6);
 
+  ///
+  /// Create vector from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param dimension the space dimension
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Vector(
@@ -156,6 +222,14 @@ public:
       ArrayT & data,
       Index index1);
 
+  ///
+  /// Create vector from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param dimension the space dimension
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Vector(
@@ -165,6 +239,15 @@ public:
       Index index1,
       Index index2);
 
+  ///
+  /// Create vector from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param dimension the space dimension
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Vector(
@@ -175,6 +258,16 @@ public:
       Index index2,
       Index index3);
 
+  ///
+  /// Create vector from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param dimension the space dimension
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  /// \param index4 fourth index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Vector(
@@ -186,6 +279,17 @@ public:
       Index index3,
       Index index4);
 
+  ///
+  /// Create vector from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param dimension the space dimension
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  /// \param index4 fourth index into the array
+  /// \param index5 fifth index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION
   Vector(
@@ -198,6 +302,18 @@ public:
       Index index4,
       Index index5);
 
+  ///
+  /// Create vector from array.
+  /// \param source kind of data source (Source::ARRAY)
+  /// \param dimension the space dimension
+  /// \param data array with source components
+  /// \param index1 first index into the array
+  /// \param index2 second index into the array
+  /// \param index3 third index into the array
+  /// \param index4 fourth index into the array
+  /// \param index5 fifth index into the array
+  /// \param index6 sixth index into the array
+  ///
   template<class ArrayT>
   KOKKOS_INLINE_FUNCTION  
   Vector(
@@ -211,9 +327,18 @@ public:
       Index index5,
       Index index6);
 
+  ///
+  /// Create vector from array defined by pointer.
+  /// \param data_ptr pointer into the array
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector(T const * data_ptr);
 
+  ///
+  /// Create vector from array defined by pointer.
+  /// \param dimension the space dimension
+  /// \param data_ptr pointer into the array
+  ///
   KOKKOS_INLINE_FUNCTION
   Vector(Index const dimension, T const * data_ptr);
 
@@ -226,6 +351,7 @@ public:
   ///
   /// Create vector specifying components
   /// \param s0 s1 are the vector components in the R^2 canonical basis
+  /// \param s1 second vector component in the R^2 canonical basis
   ///
   KOKKOS_INLINE_FUNCTION
   Vector(T const & s0, T const & s1);
@@ -234,6 +360,8 @@ public:
   /// Create vector specifying components
   /// the vector components in the R^3 canonical basis
   /// \param s0 s1 s2 are the vector components in the R^3 canonical basis
+  /// \param s1 second vector component in the R^3 canonical basis
+  /// \param s2 third vector component in the R^3 canonical basis
   ///
   KOKKOS_INLINE_FUNCTION
   Vector(T const & s0, T const & s1, T const & s2);
@@ -1383,6 +1511,7 @@ operator<<(std::ostream & os, Vector<T, N> const & u)
   return os;
 }
 
+/// @}
 } // namespace minitensor
 
 #endif //MiniTensor_Vector_h


### PR DESCRIPTION
## What this PR does

Fourth step of the MiniTensor modernization (after #15523, #15527, #15529):
comprehensive Doxygen documentation. **Documentation only — every header is
token-identical to the compiler** (verified mechanically: stripping `///`
comment and blank lines reproduces the previous contents byte-for-byte).

- **Every public entity documented.** A doxygen audit (`WARN_IF_UNDOCUMENTED`
  with hiding disabled) reported ~860 undocumented classes, functions,
  members and typedefs; all now carry `///` doc comments in the package's
  established style, with formulas derived from the code where applicable
  (solver algorithms cite the same references the code does).
- **Module organization.** Ten Doxygen groups mirroring the module-header
  structure introduced in #15527/#15529: containers, traits/scalar
  utilities, norms, inverse, factorizations, matrix functions, rotations,
  geometry, mechanics, solvers. Each header carries an `\addtogroup` block.
- **Mainpage rewritten**: overview, module table, basic usage example, and
  working links — the previous page pointed at the retired trilinos.org
  address and `\verbinclude`'d a file that does not exist.
- **Pre-existing doc defects fixed**: 24 stale `\param` lines naming
  nonexistent arguments; "multi-name" `\param` idioms (`\param c and s ...`)
  that left parameters undocumented; malformed `\param \f$...` constructs
  doxygen could not parse.
- **Doxyfile.options**: internal `minitensor::impl` namespace excluded from
  generated docs; MathJax repointed to a live CDN (the configured
  `cdn.mathjax.org` no longer exists, silently breaking every formula);
  `WARN_IF_DOC_ERROR` enabled.
- **README.md**: "Headers: include what you need" module table.
- **doc/README.md**: publishing instructions (generated HTML goes to
  `docs/minitensor/` in the trilinos.github.io repository, matching how
  other packages publish).

## Verification

- Doxygen runs with **zero warnings** in both the strict audit
  configuration and the publish configuration, and the generated HTML
  (including all ten module group pages) renders correctly.
- Stripping `///` and blank lines from every modified header reproduces
  the previous file contents byte-for-byte.
- Per-header self-containedness translation units all compile; the
  minimal configuration (Kokkos + Sacado + MiniTensor only) builds and
  its tests pass.

After this merges, the generated HTML will be submitted to
trilinos.github.io so the README's documentation link resolves.
