### PR TITLE
Add release notes for Trilinos 17.2.0

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -59,6 +59,63 @@ Krino:
 
 Minitensor:
 
+  - New capability: quaternions and conversions among rotation
+    representations (rotation matrix, unit quaternion, principal rotation
+    vector), using a singularity-free Spurrier extraction, along with a
+    helper that keeps a rotation vector continuous across the 2 pi
+    boundary and the axial vector operator vee(). Also new are exp_sym()
+    and exp_eig_sym(), the eigendecomposition exponential of a symmetric
+    tensor, mirroring the existing log_sym() and log_eig_sym().
+    https://github.com/trilinos/Trilinos/pull/15532
+    https://github.com/trilinos/Trilinos/pull/15514
+
+  - The general log() and exp() now follow the current published
+    algorithms. For dimensions three and lower, log() uses Gauss-Legendre
+    partial-fraction Pade evaluation inside the Pade trust region and
+    Schur-based inverse scaling and squaring (Al-Mohy and Higham, SIAM J.
+    Sci. Comput. 34(4), 2012) outside it, and exp() uses the parameter
+    selection of Al-Mohy and Higham, SIAM J. Matrix Anal. Appl. 31(3),
+    2009. Measured against an 80-bit eigendecomposition reference, log()
+    is 1.8 to 4.3 times more accurate and 1.4 to 4.7 times faster away
+    from the identity, with no failures in 17,500 samples.
+    https://github.com/trilinos/Trilinos/pull/15515
+
+  - Correctness and robustness fixes. log() no longer aborts in debug
+    builds or writes out of bounds in release builds on ill-conditioned
+    symmetric positive definite tensors, where a catastrophically
+    cancelling determinant produced a non-finite scaling factor: 39
+    percent of random SPD tensors at condition 1e14 used to fail, none do
+    now. eig_sym() returns a consistent (V, D) pair in two dimensions,
+    the 2x2 singular value decomposition canonicalizes its singular
+    values, operations that require symmetric positive definite input now
+    fail loudly instead of returning garbage, and the 2x2 eigenvalue and
+    square root scaling is safe for Sacado FAD scalars, which repaired
+    downstream code that instantiates log() on a tensor of FAD scalars.
+    https://github.com/trilinos/Trilinos/pull/15513
+    https://github.com/trilinos/Trilinos/pull/15393
+    https://github.com/trilinos/Trilinos/pull/15397
+    https://github.com/trilinos/Trilinos/pull/15398
+    https://github.com/trilinos/Trilinos/pull/15520
+
+  - The headers were reorganized, with no change in functionality. The
+    .i.h and .t.h sub-headers were merged into their parents. The
+    TeuchosCore and KokkosKernels dependencies were dropped. Code that
+    includes MiniTensor.h is unaffected.
+    https://github.com/trilinos/Trilinos/pull/15523
+    https://github.com/trilinos/Trilinos/pull/15527
+    https://github.com/trilinos/Trilinos/pull/15529
+
+  - The package is now documented.
+    https://trilinos.github.io/docs/minitensor/index.html
+    https://github.com/trilinos/Trilinos/pull/15531
+    https://github.com/trilinos/Trilinos/pull/15533
+
+  - The tests were split by module, property-based tests were added for
+    the matrix decompositions, and every public header is now compiled on
+    its own so that it stays self-contained.
+    https://github.com/trilinos/Trilinos/pull/15395
+    https://github.com/trilinos/Trilinos/pull/15534
+
 
 MueLu:
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,100 @@
 ###############################################################################
 #                                                                             #
+# Trilinos Release 17.2 Release Notes                         August XX, 2026 #
+#                                                                             #
+###############################################################################
+
+The test results from Trilinos testing (PRs and nightly builds) are now posted
+to a public CDash dashboard:
+https://my.cdash.org/index.php?project=Trilinos
+
+
+
+Amesos2:
+
+  - Pardiso, MUMPS changes?
+  
+
+Belos:
+
+  - Solvers now provide more more detailed solve status reporting.
+    The "Unconverged" return type has been split into "MaxItersReached",
+    "MaxRestartsReached". "OrthonormFailure", "NaNDetected", "BreakdownDetected",
+    "LossOfAccuracyDetected", "NonspecificException", "InconsistentState",
+    "Undetermined". 
+    https://github.com/trilinos/Trilinos/pull/15231
+
+
+Galeri:
+
+  - Added the creation of finite element mass matrices for use in testing.
+    https://github.com/trilinos/Trilinos/pull/15318
+    
+
+Kokkos, KokkosKernels:
+
+  - Inclusion of version 5.2.1 of Kokkos and Kokkos Kernels
+    https://github.com/trilinos/Trilinos/pull/15453
+    https://github.com/kokkos/kokkos/blob/develop/CHANGELOG.md
+    https://github.com/kokkos/kokkos-kernels/blob/develop/CHANGELOG.md
+
+
+Ifpack2:
+
+  -
+    https://github.com/trilinos/Trilinos/pull/15439
+
+
+Intrepid2:
+
+  - 
+    https://github.com/trilinos/Trilinos/pull/15269
+
+
+Krino:
+
+  - Snapshot
+    https://github.com/trilinos/Trilinos/pull/15526
+
+
+Minitensor:
+
+
+MueLu:
+
+  - Add a new stength-of-connection matrix that leverages an approximate inverse
+    of a mass matrix. 
+    https://github.com/trilinos/Trilinos/pull/15239
+
+
+Panzer:
+
+  - Large update to the documenation
+    https://github.com/trilinos/Trilinos/pull/15503
+
+
+STK:
+
+  - Inclusion of version 5.31.3
+    https://github.com/trilinos/Trilinos/pull/15427
+    https://github.com/trilinos/Trilinos/pull/15530
+    https://github.com/trilinos/Trilinos/blob/8aec0c9da36965e5b369dbc77ff97341f90b410b/packages/stk/CHANGELOG.md?plain=1#L3-L41
+
+
+Tempus:
+
+  - The tutorial pages and documentation have been updated and extended.
+    https://github.com/trilinos/Trilinos/pull/15365
+    https://github.com/trilinos/Trilinos/pull/15387
+    https://github.com/trilinos/Trilinos/pull/15423
+
+
+Teko:
+
+
+
+###############################################################################
+#                                                                             #
 # Trilinos Release 17.1.2 Release Notes                       August 13, 2026 #
 #                                                                             #
 ###############################################################################

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -41,8 +41,11 @@ Kokkos, KokkosKernels:
 
 Ifpack2:
 
