### PR TITLE
Belos: Add a utility to implement Fischer-style solution projection

### DIFF
--- a/packages/belos/src/BelosSolutionProjection.hpp
+++ b/packages/belos/src/BelosSolutionProjection.hpp
@@ -1,0 +1,556 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+#ifndef BELOS_SOLUTION_PROJECTION_HPP
+#define BELOS_SOLUTION_PROJECTION_HPP
+
+/*! \file BelosSolutionProjection.hpp
+    \brief Utility implementing Fischer's RHS / solution projection scheme.
+
+    This utility stores paired bases U and C satisfying
+
+      A U = C,   C^H C = I,
+
+    and applies the projection
+
+      x <- x + U C^H r,
+      r <- r - C C^H r,
+
+    where r = b - A x.
+
+    This is Fischer's Method 1 when U stores previous solution-like
+    vectors and C stores their corresponding operator images.
+
+    The projection tolerance is relative: a candidate image vector c is
+    rejected if, after orthogonalization against the current C basis,
+
+      ||c_orth|| <= projectionTol * ||c_original||.
+
+    The default replacement strategy is "Restart": if the basis is full
+    and a new vector is accepted, the previous basis is discarded and the
+    new vector starts the next basis.  Thus, when the history space is
+    full, the next accepted vector "kicks off" the new space using the
+    most recent information.
+*/
+
+#include "BelosConfigDefs.hpp"
+#include "BelosTypes.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosMultiVecTraits.hpp"
+#include "BelosOperatorTraits.hpp"
+#include "BelosTeuchosDenseAdapter.hpp"
+#include "BelosKokkosDenseAdapter.hpp"
+
+#include "Teuchos_ParameterList.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_ScalarTraits.hpp"
+
+#include <string>
+#include <vector>
+
+namespace Belos {
+
+class SolutionProjectionFailure : public BelosError {
+public:
+  SolutionProjectionFailure(const std::string& what_arg) :
+    BelosError(what_arg) {}
+};
+
+/*! \class Belos::SolutionProjection
+    \brief Fischer Method 1 style projection utility.
+
+    The class stores a correction basis U and an orthonormal image basis C
+    satisfying A U = C.  The projection is minimum-residual over range(U).
+
+    This utility is intended to be used as a black-box initial-guess
+    generator for sequences of related linear systems.
+*/
+template<class ScalarType, class MV, class OP,
+         class DM = DefaultDenseMatrix<int, ScalarType> >
+class SolutionProjection {
+public:
+  typedef MultiVecTraits<ScalarType,MV,DM> MVT;
+  typedef OperatorTraits<ScalarType,MV,OP> OPT;
+  typedef DenseMatTraits<ScalarType,DM> DMT;
+  typedef Teuchos::ScalarTraits<ScalarType> SCT;
+  typedef typename SCT::magnitudeType MagnitudeType;
+  typedef Teuchos::ScalarTraits<MagnitudeType> MT;
+
+  //! Constructor with explicit maximum basis size.
+  SolutionProjection(const Teuchos::RCP<const OP>& A,
+                     const int maxBasisSize) :
+    A_(A),
+    maxBasisSize_(maxBasisSize),
+    curBasisSize_(0),
+    replacementStrategy_("Restart"),
+    projectionTol_(static_cast<MagnitudeType>(100) * MT::eps()),
+    reorthogonalizationSteps_(2),
+    U_(Teuchos::null),
+    C_(Teuchos::null)
+  {
+    validateParameters();
+  }
+
+  //! Constructor with parameter list.
+  SolutionProjection(const Teuchos::RCP<const OP>& A,
+                     const Teuchos::RCP<Teuchos::ParameterList>& params) :
+    A_(A),
+    maxBasisSize_(20),
+    curBasisSize_(0),
+    replacementStrategy_("Restart"),
+    projectionTol_(static_cast<MagnitudeType>(100) * MT::eps()),
+    reorthogonalizationSteps_(2),
+    U_(Teuchos::null),
+    C_(Teuchos::null)
+  {
+    if (!params.is_null()) {
+      maxBasisSize_ =
+        params->get("Maximum Basis Size", maxBasisSize_);
+      replacementStrategy_ =
+        params->get("Replacement Strategy", replacementStrategy_);
+      projectionTol_ =
+        params->get("Projection Tolerance", projectionTol_);
+      reorthogonalizationSteps_ =
+        params->get("Reorthogonalization Steps", reorthogonalizationSteps_);
+    }
+
+    validateParameters();
+  }
+
+  //! Set or replace the operator.
+  /*!
+      Changing the operator invalidates the stored relation A U = C, so
+      the basis is reset.
+  */
+  void setOperator(const Teuchos::RCP<const OP>& A) {
+    A_ = A;
+    reset();
+  }
+
+  //! Clear the stored projection basis.
+  void reset() {
+    curBasisSize_ = 0;
+  }
+
+  //! Current number of stored basis vectors.
+  int getBasisSize() const {
+    return curBasisSize_;
+  }
+
+  //! Maximum number of stored basis vectors.
+  int getMaxBasisSize() const {
+    return maxBasisSize_;
+  }
+
+  //! Set replacement strategy.
+  void setReplacementStrategy(const std::string& strategy) {
+    replacementStrategy_ = strategy;
+    validateParameters();
+  }
+
+  //! Get replacement strategy.
+  std::string getReplacementStrategy() const {
+    return replacementStrategy_;
+  }
+
+  //! Set relative projection tolerance.
+  void setProjectionTolerance(const MagnitudeType tol) {
+    projectionTol_ = tol;
+    validateParameters();
+  }
+
+  //! Get relative projection tolerance.
+  MagnitudeType getProjectionTolerance() const {
+    return projectionTol_;
+  }
+
+  //! Set number of reorthogonalization passes.
+  void setReorthogonalizationSteps(const int steps) {
+    reorthogonalizationSteps_ = steps;
+    validateParameters();
+  }
+
+  //! Get number of reorthogonalization passes.
+  int getReorthogonalizationSteps() const {
+    return reorthogonalizationSteps_;
+  }
+
+  //! Get correction basis U.
+  Teuchos::RCP<const MV> getCorrectionBasis() const {
+    if (curBasisSize_ == 0 || U_.is_null()) {
+      return Teuchos::null;
+    }
+
+    std::vector<int> ind(curBasisSize_);
+    for (int i = 0; i < curBasisSize_; ++i) {
+      ind[i] = i;
+    }
+
+    return MVT::CloneView(*U_, ind);
+  }
+
+  //! Get image basis C.
+  Teuchos::RCP<const MV> getImageBasis() const {
+    if (curBasisSize_ == 0 || C_.is_null()) {
+      return Teuchos::null;
+    }
+
+    std::vector<int> ind(curBasisSize_);
+    for (int i = 0; i < curBasisSize_; ++i) {
+      ind[i] = i;
+    }
+
+    return MVT::CloneView(*C_, ind);
+  }
+
+  //! Add solution vector(s) u.  The class computes c = A u.
+  int addSolution(const MV& u) {
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      A_.is_null(),
+      SolutionProjectionFailure,
+      "Belos::SolutionProjection::addSolution(): operator is null.");
+
+    const int numVecs = MVT::GetNumberVecs(u);
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      numVecs <= 0,
+      std::invalid_argument,
+      "Belos::SolutionProjection::addSolution(): input multivector must contain at least one vector.");
+
+    Teuchos::RCP<MV> c = MVT::Clone(u, numVecs);
+
+    OPT::Apply(*A_, u, *c);
+
+    return addPair(u, *c);
+  }
+
+  //! Add pair(s) u and c, where c should equal A u.
+  int addPair(const MV& u, const MV& c) {
+    const int numVecs = MVT::GetNumberVecs(u);
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      numVecs <= 0,
+      std::invalid_argument,
+      "Belos::SolutionProjection::addPair(): input multivector must contain at least one vector.");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      MVT::GetNumberVecs(c) != numVecs,
+      std::invalid_argument,
+      "Belos::SolutionProjection::addPair(): u and c must have the same number of vectors.");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      MVT::GetGlobalLength(u) != MVT::GetGlobalLength(c),
+      std::invalid_argument,
+      "Belos::SolutionProjection::addPair(): u and c must have the same global length.");
+
+    if (maxBasisSize_ == 0) {
+      return 0;
+    }
+
+    ensureStorage(u, c);
+
+    int accepted = 0;
+
+    for (int j = 0; j < numVecs; ++j) {
+      std::vector<int> srcInd(1);
+      srcInd[0] = j;
+
+      Teuchos::RCP<const MV> uSrc = MVT::CloneView(u, srcInd);
+      Teuchos::RCP<const MV> cSrc = MVT::CloneView(c, srcInd);
+
+      Teuchos::RCP<MV> uNew = MVT::CloneCopy(*uSrc);
+      Teuchos::RCP<MV> cNew = MVT::CloneCopy(*cSrc);
+
+      const bool ok = addOnePair(*uNew, *cNew);
+      if (ok) {
+        ++accepted;
+      }
+    }
+
+    return accepted;
+  }
+
+  //! Apply projection to x and r, where r is assumed to be b - A x.
+  void project(MV& x, MV& r) const {
+    if (curBasisSize_ == 0) {
+      return;
+    }
+
+    validateProjectionInputs(x, r);
+
+    const ScalarType one = SCT::one();
+
+    const int numRhs = MVT::GetNumberVecs(r);
+
+    std::vector<int> ind(curBasisSize_);
+    for (int i = 0; i < curBasisSize_; ++i) {
+      ind[i] = i;
+    }
+
+    Teuchos::RCP<const MV> Ucur = MVT::CloneView(*U_, ind);
+    Teuchos::RCP<const MV> Ccur = MVT::CloneView(*C_, ind);
+
+    Teuchos::RCP<DM> gamma = DMT::Create(curBasisSize_, numRhs);
+
+    // gamma = C^H r.
+    MVT::MvTransMv(one, *Ccur, r, *gamma);
+
+    // x <- x + U gamma.
+    MVT::MvTimesMatAddMv(one, *Ucur, *gamma, one, x);
+
+    // r <- r - C gamma.
+    MVT::MvTimesMatAddMv(-one, *Ccur, *gamma, one, r);
+  }
+
+  //! Compute r = b - A x, then apply projection to x and r.
+  void project(MV& x,
+               const MV& b,
+               Teuchos::RCP<MV> projectedResidual = Teuchos::null) const {
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      A_.is_null(),
+      SolutionProjectionFailure,
+      "Belos::SolutionProjection::project(): operator is null.");
+
+    validateProjectionInputs(x, b);
+
+    if (!projectedResidual.is_null()) {
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        MVT::GetNumberVecs(*projectedResidual) != MVT::GetNumberVecs(b),
+        std::invalid_argument,
+        "Belos::SolutionProjection::project(): projectedResidual must have the same number of vectors as b.");
+
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        MVT::GetGlobalLength(*projectedResidual) != MVT::GetGlobalLength(b),
+        std::invalid_argument,
+        "Belos::SolutionProjection::project(): projectedResidual must have the same global length as b.");
+    }
+
+    Teuchos::RCP<MV> r = MVT::Clone(b, MVT::GetNumberVecs(b));
+
+    OPT::Apply(*A_, x, *r);
+    MVT::MvAddMv(-SCT::one(), *r, SCT::one(), b, *r);
+
+    project(x, *r);
+
+    if (!projectedResidual.is_null()) {
+      MVT::Assign(*r, *projectedResidual);
+    }
+  }
+
+  //! Project the current solution in a LinearProblem.
+  void project(LinearProblem<ScalarType,MV,OP,DM>& problem,
+               Teuchos::RCP<MV> projectedResidual = Teuchos::null) const {
+    Teuchos::RCP<MV> x = problem.getCurrLHSVec();
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      x.is_null(),
+      SolutionProjectionFailure,
+      "Belos::SolutionProjection::project(LinearProblem): current LHS is null. "
+      "Did you call setLSIndex() or otherwise set the current linear system?");
+
+    Teuchos::RCP<const MV> b = problem.getCurrRHSVec();
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      b.is_null(),
+      SolutionProjectionFailure,
+      "Belos::SolutionProjection::project(LinearProblem): current RHS is null. "
+      "Did you call setLSIndex() or otherwise set the current linear system?");
+
+    if (!projectedResidual.is_null()) {
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        MVT::GetNumberVecs(*projectedResidual) != MVT::GetNumberVecs(*b),
+        std::invalid_argument,
+        "Belos::SolutionProjection::project(LinearProblem): projectedResidual has wrong number of vectors.");
+
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        MVT::GetGlobalLength(*projectedResidual) != MVT::GetGlobalLength(*b),
+        std::invalid_argument,
+        "Belos::SolutionProjection::project(LinearProblem): projectedResidual has wrong global length.");
+    }
+
+    Teuchos::RCP<MV> r = MVT::Clone(*b, MVT::GetNumberVecs(*b));
+
+    // True residual, not preconditioned residual.
+    problem.computeCurrResVec(&*r);
+
+    project(*x, *r);
+
+    if (!projectedResidual.is_null()) {
+      MVT::Assign(*r, *projectedResidual);
+    }
+  }
+
+private:
+  void validateParameters() const {
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      maxBasisSize_ < 0,
+      std::invalid_argument,
+      "Belos::SolutionProjection: maximum basis size must be nonnegative.");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      projectionTol_ < MT::zero(),
+      std::invalid_argument,
+      "Belos::SolutionProjection: projection tolerance must be nonnegative.");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      reorthogonalizationSteps_ < 1,
+      std::invalid_argument,
+      "Belos::SolutionProjection: reorthogonalization steps must be at least one.");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      replacementStrategy_ != "Restart",
+      std::invalid_argument,
+      "Belos::SolutionProjection: currently only \"Restart\" replacement strategy is implemented.");
+  }
+
+  void validateProjectionInputs(const MV& x, const MV& r) const {
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      MVT::GetNumberVecs(x) != MVT::GetNumberVecs(r),
+      std::invalid_argument,
+      "Belos::SolutionProjection::project(): x and residual/right-hand side must have the same number of vectors.");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      MVT::GetGlobalLength(x) != MVT::GetGlobalLength(r),
+      std::invalid_argument,
+      "Belos::SolutionProjection::project(): x and residual/right-hand side must have the same global length.");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      !U_.is_null() && MVT::GetGlobalLength(*U_) != MVT::GetGlobalLength(x),
+      std::invalid_argument,
+      "Belos::SolutionProjection::project(): x has incompatible global length with stored basis.");
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      !C_.is_null() && MVT::GetGlobalLength(*C_) != MVT::GetGlobalLength(r),
+      std::invalid_argument,
+      "Belos::SolutionProjection::project(): residual/right-hand side has incompatible global length with stored basis.");
+  }
+
+  //! Allocate U_ and C_ if necessary.
+  void ensureStorage(const MV& uPrototype, const MV& cPrototype) {
+    if (U_.is_null()) {
+      U_ = MVT::Clone(uPrototype, maxBasisSize_);
+    }
+    else if (MVT::GetNumberVecs(*U_) < maxBasisSize_) {
+      Teuchos::RCP<const MV> tmp = U_;
+      U_ = MVT::Clone(*tmp, maxBasisSize_);
+    }
+
+    // Important: clone C_ from the image vector cPrototype, not uPrototype.
+    if (C_.is_null()) {
+      C_ = MVT::Clone(cPrototype, maxBasisSize_);
+    }
+    else if (MVT::GetNumberVecs(*C_) < maxBasisSize_) {
+      Teuchos::RCP<const MV> tmp = C_;
+      C_ = MVT::Clone(*tmp, maxBasisSize_);
+    }
+  }
+
+  //! Add one pair uNew, cNew, maintaining A U = C and C^H C = I.
+  bool addOnePair(MV& uNew, MV& cNew) {
+    const ScalarType one = SCT::one();
+
+    std::vector<MagnitudeType> initialNorm(1);
+    MVT::MvNorm(cNew, initialNorm);
+
+    if (initialNorm[0] == MT::zero()) {
+      return false;
+    }
+
+    if (curBasisSize_ == maxBasisSize_) {
+      if (replacementStrategy_ == "Restart") {
+        // The next accepted vector starts a new basis, using the most
+        // recent information available.
+        curBasisSize_ = 0;
+      }
+      else {
+        TEUCHOS_TEST_FOR_EXCEPTION(
+          true,
+          SolutionProjectionFailure,
+          "Belos::SolutionProjection: unsupported replacement strategy.");
+      }
+    }
+
+    for (int pass = 0; pass < reorthogonalizationSteps_; ++pass) {
+      if (curBasisSize_ == 0) {
+        break;
+      }
+
+      std::vector<int> ind(curBasisSize_);
+      for (int i = 0; i < curBasisSize_; ++i) {
+        ind[i] = i;
+      }
+
+      Teuchos::RCP<const MV> Ucur = MVT::CloneView(*U_, ind);
+      Teuchos::RCP<const MV> Ccur = MVT::CloneView(*C_, ind);
+
+      Teuchos::RCP<DM> h = DMT::Create(curBasisSize_, 1);
+
+      // h = C^H cNew.
+      MVT::MvTransMv(one, *Ccur, cNew, *h);
+
+      // cNew <- cNew - C h.
+      MVT::MvTimesMatAddMv(-one, *Ccur, *h, one, cNew);
+
+      // uNew <- uNew - U h.
+      //
+      // This keeps A uNew = cNew, assuming A U = C before this step.
+      MVT::MvTimesMatAddMv(-one, *Ucur, *h, one, uNew);
+    }
+
+    std::vector<MagnitudeType> finalNorm(1);
+    MVT::MvNorm(cNew, finalNorm);
+
+    if (finalNorm[0] <= projectionTol_ * initialNorm[0]) {
+      return false;
+    }
+
+    const ScalarType scale =
+      static_cast<ScalarType>(MT::one() / finalNorm[0]);
+
+    MVT::MvScale(cNew, scale);
+    MVT::MvScale(uNew, scale);
+
+    std::vector<int> dstInd(1);
+    dstInd[0] = curBasisSize_;
+
+    MVT::SetBlock(uNew, dstInd, *U_);
+    MVT::SetBlock(cNew, dstInd, *C_);
+
+    ++curBasisSize_;
+
+    return true;
+  }
+
+private:
+  Teuchos::RCP<const OP> A_;
+
+  int maxBasisSize_;
+  int curBasisSize_;
+
+  std::string replacementStrategy_;
+
+  // Relative tolerance.  Candidate pair is rejected if
+  // ||c_orth|| <= projectionTol_ * ||c_original||.
+  MagnitudeType projectionTol_;
+
+  int reorthogonalizationSteps_;
+
+  // Correction basis and image basis.
+  //
+  // Invariant:
+  //
+  //   A U = C,
+  //   C^H C = I.
+  Teuchos::RCP<MV> U_;
+  Teuchos::RCP<MV> C_;
+};
+
+} // namespace Belos
+
+#endif // BELOS_SOLUTION_PROJECTION_HPP

