### PR TITLE
Intrepid2: reintroduce setJacobian square fast path and fix CellTools correctness issues

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellDataDef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellDataDef.hpp
@@ -899,8 +899,8 @@ refCenterDataStatic_ = {
   distance(const PointViewType &point) {
     using scalar_type = typename ScalarTraits<typename PointViewType::value_type>::scalar_type;
     constexpr scalar_type one(1), two(2), three(3);
-    const scalar_type& p0 = get_scalar_value(point(0));
-    const scalar_type& p1 = get_scalar_value(point(1));
+    const scalar_type p0 = get_scalar_value(point(0));
+    const scalar_type p1 = get_scalar_value(point(1));
     return Util<scalar_type>::max(one-three*p0, three*(p0+p1)-two, one-three*p1); 
   }
 
@@ -918,8 +918,8 @@ refCenterDataStatic_ = {
   ParametricDistance<shards::Quadrilateral<>::key>::
   distance(const PointViewType &point) {
     using scalar_type = typename ScalarTraits<typename PointViewType::value_type>::scalar_type;
-    const scalar_type& p0 = get_scalar_value(point(0));
-    const scalar_type& p1 = get_scalar_value(point(1));
+    const scalar_type p0 = get_scalar_value(point(0));
+    const scalar_type p1 = get_scalar_value(point(1));
     return Util<scalar_type>::max(-p1, p0, p1, -p0); 
   }
 
@@ -938,9 +938,9 @@ refCenterDataStatic_ = {
   distance(const PointViewType &point) {
     using scalar_type = typename ScalarTraits<typename PointViewType::value_type>::scalar_type;
     constexpr scalar_type one(1), three(3), four(4);
-    const scalar_type& p0 = get_scalar_value(point(0));
-    const scalar_type& p1 = get_scalar_value(point(1));
-    const scalar_type& p2 = get_scalar_value(point(2));
+    const scalar_type p0 = get_scalar_value(point(0));
+    const scalar_type p1 = get_scalar_value(point(1));
+    const scalar_type p2 = get_scalar_value(point(2));
     return Util<scalar_type>::max(one-four*p1, four*(p0+p1+p2)-three, one-four*p0, one-four*p2);
   }
 
@@ -950,9 +950,9 @@ refCenterDataStatic_ = {
   ParametricDistance<shards::Hexahedron<>::key>::
   distance(const PointViewType &point) {
     using scalar_type = typename ScalarTraits<typename PointViewType::value_type>::scalar_type;
-    const scalar_type& p0 = get_scalar_value(point(0));
-    const scalar_type& p1 = get_scalar_value(point(1));
-    const scalar_type& p2 = get_scalar_value(point(2));
+    const scalar_type p0 = get_scalar_value(point(0));
+    const scalar_type p1 = get_scalar_value(point(1));
+    const scalar_type p2 = get_scalar_value(point(2));
     return Util<scalar_type>::max(-p1, p0, p1, -p0, -p2, p2); 
   }
 
@@ -963,9 +963,9 @@ refCenterDataStatic_ = {
   distance(const PointViewType &point) {
     using scalar_type = typename ScalarTraits<typename PointViewType::value_type>::scalar_type;
     constexpr scalar_type one(1), four(4), onethird(1.0/3.0), fourthirds(4.0/3.0);
-    const scalar_type& p0 = get_scalar_value(point(0));
-    const scalar_type& p1 = get_scalar_value(point(1));
-    const scalar_type& p2 = get_scalar_value(point(2));
+    const scalar_type p0 = get_scalar_value(point(0));
+    const scalar_type p1 = get_scalar_value(point(1));
+    const scalar_type p2 = get_scalar_value(point(2));
     return Util<scalar_type>::max(fourthirds*(p2-p1)-onethird,  fourthirds*(p2+p0)-onethird, fourthirds*(p2+p1)-onethird, fourthirds*(p2-p0)-onethird, one-four*p2);
   }
   
@@ -976,9 +976,9 @@ refCenterDataStatic_ = {
   distance(const PointViewType &point) {
     using scalar_type = typename ScalarTraits<typename PointViewType::value_type>::scalar_type;
     constexpr scalar_type one(1), two(2), three(3);
-    const scalar_type& p0 = get_scalar_value(point(0));
-    const scalar_type& p1 = get_scalar_value(point(1));
-    const scalar_type& p2 = get_scalar_value(point(2));
+    const scalar_type p0 = get_scalar_value(point(0));
+    const scalar_type p1 = get_scalar_value(point(1));
+    const scalar_type p2 = get_scalar_value(point(2));
     return Util<scalar_type>::max(one-three*p0, three*(p0+p1)-two, one-three*p1, -p2, p2);
   }
 

--- a/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
@@ -102,7 +102,7 @@ namespace Intrepid2 {
           auto out = Kokkos::subview(output_, cl, Kokkos::ALL(), pt, Kokkos::ALL()); // N, D
           ImplBasis::template Serial<OPERATOR_GRAD>::getValues(out, in);
         } else {
-          static_assert((Operator != OPERATOR_VALUE) && (Operator != OPERATOR_GRAD), "Invalid template parameter. Only OPERATOR_VALUE and OPERATOR_GRAD are supported.");
+          static_assert((Operator == OPERATOR_VALUE) || (Operator == OPERATOR_GRAD), "Invalid template parameter. Only OPERATOR_VALUE and OPERATOR_GRAD are supported.");
         } 
       }
     };

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefJacobian.hpp
@@ -39,7 +39,8 @@ namespace Intrepid2 {
     */
     template<typename jacobianViewType, 
              typename worksetCellType, 
-             typename basisGradType>
+             typename basisGradType,
+             bool squareJacobian = false>
     struct F_setJacobian {
             jacobianViewType _jacobian;
       const worksetCellType  _worksetCells;
@@ -61,26 +62,55 @@ namespace Intrepid2 {
         const ordinal_type phys_dim = _jacobian.extent(2); // dim2 and dim3 should match
         
         const ordinal_type gradRank = rank(_basisGrads);
-        const ordinal_type ref_dim = _basisGrads.extent_int(gradRank-1);
 
-        if ( gradRank == 3)
+        if constexpr (squareJacobian)
         {
-          const ordinal_type cardinality = _basisGrads.extent(0);
-          for (ordinal_type i=0;i<phys_dim;++i)
-            for (ordinal_type j=0;j<ref_dim;++j) {
+          const ordinal_type dim = phys_dim;
+
+          if ( gradRank == 3)
+          {
+            const ordinal_type cardinality = _basisGrads.extent(0);
+            for (ordinal_type i=0;i<dim;++i)
+              for (ordinal_type j=0;j<dim;++j) {
+                _jacobian(cell, point, i, j) = 0;
+                for (ordinal_type bf=0;bf<cardinality;++bf)
+                  _jacobian(cell, point, i, j) += _worksetCells(cell+_startCell, bf, i) * _basisGrads(bf, point, j);
+              }
+          }
+          else
+          {
+            const ordinal_type cardinality = _basisGrads.extent(1);
+            for (ordinal_type i=0;i<dim;++i)
+            for (ordinal_type j=0;j<dim;++j) {
               _jacobian(cell, point, i, j) = 0;
               for (ordinal_type bf=0;bf<cardinality;++bf)
-                _jacobian(cell, point, i, j) += _worksetCells(cell+_startCell, bf, i) * _basisGrads(bf, point, j);
+                _jacobian(cell, point, i, j) += _worksetCells(cell+_startCell, bf, i) * _basisGrads(cell, bf, point, j);
             }
+          }
         }
         else
         {
-          const ordinal_type cardinality = _basisGrads.extent(1);
-          for (ordinal_type i=0;i<phys_dim;++i)
-          for (ordinal_type j=0;j<ref_dim;++j) {
-            _jacobian(cell, point, i, j) = 0;
-            for (ordinal_type bf=0;bf<cardinality;++bf)
-              _jacobian(cell, point, i, j) += _worksetCells(cell+_startCell, bf, i) * _basisGrads(cell, bf, point, j);
+          const ordinal_type ref_dim = _basisGrads.extent_int(gradRank-1);
+
+          if ( gradRank == 3)
+          {
+            const ordinal_type cardinality = _basisGrads.extent(0);
+            for (ordinal_type i=0;i<phys_dim;++i)
+              for (ordinal_type j=0;j<ref_dim;++j) {
+                _jacobian(cell, point, i, j) = 0;
+                for (ordinal_type bf=0;bf<cardinality;++bf)
+                  _jacobian(cell, point, i, j) += _worksetCells(cell+_startCell, bf, i) * _basisGrads(bf, point, j);
+              }
+          }
+          else
+          {
+            const ordinal_type cardinality = _basisGrads.extent(1);
+            for (ordinal_type i=0;i<phys_dim;++i)
+            for (ordinal_type j=0;j<ref_dim;++j) {
+              _jacobian(cell, point, i, j) = 0;
+              for (ordinal_type bf=0;bf<cardinality;++bf)
+                _jacobian(cell, point, i, j) += _worksetCells(cell+_startCell, bf, i) * _basisGrads(cell, bf, point, j);
+            }
           }
         }
       }
@@ -780,7 +810,8 @@ namespace Intrepid2 {
         typename decltype(jacobian)::memory_space>::accessible;
     static_assert(is_accessible, "CellTools<DeviceType>::setJacobian(..): output view's memory space is not compatible with DeviceType");
 
-    using FunctorType      = FunctorCellTools::F_setJacobian<JacobianViewType,WorksetType,BasisGradientsType> ;
+    using SquareFunctorType      = FunctorCellTools::F_setJacobian<JacobianViewType,WorksetType,BasisGradientsType,true> ;
+    using RectangularFunctorType = FunctorCellTools::F_setJacobian<JacobianViewType,WorksetType,BasisGradientsType,false> ;
     
     // resolve the -1 default argument for endCell into the true end cell index
     // In some cases, endCell may be smaller than worksetCell.extent(0).
@@ -791,8 +822,20 @@ namespace Intrepid2 {
     using range_policy_type = Kokkos::MDRangePolicy
       < ExecSpaceType, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
     range_policy_type policy( { 0, 0 },
-                              { std::min(jacobian.extent_int(0), endCellResolved-startCell), jacobian.extent_int(1) } );
-    Kokkos::parallel_for( policy, FunctorType(jacobian, worksetCell, gradients, startCell) );
+                              { std::min<ordinal_type>(static_cast<ordinal_type>(jacobian.extent_int(0)), endCellResolved-startCell), jacobian.extent_int(1) } );
+
+    const ordinal_type gradRank = rank(gradients);
+    const ordinal_type physDim = jacobian.extent_int(2);
+    const ordinal_type refDim = gradients.extent_int(gradRank-1);
+
+    if (physDim == refDim)
+    {
+      Kokkos::parallel_for( policy, SquareFunctorType(jacobian, worksetCell, gradients, startCell) );
+    }
+    else
+    {
+      Kokkos::parallel_for( policy, RectangularFunctorType(jacobian, worksetCell, gradients, startCell) );
+    }
   }
 
 

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefPhysToRef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefPhysToRef.hpp
@@ -225,7 +225,7 @@ namespace Intrepid2 {
     auto physTmp = Impl::createMatchingDynRankView(refPoints, "CellTools::mapToReferenceFrameInitGuess::physTmp", numCells, numPoints, physDim);
 
     // deep copy may not work with FAD but this is right thing to do as it can move data between devices
-    Kokkos::deep_copy(xOld, Kokkos::subview(refPoints, Kokkos::ALL(), Kokkos::ALL(), refDimRange));
+    Kokkos::deep_copy(xOld, Kokkos::subdynrankview(refPoints, Kokkos::ALL(), Kokkos::ALL(), refDimRange));
 
     // jacobian should select fad dimension between xOld and worksetCell as they are input; no front interface yet
     using valueTypeJ = std::common_type_t<typename decltype(refPoints)::value_type, typename decltype(worksetCell)::value_type>;    
@@ -259,7 +259,7 @@ namespace Intrepid2 {
     using FunctorType = FunctorCellTools::F_maxNorm<errorViewType>;
     Kokkos::parallel_reduce("MaxReduction", policy, FunctorType(errorPointwise), Kokkos::Max<errorType>(physInfNorm));
     
-    auto refPts = Kokkos::subview(refPoints,Kokkos::ALL(), Kokkos::ALL(), refDimRange);
+    auto refPts = Kokkos::subdynrankview(refPoints,Kokkos::ALL(), Kokkos::ALL(), refDimRange);
       
 
     // Newton method to solve the equation F(refPoints) - physPoints = 0:
@@ -267,10 +267,7 @@ namespace Intrepid2 {
     bool converged(false);
     for (ordinal_type iter=0;iter<Parameters::MaxNewton;++iter) {
       
-      // Jacobians at the old iterates and their inverses. 
-      setJacobian(jacobian, xOld, worksetCell, basis);
-      
-      // The Newton step.
+      // The Newton residual at the old iterate.
       mapToPhysicalFrame(physTmp, xOld, worksetCell, basis); // physTmp <- F(xOld)
       rst::subtract(physTmp, physPoints, physTmp);           // physTmp <- physPoints - F(xOld)
 
@@ -283,9 +280,14 @@ namespace Intrepid2 {
 
       if (error < tol*physInfNorm) {
         converged = true;
+        if(isShell) { // update Jacobian so that it is consistent with xOld/refPoints
+          setJacobian(jacobian, xOld, worksetCell, basis);
+        }
         break;
       }
 
+      // Jacobians at the old iterates and their inverses. 
+      setJacobian(jacobian, xOld, worksetCell, basis);
 
       if(refDim < physDim) {
         rst::matvec(xTmp, jacobian, physTmp, true);          // xTmp <- DF^{T}( physPoints - F(xOld) ))
@@ -299,14 +301,14 @@ namespace Intrepid2 {
       }
   
       // extract values
-      rst::extractScalarValues(Kokkos::subview(xScalarTmp, Kokkos::ALL(), Kokkos::ALL(), refDimRange), refPts);
+      rst::extractScalarValues(Kokkos::subdynrankview(xScalarTmp, Kokkos::ALL(), Kokkos::ALL(), refDimRange), refPts);
 
       rst::add(refPts, xOld);                                 // refPoints <- refPoints + xOld
 
       
       error = 0;
       // l2 error (Euclidean distance) between old and new iterates: |xOld - xNew|
-      rst::vectorNorm(errorPointwise, Kokkos::subview(xScalarTmp, Kokkos::ALL(), Kokkos::ALL(), refDimRange), NORM_TWO);
+      rst::vectorNorm(errorPointwise, Kokkos::subdynrankview(xScalarTmp, Kokkos::ALL(), Kokkos::ALL(), refDimRange), NORM_TWO);
       Kokkos::parallel_reduce("MaxReduction", policy, FunctorType(errorPointwise), Kokkos::Max<errorType>(error));    
     
       // Stopping criterion:
@@ -331,7 +333,7 @@ namespace Intrepid2 {
       //(physPoints - F(xOld)) * n /|n|^2 / (H/2)
       //where H is the shell thickness and  n is the normal to the manifold defined by the map to physical frame (n is orthogonal to the tangents defined by the Jacobian)
       scaledResidualNormalComponent(
-               Kokkos::subview(refPoints,Kokkos::ALL(), Kokkos::ALL(), refDim),
+               Kokkos::subdynrankview(refPoints,Kokkos::ALL(), Kokkos::ALL(), refDim),
                jacobian,
                physTmp,
                2.0/shellThickness);

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefValidateArguments.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefValidateArguments.hpp
@@ -293,7 +293,14 @@ namespace Intrepid2 {
                                   ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): "
                                   "physPoints.extent(2) must match worksetCell.extent(2)." );
 
-    INTREPID2_TEST_FOR_EXCEPTION( refPoints.extent(2) != cellTopo.getDimension(), std::invalid_argument,
+    const ordinal_type expectedRefDim = cellTopo.getDimension();
+    const bool admitsShellThicknessDim =
+      (cellTopo.getKey() == shards::ShellLine<>::key) ||
+      (cellTopo.getKey() == shards::ShellTriangle<>::key) ||
+      (cellTopo.getKey() == shards::ShellQuadrilateral<>::key);
+
+    INTREPID2_TEST_FOR_EXCEPTION( (refPoints.extent_int(2) != expectedRefDim) &&
+                                  (!admitsShellThicknessDim || (refPoints.extent_int(2) != expectedRefDim + 1)), std::invalid_argument,
                                   ">>> ERROR (Intrepid2::CellTools::mapToReferenceFrame): "
                                   "refPoints.extent(2) must match the expected reference output dimension for cellTopo." );
 

--- a/packages/intrepid2/src/Shared/Intrepid2_RealSpaceToolsDef.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_RealSpaceToolsDef.hpp
@@ -1336,8 +1336,8 @@ det( DeterminantArrayViewType detArray, const MatrixViewType inMats );
                         rr == 2 ? Kokkos::subview(_matVecs, _i,    Kokkos::ALL()) :
                                   Kokkos::subview(_matVecs, _i, _j, Kokkos::ALL()) );
 
-        const ordinal_type iend = result.extent(0);
-        const ordinal_type jend = vec.extent(0);
+        const ordinal_type iend = transpose ? mat.extent(1) : mat.extent(0);
+        const ordinal_type jend = transpose ? mat.extent(0) : mat.extent(1);
 
         for (ordinal_type i=0;i<iend;++i) {
           result(i) = 0;

--- a/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
@@ -247,7 +247,8 @@ namespace Intrepid2 {
       return (a > b ? a : b);
     }
 
-    template <typename... Args, typename = std::enable_if_t<(std::is_same_v<T, Args> && ...)>>
+    template <typename... Args>
+    requires (std::is_same_v<T, Args> && ...)
     KOKKOS_FORCEINLINE_FUNCTION
     static T max(const T a, const T b, Args... args) {
         // Recursively find the max of everything after the first argument

--- a/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
@@ -247,8 +247,7 @@ namespace Intrepid2 {
       return (a > b ? a : b);
     }
 
-    template <typename... Args>
-    requires (std::is_same_v<T, Args> && ...)
+    template <typename... Args, typename = std::enable_if_t<(std::is_same_v<T, Args> && ...)>>
     KOKKOS_FORCEINLINE_FUNCTION
     static T max(const T a, const T b, Args... args) {
         // Recursively find the max of everything after the first argument

--- a/packages/intrepid2/unit-test/Cell/test_07.hpp
+++ b/packages/intrepid2/unit-test/Cell/test_07.hpp
@@ -90,7 +90,7 @@ namespace Intrepid2 {
       operator()(const ordinal_type i) const {
         const auto in = Kokkos::subview(_input,i,Kokkos::ALL());
         for (int k=0;k<3;++k) in(k)+=_offset;        
-        const bool check = ParametricDistance<cellTopologyKey>::distance(in) < 1.0 + threshold<ValueType>();        
+        const bool check = ParametricDistance<cellTopologyKey>::distance(in) <= 1.0 + threshold<ValueType>();        
         _output(i) = check;        
       }
     };

--- a/packages/intrepid2/unit-test/Discretization/Integration/CMakeLists.txt
+++ b/packages/intrepid2/unit-test/Discretization/Integration/CMakeLists.txt
@@ -45,6 +45,7 @@ FOREACH(I RANGE ${ETI_DEVICE_COUNT})
         ARGS PrintItAll
         NUM_MPI_PROCS 1
         PASS_REGULAR_EXPRESSION "TEST PASSED"
+        RUN_SERIAL
         ADD_DIR_TO_NAME
       )
 

--- a/packages/intrepid2/unit-test/Discretization/Integration/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Integration/test_01.hpp
@@ -38,6 +38,9 @@
 
 #include "test_util.hpp"
 
+#include <algorithm>
+#include <type_traits>
+
 namespace Intrepid2 {
 
   namespace Test {
@@ -260,7 +263,37 @@ namespace Intrepid2 {
         DynRankView ConstructWithLabel(cubPoints,  Parameters::MaxIntegrationPoints, Parameters::MaxDimension);
         DynRankView ConstructWithLabel(cubWeights, Parameters::MaxIntegrationPoints);
 
-        int maxTotalCubatureDegree = Parameters::MaxCubatureDegreeEdge; // sum in all dimensions
+        const bool limitDeviceCubatureSweeps =
+          !std::is_same<typename DeviceType::memory_space, Kokkos::HostSpace>::value;
+
+        const ordinal_type maxTotalCubatureDegree =
+          limitDeviceCubatureSweeps ?
+          std::min<ordinal_type>(static_cast<ordinal_type>(Parameters::MaxCubatureDegreeEdge), 8) :
+          static_cast<ordinal_type>(Parameters::MaxCubatureDegreeEdge); // sum in all dimensions
+        const ordinal_type maxTriDefaultDegree =
+          limitDeviceCubatureSweeps ? 8 : 20;
+        const ordinal_type maxTriSymDegree =
+          limitDeviceCubatureSweeps ?
+          std::min<ordinal_type>(static_cast<ordinal_type>(Parameters::MaxCubatureDegreeTri), 8) :
+          static_cast<ordinal_type>(Parameters::MaxCubatureDegreeTri);
+        const ordinal_type maxTetDegree =
+          limitDeviceCubatureSweeps ?
+          std::min<ordinal_type>(static_cast<ordinal_type>(Parameters::MaxCubatureDegreeTet), 8) :
+          static_cast<ordinal_type>(Parameters::MaxCubatureDegreeTet);
+        const ordinal_type maxHexStandardDegree =
+          limitDeviceCubatureSweeps ? 4 : 10;
+        const ordinal_type maxPrismLineDegree =
+          limitDeviceCubatureSweeps ?
+          std::min<ordinal_type>(static_cast<ordinal_type>(Parameters::MaxCubatureDegreeEdge), 4) :
+          static_cast<ordinal_type>(Parameters::MaxCubatureDegreeEdge);
+        const ordinal_type maxPrismTriDefaultDegree =
+          limitDeviceCubatureSweeps ? 8 : 20;
+        const ordinal_type maxPrismSymLineDegree =
+          limitDeviceCubatureSweeps ? 4 : 10;
+        const ordinal_type maxPrismSymTriDegree =
+          limitDeviceCubatureSweeps ?
+          std::min<ordinal_type>(static_cast<ordinal_type>(Parameters::MaxCubatureDegreeTri), 8) :
+          static_cast<ordinal_type>(Parameters::MaxCubatureDegreeTri);
         
         *outStream << "-> Line testing\n\n";
         {
@@ -282,7 +315,7 @@ namespace Intrepid2 {
 
         *outStream << "-> Triangle testing\n\n";
         {
-          for (auto deg=0;deg<=20;++deg) {
+          for (ordinal_type deg=0;deg<=maxTriDefaultDegree;++deg) {
             CubatureTriType cub(deg);
             cub.getCubature(cubPoints, cubWeights);
             const auto npts = cub.getNumPoints();
@@ -298,7 +331,7 @@ namespace Intrepid2 {
           }
 
           *outStream << "-> Triangle symmetric cubature testing\n\n";
-          for (auto deg=0;deg<=Parameters::MaxCubatureDegreeTri;++deg) {
+          for (ordinal_type deg=0;deg<=maxTriSymDegree;++deg) {
             CubatureTriSymType cub(deg);
             cub.getCubature(cubPoints, cubWeights);
             const auto npts = cub.getNumPoints();
@@ -341,7 +374,7 @@ namespace Intrepid2 {
         
         *outStream << "-> Tetrahedron testing\n\n";
         {
-          for (auto deg=0;deg<=Parameters::MaxCubatureDegreeTet;++deg) {
+          for (ordinal_type deg=0;deg<=maxTetDegree;++deg) {
             CubatureTetType cub(deg);
             
             cub.getCubature(cubPoints, cubWeights);
@@ -359,7 +392,7 @@ namespace Intrepid2 {
           }
 
           *outStream << "-> Tetrahedron symmetric cubature testing\n\n";
-          for (auto deg=0;deg<=Parameters::MaxCubatureDegreeTet;++deg) {
+          for (ordinal_type deg=0;deg<=maxTetDegree;++deg) {
             CubatureTetSymType cub(deg);
             
             cub.getCubature(cubPoints, cubWeights);
@@ -379,10 +412,11 @@ namespace Intrepid2 {
         
         *outStream << "-> Hexahedron testing\n\n";
         {
-          // test up to 10th order in each dimension with standard (non-tensor) points; we'll test up to max degree with tensor points below.
-          for (ordinal_type z_deg=0;z_deg<10;++z_deg)
-            for (ordinal_type y_deg=0;y_deg<10;++y_deg)
-              for (ordinal_type x_deg=0;x_deg<10;++x_deg) {
+          // Test up to 10th order in each dimension with standard (non-tensor) points on host;
+          // cap device-memory-space instantiations to avoid excessive tiny kernel launches in CI.
+          for (ordinal_type z_deg=0;z_deg<maxHexStandardDegree;++z_deg)
+            for (ordinal_type y_deg=0;y_deg<maxHexStandardDegree;++y_deg)
+              for (ordinal_type x_deg=0;x_deg<maxHexStandardDegree;++x_deg) {
                 const auto x_line = CubatureLineType(x_deg);
                 const auto y_line = CubatureLineType(y_deg);
                 const auto z_line = CubatureLineType(z_deg);
@@ -435,8 +469,8 @@ namespace Intrepid2 {
 
         *outStream << "-> Prism testing\n\n";
         {
-          for (auto z_deg=0;z_deg<Parameters::MaxCubatureDegreeEdge;++z_deg)
-            for (auto xy_deg=0;xy_deg<20;++xy_deg) {
+          for (ordinal_type z_deg=0;z_deg<maxPrismLineDegree;++z_deg)
+            for (ordinal_type xy_deg=0;xy_deg<maxPrismTriDefaultDegree;++xy_deg) {
               const auto xy_tri = CubatureTriType(xy_deg);
               const auto z_line = CubatureLineType(z_deg);
               CubatureTensorType cub( xy_tri, z_line );
@@ -455,9 +489,10 @@ namespace Intrepid2 {
             }
 
           *outStream << "-> Prism symmetric quadrature testing\n\n";
-          // test up to 10th order in the extrusion dimension with standard (non-tensor) points; we'll test up to max degree with tensor points below.
-          for (auto z_deg=0;z_deg<10;++z_deg)
-            for (auto xy_deg=0;xy_deg<Parameters::MaxCubatureDegreeTri;++xy_deg) {
+          // Test up to 10th order in the extrusion dimension with standard (non-tensor) points on host;
+          // cap device-memory-space instantiations to avoid excessive tiny kernel launches in CI.
+          for (ordinal_type z_deg=0;z_deg<maxPrismSymLineDegree;++z_deg)
+            for (ordinal_type xy_deg=0;xy_deg<maxPrismSymTriDegree;++xy_deg) {
               const auto xy_tri = CubatureTriSymType(xy_deg);
               const auto z_line = CubatureLineType(z_deg);
               CubatureTensorType cub( xy_tri, z_line );
@@ -475,8 +510,8 @@ namespace Intrepid2 {
               }
             }
           
-          for (auto z_deg=0;z_deg<Parameters::MaxCubatureDegreeEdge;++z_deg)
-            for (auto xy_deg=0;xy_deg<Parameters::MaxCubatureDegreeTri;++xy_deg) {
+          for (ordinal_type z_deg=0;z_deg<maxPrismLineDegree;++z_deg)
+            for (ordinal_type xy_deg=0;xy_deg<maxPrismSymTriDegree;++xy_deg) {
               const auto xy_tri = CubatureTriSymType(xy_deg);
               const auto z_line = CubatureLineType(z_deg);
               CubatureTensorType cub( xy_tri, z_line );

--- a/packages/intrepid2/unit-test/MonolithicExecutable/CMakeLists.txt
+++ b/packages/intrepid2/unit-test/MonolithicExecutable/CMakeLists.txt
@@ -64,6 +64,7 @@ TRIBITS_ADD_TEST(
   ARGS "--group=ProjectedGeometry* --test=CircularGeometryConvergesInP_MultiCell"
   NUM_MPI_PROCS 1
   PASS_REGULAR_EXPRESSION "TEST PASSED"
+  RUN_SERIAL
 )
 
 # other tests are divided such that they can be handled using --group argument alone


### PR DESCRIPTION
Intrepid2: reintroduce setJacobian square fast path and fix CellTools correctness issues

This PR is an effort to resolve #15350.  The primary performance-relevant change is in CellTools::setJacobian().

The recent generalized implementation supports rectangular Jacobians where the
physical and reference dimensions differ, but the common volume-cell case is
still square.  We add a compile-time boolean parameter to the setJacobian functor.
The square specialization uses a single dimension loop bound, preserving the older
square-Jacobian loop structure for the common case, while the rectangular specialization 
retains the generalized physical/reference dimension handling needed for shell/beam
topologies.  The dispatch is outside the Kokkos parallel loop, so the hot loop does 
not pay an invariant runtime branch.

We also adopt changes, described below, suggested by Gemini here:

https://github.com/csiefer2/TrilinosMirror/pull/187

Also make the setJacobian workset range construction type-safe by explicitly
selecting the ordinal_type overload of std::min and casting the Kokkos extent
accordingly.  This avoids template deduction failures when ordinal_type differs
from int.

Fix several correctness and portability issues:

  * Correct the inverted static_assert in the CellTools HGRAD getValues helper.
    Unsupported operators now correctly trigger the intended compile-time
    diagnostic instead of satisfying the assertion.

  * Make the test_07 point-inclusion check include boundary points by changing
    the ParametricDistance comparison from < to <=.  Parametric distance equal
    to one represents a point on the reference-cell boundary, so it should be
    accepted within the existing tolerance.

  * Fix RealSpaceTools::matvec() loop bounds for transposed rectangular
    matrices.  The transposed case now iterates over mat.extent(1) result
    entries and mat.extent(0) input entries, rather than using bounds derived
    from the non-transposed orientation.

Improve mapToReferenceFrame() handling for shell/beam-style rectangular
mappings:

  * Use Kokkos::subdynrankview() for reference-point slices and scalar slices
    that are passed through Intrepid2/RealSpaceTools APIs.  This preserves
    DynRankView-like types and avoids unintentionally bypassing ETI-sensitive
    overloads.

  * Reorder the Newton iteration so that the residual is computed and tested
    before forming the Jacobian.  If the current iterate is already converged,
    the iteration can now skip an unnecessary Jacobian/inverse computation.
    For shell cases, still update the Jacobian before exiting so the later
    shell normal/thickness reconstruction uses a Jacobian consistent with the
    final reference point.

  * Relax debug argument validation for shell topologies so refPoints may have
    one additional output coordinate for the reconstructed thickness/normal
    component.  Non-shell topologies still require the reference dimension to
    match the cell topology dimension.

Clean up ParametricDistance implementations by storing scalar values by value
instead of binding get_scalar_value() temporaries to const references.  This is
clearer and avoids relying on reference lifetime extension in Kokkos device
code.

The SierraGradProjection timing remained in line with the provided baseline and
did not show a performance regression when running a clang-built serial binary on a Mac.