### PR TITLE
Belos, SuiteSparse: fixed LNK2001 and LNK2019 linker errors (blocks Ifpack2 builds)

### DIFF
--- a/packages/belos/src/BelosConfigDefs.hpp
+++ b/packages/belos/src/BelosConfigDefs.hpp
@@ -90,6 +90,11 @@
 #define BELOS_MIN(x,y) (( (x) < (y) ) ? (x)  : (y) )     /* min function  */
 #define BELOS_SGN(x)   (( (x) < 0.0 ) ? -1.0 : 1.0 )     /* sign function */
 
+/* Windows shared-build DATA-symbol import/export (BELOS_LIB_DLL_EXPORT).
+ * Included here so every Belos header that pulls in BelosConfigDefs.hpp
+ * (e.g. BelosTypes.hpp DefaultSolverParameters) sees the annotation. */
+#include "Belos_DLLExportMacro.h"
+
 namespace Belos { std::string Belos_Version(); }
 
 // This include file defines macros to avoid warnings under CUDA.  See github issue #1133.

--- a/packages/belos/src/BelosTypes.cpp
+++ b/packages/belos/src/BelosTypes.cpp
@@ -196,11 +196,13 @@ namespace Belos {
   // Initialize DefaultSolverParameters.  Has to be done this way because
   // the "static consexpr double blah = ...;" pattern can create ODR-used
   // linking errors (usually in debug builds).
-  const double DefaultSolverParameters::convTol = 1.0e-8;
-  const double DefaultSolverParameters::polyTol = 1.0e-12;
-  const double DefaultSolverParameters::orthoKappa = -1.0;
-  const double DefaultSolverParameters::resScaleFactor = 1.0;
-  const double DefaultSolverParameters::impTolScale = 10.0;
+  // BELOS_LIB_DLL_EXPORT: dllexport'd from belos.dll, dllimport'd by consumers
+  // on Windows shared builds (see Belos_DLLExportMacro.h).
+  BELOS_LIB_DLL_EXPORT const double DefaultSolverParameters::convTol = 1.0e-8;
+  BELOS_LIB_DLL_EXPORT const double DefaultSolverParameters::polyTol = 1.0e-12;
+  BELOS_LIB_DLL_EXPORT const double DefaultSolverParameters::orthoKappa = -1.0;
+  BELOS_LIB_DLL_EXPORT const double DefaultSolverParameters::resScaleFactor = 1.0;
+  BELOS_LIB_DLL_EXPORT const double DefaultSolverParameters::impTolScale = 10.0;
 
 } // end Belos namespace
 

--- a/packages/belos/src/BelosTypes.hpp
+++ b/packages/belos/src/BelosTypes.hpp
@@ -310,20 +310,23 @@ namespace Belos {
     ///
     /// https://github.com/trilinos/Trilinos/pull/2677#issuecomment-395453521
     ///
-    /// Initialization of values moved to BelosTypes.cpp to fix ODR-used issues
-    static const double convTol;
+    /// Initialization of values moved to BelosTypes.cpp to fix ODR-used issues.
+    /// BELOS_LIB_DLL_EXPORT: dllexport when building belos.dll, dllimport for
+    /// consumers (e.g. belostpetra) - without it, Windows shared builds fail
+    /// with LNK2001/LNK2019 on these static DATA symbols.
+    static BELOS_LIB_DLL_EXPORT const double convTol;
 
     //! Relative residual tolerance for matrix polynomial construction
-    static const double polyTol;
+    static BELOS_LIB_DLL_EXPORT const double polyTol;
 
     //! DGKS orthogonalization constant
-    static const double orthoKappa;
+    static BELOS_LIB_DLL_EXPORT const double orthoKappa;
 
     //! User-defined residual scaling factor
-    static const double resScaleFactor;
+    static BELOS_LIB_DLL_EXPORT const double resScaleFactor;
 
     //! "Implicit Tolerance Scale Factor"
-    static const double impTolScale;
+    static BELOS_LIB_DLL_EXPORT const double impTolScale;
   };
 
 

