### PR TITLE
Ifpack2: support larger blocks in BlockTriDi

### DIFF
--- a/packages/ifpack2/example/CMakeLists.txt
+++ b/packages/ifpack2/example/CMakeLists.txt
@@ -31,7 +31,7 @@ IF(${PACKAGE_NAME}_ENABLE_Galeri)
   TRIBITS_ADD_TEST(
     BlockTriDiagonalSolver
     NAME BlockTriDiLargeBlock
-    ARGS "--matrixType=Laplace3D --blockSize=32 --nx=20 --ny=20 --nz=20"
+    ARGS "--matrixType=Laplace3D --blockSize=64 --nx=10 --ny=10 --nz=10"
     COMM serial mpi
     NUM_MPI_PROCS 1-4
     STANDARD_PASS_OUTPUT
@@ -40,7 +40,7 @@ IF(${PACKAGE_NAME}_ENABLE_Galeri)
   TRIBITS_ADD_TEST(
     BlockTriDiagonalSolver
     NAME BlockTriDiLargeBlockSchur
-    ARGS "--matrixType=Laplace3D --blockSize=32 --nx=20 --ny=20 --nz=20 --sublinesPerLine=1 --sublinesPerLineSchur=2"
+    ARGS "--matrixType=Laplace3D --blockSize=64 --nx=10 --ny=10 --nz=10 --sublinesPerLine=1 --sublinesPerLineSchur=2"
     COMM serial mpi
     NUM_MPI_PROCS 1-4
     STANDARD_PASS_OUTPUT

--- a/packages/ifpack2/src/Ifpack2_BlockComputeResidualAndSolve_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockComputeResidualAndSolve_def.hpp
@@ -43,9 +43,6 @@ struct ComputeResidualAndSolve_SinglePass_Impl {
   /// team policy member type (used in cuda)
   using member_type = typename Kokkos::TeamPolicy<execution_space>::member_type;
 
-  // enum for max blocksize and vector length
-  enum : int { max_blocksize = 32 };
-
  private:
   ConstUnmanaged<impl_scalar_type_2d_view_tpetra> b;
   ConstUnmanaged<impl_scalar_type_2d_view_tpetra> x;  // x_owned
@@ -246,9 +243,6 @@ struct ComputeResidualAndSolve_2Pass_Impl {
 
   /// team policy member type (used in cuda)
   using member_type = typename Kokkos::TeamPolicy<execution_space>::member_type;
-
-  // enum for max blocksize and vector length
-  enum : int { max_blocksize = 32 };
 
   // Tag for computing residual with owned columns only (pass 1)
   struct OwnedTag {};

--- a/packages/ifpack2/src/Ifpack2_BlockComputeResidualVector_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockComputeResidualVector_def.hpp
@@ -493,7 +493,7 @@ struct ComputeResidualFunctor {
     }
   }
 
-  // * B: block size for compile-time specialization, or 0 for general case (up to max_blocksize)
+  // * B: block size for compile-time specialization, or 0 for general case
   // * async: true if using async importer. overlap is not used in this case.
   //          Whether a column is owned or nonowned is decided at runtime.
   // * overlap: true if processing the columns that are not locally owned,
@@ -529,7 +529,7 @@ struct ComputeResidualFunctor {
     const local_ordinal_type num_local_rows = lclrow.extent(0);
 
     // temporary buffer for y flat
-    impl_scalar_type yy[B == 0 ? impl_type::max_blocksize : B] = {};
+    impl_scalar_type yy[blocksize];
 
     const local_ordinal_type lr = lclrow(rowidx);
 

--- a/packages/ifpack2/src/Ifpack2_BlockComputeResidualVector_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockComputeResidualVector_def.hpp
@@ -14,6 +14,23 @@
 
 namespace Ifpack2::BlockHelperDetails {
 
+template <typename impl_scalar_type, int B>
+struct ArrayHelper {
+  ArrayHelper(int /* blocksize_requested */) {}
+  impl_scalar_type data[B];
+  impl_scalar_type *get() { return data; }
+};
+
+template <typename impl_scalar_type>
+struct ArrayHelper<impl_scalar_type, 0> {
+  ArrayHelper(int blocksize_requested) {
+    data = (impl_scalar_type *)malloc(sizeof(impl_scalar_type) * blocksize_requested);
+  }
+  ~ArrayHelper() { free(data); }
+  impl_scalar_type *data;
+  impl_scalar_type *get() { return data; }
+};
+
 // Precompute offsets of each A and x entry to speed up residual.
 // (Applies for hasBlockCrsMatrix == true and OverlapTag/AsyncTag)
 // Reading A, x take up to 4, 6 levels of indirection respectively,
@@ -518,6 +535,8 @@ struct ComputeResidualFunctor {
   template <int B, bool async, bool overlap, bool haveBlockMatrix>
   void
   operator()(const GeneralTag<B, async, overlap, haveBlockMatrix> &, const local_ordinal_type &rowidx) const {
+    // B == 0 means blocksize is a runtime value, provided via blocksize_requested.
+    // B != 0 is a compile-time block size.
     const local_ordinal_type blocksize = (B == 0 ? blocksize_requested : B);
 
     // constants
@@ -529,7 +548,8 @@ struct ComputeResidualFunctor {
     const local_ordinal_type num_local_rows = lclrow.extent(0);
 
     // temporary buffer for y flat
-    impl_scalar_type yy[blocksize];
+    ArrayHelper<impl_scalar_type, B> yy_alloc(blocksize_requested);
+    impl_scalar_type *yy = yy_alloc.get();
 
     const local_ordinal_type lr = lclrow(rowidx);
 

--- a/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
@@ -81,10 +81,14 @@ struct TpetraLittleBlock<Kokkos::LayoutRight> {
 /// block tridiag scalar type
 ///
 template <typename T>
-struct BlockTridiagScalarType { typedef T type; };
+struct BlockTridiagScalarType {
+  typedef T type;
+};
 #if defined(IFPACK2_BLOCKHELPER_USE_SMALL_SCALAR_FOR_BLOCKTRIDIAG)
 template <>
-struct BlockTridiagScalarType<double> { typedef float type; };
+struct BlockTridiagScalarType<double> {
+  typedef float type;
+};
 // template<> struct SmallScalarType<Kokkos::complex<double> > { typedef Kokkos::complex<float> type; };
 #endif
 
@@ -369,9 +373,6 @@ struct ImplType {
   typedef Kokkos::View<btdm_scalar_type ***, Kokkos::LayoutRight, device_type> btdm_scalar_type_3d_view;
   typedef Kokkos::View<btdm_scalar_type ****, Kokkos::LayoutRight, device_type> btdm_scalar_type_4d_view;
   typedef Kokkos::View<btdm_scalar_type *****, Kokkos::LayoutRight, device_type> btdm_scalar_type_5d_view;
-
-  // maximum supported block size for BTD/BJacobi solvers (some codepaths may allow larger)
-  enum : int { max_blocksize = 32 };
 };
 
 ///

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -4447,16 +4447,16 @@ struct SolveTridiags {
     }
   }
 
-  template <int B>
+  template <int B, int ScratchLevel>
   struct SingleVectorTag {};
-  template <int B>
+  template <int B, int ScratchLevel>
   struct MultiVectorTag {};
 
-  template <int B>
+  template <int B, int ScratchLevel>
   struct SingleVectorSubLineTag {};
   template <int B>
   struct SingleVectorApplyCTag {};
-  template <int B>
+  template <int B, int ScratchLevel>
   struct SingleVectorSchurTag {};
   template <int B>
   struct SingleVectorApplyETag {};
@@ -4465,9 +4465,9 @@ struct SolveTridiags {
   template <int B>
   struct SingleZeroingTag {};
 
-  template <int B>
+  template <int B, int ScratchLevel>
   KOKKOS_INLINE_FUNCTION void
-  operator()(const SingleVectorTag<B> &, const member_type &member) const {
+  operator()(const SingleVectorTag<B, ScratchLevel> &, const member_type &member) const {
     const local_ordinal_type packidx     = member.league_rank();
     const local_ordinal_type partidx     = packptr(packidx);
     const local_ordinal_type npacks      = packptr(packidx + 1) - partidx;
@@ -4478,7 +4478,7 @@ struct SolveTridiags {
     const local_ordinal_type blocksize   = (B == 0 ? D_internal_vector_values.extent(1) : B);
     const local_ordinal_type num_vectors = 1;
     internal_vector_scratch_type_3d_view
-        WW(member.team_scratch(0), blocksize, 1, vector_loop_size);
+        WW(member.team_scratch(ScratchLevel), blocksize, 1, vector_loop_size);
     Kokkos::single(Kokkos::PerTeam(member), [&]() {
       Z_scalar_vector(member.league_rank()) = impl_scalar_type(0);
     });
@@ -4488,9 +4488,9 @@ struct SolveTridiags {
     });
   }
 
-  template <int B>
+  template <int B, int ScratchLevel>
   KOKKOS_INLINE_FUNCTION void
-  operator()(const MultiVectorTag<B> &, const member_type &member) const {
+  operator()(const MultiVectorTag<B, ScratchLevel> &, const member_type &member) const {
     const local_ordinal_type packidx     = member.league_rank();
     const local_ordinal_type partidx     = packptr(packidx);
     const local_ordinal_type npacks      = packptr(packidx + 1) - partidx;
@@ -4502,7 +4502,7 @@ struct SolveTridiags {
     const local_ordinal_type num_vectors = X_internal_vector_values.extent(2);
 
     internal_vector_scratch_type_3d_view
-        WW(member.team_scratch(0), blocksize, num_vectors, vector_loop_size);
+        WW(member.team_scratch(ScratchLevel), blocksize, num_vectors, vector_loop_size);
     Kokkos::single(Kokkos::PerTeam(member), [&]() {
       Z_scalar_vector(member.league_rank()) = impl_scalar_type(0);
     });
@@ -4512,9 +4512,9 @@ struct SolveTridiags {
     });
   }
 
-  template <int B>
+  template <int B, int ScratchLevel>
   KOKKOS_INLINE_FUNCTION void
-  operator()(const SingleVectorSubLineTag<B> &, const member_type &member) const {
+  operator()(const SingleVectorSubLineTag<B, ScratchLevel> &, const member_type &member) const {
     // btdm is packed and sorted from largest one
     const local_ordinal_type packidx = packindices_sub(member.league_rank());
 
@@ -4534,7 +4534,7 @@ struct SolveTridiags {
     (void)npacks;
 
     internal_vector_scratch_type_3d_view
-        WW(member.team_scratch(0), blocksize, 1, vector_loop_size);
+        WW(member.team_scratch(ScratchLevel), blocksize, 1, vector_loop_size);
 
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, vector_loop_size), [&](const int &v) {
       auto X_internal_vec = Kokkos::subview(X_internal_vector_values, Kokkos::ALL(), Kokkos::ALL(), active_schur_solve_vec, Kokkos::ALL());
@@ -4643,9 +4643,9 @@ struct SolveTridiags {
     }
   }
 
-  template <int B>
+  template <int B, int ScratchLevel>
   KOKKOS_INLINE_FUNCTION void
-  operator()(const SingleVectorSchurTag<B> &, const member_type &member) const {
+  operator()(const SingleVectorSchurTag<B, ScratchLevel> &, const member_type &member) const {
     const local_ordinal_type packidx = packindices_sub(member.league_rank());
 
     const local_ordinal_type partidx = packptr_sub(packidx);
@@ -4658,7 +4658,7 @@ struct SolveTridiags {
     const local_ordinal_type r0_schur = nrows * member.league_rank();
 
     internal_vector_scratch_type_3d_view
-        WW(member.team_scratch(0), blocksize, blocksize, vector_loop_size);
+        WW(member.team_scratch(ScratchLevel), blocksize, blocksize, vector_loop_size);
 
     for (local_ordinal_type schur_sub_part = 0; schur_sub_part < n_subparts_per_part - 1; ++schur_sub_part) {
       const local_ordinal_type r0 = part2packrowidx0_sub(partidx, 2 * schur_sub_part + 1);
@@ -4821,21 +4821,38 @@ struct SolveTridiags {
         SolveTridiagsDefaultModeAndAlgo<typename execution_space::memory_space>::
             recommended_team_size(blocksize, vector_length, internal_vector_length);
     const int per_team_scratch = internal_vector_scratch_type_3d_view ::shmem_size(blocksize, num_vectors, vector_loop_size);
+    const int max_scratch      = team_policy_type::scratch_size_max(0);
 
 #define BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(B)                                                                                                  \
   if (packindices_schur.extent(1) <= 0) {                                                                                                             \
     if (num_vectors == 1) {                                                                                                                           \
-      Kokkos::TeamPolicy<execution_space, SingleVectorTag<B>>                                                                                         \
-          policy(packptr.extent(0) - 1, team_size, vector_loop_size);                                                                                 \
-      policy.set_scratch_size(0, Kokkos::PerTeam(per_team_scratch));                                                                                  \
-      Kokkos::parallel_for("SolveTridiags::TeamPolicy::run<SingleVector>",                                                                            \
-                           policy, *this);                                                                                                            \
+      if (per_team_scratch < max_scratch) {                                                                                                           \
+        Kokkos::TeamPolicy<execution_space, SingleVectorTag<B, 0>>                                                                                    \
+            policy(packptr.extent(0) - 1, team_size, vector_loop_size);                                                                               \
+        policy.set_scratch_size(0, Kokkos::PerTeam(per_team_scratch));                                                                                \
+        Kokkos::parallel_for("SolveTridiags::TeamPolicy::run<SingleVector>",                                                                          \
+                             policy, *this);                                                                                                          \
+      } else {                                                                                                                                        \
+        Kokkos::TeamPolicy<execution_space, SingleVectorTag<B, 1>>                                                                                    \
+            policy(packptr.extent(0) - 1, team_size, vector_loop_size);                                                                               \
+        policy.set_scratch_size(1, Kokkos::PerTeam(per_team_scratch));                                                                                \
+        Kokkos::parallel_for("SolveTridiags::TeamPolicy::run<SingleVector>",                                                                          \
+                             policy, *this);                                                                                                          \
+      }                                                                                                                                               \
     } else {                                                                                                                                          \
-      Kokkos::TeamPolicy<execution_space, MultiVectorTag<B>>                                                                                          \
-          policy(packptr.extent(0) - 1, team_size, vector_loop_size);                                                                                 \
-      policy.set_scratch_size(0, Kokkos::PerTeam(per_team_scratch));                                                                                  \
-      Kokkos::parallel_for("SolveTridiags::TeamPolicy::run<MultiVector>",                                                                             \
-                           policy, *this);                                                                                                            \
+      if (per_team_scratch < max_scratch) {                                                                                                           \
+        Kokkos::TeamPolicy<execution_space, MultiVectorTag<B, 0>>                                                                                     \
+            policy(packptr.extent(0) - 1, team_size, vector_loop_size);                                                                               \
+        policy.set_scratch_size(0, Kokkos::PerTeam(per_team_scratch));                                                                                \
+        Kokkos::parallel_for("SolveTridiags::TeamPolicy::run<MultiVector>",                                                                           \
+                             policy, *this);                                                                                                          \
+      } else {                                                                                                                                        \
+        Kokkos::TeamPolicy<execution_space, MultiVectorTag<B, 1>>                                                                                     \
+            policy(packptr.extent(0) - 1, team_size, vector_loop_size);                                                                               \
+        policy.set_scratch_size(1, Kokkos::PerTeam(per_team_scratch));                                                                                \
+        Kokkos::parallel_for("SolveTridiags::TeamPolicy::run<MultiVector>",                                                                           \
+                             policy, *this);                                                                                                          \
+      }                                                                                                                                               \
     }                                                                                                                                                 \
   } else {                                                                                                                                            \
     {                                                                                                                                                 \
@@ -4849,11 +4866,19 @@ struct SolveTridiags {
       {                                                                                                                                               \
         IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::ApplyInverseJacobi::SingleVectorSubLineTag", SingleVectorSubLineTag0);                                 \
         write4DMultiVectorValuesToFile(part2packrowidx0_sub.extent(0), X_internal_scalar_values, "x_scalar_values_before_SingleVectorSubLineTag.mm"); \
-        Kokkos::TeamPolicy<execution_space, SingleVectorSubLineTag<B>>                                                                                \
-            policy(packindices_sub.extent(0), team_size, vector_loop_size);                                                                           \
-        policy.set_scratch_size(0, Kokkos::PerTeam(per_team_scratch));                                                                                \
-        Kokkos::parallel_for("SolveTridiags::TeamPolicy::run<SingleVector>",                                                                          \
-                             policy, *this);                                                                                                          \
+        if (per_team_scratch < max_scratch) {                                                                                                         \
+          Kokkos::TeamPolicy<execution_space, SingleVectorSubLineTag<B, 0>>                                                                           \
+              policy(packindices_sub.extent(0), team_size, vector_loop_size);                                                                         \
+          policy.set_scratch_size(0, Kokkos::PerTeam(per_team_scratch));                                                                              \
+          Kokkos::parallel_for("SolveTridiags::TeamPolicy::run<SingleVector>",                                                                        \
+                               policy, *this);                                                                                                        \
+        } else {                                                                                                                                      \
+          Kokkos::TeamPolicy<execution_space, SingleVectorSubLineTag<B, 1>>                                                                           \
+              policy(packindices_sub.extent(0), team_size, vector_loop_size);                                                                         \
+          policy.set_scratch_size(1, Kokkos::PerTeam(per_team_scratch));                                                                              \
+          Kokkos::parallel_for("SolveTridiags::TeamPolicy::run<SingleVector>",                                                                        \
+                               policy, *this);                                                                                                        \
+        }                                                                                                                                             \
         write4DMultiVectorValuesToFile(part2packrowidx0_sub.extent(0), X_internal_scalar_values, "x_scalar_values_after_SingleVectorSubLineTag.mm");  \
         IFPACK2_BLOCKHELPER_TIMER_FENCE(execution_space)                                                                                              \
       }                                                                                                                                               \
@@ -4870,11 +4895,19 @@ struct SolveTridiags {
       {                                                                                                                                               \
         IFPACK2_BLOCKHELPER_TIMER("BlockTriDi::ApplyInverseJacobi::SingleVectorSchurTag", SingleVectorSchurTag0);                                     \
         write4DMultiVectorValuesToFile(part2packrowidx0_sub.extent(0), X_internal_scalar_values, "x_scalar_values_before_SingleVectorSchurTag.mm");   \
-        Kokkos::TeamPolicy<execution_space, SingleVectorSchurTag<B>>                                                                                  \
-            policy(packindices_schur.extent(0), team_size, vector_loop_size);                                                                         \
-        policy.set_scratch_size(0, Kokkos::PerTeam(per_team_scratch));                                                                                \
-        Kokkos::parallel_for("SolveTridiags::TeamPolicy::run<SingleVector>",                                                                          \
-                             policy, *this);                                                                                                          \
+        if (per_team_scratch < max_scratch) {                                                                                                         \
+          Kokkos::TeamPolicy<execution_space, SingleVectorSchurTag<B, 0>>                                                                             \
+              policy(packindices_schur.extent(0), team_size, vector_loop_size);                                                                       \
+          policy.set_scratch_size(0, Kokkos::PerTeam(per_team_scratch));                                                                              \
+          Kokkos::parallel_for("SolveTridiags::TeamPolicy::run<SingleVector>",                                                                        \
+                               policy, *this);                                                                                                        \
+        } else {                                                                                                                                      \
+          Kokkos::TeamPolicy<execution_space, SingleVectorSchurTag<B, 1>>                                                                             \
+              policy(packindices_schur.extent(0), team_size, vector_loop_size);                                                                       \
+          policy.set_scratch_size(1, Kokkos::PerTeam(per_team_scratch));                                                                              \
+          Kokkos::parallel_for("SolveTridiags::TeamPolicy::run<SingleVector>",                                                                        \
+                               policy, *this);                                                                                                        \
+        }                                                                                                                                             \
         write4DMultiVectorValuesToFile(part2packrowidx0_sub.extent(0), X_internal_scalar_values, "x_scalar_values_after_SingleVectorSchurTag.mm");    \
         IFPACK2_BLOCKHELPER_TIMER_FENCE(execution_space)                                                                                              \
       }                                                                                                                                               \


### PR DESCRIPTION
Removes the hardcoded ``max_blocksize = 32`` from BlockTriDi that was enforced previously.
Tested standard, Schur and Jacobi modes up to block size 128, with single or multiple vectors, on CPU and GPU.

The BTD factorization and solve kernels now fall back to level-1 scratch if level-0 isn't big enough. The fused solve+residual kernels still use level-0 only, but they run smaller teams and only support ``numVecs=1``. For scalar = double and a device with 48 KB shared per block, these would not run out of level 0 until the block size was around 768.

@trilinos/ifpack2

## Motivation
SPARC requested support for larger blocks.

## Testing
There were already "large block" tests for the standard and Schur codepaths, but they used the previous maximum block size of 32. Here I increased both of those to 64.