### PR TITLE
MiniTensor: restore binary_powering to the public namespace

### DIFF
--- a/packages/minitensor/README.md
+++ b/packages/minitensor/README.md
@@ -30,7 +30,7 @@ on its own:
 | `MiniTensor_Norms.h` | Norms, determinant, trace, invariants, argmax queries |
 | `MiniTensor_Inverse.h` | Inversion, rank-one updates, preconditioners, linear solves |
 | `MiniTensor_Factorizations.h` | Givens, Cholesky, eigen, SVD, polar, condition numbers |
-| `MiniTensor_MatrixFunctions.h` | `exp`, `log`, `sqrt` families and BCH |
+| `MiniTensor_MatrixFunctions.h` | `exp`, `log`, `sqrt` families, integer powers, BCH |
 | `MiniTensor_Rotations.h` | SO(N) logarithmic and exponential maps, axial vector |
 | `MiniTensor_LinearAlgebra.h` | Umbrella over the five linear-algebra modules |
 | `MiniTensor_Quaternion.h` | Quaternions and rotation-representation conversions |

--- a/packages/minitensor/doc/MiniTensor_DoxygenDocumentation.hpp
+++ b/packages/minitensor/doc/MiniTensor_DoxygenDocumentation.hpp
@@ -129,8 +129,8 @@ polar decompositions and condition numbers.
 
 /*!
 \defgroup minitensor_matrix_functions Matrix Functions
-\brief Tensor exponential, logarithm and square root families, and the
-Baker-Campbell-Hausdorff series.
+\brief Tensor exponential, logarithm and square root families, integer
+powers, and the Baker-Campbell-Hausdorff series.
 */
 
 /*!

--- a/packages/minitensor/src/MiniTensor_MatrixFunctions.h
+++ b/packages/minitensor/src/MiniTensor_MatrixFunctions.h
@@ -127,6 +127,18 @@ KOKKOS_INLINE_FUNCTION
 Tensor<T, N>
 bch(Tensor<T, N> const & v, Tensor<T, N> const & r);
 
+///
+/// Non-negative integer power of a tensor by binary manipulation of the
+/// exponent, so that the number of multiplications is logarithmic in it.
+/// \param A tensor
+/// \param exponent non-negative integer exponent
+/// \return \f$ A^{\text{exponent}} \f$, the identity if the exponent is zero
+///
+template<typename T, Index N>
+KOKKOS_INLINE_FUNCTION
+Tensor<T, N>
+binary_powering(Tensor<T, N> const & A, Index const exponent);
+
 //
 // Exponential map
 //
@@ -2946,6 +2958,8 @@ gauss_legendre_weights(Index const m, Index const n)
   return x;
 }
 
+} // namespace impl
+
 //
 // Compute a non-negative integer power of a tensor by binary manipulation.
 //
@@ -3007,8 +3021,6 @@ binary_powering(Tensor<T, N> const & A, Index const exponent)
 
   return X;
 }
-
-} // namespace impl
 
 //
 // Exponential map by squaring and scaling and Padé approximants.
@@ -3099,7 +3111,7 @@ expm_ell(Tensor<Real, N> const & A, Index const m)
   }
 
   Tensor<Real, N> const
-  Q = impl::binary_powering(P, 2 * m + 1);
+  Q = binary_powering(P, 2 * m + 1);
 
   Real const
   alpha = norm_1(Q) / (norm_A * c_recip);
@@ -3273,7 +3285,7 @@ template <typename T, Index N> Tensor<T, N> exp_pade(Tensor<T, N> const &A) {
       Index const
       exponent = (1U << power_two);
 
-      B = impl::binary_powering(R, exponent);
+      B = binary_powering(R, exponent);
 
   }
 

--- a/packages/minitensor/test/test_matrix_functions.cc
+++ b/packages/minitensor/test/test_matrix_functions.cc
@@ -237,4 +237,27 @@ TEST(MiniTensor, BakerCampbellHausdorff)
   ASSERT_LE(error, tolerance);
 }
 
+TEST(MiniTensor, BinaryPowering)
+{
+  Tensor<Real> const A(1.1, 0.2, 0.3, 0.4, 1.2, 0.5, 0.6, 0.7, 1.3);
+
+  // Qualified on purpose: binary_powering is part of the public
+  // interface and external packages call it as minitensor::binary_powering.
+  ASSERT_LE(norm(minitensor::binary_powering(A, 0) - eye<Real>(3)),
+      machine_epsilon<Real>());
+
+  Tensor<Real> B = eye<Real>(3);
+
+  for (Index exponent = 1; exponent <= 9; ++exponent) {
+
+    B = B * A;
+
+    Real const
+    error = norm(minitensor::binary_powering(A, exponent) - B) / norm(B);
+
+    ASSERT_LE(error, 128.0 * machine_epsilon<Real>());
+
+  }
+}
+
 } // namespace minitensor


### PR DESCRIPTION
## Motivation

Krino is being synced back from Sierra into Trilinos, and its new smoothing
directory fails to compile against current `develop`:

```
packages/krino/krino/smoothing/Akri_Objective_SethHill.cpp:43:24: error:
  'binary_powering' is not a member of 'minitensor';
  did you mean 'minitensor::impl::binary_powering'?
```

`binary_powering` computes an integer power of a tensor by binary
manipulation of the exponent. It has been in the public `minitensor`
namespace since the package was first imported. The split of
`MiniTensor_LinearAlgebra.h` into module headers (#15527) swept it into
`minitensor::impl` along with the genuinely internal numerical helpers of
the matrix exponential and logarithm (Pade coefficients, Gauss-Legendre
tables, Schur and SVD kernels). That was a mistake: unlike those, it is a
general-purpose operation and an external package calls it.

## What this does

* Moves the definition back out of `minitensor::impl` into `minitensor`.
* Declares it, with documentation, next to the other matrix functions.
* Updates the two internal call sites in `exp_pade` and `expm_ell`.
* Adds `MiniTensor.BinaryPowering`, which calls it qualified as
  `minitensor::binary_powering` and checks powers 0 through 9 against
  repeated multiplication, so that the public name stays public.

No behavior change. With this, code that calls
`minitensor::binary_powering` compiles against both current `develop` and
pre-split versions of MiniTensor, which matters while Sierra tracks an
older Trilinos.

## Testing

* MiniTensor test suite, 7/7 passing, including the per-header
  self-containedness test.
* No new compiler warnings.
* Doxygen audit configuration (`EXTRACT_ALL = NO`,
  `WARN_IF_UNDOCUMENTED = YES`) reports no undocumented entities.
* A translation unit that reproduces Krino's `power()` and `safe_power()`
  usage compiles against the patched headers.
