### PR TITLE
MueLu: cut-drop fix

### DIFF
--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_decl.hpp
@@ -134,9 +134,9 @@ class CoalesceDropFactory_kokkos
 
   Teuchos::RCP<MultiVector> GetMaterial(Level& currentLevel, size_t spatialDim) const;
 
-  std::tuple<GlobalOrdinal, boundary_nodes_type> BuildScalar(Level& currentLevel) const;
+  std::tuple<GlobalOrdinal, GlobalOrdinal, boundary_nodes_type> BuildScalar(Level& currentLevel) const;
 
-  std::tuple<GlobalOrdinal, boundary_nodes_type> BuildVector(Level& currentLevel) const;
+  std::tuple<GlobalOrdinal, GlobalOrdinal, boundary_nodes_type> BuildVector(Level& currentLevel) const;
 };
 
 }  // namespace MueLu

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
@@ -155,7 +155,7 @@ void CoalesceDropFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   TEUCHOS_TEST_FOR_EXCEPTION(A->GetFixedBlockSize() % A->GetStorageBlockSize() != 0, Exceptions::RuntimeError, "A->GetFixedBlockSize() needs to be a multiple of A->GetStorageBlockSize()");
   LO blkSize = A->GetFixedBlockSize() / A->GetStorageBlockSize();
 
-  std::tuple<GlobalOrdinal, boundary_nodes_type> results;
+  std::tuple<GlobalOrdinal, GlobalOrdinal, boundary_nodes_type> results;
   if (blkSize == 1)
     results = BuildScalar(currentLevel);
   else
