### PR TITLE
Phalanx: remove fence between nodes in DAG evaluation

### DIFF
--- a/packages/phalanx/src/Phalanx_DAG_Manager_Def.hpp
+++ b/packages/phalanx/src/Phalanx_DAG_Manager_Def.hpp
@@ -456,8 +456,6 @@ evaluateFields(typename Traits::EvalData d)
     using clock = std::chrono::steady_clock;
     std::chrono::time_point<clock> start = clock::now();
 
-    typename PHX::Device().fence(); // temporary fence until UVM in evaluateFields fixed
-
     nodes_[topoSortEvalIndex[n]].getNonConst()->evaluateFields(d);
 
     nodes_[topoSortEvalIndex[n]].sumIntoExecutionTime(clock::now()-start);


### PR DESCRIPTION
@trilinos/phalanx 

## Motivation
Fence was used to protect for UVM. Not needed now. Thanks to @cgcgcg for reminding me about this.

## Testing
N/A
