### PR TITLE
Belos:  Add character string check for updated return type

### DIFF
--- a/packages/belos/test/MVOPTester/MyOperator.hpp
+++ b/packages/belos/test/MVOPTester/MyOperator.hpp
@@ -29,7 +29,7 @@
  *
  * \date Last modified on 01-Nov-05
  */
-template <class ScalarType, class DM>
+template <class ScalarType, class DM = Belos::DefaultDenseMatrix<int, ScalarType>>
 class MyOperator : public Belos::Operator<ScalarType, DM>
 {
 

--- a/packages/belos/tpetra/test/LinearSolverFactory/SolverFactoryBreakdownDetected.cpp
+++ b/packages/belos/tpetra/test/LinearSolverFactory/SolverFactoryBreakdownDetected.cpp
@@ -131,8 +131,11 @@ testSolver (Teuchos::FancyOStream& out,
   Belos::SolverFactory<SC, MV, OP> factory;
 
   // Set up Belos solver parameters.
+  int verbosity = Belos::Errors + Belos::Warnings
+                  + Belos::TimingDetails + Belos::StatusTestDetails;
+
   Teuchos::RCP<Teuchos::ParameterList> belosList = Teuchos::parameterList (solverName);
-  belosList->set ("Verbosity", Belos::Errors + Belos::Warnings);
+  belosList->set ("Verbosity", verbosity);
   belosList->set("Maximum Iterations", 1); 
 
   try {
@@ -176,6 +179,13 @@ testSolver (Teuchos::FancyOStream& out,
       << endl;
 
   if ( (ret != Belos::BreakdownDetected) ) {
+    success = false;
+    return;
+  }
+
+  if ( convertReturnTypeToString(ret) != "BreakdownDetected" ) {
+    out << "Return type and string conversion of return type do not match!"
+        << endl;
     success = false;
     return;
   }

--- a/packages/belos/tpetra/test/LinearSolverFactory/SolverFactoryLossOfAccuracy.cpp
+++ b/packages/belos/tpetra/test/LinearSolverFactory/SolverFactoryLossOfAccuracy.cpp
@@ -291,6 +291,13 @@ testSolver (Teuchos::FancyOStream& out,
     return;
   }
 
+  if ( convertReturnTypeToString(ret) != "LossOfAccuracyDetected" ) {
+    out << "Return type and string conversion of return type do not match!"
+        << endl;
+    success = false;
+    return;
+  }
+
   success = true;
 }
 

--- a/packages/belos/tpetra/test/LinearSolverFactory/SolverFactoryMaxIters.cpp
+++ b/packages/belos/tpetra/test/LinearSolverFactory/SolverFactoryMaxIters.cpp
@@ -120,8 +120,11 @@ testSolver (Teuchos::FancyOStream& out,
   Belos::SolverFactory<SC, MV, OP> factory;
 
   // Set up Belos solver parameters.
+  int verbosity = Belos::Errors + Belos::Warnings
+                  + Belos::TimingDetails + Belos::StatusTestDetails;
+
   Teuchos::RCP<Teuchos::ParameterList> belosList = Teuchos::parameterList (solverName);
-  belosList->set ("Verbosity", Belos::Errors + Belos::Warnings);
+  belosList->set ("Verbosity", verbosity);
   belosList->set("Maximum Iterations", 1); 
 
   try {
@@ -165,6 +168,13 @@ testSolver (Teuchos::FancyOStream& out,
       << endl;
 
   if ( (ret != Belos::MaxItersReached) ) {
+    success = false;
+    return;
+  }
+
+  if ( convertReturnTypeToString(ret) != "MaxItersReached" ) {
+    out << "Return type and string conversion of return type do not match!"
+        << endl;
     success = false;
     return;
   }

--- a/packages/belos/tpetra/test/LinearSolverFactory/SolverFactoryMaxRestarts.cpp
+++ b/packages/belos/tpetra/test/LinearSolverFactory/SolverFactoryMaxRestarts.cpp
@@ -131,8 +131,11 @@ testSolver (Teuchos::FancyOStream& out,
   Belos::SolverFactory<SC, MV, OP> factory;
 
   // Set up Belos solver parameters.
+  int verbosity = Belos::Errors + Belos::Warnings
+                  + Belos::TimingDetails + Belos::StatusTestDetails;
+
   Teuchos::RCP<Teuchos::ParameterList> belosList = Teuchos::parameterList (solverName);
-  belosList->set ("Verbosity", Belos::Errors + Belos::Warnings);
+  belosList->set ("Verbosity", verbosity);
   belosList->set("Maximum Iterations", 8); 
   belosList->set("Maximum Restarts", 2); 
   belosList->set("Num Blocks", 1); 
@@ -178,6 +181,13 @@ testSolver (Teuchos::FancyOStream& out,
       << endl;
 
   if ( (ret != Belos::MaxRestartsReached) ) {
+    success = false;
+    return;
+  }
+
+  if ( convertReturnTypeToString(ret) != "MaxRestartsReached" ) {
+    out << "Return type and string conversion of return type do not match!"
+        << endl;
     success = false;
     return;
   }

--- a/packages/belos/tpetra/test/LinearSolverFactory/SolverFactoryNaN.cpp
+++ b/packages/belos/tpetra/test/LinearSolverFactory/SolverFactoryNaN.cpp
@@ -134,8 +134,11 @@ testSolver (Teuchos::FancyOStream& out,
   Belos::SolverFactory<SC, MV, OP> factory;
 
   // Set up Belos solver parameters.
+  int verbosity = Belos::Errors + Belos::Warnings
+                  + Belos::TimingDetails + Belos::StatusTestDetails;
+
   Teuchos::RCP<Teuchos::ParameterList> belosList = Teuchos::parameterList (solverName);
-  belosList->set ("Verbosity", Belos::Errors + Belos::Warnings);
+  belosList->set ("Verbosity", verbosity);
 
   try {
     solver = factory.create (solverName, belosList);
@@ -188,6 +191,13 @@ testSolver (Teuchos::FancyOStream& out,
       nonZeroX = true;
   } 
   if ( nonZeroX || (ret != Belos::NaNDetected) || ( solver->achievedTol() != MTS::one() ) ) {
+    success = false;
+    return;
+  }
+
+  if ( convertReturnTypeToString(ret) != "NaNDetected" ) {
+    out << "Return type and string conversion of return type do not match!"
+        << endl;
     success = false;
     return;
   }

--- a/packages/belos/tpetra/test/LinearSolverFactory/SolverFactoryOrthonormFailure.cpp
+++ b/packages/belos/tpetra/test/LinearSolverFactory/SolverFactoryOrthonormFailure.cpp
@@ -142,8 +142,11 @@ testSolver (Teuchos::FancyOStream& out,
   Belos::SolverFactory<SC, MV, OP> factory;
 
   // Set up Belos solver parameters.
+  int verbosity = Belos::Errors + Belos::Warnings
+                  + Belos::TimingDetails + Belos::StatusTestDetails;
+
   Teuchos::RCP<Teuchos::ParameterList> belosList = Teuchos::parameterList (solverName);
-  belosList->set ("Verbosity", Belos::Errors + Belos::Warnings);
+  belosList->set ("Verbosity", verbosity);
   belosList->set("Maximum Iterations", 10);
   if (solverName == "BLOCK GMRES") {
     belosList->set("Flexible Gmres", false);
@@ -200,6 +203,13 @@ testSolver (Teuchos::FancyOStream& out,
       << endl;
 
   if ( (ret != Belos::OrthonormFailure) ) {
+    success = false;
+    return;
+  }
+
+  if ( convertReturnTypeToString(ret) != "OrthonormFailure" ) {
+    out << "Return type and string conversion of return type do not match!"
+        << endl;
     success = false;
     return;
   }


### PR DESCRIPTION
<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.
-->
@trilinos/belos 

## Motivation
 * The extended return types have a utility function to convert them to a character string.  The logic of that function would always return "Unconverged", which is an error.  This was addressed in PR #15612, but this PR adds a test to make sure that has been fixed.

## Related Issues
 * Related to #15612 

## Testing
 * Clang 21.0.0 serial and parallel