--- a/packages/belos/src/CMakeLists.txt
+++ b/packages/belos/src/CMakeLists.txt
@@ -6,6 +6,14 @@
 
 TRIBITS_CONFIGURE_FILE(${PACKAGE_NAME}_config.h)
 
+# Windows shared-library import/export for DATA symbols in belos.dll
+# (e.g. Belos::DefaultSolverParameters::convTol and related static doubles).
+# CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS exports via .def, but consumers still need
+# __declspec(dllimport) for DATA or LNK2001/LNK2019 results (see belostpetra).
+SET(CURRENT_PACKAGE BELOS)
+CONFIGURE_FILE("${Trilinos_SOURCE_DIR}/packages/Trilinos_DLLExportMacro.h.in"
+  ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_DLLExportMacro.h)
+
 ######################################################################
 ## Define the header and source files (and directories)
 ######################################################################
@@ -17,6 +25,7 @@ TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
 
 SET(HEADERS ${HEADERS}
   ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_config.h
+  ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_DLLExportMacro.h
   )
 
 TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
@@ -194,11 +203,13 @@ IF (${PACKAGE_NAME}_ENABLE_TSQR)
     belos
     HEADERS ${HEADERS}
     SOURCES ${SOURCES}
+    DEFINES -DBELOS_LIB_EXPORTS_MODE
     )
 ELSE ()
   TRIBITS_ADD_LIBRARY(
     belos
     HEADERS ${HEADERS}
     SOURCES ${SOURCES}
+    DEFINES -DBELOS_LIB_EXPORTS_MODE
     )
 ENDIF ()

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Include/trilinos_amd.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Include/trilinos_amd.h
@@ -312,7 +312,10 @@ UF_long trilinos_amd_l_valid
  * that AMD uses. */
 
 #ifndef EXTERN
-#define EXTERN extern
+/* TRILINOSSS_LIB_DLL_EXPORT: dllexport when building trilinosss.dll, dllimport
+ * for consumers (e.g. Amesos2/KLU2) - without it, Windows shared builds fail
+ * with LNK2019 on these function-pointer DATA symbols (see trilinos_UFconfig.h). */
+#define EXTERN extern TRILINOSSS_LIB_DLL_EXPORT
 #endif
 
 EXTERN void *(*trilinos_amd_malloc) (size_t) ;		    /* pointer to malloc */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Include/trilinos_amd_internal.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Include/trilinos_amd_internal.h
@@ -295,7 +295,7 @@ GLOBAL void TRILINOS_AMD_preprocess
 #include <assert.h>
 
 #ifndef EXTERN
-#define EXTERN extern
+#define EXTERN extern TRILINOSSS_LIB_DLL_EXPORT
 #endif
 
 EXTERN Int TRILINOS_AMD_debug ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_dump.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_dump.c
@@ -19,7 +19,7 @@
 #ifndef NDEBUG
 
 /* This global variable is present only when debugging */
-GLOBAL Int TRILINOS_AMD_debug = -999 ;		/* default is no debug printing */
+GLOBAL TRILINOSSS_LIB_DLL_EXPORT Int TRILINOS_AMD_debug = -999 ;		/* default is no debug printing */
 
 /* ========================================================================= */
 /* === TRILINOS_AMD_debug_init ====================================================== */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_global.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/AMD/Source/trilinos_amd_global.c
@@ -11,6 +11,10 @@
 
 #include <stdlib.h>
 
+/* For TRILINOSSS_LIB_DLL_EXPORT: these globals are dllexport'd from trilinosss.dll
+ * and dllimport'd by consumers (e.g. Amesos2/KLU2) on Windows shared builds. */
+#include "trilinos_UFconfig.h"
+
 #ifdef MATLAB_MEX_FILE
 #include "mex.h"
 #include "matrix.h"
@@ -42,23 +46,23 @@
 #ifndef NMALLOC
 #ifdef MATLAB_MEX_FILE
 /* MATLAB mexFunction: */
