### PR TITLE
Belos:  Fix Tpetra MvDot implementation, add tests for BiCGStab, TFQMR

### DIFF
--- a/packages/belos/tpetra/src/BelosMultiVecTraits_Tpetra.hpp
+++ b/packages/belos/tpetra/src/BelosMultiVecTraits_Tpetra.hpp
@@ -564,21 +564,21 @@ namespace Belos {
       Tpetra::deep_copy (C, C_mv);
     }
 
-    //! For all columns j of A, set <tt>dots[j] := A[j]^T * B[j]</tt>.
+    //! For all columns j of A, set <tt>dots[j] := A[j]^H * B[j]</tt>.
     static void
-    MvDot (const MV& A, const MV& B, std::vector<Scalar> &dots)
+    MvDot (const MV& B, const MV& A, std::vector<Scalar> &dots)
     {
       const size_t numVecs = A.getNumVectors ();
       TEUCHOS_TEST_FOR_EXCEPTION(
         numVecs != B.getNumVectors (), std::invalid_argument,
-        "Belos::MultiVecTraits::MvDot(A,B,dots): "
+        "Belos::MultiVecTraits::MvDot(B,A,dots): "
         "A and B must have the same number of columns.  "
         "A has " << numVecs << " column(s), "
         "but B has " << B.getNumVectors () << " column(s).");
 #ifdef HAVE_TPETRA_DEBUG
       TEUCHOS_TEST_FOR_EXCEPTION(
         dots.size() < numVecs, std::invalid_argument,
-        "Belos::MultiVecTraits::MvDot(A,B,dots): "
+        "Belos::MultiVecTraits::MvDot(B,A,dots): "
         "The output array 'dots' must have room for all dot products.  "
         "A and B each have " << numVecs << " column(s), "
         "but 'dots' only has " << dots.size() << " entry(/ies).");

--- a/packages/belos/tpetra/test/BiCGStab/CMakeLists.txt
+++ b/packages/belos/tpetra/test/BiCGStab/CMakeLists.txt
@@ -15,6 +15,25 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT
   )
 
+ASSERT_DEFINED(Tpetra_INST_COMPLEX_DOUBLE)
+IF (Tpetra_INST_COMPLEX_DOUBLE)
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    Tpetra_BiCGStab_complex_hb_test
+    SOURCES test_bicgstab_complex_hb.cpp
+    ARGS "--verbose"
+    COMM serial mpi
+  )
+
+  TRIBITS_COPY_FILES_TO_BINARY_DIR(
+    Tpetra_BiCGStab_complex_hb_CopyFiles
+    SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
+    SOURCE_FILES mhd1280b.cua
+    EXEDEPS Tpetra_BiCGStab_complex_hb_test
+  )
+
+ENDIF()
+
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Tpetra_CopyTestBiCGSTABFiles
   SOURCE_DIR ${${PACKAGE_NAME}_SOURCE_DIR}/testmatrices
   SOURCE_FILES cage4.hb

