### PR TITLE
RTOp, Tpetra: Fix Windows shared-lib LNK2019 for DATA symbols (blocks Ifpack2 builds)

### DIFF
--- a/packages/rtop/src/CMakeLists.txt
+++ b/packages/rtop/src/CMakeLists.txt
@@ -7,6 +7,12 @@ INCLUDE(TrilinosCreateClientTemplateHeaders)
 
 TRIBITS_CONFIGURE_FILE(${PACKAGE_NAME}_Config.h)
 
+# Windows shared-library import/export for DATA symbols in rtop.dll
+# (e.g. RTOpPack::transpMap). Consumers need __declspec(dllimport) or LNK2019.
+SET(CURRENT_PACKAGE RTOP)
+CONFIGURE_FILE("${Trilinos_SOURCE_DIR}/packages/Trilinos_DLLExportMacro.h.in"
+  ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_DLLExportMacro.h)
+
 #
 # B) Define the header and source files (and directories)
 #
@@ -71,6 +77,7 @@ TRILINOS_CREATE_CLIENT_TEMPLATE_HEADERS(${DIR})
 TRIBITS_SET_AND_INC_DIRS(DIR ${CMAKE_CURRENT_BINARY_DIR})
 APPEND_GLOB(HEADERS ${DIR}/*.hpp)
 APPEND_SET(HEADERS ${DIR}/${PACKAGE_NAME}_Config.h )
+APPEND_SET(HEADERS ${DIR}/${PACKAGE_NAME}_DLLExportMacro.h)
 
 #
 # C) Define the targets for package's library(s)
@@ -80,4 +87,5 @@ TRIBITS_ADD_LIBRARY(
   rtop
   HEADERS ${HEADERS}
   SOURCES ${SOURCES}
+  DEFINES -DRTOP_LIB_EXPORTS_MODE
   )

--- a/packages/rtop/src/lapack/RTOpPack_LapackWrappers.cpp
+++ b/packages/rtop/src/lapack/RTOpPack_LapackWrappers.cpp
@@ -10,5 +10,5 @@
 
 #include "RTOpPack_LapackWrappers.hpp"
 
-const Teuchos::Tuple<char,RTOpPack::NUM_ETRANS_ARGS>
+RTOP_LIB_DLL_EXPORT const Teuchos::Tuple<char,RTOpPack::NUM_ETRANS_ARGS>
 RTOpPack::transpMap = Teuchos::tuple('N', 'T', 'C');

--- a/packages/rtop/src/lapack/RTOpPack_LapackWrappers.hpp
+++ b/packages/rtop/src/lapack/RTOpPack_LapackWrappers.hpp
@@ -15,6 +15,7 @@
 #include "RTOpPack_Types.hpp"
 #include "Teuchos_LAPACK.hpp"
 #include "Teuchos_as.hpp"
+#include "RTOp_DLLExportMacro.h"
 
 
 namespace RTOpPack {
@@ -27,7 +28,9 @@ enum ETransp {
 const int NUM_ETRANS_ARGS = 3;
 
 /** \brief. */
-extern const Teuchos::Tuple<char,NUM_ETRANS_ARGS> transpMap;
+/// \note On Windows shared builds this DATA symbol needs dllimport in
+///   consumers (thyracore, etc.) or linking fails with LNK2019.
+extern RTOP_LIB_DLL_EXPORT const Teuchos::Tuple<char,NUM_ETRANS_ARGS> transpMap;
 
 
 /** \brief Peform an in-place factorization of a square or rectangular matrix.

--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -7,6 +7,13 @@ INCLUDE(ETI_functions)
 
 TRIBITS_CONFIGURE_FILE(${PACKAGE_NAME}_config.h)
 
+# Windows shared-library import/export for data symbols in tpetra.dll.
+# CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS exports via .def, but consumers still need
+# __declspec(dllimport) for DATA (e.g. wdvTrackingEnabled) or LNK2019 results.
+SET(CURRENT_PACKAGE TPETRA)
+CONFIGURE_FILE("${Trilinos_SOURCE_DIR}/packages/Trilinos_DLLExportMacro.h.in"
+  ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_DLLExportMacro.h)
+
 #
 # B) Define the header and source files (and directories)
 #
@@ -35,6 +42,7 @@ TRIBITS_SET_AND_INC_DIRS(DIR ${CMAKE_CURRENT_BINARY_DIR})
 APPEND_GLOB(HEADERS ${DIR}/*.hpp)
 APPEND_SET(HEADERS ${DIR}/${PACKAGE_NAME}_config.h)
 APPEND_SET(HEADERS ${DIR}/${PACKAGE_NAME}_ETIHelperMacros.h)
+APPEND_SET(HEADERS ${DIR}/${PACKAGE_NAME}_DLLExportMacro.h)
 
 IF(${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
   SET(MultiVector_ETI_SCALARS ${TpetraCore_ETI_SCALARS})
@@ -682,6 +690,7 @@ TRIBITS_ADD_LIBRARY(
   tpetra
   HEADERS ${HEADERS}
   SOURCES ${SOURCES}
+  DEFINES -DTPETRA_LIB_EXPORTS_MODE
   ADDED_LIB_TARGET_NAME_OUT TPETRA_LIBNAME
 )
 

--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -11,8 +11,7 @@ TRIBITS_CONFIGURE_FILE(${PACKAGE_NAME}_config.h)
 # CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS exports via .def, but consumers still need
 # __declspec(dllimport) for DATA (e.g. wdvTrackingEnabled) or LNK2019 results.
 SET(CURRENT_PACKAGE TPETRA)
-CONFIGURE_FILE("${Trilinos_SOURCE_DIR}/packages/Trilinos_DLLExportMacro.h.in"
-  ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_DLLExportMacro.h)
+CONFIGURE_FILE("${Trilinos_SOURCE_DIR}/packages/Trilinos_DLLExportMacro.h.in" ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_DLLExportMacro.h)
 
 #
 # B) Define the header and source files (and directories)
@@ -689,8 +688,7 @@ ENDIF()
 TRIBITS_ADD_LIBRARY(
   tpetra
   HEADERS ${HEADERS}
-  SOURCES ${SOURCES}
-  DEFINES -DTPETRA_LIB_EXPORTS_MODE
+  SOURCES ${SOURCES} DEFINES -DTPETRA_LIB_EXPORTS_MODE
   ADDED_LIB_TARGET_NAME_OUT TPETRA_LIBNAME
 )
 

--- a/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.cpp
@@ -12,7 +12,7 @@
 namespace Tpetra {
 namespace Details {
 
-bool wdvTrackingEnabled = true;
+TPETRA_LIB_DLL_EXPORT bool wdvTrackingEnabled = true;
 
 void enableWDVTracking() {
   if (wdvTrackingEnabled)

--- a/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_WrappedDualView.hpp
@@ -15,6 +15,7 @@
 #include <Kokkos_DualView.hpp>
 #include "Teuchos_TestForException.hpp"
 #include "Tpetra_Details_ExecutionSpaces.hpp"
+#include "TpetraCore_DLLExportMacro.h"
 #include <sstream>
 
 //#define DEBUG_UVM_REMOVAL  // Works only with gcc > 4.8
@@ -94,17 +95,21 @@ sync_device(DualViewType dualView) {}
 /// \brief Whether WrappedDualView reference count checking is enabled. Initially true.
 /// Since the DualView sync functions are not thread-safe, tracking should be disabled
 /// during host-parallel regions where WrappedDualView is used.
+///
+/// \note On Windows shared builds this DATA symbol must be dllimport'd by
+///   consumers (tpetraext, etc.); otherwise the linker looks for a local
+///   definition and fails with LNK2019.
 
-extern bool wdvTrackingEnabled;
+extern TPETRA_LIB_DLL_EXPORT bool wdvTrackingEnabled;
 
 /// \brief Disable WrappedDualView reference-count tracking and syncing.
 /// Call this before entering a host-parallel region that uses WrappedDualView.
 /// For each WrappedDualView used in the parallel region, its view must be accessed
 /// (e.g. getHostView...) before disabling the tracking, so that it may be synced and marked modified correctly.
-void disableWDVTracking();
+TPETRA_LIB_DLL_EXPORT void disableWDVTracking();
 
 //! Enable WrappedDualView reference-count tracking and syncing. Call this after exiting a host-parallel region that uses WrappedDualView.
-void enableWDVTracking();
+TPETRA_LIB_DLL_EXPORT void enableWDVTracking();
 
 /// \brief A wrapper around Kokkos::DualView to safely manage data
 ///        that might be replicated between host and device.


### PR DESCRIPTION
@trilinos/ifpack2
@trilinos/tpetra
@trilinos/rtop

## Motivation

Fix for the LNK2019 linkage error while compiling Ifpack2 package. 
Failing symbols:

- `RTOpPack::transpMap`
- `Tpetra::Details::wdvTrackingEnabled`
- `Tpetra::Details::enableWDVTracking()` / `disableWDVTracking()`

The fix designed by the same way as in existing code, for example:

https://github.com/trilinos/Trilinos/blob/6ae2ada387af8a9d075817dead1efd557c1e9142/packages/anasazi/src/CMakeLists.txt#L18-L20 and https://github.com/trilinos/Trilinos/blob/6ae2ada387af8a9d075817dead1efd557c1e9142/packages/anasazi/src/AnasaziConfigDefs.hpp#L104-L111

## Proofs

- [compilation-output-clangcl-21.1.5-ninja-serial-err_part1.log](https://github.com/user-attachments/files/30655147/compilation-output-clangcl-21.1.5-ninja-serial-err_part1.log)
- [compilation-output-clangcl-21.1.5-ninja-serial-err_part2.log](https://github.com/user-attachments/files/30655146/compilation-output-clangcl-21.1.5-ninja-serial-err_part2.log)
- [compilation-output-clangcl-21.1.5-ninja-serial-err_part3.log](https://github.com/user-attachments/files/30655145/compilation-output-clangcl-21.1.5-ninja-serial-err_part3.log)

Part 1 and 2 are the main issues for this PR, part 3 shows us that LNK2019 for Tpetra and RTOp dependencies are resolved successfully.

## Environment

| Item       | Value                                            |
| ---------- | ------------------------------------------------ |
| OS         | Windows 11 Pro x64, Build 26100                  |
| CPU        | Intel Core i9-12900H (20 logical cores)          |
| CMake      | 4.3.2                                           |
| MSVC       | 19.51.36246 for x64 (VS 2026 Community)                  |
| clang-cl   | 21.1.5;x86_64-pc-windows-msvc;thread-model:posix |
| Ninja      | 1.12.1                                           |
| Build type | RelWithDebInfo, shared libs, C++20               

## Related Issues

Root issue - https://github.com/trilinos/Trilinos/issues/14816

## Stakeholder Feedback

@cgcgcg. Also, I need to ask you, do I need to tag you in any PR which is aimed to fix root #14816?

## Testing

No new tests were added and no tests were run - this is a link-only fix with no behavior change. Verified by confirming that Ifpack2 (which depends on both Tpetra and RTOp) now gets past the previously-failing `LNK2019` errors during linking; the
compiler errors seen afterward in the log are pre-existing and unrelated (see part 3 of the logs in Additional Information). These part 3 errors (`trilinos_colamd_l`, `trilinos_btf_l_strongcomp`, `trilinos_amd_l_order`, `trilinos_csymamd_l`) are `no matching function` errors, not linker errors, and are unrelated to DLL export/import. They look like the same class of LP64-vs-LLP64 data-model mismatch already documented in the "Data Model / OS" table in #15309 - SuiteSparse's `UF_long`-based interfaces expect a 64-bit integer, but `long` is only 32-bit on Windows (LLP64), unlike Linux (LP64) where it's 64-bit.

## CMake command

<details><summary>Command is below 👇</summary>

```ps1
cmake `
         
           # --- Generator, source tree, build directory, configuration type (Trilinos) ---
           -G `
           Ninja `
           -DCMAKE_C_COMPILER=D:/local/LLVM/bin/clang-cl.exe `
           -DCMAKE_CXX_COMPILER=D:/local/LLVM/bin/clang-cl.exe `
           -S `
           D:/Develop/Trilinos `
           -B `
           D:/Develop/Trilinos/bifpack2serial `
           -DCMAKE_BUILD_TYPE=RelWithDebInfo `
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
           -DCMAKE_CXX_STANDARD=20 `
           -DBUILD_SHARED_LIBS=ON `
           '-DCMAKE_CXX_FLAGS=-Wno-everything -Wreturn-type -Wuninitialized -Winconsistent-missing-override -Woverloaded-virtual -Wdelete-non-virtual-dtor -Wreorder -Wswitch -Wimplicit-fallthrough -Wshift-overflow -Wshorten-64-to-32 -Wimplicit-int-conversion' `
           '-DCMAKE_C_FLAGS=-Wno-everything -Wreturn-type -Wuninitialized -Winconsistent-missing-override -Woverloaded-virtual -Wdelete-non-virtual-dtor -Wreorder -Wswitch -Wimplicit-fallthrough -Wshift-overflow -Wshorten-64-to-32 -Wimplicit-int-conversion' `
           -DTPL_ENABLE_DLlib=OFF `
           -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON `
         
           # --- Ninja: explicit x64 linker and manifest tools ---
           '-DCMAKE_LINKER=C:/Program Files/Microsoft Visual Studio/18/Community/VC/Tools/MSVC/14.51.36231/bin/HostX64/x64/link.exe' `
           '-DCMAKE_RC_COMPILER=C:/Program Files (x86)/Windows Kits/10/Bin/10.0.26100.0/x64/rc.exe' `
           '-DCMAKE_MT=C:/Program Files (x86)/Windows Kits/10/Bin/10.0.26100.0/x64/mt.exe' `
         
           # --- vcpkg toolchain and CMAKE_PREFIX_PATH ---
           -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake `
           -DCMAKE_PREFIX_PATH=C:/vcpkg/installed/x64-windows `
         
           # --- Third-party BLAS/LAPACK (OpenBLAS + lapack) ---
           -DTPL_ENABLE_BLAS=ON `
           -DBLAS_LIBRARY_DIRS=C:/vcpkg/installed/x64-windows/lib `
           -DBLAS_LIBRARY_NAMES=openblas `
           -DTPL_ENABLE_LAPACK=ON `
           -DLAPACK_LIBRARY_DIRS=C:/vcpkg/installed/x64-windows/lib `
           -DLAPACK_LIBRARY_NAMES=lapack `
         
           # --- Google Test (TriBITS TPL_gtest paths) ---
           -DTPL_gtest_INCLUDE_DIRS=C:/vcpkg/installed/x64-windows/include `
           -DTPL_gtest_LIBRARIES=C:/vcpkg/installed/x64-windows/lib/gtest.lib `
         
           # --- Kokkos backend: Serial ---
           -DKokkos_ENABLE_SERIAL=ON `
           -DKokkos_ENABLE_OPENMP=OFF `
           -DTPL_ENABLE_CUDA=OFF `
           -DTPL_ENABLE_MPI=OFF `
         
           # --- Trilinos package toggles (auto-enabling Windows-disabled required deps: Tpetra) ---
           -DTrilinos_ENABLE_ALL_PACKAGES=OFF `
           -DTrilinos_ENABLE_Ifpack2=ON `
           -DTrilinos_ENABLE_Tpetra=ON `
         
           # --- Tests, examples, PyTrilinos2, complex ---
           -DTrilinos_ENABLE_TESTS=ON `
           -DTrilinos_ENABLE_EXAMPLES=ON `
           -DTrilinos_ENABLE_PyTrilinos2=OFF `
           -DTrilinos_ENABLE_COMPLEX_DOUBLE=ON `
           -DTrilinos_ENABLE_COMPLEX_FLOAT=OFF `
           -DTrilinos_ENABLE_FLOAT=OFF `
           -DTpetra_INST_FLOAT=OFF `
           -DTpetra_INST_COMPLEX_FLOAT=OFF
```

</details>
