### PR TITLE
Tpetra: Allow to skip global constants in more operations

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -406,27 +406,18 @@ void Jacobi(typename Teuchos::ScalarTraits<Scalar>::magnitudeType omega,
 
   {
     Tpetra::Details::ProfilingRegion r("TpetraExt: Jacobi: All I&X");
-    // Enable globalConstants by default
+    // Disable globalConstants by default
     // NOTE: the I&X routine sticks an importer on the paramlist as output, so we have to use a unique guy here
-    RCP<Teuchos::ParameterList> importParams1 = Teuchos::rcp(new Teuchos::ParameterList);
+    RCP<Teuchos::ParameterList> importParams = Teuchos::rcp(new Teuchos::ParameterList);
+    importParams->set("compute global constants", false);
     if (!params.is_null()) {
-      importParams1->set("compute global constants", params->get("compute global constants: temporaries", false));
-      int mm_optimization_core_count  = 0;
-      auto slist                      = params->sublist("matrixmatrix: kernel params", false);
-      mm_optimization_core_count      = slist.get("MM_TAFC_OptimizationCoreCount", ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount());
-      int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-      if (mm_optimization_core_count2 < mm_optimization_core_count) mm_optimization_core_count = mm_optimization_core_count2;
-      bool isMM              = slist.get("isMatrixMatrix_TransferAndFillComplete", false);
-      bool overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck", false);
-      auto& ip1slist         = importParams1->sublist("matrixmatrix: kernel params", false);
-      ip1slist.set("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-      ip1slist.set("isMatrixMatrix_TransferAndFillComplete", isMM);
-      ip1slist.set("MM_TAFC_OverrideAllreduceCheck", overrideAllreduce);
+      importParams->setParameters(*params);
+      importParams->set("compute global constants", params->get("compute global constants: temporaries", false));
     }
 
     // Now import any needed remote rows and populate the Aview struct.
     RCP<const import_type> dummyImporter;
-    MMdetails::import_and_extract_views(*Aprime, targetMap_A, Aview, dummyImporter, true, label, importParams1);
+    MMdetails::import_and_extract_views(*Aprime, targetMap_A, Aview, dummyImporter, true, label, importParams);
 
     // We will also need local access to all rows of B that correspond to the
     // column-map of op(A).
@@ -434,25 +425,7 @@ void Jacobi(typename Teuchos::ScalarTraits<Scalar>::magnitudeType omega,
       targetMap_B = Aprime->getColMap();
 
     // Now import any needed remote rows and populate the Bview struct.
-    // Enable globalConstants by default
-    // NOTE: the I&X routine sticks an importer on the paramlist as output, so we have to use a unique guy here
-    RCP<Teuchos::ParameterList> importParams2 = Teuchos::rcp(new Teuchos::ParameterList);
-    if (!params.is_null()) {
-      importParams2->set("compute global constants", params->get("compute global constants: temporaries", false));
-
-      auto slist                      = params->sublist("matrixmatrix: kernel params", false);
-      int mm_optimization_core_count  = slist.get("MM_TAFC_OptimizationCoreCount", ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount());
-      bool isMM                       = slist.get("isMatrixMatrix_TransferAndFillComplete", false);
-      bool overrideAllreduce          = slist.get("MM_TAFC_OverrideAllreduceCheck", false);
-      auto& ip2slist                  = importParams2->sublist("matrixmatrix: kernel params", false);
-      int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-      if (mm_optimization_core_count2 < mm_optimization_core_count) mm_optimization_core_count = mm_optimization_core_count2;
-      ip2slist.set("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-      ip2slist.set("isMatrixMatrix_TransferAndFillComplete", isMM);
-      ip2slist.set("MM_TAFC_OverrideAllreduceCheck", overrideAllreduce);
-    }
-
-    MMdetails::import_and_extract_views(*Bprime, targetMap_B, Bview, Aprime->getGraph()->getImporter(), Aprime->getGraph()->getImporter().is_null(), label, importParams2);
+    MMdetails::import_and_extract_views(*Bprime, targetMap_B, Bview, Aprime->getGraph()->getImporter(), Aprime->getGraph()->getImporter().is_null(), label, importParams);
   }
   MM = Teuchos::null;
   MM = rcp(new Tpetra::Details::ProfilingRegion("TpetraExt: Jacobi All Multiply"));
@@ -1363,62 +1336,22 @@ void mult_AT_B_newmatrix(
   RCP<const Import<LO, GO, NO>> dummyImporter;
 
   // NOTE: the I&X routine sticks an importer on the paramlist as output, so we have to use a unique guy here
-  RCP<Teuchos::ParameterList> importParams1(new ParameterList);
+  RCP<Teuchos::ParameterList> importParams = Teuchos::rcp(new ParameterList);
+  importParams->set("compute global constants", false);
   if (!params.is_null()) {
-    importParams1->set("compute global constants",
-                       params->get("compute global constants: temporaries",
-                                   false));
-    auto slist             = params->sublist("matrixmatrix: kernel params", false);
-    bool isMM              = slist.get("isMatrixMatrix_TransferAndFillComplete", false);
-    bool overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck", false);
-    int mm_optimization_core_count =
-        ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
-    mm_optimization_core_count =
-        slist.get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-    int mm_optimization_core_count2 =
-        params->get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-    if (mm_optimization_core_count2 < mm_optimization_core_count) {
-      mm_optimization_core_count = mm_optimization_core_count2;
-    }
-    auto& sip1 = importParams1->sublist("matrixmatrix: kernel params", false);
-    sip1.set("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-    sip1.set("isMatrixMatrix_TransferAndFillComplete", isMM);
-    sip1.set("MM_TAFC_OverrideAllreduceCheck", overrideAllreduce);
+    importParams->setParameters(*params);
+    if (params->isParameter("compute global constants: temporaries"))
+      importParams->set("compute global constants",
+                        params->get<bool>("compute global constants: temporaries"));
   }
-
   MMdetails::import_and_extract_views(*Atrans, Atrans->getRowMap(),
                                       Aview, dummyImporter, true,
-                                      label, importParams1);
-
-  RCP<ParameterList> importParams2(new ParameterList);
-  if (!params.is_null()) {
-    importParams2->set("compute global constants",
-                       params->get("compute global constants: temporaries",
-                                   false));
-    auto slist             = params->sublist("matrixmatrix: kernel params", false);
-    bool isMM              = slist.get("isMatrixMatrix_TransferAndFillComplete", false);
-    bool overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck", false);
-    int mm_optimization_core_count =
-        ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
-    mm_optimization_core_count =
-        slist.get("MM_TAFC_OptimizationCoreCount",
-                  mm_optimization_core_count);
-    int mm_optimization_core_count2 =
-        params->get("MM_TAFC_OptimizationCoreCount",
-                    mm_optimization_core_count);
-    if (mm_optimization_core_count2 < mm_optimization_core_count) {
-      mm_optimization_core_count = mm_optimization_core_count2;
-    }
-    auto& sip2 = importParams2->sublist("matrixmatrix: kernel params", false);
-    sip2.set("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-    sip2.set("isMatrixMatrix_TransferAndFillComplete", isMM);
-    sip2.set("MM_TAFC_OverrideAllreduceCheck", overrideAllreduce);
-  }
+                                      label, importParams);
 
   if (B.getRowMap()->isSameAs(*Atrans->getColMap())) {
-    MMdetails::import_and_extract_views(B, B.getRowMap(), Bview, dummyImporter, true, label, importParams2);
+    MMdetails::import_and_extract_views(B, B.getRowMap(), Bview, dummyImporter, true, label, importParams);
   } else {
-    MMdetails::import_and_extract_views(B, Atrans->getColMap(), Bview, dummyImporter, false, label, importParams2);
+    MMdetails::import_and_extract_views(B, Atrans->getColMap(), Bview, dummyImporter, false, label, importParams);
   }
 
   MM = Teuchos::null;
@@ -1448,21 +1381,12 @@ void mult_AT_B_newmatrix(
     ParameterList labelList;
     labelList.set("Timer Label", label);
     if (!params.is_null()) {
-      ParameterList& params_sublist    = params->sublist("matrixmatrix: kernel params", false);
-      ParameterList& labelList_subList = labelList.sublist("matrixmatrix: kernel params", false);
-      int mm_optimization_core_count   = ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
-      mm_optimization_core_count       = params_sublist.get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-      int mm_optimization_core_count2  = params->get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-      if (mm_optimization_core_count2 < mm_optimization_core_count) mm_optimization_core_count = mm_optimization_core_count2;
-      labelList_subList.set("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count, "Core Count above which the optimized neighbor discovery is used");
-      bool isMM              = params_sublist.get("isMatrixMatrix_TransferAndFillComplete", false);
-      bool overrideAllreduce = params_sublist.get("MM_TAFC_OverrideAllreduceCheck", false);
-
-      labelList_subList.set("isMatrixMatrix_TransferAndFillComplete", isMM,
-                            "This parameter should be set to true only for MatrixMatrix operations: the optimization in Epetra that was ported to Tpetra does _not_ take into account the possibility that for any given source PID, a particular GID may not exist on the target PID: i.e. a transfer operation. A fix for this general case is in development.");
-      labelList.set("compute global constants", params->get("compute global constants", true));
-      labelList.set("MM_TAFC_OverrideAllreduceCheck", overrideAllreduce);
+      labelList.setParameters(*params);
     }
+    ParameterList& labelList_subList = labelList.sublist("matrixmatrix: kernel params", false);
+    labelList_subList.set("isMatrixMatrix_TransferAndFillComplete", true,
+                          "This parameter should be set to true only for MatrixMatrix operations: the optimization in Epetra that was ported to Tpetra does _not_ take into account the possibility that for any given source PID, a particular GID may not exist on the target PID: i.e. a transfer operation. A fix for this general case is in development.");
+
     Ctemp->exportAndFillComplete(Crcp,
                                  *Ctemp->getGraph()->getExporter(),
                                  B.getDomainMap(),
@@ -3306,25 +3230,15 @@ void import_and_extract_views(
     // Now create a new matrix into which we can import the remote rows of A that we need.
     Teuchos::ParameterList labelList;
     labelList.set("Timer Label", label);
-    auto& labelList_subList = labelList.sublist("matrixmatrix: kernel params", false);
-
-    bool isMM                      = true;
-    bool overrideAllreduce         = false;
-    int mm_optimization_core_count = ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
     // Minor speedup tweak - avoid computing the global constants
-    Teuchos::ParameterList params_sublist;
+    labelList.set("compute global constants", false);
+    auto& labelList_subList = labelList.sublist("matrixmatrix: kernel params", false);
+    labelList_subList.set("isMatrixMatrix_TransferAndFillComplete", true);
+
     if (!params.is_null()) {
-      labelList.set("compute global constants", params->get("compute global constants", false));
-      params_sublist                  = params->sublist("matrixmatrix: kernel params", false);
-      mm_optimization_core_count      = params_sublist.get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-      int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-      if (mm_optimization_core_count2 < mm_optimization_core_count) mm_optimization_core_count = mm_optimization_core_count2;
-      isMM              = params_sublist.get("isMatrixMatrix_TransferAndFillComplete", false);
-      overrideAllreduce = params_sublist.get("MM_TAFC_OverrideAllreduceCheck", false);
+      if (params->isParameter("compute global constants"))
+        labelList.set("compute global constants", params->get<bool>("compute global constants"));
     }
-    labelList_subList.set("isMatrixMatrix_TransferAndFillComplete", isMM);
-    labelList_subList.set("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-    labelList_subList.set("MM_TAFC_OverrideAllreduceCheck", overrideAllreduce);
 
     Aview.importMatrix = Tpetra::importAndFillCompleteCrsMatrix<crs_matrix_type>(rcpFromRef(A), *importer,
                                                                                  A.getDomainMap(), importer->getTargetMap(), rcpFromRef(labelList));

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -1367,7 +1367,12 @@ void mult_AT_B_newmatrix(
     Ctemp = rcp(&C, false);
   }
 
-  mult_A_B_newmatrix(Aview, Bview, *Ctemp, label, params);
+  RCP<Teuchos::ParameterList> multParams = Teuchos::rcp(new ParameterList);
+  if (!params.is_null()) {
+    multParams->setParameters(*params);
+  }
+  multParams->set("compute global constants", !needs_final_export);
+  mult_A_B_newmatrix(Aview, Bview, *Ctemp, label, multParams);
 
   /*************************************************************/
   /* 4) exportAndFillComplete matrix                           */
@@ -1731,11 +1736,11 @@ void mult_A_B_newmatrix(
 
     // Choose the right variant of setUnion
     if (!Bimport.is_null() && !Iimport.is_null()) {
-      Cimport = Bimport->setUnion(*Iimport);
+      Cimport = Bimport->setUnion(*Iimport, params);
     } else if (!Bimport.is_null() && Iimport.is_null()) {
-      Cimport = Bimport->setUnion();
+      Cimport = Bimport->setUnion(params);
     } else if (Bimport.is_null() && !Iimport.is_null()) {
-      Cimport = Iimport->setUnion();
+      Cimport = Iimport->setUnion(params);
     } else {
       throw std::runtime_error("TpetraExt::MMM status of matrix importers is nonsensical");
     }
@@ -2526,14 +2531,14 @@ void jacobi_A_B_newmatrix(
 
     // Choose the right variant of setUnion
     if (!Bimport.is_null() && !Iimport.is_null()) {
-      Cimport = Bimport->setUnion(*Iimport);
+      Cimport = Bimport->setUnion(*Iimport, params);
       Ccolmap = Cimport->getTargetMap();
 
     } else if (!Bimport.is_null() && Iimport.is_null()) {
-      Cimport = Bimport->setUnion();
+      Cimport = Bimport->setUnion(params);
 
     } else if (Bimport.is_null() && !Iimport.is_null()) {
-      Cimport = Iimport->setUnion();
+      Cimport = Iimport->setUnion(params);
 
     } else
       throw std::runtime_error("TpetraExt::Jacobi status of matrix importers is nonsensical");

--- a/packages/tpetra/core/ext/TpetraExt_TripleMatrixMultiply_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_TripleMatrixMultiply_def.hpp
@@ -278,27 +278,13 @@ void MultiplyRAP(
     Teuchos::ParameterList labelList;
     labelList.set("Timer Label", label);
     Teuchos::ParameterList& labelList_subList = labelList.sublist("matrixmatrix: kernel params", false);
-
-    RCP<crs_matrix_type> Acprime   = rcpFromRef(Ac);
-    bool isMM                      = true;
-    bool overrideAllreduce         = false;
-    int mm_optimization_core_count = ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
-    if (!params.is_null()) {
-      Teuchos::ParameterList& params_sublist = params->sublist("matrixmatrix: kernel params", false);
-      mm_optimization_core_count             = ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
-      mm_optimization_core_count             = params_sublist.get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-      int mm_optimization_core_count2        = params->get("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
-      if (mm_optimization_core_count2 < mm_optimization_core_count) mm_optimization_core_count = mm_optimization_core_count2;
-      isMM              = params_sublist.get("isMatrixMatrix_TransferAndFillComplete", false);
-      overrideAllreduce = params_sublist.get("MM_TAFC_OverrideAllreduceCheck", false);
-
-      labelList.set("compute global constants", params->get("compute global constants", true));
-    }
-    labelList_subList.set("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count, "Core Count above which the optimized neighbor discovery is used");
-
-    labelList_subList.set("isMatrixMatrix_TransferAndFillComplete", isMM,
+    labelList_subList.set("isMatrixMatrix_TransferAndFillComplete", true,
                           "This parameter should be set to true only for MatrixMatrix operations: the optimization in Epetra that was ported to Tpetra does _not_ take into account the possibility that for any given source PID, a particular GID may not exist on the target PID: i.e. a transfer operation. A fix for this general case is in development.");
-    labelList_subList.set("MM_TAFC_OverrideAllreduceCheck", overrideAllreduce);
+
+    RCP<crs_matrix_type> Acprime = rcpFromRef(Ac);
+    if (!params.is_null()) {
+      labelList.setParameters(*params);
+    }
 
     export_type exporter = export_type(*Pprime->getGraph()->getImporter());
     Actemp->exportAndFillComplete(Acprime,

--- a/packages/tpetra/core/src/Tpetra_DirectoryImpl_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DirectoryImpl_def.hpp
@@ -13,6 +13,7 @@
 /// \file Tpetra_DirectoryImpl_def.hpp
 /// \brief Definition of implementation details of Tpetra::Directory.
 
+#include "Teuchos_TestForException.hpp"
 #include "Tpetra_Distributor.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_TieBreak.hpp"
@@ -529,6 +530,7 @@ void DistributedNoncontiguousDirectory<LO, GO, NT>::
                                                                << sizeof(global_size_t) << " < sizeof(Local"
                                                                                            "Ordinal = "
                                                                << TypeNameTraits<LO>::name() << ") = " << sizeof(LO) << ".");
+  TEUCHOS_TEST_FOR_EXCEPTION(!map.haveGlobalConstants(), std::logic_error, "Map needs to have global constants.");
 
   RCP<const Teuchos::Comm<int> > comm = map.getComm();
   const LO LINVALID                   = Teuchos::OrdinalTraits<LO>::invalid();

--- a/packages/tpetra/core/src/Tpetra_Import_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_decl.hpp
@@ -296,7 +296,8 @@ class Import : public ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, N
   /// pointer but take a reference (or to take a pointer, but have
   /// the left-hand side of the + expression be a reference).
   Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Node>>
-  setUnion(const Import<LocalOrdinal, GlobalOrdinal, Node>& rhs) const;
+  setUnion(const Import<LocalOrdinal, GlobalOrdinal, Node>& rhs,
+           const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) const;
 
   /// \brief Return the union of this Import this->getSourceMap()
   ///
@@ -315,7 +316,7 @@ class Import : public ::Tpetra::Details::Transfer<LocalOrdinal, GlobalOrdinal, N
   /// creating the result matrix's column Map from scratch.
   ///
   Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Node>>
-  setUnion() const;
+  setUnion(const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) const;
 
   /// \brief Returns an importer that contains only the remote entries of this
   ///

--- a/packages/tpetra/core/src/Tpetra_Import_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_def.hpp
@@ -1303,7 +1303,8 @@ void Import<LocalOrdinal, GlobalOrdinal, Node>::
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Node>>
 Import<LocalOrdinal, GlobalOrdinal, Node>::
-    setUnion(const Import<LocalOrdinal, GlobalOrdinal, Node>& rhs) const {
+    setUnion(const Import<LocalOrdinal, GlobalOrdinal, Node>& rhs,
+             const Teuchos::RCP<Teuchos::ParameterList>& params) const {
   using Teuchos::Array;
   using Teuchos::ArrayView;
   using Teuchos::as;
@@ -1428,7 +1429,7 @@ Import<LocalOrdinal, GlobalOrdinal, Node>::
   const GST INVALID       = Teuchos::OrdinalTraits<GST>::invalid();
   const GO indexBaseUnion = std::min(tgtMap1->getIndexBase(), tgtMap2->getIndexBase());
   RCP<const map_type> unionTgtMap =
-      rcp(new map_type(INVALID, unionTgtGIDs(), indexBaseUnion, comm));
+      rcp(new map_type(INVALID, unionTgtGIDs(), indexBaseUnion, comm, params));
 
   MM2      = Teuchos::null;
   auto MM3 = Teuchos::rcp(new Tpetra::Details::ProfilingRegion("Tpetra::Import::setUnion : Export GIDs"));
@@ -1545,7 +1546,7 @@ Import<LocalOrdinal, GlobalOrdinal, Node>::
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Node>>
 Import<LocalOrdinal, GlobalOrdinal, Node>::
-    setUnion() const {
+    setUnion(const Teuchos::RCP<Teuchos::ParameterList>& params) const {
   using Teuchos::Array;
   using Teuchos::ArrayView;
   using Teuchos::as;
@@ -1590,7 +1591,7 @@ Import<LocalOrdinal, GlobalOrdinal, Node>::
   GO GO_INVALID = Teuchos::OrdinalTraits<GO>::invalid();
   RCP<const map_type> targetMapNew =
       rcp(new map_type(GO_INVALID, GIDs, tgtMap->getIndexBase(),
-                       tgtMap->getComm()));
+                       tgtMap->getComm(), params));
 
   // Exports are trivial (since the sourcemap doesn't change)
   Array<int> exportPIDsnew(this->getExportPIDs());

--- a/packages/tpetra/core/src/Tpetra_Import_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_def.hpp
@@ -1014,6 +1014,10 @@ void Import<LocalOrdinal, GlobalOrdinal, Node>::
 
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(this->getSourceMap().is_null(), std::logic_error,
                                         "Source Map is null.  " << suffix);
+  if (!useRemotePIDs && !this->getSourceMap()->haveGlobalConstants()) {
+    // Directory construction below requires global constants
+    Teuchos::rcp_const_cast<Map<LocalOrdinal, GlobalOrdinal, Node>>(this->getSourceMap())->computeGlobalConstants();
+  }
   const map_type& source = *(this->getSourceMap());
 
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(!useRemotePIDs && (userRemotePIDs.size() > 0), std::invalid_argument,

--- a/packages/tpetra/core/src/Tpetra_Map_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_decl.hpp
@@ -1153,11 +1153,11 @@ class Map : public Teuchos::Describable {
 
   /// \brief The min global index in this Map over all processes in
   ///   its communicator \c comm (see above).
-  global_ordinal_type minAllGID_;
+  mutable global_ordinal_type minAllGID_;
 
   /// \brief The max global index in this Map over all processes in
   ///   its communicator \c comm (see above).
-  global_ordinal_type maxAllGID_;
+  mutable global_ordinal_type maxAllGID_;
 
   /// \brief First contiguous GID.
   ///
@@ -1200,10 +1200,10 @@ class Map : public Teuchos::Describable {
   /// otherwise (if the Map is locally replicated).  See the
   /// documentation of isDistributed() for a definition of these two
   /// mutually exclusive terms.
-  bool distributed_;
+  mutable bool distributed_;
 
  private:
-  bool haveGlobalConstants_ = false;
+  mutable bool haveGlobalConstants_ = false;
 
  public:
   bool haveGlobalConstants() const { return haveGlobalConstants_; }
@@ -1211,7 +1211,7 @@ class Map : public Teuchos::Describable {
   /// \brief Compute global constants for the map. This method needs
   /// to be called collectively over all processes in the Map's
   /// communicator.
-  void computeGlobalConstants();
+  void computeGlobalConstants() const;
 
   /// \brief A mapping from local IDs to global IDs.
   ///

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -1042,7 +1042,7 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
 }
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
-void Map<LocalOrdinal, GlobalOrdinal, Node>::computeGlobalConstants() {
+void Map<LocalOrdinal, GlobalOrdinal, Node>::computeGlobalConstants() const {
   using GO  = global_ordinal_type;
   using GST = global_size_t;
 
@@ -2106,6 +2106,9 @@ void Map<LocalOrdinal, GlobalOrdinal, Node>::setupDirectory() const {
   // Only create the Directory if it hasn't been created yet.
   // This is a collective operation.
   if (!directory_->initialized()) {
+    // non-contiguous directory needs global constants
+    if (isDistributed() && !isUniform() && !isContiguous())
+      computeGlobalConstants();
     directory_->initialize(*this);
   }
 }

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -757,10 +757,17 @@ void Map<LocalOrdinal, GlobalOrdinal, Node>::
   const bool callComputeGlobalConstants = params.get() == nullptr ||
                                           params->get("compute global constants", true);
 
-  if (callComputeGlobalConstants)
+  if (callComputeGlobalConstants && (comm->getSize() > 1))
     computeGlobalConstants();
-  else
-    distributed_ = params->get("distributed", true) && (comm->getSize() > 1);
+  else {
+    if (comm->getSize() == 1) {
+      minAllGID_           = minMyGID_;
+      maxAllGID_           = maxMyGID_;
+      distributed_         = false;
+      haveGlobalConstants_ = true;
+    } else
+      distributed_ = params->get("distributed", true);
+  }
 
   // Create the Directory on demand in getRemoteIndexList().
   // setupDirectory ();
@@ -1020,10 +1027,17 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
   const bool callComputeGlobalConstants = params.get() == nullptr ||
                                           params->get("compute global constants", true);
 
-  if (callComputeGlobalConstants)
+  if (callComputeGlobalConstants && (comm->getSize() > 1))
     computeGlobalConstants();
-  else
-    distributed_ = params->get("distributed", true) && (comm->getSize() > 1);
+  else {
+    if (comm->getSize() == 1) {
+      minAllGID_           = minMyGID_;
+      maxAllGID_           = maxMyGID_;
+      distributed_         = false;
+      haveGlobalConstants_ = true;
+    } else
+      distributed_ = params->get("distributed", true);
+  }
 
   contiguous_ = false;  // "Contiguous" is conservative.
 
@@ -2013,8 +2027,6 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
     newComm = null;
   }
 
-  TEUCHOS_TEST_FOR_EXCEPTION(!haveGlobalConstants(), std::logic_error, "\"Map::removeEmptyProcesses\" called, but global constants have not been computed with \"Map::computeGlobalConstants\".");
-
   // Create the Map to return.
   if (newComm.is_null()) {
     return null;  // my process does not participate in the new Map
@@ -2053,6 +2065,11 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
     // make the new Map locally replicated.
     if (!distributed_ || newComm->getSize() == 1) {
       map->distributed_ = false;
+      if (newComm->getSize() == 1) {
+        map->minAllGID_           = map->minMyGID_;
+        map->maxAllGID_           = map->maxMyGID_;
+        map->haveGlobalConstants_ = true;
+      }
     } else {
       const int iOwnAllGids  = (numLocalElements_ == numGlobalElements_) ? 1 : 0;
       int allProcsOwnAllGids = 0;

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -754,19 +754,14 @@ void Map<LocalOrdinal, GlobalOrdinal, Node>::
 
   if (req) req->wait();
 
-  const bool callComputeGlobalConstants = params.get() == nullptr ||
-                                          params->get("compute global constants", true);
+  const bool callComputeGlobalConstants = (params.get() == nullptr) ||
+                                          params->get("compute global constants", true) ||
+                                          (comm->getSize() == 1);
 
-  if (callComputeGlobalConstants && (comm->getSize() > 1))
+  if (callComputeGlobalConstants)
     computeGlobalConstants();
   else {
-    if (comm->getSize() == 1) {
-      minAllGID_           = minMyGID_;
-      maxAllGID_           = maxMyGID_;
-      distributed_         = false;
-      haveGlobalConstants_ = true;
-    } else
-      distributed_ = params->get("distributed", true);
+    distributed_ = params->get("distributed", true);
   }
 
   // Create the Directory on demand in getRemoteIndexList().
@@ -1024,19 +1019,14 @@ Map<LocalOrdinal, GlobalOrdinal, Node>::
 
   if (req) req->wait();
 
-  const bool callComputeGlobalConstants = params.get() == nullptr ||
-                                          params->get("compute global constants", true);
+  const bool callComputeGlobalConstants = (params.get() == nullptr) ||
+                                          params->get("compute global constants", true) ||
+                                          (comm->getSize() == 1);
 
-  if (callComputeGlobalConstants && (comm->getSize() > 1))
+  if (callComputeGlobalConstants)
     computeGlobalConstants();
   else {
-    if (comm->getSize() == 1) {
-      minAllGID_           = minMyGID_;
-      maxAllGID_           = maxMyGID_;
-      distributed_         = false;
-      haveGlobalConstants_ = true;
-    } else
-      distributed_ = params->get("distributed", true);
+    distributed_ = params->get("distributed", true);
   }
 
   contiguous_ = false;  // "Contiguous" is conservative.
@@ -1058,6 +1048,14 @@ void Map<LocalOrdinal, GlobalOrdinal, Node>::computeGlobalConstants() {
 
   if (haveGlobalConstants_)
     return;
+
+  if (comm_->getSize() == 1) {
+    minAllGID_           = minMyGID_;
+    maxAllGID_           = maxMyGID_;
+    distributed_         = false;
+    haveGlobalConstants_ = true;
+    return;
+  }
 
   Tpetra::Details::ProfilingRegion pr("Tpetra::Map::computeGlobalConstants");
 


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
- De-duplicate copy-pasted logic for Matrix-Matrix TAFC optimizations.
- Compute global constants when required during Directory construction.
- Allow skipping global constants in additional spots