-void *(*trilinos_amd_malloc) (size_t) = mxMalloc ;
-void (*trilinos_amd_free) (void *) = mxFree ;
-void *(*trilinos_amd_realloc) (void *, size_t) = mxRealloc ;
-void *(*trilinos_amd_calloc) (size_t, size_t) = mxCalloc ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_amd_malloc) (size_t) = mxMalloc ;
+TRILINOSSS_LIB_DLL_EXPORT void (*trilinos_amd_free) (void *) = mxFree ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_amd_realloc) (void *, size_t) = mxRealloc ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_amd_calloc) (size_t, size_t) = mxCalloc ;
 #else
 /* standard ANSI-C: */
-void *(*trilinos_amd_malloc) (size_t) = malloc ;
-void (*trilinos_amd_free) (void *) = free ;
-void *(*trilinos_amd_realloc) (void *, size_t) = realloc ;
-void *(*trilinos_amd_calloc) (size_t, size_t) = calloc ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_amd_malloc) (size_t) = malloc ;
+TRILINOSSS_LIB_DLL_EXPORT void (*trilinos_amd_free) (void *) = free ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_amd_realloc) (void *, size_t) = realloc ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_amd_calloc) (size_t, size_t) = calloc ;
 #endif
 #else
 /* no memory manager defined at compile-time; you MUST define one at run-time */
-void *(*trilinos_amd_malloc) (size_t) = NULL ;
-void (*trilinos_amd_free) (void *) = NULL ;
-void *(*trilinos_amd_realloc) (void *, size_t) = NULL ;
-void *(*trilinos_amd_calloc) (size_t, size_t) = NULL ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_amd_malloc) (size_t) = NULL ;
+TRILINOSSS_LIB_DLL_EXPORT void (*trilinos_amd_free) (void *) = NULL ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_amd_realloc) (void *, size_t) = NULL ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_amd_calloc) (size_t, size_t) = NULL ;
 #endif
 
 /* ========================================================================= */
@@ -74,11 +78,11 @@ void *(*trilinos_amd_calloc) (size_t, size_t) = NULL ;
 
 #ifndef NPRINT
 #ifdef MATLAB_MEX_FILE
-int (*trilinos_amd_printf) (const char *, ...) = mexPrintf ;
+TRILINOSSS_LIB_DLL_EXPORT int (*trilinos_amd_printf) (const char *, ...) = mexPrintf ;
 #else
 #include <stdio.h>
-int (*trilinos_amd_printf) (const char *, ...) = printf ;
+TRILINOSSS_LIB_DLL_EXPORT int (*trilinos_amd_printf) (const char *, ...) = printf ;
 #endif
 #else
-int (*trilinos_amd_printf) (const char *, ...) = NULL ;
+TRILINOSSS_LIB_DLL_EXPORT int (*trilinos_amd_printf) (const char *, ...) = NULL ;
 #endif

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Include/trilinos_camd.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Include/trilinos_camd.h
@@ -323,7 +323,7 @@ UF_long trilinos_camd_l_cvalid
  * that CAMD uses. */
 
 #ifndef EXTERN
-#define EXTERN extern
+#define EXTERN extern TRILINOSSS_LIB_DLL_EXPORT
 #endif
 
 EXTERN void *(*trilinos_camd_malloc) (size_t) ;		    /* pointer to malloc */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Include/trilinos_camd_internal.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Include/trilinos_camd_internal.h
@@ -279,7 +279,7 @@ GLOBAL void TRILINOS_CAMD_preprocess
 #include <assert.h>
 
 #ifndef EXTERN
-#define EXTERN extern
+#define EXTERN extern TRILINOSSS_LIB_DLL_EXPORT
 #endif
 
 EXTERN Int TRILINOS_CAMD_debug ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_dump.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_dump.c
@@ -19,7 +19,7 @@
 #ifndef NDEBUG
 
 /* This global variable is present only when debugging */