@@ -163,7 +163,8 @@ void CoalesceDropFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
   if (GetVerbLevel() & Statistics1) {
     GlobalOrdinal numDropped = std::get<0>(results);
-    auto boundaryNodes       = std::get<1>(results);
+    GlobalOrdinal numKept    = std::get<1>(results);
+    auto boundaryNodes       = std::get<2>(results);
 
     GO numLocalBoundaryNodes = 0;
 
@@ -178,13 +179,14 @@ void CoalesceDropFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     if (IsPrint(Statistics1)) {
       auto comm = A->getRowMap()->getComm();
 
-      std::vector<GlobalOrdinal> localStats = {numLocalBoundaryNodes, numDropped};
-      std::vector<GlobalOrdinal> globalStats(2);
-      Teuchos::reduceAll(*comm, Teuchos::REDUCE_SUM, 2, localStats.data(), globalStats.data());
+      std::vector<GlobalOrdinal> localStats = {numLocalBoundaryNodes, numDropped, numKept};
+      std::vector<GlobalOrdinal> globalStats(3);
+      Teuchos::reduceAll(*comm, Teuchos::REDUCE_SUM, 3, localStats.data(), globalStats.data());
 
-      GO numGlobalTotal         = A->getGlobalNumEntries();
       GO numGlobalBoundaryNodes = globalStats[0];
       GO numGlobalDropped       = globalStats[1];
+      GO numGlobalKept          = globalStats[2];
+      GO numGlobalTotal         = numGlobalKept + numGlobalDropped;
 
       GetOStream(Statistics1) << "Detected " << numGlobalBoundaryNodes << " Dirichlet nodes" << std::endl;
       if (numGlobalTotal != 0) {
@@ -282,7 +284,7 @@ void translateOldAlgoParam(const Teuchos::ParameterList& pL, std::string& droppi
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-std::tuple<GlobalOrdinal, typename MueLu::LWGraph_kokkos<LocalOrdinal, GlobalOrdinal, Node>::boundary_nodes_type> CoalesceDropFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+std::tuple<GlobalOrdinal, GlobalOrdinal, typename MueLu::LWGraph_kokkos<LocalOrdinal, GlobalOrdinal, Node>::boundary_nodes_type> CoalesceDropFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     BuildScalar(Level& currentLevel) const {
   FactoryMonitor m(*this, "BuildScalar", currentLevel);
 
@@ -648,11 +650,11 @@ std::tuple<GlobalOrdinal, typename MueLu::LWGraph_kokkos<LocalOrdinal, GlobalOrd
   Set(currentLevel, "Graph", graph);
   Set(currentLevel, "A", filteredA);
 
-  return std::make_tuple(numDropped, boundaryNodes);
+  return std::make_tuple(numDropped, (GlobalOrdinal)nnz_filtered, boundaryNodes);
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-std::tuple<GlobalOrdinal, typename MueLu::LWGraph_kokkos<LocalOrdinal, GlobalOrdinal, Node>::boundary_nodes_type> CoalesceDropFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+std::tuple<GlobalOrdinal, GlobalOrdinal, typename MueLu::LWGraph_kokkos<LocalOrdinal, GlobalOrdinal, Node>::boundary_nodes_type> CoalesceDropFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     BuildVector(Level& currentLevel) const {
   FactoryMonitor m(*this, "BuildVector", currentLevel);
 
@@ -960,8 +962,8 @@ std::tuple<GlobalOrdinal, typename MueLu::LWGraph_kokkos<LocalOrdinal, GlobalOrd
   }
   LocalOrdinal nnz_filtered = nnz.first;
   LocalOrdinal nnz_graph    = nnz.second;
-  GO numTotal               = lclA.nnz();
-  GO numDropped             = numTotal - nnz_filtered;
+  GO numTotal               = mergedA->getLocalNumEntries();
+  GO numDropped             = numTotal - nnz_graph;
   GO numGlobalDropped;
   Teuchos::reduceAll(*A->getRowMap()->getComm(), Teuchos::REDUCE_SUM, 1, &numDropped, &numGlobalDropped);
   // We now know the number of entries of filtered A and have the final rowptr.
@@ -1062,7 +1064,7 @@ std::tuple<GlobalOrdinal, typename MueLu::LWGraph_kokkos<LocalOrdinal, GlobalOrd
   Set(currentLevel, "Graph", graph);
   Set(currentLevel, "A", filteredA);
 
-  return std::make_tuple(numDropped, boundaryNodes);
+  return std::make_tuple(numDropped, (GlobalOrdinal)nnz_graph, boundaryNodes);
 }
 
 }  // namespace MueLu

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CutDrop.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CutDrop.hpp
@@ -918,14 +918,16 @@ class CutDropFunctor {
   comparison_type comparison;
   magnitudeType eps;
   results_view results;
+  local_ordinal_type blockSize;
   Kokkos::View<local_ordinal_type*, memory_space> index;
 
  public:
-  CutDropFunctor(comparison_type& comparison_, magnitudeType threshold)
+  CutDropFunctor(comparison_type& comparison_, magnitudeType threshold, local_ordinal_type blockSize_ = 1)
     : A(comparison_.A)
     , comparison(comparison_)
     , eps(threshold)
-    , results(comparison_.results) {
+    , results(comparison_.results)
+    , blockSize(blockSize_) {
     index = Kokkos::View<local_ordinal_type*, memory_space>("indices", A.nnz());
   }
 
@@ -939,6 +941,11 @@ class CutDropFunctor {
 
     auto comparator = comparison.getComparator(rlid);
 
+    for (size_t i = 0; i < nnz; ++i) {
+      row_permutation(i) = i;
+    }
+    Misc::serialHeapSort(row_permutation, comparator);
+
 #ifdef MUELU_COALESCE_DROP_DEBUG
     {
       Kokkos::printf("SoC:        ");
@@ -946,18 +953,19 @@ class CutDropFunctor {
         Kokkos::printf("%5f ", comparator.get_value(k));
       }
       Kokkos::printf("\n");
+      Kokkos::printf("SoC sorted: ");
+      for (local_ordinal_type k = 0; k < row.length; ++k) {
+        auto const& x = row_permutation(k);
+        Kokkos::printf("%5f ", comparator.get_value(x));
+      }
+      Kokkos::printf("\n");
     }
 #endif
-
-    for (size_t i = 0; i < nnz; ++i) {
-      row_permutation(i) = i;
-    }
-    Misc::serialHeapSort(row_permutation, comparator);
 
     size_t keepStart = 0;
     size_t dropStart = nnz;
     // find index where dropping starts
-    for (size_t i = 1; i < nnz; ++i) {
+    for (size_t i = 2 * blockSize; i < nnz; ++i) {
       auto const& x = row_permutation(i - 1);
       auto const& y = row_permutation(i);
       if ((drop_view(x) != UNDECIDED) && (drop_view(y) == UNDECIDED))
@@ -968,10 +976,21 @@ class CutDropFunctor {
       magnitudeType y_aij = comparator.get_value(y);
       if (eps * eps * x_aij > y_aij) {
         if (i < dropStart) {
+#ifdef MUELU_COALESCE_DROP_DEBUG
+          {
+            Kokkos::printf("Changing dropStart: %d %5f %5f %5f\n", x_aij, y_aij, eps, i);
+          }
+#endif
           dropStart = i;
         }
       }
     }
+
+#ifdef MUELU_COALESCE_DROP_DEBUG
+    {
+      Kokkos::printf("cut-drop: %d %d %d\n", keepStart, dropStart, nnz);
+    }
+#endif
 
     // drop everything to the right of where values stop passing threshold
     for (size_t i = keepStart; i < nnz; ++i) {

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_VectorDroppingDistanceLaplacian_decl.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_VectorDroppingDistanceLaplacian_decl.hpp
@@ -98,7 +98,7 @@ class VectorDroppingDistanceLaplacian : public VectorDroppingBase<Scalar, LocalO
       }
     } else if (droppingMethod == "cut-drop") {
       auto comparison = CutDrop::make_dlap_vector_comparison_functor<SoC>(A, mergedA, dist2, results, rowTranslation, colTranslation);
-      auto cut_drop   = CutDrop::CutDropFunctor(comparison, threshold);
+      auto cut_drop   = CutDrop::CutDropFunctor(comparison, threshold, blkPartSize);
 
       if (symmetrizeDroppedGraph) {
         auto drop_boundaries = Misc::VectorSymmetricDropBoundaryFunctor(mergedA, rowTranslation, colTranslation, boundaryNodes, results);


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
- Make output about dropped entries consistent for $\text{blockSize}>1$.
- Fix a bug in CoalesceDrop_kokkos cut-drop dlap.
  Let $a_k$, $k=0,\dots$ be the ordered SoC row entries that cut-drop sees in a row. Before the algorithm would allow discarding everything except $k=0$. Now the first $2*\text{blockSize}$ entries will not get discarded.