--- a/packages/belos/tpetra/test/BiCGStab/test_bicgstab_complex_hb.cpp
+++ b/packages/belos/tpetra/test/BiCGStab/test_bicgstab_complex_hb.cpp
@@ -1,0 +1,201 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosBiCGStabSolMgr.hpp"
+#include "BelosTpetraTestFramework.hpp"
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+// I/O for Harwell-Boeing files
+#include <Tpetra_Util_iohb.h>
+
+template <typename ScalarType>
+int run(int argc, char *argv[])
+{
+  using BSC = typename Tpetra::MultiVector<ScalarType>::scalar_type;
+  using ST  = typename std::complex<BSC>;
+  
+  using OP = typename Tpetra::Operator<ST>;
+  using MV = typename Tpetra::MultiVector<ST>;
+  using tcrsmatrix_t = Tpetra::CrsMatrix<ST>;
+  
+  using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+  using MVT = typename Belos::MultiVecTraits<ST,MV>;
+
+  using SCT = typename Teuchos::ScalarTraits<ST>;
+  using MT  = typename SCT::magnitudeType;
+
+  using Tpetra::Operator;
+  using Tpetra::CrsMatrix;
+  using Tpetra::MultiVector;
+
+  using Teuchos::GlobalMPISession;
+  using Teuchos::Comm;
+  using Teuchos::RCP;
+  using Teuchos::CommandLineProcessor;
+  using Teuchos::ParameterList;
+
+  const ST one = SCT::one();
+
+  GlobalMPISession mpisess(&argc,&argv,&std::cout);
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+  int MyPID = rank(*comm);
+
+  // Get test parameters from command-line processor
+  bool verbose = false, proc_verbose = false, debug = false;
+  int frequency = -1;  // how often residuals are printed by solver
+  int numrhs = 1;      // total number of right-hand sides to solve for
+  int blocksize = 1;   // blocksize used by solver
+  int maxiters = -1;   // maximum number of iterations for solver to use
+  std::string filename("mhd1280b.cua");
+  MT tol = 1.0e-5;     // relative residual tolerance
+
+  CommandLineProcessor cmdp(false,true);
+  cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+  cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+  cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+  cmdp.setOption("tol",&tol,"Relative residual tolerance used by BiCGStab solver.");
+  cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+  cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+  cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
+  cmdp.setOption("block-size",&blocksize,"Block size to be used by the BiCGStab solver.");
+  if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
+    return -1;
+  }
+  if (debug) {
+    verbose = true;
+  }
+  if (!verbose) {
+    frequency = -1;  // reset frequency if test is not verbose
+  }
+
+  proc_verbose = ( verbose && (MyPID==0) );
+  if (proc_verbose) {
+    std::cout << Belos::Belos_Version() << std::endl << std::endl;
+  }
+
+  Belos::Tpetra::HarwellBoeingReader<tcrsmatrix_t> reader( comm );
+  RCP<tcrsmatrix_t> A = reader.readFromFile( filename );
+  RCP<const Tpetra::Map<> > map = A->getMap();
+
+  // Create initial vectors
+  RCP<MV> B, X;
+  X = rcp( new MV(map,numrhs) );
+  MVT::MvRandom( *X );
+  B = rcp( new MV(map,numrhs) );
+  OPT::Apply( *A, *X, *B );
+  MVT::MvInit( *X, 0.0 );
+
+  // Other information used by block solver (can be user specified)
+  const int NumGlobalElements = B->getGlobalLength();
+  if (maxiters == -1) {
+    maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
+  }
+
+  ParameterList belosList;
+  belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+  belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+  belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+  int verbLevel = Belos::Errors + Belos::Warnings;
+  if (debug) {
+    verbLevel += Belos::Debug;
+  }
+  if (verbose) {
+    verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
+  }
+  belosList.set( "Verbosity", verbLevel );
+  if (verbose) {
+    if (frequency > 0) {
+      belosList.set( "Output Frequency", frequency );
+    }
+  }
+  
+  // Construct an unpreconditioned linear problem instance.
+  Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+  bool set = problem.setProblem();
+  if (set == false) {
+    if (proc_verbose)
+      std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+    return -1;
+  }
+
+  // Start the BiCGStab iteration
+  Belos::BiCGStabSolMgr<ST,MV,OP> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+
+  // Print out information about problem
+  if (proc_verbose) {
+    std::cout << std::endl << std::endl;
+    std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+    std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+    std::cout << "Block size used by solver: " << blocksize << std::endl;
+    std::cout << "Max number of BiCGStab iterations: " << maxiters << std::endl;
+    std::cout << "Relative residual tolerance: " << tol << std::endl;
+    std::cout << std::endl;
+  }
+  
+  // Perform solve
+  Belos::ReturnType ret = solver.solve();
+
+  // Compute actual residuals.
+  bool badRes = false;
+  std::vector<MT> actual_resids( numrhs );
+  std::vector<MT> rhs_norm( numrhs );
+  MV resid(map, numrhs);
+  OPT::Apply( *A, *X, resid );
+  MVT::MvAddMv( -one, resid, one, *B, resid );
+  MVT::MvNorm( resid, actual_resids );
+  MVT::MvNorm( *B, rhs_norm );
+  if (proc_verbose) {
+    std::cout << "---------- Actual Residuals (normalized) ----------" << std::endl<<std::endl;
+  }
+  for ( int i=0; i<numrhs; i++) {
+    MT actRes = actual_resids[i]/rhs_norm[i];
+    if (proc_verbose) {
+      std::cout << "Problem "<<i<<" : \t"<< actRes << std::endl;
+    }
+    if (actRes > tol) badRes = true;
+  }
+
+  if (ret==Belos::Converged && !badRes) {
+    // Default return value
+    if (proc_verbose) {
+      std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+    }
+  }
+  else {
+    if (proc_verbose) {
+      std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+    return -1;
+  }
+  
+  return 0;
+} // end test_bl_cg_complex_hb.cpp
+
+int main(int argc, char *argv[]) {
+  return run<double>(argc,argv);
+
+  // wrapped with a check: CMake option Trilinos_ENABLE_FLOAT=ON
+  // return run<float>(argc,argv);
+}
+