-GLOBAL Int TRILINOS_CAMD_debug = -999 ;		/* default is no debug printing */
+GLOBAL TRILINOSSS_LIB_DLL_EXPORT Int TRILINOS_CAMD_debug = -999 ;		/* default is no debug printing */
 
 /* ========================================================================= */
 /* === TRILINOS_CAMD_debug_init ===================================================== */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_global.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CAMD/Source/trilinos_camd_global.c
@@ -11,6 +11,10 @@
 
 #include <stdlib.h>
 
+/* For TRILINOSSS_LIB_DLL_EXPORT: these globals are dllexport'd from trilinosss.dll
+ * and dllimport'd by consumers on Windows shared builds. */
+#include "trilinos_UFconfig.h"
+
 #ifdef MATLAB_MEX_FILE
 #include "mex.h"
 #include "matrix.h"
@@ -42,23 +46,23 @@
 #ifndef NMALLOC
 #ifdef MATLAB_MEX_FILE
 /* MATLAB mexFunction: */
-void *(*trilinos_camd_malloc) (size_t) = mxMalloc ;
-void (*trilinos_camd_free) (void *) = mxFree ;
-void *(*trilinos_camd_realloc) (void *, size_t) = mxRealloc ;
-void *(*trilinos_camd_calloc) (size_t, size_t) = mxCalloc ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_camd_malloc) (size_t) = mxMalloc ;
+TRILINOSSS_LIB_DLL_EXPORT void (*trilinos_camd_free) (void *) = mxFree ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_camd_realloc) (void *, size_t) = mxRealloc ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_camd_calloc) (size_t, size_t) = mxCalloc ;
 #else
 /* standard ANSI-C: */
-void *(*trilinos_camd_malloc) (size_t) = malloc ;
-void (*trilinos_camd_free) (void *) = free ;
-void *(*trilinos_camd_realloc) (void *, size_t) = realloc ;
-void *(*trilinos_camd_calloc) (size_t, size_t) = calloc ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_camd_malloc) (size_t) = malloc ;
+TRILINOSSS_LIB_DLL_EXPORT void (*trilinos_camd_free) (void *) = free ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_camd_realloc) (void *, size_t) = realloc ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_camd_calloc) (size_t, size_t) = calloc ;
 #endif
 #else
 /* no memory manager defined at compile-time; you MUST define one at run-time */
-void *(*trilinos_camd_malloc) (size_t) = NULL ;
-void (*trilinos_camd_free) (void *) = NULL ;
-void *(*trilinos_camd_realloc) (void *, size_t) = NULL ;
-void *(*trilinos_camd_calloc) (size_t, size_t) = NULL ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_camd_malloc) (size_t) = NULL ;
+TRILINOSSS_LIB_DLL_EXPORT void (*trilinos_camd_free) (void *) = NULL ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_camd_realloc) (void *, size_t) = NULL ;
+TRILINOSSS_LIB_DLL_EXPORT void *(*trilinos_camd_calloc) (size_t, size_t) = NULL ;
 #endif
 
 /* ========================================================================= */
@@ -74,11 +78,11 @@ void *(*trilinos_camd_calloc) (size_t, size_t) = NULL ;
 
 #ifndef NPRINT
 #ifdef MATLAB_MEX_FILE
-int (*trilinos_camd_printf) (const char *, ...) = mexPrintf ;
+TRILINOSSS_LIB_DLL_EXPORT int (*trilinos_camd_printf) (const char *, ...) = mexPrintf ;
 #else
 #include <stdio.h>
-int (*trilinos_camd_printf) (const char *, ...) = printf ;
+TRILINOSSS_LIB_DLL_EXPORT int (*trilinos_camd_printf) (const char *, ...) = printf ;
 #endif
 #else
-int (*trilinos_camd_printf) (const char *, ...) = NULL ;
+TRILINOSSS_LIB_DLL_EXPORT int (*trilinos_camd_printf) (const char *, ...) = NULL ;
 #endif

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CCOLAMD/Include/trilinos_ccolamd.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CCOLAMD/Include/trilinos_ccolamd.h
@@ -353,7 +353,7 @@ UF_long trilinos_ccolamd_l_post_tree
 ) ;
 
 #ifndef EXTERN
