### PR TITLE
muelu: make MueLu_UnitTests rely on MueLu_MueLu_Repartition_cp for testCoordinates.xml

### DIFF
--- a/packages/muelu/test/unit_tests/CMakeLists.txt
+++ b/packages/muelu/test/unit_tests/CMakeLists.txt
@@ -228,6 +228,11 @@ TRIBITS_ADD_EXECUTABLE(
   COMM serial mpi
 )
 
+# depending on the category (e.g. PERFORMANCE builds), these targets may not have been created
+IF(TARGET MueLu_UnitTests AND TARGET MueLu_MueLu_Repartition_cp)
+  ADD_DEPENDENCIES(MueLu_UnitTests MueLu_MueLu_Repartition_cp)
+ENDIF()
+
 TRIBITS_ADD_EXECUTABLE(
   UnitTests_Intrepid2
   SOURCES ${SOURCES_INTREPID2}


### PR DESCRIPTION
Another attempt at fixing https://github.com/trilinos/Trilinos/issues/15540

https://github.com/trilinos/Trilinos/pull/15542 wasn't quite right because in a performance build the targets don't necessarily exist.