### PR TITLE
Amesos2: remove `using namespace std` in basker solver

### DIFF
--- a/packages/amesos2/src/basker/basker_def.hpp
+++ b/packages/amesos2/src/basker/basker_def.hpp
@@ -18,8 +18,6 @@
 #include <iostream>
 #include <cstdio>
 
-using namespace std;
-
 //#define BASKER_DEBUG 1
 //#undef UDEBUG
 
@@ -282,7 +280,7 @@ namespace BaskerClassicNS{
       {
 
 #ifdef BASKER_DEBUG
-        cout << "k = " << k << endl;
+        std::cout << "k = " << k << std::endl;
 #endif
 
         value = 0.0;
@@ -322,9 +320,9 @@ namespace BaskerClassicNS{
 
         xnnz = ncol - top;
 #ifdef BASKER_DEBUG
-        cout << top << endl;
-        cout << ncol << endl;
-        cout << xnnz << endl;
+        std::cout << top << std::endl;
+        std::cout << ncol << std::endl;
+        std::cout << xnnz << std::endl;
         //BASKERASSERT(xnnz <= nrow);
 #endif
         /*Lx = b where x will be the column k in L and U*/
@@ -374,7 +372,7 @@ namespace BaskerClassicNS{
 
         if(maxindex == ncol || pivot == ((Entry)0))
           {
-            cout << "Matrix is singular at index: " << maxindex << " pivot: " << pivot << endl;
+            std::cout << "Matrix is singular at index: " << maxindex << " pivot: " << pivot << std::endl;
             ierr = maxindex;
             return ierr;
           }
@@ -383,7 +381,7 @@ namespace BaskerClassicNS{
 #ifdef BASKER_DEBUG
         if(maxindex != k )
           {
-            cout << "Permuting pivot: " << k << " for row: " << maxindex << endl;
+            std::cout << "Permuting pivot: " << k << " for row: " << maxindex << std::endl;
           }
 #endif
 
@@ -392,13 +390,13 @@ namespace BaskerClassicNS{
 
             newsize = L->nnz * 1.1 + 2*nrow + 1;
 #ifdef BASKER_DEBUG
-            cout << "Out of memory -- Reallocating.  Old Size: " << L->nnz << " New Size: " << newsize << endl;
+            std::cout << "Out of memory -- Reallocating.  Old Size: " << L->nnz << " New Size: " << newsize << std::endl;
 #endif
             //L->row_idx = (Int *) BASKERREALLOC(L->row_idx, newsize*sizeof(Int));
             L->row_idx = int_realloc(L->row_idx , L->nnz, newsize);
             if(!(L->row_idx))
               {
-                cout << "WARNING: Cannot Realloc Memory" << endl;
+                std::cout << "WARNING: Cannot Realloc Memory" << std::endl;
                 ierr = -3;
                 return ierr;
               }
@@ -406,7 +404,7 @@ namespace BaskerClassicNS{
             L->val = entry_realloc(L->val, L->nnz, newsize);
             if(!(L->val))
               {
-                cout << "WARNING: Cannot Realloc Memory" << endl;
+                std::cout << "WARNING: Cannot Realloc Memory" << std::endl;
                 ierr = -3;
                 return ierr;
               }
@@ -418,13 +416,13 @@ namespace BaskerClassicNS{
           {
             newsize = U->nnz*1.1 + 2*nrow + 1;
 #ifdef BASKER_DEBUG
-            cout << "Out of memory -- Reallocating.  Old Size: " << U->nnz << " New Size: " << newsize << endl;
+            std::cout << "Out of memory -- Reallocating.  Old Size: " << U->nnz << " New Size: " << newsize << std::endl;
 #endif
             //U->row_idx = (Int *) BASKERREALLOC(U->row_idx, newsize*sizeof(Int));
             U->row_idx = int_realloc(U->row_idx, U->nnz, newsize);
             if(!(U->row_idx))
               {
-                cout << "WARNING: Cannot Realloc Memory" << endl;
+                std::cout << "WARNING: Cannot Realloc Memory" << std::endl;
                 ierr = -3;
                 return ierr;
               }
@@ -433,7 +431,7 @@ namespace BaskerClassicNS{
             U->val = entry_realloc(U->val, U->nnz, newsize);
             if(!(U->val))
               {
-                cout << "WARNING: Cannot Realloc Memory" << endl;
+                std::cout << "WARNING: Cannot Realloc Memory" << std::endl;
                 ierr = -3;
                 return ierr;
               }
@@ -462,7 +460,7 @@ namespace BaskerClassicNS{
                   {
                     if(unnz >= U->nnz)
                       {
-                        cout << "BASKER: Insufficent memory for U" << endl;
+                        std::cout << "BASKER: Insufficent memory for U" << std::endl;
                         ierr = -3;
                         return ierr;
                       }
@@ -477,7 +475,7 @@ namespace BaskerClassicNS{
                       {
 
                         last_v_temp = X[j];
-                        //cout << "Called.  t: " << t << "Val: " << last_v_temp << endl;
+                        //std::cout << "Called.  t: " << t << "Val: " << last_v_temp << std::endl;
                       }
 
                   }
@@ -485,7 +483,7 @@ namespace BaskerClassicNS{
                   {
                     if(lnnz >= L->nnz)
                       {
-                        cout << "BASKER: Insufficent memory for L" << endl;
+                        std::cout << "BASKER: Insufficent memory for L" << std::endl;
                         ierr = -3;
                         return ierr;
                       }
@@ -503,7 +501,7 @@ namespace BaskerClassicNS{
             X[j] = 0;
 
           }
-        //cout << "Value added at end: " << last_v_temp << endl;
+        //std::cout << "Value added at end: " << last_v_temp << std::endl;
         U->row_idx[unnz] = k;
         U->val[unnz] = last_v_temp;
         unnz++;
@@ -527,35 +525,35 @@ namespace BaskerClassicNS{
       {
         printf("L[%d]=%g" , k , L->val[k]);
       }
-    cout << endl;
+    std::cout << std::endl;
     for(k = 0; k < lnnz; k++)
       {
         printf("Li[%d]=%d", k, L->row_idx[k]);
       }
-    cout << endl;
+    std::cout << std::endl;
     for(k = 0; k < nrow; k++)
       {
         printf("p[%d]=%d", k, pinv[k]);
       }
-    cout << endl;
-    cout << endl;
+    std::cout << std::endl;
+    std::cout << std::endl;
 
     for(k = 0; k < ncol; k++)
       {
         printf("Up[%d]=%d", k, U->col_ptr[k]);
       }
-    cout << endl;
+    std::cout << std::endl;
 
     for(k = 0; k < unnz; k++)
       {
         printf("U[%d]=%g" , k , U->val[k]);
       }
-    cout << endl;
+    std::cout << std::endl;
     for(k = 0; k < unnz; k++)
       {
         printf("Ui[%d]=%d", k, U->row_idx[k]);
       }
-    cout << endl;
+    std::cout << std::endl;
 
 
 #endif
@@ -572,12 +570,12 @@ namespace BaskerClassicNS{
     //sort_factors();
 
 #ifdef BASKER_DEBUG
-    cout << "After Permuting" << endl;
+    std::cout << "After Permuting" << std::endl;
     for(k = 0; k < lnnz; k++)
       {
         printf("Li[%d]=%d", k, L->row_idx[k]);
       }
-    cout << endl;
+    std::cout << std::endl;
 #endif
 
     // Cleanup workspace allocations
@@ -736,7 +734,7 @@ namespace BaskerClassicNS{
         int result = solve(&(b[k]), &(x[k]));
         if(result != 0)
           {
-            cout << "Error in Solving \n";
+            std::cout << "Error in Solving \n";
             return result;
           }
       }
@@ -812,7 +810,7 @@ namespace BaskerClassicNS{
 #else
         if(val[col_ptr[i]-1] == (Entry) 0)
           {
-            cout << "Dig(" << i << ") = " << val[col_ptr[i]-1] << endl;
+            std::cout << "Dig(" << i << ") = " << val[col_ptr[i]-1] << std::endl;
             return i;
           }
 #endif

--- a/packages/amesos2/src/basker/basker_driver.cpp
+++ b/packages/amesos2/src/basker/basker_driver.cpp
@@ -15,9 +15,6 @@
 #include "basker_decl.hpp"
 #include "basker_def.hpp"
 
-
-using namespace std;
-
 int main(int argc, char* argv[])
 {
 
@@ -46,7 +43,7 @@ int main(int argc, char* argv[])
   fp >> temp;
   annz = atoi(temp.c_str());
 
-  cout << "Size: " << anrow << " nnz: " << annz << endl;
+  std::cout << "Size: " << anrow << " nnz: " << annz << std::endl;
   Ap = new Int[anrow+1];
   Ai = new Int[annz];
   Ax = new Entry[annz];
@@ -63,7 +60,7 @@ int main(int argc, char* argv[])
       Ai[i] = atoi(t.c_str())-1;
       if(i == 0)
         {
-          cout << "First index: " << Ai[i] << endl;
+          std::cout << "First index: " << Ai[i] << std::endl;
         }
     }
   for(int i=0; i < annz; i++)
@@ -92,7 +89,7 @@ int main(int argc, char* argv[])
 
 
 
-  cout << "Done allocating space" << endl;
+  std::cout << "Done allocating space" << std::endl;
   BaskerClassicNS::BaskerClassic<int, double> mybasker;
   mybasker.factor(anrow, ancol,annz, Ap, Ai, Ax);
 
@@ -101,8 +98,8 @@ int main(int argc, char* argv[])
 
 
   free(pp);
-  //cout << "pp(0): " << pp[0] << endl;
-  //cout << "pp(2): " << pp[2] << endl;
+  //std::cout << "pp(0): " << pp[0] << std::endl;
+  //std::cout << "pp(2): " << pp[2] << std::endl;
 
   /*Try to solve a problem*/
   Entry *x = (Entry *)calloc(anrow, sizeof(Entry));
@@ -119,10 +116,10 @@ int main(int argc, char* argv[])
  mybasker.solve(b, x);
 
 
-  cout << "Solution:" << endl;
+  std::cout << "Solution:" << std::endl;
   for(int i = 0; i < anrow; i++)
     {
-      cout << x[i] << endl;
+      std::cout << x[i] << std::endl;
     }
 
 

--- a/packages/amesos2/src/basker/baskermex_solve.cpp
+++ b/packages/amesos2/src/basker/baskermex_solve.cpp
@@ -163,7 +163,7 @@ void mexFunction
 
     for (i=0; i < ancol; i++)
       {
-	//cout << solution[i] << endl;
+	//std::cout << solution[i] << std::endl;
 	sol_out[i] = solution[i];
       }
 


### PR DESCRIPTION
@trilinos/amesos2

This PR: 
- removes two `using namespace std` in the basker solver in Amesos2.

Correspondingly, a number of instances of `cout` and `endl` are replaced with `std::cout` and `std::endl`.

The immediate motivation is to fix a compile-time error when compiling Trilinos with CUDA 13.3.1.

- https://github.com/NVIDIA/cccl/issues/11003#issuecomment-5414404576
