### PR TITLE
AT2: Set target branch parameter

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -26,6 +26,7 @@ jobs:
       dashboard-build-name: PR-${{ github.event.pull_request.number }}_${AT2_IMAGE}_debug_shared
       max-cores-allowed: 29
       num-concurrent-tests: 16
+      target-branch: ${{ github.base_ref }}
 
   clang19-openmpi4:
     uses: ./.github/workflows/ci.yml
@@ -37,6 +38,7 @@ jobs:
       dashboard-build-name: PR-${{ github.event.pull_request.number }}_${AT2_IMAGE}_release-debug_shared
       max-cores-allowed: 29
       num-concurrent-tests: 16
+      target-branch: ${{ github.base_ref }}
 
   cuda12:
     uses: ./.github/workflows/ci.yml
@@ -49,6 +51,7 @@ jobs:
       max-cores-allowed: 56
       num-concurrent-tests: 112
       slots-per-gpu: 8
+      target-branch: ${{ github.base_ref }}
 
   gcc14:
     uses: ./.github/workflows/ci.yml
@@ -60,6 +63,7 @@ jobs:
       dashboard-build-name: PR-${{ github.event.pull_request.number }}_${AT2_IMAGE}_release-debug_shared
       max-cores-allowed: 29
       num-concurrent-tests: 16
+      target-branch: ${{ github.base_ref }}
 
   cuda12-uvm:
     uses: ./.github/workflows/ci.yml
@@ -71,6 +75,7 @@ jobs:
       dashboard-build-name: PR-${{ github.event.pull_request.number }}_${AT2_IMAGE}_release_static_uvm
       max-cores-allowed: 56
       skip-run-tests: true
+      target-branch: ${{ github.base_ref }}
 
   oneapi2024:
     uses: ./.github/workflows/ci.yml
@@ -82,6 +87,7 @@ jobs:
       dashboard-build-name: PR-${{ github.event.pull_request.number }}_${AT2_IMAGE}_release-debug_shared
       max-cores-allowed: 29
       num-concurrent-tests: 16
+      target-branch: ${{ github.base_ref }}
 
   openmp:
     uses: ./.github/workflows/ci.yml
@@ -93,6 +99,7 @@ jobs:
       dashboard-build-name: PR-${{ github.event.pull_request.number }}_${AT2_IMAGE}_release-debug_static_openmp
       max-cores-allowed: 29
       num-concurrent-tests: 16
+      target-branch: ${{ github.base_ref }}
 
   framework-tests:
     uses: ./.github/workflows/ci.yml
@@ -103,6 +110,7 @@ jobs:
       cdash-track: "Pull Request"
       dashboard-build-name: PR-${{ github.event.pull_request.number }}_${AT2_IMAGE}_framework-tests
       skip-create-packageenables: true
+      target-branch: ${{ github.base_ref }}
 
   ramses-openmp:
     uses: ./.github/workflows/ci.yml
@@ -116,4 +124,5 @@ jobs:
       num-concurrent-tests: 16
       skip-create-packageenables: true
       extra-pr-driver-args: --extra-configure-args=-C;${GITHUB_WORKSPACE}/packages/framework/cmake-fragments/ramses/gcc-mpi-openmp.cmake
+      target-branch: ${{ github.base_ref }}
 


### PR DESCRIPTION
@trilinos/framework

## Motivation
dev->master is currently comparing against develop and hence is not enabling any packages. Setting the target-branch should fix that.
