### PR TITLE
Remove view mapping usage from sacado

### DIFF
--- a/packages/sacado/src/Kokkos_LayoutContiguous.hpp
+++ b/packages/sacado/src/Kokkos_LayoutContiguous.hpp
@@ -48,14 +48,12 @@ struct LayoutContiguous : public Layout {
   Layout base_layout() const { return *this; }
 };
 
-#ifdef SACADO_HAS_NEW_KOKKOS_VIEW_IMPL
 namespace Impl {
 template <class Layout, unsigned Stride>
 struct LayoutFromArrayLayout<LayoutContiguous<Layout, Stride>> {
   using type = typename LayoutFromArrayLayout<Layout>::type;
 };
 }
-#endif
 
 // Is Layout == LayoutContiguous<L> for some L
 template <class Layout>
@@ -96,11 +94,7 @@ namespace Impl {
   //       std::conditional_t<view_type::traits::impl_is_customized, bool, void>>;
   // #endif
   template <>
-#ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
-  struct DynRankDimTraits<ViewSpecializeSacadoFadContiguous> {
-#else
   struct DynRankDimTraits<bool> {
-#endif
     using drdtraits = DynRankDimTraits<void>;
     enum : size_t { unspecified = drdtraits::unspecified };
 
@@ -157,14 +151,11 @@ namespace Impl {
         typename Traits::array_layout>
     createLayout(const Kokkos::Impl::ViewCtorProp<P...>& prop,
                 typename Traits::array_layout layout) {
-      //return drdtraits::template createLayout<Traits,P...>(prop, layout);
-#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
       if constexpr (Traits::impl_is_customized &&
                     !Kokkos::Impl::ViewCtorProp<P...>::has_accessor_arg) {
         auto rank              = computeRank(prop, layout) - 1;
         layout.dimension[rank] = unspecified;
       }
-#endif
       return createLayout(layout);
     }
 
@@ -175,14 +166,11 @@ namespace Impl {
         typename Traits::array_layout>
     createLayout(const Kokkos::Impl::ViewCtorProp<P...>& prop,
                 typename Traits::array_layout layout) {
-      //return Layout(drdtraits::template createLayout<Traits,P...>(prop, layout.base_layout()));
-#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
       if constexpr (Traits::impl_is_customized &&
                     !Kokkos::Impl::ViewCtorProp<P...>::has_accessor_arg) {
         auto rank              = computeRank(prop, layout) - 1;
         layout.dimension[rank] = unspecified;
       }
-#endif
       return createLayout(layout);
     }
 
@@ -210,36 +198,8 @@ namespace Impl {
 
 } // namespace Kokkos
 
-#include "View/Kokkos_ViewMapping.hpp"
-
 namespace Kokkos {
 namespace Impl {
-
-// Implement ViewOffset for LayoutContiguous
-template < class Dimension , class Layout , unsigned Stride >
-struct ViewOffset<Dimension, LayoutContiguous<Layout,Stride>, void>
-  : public ViewOffset<Dimension,Layout> {
-public:
-
-  // Would like to use inherited constructors, but gcc 4.7 doesn't support it
-  //using ViewOffset<Dimension,Layout>::ViewOffset;
-
-  typedef ViewOffset<Dimension,Layout> Base;
-
-  ViewOffset() = default ;
-  ViewOffset( const ViewOffset & ) = default ;
-  ViewOffset & operator = ( const ViewOffset & ) = default ;
-
-  // All constructors take one or two arguments
-
-  template <typename Arg1>
-  KOKKOS_INLINE_FUNCTION
-  constexpr ViewOffset(const Arg1& arg1) : Base(arg1) {}
-
-  template <typename Arg1, typename Arg2>
-  KOKKOS_INLINE_FUNCTION
-  constexpr ViewOffset(const Arg1& arg1, const Arg2& arg2) : Base(arg1,arg2) {}
-};
 
 template <typename Layout>
 struct LayoutScalarStride {

--- a/packages/sacado/src/Sacado_Fad_Kokkos_Specialization.hpp
+++ b/packages/sacado/src/Sacado_Fad_Kokkos_Specialization.hpp
@@ -24,44 +24,6 @@ namespace Impl {
 
 // Rules for subview arguments and layouts matching
 
-template <class LayoutDest, unsigned StrideDst, class LayoutSrc, int RankDest,
-          int RankSrc, int CurrentArg, class... SubViewArgs>
-struct SubviewLegalArgsCompileTime<
-    Kokkos::LayoutContiguous<LayoutDest, StrideDst>, LayoutSrc, RankDest,
-    RankSrc, CurrentArg, SubViewArgs...> {
-  enum {
-    value =
-        SubviewLegalArgsCompileTime<LayoutDest, LayoutSrc, RankDest, RankSrc,
-                                    CurrentArg, SubViewArgs...>::value
-  };
-};
-
-template <class LayoutDest, class LayoutSrc, unsigned StrideSrc, int RankDest,
-          int RankSrc, int CurrentArg, class... SubViewArgs>
-struct SubviewLegalArgsCompileTime<
-    LayoutDest, Kokkos::LayoutContiguous<LayoutSrc, StrideSrc>, RankDest,
-    RankSrc, CurrentArg, SubViewArgs...> {
-  enum {
-    value =
-        SubviewLegalArgsCompileTime<LayoutDest, LayoutSrc, RankDest, RankSrc,
-                                    CurrentArg, SubViewArgs...>::value
-  };
-};
-
-template <class LayoutDest, unsigned StrideDest, class LayoutSrc,
-          unsigned StrideSrc, int RankDest, int RankSrc, int CurrentArg,
-          class... SubViewArgs>
-struct SubviewLegalArgsCompileTime<
-    Kokkos::LayoutContiguous<LayoutDest, StrideDest>,
-    Kokkos::LayoutContiguous<LayoutSrc, StrideSrc>, RankDest, RankSrc,
-    CurrentArg, SubViewArgs...> {
-  enum {
-    value =
-        SubviewLegalArgsCompileTime<LayoutDest, LayoutSrc, RankDest, RankSrc,
-                                    CurrentArg, SubViewArgs...>::value
-  };
-};
-
 template <class DstT, class DstL, unsigned DstS, class... DstArgs, class SrcT,
           class SrcL, unsigned SrcS, class... SrcArgs, class... Args>
 struct CommonSubview<
@@ -115,37 +77,6 @@ KOKKOS_INLINE_FUNCTION auto subview(
               typename view_t::device_type, typename view_t::memory_traits>(
       src.accessor().offset(src.data_handle(), submapping_result.offset),
       submapping_result.mapping, src.accessor());
-}
-
-// This is needed to deal with the return Layout Deduction for LayoutContiguous
-// ...
-template <class D, class LayoutSrc, unsigned StrideSrc, class... P,
-          class... Args>
-KOKKOS_INLINE_FUNCTION auto
-subview(const DynRankView<D, Kokkos::LayoutContiguous<LayoutSrc, StrideSrc>,
-                          P...> &src,
-        Args... args) {
-  static_assert(View<D, P...>::rank == sizeof...(Args),
-                "subview requires one argument for each source View rank");
-
-  using sub_mdspan_t = decltype(submdspan(
-      src.to_mdspan(), Impl::transform_kokkos_slice_to_mdspan_slice(args)...));
-  if constexpr (std::is_same_v<typename sub_mdspan_t::layout_type,
-                               layout_stride>) {
-    return typename Kokkos::Impl::ViewMapping<
-        void /* deduce subview type from source view traits */
-        ,
-        typename Impl::RemoveAlignedMemoryTrait<
-            D, Kokkos::LayoutContiguous<LayoutStride, StrideSrc>, P...>::type,
-        Args...>::type(src, args...);
-  } else {
-    return typename Kokkos::Impl::ViewMapping<
-        void /* deduce subview type from source view traits */
-        ,
-        typename Impl::RemoveAlignedMemoryTrait<
-            D, Kokkos::LayoutContiguous<LayoutSrc, StrideSrc>, P...>::type,
-        Args...>::type(src, args...);
-  }
 }
 
 // Helper function to create a mapping for subdynrankview that avoids calling SubT::layout()


### PR DESCRIPTION
This is related to Kokkos changes post 5.2 where we remove the code base for Legacy View.

One last vestige of that old code base was some isolated uses of `ViewMapping`
