### PR TITLE
MiniTensor: hook documentation into the website workflow

### DIFF
--- a/packages/minitensor/doc/DoxyfileWeb
+++ b/packages/minitensor/doc/DoxyfileWeb
@@ -1,0 +1,2 @@
+@INCLUDE               = Doxyfile.options
+INPUT                  = MiniTensor_DoxygenDocumentation.hpp ../src

--- a/packages/minitensor/doc/README.md
+++ b/packages/minitensor/doc/README.md
@@ -7,6 +7,10 @@
 
 The documentation will be placed in `<buildDirectory>/packages/minitensor/doc/html`.
 
+The documentation can also be built without configuring, directly in
+the source tree, by running `./build_docs` in this directory; the
+HTML is then placed in `doc/html`.
+
 ## Publishing to the Trilinos website
 
 The Trilinos website serves package documentation from the
@@ -15,10 +19,10 @@ repository: the generated HTML for a package `<pkg>` lives under
 `docs/<pkg>/` there and is served at
 `https://trilinos.github.io/docs/<pkg>/index.html`.
 
-To publish or refresh MiniTensor's pages:
-
-1. Build the documentation as above (`make doc_minitensor`).
-1. Clone `trilinos/trilinos.github.io` and replace the contents of
-   `docs/minitensor/` with the contents of
-   `<buildDirectory>/packages/minitensor/doc/html/`.
-1. Open a pull request against `trilinos/trilinos.github.io`.
+Publishing is automated: the `documentation` workflow in
+`trilinos.github.io` runs weekly (and on demand), executes every
+package's `doc/build_docs` script from the Trilinos `develop` branch
+via `doc/build_docs.pl`, copies each resulting `doc/html` into
+`docs/<pkg>/`, and opens a pull request with the refreshed pages.
+The `build_docs` script in this directory hooks MiniTensor into that
+workflow; no manual publishing steps are required.

--- a/packages/minitensor/doc/build_docs
+++ b/packages/minitensor/doc/build_docs
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ $TRILINOS_HOME ]; then
+  echo "TRILINOS_HOME has already been set!"
+else
+  echo "TRILINOS_HOME has not been set.  Setting it!"
+  export TRILINOS_HOME=`pwd`/../../..
+fi
+
+echo
+echo "Generating main minitensor doxygen documentation ..."
+echo
+
+doxygen DoxyfileWeb


### PR DESCRIPTION
The `documentation` workflow in [trilinos.github.io](https://github.com/trilinos/trilinos.github.io/blob/master/.github/workflows/doxygen.yaml) regenerates the website's `docs/` tree weekly: it runs every package's `doc/build_docs` script from develop via `doc/build_docs.pl`, wipes `docs/`, and repopulates it from each resulting `doc/html`. MiniTensor had no `build_docs` script, so the pages published manually in trilinos/trilinos.github.io#149 would be dropped on the workflow's next scheduled run.

This PR hooks MiniTensor into that workflow, mimicking the other packages (as suggested by @cgcgcg in trilinos/trilinos.github.io#149):

- `doc/build_docs`: executable script following the Sacado pattern (sets `TRILINOS_HOME` if unset, runs `doxygen DoxyfileWeb`).
- `doc/DoxyfileWeb`: two lines — includes the existing `Doxyfile.options` (single source of truth, shared with the CMake-configured build-tree documentation) and supplies the source-tree `INPUT` paths.
- `doc/README.md`: documents the automated publishing flow in place of the manual instructions.

Verified by running `./build_docs` from the doc directory as `build_docs.pl` does: HTML generated in `doc/html` with zero doxygen warnings, tag file written to `packages/common/tag_files/minitensor.tag`. Documentation-only change — no source files touched, no test or build impact.

@trilinos/minitensor