-  -
+  - Cache local CRS structure in par_ILUT to improve setup related costs
     https://github.com/trilinos/Trilinos/pull/15439
+    
+  - Use KSPTRSV as default triangular solver on GPU platforms
+    https://github.com/trilinos/Trilinos/pull/15490
 
 
 Intrepid2:
@@ -119,6 +122,9 @@ Minitensor:
 
 MueLu:
 
+  - Improve support for Teko-based smoothers via specifying `smoother: type = teko`
+    https://github.com/trilinos/Trilinos/pull/15238
+    
   - Add a new stength-of-connection matrix that leverages an approximate inverse
     of a mass matrix. 
     https://github.com/trilinos/Trilinos/pull/15239
@@ -148,7 +154,17 @@ Tempus:
 
 Teko:
 
+  - Port ProbingPreconditionerFactory to Tpetra
+    https://github.com/trilinos/Trilinos/pull/15386
+  
+  - Port majority of tests/examples to Tpetra
 
+
+Zoltan2:
+
+  - Provide option to opt-out of potentially expensive symmetrization in metis algorithm
+    https://github.com/trilinos/Trilinos/pull/15496
+  
 
 ###############################################################################
 #                                                                             #

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -50,8 +50,18 @@ Ifpack2:
 
 Intrepid2:
 
-  - 
-    https://github.com/trilinos/Trilinos/pull/15269
+  - Redesigned PointInclusion tools to expose parametric distance and
+    extended CellTools to support beam and shell elements, including mappings
+    from (D+1)-dimensional physical space to D-dimensional reference space.
+    PR: https://github.com/trilinos/Trilinos/pull/15269
+
+  - Refactored Intrepid2 operators to improve performance by introducing an
+    orientation operator that stores subcell orientation matrices in
+    compressed-row storage format.
+    PR: https://github.com/trilinos/Trilinos/pull/14450
+
+  - Improved the parallel implementation of Basis::getValues.
+    PR: https://github.com/trilinos/Trilinos/pull/15234
 
 
 Krino:

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -12,8 +12,11 @@ https://my.cdash.org/index.php?project=Trilinos
 
 Amesos2:
 
-  - Pardiso, MUMPS changes?
-  
+  - new "partial-factorization" option (to improve performance of computing
+    local Schur complement) with PardisoMKL & MUMPS 
+    https://github.com/trilinos/Trilinos/pull/15404
+    https://github.com/trilinos/Trilinos/pull/15484  
+
 
 Belos:
 
@@ -53,15 +56,15 @@ Intrepid2:
   - Redesigned PointInclusion tools to expose parametric distance and
     extended CellTools to support beam and shell elements, including mappings
     from (D+1)-dimensional physical space to D-dimensional reference space.
-    PR: https://github.com/trilinos/Trilinos/pull/15269
+    https://github.com/trilinos/Trilinos/pull/15269
 
   - Refactored Intrepid2 operators to improve performance by introducing an
     orientation operator that stores subcell orientation matrices in
     compressed-row storage format.
-    PR: https://github.com/trilinos/Trilinos/pull/14450
+    https://github.com/trilinos/Trilinos/pull/14450
 
   - Improved the parallel implementation of Basis::getValues.
-    PR: https://github.com/trilinos/Trilinos/pull/15234
+    https://github.com/trilinos/Trilinos/pull/15234
 
 
 Krino:


### PR DESCRIPTION
In preparation for Trilinos 17.2.0 we are collecting our release notes. We want to mention noteworthy changes since the last minor release, i.e after May 18. I have taken a first pass, but I will need some help.

- @iyamazaki Could you provide me with some content for the Amesos2 changes?
  https://github.com/trilinos/Trilinos/pulls?q=is%3Apr+is%3Aclosed+label%3A%22pkg%3A+Amesos2%22+
- @lxmota Could you provide me with a summary of the Minitensor changes?
  https://github.com/trilinos/Trilinos/pulls?q=is%3Apr+is%3Aclosed+label%3A%22pkg%3A+minitensor%22
- @dridzal Should #15528 be mentioned?
- @MalachiTimothyPhillips Should #15439 be mentioned? Do you want to add something about your work on tests in Teko?
- @mperego @CamelliaDPG Could you provide a short summary for #15269?

Did I forget anything else that should be included?