### PR TITLE
MiniTensor: discard dimension branches a static tensor cannot reach

### DIFF
--- a/packages/minitensor/src/MiniTensor_Inverse.h
+++ b/packages/minitensor/src/MiniTensor_Inverse.h
@@ -219,10 +219,23 @@ inverse_fast23(Tensor<T, N> const & A)
   Index const
   dimension = A.get_dimension();
 
-  switch (dimension) {
+  // As in det, the branches that a statically sized tensor can never
+  // reach are discarded, since they index past its storage.
 
-  case 3:
-    {
+  if (dimension == 1) {
+    return Tensor<T, N>(1, Filler::ONES) / A(0,0);
+  }
+
+  if constexpr (dimension_reachable<N, 2>) {
+    if (dimension == 2) {
+      T const determinant = det(A);
+      assert(determinant != 0.0);
+      return Tensor<T, N>(A(1,1), -A(0,1), -A(1,0), A(0,0)) / determinant;
+    }
+  }
+
+  if constexpr (dimension_reachable<N, 3>) {
+    if (dimension == 3) {
       T const determinant = det(A);
       assert(determinant != 0.0);
       return Tensor<T, N>(
@@ -237,22 +250,15 @@ inverse_fast23(Tensor<T, N> const & A)
         -A(0,1)*A(1,0) + A(0,0)*A(1,1)
         ) / determinant;
     }
-
-  case 2:
-    {
-      T const determinant = det(A);
-      assert(determinant != 0.0);
-      return Tensor<T, N>(A(1,1), -A(0,1), -A(1,0), A(0,0)) / determinant;
-    }
-
-  case 1:
-    return Tensor<T, N>(1, Filler::ONES) / A(0,0);
-
-  default:
-    break;
   }
 
-  return inverse_full_pivot(A);
+  if constexpr (dimension_reachable<N, 4>) {
+    return inverse_full_pivot(A);
+  }
+
+  // Unreachable: a statically sized tensor of dimension three or less
+  // has been inverted above.
+  return A;
 }
 
 //

--- a/packages/minitensor/src/MiniTensor_Norms.h
+++ b/packages/minitensor/src/MiniTensor_Norms.h
@@ -305,33 +305,40 @@ det(Tensor<T, N> const & A)
   T
   s = 0.0;
 
-  switch (dimension) {
+  // The dimension is a run-time quantity, so every branch of the
+  // dispatch below is compiled even for a statically sized tensor that
+  // can never reach it. The branches for the larger dimensions index
+  // past the storage of the smaller ones, which the compiler reports as
+  // an out-of-bounds access, so they are discarded here instead.
 
-    default:
-    {
-      int sign = 1;
-      for (Index i = 0; i < dimension; ++i) {
-        const T d = det(subtensor(A, i, 1));
-        s += sign * d * A(i, 1);
-        sign *= -1;
-      }
+  if (dimension == 1) {
+    s = A(0,0);
+    return s;
+  }
+
+  if constexpr (dimension_reachable<N, 2>) {
+    if (dimension == 2) {
+      s = A(0,0) * A(1,1) - A(1,0) * A(0,1);
+      return s;
     }
-    break;
+  }
 
-    case 3:
+  if constexpr (dimension_reachable<N, 3>) {
+    if (dimension == 3) {
       s = -A(0,2)*A(1,1)*A(2,0) + A(0,1)*A(1,2)*A(2,0) +
            A(0,2)*A(1,0)*A(2,1) - A(0,0)*A(1,2)*A(2,1) -
            A(0,1)*A(1,0)*A(2,2) + A(0,0)*A(1,1)*A(2,2);
-      break;
+      return s;
+    }
+  }
 
-    case 2:
-      s = A(0,0) * A(1,1) - A(1,0) * A(0,1);
-      break;
-
-    case 1:
-      s = A(0,0);
-      break;
-
+  if constexpr (dimension_reachable<N, 4>) {
+    int sign = 1;
+    for (Index i = 0; i < dimension; ++i) {
+      const T d = det(subtensor(A, i, 1));
+      s += sign * d * A(i, 1);
+      sign *= -1;
+    }
   }
 
   return s;

--- a/packages/minitensor/src/MiniTensor_Traits.h
+++ b/packages/minitensor/src/MiniTensor_Traits.h
@@ -81,6 +81,18 @@ template <typename T, Index M, Index N> class Matrix;
 constexpr Index
 DYNAMIC{0};
 
+///
+/// Whether a container whose static dimension is N can ever have the
+/// run-time dimension D. Dynamically sized containers can have any
+/// dimension, statically sized ones are bounded by N. Use it with
+/// if constexpr to discard the branches of a dimension dispatch that a
+/// statically sized argument can never take, and that would otherwise
+/// look to the compiler like accesses past the end of its storage.
+///
+template<Index N, Index D>
+inline constexpr bool
+dimension_reachable{N == DYNAMIC || N >= D};
+
 /// For use with type promotion
 using Sacado::Promote;
 using Sacado::mpl::lazy_disable_if;

--- a/packages/minitensor/test/test_linear_algebra.cc
+++ b/packages/minitensor/test/test_linear_algebra.cc
@@ -170,6 +170,94 @@ TEST(MiniTensor, TensorManipulation)
   ASSERT_LE(error, machine_epsilon<Real>());
 }
 
+TEST(MiniTensor, Determinant)
+{
+  // The determinant dispatches on the run-time dimension, and the
+  // branches that a statically sized tensor can never take are discarded
+  // at compile time. Exercise every branch that remains, both statically
+  // and dynamically sized, against determinants known in closed form.
+
+  Tensor<Real, 1>
+  A1(Filler::ZEROS);
+
+  A1(0, 0) = 3.0;
+
+  ASSERT_LE(std::abs(det(A1) - 3.0), machine_epsilon<Real>());
+
+  Tensor<Real, 2> const
+  A2(1.0, 2.0, 3.0, 4.0);
+
+  ASSERT_LE(std::abs(det(A2) + 2.0), 8 * machine_epsilon<Real>());
+
+  Tensor<Real, 3> const
+  A3(2.0, -1.0, 0.0, -1.0, 2.0, -1.0, 0.0, -1.0, 2.0);
+
+  ASSERT_LE(std::abs(det(A3) - 4.0), 8 * machine_epsilon<Real>());
+
+  // Dimensions above three go through the Laplace expansion, which
+  // recurses on subtensors that have the same static dimension but a
+  // smaller run-time dimension. L and U are triangular, so the
+  // determinant of their product is the product of all their diagonal
+  // entries, here 24 * 1/24 = 1.
+  Index const
+  N = 4;
+
+  Tensor<Real, N>
+  L(Filler::ZEROS);
+
+  Tensor<Real, N>
+  U(Filler::ZEROS);
+
+  for (Index i = 0; i < N; ++i) {
+
+    L(i, i) = static_cast<Real>(i + 1);
+
+    U(i, i) = 1.0 / static_cast<Real>(i + 1);
+
+    for (Index j = 0; j < i; ++j) {
+      L(i, j) = 0.5 * static_cast<Real>(i + j);
+      U(j, i) = 0.25 * static_cast<Real>(i - j);
+    }
+
+  }
+
+  Tensor<Real, N> const
+  A4 = L * U;
+
+  ASSERT_LE(std::abs(det(A4) - 1.0), 64 * machine_epsilon<Real>());
+
+  // Dynamically sized tensors keep every branch, and must agree with
+  // their statically sized counterparts.
+  for (Index dimension = 1; dimension <= N; ++dimension) {
+
+    Tensor<Real>
+    A(dimension);
+
+    Tensor<Real, N> const
+    B = A4;
+
+    for (Index i = 0; i < dimension; ++i) {
+      for (Index j = 0; j < dimension; ++j) {
+        A(i, j) = B(i, j);
+      }
+    }
+
+    Tensor<Real, N>
+    C(Filler::ZEROS);
+
+    C.set_dimension(dimension);
+
+    for (Index i = 0; i < dimension; ++i) {
+      for (Index j = 0; j < dimension; ++j) {
+        C(i, j) = B(i, j);
+      }
+    }
+
+    ASSERT_LE(std::abs(det(A) - det(C)), 64 * machine_epsilon<Real>());
+
+  }
+}
+
 TEST(MiniTensor, Inverse2x2)
 {
   Index const


### PR DESCRIPTION
## Motivation

`det` and `inverse_fast23` dispatch on the run-time dimension of their argument, so every branch of the dispatch is compiled even for a statically sized tensor that can never reach it. The branches for the larger dimensions index past the storage of the smaller ones. Whenever inlining makes the size of that storage visible, GCC reports the dead branch as an out-of-bounds access:

```
MiniTensor_Norms.h:322:18: warning: array subscript 'const minitensor::Storage<double, 9>[0]'
  is partly outside array bounds of 'minitensor::Tensor<double, 2> [1]' [-Warray-bounds]
  322 |       s = -A(0,2)*A(1,1)*A(2,0) + A(0,1)*A(1,2)*A(2,0) +
```

Krino gets a wall of these when it builds `packages/krino/krino/smoothing`, which takes determinants and inverses of `minitensor::Tensor<double, 2>`. The suggestion to use `if constexpr` came from @drnoble.

## What this does

- Adds `dimension_reachable<N, D>` to `MiniTensor_Traits.h`: true when a container with static dimension `N` can have run-time dimension `D`, that is, when `N` is `DYNAMIC` or at least `D`.
- Uses it in `det` and `inverse_fast23` to discard, with `if constexpr`, the branches that a statically sized argument cannot take. Dynamically sized tensors keep the whole dispatch, statically sized ones keep only the part they can reach, including the smaller dimensions that the Laplace expansion produces through `subtensor`.
- Adds a `Determinant` test covering dimensions one through four, statically and dynamically sized, checked against determinants known in closed form, plus agreement between a statically sized tensor of reduced run-time dimension and its dynamically sized counterpart.

No behavior changes: this is the same dispatch with the unreachable arms removed.

## Verification

- MiniTensor test suite (minimal build, GCC 16.1.1): 7/7 pass, including `Self_Contained`.
- Warning A/B against `develop` with the same configuration: no new warnings, none removed locally either, since this GCC does not emit the `-Warray-bounds` family from `det` in the first place. The dead code is gone all the same: the assembly for a translation unit that takes `det` of `Tensor<double, 2>`, `Tensor<double, 3>` and `Tensor<double>` shrinks from 2687 to 2079 lines at `-O2`.
- Documentation audit (doxygen with `EXTRACT_ALL = NO`, `WARN_IF_UNDOCUMENTED = YES`): no warnings.
- Full Albany/LCM build and regression suite against this branch.
