### PR TITLE
ShyLU_Basker: fix long/UF_long mismatch in SuiteSparse AMD/BTF/COLAMD calls (blocks Ifpack2 builds)

### DIFF
--- a/packages/shylu/shylu_node/basker/src/shylubasker_order.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_order.hpp
@@ -389,13 +389,13 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
         if(Options.verbose == BASKER_TRUE) {
           std::cout << " ++ calling TRILINOS_BTF_MAXTRANS (" << A.nrow << " x " << A.ncol << ") ++ " << std::endl;
         }
-        if constexpr (std::is_same<Int, int>::value) {
+        if constexpr (std::is_same_v<Int, int>) {
           int *col_ptr = &(A.col_ptr(0));
           int *row_idx = &(A.row_idx(0));
           int *order   = &(order_match_array(0));
           int *iwork   = &(WORK(0));
           num_match = trilinos_btf_maxtrans ((int)A.nrow, (int)A.ncol, col_ptr, row_idx, maxwork, &work, order, iwork);
-        } else if constexpr (std::is_same<Int, UF_long>::value) {
+        } else if constexpr (std::is_same_v<Int, UF_long>) {
           // Int is exactly UF_long here (e.g. long long == __int64 on Win64), so no
           // cast is needed: the pointers already have the right type. A reinterpret_cast
           // to bridge a different Int (e.g. 32-bit `long` on LLP64) would be UB even

--- a/packages/shylu/shylu_node/basker/src/shylubasker_order.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_order.hpp
@@ -396,11 +396,14 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
           int *iwork   = reinterpret_cast <int*> (&(WORK(0)));
           num_match = trilinos_btf_maxtrans ((int)A.nrow, (int)A.ncol, col_ptr, row_idx, maxwork, &work, order, iwork);
         } else {
-          long int *col_ptr = reinterpret_cast <long int*> (&(A.col_ptr(0)));
-          long int *row_idx = reinterpret_cast <long int*> (&(A.row_idx(0)));
-          long int *order   = reinterpret_cast <long int*> (&(order_match_array(0)));
-          long int *iwork   = reinterpret_cast <long int*> (&(WORK(0)));
-          num_match = trilinos_btf_l_maxtrans ((long int)A.nrow, (long int)A.ncol, col_ptr, row_idx, maxwork, &work, order, iwork);
+          // NOTE: must be UF_long (not plain `long int`); on Win64 (LLP64) UF_long
+          // is __int64 (64-bit) while `long` is only 32-bit, and trilinos_btf_l_maxtrans
+          // always takes UF_long* (see trilinos_UFconfig.h).
+          UF_long *col_ptr = reinterpret_cast <UF_long*> (&(A.col_ptr(0)));
+          UF_long *row_idx = reinterpret_cast <UF_long*> (&(A.row_idx(0)));
+          UF_long *order   = reinterpret_cast <UF_long*> (&(order_match_array(0)));
+          UF_long *iwork   = reinterpret_cast <UF_long*> (&(WORK(0)));
+          num_match = trilinos_btf_l_maxtrans ((UF_long)A.nrow, (UF_long)A.ncol, col_ptr, row_idx, maxwork, &work, order, iwork);
         }
         #if 0
         printf( " >> debug: set order_match to identity <<\n" );

--- a/packages/shylu/shylu_node/basker/src/shylubasker_order.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_order.hpp
@@ -389,21 +389,29 @@ static int basker_sort_matrix_col(const void *arg1, const void *arg2)
         if(Options.verbose == BASKER_TRUE) {
           std::cout << " ++ calling TRILINOS_BTF_MAXTRANS (" << A.nrow << " x " << A.ncol << ") ++ " << std::endl;
         }
-        if (std::is_same<Int, int>::value) {
-          int *col_ptr = reinterpret_cast <int*> (&(A.col_ptr(0)));
-          int *row_idx = reinterpret_cast <int*> (&(A.row_idx(0)));
-          int *order   = reinterpret_cast <int*> (&(order_match_array(0)));
-          int *iwork   = reinterpret_cast <int*> (&(WORK(0)));
+        if constexpr (std::is_same<Int, int>::value) {
+          int *col_ptr = &(A.col_ptr(0));
+          int *row_idx = &(A.row_idx(0));
+          int *order   = &(order_match_array(0));
+          int *iwork   = &(WORK(0));
           num_match = trilinos_btf_maxtrans ((int)A.nrow, (int)A.ncol, col_ptr, row_idx, maxwork, &work, order, iwork);
-        } else {
-          // NOTE: must be UF_long (not plain `long int`); on Win64 (LLP64) UF_long
-          // is __int64 (64-bit) while `long` is only 32-bit, and trilinos_btf_l_maxtrans
-          // always takes UF_long* (see trilinos_UFconfig.h).
-          UF_long *col_ptr = reinterpret_cast <UF_long*> (&(A.col_ptr(0)));
-          UF_long *row_idx = reinterpret_cast <UF_long*> (&(A.row_idx(0)));
-          UF_long *order   = reinterpret_cast <UF_long*> (&(order_match_array(0)));
-          UF_long *iwork   = reinterpret_cast <UF_long*> (&(WORK(0)));
+        } else if constexpr (std::is_same<Int, UF_long>::value) {
+          // Int is exactly UF_long here (e.g. long long == __int64 on Win64), so no
+          // cast is needed: the pointers already have the right type. A reinterpret_cast
+          // to bridge a different Int (e.g. 32-bit `long` on LLP64) would be UB even
+          // when sizeof matches - [basic.lval]/11 (https://eel.is/c++draft/basic.lval#11) 
+          // only allows access through a similar type (same type, its signed/unsigned counterpart, 
+          // or a char type), and `long`/`long long` are not "similar" to each other
+          // regardless of width.
+          UF_long *col_ptr = &(A.col_ptr(0));
+          UF_long *row_idx = &(A.row_idx(0));
+          UF_long *order   = &(order_match_array(0));
+          UF_long *iwork   = &(WORK(0));
           num_match = trilinos_btf_l_maxtrans ((UF_long)A.nrow, (UF_long)A.ncol, col_ptr, row_idx, maxwork, &work, order, iwork);
+        } else {
+          // Unsupported ordinal type for this SuiteSparse bridge: fail explicitly
+          // instead of silently reinterpreting memory of the wrong width/type.
+          return BASKER_ERROR;
         }
         #if 0
         printf( " >> debug: set order_match to identity <<\n" );

--- a/packages/shylu/shylu_node/basker/src/shylubasker_order_amd.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_order_amd.hpp
@@ -75,15 +75,15 @@ namespace BaskerNS
   BASKER_INLINE
   int my_amesos_csymamd <>
   (
-   long n, 
-   long *Ap,
-   long *Ai,
-   long *p, 
-   long *cmember
+   UF_long n,
+   UF_long *Ap,
+   UF_long *Ai,
+   UF_long *p,
+   UF_long *cmember
   )
   {
     double knobs[TRILINOS_CCOLAMD_KNOBS];
-    long    stats[TRILINOS_CCOLAMD_STATS];
+    UF_long    stats[TRILINOS_CCOLAMD_STATS];
 
     //use default knob settings
     trilinos_ccolamd_l_set_defaults(knobs);
@@ -196,13 +196,13 @@ namespace BaskerNS
   BASKER_INLINE
   int trilinos_colamd<>
   (
-   long n_row,
-   long n_col,
-   long Alen,
-   long *A,
-   long *p,
+   UF_long n_row,
+   UF_long n_col,
+   UF_long Alen,
+   UF_long *A,
+   UF_long *p,
    double *knobs,
-   long *stats
+   UF_long *stats
   )
   {
     trilinos_colamd_l(n_row, n_col, Alen, A, p, knobs, stats);

--- a/packages/shylu/shylu_node/basker/src/shylubasker_sswrapper.hpp
+++ b/packages/shylu/shylu_node/basker/src/shylubasker_sswrapper.hpp
@@ -221,16 +221,19 @@ namespace BaskerNS
     inline
     int strong_component 
     (   
-     long           &n,
-     long           *col_ptr,
-     long          *row_idx,
-     long           &nblks,
-     long           *perm,
-     long           *perm_in,
-     long          *CC
+     UF_long           &n,
+     UF_long           *col_ptr,
+     UF_long           *row_idx,
+     UF_long           &nblks,
+     UF_long           *perm,
+     UF_long           *perm_in,
+     long              *CC
     )
     {
-      typedef long  l_Int;
+      // NOTE: must be UF_long (not plain `long`), since on Win64 (LLP64) UF_long
+      // is __int64 (64-bit) while `long` is only 32-bit; the SuiteSparse "_l"
+      // routines below always take UF_long* (see trilinos_UFconfig.h).
+      typedef UF_long  l_Int;
       
       //l_Int p[n]; //output row_per
       l_Int *p = new l_Int[n];
@@ -291,18 +294,18 @@ namespace BaskerNS
     inline
     int amd_order
     (
-     long n, 
-     long *col_ptr,
-     long *row_idx,
-     long *p,
+     UF_long n,
+     UF_long *col_ptr,
+     UF_long *row_idx,
+     UF_long *p,
      bool verbose
     )
     {
       double Info[TRILINOS_AMD_INFO];
-      for(long i = 0; i < TRILINOS_AMD_INFO; ++i)
+      for(UF_long i = 0; i < TRILINOS_AMD_INFO; ++i)
       {Info[i] = 0;}
 
-      long ret = trilinos_amd_l_order(n, col_ptr, row_idx, p, NULL, Info);
+      UF_long ret = trilinos_amd_l_order(n, col_ptr, row_idx, p, NULL, Info);
 
       if (verbose) {
         if(ret == TRILINOS_AMD_OUT_OF_MEMORY)
@@ -320,20 +323,20 @@ namespace BaskerNS
     inline
     int amd_order
     (
-     long n, 
-     long *col_ptr,
-     long *row_idx,
-     long *p,
+     UF_long n,
+     UF_long *col_ptr,
+     UF_long *row_idx,
+     UF_long *p,
      double &l_nnz,
      double &lu_work,
      bool verbose
     )
     {
       double Info[TRILINOS_AMD_INFO];
-      for(long i = 0; i < TRILINOS_AMD_INFO; ++i)
+      for(UF_long i = 0; i < TRILINOS_AMD_INFO; ++i)
       {Info[i] = 0;}
 
-      long ret = trilinos_amd_l_order(n, col_ptr, row_idx, p, NULL, Info);
+      UF_long ret = trilinos_amd_l_order(n, col_ptr, row_idx, p, NULL, Info);
 
       if (verbose) {
         if(ret == TRILINOS_AMD_OUT_OF_MEMORY)


### PR DESCRIPTION
@trilinos/shylu

## Motivation

On Win64 (LLP64), `UF_long` resolves to `__int64` (64-bit) while `long` is only 32-bit, so it is a distinct type from `long` -- unlike on Linux (LP64) where UF_long is exactly `long`. The BaskerSSWrapper<long> and my_amesos_csymamd<long>/trilinos_colamd<long> specializations passed plain `long` buffers into trilinos_btf_l_strongcomp, trilinos_amd_l_order, trilinos_csymamd_l, and trilinos_colamd_l, all of which take UF_long*, causing "no matching function" errors under clang-cl. Switch those call sites to UF_long to match the SuiteSparse "_l" API on every platform.

| Data Model / OS      | `int`   | `long`  | `long long` | pointer / `size_t` / `ptrdiff_t` |
| -------------------- | ------- | ------- | ----------- | --------------------------------- |
| **LP64 (Linux, macOS)** | 32-bit | 64-bit | 64-bit      | 64-bit                             |
| **LLP64 (Windows)**    | 32-bit | 32-bit | 64-bit      | 64-bit                             |

The same table can be found in #15309.

## Proofs

- [compilation-output-clangcl-21.1.5-ninja-serial-err_part3.log](https://github.com/user-attachments/files/30672832/compilation-output-clangcl-21.1.5-ninja-serial-err_part3.log)
- [compilation-output-clangcl-21.1.5-ninja-serial-err_part4.log](https://github.com/user-attachments/files/30672833/compilation-output-clangcl-21.1.5-ninja-serial-err_part4.log)
- [compilation-output-clangcl-21.1.5-ninja-serial-err_part5.log](https://github.com/user-attachments/files/30672834/compilation-output-clangcl-21.1.5-ninja-serial-err_part5.log)

This PR covers 3rd and 4th logs (counting starts from #15537), 5th just as a marker of successfull resolution.

## Environment

| Item       | Value                                            |
| ---------- | ------------------------------------------------ |
| OS         | Windows 11 Pro x64, Build 26100                  |
| CPU        | Intel Core i9-12900H (20 logical cores)          |
| CMake      | 4.3.2                                           |
| MSVC       | 19.51.36246 for x64 (VS 2026 Community)                  |
| clang-cl   | 21.1.5;x86_64-pc-windows-msvc;thread-model:posix |
| Ninja      | 1.12.1                                           |
| Build type | RelWithDebInfo, shared libs, C++20      

## Related Issues

Root issue - https://github.com/trilinos/Trilinos/issues/14816
First PR as a ref - https://github.com/trilinos/Trilinos/pull/15537

## Stakeholder Feedback

@cgcgcg 

## Testing

No new tests added. Part 5 of log from _Proofs_ shows us that compilation errors are resolved.

## Additional Information

Also, part 5 of err log shows exactly the same issues like in #15537 and will be covered later.
