### PR TITLE
Remove Stokhos invalid ViewMapping use

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Utils.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Kokkos_View_MP_Vector_Utils.hpp
@@ -16,6 +16,7 @@
 namespace Kokkos {
 
 // Type name for a local, unmanaged view with possibly a different static size
+// TODO: Not sure these are really useful anymore, only used in a performance example
 template <typename ViewType,
           unsigned LocalSize,
           bool isStatic = Sacado::IsStaticallySized<typename ViewType::value_type>::value>
@@ -24,11 +25,6 @@ struct LocalMPVectorView {};
 template <typename ViewType, unsigned LocalSize>
 struct LocalMPVectorView<ViewType, LocalSize, false> {
   typedef ViewType type;
-};
-
-template <typename D, typename ... P, unsigned LocalSize>
-struct LocalMPVectorView< View<D,P...>, LocalSize, true > {
-  typedef typename Kokkos::Impl::ViewMapping< void, typename Kokkos::ViewTraits<D,P...>, Sacado::MP::VectorPartition<LocalSize> >::type type;
 };
 
 namespace Impl {


### PR DESCRIPTION
This is in prep for Kokkos 5.3 (and current Kokkos develop build).

I did a very simple build (no Tpetra etc. enabled) that did reproduce a compilation error which is now gone. Nathan will do more testing against Kokkos develop. 