--- a/packages/belos/src/CMakeLists.txt
+++ b/packages/belos/src/CMakeLists.txt
@@ -82,6 +82,7 @@ APPEND_SET(HEADERS
   BelosRCGIter.hpp
   BelosRCGSolMgr.hpp
   BelosSimpleOrthoManager.hpp
+  BelosSolutionProjection.hpp
   BelosSolverManager.hpp
   BelosSolverFactory.hpp
   BelosSolverFactory_Belos.hpp

--- a/packages/belos/test/GCRODR/CMakeLists.txt
+++ b/packages/belos/test/GCRODR/CMakeLists.txt
@@ -14,6 +14,13 @@ IF(Teuchos_ENABLE_COMPLEX)
       "--verbose --filename=mhd1280b.cua"
     )
 
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      solution_projection_complex_hb
+      SOURCES test_solution_projection_complex_hb.cpp
+      ARGS
+        "--verbose --filename=mhd1280b.cua --epsilon=1e-4 --projection-reduction-tol=1e-3 --require-projection-beats-recycled --min-iteration-improvement=200"
+    )
+
   TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyTestGCRODRComplexFiles
     SOURCE_DIR ${Belos_SOURCE_DIR}/testmatrices
     SOURCE_FILES mhd1280b.cua

--- a/packages/belos/test/GCRODR/test_solution_projection_complex_hb.cpp
+++ b/packages/belos/test/GCRODR/test_solution_projection_complex_hb.cpp
@@ -1,0 +1,596 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+//
+// This driver tests Belos::SolutionProjection using a complex
+// Harwell-Boeing matrix.
+//
+// The test does the following:
+//
+//   1. Generate two historical exact solutions u1Exact and u2Exact.
+//   2. Form b1 = A u1Exact and b2 = A u2Exact.
+//   3. Solve these two systems with one persistent GCRODR solver, so that
+//      GCRODR accumulates a recycle space.
+//   4. Add the computed historical solutions to Belos::SolutionProjection.
+//   5. Construct a target exact solution mostly in the span of the computed
+//      historical solutions.
+//   6. Compare:
+//        a. trained GCRODR using its internal recycle space,
+//        b. fresh GCRODR using a SolutionProjection initial guess.
+//
+// The projection utility implements Fischer's Method 1:
+//
+//      A U = C, C^H C = I,
+//      x <- x + U C^H r,
+//      r <- r - C C^H r.
+//
+#include "BelosConfigDefs.hpp"
+#include "BelosLinearProblem.hpp"
+#include "BelosGCRODRSolMgr.hpp"
+#include "BelosSolutionProjection.hpp"
+
+#include "Teuchos_CommandLineProcessor.hpp"
+#include "Teuchos_ParameterList.hpp"
+
+#ifdef HAVE_MPI
+#include <mpi.h>
+#endif
+
+// I/O for Harwell-Boeing files
+#include "Tpetra_Util_iohb.h"
+
+#include "MyMultiVec.hpp"
+#include "MyBetterOperator.hpp"
+#include "MyOperator.hpp"
+
+#include <complex>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include <stdexcept>
+#include <vector>
+
+using namespace Teuchos;
+
+int main(int argc, char *argv[]) {
+  typedef std::complex<double>              ST;
+  typedef ScalarTraits<ST>                  SCT;
+  typedef SCT::magnitudeType                MT;
+  typedef Belos::MultiVec<ST>               MV;
+  typedef Belos::Operator<ST>               OP;
+  typedef Belos::MultiVecTraits<ST,MV>      MVT;
+  typedef Belos::OperatorTraits<ST,MV,OP>   OPT;
+
+  const ST one  = SCT::one();
+  const ST zero = SCT::zero();
+
+  bool success = false;
+  bool verbose = false;
+  bool debug = false;
+
+  int info = 0;
+
+  Teuchos::GlobalMPISession session(&argc, &argv, NULL);
+  const int MyPID = session.getRank();
+
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  try {
+    bool proc_verbose = false;
+    bool requireProjectionBeatsRecycled = false;
+
+    std::string filename("mhd1280b.cua");
+
+    MT solverTol = 1.0e-6;
+    MT projectionReductionTol = 5.0e-2;
+    MT epsilon = 1.0e-2;
+
+    int maxBasisSize = 4;
+    int numBlocks = 100;
+    int numRecycledBlocks = 20;
+    int maxIters = 1000;
+    int minIterationImprovement = 1;
+
+    CommandLineProcessor cmdp(false,true);
+    cmdp.setOption("verbose","quiet",&verbose,"Print messages and results.");
+    cmdp.setOption("debug","no-debug",&debug,"Print debug messages.");
+    cmdp.setOption("filename",&filename,"Filename for Harwell-Boeing test matrix.");
+    cmdp.setOption("solver-tol",&solverTol,
+                   "Relative residual tolerance used by GCRODR solver.");
+    cmdp.setOption("projection-reduction-tol",&projectionReductionTol,
+                   "Required residual reduction from SolutionProjection.");
+    cmdp.setOption("epsilon",&epsilon,
+                   "Size of component outside the stored solution projection space.");
+    cmdp.setOption("max-basis-size",&maxBasisSize,
+                   "Maximum number of vectors stored by SolutionProjection.");
+    cmdp.setOption("num-blocks",&numBlocks,"Number of GCRODR blocks.");
+    cmdp.setOption("num-recycled-blocks",&numRecycledBlocks,
+                   "Number of GCRODR recycled blocks.");
+    cmdp.setOption("max-iters",&maxIters,"Maximum GCRODR iterations.");
+    cmdp.setOption("require-projection-beats-recycled",
+                   "no-require-projection-beats-recycled",
+                   &requireProjectionBeatsRecycled,
+                   "Require fresh GCRODR with SolutionProjection initial guess "
+                   "to use fewer iterations than trained recycled GCRODR.");
+    cmdp.setOption("min-iteration-improvement",&minIterationImprovement,
+                   "Minimum required iteration reduction when "
+                   "--require-projection-beats-recycled is enabled.");
+
+    if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
+      return EXIT_FAILURE;
+    }
+
+    proc_verbose = verbose && (MyPID == 0);
+
+    if (proc_verbose) {
+      std::cout << Belos::Belos_Version() << std::endl << std::endl;
+    }
+
+    // ------------------------------------------------------------------
+    // Read HB matrix.
+    // ------------------------------------------------------------------
+
+    int dim = 0;
+    int dim2 = 0;
+    int nnz = -1;
+
+    MT *dvals = NULL;
+    int *colptr = NULL;
+    int *rowind = NULL;
+    ST *cvals = NULL;
+
+    info = Tpetra::HB::readHB_newmat_double(filename.c_str(), &dim, &dim2, &nnz,
+                                            &colptr, &rowind, &dvals);
+
+    if (info == 0 || nnz < 0) {
+      if (MyPID == 0) {
+        std::cout << "Error reading '" << filename << "'" << std::endl;
+        std::cout << "End Result: TEST FAILED" << std::endl;
+      }
+      return EXIT_FAILURE;
+    }
+
+    // Convert interleaved doubles to std::complex values.
+    cvals = new ST[nnz];
+    for (int ii = 0; ii < nnz; ++ii) {
+      cvals[ii] = ST(dvals[ii*2], dvals[ii*2+1]);
+    }
+
+    RCP<MyBetterOperator<ST> > A =
+      rcp(new MyBetterOperator<ST>(dim, colptr, nnz, rowind, cvals));
+
+    // ------------------------------------------------------------------
+    // Solver parameter list.
+    // ------------------------------------------------------------------
+
+    ParameterList belosList;
+    belosList.set("Maximum Iterations", maxIters);
+    belosList.set("Convergence Tolerance", solverTol);
+    belosList.set("Num Blocks", numBlocks);
+    belosList.set("Num Recycled Blocks", numRecycledBlocks);
+
+    // Use RHS scaling because SolutionProjection changes the initial guess
+    // before LinearProblem::setProblem().
+    belosList.set("Implicit Residual Scaling", "Norm of RHS");
+    belosList.set("Explicit Residual Scaling", "Norm of RHS");
+
+    if (verbose) {
+      int verbosity = Belos::Errors + Belos::Warnings +
+        Belos::TimingDetails + Belos::StatusTestDetails;
+      if (debug) {
+        verbosity += Belos::OrthoDetails + Belos::Debug;
+      }
+      belosList.set("Verbosity", verbosity);
+    }
+    else {
+      belosList.set("Verbosity", Belos::Errors + Belos::Warnings);
+    }
+
+    if (proc_verbose) {
+      std::cout << "Dimension of matrix: " << dim << std::endl;
+      std::cout << "GCRODR Num Blocks: " << numBlocks << std::endl;
+      std::cout << "GCRODR Num Recycled Blocks: " << numRecycledBlocks << std::endl;
+      std::cout << "GCRODR tolerance: " << solverTol << std::endl;
+      std::cout << "Projection epsilon: " << epsilon << std::endl;
+      std::cout << std::endl;
+    }
+
+    // ------------------------------------------------------------------
+    // Helper for forming b = A x.
+    // ------------------------------------------------------------------
+
+    auto makeRHS =
+      [&](const RCP<MyMultiVec<ST> >& xExact) -> RCP<MyMultiVec<ST> >
+      {
+        RCP<MyMultiVec<ST> > b = rcp(new MyMultiVec<ST>(dim, 1));
+        OPT::Apply(*A, *xExact, *b);
+        return b;
+      };
+
+    // ------------------------------------------------------------------
+    // Helper for computing ||b - A x|| / ||b||.
+    // ------------------------------------------------------------------
+
+    auto computeRelativeResidual =
+      [&](const RCP<MyMultiVec<ST> >& x,
+          const RCP<MyMultiVec<ST> >& b) -> MT
+      {
+        RCP<MyMultiVec<ST> > residual = rcp(new MyMultiVec<ST>(dim, 1));
+
+        OPT::Apply(*A, *x, *residual);
+        MVT::MvAddMv(one, *b, -one, *residual, *residual);
+
+        std::vector<MT> residualNorm(1);
+        std::vector<MT> rhsNorm(1);
+
+        MVT::MvNorm(*residual, residualNorm);
+        MVT::MvNorm(*b, rhsNorm);
+
+        return residualNorm[0] / rhsNorm[0];
+      };
+
+    // ------------------------------------------------------------------
+    // Helper result type.
+    // ------------------------------------------------------------------
+
+    struct SolveResult {
+      int iters;
+      MT finalRelResidual;
+      Belos::ReturnType ret;
+      RCP<MyMultiVec<ST> > solution;
+    };
+
+    // ------------------------------------------------------------------
+    // Helper for solving with an existing GCRODR solver and LinearProblem.
+    //
+    // This is used to preserve GCRODR's recycle space across historical
+    // solves and the target solve.
+    // ------------------------------------------------------------------
+
+    auto solveWithExistingSolver =
+      [&](Belos::GCRODRSolMgr<ST,MV,OP>& solver,
+          const RCP<Belos::LinearProblem<ST,MV,OP> >& problem,
+          const RCP<MyMultiVec<ST> >& x,
+          const RCP<MyMultiVec<ST> >& b,
+          const std::string& label) -> SolveResult
+      {
+        const bool set = problem->setProblem(x, b);
+
+        TEUCHOS_TEST_FOR_EXCEPTION(
+          !set,
+          std::runtime_error,
+          "Belos::LinearProblem failed to set up correctly.");
+
+        Belos::ReturnType ret = solver.solve();
+
+        SolveResult result;
+        result.iters = solver.getNumIters();
+        result.finalRelResidual = computeRelativeResidual(x, b);
+        result.ret = ret;
+        result.solution = x;
+
+        if (proc_verbose) {
+          std::cout << label << " iterations: "
+                    << result.iters << std::endl;
+          std::cout << label << " final relative true residual: "
+                    << result.finalRelResidual << std::endl;
+        }
+
+        return result;
+      };
+
+    // ------------------------------------------------------------------
+    // Helper for solving with a fresh GCRODR solver.
+    // ------------------------------------------------------------------
+
+    auto solveWithFreshSolver =
+      [&](const RCP<MyMultiVec<ST> >& x,
+          const RCP<MyMultiVec<ST> >& b,
+          const std::string& label) -> SolveResult
+      {
+        RCP<Belos::LinearProblem<ST,MV,OP> > problem =
+          rcp(new Belos::LinearProblem<ST,MV,OP>(A, x, b));
+
+        const bool set = problem->setProblem();
+
+        TEUCHOS_TEST_FOR_EXCEPTION(
+          !set,
+          std::runtime_error,
+          "Belos::LinearProblem failed to set up correctly.");
+
+        Belos::GCRODRSolMgr<ST,MV,OP> solver(problem, rcp(&belosList, false));
+
+        Belos::ReturnType ret = solver.solve();
+
+        SolveResult result;
+        result.iters = solver.getNumIters();
+        result.finalRelResidual = computeRelativeResidual(x, b);
+        result.ret = ret;
+        result.solution = x;
+
+        if (proc_verbose) {
+          std::cout << label << " iterations: "
+                    << result.iters << std::endl;
+          std::cout << label << " final relative true residual: "
+                    << result.finalRelResidual << std::endl;
+        }
+
+        return result;
+      };
+
+    // ------------------------------------------------------------------
+    // Build historical exact solutions and RHS vectors.
+    // ------------------------------------------------------------------
+
+    RCP<MyMultiVec<ST> > u1Exact = rcp(new MyMultiVec<ST>(dim, 1));
+    RCP<MyMultiVec<ST> > u2Exact = rcp(new MyMultiVec<ST>(dim, 1));
+    RCP<MyMultiVec<ST> > noise = rcp(new MyMultiVec<ST>(dim, 1));
+
+    MVT::MvRandom(*u1Exact);
+    MVT::MvRandom(*u2Exact);
+    MVT::MvRandom(*noise);
+
+    RCP<MyMultiVec<ST> > b1 = makeRHS(u1Exact);
+    RCP<MyMultiVec<ST> > b2 = makeRHS(u2Exact);
+
+    // ------------------------------------------------------------------
+    // Persistent GCRODR solver for historical solves.
+    // ------------------------------------------------------------------
+
+    RCP<MyMultiVec<ST> > dummyX = rcp(new MyMultiVec<ST>(dim, 1));
+    RCP<MyMultiVec<ST> > dummyB = rcp(new MyMultiVec<ST>(dim, 1));
+    MVT::MvInit(*dummyX, zero);
+    MVT::MvInit(*dummyB, zero);
+
+    RCP<Belos::LinearProblem<ST,MV,OP> > recycledProblem =
+      rcp(new Belos::LinearProblem<ST,MV,OP>(A, dummyX, dummyB));
+
+    recycledProblem->setProblem();
+
+    Belos::GCRODRSolMgr<ST,MV,OP> recycledSolver(
+      recycledProblem, rcp(&belosList, false));
+
+    // ------------------------------------------------------------------
+    // SolutionProjection database.
+    // ------------------------------------------------------------------
+
+    Belos::SolutionProjection<ST,MV,OP> projection(A, maxBasisSize);
+
+    // ------------------------------------------------------------------
+    // Historical solve 1.
+    // ------------------------------------------------------------------
+
+    RCP<MyMultiVec<ST> > xHist1 = rcp(new MyMultiVec<ST>(dim, 1));
+    MVT::MvInit(*xHist1, zero);
+
+    SolveResult hist1 =
+      solveWithExistingSolver(recycledSolver, recycledProblem,
+                              xHist1, b1, "History solve 1");
+
+    bool historyFailure = false;
+    if (hist1.ret != Belos::Converged ||
+        hist1.finalRelResidual > solverTol) {
+      historyFailure = true;
+      if (proc_verbose) {
+        std::cout << "ERROR: History solve 1 failed." << std::endl;
+      }
+    }
+
+    const int accepted1 = projection.addSolution(*hist1.solution);
+
+    // ------------------------------------------------------------------
+    // Historical solve 2.
+    // ------------------------------------------------------------------
+
+    RCP<MyMultiVec<ST> > xHist2 = rcp(new MyMultiVec<ST>(dim, 1));
+    MVT::MvInit(*xHist2, zero);
+
+    SolveResult hist2 =
+      solveWithExistingSolver(recycledSolver, recycledProblem,
+                              xHist2, b2, "History solve 2");
+
+    if (hist2.ret != Belos::Converged ||
+        hist2.finalRelResidual > solverTol) {
+      historyFailure = true;
+      if (proc_verbose) {
+        std::cout << "ERROR: History solve 2 failed." << std::endl;
+      }
+    }
+
+    const int accepted2 = projection.addSolution(*hist2.solution);
+
+    if (proc_verbose) {
+      std::cout << "SolutionProjection accepted historical vectors: "
+                << accepted1 << " + " << accepted2 << std::endl;
+      std::cout << "Projection basis size after history: "
+                << projection.getBasisSize() << std::endl;
+    }
+
+    bool projectionBasisFailure = false;
+    if (projection.getBasisSize() < 2) {
+      projectionBasisFailure = true;
+      if (proc_verbose) {
+        std::cout << "ERROR: SolutionProjection failed to build a basis of size 2."
+                  << std::endl;
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // Construct target exact solution from computed historical solutions.
+    //
+    //   xTarget = 0.7 xHist1 - 0.25 xHist2 + epsilon * noise.
+    //
+    // Then targetB = A xTarget.
+    // ------------------------------------------------------------------
+
+    RCP<MyMultiVec<ST> > xTargetExact = rcp(new MyMultiVec<ST>(dim, 1));
+    RCP<MyMultiVec<ST> > tmp = rcp(new MyMultiVec<ST>(dim, 1));
+
+    MVT::MvAddMv(ST(0.7), *hist1.solution,
+                 ST(-0.25), *hist2.solution,
+                 *xTargetExact);
+
+    MVT::MvAddMv(one, *xTargetExact,
+                 ST(epsilon), *noise,
+                 *tmp);
+
+    MVT::Assign(*tmp, *xTargetExact);
+
+    RCP<MyMultiVec<ST> > targetB = makeRHS(xTargetExact);
+
+    // ------------------------------------------------------------------
+    // Apply SolutionProjection to zero target initial guess.
+    // ------------------------------------------------------------------
+
+    RCP<MyMultiVec<ST> > targetXProjected =
+      rcp(new MyMultiVec<ST>(dim, 1));
+    RCP<MyMultiVec<ST> > targetXRecycled =
+      rcp(new MyMultiVec<ST>(dim, 1));
+
+    MVT::MvInit(*targetXProjected, zero);
+    MVT::MvInit(*targetXRecycled, zero);
+
+    RCP<MyMultiVec<ST> > projectedResidual =
+      rcp(new MyMultiVec<ST>(dim, 1));
+
+    projection.project(*targetXProjected, *targetB, projectedResidual);
+
+    std::vector<MT> projectedResidualNorm(1);
+    std::vector<MT> targetRhsNorm(1);
+
+    MVT::MvNorm(*projectedResidual, projectedResidualNorm);
+    MVT::MvNorm(*targetB, targetRhsNorm);
+
+    const MT projectionReduction =
+      projectedResidualNorm[0] / targetRhsNorm[0];
+
+    if (proc_verbose) {
+      std::cout << "Target projection residual ratio: "
+                << projectionReduction << std::endl;
+    }
+
+    bool projectionFailure = false;
+    if (projectionReduction > projectionReductionTol) {
+      projectionFailure = true;
+      if (proc_verbose) {
+        std::cout << "ERROR: SolutionProjection did not sufficiently reduce "
+                  << "the target residual." << std::endl;
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // Target solve A: trained GCRODR with its internal recycle space.
+    // ------------------------------------------------------------------
+
+    SolveResult recycledTarget =
+      solveWithExistingSolver(recycledSolver, recycledProblem,
+                              targetXRecycled, targetB,
+                              "Target trained GCRODR");
+
+    bool recycledTargetFailure = false;
+    if (recycledTarget.ret != Belos::Converged ||
+        recycledTarget.finalRelResidual > solverTol) {
+      recycledTargetFailure = true;
+      if (proc_verbose) {
+        std::cout << "ERROR: Trained recycled GCRODR target solve failed."
+                  << std::endl;
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // Target solve B: fresh GCRODR with SolutionProjection initial guess.
+    // ------------------------------------------------------------------
+
+    SolveResult projectedTarget =
+      solveWithFreshSolver(targetXProjected, targetB,
+                           "Target projected fresh GCRODR");
+
+    bool projectedTargetFailure = false;
+    if (projectedTarget.ret != Belos::Converged ||
+        projectedTarget.finalRelResidual > solverTol) {
+      projectedTargetFailure = true;
+      if (proc_verbose) {
+        std::cout << "ERROR: Projected fresh GCRODR target solve failed."
+                  << std::endl;
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // Optional strict comparison.
+    // ------------------------------------------------------------------
+
+    bool comparisonFailure = false;
+
+    const int observedImprovement =
+      recycledTarget.iters - projectedTarget.iters;
+
+    if (proc_verbose) {
+      std::cout << "Target trained GCRODR iterations: "
+                << recycledTarget.iters << std::endl;
+      std::cout << "Target projected fresh GCRODR iterations: "
+                << projectedTarget.iters << std::endl;
+      std::cout << "Projected-vs-recycled iteration improvement: "
+                << observedImprovement << std::endl;
+    }
+
+    if (requireProjectionBeatsRecycled &&
+        observedImprovement < minIterationImprovement) {
+      comparisonFailure = true;
+      if (proc_verbose) {
+        std::cout << "ERROR: Projection initial guess did not beat trained "
+                  << "GCRODR recycle space by the required amount.  Required "
+                  << "improvement: " << minIterationImprovement
+                  << ", observed improvement: " << observedImprovement
+                  << std::endl;
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // Add the target projected solution to the projection basis.
+    // This exercises post-solve basis update.
+    // ------------------------------------------------------------------
+
+    const int acceptedTarget =
+      projection.addSolution(*projectedTarget.solution);
+
+    if (proc_verbose) {
+      std::cout << "Accepted target solution vector(s): "
+                << acceptedTarget << std::endl;
+      std::cout << "Final projection basis size: "
+                << projection.getBasisSize() << std::endl;
+    }
+
+    // Clean up.
+    delete [] dvals;
+    delete [] colptr;
+    delete [] rowind;
+    delete [] cvals;
+
+    success =
+      !historyFailure &&
+      !projectionBasisFailure &&
+      !projectionFailure &&
+      !recycledTargetFailure &&
+      !projectedTargetFailure &&
+      !comparisonFailure;
+
+    if (proc_verbose) {
+      if (success) {
+        std::cout << "End Result: TEST PASSED" << std::endl;
+      }
+      else {
+        std::cout << "End Result: TEST FAILED" << std::endl;
+      }
+    }
+  }
+  TEUCHOS_STANDARD_CATCH_STATEMENTS(verbose, std::cerr, success);
+
+  return success ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
@trilinos/belos

Adds a utility that implements method 1 from:

```
@article{fischer1998projection,
  title={Projection techniques for iterative solution of Ax= b with successive right-hand sides},
  author={Fischer, Paul F},
  journal={Computer methods in applied mechanics and engineering},
  volume={163},
  number={1-4},
  pages={193--204},
  year={1998},
  publisher={Elsevier}
}
```

While not a "solver" per se, I think this makes sense to have housed inside Belos.