### PR TITLE
MiniTensor: add quaternions and rotation-representation conversions

### DIFF
--- a/packages/minitensor/README.md
+++ b/packages/minitensor/README.md
@@ -31,8 +31,9 @@ on its own:
 | `MiniTensor_Inverse.h` | Inversion, rank-one updates, preconditioners, linear solves |
 | `MiniTensor_Factorizations.h` | Givens, Cholesky, eigen, SVD, polar, condition numbers |
 | `MiniTensor_MatrixFunctions.h` | `exp`, `log`, `sqrt` families and BCH |
-| `MiniTensor_Rotations.h` | SO(N) logarithmic and exponential maps |
+| `MiniTensor_Rotations.h` | SO(N) logarithmic and exponential maps, axial vector |
 | `MiniTensor_LinearAlgebra.h` | Umbrella over the five linear-algebra modules |
+| `MiniTensor_Quaternion.h` | Quaternions and rotation-representation conversions |
 | `MiniTensor_Geometry.h` | Element lengths, areas, volumes, centroids |
 | `MiniTensor_Mechanics.h` | Continuum-mechanics operations |
 | `MiniTensor_Solvers.h` | Nonlinear solvers and optimization (opt-in) |

--- a/packages/minitensor/doc/MiniTensor_DoxygenDocumentation.hpp
+++ b/packages/minitensor/doc/MiniTensor_DoxygenDocumentation.hpp
@@ -52,6 +52,7 @@ mechanics; each module header can also be included on its own.
 | MiniTensor_MatrixFunctions.h | \ref minitensor_matrix_functions |
 | MiniTensor_Rotations.h | \ref minitensor_rotations |
 | MiniTensor_LinearAlgebra.h | Umbrella over the five linear-algebra modules above |
+| MiniTensor_Quaternion.h | Quaternions and rotation-representation conversions: \ref minitensor_rotations |
 | MiniTensor_Geometry.h | \ref minitensor_geometry |
 | MiniTensor_Mechanics.h | \ref minitensor_mechanics |
 | MiniTensor_Solvers.h, MiniTensor_TestFunctions.h | \ref minitensor_solvers |
