### PR TITLE
Framework: Diagnose missing coverage info

### DIFF
--- a/cmake/SimpleTesting/cmake/ctest-cdash-setup.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-cdash-setup.cmake
@@ -18,7 +18,10 @@ print_options_list()
 # -- Specify the Generator
 # -----------------------------------------------------------
 set(CTEST_CMAKE_GENERATOR "Ninja")
-
+if(${CTEST_BUILD_NAME} MATCHES "coverage")
+    # Ninja messed up coverage builds
+    set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+endif()
 
 set(CTEST_CONFIGURE_COMMAND_ARGS
     "${CMAKE_COMMAND}"

--- a/cmake/SimpleTesting/cmake/ctest-common.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-common.cmake
@@ -149,8 +149,10 @@ endif()
 # -k NNN - keep going until NNN jobs fail. 0 == infinity
 # -l N   - might be an interesting option to reduce # of jobs based on LOAD AVERAGE
 #          but load average is dependent on the # of cores on a system.
-set(CTEST_BUILD_FLAGS "-j${PARALLEL_LEVEL} -k 0")
-
+set(CTEST_BUILD_FLAGS "-j${PARALLEL_LEVEL}")
+if(CTEST_CMAKE_GENERATOR STREQUAL "Ninja")
+  string(APPEND CTEST_BUILD_FLAGS " -k 0")
+endif()
 
 
 

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -461,6 +461,7 @@ opt-set-cmake-var TPL_HDF5_LIBRARIES   STRING FORCE : ""
 #
 
 [COVERAGE]
+opt-set-cmake-var CMAKE_GENERATOR STRING FORCE : "Unix Makefiles"
 opt-set-cmake-var CMAKE_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} --coverage -O0 -g -fprofile-abs-path
 
 

--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -461,7 +461,7 @@ opt-set-cmake-var TPL_HDF5_LIBRARIES   STRING FORCE : ""
 #
 
 [COVERAGE]
-opt-set-cmake-var CMAKE_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} --coverage -O0 -fprofile-abs-path
+opt-set-cmake-var CMAKE_CXX_FLAGS STRING FORCE : ${CMAKE_CXX_FLAGS|CMAKE} --coverage -O0 -g -fprofile-abs-path
 
 
 #


### PR DESCRIPTION
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-762

@trilinos/framework 

## Motivation
 * many (all?) of our test files cannot be found during the coverage phase.  A brief subset is below:
 ```
Cannot find file: /home/Trilinos/build/runner/_work/Trilinos/Trilinos/packages/zoltan2/test/core/unit/util/StridedData.cpp
Cannot find file: /home/Trilinos/build/runner/_work/Trilinos/Trilinos/packages/zoltan2/test/core/unit/util/TPLTraits.cpp
Cannot find file: /home/Trilinos/build/runner/_work/Trilinos/Trilinos/packages/zoltan2/test/core/unit/util/componentMetrics.cpp
Cannot find file: /home/Trilinos/build/runner/_work/Trilinos/Trilinos/packages/zoltan2/test/core/unit/util/findUniqueGids.cpp
 ```
Many more files (thousands) cannot be found as well.