--- a/packages/belos/tpetra/test/MINRES/CMakeLists.txt
+++ b/packages/belos/tpetra/test/MINRES/CMakeLists.txt
@@ -24,6 +24,27 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT 
 )
 
+ASSERT_DEFINED(Tpetra_INST_COMPLEX_DOUBLE)
+IF (Tpetra_INST_COMPLEX_DOUBLE)
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    Tpetra_minres_complex_hb_test
+    SOURCES test_minres_complex_hb.cpp
+    ARGS
+      "--verbose"
+      "--verbose --num-rhs=2"
+    COMM serial mpi
+  )
+
+  TRIBITS_COPY_FILES_TO_BINARY_DIR(
+    Tpetra_CopyComplexTestMinresFiles
+    SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
+    SOURCE_FILES mhd1280b.cua
+    EXEDEPS Tpetra_minres_complex_hb_test
+  )
+
+ENDIF()
+
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Tpetra_CopyTestMinresFiles
   SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
   SOURCE_FILES bcsstk14.hb

--- a/packages/belos/tpetra/test/MINRES/test_minres_complex_hb.cpp
+++ b/packages/belos/tpetra/test/MINRES/test_minres_complex_hb.cpp
@@ -1,0 +1,200 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosTpetraTestFramework.hpp"
+#include "BelosSolverFactory.hpp"
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+// I/O for Harwell-Boeing files
+#include <Tpetra_Util_iohb.h>
+
+template <typename ScalarType>
+int run(int argc, char *argv[])
+{
+  using BSC = typename Tpetra::MultiVector<ScalarType>::scalar_type;
+  using ST  = typename std::complex<BSC>;
+  
+  using OP = typename Tpetra::Operator<ST>;
+  using MV = typename Tpetra::MultiVector<ST>;
+  using tcrsmatrix_t = Tpetra::CrsMatrix<ST>;
+  
+  using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+  using MVT = typename Belos::MultiVecTraits<ST,MV>;
+
+  using SCT = typename Teuchos::ScalarTraits<ST>;
+  using MT  = typename SCT::magnitudeType;
+
+  using Tpetra::Operator;
+  using Tpetra::CrsMatrix;
+  using Tpetra::MultiVector;
+
+  using Teuchos::GlobalMPISession;
+  using Teuchos::Comm;
+  using Teuchos::RCP;
+  using Teuchos::CommandLineProcessor;
+  using Teuchos::ParameterList;
+
+  const ST one = SCT::one();
+
+  GlobalMPISession mpisess(&argc,&argv,&std::cout);
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+  int MyPID = rank(*comm);
+
+  // Get test parameters from command-line processor
+  bool verbose = false, proc_verbose = false, debug = false;
+  int frequency = -1;  // how often residuals are printed by solver
+  int numrhs = 1;      // total number of right-hand sides to solve for
+  int maxiters = -1;   // maximum number of iterations for solver to use
+  std::string filename("mhd1280b.cua");
+  MT tol = 1.0e-5;     // relative residual tolerance
+
+  CommandLineProcessor cmdp(false,true);
+  cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+  cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+  cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+  cmdp.setOption("tol",&tol,"Relative residual tolerance used by MINRES solver.");
+  cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+  cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+  cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
+  if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
+    return -1;
+  }
+  if (debug) {
+    verbose = true;
+  }
+  if (!verbose) {
+    frequency = -1;  // reset frequency if test is not verbose
+  }
+
+  proc_verbose = ( verbose && (MyPID==0) );
+  if (proc_verbose) {
+    std::cout << Belos::Belos_Version() << std::endl << std::endl;
+  }
+
+  Belos::Tpetra::HarwellBoeingReader<tcrsmatrix_t> reader( comm );
+  RCP<tcrsmatrix_t> A = reader.readFromFile( filename );
+  RCP<const Tpetra::Map<> > map = A->getMap();
+
+  // Create initial vectors
+  RCP<MV> B, X;
+  X = rcp( new MV(map,numrhs) );
+  MVT::MvRandom( *X );
+  B = rcp( new MV(map,numrhs) );
+  OPT::Apply( *A, *X, *B );
+  MVT::MvInit( *X, 0.0 );
+
+  // Other information used by block solver (can be user specified)
+  const int NumGlobalElements = B->getGlobalLength();
+  if (maxiters == -1) {
+    maxiters = NumGlobalElements - 1; // maximum number of iterations to run
+  }
+
+  RCP<ParameterList> belosList = Teuchos::parameterList ("MINRES");
+  belosList->set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+  belosList->set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+  int verbLevel = Belos::Errors + Belos::Warnings;
+  if (debug) {
+    verbLevel += Belos::Debug;
+  }
+  if (verbose) {
+    verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
+  }
+  belosList->set( "Verbosity", verbLevel );
+  if (verbose) {
+    if (frequency > 0) {
+      belosList->set( "Output Frequency", frequency );
+    }
+  }
+  
+  // Construct an unpreconditioned linear problem instance.
+  Teuchos::RCP<Belos::LinearProblem<ST,MV,OP> > problem = Teuchos::rcp( new Belos::LinearProblem<ST,MV,OP>( A, X, B ) );
+  bool set = problem->setProblem();
+  if (set == false) {
+    if (proc_verbose)
+      std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+    return -1;
+  }
+
+  // Create an iterative solver manager.
+  Belos::SolverFactory<ST, MV, OP> factory;
+  RCP<Belos::SolverManager<ST,MV,OP> > newSolver =
+    factory.create ("MINRES", belosList);
+  newSolver->setProblem (problem);
+
+  // Print out information about problem
+  if (proc_verbose) {
+    std::cout << std::endl << std::endl;
+    std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+    std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+    std::cout << "Max number of MINRES iterations: " << maxiters << std::endl;
+    std::cout << "Relative residual tolerance: " << tol << std::endl;
+    std::cout << std::endl;
+  }
+  
+  // Perform solve
+  Belos::ReturnType ret = newSolver->solve();
+
+  // Compute actual residuals.
+  bool badRes = false;
+  std::vector<MT> actual_resids( numrhs );
+  std::vector<MT> rhs_norm( numrhs );
+  MV resid(map, numrhs);
+  OPT::Apply( *A, *X, resid );
+  MVT::MvAddMv( -one, resid, one, *B, resid );
+  MVT::MvNorm( resid, actual_resids );
+  MVT::MvNorm( *B, rhs_norm );
+  if (proc_verbose) {
+    std::cout << "---------- Actual Residuals (normalized) ----------" << std::endl<<std::endl;
+  }
+  for ( int i=0; i<numrhs; i++) {
+    MT actRes = actual_resids[i]/rhs_norm[i];
+    if (proc_verbose) {
+      std::cout << "Problem "<<i<<" : \t"<< actRes << std::endl;
+    }
+    if (actRes > tol) badRes = true;
+  }
+
+  if (ret==Belos::Converged && !badRes) {
+    // Default return value
+    if (proc_verbose) {
+      std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+    }
+  }
+  else {
+    if (proc_verbose) {
+      std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+    return -1;
+  }
+  
+  return 0;
+} // end test_bl_cg_complex_hb.cpp
+
+int main(int argc, char *argv[]) {
+  return run<double>(argc,argv);
+
+  // wrapped with a check: CMake option Trilinos_ENABLE_FLOAT=ON
+  // return run<float>(argc,argv);
+}
+

