### PR TITLE
Belos: slightly relax tolerance on MV nrm2 tests

### DIFF
--- a/packages/belos/src/BelosMVOPTester.hpp
+++ b/packages/belos/src/BelosMVOPTester.hpp
@@ -67,7 +67,7 @@ namespace Belos {
     // FIXME (mfh 09 Jan 2013) Added an arbitrary tolerance in case
     // norms are not computed deterministically (which is possible
     // even with MPI only, and more likely with threads).
-    const MagType tol = Teuchos::as<MagType> (100) * STS::eps ();
+    const MagType tol = Teuchos::as<MagType> (120) * STS::eps ();
 
     /* MVT Contract:
 
@@ -1454,7 +1454,7 @@ namespace Belos {
     // FIXME (mfh 09 Jan 2013) Added an arbitrary tolerance in case
     // norms are not computed deterministically (which is possible
     // even with MPI only, and more likely with threads).
-    const MagType tol = Teuchos::as<MagType> (100) * STS::eps ();
+    const MagType tol = Teuchos::as<MagType> (120) * STS::eps ();
 
     /* OPT Contract:
        Apply()


### PR DESCRIPTION
### Motivation

Increase the tolerance by 20% so that the test accepts the numerical differences between Kokkos parallel_reduce nrm2, and BLAS nrm2. Constant-stride MVs use the Kokkos impl. Non-constant-stride MVs previously also used the Kokkos impl, but recent KokkosKernels changes (https://github.com/kokkos/kokkos-kernels/pull/3183) enabled the TPL/BLAS path.

@trilinos/belos 
@ndellingwood 