-#define EXTERN extern
+#define EXTERN extern TRILINOSSS_LIB_DLL_EXPORT
 #endif
 
 EXTERN int (*trilinos_ccolamd_printf) (const char *, ...) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CCOLAMD/Source/trilinos_ccolamd_global.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CCOLAMD/Source/trilinos_ccolamd_global.c
@@ -11,15 +11,19 @@
 
 /* Global variables for CCOLAMD */
 
+/* For TRILINOSSS_LIB_DLL_EXPORT: dllexport'd from trilinosss.dll, dllimport'd by
+ * consumers on Windows shared builds. */
+#include "trilinos_UFconfig.h"
+
 #ifndef NPRINT
 #ifdef MATLAB_MEX_FILE
 #include "mex.h"
-int (*trilinos_ccolamd_printf) (const char *, ...) = mexPrintf ;
+TRILINOSSS_LIB_DLL_EXPORT int (*trilinos_ccolamd_printf) (const char *, ...) = mexPrintf ;
 #else
 #include <stdio.h>
-int (*trilinos_ccolamd_printf) (const char *, ...) = printf ;
+TRILINOSSS_LIB_DLL_EXPORT int (*trilinos_ccolamd_printf) (const char *, ...) = printf ;
 #endif
 #else
-int (*trilinos_ccolamd_printf) (const char *, ...) = ((void *) 0) ;
+TRILINOSSS_LIB_DLL_EXPORT int (*trilinos_ccolamd_printf) (const char *, ...) = ((void *) 0) ;
 #endif
 

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Include/amesos_cholmod_internal.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CHOLMOD/Include/amesos_cholmod_internal.h
@@ -305,7 +305,7 @@ size_t amesos_cholmod_l_mult_size_t (size_t a, size_t k, int *ok) ;
  * workspace if they need it. */
 
 #ifndef EXTERN
-#define EXTERN extern
+#define EXTERN extern TRILINOSSS_LIB_DLL_EXPORT
 #endif
 
 /* double, int */

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/CMakeLists.txt
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/CMakeLists.txt
@@ -17,8 +17,17 @@ TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_ENABLE_OpenMP
 
 TRIBITS_CONFIGURE_FILE(${PACKAGE_NAME}_config.h)
 
+# Windows shared-library import/export for DATA symbols in trilinosss.dll
+# (e.g. trilinos_amd_malloc/free/calloc/realloc function-pointer globals).
+# CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS exports via .def, but consumers still need
+# __declspec(dllimport) for DATA or LNK2019 results.
+SET(CURRENT_PACKAGE TRILINOSSS)
+CONFIGURE_FILE("${Trilinos_SOURCE_DIR}/packages/Trilinos_DLLExportMacro.h.in"
+  ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_DLLExportMacro.h)
+
 SET(HEADERS ${HEADERS}
   ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_config.h
+  ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}_DLLExportMacro.h
   )
 
 TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
@@ -85,4 +94,5 @@ TRIBITS_ADD_LIBRARY(
   HEADERS ${HEADERS}
   SOURCES ${SOURCES}
   IMPORTEDLIBS ${IMPORTEDLIBS}
+  DEFINES -DTRILINOSSS_LIB_EXPORTS_MODE
   )

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/COLAMD/Include/trilinos_colamd.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/COLAMD/Include/trilinos_colamd.h
@@ -243,7 +243,7 @@ void trilinos_symamd_l_report
 ) ;
 
 #ifndef EXTERN
-#define EXTERN extern
+#define EXTERN extern TRILINOSSS_LIB_DLL_EXPORT
 #endif
 
 EXTERN int (*trilinos_colamd_printf) (const char *, ...) ;

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/COLAMD/Source/trilinos_colamd_global.c
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/COLAMD/Source/trilinos_colamd_global.c
@@ -10,15 +10,19 @@
 
 /* Global variables for TRILINOS_COLAMD */
 
+/* For TRILINOSSS_LIB_DLL_EXPORT: dllexport'd from trilinosss.dll, dllimport'd by
+ * consumers on Windows shared builds. */
+#include "trilinos_UFconfig.h"
+
 #ifndef NPRINT
 #ifdef MATLAB_MEX_FILE
 #include "mex.h"