@@ -134,7 +135,9 @@ Baker-Campbell-Hausdorff series.
 
 /*!
 \defgroup minitensor_rotations Rotations
-\brief Logarithmic and exponential maps on SO(N).
+\brief Logarithmic and exponential maps on SO(N), quaternions, and
+conversions among rotation representations: rotation matrix, unit
+quaternion and principal rotation vector.
 */
 
 /*!

--- a/packages/minitensor/src/MiniTensor.h
+++ b/packages/minitensor/src/MiniTensor.h
@@ -19,5 +19,6 @@
 #include "MiniTensor_Geometry.h"
 #include "MiniTensor_LinearAlgebra.h"
 #include "MiniTensor_Mechanics.h"
+#include "MiniTensor_Quaternion.h"
 
 #endif //MiniTensor_h

--- a/packages/minitensor/src/MiniTensor_Quaternion.h
+++ b/packages/minitensor/src/MiniTensor_Quaternion.h
@@ -1,0 +1,782 @@
+// @HEADER
+// *****************************************************************************
+//                           MiniTensor Package
+//
+// Copyright 2016 NTESS and the MiniTensor contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#if !defined(MiniTensor_Quaternion_h)
+#define MiniTensor_Quaternion_h
+
+// Quaternions and conversions among rotation representations:
+// rotation matrix (rt), unit quaternion (q) and principal rotation
+// vector (rv). Ported from Norma.jl, which in turn adopted them from
+// the ONDAP FEM code. See: Object-oriented finite-element dynamic
+// simulation of geometrically nonlinear space structures, Victor
+// Balopoulos, Ph.D. dissertation, Cornell University, 1997.
+#include "MiniTensor_Rotations.h"
+
+namespace minitensor {
+
+namespace impl {
+
+//
+// Compute sin(x)/x with asymptotic expansions near zero to avoid
+// division by small values. This function is frequently encountered
+// in rotational algebra when evaluating exp/log maps of
+// skew-symmetric matrices.
+//
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+T
+sin_x_over_x(T const & x)
+{
+  using S = typename Sacado::ScalarType<T>::type;
+
+  T const
+  y = std::abs(x);
+
+  S const
+  y_val = Sacado::ScalarValue<T>::eval(y);
+
+  S const
+  epsilon2 = std::sqrt(machine_epsilon<T>());
+
+  S const
+  epsilon4 = std::sqrt(epsilon2);
+
+  if (y_val > epsilon4) {
+    return std::sin(y) / y;
+  } else if (y_val > epsilon2) {
+    return 1.0 - y * y / 6.0;
+  }
+
+  return T(1.0);
+}
+
+} // namespace impl
+
+/// \addtogroup minitensor_rotations
+/// @{
+
+///
+/// Quaternion class. Scalar-first convention: the quaternion
+/// \f$ q = (q_s; q_v) \f$ has scalar part \f$ q_s \f$ and vector part
+/// \f$ q_v \in R^3 \f$. A unit quaternion encodes the rotation by
+/// angle \f$ \theta \f$ about the unit axis \f$ n \f$ as
+/// \f$ q_s = \cos(\theta/2) \f$, \f$ q_v = \sin(\theta/2)\, n \f$.
+///
+template<typename T>
+class Quaternion
+{
+public:
+
+  ///
+  /// Default construction: identity quaternion \f$ (1; 0, 0, 0) \f$.
+  ///
+  KOKKOS_INLINE_FUNCTION
+  Quaternion() : s_(1.0), v_(Filler::ZEROS)
+  {
+  }
+
+  ///
+  /// Construction from scalar and vector parts.
+  /// \param s scalar part
+  /// \param v vector part
+  ///
+  KOKKOS_INLINE_FUNCTION
+  Quaternion(T const & s, Vector<T, 3> const & v) : s_(s), v_(v)
+  {
+  }
+
+  ///
+  /// Construction from four components, scalar first.
+  /// \param s scalar part
+  /// \param v0 first component of the vector part
+  /// \param v1 second component of the vector part
+  /// \param v2 third component of the vector part
+  ///
+  KOKKOS_INLINE_FUNCTION
+  Quaternion(T const & s, T const & v0, T const & v1, T const & v2) :
+      s_(s), v_(v0, v1, v2)
+  {
+  }
+
+  ///
+  /// Construction from a 4-vector in scalar-first order.
+  /// \param q 4-vector \f$ (q_s, q_{v0}, q_{v1}, q_{v2}) \f$
+  ///
+  explicit
+  KOKKOS_INLINE_FUNCTION
+  Quaternion(Vector<T, 4> const & q) : s_(q(0)), v_(q(1), q(2), q(3))
+  {
+  }
+
+  ///
+  /// Scalar part.
+  ///
+  KOKKOS_INLINE_FUNCTION
+  T const &
+  scalar() const
+  {
+    return s_;
+  }
+
+  ///
+  /// Scalar part, mutable.
+  ///
+  KOKKOS_INLINE_FUNCTION
+  T &
+  scalar()
+  {
+    return s_;
+  }
+
+  ///
+  /// Vector part.
+  ///
+  KOKKOS_INLINE_FUNCTION
+  Vector<T, 3> const &
+  vector() const
+  {
+    return v_;
+  }
+
+  ///
+  /// Vector part, mutable.
+  ///
+  KOKKOS_INLINE_FUNCTION
+  Vector<T, 3> &
+  vector()
+  {
+    return v_;
+  }
+
+  ///
+  /// Indexed access, scalar first.
+  /// \param i component index: 0 is the scalar part, 1..3 the vector part
+  ///
+  KOKKOS_INLINE_FUNCTION
+  T const &
+  operator()(Index const i) const
+  {
+    assert(i < 4);
+    return i == 0 ? s_ : v_(i - 1);
+  }
+
+  ///
+  /// Indexed access, scalar first, mutable.
+  /// \param i component index: 0 is the scalar part, 1..3 the vector part
+  ///
+  KOKKOS_INLINE_FUNCTION
+  T &
+  operator()(Index const i)
+  {
+    assert(i < 4);
+    return i == 0 ? s_ : v_(i - 1);
+  }
+
+  ///
+  /// Components as a 4-vector in scalar-first order.
+  ///
+  KOKKOS_INLINE_FUNCTION
+  Vector<T, 4>
+  to_vector() const
+  {
+    Vector<T, 4>
+    q(4);
+
+    q(0) = s_;
+    q(1) = v_(0);
+    q(2) = v_(1);
+    q(3) = v_(2);
+
+    return q;
+  }
+
+private:
+
+  ///
+  /// Scalar part.
+  ///
+  T
+  s_{};
+
+  ///
+  /// Vector part.
+  ///
+  Vector<T, 3>
+  v_;
+};
+
+///
+/// Hamilton product of two quaternions
+/// \param p quaternion
+/// \param q quaternion
+/// \return \f$ p q = (p_s q_s - p_v \cdot q_v;
+/// \; p_s q_v + q_s p_v + p_v \times q_v) \f$
+///
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+Quaternion<T>
+operator*(Quaternion<T> const & p, Quaternion<T> const & q);
+
+///
+/// Quaternion equality, tested component-wise.
+/// \param p quaternion
+/// \param q quaternion
+///
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+bool
+operator==(Quaternion<T> const & p, Quaternion<T> const & q);
+
+///
+/// Quaternion inequality, tested component-wise.
+/// \param p quaternion
+/// \param q quaternion
+///
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+bool
+operator!=(Quaternion<T> const & p, Quaternion<T> const & q);
+
+///
+/// Quaternion conjugate
+/// \param q quaternion
+/// \return \f$ \bar{q} = (q_s; -q_v) \f$
+///
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+Quaternion<T>
+conjugate(Quaternion<T> const & q);
+
+///
+/// Quaternion norm
+/// \param q quaternion
+/// \return \f$ \sqrt{q_s^2 + q_v \cdot q_v} \f$
+///
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+T
+norm(Quaternion<T> const & q);
+
+///
+/// Quaternion inverse
+/// \param q quaternion
+/// \return \f$ q^{-1} = \bar{q} / |q|^2 \f$
+///
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+Quaternion<T>
+inverse(Quaternion<T> const & q);
+
+///
+/// Quaternion normalized to unit norm
+/// \param q quaternion
+/// \return \f$ q / |q| \f$
+///
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+Quaternion<T>
+unit(Quaternion<T> const & q);
+
+///
+/// Quaternion output, scalar-first components separated by commas.
+/// \param os output stream
+/// \param q quaternion
+/// \return os
+///
+template<typename T>
+std::ostream &
+operator<<(std::ostream & os, Quaternion<T> const & q);
+
+///
+/// Quaternion of a rotation matrix, using Spurrier's singularity-free
+/// algorithm. Selects the largest of the trace and the diagonal
+/// entries of the matrix and computes the quaternion components
+/// accordingly, which ensures a stable evaluation for all rotation
+/// angles including \f$ \theta = \pi \f$.
+/// \param R rotation matrix with \f$ R \in SO(3) \f$
+/// \return unit quaternion \f$ q \f$ such that rt_of_q(q) recovers R
+///
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Quaternion<T>
+q_of_rt(Tensor<T, N> const & R);
+
+///
+/// Principal rotation vector of a quaternion. The sign of the
+/// quaternion is first normalized so that \f$ q_s \geq 0 \f$, which
+/// selects the principal rotation \f$ |rv| \leq \pi \f$. Small
+/// rotations use an alternate evaluation to avoid numerical
+/// instability.
+/// \param q unit quaternion
+/// \return rotation vector \f$ rv \f$ with \f$ |rv| \leq \pi \f$
+///
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+Vector<T, 3>
+rv_of_q(Quaternion<T> const & q);
+
+///
+/// Quaternion of a rotation vector, computed as
+/// \f$ q_s = \cos(|rv|/2) \f$,
+/// \f$ q_v = \frac{1}{2}\,\psi(|rv|/2)\, rv \f$ with
+/// \f$ \psi(x) = \sin(x)/x \f$, using asymptotic expansions of
+/// \f$ \psi \f$ for small angles.
+/// \param rv rotation vector
+/// \return unit quaternion
+///
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Quaternion<T>
+q_of_rv(Vector<T, N> const & rv);
+
+///
+/// Rotation matrix of a quaternion, based on the identity
+/// \f$ R = 2 q_v \otimes q_v + 2 q_s \mathrm{skew}(q_v) + (2 q_s^2 - 1) I \f$.
+/// \param q unit quaternion
+/// \return rotation matrix \f$ R \in SO(3) \f$
+///
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+Tensor<T, 3>
+rt_of_q(Quaternion<T> const & q);
+
+///
+/// Principal rotation vector of a rotation matrix, computed through
+/// the quaternion representation as rv_of_q(q_of_rt(R)). Unlike
+/// log_rotation, this path is singularity-free for all rotation
+/// angles including \f$ \theta = \pi \f$.
+/// \param R rotation matrix with \f$ R \in SO(3) \f$
+/// \return rotation vector \f$ rv \f$ with \f$ |rv| \leq \pi \f$
+///
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Vector<T, 3>
+rv_of_rt(Tensor<T, N> const & R);
+
+///
+/// Rotation matrix of a rotation vector, computed through the
+/// quaternion representation as rt_of_q(q_of_rv(rv)).
+/// \param rv rotation vector
+/// \return rotation matrix \f$ R \in SO(3) \f$
+///
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Tensor<T, 3>
+rt_of_rv(Vector<T, N> const & rv);
+
+///
+/// Rotation vector equivalent to old (representing the same rotation)
+/// but as close as possible to prev. Resolves the \f$ 2 \pi k \f$
+/// ambiguity of the rotation-vector representation, which enforces
+/// continuity in incremental rotation updates such as time stepping.
+/// \param old rotation vector to continue
+/// \param prev previous rotation vector
+/// \return rotation vector equivalent to old and closest to prev
+///
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Vector<T, N>
+rv_continue(Vector<T, N> const & old, Vector<T, N> const & prev);
+
+//
+// Hamilton product of two quaternions.
+//
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+Quaternion<T>
+operator*(Quaternion<T> const & p, Quaternion<T> const & q)
+{
+  T const
+  s = p.scalar() * q.scalar() - dot(p.vector(), q.vector());
+
+  Vector<T, 3> const
+  v = p.scalar() * q.vector() + q.scalar() * p.vector() +
+      cross(p.vector(), q.vector());
+
+  return Quaternion<T>(s, v);
+}
+
+//
+// Quaternion equality.
+//
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+bool
+operator==(Quaternion<T> const & p, Quaternion<T> const & q)
+{
+  return p.scalar() == q.scalar() && p.vector() == q.vector();
+}
+
+//
+// Quaternion inequality.
+//
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+bool
+operator!=(Quaternion<T> const & p, Quaternion<T> const & q)
+{
+  return !(p == q);
+}
+
+//
+// Quaternion conjugate.
+//
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+Quaternion<T>
+conjugate(Quaternion<T> const & q)
+{
+  return Quaternion<T>(q.scalar(), -q.vector());
+}
+
+//
+// Quaternion norm.
+//
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+T
+norm(Quaternion<T> const & q)
+{
+  return std::sqrt(
+      q.scalar() * q.scalar() + dot(q.vector(), q.vector()));
+}
+
+//
+// Quaternion inverse.
+//
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+Quaternion<T>
+inverse(Quaternion<T> const & q)
+{
+  T const
+  norm_square = q.scalar() * q.scalar() + dot(q.vector(), q.vector());
+
+  return Quaternion<T>(q.scalar() / norm_square, -q.vector() / norm_square);
+}
+
+//
+// Quaternion normalized to unit norm.
+//
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+Quaternion<T>
+unit(Quaternion<T> const & q)
+{
+  T const
+  norm_q = norm(q);
+
+  return Quaternion<T>(q.scalar() / norm_q, q.vector() / norm_q);
+}
+
+//
+// Quaternion output.
+//
+template<typename T>
+std::ostream &
+operator<<(std::ostream & os, Quaternion<T> const & q)
+{
+  os << std::scientific << std::setprecision(17);
+
+  os << std::setw(24) << q.scalar();
+
+  for (Index i = 0; i < 3; ++i) {
+    os << "," << std::setw(24) << q.vector()(i);
+  }
+
+  return os;
+}
+
+//
+// Quaternion of a rotation matrix, Spurrier's algorithm.
+//
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Quaternion<T>
+q_of_rt(Tensor<T, N> const & R)
+{
+  assert(R.get_dimension() == 3);
+
+  //firewalls, make sure R \in SO(3)
+  assert(norm(dot_t(R, R) - eye<T, N>(3)) <
+         std::max(1.0e-12 * norm(R), 1.0e-12));
+  assert(std::abs(det(R) - 1.0) <
+         std::max(1.0e-12 * norm(R), 1.0e-12));
+
+  using S = typename Sacado::ScalarType<T>::type;
+
+  T const
+  trace_R = trace(R);
+
+  // Select the largest of the trace and the diagonal entries. The
+  // sentinel index 3 denotes the trace.
+  S
+  max_value = Sacado::ScalarValue<T>::eval(trace_R);
+
+  Index
+  max_index = 3;
+
+  for (Index i = 0; i < 3; ++i) {
+
+    S const
+    diagonal_value = Sacado::ScalarValue<T>::eval(R(i, i));
+
+    if (diagonal_value > max_value) {
+      max_value = diagonal_value;
+      max_index = i;
+    }
+  }
+
+  Quaternion<T>
+  q;
+
+  switch (max_index) {
+
+  case 3:
+  {
+    T const
+    root = std::sqrt(trace_R + 1.0);
+
+    T const
+    factor = 0.5 / root;
+
+    q = Quaternion<T>(
+        0.5 * root,
+        factor * (R(2, 1) - R(1, 2)),
+        factor * (R(0, 2) - R(2, 0)),
+        factor * (R(1, 0) - R(0, 1)));
+  }
+  break;
+
+  case 2:
+  {
+    T const
+    root = std::sqrt(2.0 * R(2, 2) + 1.0 - trace_R);
+
+    T const
+    factor = 0.5 / root;
+
+    q = Quaternion<T>(
+        factor * (R(1, 0) - R(0, 1)),
+        factor * (R(0, 2) + R(2, 0)),
+        factor * (R(1, 2) + R(2, 1)),
+        0.5 * root);
+  }
+  break;
+
+  case 1:
+  {
+    T const
+    root = std::sqrt(2.0 * R(1, 1) + 1.0 - trace_R);
+
+    T const
+    factor = 0.5 / root;
+
+    q = Quaternion<T>(
+        factor * (R(0, 2) - R(2, 0)),
+        factor * (R(0, 1) + R(1, 0)),
+        0.5 * root,
+        factor * (R(1, 2) + R(2, 1)));
+  }
+  break;
+
+  case 0:
+  {
+    T const
+    root = std::sqrt(2.0 * R(0, 0) + 1.0 - trace_R);
+
+    T const
+    factor = 0.5 / root;
+
+    q = Quaternion<T>(
+        factor * (R(2, 1) - R(1, 2)),
+        0.5 * root,
+        factor * (R(0, 1) + R(1, 0)),
+        factor * (R(0, 2) + R(2, 0)));
+  }
+  break;
+
+  }
+
+  return q;
+}
+
+//
+// Principal rotation vector of a quaternion.
+//
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+Vector<T, 3>
+rv_of_q(Quaternion<T> const & q)
+{
+  // Normalize the sign so that the scalar part is non-negative,
+  // which selects the principal rotation |rv| <= pi.
+  bool const
+  negative = Sacado::ScalarValue<T>::eval(q.scalar()) < 0.0;
+
+  T const
+  qs = negative == true ? T(-q.scalar()) : q.scalar();
+
+  Vector<T, 3>
+  qv(q.vector()(0), q.vector()(1), q.vector()(2));
+
+  if (negative == true) {
+    for (Index i = 0; i < 3; ++i) {
+      qv(i) = -qv(i);
+    }
+  }
+
+  T const
+  qv_norm = norm(qv);
+
+  // Small rotation: rv = 2 qv to leading order.
+  if (Sacado::ScalarValue<T>::eval(qv_norm) <
+      std::sqrt(machine_epsilon<T>())) {
+    return 2.0 * qv;
+  }
+
+  T
+  rv_norm;
+
+  // asin is accurate for small vector parts, acos otherwise.
+  if (Sacado::ScalarValue<T>::eval(qv_norm) < std::sqrt(0.5)) {
+    rv_norm = 2.0 * std::asin(qv_norm);
+  } else {
+    rv_norm = 2.0 * std::acos(qs);
+  }
+
+  return rv_norm / qv_norm * qv;
+}
+
+//
+// Quaternion of a rotation vector.
+//
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Quaternion<T>
+q_of_rv(Vector<T, N> const & rv)
+{
+  assert(rv.get_dimension() == 3);
+
+  T const
+  half_norm = 0.5 * norm(rv);
+
+  T const
+  factor = 0.5 * impl::sin_x_over_x(half_norm);
+
+  return Quaternion<T>(
+      std::cos(half_norm),
+      factor * rv(0),
+      factor * rv(1),
+      factor * rv(2));
+}
+
+//
+// Rotation matrix of a quaternion.
+//
+template<typename T>
+KOKKOS_INLINE_FUNCTION
+Tensor<T, 3>
+rt_of_q(Quaternion<T> const & q)
+{
+  T const &
+  qs = q.scalar();
+
+  Vector<T, 3> const &
+  qv = q.vector();
+
+  Tensor<T, 3> const
+  R = 2.0 * dyad(qv, qv) + 2.0 * qs * skew(qv) +
+      (2.0 * qs * qs - 1.0) * identity<T, 3>(3);
+
+  return R;
+}
+
+//
+// Principal rotation vector of a rotation matrix.
+//
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Vector<T, 3>
+rv_of_rt(Tensor<T, N> const & R)
+{
+  return rv_of_q(q_of_rt(R));
+}
+
+//
+// Rotation matrix of a rotation vector.
+//
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Tensor<T, 3>
+rt_of_rv(Vector<T, N> const & rv)
+{
+  return rt_of_q(q_of_rv(rv));
+}
+
+//
+// Rotation vector equivalent to old but closest to prev.
+//
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Vector<T, N>
+rv_continue(Vector<T, N> const & old, Vector<T, N> const & prev)
+{
+  assert(old.get_dimension() == 3);
+  assert(prev.get_dimension() == 3);
+
+  using S = typename Sacado::ScalarType<T>::type;
+
+  T const
+  norm_old = norm(old);
+
+  Vector<T, N>
+  direction(old.get_dimension());
+
+  T
+  projection;
+
+  if (Sacado::ScalarValue<T>::eval(norm_old) > 0.0) {
+    direction = old / norm_old;
+    projection = dot(direction, prev);
+  } else {
+    projection = norm(prev);
+    if (Sacado::ScalarValue<T>::eval(projection) == 0.0) {
+      return old;
+    }
+    direction = prev / projection;
+  }
+
+  if (Sacado::ScalarValue<T>::eval(projection) == 0.0) {
+    return old;
+  }
+
+  S const
+  pi = std::acos(S(-1.0));
+
+  // The equivalent rotation vectors are (|old| + 2 pi k) direction;
+  // their signed coordinate along direction closest to that of prev
+  // determines the number of turns k.
+  S const
+  number_turns = std::round(
+      0.5 *
+      (Sacado::ScalarValue<T>::eval(projection) -
+       Sacado::ScalarValue<T>::eval(norm_old)) / pi);
+
+  if (number_turns == 0.0) {
+    return old;
+  }
+
+  return (2.0 * number_turns * pi + norm_old) * direction;
+}
+
+/// @}
+} // namespace minitensor
+
+#endif // MiniTensor_Quaternion_h

--- a/packages/minitensor/src/MiniTensor_Rotations.h
+++ b/packages/minitensor/src/MiniTensor_Rotations.h
@@ -49,6 +49,17 @@ KOKKOS_INLINE_FUNCTION
 Tensor<T, N>
 exp_skew_symmetric(Tensor<T, N> const & r);
 
+///
+/// Axial vector of a skew-symmetric tensor, the inverse of
+/// skew(Vector). Defined for 3D only.
+/// \param W skew-symmetric tensor \f$ W \in so(3) \f$
+/// \return \f$ w \f$ such that \f$ W u = w \times u \f$ for all \f$ u \f$
+///
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Vector<T, N>
+vee(Tensor<T, N> const & W);
+
 //
 // R^N logarithmic map of a rotation.
 // \param R with \f$ R \in SO(N) \f$
@@ -270,6 +281,40 @@ exp_skew_symmetric(Tensor<T, N> const & r)
  }
 
   return R;
+}
+
+//
+// R^N axial vector of a skew-symmetric tensor, undefined for N != 3.
+//
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Vector<T, N>
+vee(Tensor<T, N> const & W)
+{
+  // Check whether skew-symmetry holds
+  assert(norm(sym(W)) < std::max(1.0e-12 * norm(W), 1.0e-12));
+
+  Index const
+  dimension = W.get_dimension();
+
+  Vector<T, N>
+  w(dimension);
+
+  switch (dimension) {
+
+  case 3:
+    w(0) = W(2, 1);
+    w(1) = W(0, 2);
+    w(2) = W(1, 0);
+    break;
+
+  default:
+    MT_ERROR_EXIT("Axial vector from tensor defined for 3D only");
+    break;
+
+  }
+
+  return w;
 }
 
 /// @}

--- a/packages/minitensor/test/test_01.cc
+++ b/packages/minitensor/test/test_01.cc
@@ -1137,6 +1137,371 @@ TEST(MiniTensor, BakerCampbellHausdorff)
   ASSERT_LE(error, tolerance);
 }
 
+TEST(MiniTensor, QuaternionAlgebra)
+{
+  // Default construction is the identity quaternion.
+  Quaternion<Real> const
+  id;
+
+  ASSERT_EQ(id.scalar(), 1.0);
+  ASSERT_EQ(norm(id.vector()), 0.0);
+
+  Quaternion<Real> const
+  q(0.5, Vector<Real, 3>(0.5, -0.5, 0.5));
+
+  // Identity is the neutral element of the Hamilton product.
+  ASSERT_TRUE(q * id == q);
+  ASSERT_TRUE(id * q == q);
+  ASSERT_TRUE(q != id);
+
+  // Indexed access is scalar-first and consistent with to_vector
+  // and the 4-vector constructor.
+  Vector<Real, 4> const
+  c = q.to_vector();
+
+  for (Index i = 0; i < 4; ++i) {
+    ASSERT_EQ(c(i), q(i));
+  }
+
+  Quaternion<Real> const
+  p(c);
+
+  ASSERT_TRUE(p == q);
+
+  // q conjugate(q) has zero vector part and scalar part |q|^2.
+  Quaternion<Real> const
+  qqbar = q * conjugate(q);
+
+  Real const
+  norm_q = norm(q);
+
+  ASSERT_LE(
+      std::abs(qqbar.scalar() - norm_q * norm_q),
+      machine_epsilon<Real>());
+
+  ASSERT_LE(norm(qqbar.vector()), machine_epsilon<Real>());
+
+  // q inverse(q) is the identity.
+  Quaternion<Real> const
+  qqinv = q * inverse(q);
+
+  ASSERT_LE(std::abs(qqinv.scalar() - 1.0), 2.0 * machine_epsilon<Real>());
+  ASSERT_LE(norm(qqinv.vector()), 2.0 * machine_epsilon<Real>());
+
+  // unit(q) has unit norm.
+  ASSERT_LE(
+      std::abs(norm(unit(q)) - 1.0),
+      2.0 * machine_epsilon<Real>());
+
+  // The Hamilton product corresponds to rotation composition.
+  Vector<Real, 3> const
+  rv1(0.4, -0.3, 0.8);
+
+  Vector<Real, 3> const
+  rv2(-0.2, 0.7, 0.1);
+
+  Quaternion<Real> const
+  q1 = q_of_rv(rv1);
+
+  Quaternion<Real> const
+  q2 = q_of_rv(rv2);
+
+  Tensor<Real, 3> const
+  R12 = rt_of_q(q1 * q2);
+
+  Tensor<Real, 3> const
+  R1R2 = rt_of_q(q1) * rt_of_q(q2);
+
+  Real const
+  error = norm(R12 - R1R2) / norm(R1R2);
+
+  ASSERT_LE(error, 16 * machine_epsilon<Real>());
+}
+
+TEST(MiniTensor, QuaternionRoundTrips)
+{
+  Real const
+  Pi = std::acos(-1.0);
+
+  Vector<Real, 3> const
+  axis = unit(Vector<Real, 3>(1.0, 1.0, 1.0));
+
+  // Rotation angles exercising: zero, both asymptotic tiers of
+  // sin(x)/x, generic angles, near pi and exactly pi.
+  Real const
+  angles[] = {0.0, 1.0e-8, 1.0e-4, 0.01, 0.5, 2.0, 3.0,
+      Pi - 1.0e-6, Pi};
+
+  for (Real const angle : angles) {
+
+    Vector<Real, 3> const
+    w = angle * axis;
+
+    Tensor<Real, 3> const
+    R = rt_of_rv(w);
+
+    // Rotation matrix invariants.
+    Real const
+    error_orthogonal = norm(dot_t(R, R) - identity<Real, 3>(3));
+
+    ASSERT_LE(error_orthogonal, 16 * machine_epsilon<Real>());
+
+    ASSERT_LE(std::abs(det(R) - 1.0), 16 * machine_epsilon<Real>());
+
+    // Unit quaternion with non-negative scalar part after
+    // sign normalization.
+    Quaternion<Real> const
+    q = q_of_rt(R);
+
+    ASSERT_LE(std::abs(norm(q) - 1.0), 16 * machine_epsilon<Real>());
+
+    // Matrix round trip, valid for all angles including pi.
+    Vector<Real, 3> const
+    v = rv_of_rt(R);
+
+    Tensor<Real, 3> const
+    S = rt_of_rv(v);
+
+    ASSERT_LE(norm(S - R), 64 * machine_epsilon<Real>());
+
+    // Principal property.
+    ASSERT_LE(norm(v), Pi + 16 * machine_epsilon<Real>());
+
+    // Vector round trip, unique for angles below pi.
+    if (angle < Pi) {
+      ASSERT_LE(norm(v - w), 64 * machine_epsilon<Real>() * (1.0 + angle));
+    } else {
+      ASSERT_LE(std::abs(norm(v) - Pi), 64 * machine_epsilon<Real>());
+    }
+  }
+
+  // Exactly pi about each coordinate axis: the rotation matrix
+  // round trip must be exact even though the rotation vector is
+  // determined only up to sign.
+  for (Index i = 0; i < 3; ++i) {
+
+    Vector<Real, 3>
+    w(0.0, 0.0, 0.0);
+
+    w(i) = Pi;
+
+    Tensor<Real, 3> const
+    R = rt_of_rv(w);
+
+    Tensor<Real, 3> const
+    S = rt_of_rv(rv_of_rt(R));
+
+    ASSERT_LE(norm(S - R), 64 * machine_epsilon<Real>());
+  }
+}
+
+TEST(MiniTensor, QuaternionSpurrierBranches)
+{
+  Real const
+  Pi = std::acos(-1.0);
+
+  // Small rotation: the trace is dominant.
+  // Rotations by pi about each coordinate axis: the corresponding
+  // diagonal entry is dominant.
+  Vector<Real, 3> const
+  rvs[] = {
+      Vector<Real, 3>(0.1, 0.2, -0.1),
+      Vector<Real, 3>(Pi, 0.0, 0.0),
+      Vector<Real, 3>(0.0, Pi, 0.0),
+      Vector<Real, 3>(0.0, 0.0, Pi)};
+
+  for (Vector<Real, 3> const & rv : rvs) {
+
+    Tensor<Real, 3> const
+    R = rt_of_rv(rv);
+
+    Quaternion<Real> const
+    q = q_of_rt(R);
+
+    ASSERT_LE(std::abs(norm(q) - 1.0), 16 * machine_epsilon<Real>());
+
+    Real const
+    error = norm(rt_of_q(q) - R);
+
+    ASSERT_LE(error, 16 * machine_epsilon<Real>());
+  }
+}
+
+TEST(MiniTensor, QuaternionRotationConsistency)
+{
+  Vector<Real, 3> const
+  w(0.4, -0.3, 0.8);
+
+  // The quaternion path agrees with the exponential map ...
+  Tensor<Real, 3> const
+  R = rt_of_rv(w);
+
+  Tensor<Real, 3> const
+  E = exp_skew_symmetric(skew(w));
+
+  ASSERT_LE(norm(R - E) / norm(E), 16 * machine_epsilon<Real>());
+
+  // ... and with the logarithmic map away from pi.
+  Tensor<Real, 3> const
+  r = log_rotation(R);
+
+  ASSERT_LE(norm(skew(rv_of_rt(R)) - r), 16 * machine_epsilon<Real>());
+
+  // vee inverts skew from vector.
+  ASSERT_TRUE(vee(skew(w)) == w);
+}
+
+TEST(MiniTensor, RotationVectorContinuation)
+{
+  Real const
+  Pi = std::acos(-1.0);
+
+  Vector<Real, 3> const
+  zero(0.0, 0.0, 0.0);
+
+  Vector<Real, 3> const
+  old(0.1, 0.2, 0.3);
+
+  Vector<Real, 3> const
+  direction = unit(old);
+
+  // Close previous vector: no continuation.
+  ASSERT_TRUE(rv_continue(old, old) == old);
+
+  // Zero previous vector: no continuation.
+  ASSERT_TRUE(rv_continue(old, zero) == old);
+
+  // Zero rotation with a previous full turn: the full turn
+  // is recovered.
+  Vector<Real, 3> const
+  turn = 2.0 * Pi * Vector<Real, 3>(0.0, 1.0, 0.0);
+
+  Real const
+  error_zero = norm(rv_continue(zero, turn) - turn);
+
+  ASSERT_LE(error_zero, 16 * machine_epsilon<Real>());
+
+  // Previous vector one and two full turns ahead: the equivalent
+  // rotation vector closest to it is recovered exactly.
+  for (Real const turns : {1.0, 2.0}) {
+
+    Vector<Real, 3> const
+    prev = old + turns * 2.0 * Pi * direction;
+
+    Vector<Real, 3> const
+    continued = rv_continue(old, prev);
+
+    Real const
+    error = norm(continued - prev) / norm(prev);
+
+    ASSERT_LE(error, 16 * machine_epsilon<Real>());
+
+    // The continued vector represents the same rotation.
+    Real const
+    error_rotation = norm(rt_of_rv(continued) - rt_of_rv(old));
+
+    ASSERT_LE(error_rotation, 256 * machine_epsilon<Real>());
+  }
+
+  // Previous vector a full turn behind, anti-parallel.
+  Vector<Real, 3> const
+  prev = old - 2.0 * Pi * direction;
+
+  Vector<Real, 3> const
+  continued = rv_continue(old, prev);
+
+  Real const
+  error = norm(continued - prev) / norm(prev);
+
+  ASSERT_LE(error, 16 * machine_epsilon<Real>());
+
+  Real const
+  error_rotation = norm(rt_of_rv(continued) - rt_of_rv(old));
+
+  ASSERT_LE(error_rotation, 256 * machine_epsilon<Real>());
+
+  // Continuity across the pi and 2 pi crossings: sweep the rotation
+  // angle, continuing each principal rotation vector from the
+  // previous continued one, and recover the swept vector throughout.
+  Vector<Real, 3> const
+  sweep_axis = unit(Vector<Real, 3>(1.0, -2.0, 2.0));
+
+  Vector<Real, 3>
+  swept(0.0, 0.0, 0.0);
+
+  for (Real angle = 0.05; angle < 7.0; angle += 0.1) {
+
+    Vector<Real, 3> const
+    principal = rv_of_rt(rt_of_rv(angle * sweep_axis));
+
+    swept = rv_continue(principal, swept);
+
+    Real const
+    error_sweep = norm(swept - angle * sweep_axis);
+
+    ASSERT_LE(error_sweep, 1.0e-12);
+  }
+}
+
+TEST(MiniTensor, QuaternionFad)
+{
+  using FAD = Sacado::Fad::DFad<Real>;
+
+  Real const
+  w0[3] = {0.1, -0.2, 0.3};
+
+  Vector<FAD, 3>
+  w(3);
+
+  for (Index i = 0; i < 3; ++i) {
+    w(i) = FAD(3, i, w0[i]);
+  }
+
+  // The whole conversion cycle instantiates with a FAD scalar.
+  Tensor<FAD, 3> const
+  R = rt_of_q(q_of_rv(w));
+
+  Vector<FAD, 3> const
+  v = rv_of_q(q_of_rt(R));
+
+  FAD const
+  error = norm(v - w) / norm(w);
+
+  ASSERT_LE(error.val(), 64 * machine_epsilon<Real>());
+
+  // Derivative spot check of rt_of_rv against central differences.
+  Real const
+  h = 1.0e-6;
+
+  for (Index k = 0; k < 3; ++k) {
+
+    Vector<Real, 3>
+    wp(w0[0], w0[1], w0[2]);
+
+    Vector<Real, 3>
+    wm(w0[0], w0[1], w0[2]);
+
+    wp(k) += h;
+    wm(k) -= h;
+
+    Tensor<Real, 3> const
+    Rp = rt_of_rv(wp);
+
+    Tensor<Real, 3> const
+    Rm = rt_of_rv(wm);
+
+    for (Index i = 0; i < 3; ++i) {
+      for (Index j = 0; j < 3; ++j) {
+
+        Real const
+        finite_difference = (Rp(i, j) - Rm(i, j)) / (2.0 * h);
+
+        ASSERT_NEAR(R(i, j).dx(k), finite_difference, 1.0e-9);
+      }
+    }
+  }
+}
+
 TEST(MiniTensor, PolarLeftLog)
 {
   Real const


### PR DESCRIPTION
## Motivation

This PR ports quaternion support to MiniTensor from Norma.jl, which in turn adopted it from the ONDAP FEM code (Victor Balopoulos, *Object-oriented finite-element dynamic simulation of geometrically nonlinear space structures*, Ph.D. dissertation, Cornell University, 1997). It provides conversions among the three common rotation representations — rotation matrix, unit quaternion and principal rotation vector — used for incremental rotation updates in nonlinear structural dynamics.

The conversion from rotation matrix to rotation vector goes through Spurrier's singularity-free algorithm and is numerically stable for **all** rotation angles, including θ = π where the existing `log_rotation` must fall back to the special-cased `log_rotation_pi`.

## What is added

New header `MiniTensor_Quaternion.h` (included from the `MiniTensor.h` umbrella, documented in the `minitensor_rotations` Doxygen group):

- `Quaternion<T>`: a lean fixed-size class in scalar-first convention (q_s; q_v), with Hamilton product, `conjugate`, `inverse`, `norm`, `unit`, comparison and stream output as free functions.
- Conversions, keeping the Norma names so the two implementations stay mutually checkable: `q_of_rt` (Spurrier), `rv_of_q`, `q_of_rv`, `rt_of_q`, and the compositions `rv_of_rt` / `rt_of_rv`.
- `rv_continue`: resolves the 2πk ambiguity of the rotation-vector representation to enforce continuity in incremental rotation updates (time stepping). The number of turns is chosen to minimize the distance to the previous vector, `k = round((proj − |old|)/2π)`; this corrects the original algorithm (which omitted `|old|` and could fail to continue in a band right after the principal vector flips at θ = π). Norma.jl has been fixed in tandem (sandialabs/Norma.jl@a4cf1119), so the two implementations remain mutually checkable.
- In `MiniTensor_Rotations.h`: `vee`, the axial vector of a skew-symmetric tensor (inverse of the existing `skew(Vector)`).

No existing function is modified — the change is purely additive (the only touched lines outside the new header are the `vee` addition, one umbrella include, and documentation).

## Design notes

- All functions are templated on the scalar type. Branch predicates (Spurrier max-selection, small-angle tiers, continuation projections) are evaluated through `Sacado::ScalarValue<T>::eval`, so AD types take the same branch as their values and derivatives stay consistent within each branch. Thresholds use `machine_epsilon<T>()`. `KOKKOS_INLINE_FUNCTION` throughout.
- The sin(x)/x helper with two-tier small-angle asymptotics lives in `minitensor::impl` (excluded from the documentation, as established in #15531).
- `Quaternion<T>` is deliberately not derived from `TensorBase`: quaternions are inherently 4-component with no dynamic-dimension story.

## Testing

- Six new test cases (343 lines) in the MiniTensor test suite:
  - Quaternion algebra: identity element, Hamilton product against rotation composition, conjugate/inverse identities, unit normalization, accessor consistency.
  - Round trips over angles covering zero, both asymptotic tiers, generic angles, θ near π, and θ = π exactly about coordinate and skew axes (where the rotation matrix must be recovered even though the rotation vector is determined only up to sign), plus rotation-matrix orthogonality/determinant and unit-quaternion invariants.
  - All four branches of Spurrier's algorithm.
  - Consistency with the existing maps: `rt_of_rv` ≈ `exp_skew_symmetric∘skew`, `skew∘rv_of_rt` ≈ `log_rotation` away from π, `vee∘skew = id`.
  - `rv_continue` no-op and ±1, ±2 full-turn cases, verifying the represented rotation is preserved, plus a sweep of the rotation angle across the π and 2π crossings verifying continuity throughout.
  - Sacado FAD instantiation with a derivative check of `rt_of_rv` against central finite differences.
- Minimal configuration (MiniTensor + Kokkos + Sacado only, tests on): all 3 test executables pass, 42/42 gtest cases in test 01. The new header introduces no new compiler warnings.
- Per-header self-containedness translation units compile for `MiniTensor_Quaternion.h` (instantiating the full API with `double` and `Sacado::Fad::DFad<double>`) and `MiniTensor_Rotations.h`.
- Doxygen: both the publishing configuration and the strict audit configuration (`EXTRACT_ALL=NO`, `WARN_IF_UNDOCUMENTED=YES`) remain warning-free.
- Full clean build of Trilinos + the LCM application against this branch: all 196 LCM tests pass (one unrelated Navier–Stokes demo test timed out under full parallel load and passes on rerun; the full build emits no warnings from the new header).

@trilinos/minitensor