--- a/packages/belos/tpetra/test/TFQMR/CMakeLists.txt
+++ b/packages/belos/tpetra/test/TFQMR/CMakeLists.txt
@@ -26,6 +26,25 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT
 )
 
+ASSERT_DEFINED(Tpetra_INST_COMPLEX_DOUBLE)
+IF (Tpetra_INST_COMPLEX_DOUBLE)
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    Tpetra_TFQMR_complex_hb_test
+    SOURCES test_tfqmr_complex_hb.cpp
+    ARGS "--verbose"
+    COMM serial mpi
+  )
+
+  TRIBITS_COPY_FILES_TO_BINARY_DIR(
+    Tpetra_TFQMR_complex_hb_CopyFiles
+    SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
+    SOURCE_FILES mhd1280b.cua
+    EXEDEPS Tpetra_TFQMR_complex_hb_test
+  )
+
+ENDIF()
+
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Tpetra_CopyTestTFQMRFiles
   SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
   SOURCE_FILES orsirr1.hb orsirr1_scaled.hb

--- a/packages/belos/tpetra/test/TFQMR/test_tfqmr_complex_hb.cpp
+++ b/packages/belos/tpetra/test/TFQMR/test_tfqmr_complex_hb.cpp
@@ -1,0 +1,201 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver reads a problem from a Harwell-Boeing (HB) file.
+// The right-hand-side corresponds to a randomly generated solution.
+// The initial guesses are all set to zero.
+//
+// NOTE: No preconditioner is used in this case.
+
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosTpetraAdapter.hpp"
+#include "BelosTFQMRSolMgr.hpp"
+#include "BelosTpetraTestFramework.hpp"
+
+#include <Teuchos_CommandLineProcessor.hpp>
+#include <Teuchos_ParameterList.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+
+#include <Tpetra_Core.hpp>
+#include <Tpetra_CrsMatrix.hpp>
+
+// I/O for Harwell-Boeing files
+#include <Tpetra_Util_iohb.h>
+
+template <typename ScalarType>
+int run(int argc, char *argv[])
+{
+  using BSC = typename Tpetra::MultiVector<ScalarType>::scalar_type;
+  using ST  = typename std::complex<BSC>;
+  
+  using OP = typename Tpetra::Operator<ST>;
+  using MV = typename Tpetra::MultiVector<ST>;
+  using tcrsmatrix_t = Tpetra::CrsMatrix<ST>;
+  
+  using OPT = typename Belos::OperatorTraits<ST,MV,OP>;
+  using MVT = typename Belos::MultiVecTraits<ST,MV>;
+
+  using SCT = typename Teuchos::ScalarTraits<ST>;
+  using MT  = typename SCT::magnitudeType;
+
+  using Tpetra::Operator;
+  using Tpetra::CrsMatrix;
+  using Tpetra::MultiVector;
+
+  using Teuchos::GlobalMPISession;
+  using Teuchos::Comm;
+  using Teuchos::RCP;
+  using Teuchos::CommandLineProcessor;
+  using Teuchos::ParameterList;
+
+  const ST one = SCT::one();
+
+  GlobalMPISession mpisess(&argc,&argv,&std::cout);
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+  int MyPID = rank(*comm);
+
+  // Get test parameters from command-line processor
+  bool verbose = false, proc_verbose = false, debug = false;
+  int frequency = -1;  // how often residuals are printed by solver
+  int numrhs = 1;      // total number of right-hand sides to solve for
+  int blocksize = 1;   // blocksize used by solver
+  int maxiters = -1;   // maximum number of iterations for solver to use
+  std::string filename("mhd1280b.cua");
+  MT tol = 1.0e-5;     // relative residual tolerance
+
+  CommandLineProcessor cmdp(false,true);
+  cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+  cmdp.setOption("debug","nodebug",&debug,"Run debugging checks.");
+  cmdp.setOption("frequency",&frequency,"Solvers frequency for printing residuals (#iters).");
+  cmdp.setOption("tol",&tol,"Relative residual tolerance used by TFQMR solver.");
+  cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+  cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
+  cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
+  cmdp.setOption("block-size",&blocksize,"Block size to be used by the TFQMR solver.");
+  if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
+    return -1;
+  }
+  if (debug) {
+    verbose = true;
+  }
+  if (!verbose) {
+    frequency = -1;  // reset frequency if test is not verbose
+  }
+
+  proc_verbose = ( verbose && (MyPID==0) );
+  if (proc_verbose) {
+    std::cout << Belos::Belos_Version() << std::endl << std::endl;
+  }
+
+  Belos::Tpetra::HarwellBoeingReader<tcrsmatrix_t> reader( comm );
+  RCP<tcrsmatrix_t> A = reader.readFromFile( filename );
+  RCP<const Tpetra::Map<> > map = A->getMap();
+
+  // Create initial vectors
+  RCP<MV> B, X;
+  X = rcp( new MV(map,numrhs) );
+  MVT::MvRandom( *X );
+  B = rcp( new MV(map,numrhs) );
+  OPT::Apply( *A, *X, *B );
+  MVT::MvInit( *X, 0.0 );
+
+  // Other information used by block solver (can be user specified)
+  const int NumGlobalElements = B->getGlobalLength();
+  if (maxiters == -1) {
+    maxiters = NumGlobalElements/blocksize - 1; // maximum number of iterations to run
+  }
+
+  ParameterList belosList;
+  belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
+  belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
+  belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+  int verbLevel = Belos::Errors + Belos::Warnings;
+  if (debug) {
+    verbLevel += Belos::Debug;
+  }
+  if (verbose) {
+    verbLevel += Belos::TimingDetails + Belos::FinalSummary + Belos::StatusTestDetails;
+  }
+  belosList.set( "Verbosity", verbLevel );
+  if (verbose) {
+    if (frequency > 0) {
+      belosList.set( "Output Frequency", frequency );
+    }
+  }
+  
+  // Construct an unpreconditioned linear problem instance.
+  Belos::LinearProblem<ST,MV,OP> problem( A, X, B );
+  bool set = problem.setProblem();
+  if (set == false) {
+    if (proc_verbose)
+      std::cout << std::endl << "ERROR:  Belos::LinearProblem failed to set up correctly!" << std::endl;
+    return -1;
+  }
+
+  // Start the TFQMR iteration
+  Belos::TFQMRSolMgr<ST,MV,OP> solver( rcpFromRef(problem), rcpFromRef(belosList) );
+
+  // Print out information about problem
+  if (proc_verbose) {
+    std::cout << std::endl << std::endl;
+    std::cout << "Dimension of matrix: " << NumGlobalElements << std::endl;
+    std::cout << "Number of right-hand sides: " << numrhs << std::endl;
+    std::cout << "Block size used by solver: " << blocksize << std::endl;
+    std::cout << "Max number of TFQMR iterations: " << maxiters << std::endl;
+    std::cout << "Relative residual tolerance: " << tol << std::endl;
+    std::cout << std::endl;
+  }
+  
+  // Perform solve
+  Belos::ReturnType ret = solver.solve();
+
+  // Compute actual residuals.
+  bool badRes = false;
+  std::vector<MT> actual_resids( numrhs );
+  std::vector<MT> rhs_norm( numrhs );
+  MV resid(map, numrhs);
+  OPT::Apply( *A, *X, resid );
+  MVT::MvAddMv( -one, resid, one, *B, resid );
+  MVT::MvNorm( resid, actual_resids );
+  MVT::MvNorm( *B, rhs_norm );
+  if (proc_verbose) {
+    std::cout << "---------- Actual Residuals (normalized) ----------" << std::endl<<std::endl;
+  }
+  for ( int i=0; i<numrhs; i++) {
+    MT actRes = actual_resids[i]/rhs_norm[i];
+    if (proc_verbose) {
+      std::cout << "Problem "<<i<<" : \t"<< actRes << std::endl;
+    }
+    if (actRes > tol) badRes = true;
+  }
+
+  if (ret==Belos::Converged && !badRes) {
+    // Default return value
+    if (proc_verbose) {
+      std::cout << "\nEnd Result: TEST PASSED" << std::endl;
+    }
+  }
+  else {
+    if (proc_verbose) {
+      std::cout << "\nEnd Result: TEST FAILED" << std::endl;
+    }
+    return -1;
+  }
+  
+  return 0;
+} // end test_bl_cg_complex_hb.cpp
+
+int main(int argc, char *argv[]) {
+  return run<double>(argc,argv);
+
+  // wrapped with a check: CMake option Trilinos_ENABLE_FLOAT=ON
+  // return run<float>(argc,argv);
+}
+


### PR DESCRIPTION
## Motivation

The Tpetra MvDot traits implementation is not consistent with the documentation of the MvDot method in the abstract traits class.  This resulted in complex-valued tests of BiCGStab and TFQMR failing to converge.  Additionally, complex-valued tests of the MINRES solver were missing.  This commit fixes the implementation issue and adds tests to ensure the fix is correct.

## Team
@trilinos/belos 

## Testing
OSX Clang 21.0.0 serial and parallel

## Additional Information
This bug fix should be included in release notes.

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
