### PR TITLE
Ifpack2/shylu: GPU improvements for ParILU algorithm

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_CrsArrays.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_CrsArrays.hpp
@@ -69,8 +69,10 @@ struct CrsArrayReader {
     size_t nnz         = A->getLocalNumEntries();
     size_t maxNnz      = A->getLocalMaxNumRowEntries();
 
-    vals          = ScalarArray("Values", nnz);
-    auto valsHost = Kokkos::create_mirror(vals);
+    if (vals.extent(0) != nnz) {
+      vals = ScalarArray(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Values"), nnz);
+    }
+    auto valsHost = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, vals);
     local_inds_host_view_type lclColInds("lclColinds", maxNnz);
 
     nnz = 0;
@@ -141,7 +143,9 @@ struct CrsArrayReader {
     auto localA = A->getLocalMatrixDevice();
     auto values = localA.values;
     auto nnz    = values.extent(0);
-    values_     = ScalarArray("Values", nnz);
+    if (values_.extent(0) != nnz) {
+      values_ = ScalarArray(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Values"), nnz);
+    }
     Kokkos::deep_copy(values_, values);
   }
 
@@ -168,7 +172,9 @@ struct CrsArrayReader {
     auto localA = A->getLocalMatrixDevice();
     auto values = localA.values;
     auto nnz    = values.extent(0);
-    values_     = ScalarArray("Values", nnz);
+    if (values_.extent(0) != nnz) {
+      values_ = ScalarArray(Kokkos::view_alloc(Kokkos::WithoutInitializing, "Values"), nnz);
+    }
     Kokkos::deep_copy(values_, values);
   }
 

--- a/packages/ifpack2/src/Ifpack2_Details_FastILU_Base_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_FastILU_Base_decl.hpp
@@ -163,6 +163,13 @@ class FastILU_Base : public Ifpack2::Preconditioner<Scalar, LocalOrdinal, Global
   int nInit_;
   int nComputed_;
   mutable int nApply_;
+  // Cached local CRS matrix used for efficient value extraction.
+  // If mat_ is already a Tpetra::CrsMatrix, localCrs_ aliases it.
+  // If mat_ is a generic RowMatrix wrapper, localCrsNonConst_ owns a materialized CRS copy.
+  Teuchos::RCP<const TCrsMatrix> localCrs_;
+  Teuchos::RCP<TCrsMatrix> localCrsNonConst_;
+  bool localCrsIsOwnedCopy_;
+
   // store the local CRS components
   ImplScalarArray localValues_;        // set at beginning of compute()
   OrdinalArray localRowPtrs_;          // set in initialize()

--- a/packages/ifpack2/src/Ifpack2_Details_FastILU_Base_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_FastILU_Base_def.hpp
@@ -19,6 +19,7 @@
 #include <KokkosKernels_Utils.hpp>
 #include <Kokkos_Timer.hpp>
 #include <Teuchos_TimeMonitor.hpp>
+#include <Teuchos_Array.hpp>
 #include <stdexcept>
 
 namespace Ifpack2 {
@@ -33,6 +34,9 @@ FastILU_Base<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   , nInit_(0)
   , nComputed_(0)
   , nApply_(0)
+  , localCrs_(Teuchos::null)
+  , localCrsNonConst_(Teuchos::null)
+  , localCrsIsOwnedCopy_(false)
   , initTime_(0.0)
   , computeTime_(0.0)
   , applyTime_(0.0)
@@ -146,8 +150,64 @@ void FastILU_Base<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   }
 
   Kokkos::Timer copyTimer;
-  CrsArrayReader<Scalar, ImplScalar, LocalOrdinal, GlobalOrdinal, Node>::getStructure(mat_.get(), localRowPtrsHost_, localRowPtrs_, localColInds_);
-  CrsArrayReader<Scalar, ImplScalar, LocalOrdinal, GlobalOrdinal, Node>::getValues(mat_.get(), localValues_, localRowPtrsHost_);
+
+  // Try to ensure that FastILU reads structure and values from a concrete
+  // Tpetra::CrsMatrix whenever possible.  This lets CrsArrayReader use its
+  // getStructureCrs/getValuesCrs fast paths instead of the generic RowMatrix
+  // host-row loop.  In BlockCrs mode, keep using mat_ directly so the BCRS
+  // specialization in CrsArrayReader remains available.
+  localCrs_            = Teuchos::null;
+  localCrsNonConst_    = Teuchos::null;
+  localCrsIsOwnedCopy_ = false;
+
+  const TRowMatrix* crsArraySource = mat_.get();
+  if (!isBlockCrs()) {
+    localCrs_ = Ifpack2::Details::getCrsMatrix(mat_);
+
+    if (localCrs_.is_null()) {
+      const LocalOrdinal numRows = static_cast<LocalOrdinal>(mat_->getLocalNumRows());
+      Teuchos::Array<size_t> entriesPerRow(numRows);
+      for (LocalOrdinal i = 0; i < numRows; ++i) {
+        entriesPerRow[i] = mat_->getNumEntriesInLocalRow(i);
+      }
+
+      localCrsNonConst_ = Teuchos::rcp(new TCrsMatrix(mat_->getRowMap(), mat_->getColMap(), entriesPerRow()));
+
+      using local_inds_host_view_type = typename TRowMatrix::nonconst_local_inds_host_view_type;
+      using values_host_view_type     = typename TRowMatrix::nonconst_values_host_view_type;
+
+      const size_t maxNnz = mat_->getLocalMaxNumRowEntries();
+      local_inds_host_view_type indices("FastILU local CRS indices", maxNnz);
+      values_host_view_type values("FastILU local CRS values", maxNnz);
+
+      for (LocalOrdinal i = 0; i < numRows; ++i) {
+        size_t numEntries = 0;
+        mat_->getLocalRowCopy(i, indices, values, numEntries);
+        localCrsNonConst_->insertLocalValues(
+            i,
+            numEntries,
+            reinterpret_cast<Scalar*>(values.data()),
+            indices.data());
+      }
+
+      localCrsNonConst_->fillComplete(mat_->getDomainMap(), mat_->getRangeMap());
+      localCrs_            = localCrsNonConst_;
+      localCrsIsOwnedCopy_ = true;
+    }
+
+    crsArraySource = localCrs_.get();
+  }
+
+  {
+    CrsArrayReader<Scalar, ImplScalar, LocalOrdinal, GlobalOrdinal, Node>::getStructure(
+        crsArraySource, localRowPtrsHost_, localRowPtrs_, localColInds_);
+  }
+
+  {
+    CrsArrayReader<Scalar, ImplScalar, LocalOrdinal, GlobalOrdinal, Node>::getValues(
+        crsArraySource, localValues_, localRowPtrsHost_);
+  }
+
   crsCopyTime_ = copyTimer.seconds();
 
   if (params_.use_metis) {
@@ -249,7 +309,42 @@ void FastILU_Base<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
   // get copy of values array from matrix
   Kokkos::Timer copyTimer;
-  CrsArrayReader<Scalar, ImplScalar, LocalOrdinal, GlobalOrdinal, Node>::getValues(mat_.get(), localValues_, localRowPtrsHost_);
+  const TRowMatrix* crsArraySource = mat_.get();
+
+  if (!isBlockCrs() && !localCrs_.is_null()) {
+    if (localCrsIsOwnedCopy_) {
+      localCrsNonConst_->resumeFill();
+
+      using local_inds_host_view_type = typename TRowMatrix::nonconst_local_inds_host_view_type;
+      using values_host_view_type     = typename TRowMatrix::nonconst_values_host_view_type;
+
+      const LocalOrdinal numRows = static_cast<LocalOrdinal>(mat_->getLocalNumRows());
+      const size_t maxNnz        = mat_->getLocalMaxNumRowEntries();
+      local_inds_host_view_type indices("FastILU refresh CRS indices", maxNnz);
+      values_host_view_type values("FastILU refresh CRS values", maxNnz);
+
+      for (LocalOrdinal i = 0; i < numRows; ++i) {
+        size_t numEntries = 0;
+        mat_->getLocalRowCopy(i, indices, values, numEntries);
+        localCrsNonConst_->replaceLocalValues(
+            i,
+            numEntries,
+            reinterpret_cast<Scalar*>(values.data()),
+            indices.data());
+      }
+
+      localCrsNonConst_->fillComplete(mat_->getDomainMap(), mat_->getRangeMap());
+      localCrs_ = localCrsNonConst_;
+    }
+
+    crsArraySource = localCrs_.get();
+  }
+
+  {
+    CrsArrayReader<Scalar, ImplScalar, LocalOrdinal, GlobalOrdinal, Node>::getValues(
+        crsArraySource, localValues_, localRowPtrsHost_);
+  }
+
   crsCopyTime_ += copyTimer.seconds();  // add to the time spent getting rowptrs/colinds
   computeLocalPrec();                   // this updates computeTime_
   computedFlag_ = true;
@@ -354,9 +449,12 @@ void FastILU_Base<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   }
   // bmk note: this modeled after RILUK::setMatrix
   if (mat_.get() != A.get()) {
-    mat_          = A;
-    initFlag_     = false;
-    computedFlag_ = false;
+    mat_                 = A;
+    localCrs_            = Teuchos::null;
+    localCrsNonConst_    = Teuchos::null;
+    localCrsIsOwnedCopy_ = false;
+    initFlag_            = false;
+    computedFlag_        = false;
   }
 }
 

--- a/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Filu_def.hpp
@@ -61,7 +61,7 @@ void Filu<Scalar, LocalOrdinal, GlobalOrdinal, Node, BlockCrsEnabled>::
     initLocalPrec() {
   auto nRows  = this->mat_->getLocalNumRows();
   auto& p     = this->params_;
-  auto matCrs = Ifpack2::Details::getCrsMatrix(this->mat_);
+  auto matCrs = this->localCrs_;
 
   if (p.blockCrsSize > 1 && !BlockCrsEnabled) {
     throw std::runtime_error("Must use prec type FAST_ILU_B if you want blockCrs support");

--- a/packages/shylu/shylu_node/fastilu/src/shylu_fastilu.hpp
+++ b/packages/shylu/shylu_node/fastilu/src/shylu_fastilu.hpp
@@ -239,6 +239,81 @@ class MemoryPrimeFunctorNnzCoo;
 template<class Ordinal, class Scalar, class ExecSpace>
 class MemoryPrimeFunctorNnzCsr;
 
+
+template<class Ordinal, class Scalar, class ExecSpace>
+class ParCopyUToUtFunctor
+{
+    public:
+        typedef ExecSpace execution_space;
+        typedef Kokkos::View<Ordinal *, ExecSpace> ordinal_array_type;
+        typedef Kokkos::View<Scalar *, ExecSpace> scalar_array_type;
+
+        ParCopyUToUtFunctor(ordinal_array_type u2utMap,
+                             scalar_array_type uVal,
+                             scalar_array_type utVal)
+            :
+                u2utMap_(u2utMap),
+                uVal_(uVal),
+                utVal_(utVal)
+        {}
+
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const Ordinal uPos) const
+        {
+            utVal_(u2utMap_(uPos)) = uVal_(uPos);
+        }
+
+        ordinal_array_type u2utMap_;
+        scalar_array_type  uVal_;
+        scalar_array_type  utVal_;
+};
+
+
+template<class Ordinal, class ExecSpace>
+class ParInitOrdinalFunctor
+{
+    public:
+        typedef ExecSpace execution_space;
+        typedef Kokkos::View<Ordinal *, ExecSpace> ordinal_array_type;
+
+        ParInitOrdinalFunctor(ordinal_array_type out)
+            :
+                out_(out)
+        {}
+
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const Ordinal i) const
+        {
+            out_(i) = i;
+        }
+
+        ordinal_array_type out_;
+};
+
+template<class Ordinal, class ExecSpace>
+class ParInvertOrdinalMapFunctor
+{
+    public:
+        typedef ExecSpace execution_space;
+        typedef Kokkos::View<Ordinal *, ExecSpace> ordinal_array_type;
+
+        ParInvertOrdinalMapFunctor(ordinal_array_type transposedOrdinal,
+                                   ordinal_array_type inverseMap)
+            :
+                transposedOrdinal_(transposedOrdinal),
+                inverseMap_(inverseMap)
+        {}
+
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const Ordinal transposedPos) const
+        {
+            inverseMap_(transposedOrdinal_(transposedPos)) = transposedPos;
+        }
+
+        ordinal_array_type transposedOrdinal_;
+        ordinal_array_type inverseMap_;
+};
+
 template<class Ordinal, class Scalar, class ExecSpace, bool BlockCrsEnabled=false>
 class FastILUPrec
 {
@@ -669,7 +744,6 @@ class FastILUPrec
         OrdinalArray       m_aRowMapIn;
         OrdinalArray       m_aColIdxIn;
         // host
-        ScalarArrayMirror  m_aValInHost;
         OrdinalArrayMirror m_aRowMapInHost;
         OrdinalArrayMirror m_aColIdxInHost;
 
@@ -705,6 +779,20 @@ class FastILUPrec
 
         KernelHandle khL;
         KernelHandle khU;
+
+        bool m_sptrsvHandlesInitialized;
+        bool m_utGraphInitialized;
+        OrdinalArray m_u2utMap;
+
+        // ILU(0)-specific symbolic maps used by the numeric fast path.
+        // m_a2aInMap maps final symbolic A positions to input A positions.
+        // m_diagApos maps rows to diagonal positions in final symbolic A.
+        // m_a2lMap maps final symbolic A positions to L positions, or -1.
+        // m_a2uDirectMap maps final symbolic A positions to U positions, or -1.
+        OrdinalArray m_a2aInMap;
+        OrdinalArray m_diagApos;
+        OrdinalArray m_a2lMap;
+        OrdinalArray m_a2uDirectMap;
 
         void findFills(int levfill, OrdinalArrayMirror aRowMap, OrdinalArrayMirror aColIdx,
                        int& nzl, std::vector<int> &lRowMap, std::vector<int> &lColIdx, std::vector<int> &lLevel,
@@ -838,6 +926,181 @@ class FastILUPrec
             nzu = knzu;
         }
 
+
+        // Fast symbolic path for ILU(0) without Metis.
+        //
+        // For level-of-fill zero, the symbolic pattern is exactly the input
+        // graph.  Avoid the general findFills() algorithm, which is designed
+        // for ILU(k), k > 0, and is expensive on large subdomains.
+        void symbolicILU0(OrdinalArrayMirror ia, OrdinalArrayMirror ja)
+        {
+
+            using WithoutInit = Kokkos::ViewAllocateWithoutInitializing;
+            const Ordinal nRowsUnblocked = ia.extent(0) - 1;
+            const Ordinal nnzA = ia[nRowsUnblocked];
+
+            m_aRowMapHost = OrdinalArrayMirror(WithoutInit("aRowMap"), nRowsUnblocked + 1);
+            m_aColIdxHost = OrdinalArrayMirror(WithoutInit("aColIdx"), nnzA);
+            m_aRowIdxHost = OrdinalArrayMirror(WithoutInit("aRowIdx"), nnzA);
+            m_aLvlIdxHost = OrdinalArrayHost(WithoutInit("aLvlIdx"), nnzA);
+
+
+            Kokkos::deep_copy(m_aRowMapHost, ia);
+            Kokkos::deep_copy(m_aColIdxHost, ja);
+
+            // Sort only if the input graph is not known to be sorted.
+            // For ILU(0), all levels are zero, and row indices are constant
+            // within each row, so sorting only column indices is sufficient.
+            if (!m_skipSortMatrix) {
+
+                using host_space = typename HostSpace::execution_space;
+                KokkosSparse::sort_crs_graph<host_space, OrdinalArrayMirror, OrdinalArrayMirror>
+                  (m_aRowMapHost, m_aColIdxHost);
+            }
+
+
+            for (Ordinal i = 0; i < nRowsUnblocked; ++i) {
+                for (Ordinal k = m_aRowMapHost[i]; k < m_aRowMapHost[i + 1]; ++k) {
+                    m_aRowIdxHost[k] = i;
+                    m_aLvlIdxHost[k] = 0;
+                }
+            }
+
+
+            m_a2aInMap = OrdinalArray(WithoutInit("a2aInMap"), nnzA);
+            auto a2aInMapHost = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, m_a2aInMap);
+
+            if (m_skipSortMatrix) {
+                for (Ordinal k = 0; k < nnzA; ++k) {
+                    a2aInMapHost(k) = k;
+                }
+            }
+            else {
+                // The symbolic ILU(0) graph may have been sorted above.
+                // Map each final symbolic position back to its original input position.
+                for (Ordinal i = 0; i < nRowsUnblocked; ++i) {
+                    for (Ordinal k = m_aRowMapHost[i]; k < m_aRowMapHost[i + 1]; ++k) {
+                        const Ordinal col = m_aColIdxHost[k];
+                        Ordinal found = -1;
+                        for (Ordinal inPos = ia[i]; inPos < ia[i + 1]; ++inPos) {
+                            if (ja[inPos] == col) {
+                                found = inPos;
+                                break;
+                            }
+                        }
+                        assert(found >= 0);
+                        a2aInMapHost(k) = found;
+                    }
+                }
+            }
+
+            Kokkos::deep_copy(m_a2aInMap, a2aInMapHost);
+        }
+
+        // Combined L/U row-map and A-to-U map construction for ILU(0).
+        //
+        // This avoids separate countL() and countU() passes for the common
+        // level-zero, no-Metis case.  It preserves the existing U storage
+        // convention, where m_uRowMap indexes rows of U^T / columns of U and
+        // m_a2uMap maps U storage positions back to positions in A.
+        void countLU_ilu0(Ordinal& nnzL, Ordinal& nnzU)
+        {
+
+            using WithoutInit = Kokkos::ViewAllocateWithoutInitializing;
+
+            m_lRowMapHost[0] = 0;
+            for (Ordinal i = 0; i <= m_nRows; ++i) {
+                m_uRowMapHost[i] = 0;
+            }
+
+
+            for (Ordinal i = 0; i < m_nRows; ++i) {
+                Ordinal lCount = 0;
+
+                for (Ordinal k = m_aRowMapHost[i]; k < m_aRowMapHost[i + 1]; ++k) {
+                    const Ordinal col = m_aColIdxHost[k];
+
+                    if (i >= col) {
+                        ++lCount;
+                    }
+
+                    if (i <= col) {
+                        ++m_uRowMapHost[col + 1];
+                    }
+                }
+
+                m_lRowMapHost[i + 1] = m_lRowMapHost[i] + lCount;
+            }
+
+            for (Ordinal i = 0; i < m_nRows; ++i) {
+                m_uRowMapHost[i + 1] += m_uRowMapHost[i];
+            }
+
+            nnzL = m_lRowMapHost[m_nRows];
+            nnzU = m_uRowMapHost[m_nRows];
+
+
+            const Ordinal nnzA = static_cast<Ordinal>(m_aColIdxHost.extent(0));
+
+            m_a2uMap = OrdinalArray(WithoutInit("a2uMap"), nnzU);
+            m_diagApos = OrdinalArray(WithoutInit("diagApos"), m_nRows);
+            m_a2lMap = OrdinalArray(WithoutInit("a2lMap"), nnzA);
+            m_a2uDirectMap = OrdinalArray(WithoutInit("a2uDirectMap"), nnzA);
+
+            auto a2uMapHost = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, m_a2uMap);
+            auto diagAposHost = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, m_diagApos);
+            auto a2lMapHost = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, m_a2lMap);
+            auto a2uDirectMapHost = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, m_a2uDirectMap);
+
+            for (Ordinal i = 0; i < m_nRows; ++i) {
+                diagAposHost(i) = -1;
+            }
+            for (Ordinal k = 0; k < nnzA; ++k) {
+                a2lMapHost(k) = -1;
+                a2uDirectMapHost(k) = -1;
+            }
+
+            std::vector<Ordinal> nextU(static_cast<size_t>(m_nRows));
+            for (Ordinal i = 0; i < m_nRows; ++i) {
+                nextU[static_cast<size_t>(i)] = m_uRowMapHost[i];
+            }
+
+            for (Ordinal i = 0; i < m_nRows; ++i) {
+                Ordinal nextL = m_lRowMapHost[i];
+                for (Ordinal k = m_aRowMapHost[i]; k < m_aRowMapHost[i + 1]; ++k) {
+                    const Ordinal col = m_aColIdxHost[k];
+
+                    if (i >= col) {
+                        const Ordinal lPos = nextL++;
+                        a2lMapHost(k) = lPos;
+                    }
+
+                    if (i == col) {
+                        diagAposHost(i) = k;
+                    }
+
+                    if (i <= col) {
+                        const Ordinal uPos = nextU[static_cast<size_t>(col)]++;
+                        a2uMapHost(uPos) = k;
+                        a2uDirectMapHost(k) = uPos;
+                    }
+                }
+                assert(nextL == m_lRowMapHost[i + 1]);
+            }
+
+            for (Ordinal i = 0; i < m_nRows; ++i) {
+                assert(diagAposHost(i) >= 0);
+            }
+
+            Kokkos::deep_copy(m_a2uMap, a2uMapHost);
+            Kokkos::deep_copy(m_diagApos, diagAposHost);
+            Kokkos::deep_copy(m_a2lMap, a2lMapHost);
+            Kokkos::deep_copy(m_a2uDirectMap, a2uDirectMapHost);
+
+            Kokkos::deep_copy(m_lRowMap, m_lRowMapHost);
+            Kokkos::deep_copy(m_uRowMap, m_uRowMapHost);
+        }
+
         //Symbolic ILU code
         //initializes the matrices L and U and readies them
         //according to the level of fill