-int (*trilinos_colamd_printf) (const char *, ...) = mexPrintf ;
+TRILINOSSS_LIB_DLL_EXPORT int (*trilinos_colamd_printf) (const char *, ...) = mexPrintf ;
 #else
 #include <stdio.h>
-int (*trilinos_colamd_printf) (const char *, ...) = printf ;
+TRILINOSSS_LIB_DLL_EXPORT int (*trilinos_colamd_printf) (const char *, ...) = printf ;
 #endif
 #else
-int (*trilinos_colamd_printf) (const char *, ...) = ((void *) 0) ;
+TRILINOSSS_LIB_DLL_EXPORT int (*trilinos_colamd_printf) (const char *, ...) = ((void *) 0) ;
 #endif
 

--- a/packages/common/auxiliarySoftware/SuiteSparse/src/UFconfig/trilinos_UFconfig.h
+++ b/packages/common/auxiliarySoftware/SuiteSparse/src/UFconfig/trilinos_UFconfig.h
@@ -43,6 +43,12 @@ extern "C" {
 
 #include <limits.h>
 
+/* Windows shared-build DATA-symbol import/export annotation (TRILINOSSS_LIB_DLL_EXPORT).
+ * Included here since every SuiteSparse header in this package pulls in UFconfig.h;
+ * see the EXTERN macro in trilinos_amd.h / trilinos_camd.h / trilinos_ccolamd.h /
+ * trilinos_colamd.h / amesos_cholmod_internal.h and their *_internal.h counterparts. */
+#include "TrilinosSS_DLLExportMacro.h"
+
 /* ========================================================================== */
 /* === UF_long ============================================================== */
 /* ========================================================================== */


### PR DESCRIPTION
@trilinos/belos

## Motivation

Fixed linker errors [LNK2001](https://learn.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-error-lnk2001?view=msvc-170) and [LNK2019](https://learn.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-error-lnk2019?view=msvc-170) for Windows builds.
The fix designed by the same way as in existing code as mentioned in https://github.com/trilinos/Trilinos/pull/15537.
After these changes the whole Ifpack2 will be compiled successfully:

<img width="837" height="682" alt="image" src="https://github.com/user-attachments/assets/925f92dd-fb3d-4519-993c-6e34dc2a0c30" />

## Proofs

- [compilation-output-clangcl-21.1.5-ninja-serial-err_part5.log](https://github.com/user-attachments/files/30878520/compilation-output-clangcl-21.1.5-ninja-serial-err_part5.log)
- [compilation-output-clangcl-21.1.5-ninja-serial-err_part6.log](https://github.com/user-attachments/files/30878519/compilation-output-clangcl-21.1.5-ninja-serial-err_part6.log)

## Environment

| Item       | Value                                            |
| ---------- | ------------------------------------------------ |
| OS         | Windows 11 Pro x64, Build 26100                  |
| CPU        | Intel Core i9-12900H (20 logical cores)          |
| CMake      | 4.3.2                                           |
| MSVC       | 19.51.36246 for x64 (VS 2026 Community)                  |
| clang-cl   | 21.1.5;x86_64-pc-windows-msvc;thread-model:posix |
| Ninja      | 1.12.1                                           |
| Build type | RelWithDebInfo, shared libs, C++20      

## Related Issues

|Description|Link|
|:-|:-|
|Root issue | https://github.com/trilinos/Trilinos/issues/14816 |
|First PR as a ref | https://github.com/trilinos/Trilinos/pull/15537 |
|Second PR as a ref | https://github.com/trilinos/Trilinos/pull/15538 |
|Windows build checklist table | https://github.com/trilinos/Trilinos/issues/15557 |

## Stakeholder Feedback

@cgcgcg

## Testing

No new tests added and no tests launched, because this PR aimed to fix only compilation & linker erros.

## Additional Information

Next PRs will aimed to fix tests errors if any.