@@ -849,6 +1112,12 @@ class FastILUPrec
             using std::stable_sort;
             using std::sort;
             const Ordinal nRowsUnblocked = ia.extent(0) - 1;
+
+            if (m_level == 0 && !m_useMetis) {
+                symbolicILU0(ia, ja);
+                return;
+            }
+
             int nzu = ia[nRowsUnblocked];
             int nzl = ia[nRowsUnblocked];
             Ordinal i;
@@ -979,19 +1248,26 @@ class FastILUPrec
             FASTILU_DBG_COUT("**Finished initializing A");
 
             //Compute RowMap for L and U.
-            // > form RowMap for L
             m_lRowMap = OrdinalArray(WithoutInit("lRowMap"), m_nRows + 1);
             m_lRowMapHost = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, m_lRowMap);
-            const Ordinal nnzL = countL();
-            FASTILU_DBG_COUT("**Finished counting L");
 
-            // > form RowMap for U and Ut
             m_uRowMap  = OrdinalArray(WithoutInit("uRowMap"), m_nRows + 1);
             m_utRowMap = OrdinalArray(WithoutInit("utRowMap"), m_nRows + 1);
             m_utRowMapHost = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, m_utRowMap);
             m_uRowMapHost  = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, m_uRowMap);
-            const Ordinal nnzU = countU();
-            FASTILU_DBG_COUT("**Finished counting U");
+
+            Ordinal nnzL = 0;
+            Ordinal nnzU = 0;
+            if (m_level == 0 && !m_useMetis) {
+                countLU_ilu0(nnzL, nnzU);
+                FASTILU_DBG_COUT("**Finished counting L/U with ILU0 fast path");
+            }
+            else {
+                nnzL = countL();
+                FASTILU_DBG_COUT("**Finished counting L");
+                nnzU = countU();
+                FASTILU_DBG_COUT("**Finished counting U");
+            }
 
             //Allocate memory and initialize pattern for L, U (transpose).
             m_lColIdx = OrdinalArray(WithoutInit("lColIdx"), nnzL);
@@ -1012,10 +1288,293 @@ class FastILUPrec
             m_utValHost   = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, m_utVal);
         }
 
+
+        void resetStandardSpTRSVState()
+        {
+
+            if (m_sptrsvHandlesInitialized) {
+                khL.destroy_sptrsv_handle();
+                khU.destroy_sptrsv_handle();
+            }
+            m_sptrsvHandlesInitialized = false;
+            m_utGraphInitialized = false;
+            m_u2utMap = OrdinalArray();
+        }
+
+        KokkosSparse::Experimental::SPTRSVAlgorithm standardSpTRSVAlgorithm() const
+        {
+#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
+            return KokkosSparse::Experimental::SPTRSVAlgorithm::SPTRSV_CUSPARSE;
+#else
+            return KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_TP1;
+#endif
+        }
+
+        void initializeStandardSpTRSVHandles()
+        {
+            if (m_sptrsv_algo != FastILU::SpTRSV::Standard) {
+                return;
+            }
+
+            assert(m_blockCrsSize == 1); // Standard SpTRSV path does not support block CRS here
+
+            if (!m_sptrsvHandlesInitialized) {
+
+                const auto algo = standardSpTRSVAlgorithm();
+
+                khL.create_sptrsv_handle(algo, m_nRows, true);
+                khU.create_sptrsv_handle(algo, m_nRows, false);
+
+                m_sptrsvHandlesInitialized = true;
+            }
+        }
+
+        void buildUTransposeMapForStandardSpTRSV()
+        {
+            assert(m_blockCrsSize == 1);
+
+
+            using WithoutInit = Kokkos::ViewAllocateWithoutInitializing;
+
+            const Ordinal nnzU = static_cast<Ordinal>(m_uColIdx.extent(0));
+
+            m_u2utMap = OrdinalArray(WithoutInit("u2utMap"), nnzU);
+            OrdinalArray uOrdinal(WithoutInit("uOrdinal"), nnzU);
+            OrdinalArray utOrdinal(WithoutInit("utOrdinal"), nnzU);
+
+
+            ParInitOrdinalFunctor<Ordinal, ExecSpace> initOrdinal(uOrdinal);
+            Kokkos::parallel_for(
+                "compute::initUOrdinal",
+                Kokkos::RangePolicy<ExecSpace>(0, nnzU),
+                initOrdinal);
+
+
+            Kokkos::deep_copy(m_utRowMap, 0);
+            KokkosSparse::Impl::transpose_matrix<
+                OrdinalArray,
+                OrdinalArray,
+                OrdinalArray,
+                OrdinalArray,
+                OrdinalArray,
+                OrdinalArray,
+                OrdinalArray,
+                ExecSpace>
+              (m_nRows, m_nRows,
+               m_uRowMap, m_uColIdx, uOrdinal,
+               m_utRowMap, m_utColIdx, utOrdinal);
+
+
+            KokkosSparse::sort_crs_matrix<ExecSpace, OrdinalArray, OrdinalArray, OrdinalArray>
+              (m_utRowMap, m_utColIdx, utOrdinal);
+
+
+            ParInvertOrdinalMapFunctor<Ordinal, ExecSpace> invertOrdinal(utOrdinal, m_u2utMap);
+            Kokkos::parallel_for(
+                "compute::invertUOrdinalToU2Ut",
+                Kokkos::RangePolicy<ExecSpace>(0, nnzU),
+                invertOrdinal);
+
+
+            ParCopyUToUtFunctor<Ordinal, Scalar, ExecSpace> copyUToUt(m_u2utMap, m_uVal, m_utVal);
+            Kokkos::parallel_for(
+                "compute::initialCopyUToUt",
+                Kokkos::RangePolicy<ExecSpace>(0, nnzU),
+                copyUToUt);
+        }
+
+        void refreshUtForStandardSpTRSV()
+        {
+            assert(m_blockCrsSize == 1);
+
+            if (!m_utGraphInitialized) {
+                // First compute for this graph: build the sorted U^T graph
+                // and the U-entry -> U^T-entry value map entirely on device.
+                //
+                // This replaces the old path that transposed/sorted U values,
+                // copied the graph to host, and searched host rows to build
+                // m_u2utMap.
+                buildUTransposeMapForStandardSpTRSV();
+                m_utGraphInitialized = true;
+            }
+            else {
+                // Later computes: U's graph is unchanged, so only refresh U^T's
+                // values.  Do not rebuild or sort the U^T graph.
+
+                ParCopyUToUtFunctor<Ordinal, Scalar, ExecSpace> copyUToUt(m_u2utMap, m_uVal, m_utVal);
+                Kokkos::parallel_for(
+                    "compute::copyUToUt",
+                    Kokkos::RangePolicy<ExecSpace>(0, static_cast<Ordinal>(m_u2utMap.extent(0))),
+                    copyUToUt);
+            }
+        }
+
+
+
+        struct ILU0GetDiagFunctor
+        {
+            ScalarArray aValIn;
+            OrdinalArray a2aInMap;
+            OrdinalArray diagApos;
+            RealArray diagFact;
+
+            ILU0GetDiagFunctor(ScalarArray aValIn_,
+                                OrdinalArray a2aInMap_,
+                                OrdinalArray diagApos_,
+                                RealArray diagFact_)
+                :
+                  aValIn(aValIn_),
+                  a2aInMap(a2aInMap_),
+                  diagApos(diagApos_),
+                  diagFact(diagFact_)
+            {}
+
+            KOKKOS_INLINE_FUNCTION
+            void operator()(const Ordinal i) const
+            {
+                InvSqrtFunctor invSqrt;
+                const Ordinal aPos = diagApos(i);
+                const Ordinal inPos = a2aInMap(aPos);
+                diagFact(i) = invSqrt(aValIn(inPos));
+            }
+        };
+
+        struct ILU0ScaleScatterFunctor
+        {
+            ScalarArray aValIn;
+            OrdinalArray a2aInMap;
+            OrdinalArray aRowIdx;
+            OrdinalArray aColIdx;
+            ScalarArray aVal;
+            RealArray diagFact;
+            OrdinalArray a2lMap;
+            OrdinalArray a2uDirectMap;
+            ScalarArray lVal;
+            OrdinalArray lColIdx;
+            ScalarArray uVal;
+            OrdinalArray uColIdx;
+            ScalarArray diagElems;
+
+            ILU0ScaleScatterFunctor(ScalarArray aValIn_,
+                                     OrdinalArray a2aInMap_,
+                                     OrdinalArray aRowIdx_,
+                                     OrdinalArray aColIdx_,
+                                     ScalarArray aVal_,
+                                     RealArray diagFact_,
+                                     OrdinalArray a2lMap_,
+                                     OrdinalArray a2uDirectMap_,
+                                     ScalarArray lVal_,
+                                     OrdinalArray lColIdx_,
+                                     ScalarArray uVal_,
+                                     OrdinalArray uColIdx_,
+                                     ScalarArray diagElems_)
+                :
+                  aValIn(aValIn_),
+                  a2aInMap(a2aInMap_),
+                  aRowIdx(aRowIdx_),
+                  aColIdx(aColIdx_),
+                  aVal(aVal_),
+                  diagFact(diagFact_),
+                  a2lMap(a2lMap_),
+                  a2uDirectMap(a2uDirectMap_),
+                  lVal(lVal_),
+                  lColIdx(lColIdx_),
+                  uVal(uVal_),
+                  uColIdx(uColIdx_),
+                  diagElems(diagElems_)
+            {}
+
+            KOKKOS_INLINE_FUNCTION
+            void operator()(const Ordinal aPos) const
+            {
+                const Scalar one = STS::one();
+
+                const Ordinal inPos = a2aInMap(aPos);
+                const Ordinal row = aRowIdx(aPos);
+                const Ordinal col = aColIdx(aPos);
+
+                const Scalar scaled = aValIn(inPos) * diagFact(row) * diagFact(col);
+                aVal(aPos) = scaled;
+
+                const Ordinal lPos = a2lMap(aPos);
+                if (lPos >= 0) {
+                    lColIdx(lPos) = col;
+                    if (row == col) {
+                        diagElems(row) = scaled;
+                        lVal(lPos) = one;
+                    }
+                    else {
+                        lVal(lPos) = scaled;
+                    }
+                }
+
+                const Ordinal uPos = a2uDirectMap(aPos);
+                if (uPos >= 0) {
+                    uVal(uPos) = scaled;
+                    uColIdx(uPos) = row;
+                }
+            }
+        };
+
+        void numericILU0()
+        {
+
+            assert(m_level == 0);
+            assert(!m_useMetis);
+            assert(m_blockCrsSize == 1);
+
+            {
+
+                ILU0GetDiagFunctor diagFunctor(m_aValIn, m_a2aInMap, m_diagApos, m_diagFact);
+                Kokkos::parallel_for(
+                    "numericILU0::getDiags",
+                    Kokkos::RangePolicy<ExecSpace>(0, m_nRows),
+                    diagFunctor);
+            }
+
+            {
+
+                ILU0ScaleScatterFunctor scatterFunctor(
+                    m_aValIn,
+                    m_a2aInMap,
+                    m_aRowIdx,
+                    m_aColIdx,
+                    m_aVal,
+                    m_diagFact,
+                    m_a2lMap,
+                    m_a2uDirectMap,
+                    m_lVal,
+                    m_lColIdx,
+                    m_uVal,
+                    m_uColIdx,
+                    m_diagElems);
+
+                Kokkos::parallel_for(
+                    "numericILU0::scaleScatter",
+                    Kokkos::RangePolicy<ExecSpace>(0, static_cast<Ordinal>(m_aColIdx.extent(0))),
+                    scatterFunctor);
+            }
+        }
+
         void numericILU()
         {
             const Scalar zero = STS::zero();
             FASTILU_CREATE_TIMER(Timer);
+
+            // Fast scalar ILU(0) numeric path.  This bypasses the generic
+            // ILU(k) setup sequence: copyVals, getDiags, diagScal, fillL,
+            // and fillU.  It is enabled only for the conservative case where
+            // the symbolic maps were built by symbolicILU0/countLU_ilu0 and
+            // no Manteuffel shift is requested.
+            if (m_level == 0 && !m_useMetis && m_blockCrsSize == 1 &&
+                m_shift == zero &&
+                m_a2aInMap.extent(0) == m_aColIdx.extent(0) &&
+                m_a2lMap.extent(0) == m_aColIdx.extent(0) &&
+                m_a2uDirectMap.extent(0) == m_aColIdx.extent(0) &&
+                m_diagApos.extent(0) == static_cast<size_t>(m_nRows)) {
+                numericILU0();
+                return;
+            }
             if (m_useMetis && (m_guessFlag == 0 || m_level == 0)) { // applied only at the first call (level 0)
               // apply column permutation before sorting it
               FastILUPrec_Functor perm_functor(m_aColIdxIn, m_ipermMetis);
@@ -1066,11 +1625,9 @@ class FastILUPrec
                 applyManteuffelShift();
                 Kokkos::deep_copy(m_aVal, m_aValHost);
             }
-            else {
-              Kokkos::deep_copy(m_aValHost, m_aVal); // keep in-sync
-            }
             FASTILU_FENCE_REPORT_TIMER(Timer, ExecSpace(), "   + apply shift/scale");
             FASTILU_DBG_COUT("**Finished diagonal scaling");
+
 
             fillL();
             FASTILU_FENCE_REPORT_TIMER(Timer, ExecSpace(), "   + fill L");
@@ -1361,6 +1918,8 @@ class FastILUPrec
             m_blockCrsSize = blockCrsSize;
             m_doUnitDiag_TRSV = true; // perform TRSV with unit diagonals
             m_sptrsv_KKSpMV = true;   // use Kokkos-Kernels SpMV for Fast SpTRSV
+            m_sptrsvHandlesInitialized = false;
+            m_utGraphInitialized = false;
 
             if (!BlockCrsEnabled) {
               assert(blockCrsSize == 1);
@@ -1377,10 +1936,8 @@ class FastILUPrec
 
             m_aRowMapInHost = OrdinalArrayMirror("aRowMapHost", m_aRowMapIn.size());
             m_aColIdxInHost = OrdinalArrayMirror("aColIdxHost", m_aColIdxIn.size());
-            m_aValInHost    = ScalarArrayMirror("aValHost",     m_aValIn.size());
             Kokkos::deep_copy(m_aRowMapInHost, aRowMapIn);
             Kokkos::deep_copy(m_aColIdxInHost, aColIdxIn);
-            Kokkos::deep_copy(m_aValInHost,    aValIn);
 #ifdef FASTILU_ONE_TO_ONE_UNBLOCKED
             if (m_blockCrsSize > 1) {
               unblock(m_aRowMapHost, m_aColIdxHost, m_aValHost, m_blockCrsSize);
@@ -1725,6 +2282,10 @@ class FastILUPrec
 
         void initialize_common(Kokkos::Timer& timer)
         {
+            // The symbolic graph may be rebuilt here, so any cached Standard
+            // SpTRSV handles or U^T graph/value maps are no longer valid.
+            resetStandardSpTRSVState();
+
             //Allocate memory for the local A.
             //initialize L, U, A patterns
             symbolicILU_common();
@@ -1736,8 +2297,6 @@ class FastILUPrec
         void setValues(ScalarArray& aValIn_)
         {
           this->m_aValIn = aValIn_;
-          this->m_aValInHost = Kokkos::create_mirror_view(aValIn_);
-          Kokkos::deep_copy(this->m_aValInHost, aValIn_);
           if(!m_initGuessPrec.is_null())
           {
             m_initGuessPrec->setValues(aValIn_);
@@ -1786,26 +2345,39 @@ class FastILUPrec
             FASTILU_FENCE_REPORT_TIMER(Timer, ExecSpace(), "  > iluFunctor (" << m_nFact << ")");
 
             // transpose u
-            Kokkos::deep_copy(m_utRowMap, 0);
-            if (m_blockCrsSize == 1) {
-              KokkosSparse::Impl::transpose_matrix<OrdinalArray, OrdinalArray, ScalarArray, OrdinalArray, OrdinalArray, ScalarArray, OrdinalArray, ExecSpace>
-                (m_nRows, m_nRows, m_uRowMap, m_uColIdx, m_uVal, m_utRowMap, m_utColIdx, m_utVal);
+            if (m_sptrsv_algo == FastILU::SpTRSV::Standard) {
+              // For Standard SpTRSV, keep the U^T graph fixed after the first
+              // compute for this symbolic pattern.  Subsequent computes update
+              // only m_utVal using a precomputed U -> U^T value map.  This avoids
+              // repeated transpose/sort allocations while still allowing the
+              // cuSPARSE-backed sptrsv_symbolic call below to see current values.
+              assert(m_blockCrsSize == 1); // Not yet supported for block crs
+              refreshUtForStandardSpTRSV();
             }
             else {
-              KokkosSparse::Impl::transpose_bsr_matrix<OrdinalArray, OrdinalArray, ScalarArray, OrdinalArray, OrdinalArray, ScalarArray, ExecSpace>
-                (m_nRows, m_nRows, m_blockCrsSize, m_uRowMap, m_uColIdx, m_uVal, m_utRowMap, m_utColIdx, m_utVal);
-            }
-
-            // sort, if the triangular solve algorithm requires a sorted matrix.
-            bool sortRequired = m_sptrsv_algo != FastILU::SpTRSV::Fast && m_sptrsv_algo != FastILU::SpTRSV::StandardHost;
-            if (sortRequired) {
-              if (m_blockCrsSize == 1) {
-                KokkosSparse::sort_crs_matrix<ExecSpace, OrdinalArray, OrdinalArray, ScalarArray>
-                  (m_utRowMap, m_utColIdx, m_utVal);
+              {
+                Kokkos::deep_copy(m_utRowMap, 0);
+                if (m_blockCrsSize == 1) {
+                  KokkosSparse::Impl::transpose_matrix<OrdinalArray, OrdinalArray, ScalarArray, OrdinalArray, OrdinalArray, ScalarArray, OrdinalArray, ExecSpace>
+                    (m_nRows, m_nRows, m_uRowMap, m_uColIdx, m_uVal, m_utRowMap, m_utColIdx, m_utVal);
+                }
+                else {
+                  KokkosSparse::Impl::transpose_bsr_matrix<OrdinalArray, OrdinalArray, ScalarArray, OrdinalArray, OrdinalArray, ScalarArray, ExecSpace>
+                    (m_nRows, m_nRows, m_blockCrsSize, m_uRowMap, m_uColIdx, m_uVal, m_utRowMap, m_utColIdx, m_utVal);
+                }
               }
-              else {
-                KokkosSparse::sort_bsr_matrix<ExecSpace, OrdinalArray, OrdinalArray, ScalarArray>(
-                  m_blockCrsSize, m_utRowMap, m_utColIdx, m_utVal);
+
+              // sort, if the triangular solve algorithm requires a sorted matrix.
+              bool sortRequired = m_sptrsv_algo != FastILU::SpTRSV::Fast && m_sptrsv_algo != FastILU::SpTRSV::StandardHost;
+              if (sortRequired) {
+                if (m_blockCrsSize == 1) {
+                  KokkosSparse::sort_crs_matrix<ExecSpace, OrdinalArray, OrdinalArray, ScalarArray>
+                    (m_utRowMap, m_utColIdx, m_utVal);
+                }
+                else {
+                  KokkosSparse::sort_bsr_matrix<ExecSpace, OrdinalArray, OrdinalArray, ScalarArray>(
+                    m_blockCrsSize, m_utRowMap, m_utColIdx, m_utVal);
+                }
               }
             }
 
@@ -1822,20 +2394,25 @@ class FastILUPrec
 
             if (m_sptrsv_algo == FastILU::SpTRSV::Standard) {
                 assert(m_blockCrsSize == 1); // Not yet supported for block crs
-                #if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
-                KokkosSparse::Experimental::SPTRSVAlgorithm algo = KokkosSparse::Experimental::SPTRSVAlgorithm::SPTRSV_CUSPARSE;
-                #else
-                KokkosSparse::Experimental::SPTRSVAlgorithm algo = KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_TP1;
-                #endif
-                // setup L solve
-                khL.create_sptrsv_handle(algo, m_nRows, true);
+
+                // Reuse the SpTRSV handles across compute() calls, like
+                // Ifpack2::LocalSparseTriangularSolver does.  Do not skip
+                // sptrsv_symbolic here: for CUDA/cuSPARSE SpSV, values are
+                // relevant and must be refreshed/analyzed when the factors
+                // change.  The optimization is handle reuse plus avoiding
+                // repeated U^T graph transpose/sort above.
+                initializeStandardSpTRSVHandles();
+
+
+                // setup/update L solve
                 #if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
                 KokkosSparse::sptrsv_symbolic(&khL, m_lRowMap, m_lColIdx, m_lVal);
                 #else
                 KokkosSparse::sptrsv_symbolic(&khL, m_lRowMap, m_lColIdx);
                 #endif
-                // setup U solve
-                khU.create_sptrsv_handle(algo, m_nRows, false);
+
+
+                // setup/update U solve
                 #if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
                 KokkosSparse::sptrsv_symbolic(&khU, m_utRowMap, m_utColIdx, m_utVal);
                 #else
@@ -1995,10 +2572,6 @@ class FastILUPrec
         void apply(ScalarArray &x, ScalarArray &y)
         {
             Kokkos::Timer timer;
-
-            //required to prevent contamination of the input.
-            ParCopyFunctor<Ordinal, Scalar, ExecSpace> parCopyFunctor(m_xTemp, x);
-            Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, x.extent(0)), parCopyFunctor);
 
             //apply D
             if (m_useMetis) {

--- a/packages/shylu/shylu_node/fastilu/src/shylu_fastilu.hpp
+++ b/packages/shylu/shylu_node/fastilu/src/shylu_fastilu.hpp
@@ -1303,11 +1303,17 @@ class FastILUPrec
 
         KokkosSparse::Experimental::SPTRSVAlgorithm standardSpTRSVAlgorithm() const
         {
-#if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
-            return KokkosSparse::Experimental::SPTRSVAlgorithm::SPTRSV_CUSPARSE;
-#else
+ #if defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && defined(KOKKOS_ENABLE_CUDA)
+            if constexpr (std::is_same<Kokkos::Cuda, ExecSpace>::value &&
+                          std::is_same<int, Ordinal>::value &&
+                          (std::is_same<Scalar, float>::value ||
+                           std::is_same<Scalar, double>::value ||
+                           std::is_same<Scalar, Kokkos::complex<float>>::value ||
+                           std::is_same<Scalar, Kokkos::complex<double>>::value)) {
+                return KokkosSparse::Experimental::SPTRSVAlgorithm::SPTRSV_CUSPARSE;
+            }
+ #endif
             return KokkosSparse::Experimental::SPTRSVAlgorithm::SEQLVLSCHD_TP1;
-#endif
         }
 
         void initializeStandardSpTRSVHandles()


### PR DESCRIPTION
@trilinos/ifpack2 
@trilinos/shylu 

For a Sierra use-case, these changes improved execution time on hops significantly from

```
Initial Setup:
|   |   |   |   |-> 3.72e+01 sec 23.3% 13.2% 0.7% 0.0% 1.37e+00 1 Ifpack2::AdditiveSchwarz::initialize [region]
|   |   |   |   |   |-> 2.36e+01 sec 14.8% 16.1% 0.9% 83.9% 1.02e+00 1 Ifpack2::FastILU::initialize [region]
|   |   |   |   |   |   |-> 1.87e+00 sec 1.2% 100.0% 6.9% ------ 1 sort_crs_graph[CPU,radix] [for]
|   |   |   |   |   |   |-> 4.19e-01 sec 0.3% 100.0% 2.0% ------ 1 Kokkos::View::initialization [Values_mirror] via memset [for]
|   |   |   |   |   |   |-> 4.17e-01 sec 0.3% 100.0% 2.7% ------ 1 Kokkos::View::initialization [aValHost] via memset [for]
|   |   |   |   |   |   |-> 4.15e-01 sec 0.3% 100.0% 3.0% ------ 1 Kokkos::View::initialization [aVal] via memset [for]
|   |   |   |   |   |   |-> 2.13e-01 sec 0.1% 100.0% 0.5% ------ 1 Kokkos::View::initialization [aColIdxHost] via memset [for]
|   |   |   |   |   |   |-> 2.10e-01 sec 0.1% 100.0% 1.9% ------ 1 Kokkos::View::initialization [ColInds_mirror] via memset [for]
|   |   |   |   |   |-> 1.34e+01 sec 8.4% 6.5% 0.4% 93.5% 3.73e-01 1 Reordering [region]
|   |   |   |   |   |   |-> 4.37e-01 sec 0.3% 100.0% 2.8% ------ 1 Kokkos::View::initialization [adjIdsHost_] via memset [for]
|   |   |   |   |   |   |-> 4.28e-01 sec 0.3% 100.0% 2.6% ------ 1 Kokkos::View::initialization [metis_colidx] via memset [for]
|   |   |   |   |   |-> 2.75e-01 sec 0.2% 89.1% 1.2% 10.8% 7.63e+01 1 Filter construction [region]

Compute:
|   |   |   |-> 5.52e+01 sec 34.6% 36.8% 4.3% 0.0% 1.20e+01 19 Ifpack2::AdditiveSchwarz::compute [region]
|   |   |   |   |-> 5.34e+01 sec 33.5% 36.1% 4.4% 63.9% 7.11e+00 19 Ifpack2::FastILU::compute [region]
|   |   |   |   |   |-> 1.59e+01 sec 9.9% 100.0% 2.3% ------ 38 Kokkos::View::initialization [Values_mirror] via memset [for]
|   |   |   |   |   |-> 1.42e+00 sec 0.9% 100.0% 1.0% ------ 38 FastILUFunctor<int, double, Kokkos::Cuda> [for]
|   |   |   |   |   |-> 6.31e-01 sec 0.4% 100.0% 1.5% ------ 19 numericILU::copyVals [for]
|   |   |   |   |   |-> 4.85e-01 sec 0.3% 100.0% 1.0% ------ 19 numericILU::diagScal [for]
|   |   |   |   |   |-> 3.63e-01 sec 0.2% 100.0% 0.9% ------ 19 numericILU::getLower [for]
|   |   |   |   |   |-> 1.92e-01 sec 0.1% 100.0% 1.3% ------ 19 numericILU::getDiags [for]

Solve:
|   |   |   |-> 4.91e+00 sec 3.1% 11.0% 0.0% 0.7% 2.82e+03 19 Belos: PseudoBlockGmresSolMgr total solve time [region]
|   |   |   |   |-> 3.17e+00 sec 2.0% 6.1% 12.4% 0.0% 1.64e+03 575 Belos: Operation Prec*x [region]
|   |   |   |   |   |-> 3.16e+00 sec 2.0% 6.1% 12.4% 2.1% 1.64e+03 575 Ifpack2::AdditiveSchwarz::apply [region]
|   |   |   |   |       |-> 2.97e+00 sec 1.9% 2.1% 13.2% 97.9% 5.82e+02 575 Ifpack2::FastILU::apply [region]
|   |   |   |   |-> 9.27e-01 sec 0.6% 1.3% 38.4% 7.9% 1.24e+03 575 Belos: Operation Op*x [region]
|   |   |   |   |   |-> 4.12e-01 sec 0.3% 0.0% 1.4% 100.0% 0.00e+00 575 KokkosSparse::spmv[TPL_CUSPARSE,double] [region]
|   |   |   |   |   |-> 3.22e-01 sec 0.2% 0.0% 147.8% 100.0% 0.00e+00 575 Teuchos::MpiComm::waitAll(requests) [region]
|   |   |   |   |-> 7.17e-01 sec 0.4% 38.7% 3.6% 1.1% 9.20e+03 575 Belos: ICGS[2]: Orthogonalization [region]
|   |   |   |   |   |-> 3.36e-01 sec 0.2% 57.7% 8.4% 25.0% 1.13e+04 1112 Belos: ICGS[2]: Ortho (Inner Product) [region]
|   |   |   |   |   |   |-> 1.95e-01 sec 0.1% 98.3% 1.3% 1.7% 1.10e+04 1074 KokkosBlas::gemm[TPL_CUBLAS,double] [region]
|   |   |   |   |   |   |   |-> 1.67e-01 sec 0.1% 100.0% 1.2% ------ 1074 Perform Dot Product Based GEMM [for]
|   |   |   |   |   |-> 2.80e-01 sec 0.2% 6.1% 0.9% 6.9% 5.90e+03 1112 Belos: ICGS[2]: Ortho (Update) [region]
|   |   |   |   |   |   |-> 2.43e-01 sec 0.2% 0.0% 0.8% 100.0% 0.00e+00 1074 KokkosBlas::gemv[TPL_CUBLAS,double] [region]

```

to:

```
Initial Setup:
|   |   |   |   |-> 1.74e+01 sec 13.0% 11.1% 2.1% 0.0% 2.47e+00 1 Ifpack2::AdditiveSchwarz::initialize [region]
|   |   |   |   |   |-> 1.37e+01 sec 10.2% 6.3% 1.7% 93.7% 3.65e-01 1 Reordering [region]
|   |   |   |   |   |   |-> 4.39e-01 sec 0.3% 100.0% 3.3% ------ 1 Kokkos::View::initialization [adjIdsHost_] via memset [for]
|   |   |   |   |   |   |-> 4.21e-01 sec 0.3% 100.0% 2.2% ------ 1 Kokkos::View::initialization [metis_colidx] via memset [for]
|   |   |   |   |   |-> 3.42e+00 sec 2.6% 24.0% 3.8% 1.8% 4.68e+00 1 Ifpack2::FastILU::initialize [region]
|   |   |   |   |   |   |-> 2.05e+00 sec 1.5% 27.4% 4.1% 0.0% 1.95e+00 1 Ifpack2::FastILU::initialize_common [region]
|   |   |   |   |   |   |   |-> 2.05e+00 sec 1.5% 27.4% 4.1% 14.9% 1.95e+00 1 Ifpack2::FastILU::symbolicILU_common [region]
|   |   |   |   |   |   |   |   |-> 1.18e+00 sec 0.9% 0.0% 3.0% 0.2% 0.00e+00 1 Ifpack2::FastILU::countLU_ilu0 [region]
|   |   |   |   |   |   |   |   |   |-> 1.04e+00 sec 0.8% 0.0% 3.2% 100.0% 0.00e+00 1 Ifpack2::FastILU::countLU_ilu0: build numeric maps [region]
|   |   |   |   |   |   |   |   |   |-> 1.36e-01 sec 0.1% 0.0% 7.9% 100.0% 0.00e+00 1 Ifpack2::FastILU::countLU_ilu0: count row maps [region]
|   |   |   |   |   |   |   |   |-> 4.28e-01 sec 0.3% 100.0% 3.9% ------ 1 Kokkos::View::initialization [aVal] via memset [for]
|   |   |   |   |   |   |-> 1.04e+00 sec 0.8% 0.0% 3.3% 0.0% 0.00e+00 1 Ifpack2::FastILU::symbolicILU [region]
|   |   |   |   |   |   |   |-> 1.04e+00 sec 0.8% 0.0% 3.3% 0.1% 0.00e+00 1 Ifpack2::FastILU::symbolicILU0 fast path [region]
|   |   |   |   |   |   |       |-> 4.54e-01 sec 0.3% 0.0% 3.6% 100.0% 0.00e+00 1 Ifpack2::FastILU::symbolicILU0: fill row/level indices [region]
|   |   |   |   |   |   |       |-> 3.00e-01 sec 0.2% 0.0% 4.3% 100.0% 0.00e+00 1 Ifpack2::FastILU::symbolicILU0: build a2aInMap [region]
|   |   |   |   |   |   |       |-> 2.87e-01 sec 0.2% 0.0% 4.8% 100.0% 0.00e+00 1 Ifpack2::FastILU::symbolicILU0: copy graph [region]
|   |   |   |   |   |   |-> 2.15e-01 sec 0.2% 100.0% 3.7% ------ 1 Kokkos::View::initialization [aColIdxHost] via memset [for]
|   |   |   |   |   |-> 2.83e-01 sec 0.2% 87.9% 5.3% 12.0% 7.43e+01 1 Filter construction [region]

Compute:
|   |   |   |-> 5.94e+00 sec 4.4% 93.9% 1.1% 0.0% 1.33e+02 39 Ifpack2::AdditiveSchwarz::compute [region]
|   |   |   |   |-> 3.61e+00 sec 2.7% 93.0% 0.9% 0.0% 5.70e+01 39 Ifpack2::FastILU::compute [region]
|   |   |   |   |   |-> 3.58e+00 sec 2.7% 94.0% 0.9% 0.0% 5.76e+01 39 Ifpack2::FastILU::compute internal [region]
|   |   |   |   |   |   |-> 2.90e+00 sec 2.2% 100.0% 1.1% 0.0% 2.69e+01 39 Ifpack2::FastILU::compute: FastILUFunctor iterations [region]
|   |   |   |   |   |   |   |-> 2.90e+00 sec 2.2% 100.0% 1.1% ------ 78 FastILUFunctor<int, double, Kokkos::Cuda> [for]
|   |   |   |   |   |   |-> 2.54e-01 sec 0.2% 99.7% 3.3% 0.0% 3.07e+02 39 Ifpack2::FastILU::numericILU [region]
|   |   |   |   |   |   |   |-> 2.54e-01 sec 0.2% 99.8% 3.3% 0.1% 3.07e+02 39 Ifpack2::FastILU::numericILU0 fast path [region]
|   |   |   |   |   |   |       |-> 2.28e-01 sec 0.2% 99.9% 2.2% 0.1% 1.71e+02 39 Ifpack2::FastILU::numericILU0: fused scale/scatter L/U [region]
|   |   |   |   |   |   |       |   |-> 2.28e-01 sec 0.2% 100.0% 2.2% ------ 39 numericILU0::scaleScatter [for]
|   |   |   |   |   |   |-> 1.64e-01 sec 0.1% 86.1% 18.6% 2.6% 4.88e+01 1 Ifpack2::FastILU::compute: build U-to-U^T value map [region]

Solve:
|   |   |   |-> 1.26e+01 sec 9.5% 9.3% 0.0% 0.5% 2.77e+03 39 Belos: PseudoBlockGmresSolMgr total solve time [region]
|   |   |   |   |-> 8.18e+00 sec 6.1% 3.9% 12.8% 0.0% 1.49e+03 1521 Belos: Operation Prec*x [region]
|   |   |   |   |   |-> 8.18e+00 sec 6.1% 3.9% 12.8% 2.0% 1.49e+03 1521 Ifpack2::AdditiveSchwarz::apply [region]
|   |   |   |   |       |-> 7.77e+00 sec 5.8% 1.0% 13.6% 0.1% 3.91e+02 1521 Ifpack2::FastILU::apply [region]
|   |   |   |   |       |   |-> 7.77e+00 sec 5.8% 1.0% 13.6% 98.9% 3.92e+02 1521 Ifpack2::FastILU::apply internal [region]
|   |   |   |   |-> 2.47e+00 sec 1.8% 1.4% 37.9% 8.6% 1.23e+03 1521 Belos: Operation Op*x [region]
|   |   |   |   |   |-> 1.09e+00 sec 0.8% 0.0% 1.5% 100.0% 0.00e+00 1521 KokkosSparse::spmv[TPL_CUSPARSE,double] [region]
|   |   |   |   |   |-> 8.33e-01 sec 0.6% 0.0% 156.7% 100.0% 0.00e+00 1521 Teuchos::MpiComm::waitAll(requests) [region]
|   |   |   |   |   |-> 2.95e-01 sec 0.2% 0.0% 235.2% 100.0% 0.00e+00 3042 Teuchos::sendImpl<double> [region]
|   |   |   |   |-> 1.83e+00 sec 1.4% 40.9% 4.0% 1.0% 9.63e+03 1521 Belos: ICGS[2]: Orthogonalization [region]
|   |   |   |   |   |-> 1.01e+00 sec 0.8% 61.2% 7.3% 22.3% 1.01e+04 2964 Belos: ICGS[2]: Ortho (Inner Product) [region]
|   |   |   |   |   |   |-> 6.22e-01 sec 0.5% 98.2% 1.6% 1.8% 9.28e+03 2886 KokkosBlas::gemm[TPL_CUBLAS,double] [region]
|   |   |   |   |   |   |   |-> 5.67e-01 sec 0.4% 100.0% 1.4% ------ 2886 Perform Dot Product Based GEMM [for]
|   |   |   |   |   |-> 6.28e-01 sec 0.5% 3.7% 1.2% 8.5% 7.01e+03 2964 Belos: ICGS[2]: Ortho (Update) [region]
|   |   |   |   |   |   |-> 5.51e-01 sec 0.4% 0.0% 0.8% 100.0% 0.00e+00 2886 KokkosBlas::gemv[TPL_CUBLAS,double] [region]
```

Note the latter profiles are from a longer run, so this isn't quite apples-to-apples.