### PR TITLE
MueLu: FSAI sparse approximate inverse added to MueLu for MinvA SOC 

### DIFF
--- a/packages/galeri/src/Galeri_XpetraMatrixTypes.hpp
+++ b/packages/galeri/src/Galeri_XpetraMatrixTypes.hpp
@@ -1093,15 +1093,62 @@ class Scalar3D_27PtStencil {
         }
       }
     } else {  // Implicitly handled Dirichlet bcs. Truncate stencil for entries that fall over the boundary
+      GlobalOrdinal ii, jj, kk, remainder;
+      // compute grid location (ii,jj,kk) corresponding to center
+      ii          = (center % nx);
+      remainder   = (center - ii) / nx;
+      jj          = (remainder % ny);
+      kk          = (remainder - jj) / ny;
+      bool LeftBc = (DirichletBC & DIR_LEFT);
+      bool RghtBc = (DirichletBC & DIR_RIGHT);
+      bool BottBc = (DirichletBC & DIR_BOTTOM);
+      bool TopBc  = (DirichletBC & DIR_TOP);
+      bool FronBc = (DirichletBC & DIR_FRONT);
+      bool BackBc = (DirichletBC & DIR_BACK);
       for (size_t k0 = 0; k0 < 3; ++k0) {
         for (size_t k1 = 0; k1 < 3; ++k1) {
           for (size_t k2 = 0; k2 < 3; ++k2) {
-            if ((k0 != MID) || (k1 != MID) || (k2 != MID))
-              Galeri_enterValue(rowStart, stencil_indices[k0][k1][k2], (stencil_entries(k0, k1, k2)));
+            impl_scalar_type scaleFactor = one;
+            if ((ii == 0) && !LeftBc) {
+              if (k0 == 0)
+                scaleFactor = zero;
+              else if (k0 == 1)
+                scaleFactor /= 2.;
+            }
+            if ((ii == nx - 1) && !RghtBc) {
+              if (k0 == 2)
+                scaleFactor = zero;
+              else if (k0 == 1)
+                scaleFactor /= 2.;
+            }
+            if ((jj == 0) && !BottBc) {
+              if (k1 == 0)
+                scaleFactor = zero;
+              else if (k1 == 1)
+                scaleFactor /= 2.;
+            }
+            if ((jj == ny - 1) && !TopBc) {
+              if (k1 == 2)
+                scaleFactor = zero;
+              else if (k1 == 1)
+                scaleFactor /= 2.;
+            }
+            if ((kk == 0) && !BackBc) {
+              if (k2 == 0)
+                scaleFactor = zero;
+              else if (k2 == 1)
+                scaleFactor /= 2.;
+            }
+            if ((kk == nz - 1) && !FronBc) {
+              if (k2 == 2)
+                scaleFactor = zero;
+              else if (k2 == 1)
+                scaleFactor /= 2.;
+            }
+            Galeri_enterValue(rowStart, stencil_indices[k0][k1][k2], (scaleFactor * stencil_entries(k0, k1, k2)));
           }
         }
       }
-      Galeri_enterValue(rowStart, center, (IsBoundary(center) && !isDirichlet) ? -offDiagonalSum : stencil_entries(MID, MID, MID));
     }
   }
 };
@@ -1511,8 +1558,8 @@ StencilMatrix(const Teuchos::RCP<const Map>& map,
   ///////////////////////////
   // Step 2 - Column map
 
-  tm1 = Teuchos::null;
-  tm1 = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Galeri: " + matLabel + " generation: column map")));
+  tm1                    = Teuchos::null;
+  tm1                    = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Galeri: " + matLabel + " generation: column map")));
   auto columnMap_entries = Kokkos::View<GlobalOrdinal*, memory_space>("columnMap_entries", numMyElements + stencil.off_rank_indices.size());
   // Copy over on-rank entries from rowmap
   Kokkos::deep_copy(Kokkos::subview(columnMap_entries, Kokkos::make_pair(0, numMyElements)),
@@ -1583,8 +1630,8 @@ StencilMatrix(const Teuchos::RCP<const Map>& map,
   ///////////////////////////
   // Step 3 - Fill
 
-  tm1 = Teuchos::null;
-  tm1 = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Galeri: " + matLabel + " generation: fill")));
+  tm1               = Teuchos::null;
+  tm1               = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Galeri: " + matLabel + " generation: fill")));
   stencil.lclColMap = ghosted_map->getLocalMap();
   stencil.colidx    = colidx_type("colidx", myNNZ);
   stencil.values    = values_type("values", myNNZ);

--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -553,6 +553,14 @@
     </parameter>
 
     <parameter>
+      <name>aggregation: Minv scheme</name>
+      <type>string</type>
+      <default>fsai</default>
+      <description>Algorithm used to approximate inverse mass matrix when using MinvA scheme for strength-of-connection matrix. Possible values: "fsai", "spai"</description>
+      <comment-ML>parameter not existing in ML</comment-ML>
+    </parameter>
+
+    <parameter>
       <name>aggregation: classical algo</name>
       <type>string</type>
       <default>"default"</default>

--- a/packages/muelu/doc/UsersGuide/options_aggregation.tex
+++ b/packages/muelu/doc/UsersGuide/options_aggregation.tex
@@ -20,6 +20,8 @@
           
 \cbb{aggregation: distance laplacian metric}{string}{unweighted}{Metric used to compute the distance Laplacian. Possible values: "unweighted", "material"}
           
+\cbb{aggregation: Minv scheme}{string}{fsai}{Algorithm used to approximate inverse mass matrix when using MinvA scheme for strength-of-connection matrix. Possible values: "fsai", "spai"}
+          
 \cbb{aggregation: drop tol}{double}{0.0}{Connectivity dropping threshold for a graph used in aggregation.}
           
 \cbb{aggregation: use ml scaling of drop tol}{bool}{false}{Enables ML-style scaling of drop tol, where the drop tol halves with each successive level.}

--- a/packages/muelu/doc/UsersGuide/paramlist.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist.tex
@@ -73,6 +73,8 @@
           
 \cbb{aggregation: distance laplacian metric}{string}{unweighted}{Metric used to compute the distance Laplacian. Possible values: "unweighted", "material"}
           
+\cbb{aggregation: Minv scheme}{string}{fsai}{Algorithm used to approximate inverse mass matrix when using MinvA scheme for strength-of-connection matrix. Possible values: "fsai", "spai"}
+          
 \cbb{aggregation: drop tol}{double}{0.0}{Connectivity dropping threshold for a graph used in aggregation.}
           
 \cbb{aggregation: use ml scaling of drop tol}{bool}{false}{Enables ML-style scaling of drop tol, where the drop tol halves with each successive level.}

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -102,6 +102,8 @@
         
 \cbb{aggregation: distance laplacian metric}{string}{unweighted}{Metric used to compute the distance Laplacian. Possible values: "unweighted", "material"}
         
+\cbb{aggregation: Minv scheme}{string}{fsai}{Algorithm used to approximate inverse mass matrix when using MinvA scheme for strength-of-connection matrix. Possible values: "fsai", "spai"}
+        
 \cbb{aggregation: classical algo}{string}{"default"}{Type of sub-algorithm for "classical" dropping. Possible values: "default", "unscaled cut", "scaled cut".}
         
 \cbb{aggregation: drop tol}{double}{0.0}{Connectivity dropping threshold for a graph used in aggregation.}

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
@@ -407,10 +407,10 @@ std::tuple<GlobalOrdinal, GlobalOrdinal, typename MueLu::LWGraph_kokkos<LocalOrd
             storeMinvAOnLevel = true;
           else {
             if (projectList.isParameter("Minv")) storeMinvOnLevel = true;
+            else storeMinvAOnLevel = true; // nothing found in project list, so default to storing MinvA
           }
-          // project list appears to be empty, so default behavior is to store MinvA
         } else
-          storeMinvAOnLevel = true;  // default behavior is to project MinvA
+          storeMinvAOnLevel = true;  // no project list given, so default to storing MinvA
 
         if (IsAvailable(currentLevel, "MinvA")) {
           A_drop = Get<RCP<Matrix>>(currentLevel, "MinvA");

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
@@ -406,8 +406,10 @@ std::tuple<GlobalOrdinal, GlobalOrdinal, typename MueLu::LWGraph_kokkos<LocalOrd
           if (projectList.isParameter("MinvA"))
             storeMinvAOnLevel = true;
           else {
-            if (projectList.isParameter("Minv")) storeMinvOnLevel = true;
-            else storeMinvAOnLevel = true; // nothing found in project list, so default to storing MinvA
+            if (projectList.isParameter("Minv"))
+              storeMinvOnLevel = true;
+            else
+              storeMinvAOnLevel = true;  // nothing found in project list, so default to storing MinvA
           }
         } else
           storeMinvAOnLevel = true;  // no project list given, so default to storing MinvA

--- a/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/MatrixTransformation/MueLu_CoalesceDropFactory_kokkos_def.hpp
@@ -58,6 +58,7 @@ RCP<const ParameterList> CoalesceDropFactory_kokkos<Scalar, LocalOrdinal, Global
   SET_VALID_ENTRY("aggregation: drop scheme");
   SET_VALID_ENTRY("aggregation: block diagonal: interleaved blocksize");
   SET_VALID_ENTRY("aggregation: distance laplacian metric");
+  SET_VALID_ENTRY("aggregation: Minv scheme");
   SET_VALID_ENTRY("aggregation: distance laplacian directional weights");
   SET_VALID_ENTRY("aggregation: dropping may create Dirichlet");
 #ifdef HAVE_MUELU_COALESCEDROP_ALLOW_OLD_PARAMETERS
@@ -92,6 +93,7 @@ RCP<const ParameterList> CoalesceDropFactory_kokkos<Scalar, LocalOrdinal, Global
   validParamList->getEntry("aggregation: strength-of-connection: matrix").setValidator(rcp(new Teuchos::StringValidator(Teuchos::tuple<std::string>("A", "distance laplacian", "MinvA"))));
   validParamList->getEntry("aggregation: strength-of-connection: measure").setValidator(rcp(new Teuchos::StringValidator(Teuchos::tuple<std::string>("smoothed aggregation", "signed smoothed aggregation", "signed ruge-stueben", "unscaled"))));
   validParamList->getEntry("aggregation: distance laplacian metric").setValidator(rcp(new Teuchos::StringValidator(Teuchos::tuple<std::string>("unweighted", "material"))));
+  validParamList->getEntry("aggregation: Minv scheme").setValidator(rcp(new Teuchos::StringValidator(Teuchos::tuple<std::string>("spai", "fsai"))));
 
   validParamList->set<RCP<const FactoryBase>>("A", Teuchos::null, "Generating factory of the matrix A");
   validParamList->set<RCP<const FactoryBase>>("UnAmalgamationInfo", Teuchos::null, "Generating factory for UnAmalgamationInfo");
@@ -133,9 +135,12 @@ void CoalesceDropFactory_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Decl
   if (needM && (currentLevel.GetLevelID() != 0)) {
     if (pL.isSublist("project auxiliary matrices")) {
       auto projectList = pL.sublist("project auxiliary matrices");
-      if (projectList.isParameter("M")) Input(currentLevel, "M");
-      if (projectList.isParameter("Minv")) Input(currentLevel, "Minv");
-      if (projectList.isParameter("MinvA")) Input(currentLevel, "MinvA");
+      if (projectList.isParameter("MinvA"))
+        Input(currentLevel, "MinvA");
+      else if (projectList.isParameter("Minv"))
+        Input(currentLevel, "Minv");
+      else if (projectList.isParameter("M"))
+        Input(currentLevel, "M");
     }
   }
 
@@ -323,6 +328,7 @@ std::tuple<GlobalOrdinal, GlobalOrdinal, typename MueLu::LWGraph_kokkos<LocalOrd
   std::string socUsesMatrix           = pL.get<std::string>("aggregation: strength-of-connection: matrix");
   std::string socUsesMeasure          = pL.get<std::string>("aggregation: strength-of-connection: measure");
   std::string distanceLaplacianMetric = pL.get<std::string>("aggregation: distance laplacian metric");
+  std::string MinvScheme              = pL.get<std::string>("aggregation: Minv scheme");
   bool symmetrizeDroppedGraph         = pL.get<bool>("aggregation: symmetrize graph after dropping");
   magnitudeType threshold;
   // If we're doing the ML-style halving of the drop tol at each level, we do that here.
@@ -397,10 +403,12 @@ std::tuple<GlobalOrdinal, GlobalOrdinal, typename MueLu::LWGraph_kokkos<LocalOrd
         bool storeMinvOnLevel = false, storeMinvAOnLevel = false;
         if (pL.isSublist("project auxiliary matrices")) {
           auto projectList = pL.sublist("project auxiliary matrices");
-          if (projectList.isParameter("Minv")) storeMinvOnLevel = true;
-          if (projectList.isParameter("MinvA")) storeMinvAOnLevel = true;
+          if (projectList.isParameter("MinvA"))
+            storeMinvAOnLevel = true;
+          else {
+            if (projectList.isParameter("Minv")) storeMinvOnLevel = true;
+          }
           // project list appears to be empty, so default behavior is to store MinvA
-          if (!projectList.isParameter("M") && !storeMinvOnLevel && !storeMinvAOnLevel) storeMinvAOnLevel = true;
         } else
           storeMinvAOnLevel = true;  // default behavior is to project MinvA
 
@@ -408,18 +416,48 @@ std::tuple<GlobalOrdinal, GlobalOrdinal, typename MueLu::LWGraph_kokkos<LocalOrd
           A_drop = Get<RCP<Matrix>>(currentLevel, "MinvA");
         } else {
           RCP<Matrix> Minv;
-          if (IsAvailable(currentLevel, "Minv")) {
-            Minv = Get<RCP<Matrix>>(currentLevel, "Minv");
+          bool MueLu_Minv = IsAvailable(currentLevel, "Minv");
+          bool User_Minv  = currentLevel.IsAvailable("Minv", NoFactory::get());
+          if (MueLu_Minv || User_Minv) {
+            if (MueLu_Minv)
+              Minv = Get<RCP<Matrix>>(currentLevel, "Minv");
+            else
+              Minv = currentLevel.Get<RCP<Matrix>>("Minv", NoFactory::get());
           } else {  // get M and create Minv
+
+            RCP<Matrix> M;
             if (currentLevel.GetLevelID() == 0) {
-              auto M = currentLevel.Get<RCP<Matrix>>("M", NoFactory::get());
-              // Create Minv via sparse approximate inverse
-              Minv = Utilities::SPAI(M);
+              M = currentLevel.Get<RCP<Matrix>>("M", NoFactory::get());
             } else {
-              auto M = Get<RCP<Matrix>>(currentLevel, "M");
-              // Create Minv via sparse approximate inverse
-              Minv = Utilities::SPAI(M);
+              M = Get<RCP<Matrix>>(currentLevel, "M");
             }
+            // Find Dirichlets in A to stick corresponding Dirichlets in M
+#ifdef moreExperimentsToSeeIfHelpful
+            auto boundaryNodes = MueLu::Utilities<SC, LO, GO, NO>::DetectDirichletRows_kokkos(*A, 8.0 * Teuchos::ScalarTraits<magnitudeType>::eps());
+            if (GetVerbLevel() & Statistics1) {
+              int nAbc = 0;
+              for (size_t iii = 0; iii < A->getLocalNumRows(); iii++)
+                if (boundaryNodes[iii]) nAbc++;
+              auto MbcBefore = MueLu::Utilities<SC, LO, GO, NO>::DetectDirichletRows_kokkos(*M, 8.0 * Teuchos::ScalarTraits<magnitudeType>::eps());
+              int nMbcBefore = 0;
+              for (size_t iii = 0; iii < M->getLocalNumRows(); iii++)
+                if (MbcBefore[iii]) nMbcBefore++;
+              GetOStream(Statistics1) << "MueLu_CoalesceDropFactory_kokkos_def: # A bcs = " << nAbc << ", # M bcs before MueLu enforcement = " << nMbcBefore;
+            }
+            MueLu::Utilities<SC, LO, GO, NO>::ApplyOAZToMatrixRows(M, boundaryNodes);
+            if (GetVerbLevel() & Statistics1) {
+              auto MbcAfter = MueLu::Utilities<SC, LO, GO, NO>::DetectDirichletRows_kokkos(*M, 8.0 * Teuchos::ScalarTraits<magnitudeType>::eps());
+              int nMbcAfter = 0;
+              for (size_t iii = 0; iii < M->getLocalNumRows(); iii++)
+                if (MbcAfter[iii]) nMbcAfter++;
+              GetOStream(Statistics1) << ", # M bcs after MueLu enforcement = " << nMbcAfter << std::endl;
+            }
+#endif
+
+            // Create Minv via sparse approximate inverse
+
+            Minv = Utilities::SPAI(M, MinvScheme);
+
             if (storeMinvOnLevel) currentLevel.Set("Minv", Minv);
           }  // finished if/else (currentLevel.IsAvailable("Minv", *mtf)
 
@@ -428,6 +466,13 @@ std::tuple<GlobalOrdinal, GlobalOrdinal, typename MueLu::LWGraph_kokkos<LocalOrd
           auto params = Teuchos::rcp(new Teuchos::ParameterList());
           params->set("MM Throw For Non-Existent Entries", false);
           A_drop = Xpetra::MatrixMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Multiply(*Minv, false, *A, false, A_drop, GetOStream(Statistics2), true, true, std::string("MinvA"), params);
+
+          // Enforce Dirichlet BCs by zeroing out off-diagonal rows and columns and putting a 1 on diag of MinvA
+          auto boundaryNodes = MueLu::Utilities<SC, LO, GO, NO>::DetectDirichletRows_kokkos(*A, 8.0 * Teuchos::ScalarTraits<magnitudeType>::eps());
+          auto dirichletCols = MueLu::Utilities<SC, LO, GO, NO>::DetectDirichletCols(*A, boundaryNodes);
+          MueLu::Utilities<SC, LO, GO, NO>::ApplyOAZToMatrixRows(A_drop, boundaryNodes);
+          MueLu::Utilities<SC, LO, GO, NO>::ZeroDirichletCols(A_drop, dirichletCols, Teuchos::ScalarTraits<SC>::zero(), true);
+
           if (storeMinvAOnLevel) currentLevel.Set("MinvA", A_drop);
         }  // finished if/else  (currentLevel.IsAvailable("MinvA", NoFactory::get()))
       }    // else if (socUsesMatrix == "MinvA") {

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -192,8 +192,8 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetPar
                                  "MueLu_CreateXpetraPreconditioner: Must supply Minv  as NoFactory is listed as supplier of Minv  in the project auxiliary matrices sublist");
       TEUCHOS_TEST_FOR_EXCEPTION(projectList.isParameter("MinvA") && (projectList.get("MinvA", "") == "NoFactory") && !MinvA_Supplied, Exceptions::Incompatible,
                                  "MueLu_CreateXpetraPreconditioner: Must supply MinvA as NoFactory is listed as supplier of MinvA in the project auxiliary matrices sublist");
-    } else {  // default behavior if sublist("project auxiliary matrices") not user-supplied requires "M" to be user-supplied.
-      TEUCHOS_TEST_FOR_EXCEPTION(!M_Supplied, Exceptions::Incompatible, "MueLu_CreateXpetraPreconditioner: Must supply M when 'aggregation: strength-of-connection: matrix'= MinvA and sublist('project auxiliary matrices') not supplied.");
+    } else {  // default behavior if sublist("project auxiliary matrices") not user-supplied requires "M" or "Minv" to be user-supplied.
+      TEUCHOS_TEST_FOR_EXCEPTION(!M_Supplied && !Minv_Supplied, Exceptions::Incompatible, "MueLu_CreateXpetraPreconditioner: Must supply M or Minv when 'aggregation: strength-of-connection: matrix'= MinvA and sublist('project auxiliary matrices') not supplied.");
     }
   }
 }
@@ -272,16 +272,21 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   projectMinvA_ = true;
   if (constParamList.isSublist("project auxiliary matrices")) {
     auto projectList = constParamList.sublist("project auxiliary matrices");
+    // only one is true. MinvA takes precedence over Minv which takes precedence over M.
     if (projectList.isParameter("M")) {
       projectM_     = true;
+      projectMinv_  = false;
       projectMinvA_ = false;
     }
     if (projectList.isParameter("Minv")) {
+      projectM_     = false;
       projectMinv_  = true;
       projectMinvA_ = false;
     }
     if (projectList.isParameter("MinvA")) {
       projectMinvA_ = true;
+      projectM_     = false;
+      projectMinv_  = true;
     }
   } else {  // default settings when "project auxiliary matrices" not specified by user
     projectM_     = false;
@@ -1296,6 +1301,9 @@ void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     test_and_set_param_2list<bool>(paramList, defaultList, "aggregation: greedy Dirichlet", dropParams);
     if (useKokkos_)
       test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: distance laplacian metric", dropParams);
+    if (useKokkos_)
+      test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: Minv scheme", dropParams);
+
 #ifdef HAVE_MUELU_COALESCEDROP_ALLOW_OLD_PARAMETERS
     test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: distance laplacian algo", dropParams);
     test_and_set_param_2list<std::string>(paramList, defaultList, "aggregation: classical algo", dropParams);

--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_decl.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_decl.hpp
@@ -92,6 +92,9 @@ class InverseApproximationFactory : public SingleLevelFactoryBase {
   //! Sparse inverse calculation method.
   RCP<Matrix> GetSparseInverse(const RCP<Matrix>& A, const RCP<const CrsGraph>& sparsityPattern) const;
 
+  //! Sparse factor inverse calculation method.
+  RCP<Matrix> GetFactoredSparseInverse(const RCP<Matrix>& A, const RCP<const CrsGraph>& sparsityPattern) const;
+
 };  // class InverseApproximationFactory
 
 }  // namespace MueLu

--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
@@ -21,9 +21,6 @@
 #include "Kokkos_Sort.hpp"
 #include "KokkosBlas1_set.hpp"
 #include "KokkosBatched_QR_Decl.hpp"
-#ifdef out
-#include <KokkosBatched_Cholesky.hpp>
-#endif
 #include "KokkosBatched_ApplyQ_Decl.hpp"
 #include "KokkosBatched_Trsv_Decl.hpp"
 #include "KokkosBatched_Util.hpp"
@@ -572,8 +569,8 @@ class LocalFSAIFunctor {
     auto scale_factor = impl_ATS::one() / impl_ATS::sqrt(diagValue);
     for (local_ordinal_type i = 0; i < rowAinv.length; ++i) {
       auto thevalue = sub_ek(i) * scale_factor;
-      ;
-      if (thevalue == impl_ATS::zero()) thevalue = Teuchos::as<scalar_type>(1.e-15);  // make sure value retained in sparsity pattern
+
+      if (thevalue == impl_ATS::zero()) thevalue = Teuchos::as<decltype(thevalue)>(1.e-15);  // make sure value retained in sparsity pattern
       rowAinv.value(i) = thevalue;
     }
   }

--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
@@ -568,7 +568,6 @@ class LocalFSAIFunctor {
                                "MueLu::InverseApproximationFactory::GetSparseInverse: non positive diagonal entry.");
     auto scale_factor = impl_ATS::one() / impl_ATS::sqrt(diagValue);
     for (local_ordinal_type i = 0; i < rowAinv.length; ++i) {
-//      auto thevalue = sub_ek(i) * scale_factor;
       typename KokkosKernels::ArithTraits<decltype(diagValue)>::val_type thevalue = sub_ek(i) * scale_factor;
 
       if (thevalue == impl_ATS::zero()) thevalue = impl_ATS::eps();

--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
@@ -421,14 +421,8 @@ class LocalFSAIFunctor {
   using execution_space    = typename local_matrix_type::execution_space;
   using impl_scalar_type   = typename KokkosKernels::ArithTraits<scalar_type>::val_type;
   using impl_ATS           = KokkosKernels::ArithTraits<impl_scalar_type>;
-  using local_map_type     = Tpetra::Details::LocalMap<local_ordinal_type, global_ordinal_type, Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace>>;
-  // rstumin: I hope it is okay to use Tpetra::Details::LocalMap in this function???
-  // rstumin: I suspect that I'm not supposed to have Serial, Kokkos::HostSpace above and am supposed to get the device from somewhere
-  // perhaps something like one of these two
-  // using device            = typename local_matrix_type::device_type;
-  // using device            = typename matrix_type::local_graph_type::device_type;
-  // in conjunction with
-  // using local_map_type     = Tpetra::Details::LocalMap<local_ordinal_type, global_ordinal_type , device_type>;
+  using device_type        = typename local_matrix_type::device_type;
+  using local_map_type     = Tpetra::Details::LocalMap<local_ordinal_type, global_ordinal_type, device_type>;
 
  public:
   using shared_matrix    = Kokkos::View<impl_scalar_type**, typename execution_space::scratch_memory_space, Kokkos::MemoryUnmanaged>;

--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
@@ -24,6 +24,7 @@
 #include "KokkosBatched_ApplyQ_Decl.hpp"
 #include "KokkosBatched_Trsv_Decl.hpp"
 #include "KokkosBatched_Util.hpp"
+#include <KokkosKernels_SimpleUtils.hpp>
 
 #include "MueLu_Level.hpp"
 #include "MueLu_Monitor.hpp"
@@ -215,7 +216,7 @@ class LocalSPAIFunctor {
     local_ordinal_type diagOffset         = 0;
     {
       // Sort
-      Kokkos::Experimental::sort_team(thread, Kokkos::subview(column_indices, Kokkos::make_pair(0, numColEntries)));
+      Kokkos::Experimental::sort_thread(thread, Kokkos::subview(column_indices, Kokkos::make_pair(0, numColEntries)));
       // Merge
       if (numColEntries > 0)
         ++numUniqeColEntries;
@@ -230,7 +231,7 @@ class LocalSPAIFunctor {
         }
       }
     }
-    // create a unique version of the column indicies that has the correct length (as opposed
+    // create a unique version of the column indices that has the correct length (as opposed
     // to column_indices).  Can we instead resize column_indices with MemoryUnmanaged?
     // This is so that we can use binary search later on sorted list
     shared_lo_vector uniqueColIndicies(thread.team_scratch(scratchLevel), numUniqeColEntries);
@@ -251,9 +252,8 @@ class LocalSPAIFunctor {
         auto v = rowA.value(jj);
 
         // do binary search to find column in uniqueColIndices
-        auto it              = std::lower_bound(Kokkos::Experimental::begin(uniqueColIndicies), Kokkos::Experimental::end(uniqueColIndicies), j);
-        ptrdiff_t newIndex   = it - Kokkos::Experimental::begin(uniqueColIndicies);
-        localA(newIndex, ii) = v;
+        auto it        = KokkosKernels::lower_bound_thread(uniqueColIndicies, j);
+        localA(it, ii) = v;
       }
     }
 
@@ -492,15 +492,17 @@ class LocalFSAIFunctor {
         A_lclRowIndForDiag = A_lclRowInd;
       }
     }
-    TEUCHOS_TEST_FOR_EXCEPTION(A_lclRowIndForDiag == -1, Exceptions::RuntimeError,
-                               "MueLu::InverseApproximationFactory::GetSparseInverse: no diagonal entry found in A.");
+#ifdef HAVE_MUELU_DEBUG  // code must also be compiled with -DKokkos_ENABLE_DEBUG=ON
+    KOKKOS_ASSERT(A_lclRowIndForDiag == -1 && "MueLu::InverseApproximationFactory::GetSparseInverse: no diagonal entry found in A.");
+#endif
 
-    Kokkos::Experimental::sort_team(thread, column_indices);  // in order to apply binary search later
+    Kokkos::Experimental::sort_thread(thread, column_indices);  // in order to apply binary search later
     for (int kkk = 0; kkk < numColEntries; kkk++) {
       if (column_indices(kkk) == A_lclRowIndForDiag) diagOffset = kkk;
     }
-    TEUCHOS_TEST_FOR_EXCEPTION(diagOffset == -1, Exceptions::RuntimeError,
-                               "MueLu::InverseApproximationFactory::GetSparseInverse: no diagonal entry found in A.");
+#ifdef HAVE_MUELU_DEBUG
+    KOKKOS_ASSERT(diagOffset == -1 && "MueLu::InverseApproximationFactory::GetSparseInverse: no diagonal entry found in A.");
+#endif
 
     // Extract local part of A into a dense view.
     shared_matrix localA(thread.team_scratch(scratchLevel), numRowEntries, rowAinv.length);
@@ -511,7 +513,9 @@ class LocalFSAIFunctor {
       auto i                         = rowAinv.colidx(ii);
       auto Ainv_colGid               = lclAinvColMap.getGlobalElement(i);  // for debugging
       local_ordinal_type A_lclRowInd = lclARowMap.getLocalElement(Ainv_colGid);
-      TEUCHOS_TEST_FOR_EXCEPTION(A_lclRowInd == -1, Exceptions::RuntimeError, "MueLu::InverseApproximationFactory: Column global ID in Ainv not found in A rowmap\n");
+#ifdef HAVE_MUELU_DEBUG
+      KOKKOS_ASSERT(A_lclRowInd == -1 && "MueLu::InverseApproximationFactory: Column global ID in Ainv not found in A rowmap");
+#endif
       auto rowA = lclA.rowConst(A_lclRowInd);
 
       for (local_ordinal_type jj = 0; jj < rowA.length; ++jj) {
@@ -520,12 +524,9 @@ class LocalFSAIFunctor {
         // in lower triangular portion of matrix (because this might be faster?)
         auto A_colGid = lclAColMap.getGlobalElement(j);
         if (A_colGid <= A_rowGid) {
-          auto it = std::lower_bound(Kokkos::Experimental::begin(column_indices), Kokkos::Experimental::end(column_indices), j);
-          if (it != Kokkos::Experimental::end(column_indices) && *it == j) {
-            ptrdiff_t newIndex   = it - Kokkos::Experimental::begin(column_indices);
-            auto v               = rowA.value(jj);
-            localA(newIndex, ii) = v;
-          }
+          auto newIndex = KokkosKernels::lower_bound_thread(column_indices, j);
+          if ((newIndex < column_indices.extent(0)) && (column_indices(newIndex) == j))
+            localA(newIndex, ii) = rowA.value(jj);
         }
       }
     }
@@ -564,8 +565,9 @@ class LocalFSAIFunctor {
     // Set entries of Ainv.
 
     diagValue = sub_ek(diagOffset);
-    TEUCHOS_TEST_FOR_EXCEPTION(impl_ATS::real(diagValue) <= 0.0, Exceptions::RuntimeError,
-                               "MueLu::InverseApproximationFactory::GetSparseInverse: non positive diagonal entry.");
+#ifdef HAVE_MUELU_DEBUG
+    KOKKOS_ASSERT(impl_ATS::real(diagValue) <= 0.0 && "MueLu::InverseApproximationFactory::GetSparseInverse: non positive diagonal entry.");
+#endif
     auto scale_factor = impl_ATS::one() / impl_ATS::sqrt(diagValue);
     for (local_ordinal_type i = 0; i < rowAinv.length; ++i) {
       typename KokkosKernels::ArithTraits<decltype(diagValue)>::val_type thevalue = sub_ek(i) * scale_factor;

--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
@@ -21,6 +21,9 @@
 #include "Kokkos_Sort.hpp"
 #include "KokkosBlas1_set.hpp"
 #include "KokkosBatched_QR_Decl.hpp"
+#ifdef out
+#include <KokkosBatched_Cholesky.hpp>
+#endif
 #include "KokkosBatched_ApplyQ_Decl.hpp"
 #include "KokkosBatched_Trsv_Decl.hpp"
 #include "KokkosBatched_Util.hpp"
@@ -70,9 +73,9 @@ void InverseApproximationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Bui
 
   // check which approximation type to use
   const std::string method = pL.get<std::string>("inverse: approximation type");
-  TEUCHOS_TEST_FOR_EXCEPTION(method != "diagonal" && method != "lumping" && method != "sparseapproxinverse", Exceptions::RuntimeError,
+  TEUCHOS_TEST_FOR_EXCEPTION(method != "diagonal" && method != "lumping" && method != "sparseapproxinverse" && method != "factoredsparseapproxinverse", Exceptions::RuntimeError,
                              "MueLu::InverseApproximationFactory::Build: Approximation type can be 'diagonal' or 'lumping' or "
-                             "'sparseapproxinverse'.");
+                             "'sparseapproxinverse' or 'factoredsparseapproxinverse'.");
 
   RCP<Matrix> A            = Get<RCP<Matrix>>(currentLevel, "A");
   RCP<BlockedCrsMatrix> bA = Teuchos::rcp_dynamic_cast<BlockedCrsMatrix>(A);
@@ -81,8 +84,8 @@ void InverseApproximationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Bui
   // if blocked operator is used, defaults to A(0,0)
   if (isBlocked) A = bA->getMatrix(0, 0);
 
-  const Magnitude tol = pL.get<Magnitude>("inverse: drop tolerance");
-  RCP<Matrix> Ainv    = Teuchos::null;
+  Magnitude tol    = pL.get<Magnitude>("inverse: drop tolerance");
+  RCP<Matrix> Ainv = Teuchos::null;
 
   if (method == "diagonal") {
     const auto diag = VectorFactory::Build(A->getRangeMap(), true);
@@ -95,6 +98,20 @@ void InverseApproximationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Bui
     Ainv                      = MatrixFactory::Build(D);
   } else if (method == "sparseapproxinverse") {
     RCP<CrsGraph> sparsityPattern = Utilities::GetThresholdedGraph(A, tol);
+    auto maxRowEntries            = sparsityPattern->getLocalMaxNumRowEntries();
+    // too many nonzeros per row will cause us to exceed L1 memory space size
+    // lets increase threshold to reduce nnzs per row
+    while (maxRowEntries > 200) {
+      if (tol == 0.0)
+        tol = .005;
+      else
+        tol *= 1.5;
+      if (IsPrint(Statistics1)) {
+        GetOStream(Statistics1) << "MueLu_InverseApproximationFactory: Too many NNZs per row (" << maxRowEntries << "). Reducing NNZs per row by increasing drop threshold to " << tol << std::endl;
+      }
+      sparsityPattern = Utilities::GetThresholdedGraph(A, tol);
+      maxRowEntries   = sparsityPattern->getLocalMaxNumRowEntries();
+    }
     if (IsPrint(Statistics1)) {
       sparsityPattern->computeGlobalConstants();
       GetOStream(Statistics1) << "NNZ Graph(A): " << A->getCrsGraph()->getGlobalNumEntries() << " , NNZ Tresholded Graph(A): " << sparsityPattern->getGlobalNumEntries() << std::endl;
@@ -104,6 +121,42 @@ void InverseApproximationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Bui
     if (IsPrint(Statistics1)) {
       rcp_const_cast<CrsGraph>(Ainv->getCrsGraph())->computeGlobalConstants();
       GetOStream(Statistics1) << "NNZ Ainv: " << pAinv->getGlobalNumEntries() << ", NNZ Tresholded Ainv (parameter: " << tol << "): " << Ainv->getGlobalNumEntries() << std::endl;
+    }
+  } else if (method == "factoredsparseapproxinverse") {
+    RCP<CrsGraph> sparsityPattern = Utilities::GetThresholdedLowerTriangularGraph(A, tol);
+    auto maxRowEntries            = sparsityPattern->getLocalMaxNumRowEntries();
+    // too many nonzeros per row will cause us to exceed L1 memory space size
+    // lets increase threshold to reduce nnzs per row
+    while (maxRowEntries > 200) {
+      if (tol == 0.0)
+        tol = .005;
+      else
+        tol *= 1.5;
+      if (IsPrint(Statistics1)) {
+        GetOStream(Statistics1) << "MueLu_InverseApproximationFactory: Too many NNZs per row (" << maxRowEntries << "). Reducing NNZs per row by increasing drop threshold to " << tol << std::endl;
+      }
+      sparsityPattern = Utilities::GetThresholdedLowerTriangularGraph(A, tol);
+      maxRowEntries   = sparsityPattern->getLocalMaxNumRowEntries();
+    }
+
+    if (IsPrint(Statistics1)) {
+      sparsityPattern->computeGlobalConstants();
+      GetOStream(Statistics1) << "NNZ Graph(A): " << A->getCrsGraph()->getGlobalNumEntries() << " , NNZ Tresholded Graph(triLower(A)): " << sparsityPattern->getGlobalNumEntries() << std::endl;
+    }
+    RCP<Matrix> pLinvFactor = GetFactoredSparseInverse(A, sparsityPattern);
+    RCP<Matrix> LinvFactor  = Utilities::GetThresholdedMatrix(pLinvFactor, tol, fixing);
+    // To create the inverse from the inverse factor, we need to multiply Linv' * LinvFactor. Of course, we could
+    // save a fair amount of storage by delaying this to when we actually need it as Linv' * LinvFactor has
+    // many more nonzeros than just Linv. One other thing, I'm explicitly using the Transpose computation as opposed to
+    // setting one of the booleans to true in the MatrixMatrix:Multiply. There are some comments about true/false combinations
+    // that don't work, so I decided not to push my luck here.
+
+    RCP<Matrix> LinvTrans = Utilities::Transpose(*LinvFactor, true);
+    Ainv                  = Xpetra::MatrixMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Multiply(*LinvTrans, false, *LinvFactor, false, GetOStream(Statistics2), true, true, std::string("Ainv"));
+
+    if (IsPrint(Statistics1)) {
+      rcp_const_cast<CrsGraph>(Ainv->getCrsGraph())->computeGlobalConstants();
+      GetOStream(Statistics1) << "NNZ Linv: " << LinvFactor->getGlobalNumEntries() << ", NNZ Tresholded Linv (parameter: " << tol << "): " << pLinvFactor->getGlobalNumEntries() << std::endl;
     }
   }
 
@@ -180,6 +233,13 @@ class LocalSPAIFunctor {
         }
       }
     }
+    // create a unique version of the column indicies that has the correct length (as opposed
+    // to column_indices).  Can we instead resize column_indices with MemoryUnmanaged?
+    // This is so that we can use binary search later on sorted list
+    shared_lo_vector uniqueColIndicies(thread.team_scratch(scratchLevel), numUniqeColEntries);
+    for (local_ordinal_type m = 0; m < numUniqeColEntries; ++m) {
+      uniqueColIndicies(m) = column_indices(m);
+    }
 
     // Extract local part of A into a dense view.
     shared_matrix localA(thread.team_scratch(scratchLevel), numUniqeColEntries, rowAinv.length);
@@ -192,14 +252,11 @@ class LocalSPAIFunctor {
       for (local_ordinal_type jj = 0; jj < rowA.length; ++jj) {
         auto j = rowA.colidx(jj);
         auto v = rowA.value(jj);
-        // Determine local index.
-        // Sequential search might not be a great idea.
-        for (local_ordinal_type m = 0; m < numUniqeColEntries; ++m) {
-          if (column_indices(m) == j) {
-            localA(m, ii) = v;
-            break;
-          }
-        }
+
+        // do binary search to find column in uniqueColIndices
+        auto it              = std::lower_bound(Kokkos::Experimental::begin(uniqueColIndicies), Kokkos::Experimental::end(uniqueColIndicies), j);
+        ptrdiff_t newIndex   = it - Kokkos::Experimental::begin(uniqueColIndicies);
+        localA(newIndex, ii) = v;
       }
     }
 
@@ -276,6 +333,10 @@ InverseApproximationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetSpars
 
   Ainv->fillComplete();
 
+  // Transpose needed to match published paper algorithms as the inverse is not symmetric
+  // However, non-transposed version seems to work better in row-oriented MinvA algorithm
+  // RCP<Matrix> actualSpai = Utilities::Transpose(*Ainv, true); // , label, Tparams);
+
   return Ainv;
 }
 
@@ -343,10 +404,240 @@ InverseApproximationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetSpars
   }
   Ainv->fillComplete();
 
+  // Transpose needed to match published paper algorithms as the inverse is not symmetric
+  // However, non-transposed version seems to work better in row-oriented MinvA algorithm
+  // RCP<Matrix> actualSpai = Utilities::Transpose(*Ainv, true); // , label, Tparams);
+
   return Ainv;
 }
 
 #endif
+
+template <class local_matrix_type, typename global_ordinal_type>
+class LocalFSAIFunctor {
+ private:
+  using scalar_type        = typename local_matrix_type::value_type;
+  using local_ordinal_type = typename local_matrix_type::ordinal_type;
+  using execution_space    = typename local_matrix_type::execution_space;
+  using impl_scalar_type   = typename KokkosKernels::ArithTraits<scalar_type>::val_type;
+  using impl_ATS           = KokkosKernels::ArithTraits<impl_scalar_type>;
+  using local_map_type     = Tpetra::Details::LocalMap<local_ordinal_type, global_ordinal_type, Kokkos::Device<Kokkos::Serial, Kokkos::HostSpace>>;
+  // rstumin: I hope it is okay to use Tpetra::Details::LocalMap in this function???
+  // rstumin: I suspect that I'm not supposed to have Serial, Kokkos::HostSpace above and am supposed to get the device from somewhere
+  // perhaps something like one of these two
+  // using device            = typename local_matrix_type::device_type;
+  // using device            = typename matrix_type::local_graph_type::device_type;
+  // in conjunction with
+  // using local_map_type     = Tpetra::Details::LocalMap<local_ordinal_type, global_ordinal_type , device_type>;
+
+ public:
+  using shared_matrix    = Kokkos::View<impl_scalar_type**, typename execution_space::scratch_memory_space, Kokkos::MemoryUnmanaged>;
+  using shared_vector    = Kokkos::View<impl_scalar_type*, typename execution_space::scratch_memory_space, Kokkos::MemoryUnmanaged>;
+  using shared_lo_vector = Kokkos::View<local_ordinal_type*, typename execution_space::scratch_memory_space, Kokkos::MemoryUnmanaged>;
+
+ private:
+  const local_matrix_type lclA;
+  local_matrix_type lclAinv;
+  local_map_type lclARowMap;
+  local_map_type lclAColMap;
+  local_map_type lclAinvRowMap;
+  local_map_type lclAinvColMap;
+  const int scratchLevel;
+
+ public:
+  LocalFSAIFunctor(const local_matrix_type& lclA_, local_matrix_type& lclAinv_, const local_map_type& lclARowMap_, const local_map_type& lclAColMap_,
+                   const local_map_type& lclAinvRowMap_, const local_map_type& lclAinvColMap_, int scratchLevel_)
+    : lclA(lclA_)
+    , lclAinv(lclAinv_)
+    , lclARowMap(lclARowMap_)
+    , lclAColMap(lclAColMap_)
+    , lclAinvRowMap(lclAinvRowMap_)
+    , lclAinvColMap(lclAinvColMap_)
+    , scratchLevel(scratchLevel_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const typename Kokkos::TeamPolicy<execution_space>::member_type& thread) const {
+    auto rlid    = thread.league_rank();
+    auto rowAinv = lclAinv.row(rlid);
+
+    // matlab version of algorithm
+    //  n = size(A,1);    nzs = nnz(S);
+    //  newrows = zeros(nzs,1); newcols = zeros(nzs,1); newvals= zeros(nzs,1);
+    //  count = 0;
+    //  for i=1:n,
+    //    [~,subCols,~] = find(S(i,:));
+    //    diagLocation = find(subCols == i);
+    //    submat = A(subCols,subCols);
+    //    subn = size(submat,1);
+    //    if diagLocation ~= subn, fprintf('pattern not lower triangular?\n'); keyboard; end;
+    //    identCol = zeros(subn,1); identCol(diagLocation) = 1;
+    //    AinvFactorRow = submat\identCol;
+    //    normalizedFactor = AinvFactorRow/sqrt(AinvFactorRow(diagLocation));
+    //    newrows(count+1:count+subn) = i;
+    //    newcols(count+1:count+subn) = subCols;
+    //    newvals(count+1:count+subn) = normalizedFactor;
+    //    count = count + subn;
+    // end;
+    // Lfactor  = sparse(newrows,newcols,newvals,n,n);
+    //
+
+    auto A_rowGid = lclARowMap.getGlobalElement(rlid);
+
+    auto numRowEntries                    = rowAinv.length;
+    local_ordinal_type diagOffset         = -1;
+    scalar_type diagValue                 = 0.0;
+    local_ordinal_type A_lclRowIndForDiag = -1;
+
+    // Loop over entries in row rlid of Ainv and collect all of A's column indices.
+    shared_lo_vector column_indices(thread.team_scratch(scratchLevel), numRowEntries);
+    local_ordinal_type numColEntries = rowAinv.length;
+    for (local_ordinal_type ii = 0; ii < rowAinv.length; ++ii) {
+      auto i                         = rowAinv.colidx(ii);
+      auto Ainv_colGid               = lclAinvColMap.getGlobalElement(i);  // for debugging
+      local_ordinal_type A_lclRowInd = lclARowMap.getLocalElement(Ainv_colGid);
+      local_ordinal_type A_lclColInd = lclAColMap.getLocalElement(Ainv_colGid);
+      column_indices(ii)             = A_lclColInd;
+      if (A_rowGid == Ainv_colGid) {
+        A_lclRowIndForDiag = A_lclRowInd;
+      }
+    }
+    TEUCHOS_TEST_FOR_EXCEPTION(A_lclRowIndForDiag == -1, Exceptions::RuntimeError,
+                               "MueLu::InverseApproximationFactory::GetSparseInverse: no diagonal entry found in A.");
+
+    Kokkos::Experimental::sort_team(thread, column_indices);  // in order to apply binary search later
+    for (int kkk = 0; kkk < numColEntries; kkk++) {
+      if (column_indices(kkk) == A_lclRowIndForDiag) diagOffset = kkk;
+    }
+    TEUCHOS_TEST_FOR_EXCEPTION(diagOffset == -1, Exceptions::RuntimeError,
+                               "MueLu::InverseApproximationFactory::GetSparseInverse: no diagonal entry found in A.");
+
+    // Extract local part of A into a dense view.
+    shared_matrix localA(thread.team_scratch(scratchLevel), numRowEntries, rowAinv.length);
+    KokkosBlas::SerialSet::invoke(impl_ATS::zero(), localA);
+
+    // Now fill localA.
+    for (local_ordinal_type ii = 0; ii < rowAinv.length; ++ii) {
+      auto i                         = rowAinv.colidx(ii);
+      auto Ainv_colGid               = lclAinvColMap.getGlobalElement(i);  // for debugging
+      local_ordinal_type A_lclRowInd = lclARowMap.getLocalElement(Ainv_colGid);
+      TEUCHOS_TEST_FOR_EXCEPTION(A_lclRowInd == -1, Exceptions::RuntimeError, "MueLu::InverseApproximationFactory: Column global ID in Ainv not found in A rowmap\n");
+      auto rowA = lclA.rowConst(A_lclRowInd);
+
+      for (local_ordinal_type jj = 0; jj < rowA.length; ++jj) {
+        auto j = rowA.colidx(jj);
+        // do binary search to find column in column_indices, but first check that it is
+        // in lower triangular portion of matrix (because this might be faster?)
+        auto A_colGid = lclAColMap.getGlobalElement(j);
+        if (A_colGid <= A_rowGid) {
+          auto it = std::lower_bound(Kokkos::Experimental::begin(column_indices), Kokkos::Experimental::end(column_indices), j);
+          if (it != Kokkos::Experimental::end(column_indices) && *it == j) {
+            ptrdiff_t newIndex   = it - Kokkos::Experimental::begin(column_indices);
+            auto v               = rowA.value(jj);
+            localA(newIndex, ii) = v;
+          }
+        }
+      }
+    }
+    shared_matrix ek(thread.team_scratch(scratchLevel), numRowEntries, 1);
+    // set to zero, set diagonal entry to one
+    for (local_ordinal_type i = 0; i < numRowEntries; ++i) {
+      ek(i, 0) = (i == diagOffset) ? impl_ATS::one() : impl_ATS::zero();
+    }
+
+    // QR solve
+    shared_vector tau(thread.team_scratch(scratchLevel), rowAinv.length);
+    shared_vector work(thread.team_scratch(scratchLevel), numRowEntries);
+    // factorize localA = Q*R in-place
+#define QRway
+#ifdef QRway
+    KokkosBatched::SerialQR<KokkosBatched::Algo::QR::Unblocked>::invoke(localA, tau, work);
+#else
+    KokkosBatched::SerialCholesky<KokkosBatched::Uplo::Lower, KokkosBatched::Algo::Cholesky::Unblocked>::invoke(localA);                                                                                   // use Cholesky
+#endif
+    // ek := Q^T ek
+#ifdef QRway
+    KokkosBatched::SerialApplyQ<KokkosBatched::Side::Left, KokkosBatched::Trans::Transpose, KokkosBatched::Algo::ApplyQ::Unblocked>::invoke(localA, tau, ek, work);
+    // ek[:rowLength] := R^{-1} ek[:rowLength]
+    auto sub_A = Kokkos::subview(localA, Kokkos::make_pair(0, rowAinv.length), Kokkos::ALL());
+#else
+    auto sub_A = Kokkos::subview(localA, Kokkos::make_pair(0, rowAinv.length), Kokkos::make_pair(0, rowAinv.length));                                                                                      // use Cholesky
+#endif
+    auto sub_ek = Kokkos::subview(ek, Kokkos::make_pair(0, rowAinv.length), 0);
+#ifdef QRway
+    KokkosBatched::SerialTrsv<KokkosBatched::Uplo::Upper, KokkosBatched::Trans::NoTranspose, KokkosBatched::Diag::NonUnit, KokkosBatched::Algo::Trsv::Unblocked>::invoke(impl_ATS::one(), sub_A, sub_ek);
+#else
+    KokkosBatched::SerialTrsv<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::NoTranspose, KokkosBatched::Diag::NonUnit, KokkosBatched::Algo::Trsv::Unblocked>::invoke(impl_ATS::one(), sub_A, sub_ek);  // use Cholesky
+    KokkosBatched::SerialTrsv<KokkosBatched::Uplo::Lower, KokkosBatched::Trans::Transpose, KokkosBatched::Diag::NonUnit, KokkosBatched::Algo::Trsv::Unblocked>::invoke(impl_ATS::one(), sub_A, sub_ek);    // use Cholesky
+#endif
+
+    // Set entries of Ainv.
+
+    diagValue = sub_ek(diagOffset);
+    TEUCHOS_TEST_FOR_EXCEPTION(impl_ATS::real(diagValue) <= 0.0, Exceptions::RuntimeError,
+                               "MueLu::InverseApproximationFactory::GetSparseInverse: non positive diagonal entry.");
+    auto scale_factor = impl_ATS::one() / impl_ATS::sqrt(diagValue);
+    for (local_ordinal_type i = 0; i < rowAinv.length; ++i) {
+      auto thevalue = sub_ek(i) * scale_factor;
+      ;
+      if (thevalue == impl_ATS::zero()) thevalue = 1.e-15;  // make sure value retained in sparsity pattern
+      rowAinv.value(i) = thevalue;
+    }
+  }
+};
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
+InverseApproximationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetFactoredSparseInverse(const RCP<Matrix>& Aorg, const RCP<const CrsGraph>& sparsityPattern) const {
+  using execution_space = typename Node::execution_space;
+
+  // construct the inverse matrix with factor the given sparsity pattern
+  RCP<Matrix> Ainv = MatrixFactory::Build(sparsityPattern);
+  Ainv->resumeFill();
+
+  // gather missing rows from other procs to generate an overlapping map
+  RCP<Import> rowImport = ImportFactory::Build(sparsityPattern->getRowMap(), sparsityPattern->getColMap());
+  RCP<Matrix> A         = MatrixFactory::Build(Aorg, *rowImport);
+
+  auto maxRowEntriesAinv = Ainv->getLocalMaxNumRowEntries();
+  {
+    auto lclA          = A->getLocalMatrixDevice();
+    auto lclAinv       = Ainv->getLocalMatrixDevice();
+    auto lclARowmap    = A->getRowMap()->getLocalMap();
+    auto lclAColmap    = A->getColMap()->getLocalMap();
+    auto lclAinvRowmap = Ainv->getRowMap()->getLocalMap();
+    auto lclAinvColmap = Ainv->getColMap()->getLocalMap();
+    auto lclAorgRowmap = Aorg->getRowMap()->getLocalMap();
+
+    Kokkos::TeamPolicy<execution_space> policy(lclAinv.numRows(), 1);
+
+    using fsai_functor_type = LocalFSAIFunctor<decltype(lclAinv), GlobalOrdinal>;
+    using shared_matrix     = typename fsai_functor_type::shared_matrix;
+    using shared_vector     = typename fsai_functor_type::shared_vector;
+    using shared_lo_vector  = typename fsai_functor_type::shared_lo_vector;
+
+    int size = shared_matrix::shmem_size(maxRowEntriesAinv, maxRowEntriesAinv) + shared_matrix::shmem_size(maxRowEntriesAinv, 1) + shared_vector::shmem_size(3 * maxRowEntriesAinv) + shared_vector::shmem_size(maxRowEntriesAinv) + shared_lo_vector::shmem_size(maxRowEntriesAinv);
+
+    int scratchLevel = -1;
+    if (size < policy.scratch_size_max(/*level=*/(int)0)) {
+      policy.set_scratch_size(/*level=*/(int)0, Kokkos::PerTeam(size));
+      scratchLevel = 0;
+    } else if (size < policy.scratch_size_max(/*level=*/(int)1)) {
+      policy.set_scratch_size(/*level=*/(int)1, Kokkos::PerTeam(size));
+      scratchLevel = 1;
+    } else
+      throw Exceptions::RuntimeError("Neither L0 scratch memory (max size " + std::to_string(policy.scratch_size_max((int)0)) +
+                                     "), nor L1 scratch memory (max size " + std::to_string(policy.scratch_size_max((int)1)) +
+                                     ") is large enough for requested allocation of size " + std::to_string(size));
+
+    LocalFSAIFunctor fsaiFunctor(lclA, lclAinv, lclARowmap, lclAColmap, lclAinvRowmap, lclAinvColmap, scratchLevel);
+
+    Kokkos::parallel_for("MueLu::InverseFactory::LocalSpai", policy, fsaiFunctor);
+  }
+
+  Ainv->fillComplete();
+
+  return Ainv;
+}
 
 }  // namespace MueLu
 

--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
@@ -570,7 +570,7 @@ class LocalFSAIFunctor {
     for (local_ordinal_type i = 0; i < rowAinv.length; ++i) {
       auto thevalue = sub_ek(i) * scale_factor;
 
-      if (thevalue == impl_ATS::zero()) thevalue = Teuchos::as<decltype(thevalue)>(1.e-15);  // make sure value retained in sparsity pattern
+      if (thevalue == impl_ATS::zero()) thevalue = impl_ATS::eps();
       rowAinv.value(i) = thevalue;
     }
   }

--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
@@ -96,20 +96,6 @@ void InverseApproximationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Bui
     Ainv                      = MatrixFactory::Build(D);
   } else if (method == "sparseapproxinverse") {
     RCP<CrsGraph> sparsityPattern = Utilities::GetThresholdedGraph(A, tol);
-    auto maxRowEntries            = sparsityPattern->getLocalMaxNumRowEntries();
-    // too many nonzeros per row will cause us to exceed L1 memory space size
-    // lets increase threshold to reduce nnzs per row
-    while (maxRowEntries > 200) {
-      if (tol == 0.0)
-        tol = .005;
-      else
-        tol *= 1.5;
-      if (IsPrint(Statistics1)) {
-        GetOStream(Statistics1) << "MueLu_InverseApproximationFactory: Too many NNZs per row (" << maxRowEntries << "). Reducing NNZs per row by increasing drop threshold to " << tol << std::endl;
-      }
-      sparsityPattern = Utilities::GetThresholdedGraph(A, tol);
-      maxRowEntries   = sparsityPattern->getLocalMaxNumRowEntries();
-    }
     if (IsPrint(Statistics1)) {
       sparsityPattern->computeGlobalConstants();
       GetOStream(Statistics1) << "NNZ Graph(A): " << A->getCrsGraph()->getGlobalNumEntries() << " , NNZ Tresholded Graph(A): " << sparsityPattern->getGlobalNumEntries() << std::endl;
@@ -122,21 +108,6 @@ void InverseApproximationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Bui
     }
   } else if (method == "factoredsparseapproxinverse") {
     RCP<CrsGraph> sparsityPattern = Utilities::GetThresholdedLowerTriangularGraph(A, tol);
-    auto maxRowEntries            = sparsityPattern->getLocalMaxNumRowEntries();
-    // too many nonzeros per row will cause us to exceed L1 memory space size
-    // lets increase threshold to reduce nnzs per row
-    while (maxRowEntries > 200) {
-      if (tol == 0.0)
-        tol = .005;
-      else
-        tol *= 1.5;
-      if (IsPrint(Statistics1)) {
-        GetOStream(Statistics1) << "MueLu_InverseApproximationFactory: Too many NNZs per row (" << maxRowEntries << "). Reducing NNZs per row by increasing drop threshold to " << tol << std::endl;
-      }
-      sparsityPattern = Utilities::GetThresholdedLowerTriangularGraph(A, tol);
-      maxRowEntries   = sparsityPattern->getLocalMaxNumRowEntries();
-    }
-
     if (IsPrint(Statistics1)) {
       sparsityPattern->computeGlobalConstants();
       GetOStream(Statistics1) << "NNZ Graph(A): " << A->getCrsGraph()->getGlobalNumEntries() << " , NNZ Tresholded Graph(triLower(A)): " << sparsityPattern->getGlobalNumEntries() << std::endl;

--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
@@ -568,7 +568,8 @@ class LocalFSAIFunctor {
                                "MueLu::InverseApproximationFactory::GetSparseInverse: non positive diagonal entry.");
     auto scale_factor = impl_ATS::one() / impl_ATS::sqrt(diagValue);
     for (local_ordinal_type i = 0; i < rowAinv.length; ++i) {
-      auto thevalue = sub_ek(i) * scale_factor;
+//      auto thevalue = sub_ek(i) * scale_factor;
+      typename KokkosKernels::ArithTraits<decltype(diagValue)>::val_type thevalue = sub_ek(i) * scale_factor;
 
       if (thevalue == impl_ATS::zero()) thevalue = impl_ATS::eps();
       rowAinv.value(i) = thevalue;

--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
@@ -573,7 +573,7 @@ class LocalFSAIFunctor {
     for (local_ordinal_type i = 0; i < rowAinv.length; ++i) {
       auto thevalue = sub_ek(i) * scale_factor;
       ;
-      if (thevalue == impl_ATS::zero()) thevalue = 1.e-15;  // make sure value retained in sparsity pattern
+      if (thevalue == impl_ATS::zero()) thevalue = Teuchos::as<scalar_type>(1.e-15);  // make sure value retained in sparsity pattern
       rowAinv.value(i) = thevalue;
     }
   }

--- a/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_InverseApproximationFactory_def.hpp
@@ -493,7 +493,7 @@ class LocalFSAIFunctor {
       }
     }
 #ifdef HAVE_MUELU_DEBUG  // code must also be compiled with -DKokkos_ENABLE_DEBUG=ON
-    KOKKOS_ASSERT(A_lclRowIndForDiag == -1 && "MueLu::InverseApproximationFactory::GetSparseInverse: no diagonal entry found in A.");
+    KOKKOS_ASSERT(A_lclRowIndForDiag != -1 && "MueLu::InverseApproximationFactory::GetSparseInverse: no diagonal entry found in A.");
 #endif
 
     Kokkos::Experimental::sort_thread(thread, column_indices);  // in order to apply binary search later
@@ -501,7 +501,7 @@ class LocalFSAIFunctor {
       if (column_indices(kkk) == A_lclRowIndForDiag) diagOffset = kkk;
     }
 #ifdef HAVE_MUELU_DEBUG
-    KOKKOS_ASSERT(diagOffset == -1 && "MueLu::InverseApproximationFactory::GetSparseInverse: no diagonal entry found in A.");
+    KOKKOS_ASSERT(diagOffset != -1 && "MueLu::InverseApproximationFactory::GetSparseInverse: no diagonal entry offset found in A.");
 #endif
 
     // Extract local part of A into a dense view.
@@ -514,7 +514,7 @@ class LocalFSAIFunctor {
       auto Ainv_colGid               = lclAinvColMap.getGlobalElement(i);  // for debugging
       local_ordinal_type A_lclRowInd = lclARowMap.getLocalElement(Ainv_colGid);
 #ifdef HAVE_MUELU_DEBUG
-      KOKKOS_ASSERT(A_lclRowInd == -1 && "MueLu::InverseApproximationFactory: Column global ID in Ainv not found in A rowmap");
+      KOKKOS_ASSERT(A_lclRowInd != -1 && "MueLu::InverseApproximationFactory: Column global ID in Ainv not found in A rowmap");
 #endif
       auto rowA = lclA.rowConst(A_lclRowInd);
 
@@ -566,7 +566,7 @@ class LocalFSAIFunctor {
 
     diagValue = sub_ek(diagOffset);
 #ifdef HAVE_MUELU_DEBUG
-    KOKKOS_ASSERT(impl_ATS::real(diagValue) <= 0.0 && "MueLu::InverseApproximationFactory::GetSparseInverse: non positive diagonal entry.");
+    KOKKOS_ASSERT(impl_ATS::real(diagValue) > 0.0 && "MueLu::InverseApproximationFactory::GetSparseInverse: non positive diagonal entry.");
 #endif
     auto scale_factor = impl_ATS::one() / impl_ATS::sqrt(diagValue);
     for (local_ordinal_type i = 0; i < rowAinv.length; ++i) {

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -189,6 +189,7 @@ namespace MueLu {
   "<Parameter name=\"aggregation: distance laplacian directional weights\" type=\"Array(double)\" value=\"{1,1,1}\"/>"
   "<Parameter name=\"aggregation: distance laplacian algo\" type=\"string\" value=\"default\"/>"
   "<Parameter name=\"aggregation: distance laplacian metric\" type=\"string\" value=\"unweighted\"/>"
+  "<Parameter name=\"aggregation: Minv scheme\" type=\"string\" value=\"fsai\"/>"
   "<Parameter name=\"aggregation: classical algo\" type=\"string\" value=\"default\"/>"
   "<Parameter name=\"aggregation: drop tol\" type=\"double\" value=\"0.0\"/>"
   "<Parameter name=\"aggregation: use ml scaling of drop tol\" type=\"bool\" value=\"false\"/>"
@@ -658,6 +659,8 @@ namespace MueLu {
          ("aggregation: distance laplacian algo","aggregation: distance laplacian algo")
       
          ("aggregation: distance laplacian metric","aggregation: distance laplacian metric")
+      
+         ("aggregation: Minv scheme","aggregation: Minv scheme")
       
          ("aggregation: classical algo","aggregation: classical algo")
       

--- a/packages/muelu/src/Operators/MueLu_CreateXpetraPreconditioner.hpp
+++ b/packages/muelu/src/Operators/MueLu_CreateXpetraPreconditioner.hpp
@@ -111,7 +111,7 @@ CreateXpetraPreconditioner(Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, Glo
     const Teuchos::ParameterList& userList = inParamList.sublist("user data");
     if (userList.isParameter("M")) M_Supplied = true;
     if (userList.isParameter("Minv")) Minv_Supplied = true;
-    if (userList.isParameter("MinvA")) Minv_Supplied = true;
+    if (userList.isParameter("MinvA")) MinvA_Supplied = true;
   }
   if (inParamList.isParameter("aggregation: strength-of-connection: matrix") && (inParamList.get<std::string>("aggregation: strength-of-connection: matrix") == "MinvA")) {
     if (inParamList.isSublist("project auxiliary matrices")) {
@@ -122,7 +122,7 @@ CreateXpetraPreconditioner(Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, Glo
       TEUCHOS_TEST_FOR_EXCEPTION(projectList.isParameter("MinvA") && (projectList.get("MinvA", "") == "NoFactory") && !MinvA_Supplied, Exceptions::Incompatible,
                                  "MueLu_CreateXpetraPreconditioner: Must supply MinvA as NoFactory is listed as supplier of MinvA in the project auxiliary matrices sublist");
     } else {  // default behavior if sublist("project auxiliary matrices") not user-supplied requires "M" to be user-supplied.
-      TEUCHOS_TEST_FOR_EXCEPTION(!M_Supplied, Exceptions::Incompatible, "MueLu_CreateXpetraPreconditioner: Must supply M when 'aggregation: strength-of-connection: matrix'= MinvA and sublist('project auxiliary matrices') not supplied.");
+      TEUCHOS_TEST_FOR_EXCEPTION(!M_Supplied && !Minv_Supplied, Exceptions::Incompatible, "MueLu_CreateXpetraPreconditioner: Must supply M or Minv when 'aggregation: strength-of-connection: matrix'= MinvA and sublist('project auxiliary matrices') not supplied.");
     }
   }
 

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceAcFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceAcFactory_def.hpp
@@ -69,7 +69,13 @@ void RebalanceAcFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level 
   else
     coarseMatrixName = matrixName + "_coarse";
 
-  if (!(coarseLevel.IsAvailable(matrixName, GetFactory("A").get()))) return;
+  // ugly hack to fix issue with MinvA when number of max levels is small. Arises because
+  // M, Minv, or MinvA are not needed or requested/produced on last level and so we shouldn't
+  // try to rebalance them in this case. Note: Limiting the possible early return from this
+  // function only for M, Minv, or MinvA as in the reuse case data might not be available
+  // but Get() knows how to produce (or reuse it).
+
+  if (!(coarseLevel.IsAvailable(matrixName, GetFactory("A").get())) && ((matrixName == "M") || (matrixName == "Minv") || (matrixName == "MinvA"))) return;
   FactoryMonitor m(*this, "Computing " + coarseMatrixName, coarseLevel);
 
   RCP<Matrix> originalAc = coarseLevel.Get<RCP<Matrix> >(matrixName, GetFactory("A").get());

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceAcFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceAcFactory_def.hpp
@@ -69,6 +69,7 @@ void RebalanceAcFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level 
   else
     coarseMatrixName = matrixName + "_coarse";
 
+  if (!(coarseLevel.IsAvailable(matrixName, GetFactory("A").get()))) return;
   FactoryMonitor m(*this, "Computing " + coarseMatrixName, coarseLevel);
 
   RCP<Matrix> originalAc = coarseLevel.Get<RCP<Matrix> >(matrixName, GetFactory("A").get());

--- a/packages/muelu/src/Utils/MueLu_UtilitiesBase_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_UtilitiesBase_decl.hpp
@@ -92,6 +92,14 @@ class UtilitiesBase {
   */
   static RCP<Xpetra::CrsGraph<LocalOrdinal, GlobalOrdinal, Node>> GetThresholdedGraph(const RCP<Matrix>& A, const Magnitude threshold);
 
+  /*! @brief Threshold a graph
+
+    Returns graph associated with lower triangular matrix that is also filtered with a threshold value.
+
+    NOTE -- it's assumed that A has been fillComplete'd.
+  */
+  static RCP<Xpetra::CrsGraph<LocalOrdinal, GlobalOrdinal, Node>> GetThresholdedLowerTriangularGraph(const RCP<Matrix>& A, const Magnitude threshold);
+
   /*! @brief Extract Matrix Diagonal
 
     Returns Matrix diagonal in ArrayRCP.
@@ -444,7 +452,7 @@ class UtilitiesBase {
                                 const Teuchos::ArrayRCP<const bool>& dirichletCols,
                                 Scalar replaceWith = Teuchos::ScalarTraits<Scalar>::zero());
 
-  static void ZeroDirichletCols(RCP<Matrix>& A, const Kokkos::View<const bool*, typename NO::device_type>& dirichletCols, SC replaceWith = Teuchos::ScalarTraits<SC>::zero());
+  static void ZeroDirichletCols(RCP<Matrix>& A, const Kokkos::View<const bool*, typename NO::device_type>& dirichletCols, SC replaceWith = Teuchos::ScalarTraits<SC>::zero(), const bool DontZeroDiagEntries = false);
 
   // Finds the OAZ Dirichlet rows for this matrix
   static void FindDirichletRowsAndPropagateToCols(Teuchos::RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& A,
@@ -456,7 +464,7 @@ class UtilitiesBase {
   static RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> ReplaceNonZerosWithOnes(const RCP<Matrix>& original);
 
   //! Creates a sparse approximate inverse of a matrix with the same nonzero pattern as the input matrix
-  static RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> SPAI(const RCP<Matrix>& original);
+  static RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>> SPAI(const RCP<Matrix>& original, const std::string& MinvScheme);
 
   // This routine takes a BlockedMap and an Importer (assuming that the BlockedMap matches the source of the importer) and generates a BlockedMap corresponding
   // to the Importer's target map.  We assume that the targetMap is unique (which, is not a strict requirement of an Importer, but is here and no, we don't check)

--- a/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
@@ -1688,6 +1688,10 @@ UtilitiesBase<SC, LO, GO, NO>::
   using ATS        = KokkosKernels::ArithTraits<SC>;
   using impl_ATS   = KokkosKernels::ArithTraits<typename ATS::val_type>;
   using range_type = Kokkos::RangePolicy<LO, typename NO::execution_space>;
+  using scalar_type = typename KokkosKernels::ArithTraits<SC>::val_type;
+  using mag_type    = typename KokkosKernels::ArithTraits<scalar_type>::mag_type;
+  using KAT_M       = typename KokkosKernels::ArithTraits<mag_type>;
+  using KAT_S       = typename KokkosKernels::ArithTraits<scalar_type>;
 
   SC zero = ATS::zero();
 
@@ -1708,7 +1712,7 @@ UtilitiesBase<SC, LO, GO, NO>::
           auto length  = rowView.length;
 
           for (decltype(length) colID = 0; colID < length; colID++) {
-            if (impl_ATS::magnitude(rowView.value(colID)) != zero)
+            if ( KAT_S::abs(rowView.value(colID)) >  KAT_M::zero())
               myColsToZeroView(rowView.colidx(colID), 0) = impl_ATS::one();
           }
         }

--- a/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
@@ -278,6 +278,93 @@ UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+RCP<Xpetra::CrsGraph<LocalOrdinal, GlobalOrdinal, Node>>
+UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+    GetThresholdedLowerTriangularGraph(const RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& A, const Magnitude threshold) {
+  RCP<CrsGraph> sparsityPattern;
+  {
+    using matrix_type      = Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+    using graph_type       = Xpetra::CrsGraph<LocalOrdinal, GlobalOrdinal, Node>;
+    using local_graph_type = typename graph_type::local_graph_device_type;
+    using execution_space  = typename Node::execution_space;
+    using rowmap_type      = typename local_graph_type::row_map_type::non_const_type;
+    using entries_type     = typename local_graph_type::entries_type::non_const_type;
+    using range_type       = Kokkos::RangePolicy<execution_space, LocalOrdinal>;
+    using implATS          = KokkosKernels::ArithTraits<typename matrix_type::impl_scalar_type>;
+    using magATS           = KokkosKernels::ArithTraits<typename implATS::magnitudeType>;
+    auto lclA              = A->getLocalMatrixDevice();
+    auto lclRowmap         = A->getRowMap()->getLocalMap();
+    auto lclColmap         = A->getColMap()->getLocalMap();
+
+    rowmap_type rowptr("MueLu::GetLowerTriangularGraph::rowptr", lclA.numRows() + 1);
+
+    LocalOrdinal nnz = 0;
+    Kokkos::parallel_scan(
+        range_type(0, lclA.numRows()), KOKKOS_LAMBDA(const LocalOrdinal rlid, LocalOrdinal& my_nnz, const bool is_final) {
+          auto row     = lclA.rowConst(rlid);
+          auto row_gid = lclRowmap.getGlobalElement(rlid);
+
+          typename implATS::magnitudeType d = magATS::one();
+          for (LocalOrdinal offset = 0; offset < row.length; ++offset) {
+            auto clid    = row.colidx(offset);
+            auto col_gid = lclColmap.getGlobalElement(clid);
+            if (row_gid == col_gid) {
+              auto val = implATS::magnitude(row.value(offset));
+              if (val > implATS::epsilon())
+                d = val;
+            }
+          }
+
+          for (LocalOrdinal offset = 0; offset < row.length; ++offset) {
+            auto clid    = row.colidx(offset);
+            auto val     = row.value(offset);
+            auto col_gid = lclColmap.getGlobalElement(clid);
+            if ((row_gid == col_gid) || ((row_gid > col_gid) && implATS::magnitude(val) > d * threshold)) {
+              ++my_nnz;
+              if (is_final && (rlid + 1 < lclA.numRows())) {
+                rowptr(rlid + 2) = my_nnz;
+              }
+            }
+          }
+        },
+        nnz);
+
+    entries_type entries(Kokkos::ViewAllocateWithoutInitializing("MueLu::GetThresholdedLowerTriangularGraph::indices"), nnz);
+    Kokkos::parallel_for(
+        range_type(0, lclA.numRows()), KOKKOS_LAMBDA(const LocalOrdinal rlid) {
+          auto row     = lclA.rowConst(rlid);
+          auto row_gid = lclRowmap.getGlobalElement(rlid);
+
+          typename implATS::magnitudeType d = magATS::one();
+          for (LocalOrdinal offset = 0; offset < row.length; ++offset) {
+            auto clid    = row.colidx(offset);
+            auto col_gid = lclColmap.getGlobalElement(clid);
+            if (row_gid == col_gid) {
+              auto val = implATS::magnitude(row.value(offset));
+              if (val > implATS::epsilon())
+                d = val;
+            }
+          }
+
+          for (LocalOrdinal offset = 0; offset < row.length; ++offset) {
+            auto clid    = row.colidx(offset);
+            auto val     = row.value(offset);
+            auto col_gid = lclColmap.getGlobalElement(clid);
+            if ((row_gid == col_gid) || ((row_gid > col_gid) && implATS::magnitude(val) > d * threshold)) {
+              entries(rowptr(rlid + 1)) = clid;
+              ++rowptr(rlid + 1);
+            }
+          }
+        });
+
+    sparsityPattern = CrsGraphFactory::Build(A->getRowMap(), A->getColMap(), rowptr, entries);
+    sparsityPattern->fillComplete(A->getDomainMap(), A->getRangeMap());
+  }
+
+  return sparsityPattern;
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::ArrayRCP<Scalar>
 UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     GetMatrixDiagonal_arcp(const Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A) {
@@ -1603,6 +1690,7 @@ UtilitiesBase<SC, LO, GO, NO>::
   using range_type = Kokkos::RangePolicy<LO, typename NO::execution_space>;
 
   SC zero = ATS::zero();
+  SC one  = ATS::one();
 
   auto localMatrix = A.getLocalMatrixDevice();
   LO numRows       = A.getLocalNumRows();
@@ -1620,8 +1708,10 @@ UtilitiesBase<SC, LO, GO, NO>::
           auto rowView = localMatrix.row(row);
           auto length  = rowView.length;
 
-          for (decltype(length) colID = 0; colID < length; colID++)
-            myColsToZeroView(rowView.colidx(colID), 0) = impl_ATS::one();
+          for (decltype(length) colID = 0; colID < length; colID++) {
+            if (rowView.value(colID) == one)
+              myColsToZeroView(rowView.colidx(colID), 0) = impl_ATS::one();
+          }
         }
       });
 
@@ -1965,7 +2055,7 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     ZeroDirichletCols(RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& A,
                       const Kokkos::View<const bool*, typename Node::device_type>& dirichletCols,
-                      Scalar replaceWith) {
+                      Scalar replaceWith, const bool DontZeroDiagEntries) {
   using ATS        = KokkosKernels::ArithTraits<Scalar>;
   using range_type = Kokkos::RangePolicy<LocalOrdinal, typename Node::execution_space>;
 
@@ -1973,16 +2063,29 @@ void UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
   auto localMatrix     = A->getLocalMatrixDevice();
   LocalOrdinal numRows = A->getLocalNumRows();
+  auto lclRowmap       = A->getRowMap()->getLocalMap();
+  auto lclCowmap       = A->getColMap()->getLocalMap();
 
   Kokkos::parallel_for(
       "MueLu:Utils::ZeroDirichletCols", range_type(0, numRows),
       KOKKOS_LAMBDA(const LocalOrdinal row) {
         auto rowView = localMatrix.row(row);
         auto length  = rowView.length;
-        for (decltype(length) colID = 0; colID < length; colID++)
-          if (dirichletCols(rowView.colidx(colID))) {
-            rowView.value(colID) = impl_replaceWith;
+
+        if (DontZeroDiagEntries) {
+          auto rgid = lclRowmap.getGlobalElement(row);
+          for (decltype(length) colID = 0; colID < length; colID++) {
+            if (dirichletCols(rowView.colidx(colID))) {
+              auto cgid = lclCowmap.getGlobalElement(rowView.colidx(colID));
+              if (rgid != cgid) rowView.value(colID) = impl_replaceWith;
+            }
           }
+        } else {
+          for (decltype(length) colID = 0; colID < length; colID++)
+            if (dirichletCols(rowView.colidx(colID))) {
+              rowView.value(colID) = impl_replaceWith;
+            }
+        }
       });
 }
 
@@ -2062,7 +2165,7 @@ UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
-UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SPAI(const RCP<Matrix>& M) {
+UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SPAI(const RCP<Matrix>& M, const std::string& MinvScheme) {
   // Create Minv via sparse apprximate inverse
 
   Level miniLevel;
@@ -2076,7 +2179,11 @@ UtilitiesBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SPAI(const RCP<Matrix>
 
   auto invapproxFact = rcp(new InverseApproximationFactory());
   invapproxFact->SetFactory("A", MueLu::NoFactory::getRCP());
-  invapproxFact->SetParameter("inverse: approximation type", Teuchos::ParameterEntry(std::string("sparseapproxinverse")));
+  if (MinvScheme == "fsai")
+    invapproxFact->SetParameter("inverse: approximation type", Teuchos::ParameterEntry(std::string("factoredsparseapproxinverse")));
+  else
+    invapproxFact->SetParameter("inverse: approximation type", Teuchos::ParameterEntry(std::string("sparseapproxinverse")));
+
   miniLevel.Request("Ainv", invapproxFact.get());
   invapproxFact->Build(miniLevel);
   RCP<Matrix> NewMatrix = miniLevel.Get<RCP<Matrix>>("Ainv", invapproxFact.get());

--- a/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
@@ -1708,7 +1708,7 @@ UtilitiesBase<SC, LO, GO, NO>::
           auto length  = rowView.length;
 
           for (decltype(length) colID = 0; colID < length; colID++) {
-            if (rowView.value(colID) != zero)
+            if (impl_ATS::magnitude(rowView.value(colID)) != zero)
               myColsToZeroView(rowView.colidx(colID), 0) = impl_ATS::one();
           }
         }

--- a/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
@@ -1690,7 +1690,6 @@ UtilitiesBase<SC, LO, GO, NO>::
   using range_type = Kokkos::RangePolicy<LO, typename NO::execution_space>;
 
   SC zero = ATS::zero();
-  SC one  = ATS::one();
 
   auto localMatrix = A.getLocalMatrixDevice();
   LO numRows       = A.getLocalNumRows();

--- a/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
@@ -1709,7 +1709,7 @@ UtilitiesBase<SC, LO, GO, NO>::
           auto length  = rowView.length;
 
           for (decltype(length) colID = 0; colID < length; colID++) {
-            if (rowView.value(colID) == one)
+            if (rowView.value(colID) != zero)
               myColsToZeroView(rowView.colidx(colID), 0) = impl_ATS::one();
           }
         }

--- a/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_UtilitiesBase_def.hpp
@@ -1685,9 +1685,9 @@ Kokkos::View<bool*, typename NO::device_type>
 UtilitiesBase<SC, LO, GO, NO>::
     DetectDirichletCols(const Xpetra::Matrix<SC, LO, GO, NO>& A,
                         const Kokkos::View<const bool*, typename NO::device_type>& dirichletRows) {
-  using ATS        = KokkosKernels::ArithTraits<SC>;
-  using impl_ATS   = KokkosKernels::ArithTraits<typename ATS::val_type>;
-  using range_type = Kokkos::RangePolicy<LO, typename NO::execution_space>;
+  using ATS         = KokkosKernels::ArithTraits<SC>;
+  using impl_ATS    = KokkosKernels::ArithTraits<typename ATS::val_type>;
+  using range_type  = Kokkos::RangePolicy<LO, typename NO::execution_space>;
   using scalar_type = typename KokkosKernels::ArithTraits<SC>::val_type;
   using mag_type    = typename KokkosKernels::ArithTraits<scalar_type>::mag_type;
   using KAT_M       = typename KokkosKernels::ArithTraits<mag_type>;
@@ -1712,7 +1712,7 @@ UtilitiesBase<SC, LO, GO, NO>::
           auto length  = rowView.length;
 
           for (decltype(length) colID = 0; colID < length; colID++) {
-            if ( KAT_S::abs(rowView.value(colID)) >  KAT_M::zero())
+            if (KAT_S::abs(rowView.value(colID)) > KAT_M::zero())
               myColsToZeroView(rowView.colidx(colID), 0) = impl_ATS::one();
           }
         }

--- a/packages/muelu/test/interface/default/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin1_tpetra.gold
@@ -41,7 +41,7 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestGenResNorm<>: (2-Norm Imp Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    6.665458e+01
-Iter 1, [ 1] :    2.307178e-13
+Iter 1, [ 1] :    6.447167e-12
 Transpose P (MueLu::TransPFactory)
 matrixmatrix: kernel params -> 
  [empty list]
@@ -88,7 +88,7 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestGenResNorm<>: (2-Norm Imp Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    4.275004e+00
-Iter 1, [ 1] :    1.202650e-14
+Iter 1, [ 1] :    5.179015e-13
 Transpose P (MueLu::TransPFactory)
 matrixmatrix: kernel params -> 
  [empty list]

--- a/packages/muelu/test/interface/default/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin3_tpetra.gold
@@ -41,7 +41,7 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestImpResNorm<>: (2-Norm Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    6.665458e+01
-Iter 1, [ 1] :    1.690194e-16
+Iter 1, [ 1] :    1.473085e-16
 emin: num iterations = 1
 emin: iterative method = gmres
 Transpose P (MueLu::TransPFactory)
@@ -90,7 +90,7 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestImpResNorm<>: (2-Norm Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    4.275004e+00
-Iter 1, [ 1] :    7.387975e-16
+Iter 1, [ 1] :    7.060568e-17
 emin: num iterations = 1
 emin: iterative method = gmres
 Transpose P (MueLu::TransPFactory)

--- a/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
@@ -40,7 +40,7 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestGenResNorm<>: (2-Norm Imp Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    6.665458e+01
-Iter 1, [ 1] :    2.307178e-13
+Iter 1, [ 1] :    6.447167e-12
 Transpose P (MueLu::TransPFactory)
 matrixmatrix: kernel params -> 
  [empty list]
@@ -86,7 +86,7 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestGenResNorm<>: (2-Norm Imp Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    4.275004e+00
-Iter 1, [ 1] :    1.202650e-14
+Iter 1, [ 1] :    5.179015e-13
 Transpose P (MueLu::TransPFactory)
 matrixmatrix: kernel params -> 
  [empty list]

--- a/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
@@ -40,7 +40,7 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestImpResNorm<>: (2-Norm Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    6.665458e+01
-Iter 1, [ 1] :    1.690194e-16
+Iter 1, [ 1] :    1.473085e-16
 emin: num iterations = 1
 emin: iterative method = gmres
 Transpose P (MueLu::TransPFactory)
@@ -88,7 +88,7 @@ Getting P from coarseLevel
 *****   Test 1 : Belos::StatusTestImpResNorm<>: (2-Norm Res Vec) , tol = 1e-08
 *******************************************************
 Iter 0, [ 1] :    4.275004e+00
-Iter 1, [ 1] :    7.387975e-16
+Iter 1, [ 1] :    7.060568e-17
 emin: num iterations = 1
 emin: iterative method = gmres
 Transpose P (MueLu::TransPFactory)

--- a/packages/muelu/test/scaling/MinvA.xml
+++ b/packages/muelu/test/scaling/MinvA.xml
@@ -18,6 +18,7 @@
   <Parameter        name="use kokkos refactor"                  type="bool" value="true"/>
   <Parameter        name="tentative: calculate qr"              type="bool" value="false"/>
 
+  <Parameter        name="aggregation: Minv scheme" type="string"  value="spai"/>
   <Parameter        name="aggregation: strength-of-connection: matrix" type="string"  value="MinvA"  />
   <Parameter        name="aggregation: strength-of-connection: measure" type="string" value="signed ruge-stueben"/>
   <Parameter        name="aggregation: drop scheme" type="string"                     value="point-wise"          />

--- a/packages/muelu/test/scaling/MinvA_ProjM.xml
+++ b/packages/muelu/test/scaling/MinvA_ProjM.xml
@@ -18,6 +18,7 @@
   <Parameter        name="use kokkos refactor"                  type="bool" value="true"/>
   <Parameter        name="tentative: calculate qr"              type="bool" value="false"/>
 
+  <Parameter        name="aggregation: Minv scheme" type="string"  value="fsai"/>
   <Parameter        name="aggregation: strength-of-connection: matrix" type="string"  value="MinvA"  />
   <Parameter        name="aggregation: strength-of-connection: measure" type="string" value="signed ruge-stueben"/>
   <Parameter        name="aggregation: drop scheme" type="string"                     value="point-wise"          />

--- a/packages/muelu/test/scaling/MinvA_ProjM.xml
+++ b/packages/muelu/test/scaling/MinvA_ProjM.xml
@@ -1,9 +1,9 @@
 <ParameterList name="MueLu">
   <!-- ===========  GENERAL ================ -->
   <Parameter        name="verbosity"                            type="string"   value="high"/>
-  <Parameter        name="coarse: max size"                     type="int"      value="500"/>
+  <Parameter        name="coarse: max size"                     type="int"      value="100"/>
   <Parameter        name="transpose: use implicit"              type="bool"     value="true"/>
-  <Parameter        name="max levels"                	          type="int"      value="10"/>
+  <Parameter        name="max levels"                	        type="int"      value="4"/>
   <Parameter        name="number of equations"                  type="int"      value="1"/>
 
   <Parameter        name="multigrid algorithm"                  type="string"   value="sa"/>

--- a/packages/muelu/test/scaling/MinvA_ProjMinv.xml
+++ b/packages/muelu/test/scaling/MinvA_ProjMinv.xml
@@ -18,6 +18,7 @@
   <Parameter        name="use kokkos refactor"                  type="bool" value="true"/>
   <Parameter        name="tentative: calculate qr"              type="bool" value="false"/>
 
+  <Parameter        name="aggregation: Minv scheme" type="string"  value="spai"/>
   <Parameter        name="aggregation: strength-of-connection: matrix" type="string"  value="MinvA"  />
   <Parameter        name="aggregation: strength-of-connection: measure" type="string" value="signed ruge-stueben"/>
   <Parameter        name="aggregation: drop scheme" type="string"                     value="point-wise"          />

--- a/packages/muelu/test/unit_tests_kokkos/CoalesceDropFactory_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/CoalesceDropFactory_kokkos.cpp
@@ -1055,6 +1055,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CoalesceDropFactory_kokkos, MassMatrixSOC, Sca
     coalesceDropFact.SetParameter("aggregation: drop scheme", Teuchos::ParameterEntry(std::string("point-wise")));
     coalesceDropFact.SetParameter("aggregation: strength-of-connection: measure", Teuchos::ParameterEntry(std::string("smoothed aggregation")));
     coalesceDropFact.SetParameter("aggregation: strength-of-connection: matrix", Teuchos::ParameterEntry(std::string("MinvA")));
+    coalesceDropFact.SetParameter("aggregation: Minv scheme", Teuchos::ParameterEntry(std::string("spai")));
     fineLevel.Request("Graph", &coalesceDropFact);
     fineLevel.Request("A", &coalesceDropFact);
     fineLevel.Request("M", &coalesceDropFact);
@@ -1137,6 +1138,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CoalesceDropFactory_kokkos, MinvADropsTwoThird
     coalesceDropFact.SetParameter("aggregation: drop scheme", Teuchos::ParameterEntry(std::string("point-wise")));
     coalesceDropFact.SetParameter("aggregation: strength-of-connection: measure", Teuchos::ParameterEntry(std::string("smoothed aggregation")));
     coalesceDropFact.SetParameter("aggregation: strength-of-connection: matrix", Teuchos::ParameterEntry(std::string("MinvA")));
+    coalesceDropFact.SetParameter("aggregation: Minv scheme", Teuchos::ParameterEntry(std::string("spai")));
     fineLevel.Request("Graph", &coalesceDropFact);
     fineLevel.Request("A", &coalesceDropFact);
     fineLevel.Request("M", &coalesceDropFact);
@@ -1155,6 +1157,121 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CoalesceDropFactory_kokkos, MinvADropsTwoThird
 
   out << "Global number of nonzeros in original A vs. filteredA is " << A->getGlobalNumEntries() << " vs. " << filteredA->getGlobalNumEntries() << std::endl;
   TEUCHOS_ASSERT_EQUALITY(filteredA->getGlobalNumEntries(), (nx - 2) * (nx - 2) * 3 + (nx - 2) * 2 * 3 + (nx - 2) * 2 * 2 + 4 * 2);
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CoalesceDropFactory_kokkos, MinvADirichletTest, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
+#include <MueLu_UseShortNames.hpp>
+  typedef Teuchos::ScalarTraits<SC> STS;
+  typedef typename STS::magnitudeType real_type;
+  typedef Xpetra::MultiVector<real_type, LO, GO, NO> RealValuedMultiVector;
+
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar, GlobalOrdinal, Node);
+  out << "version: " << MueLu::Version() << std::endl;
+
+  RCP<const Teuchos::Comm<int>> comm = Parameters::getDefaultComm();
+  Xpetra::UnderlyingLib lib          = TestHelpers_kokkos::Parameters::getLib();
+
+  RCP<Matrix> A;
+  const int nx = 20;
+  {
+    // Make a 2D Star2D Matrix with up/down as a "weak connection"
+    Teuchos::ParameterList stiff_Pl;
+    stiff_Pl.set("matrixType", "Star2D");
+    stiff_Pl.set("nx", (GO)nx);
+    stiff_Pl.set("ny", (GO)nx);
+    stiff_Pl.set("a", 17.0);
+    stiff_Pl.set("b", 3.5);
+    stiff_Pl.set("c", 3.5);
+    stiff_Pl.set("d", -7.75);
+    stiff_Pl.set("e", -7.75);
+    stiff_Pl.set("z1", -2.125);
+    stiff_Pl.set("z2", -2.125);
+    stiff_Pl.set("z3", -2.125);
+    stiff_Pl.set("z4", -2.125);
+    A = TestHelpers_kokkos::TestFactory<SC, LO, GO, NO>::BuildMatrix(stiff_Pl, lib);
+  }
+  const auto INVALID = Teuchos::OrdinalTraits<LocalOrdinal>::invalid();
+
+  RCP<Matrix> filteredA;
+  {
+    Level fineLevel;
+    TestHelpers_kokkos::TestFactory<SC, LO, GO, NO>::createSingleLevelHierarchy(fineLevel);
+
+    auto crsA = Teuchos::rcp_dynamic_cast<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(A, true)->getCrsMatrix();
+    crsA->resumeFill();
+
+    auto rowmap = A->getRowMap();
+    auto colmap = A->getColMap();
+    auto lclA   = A->getLocalMatrixHost();
+
+    // set first nx rows of A to be Dirichlet
+    for (GO row_gid = 0; row_gid < nx; row_gid++) {
+      auto row_lid = rowmap->getLocalElement(row_gid);
+      auto col_lid = colmap->getLocalElement(row_gid);
+      if ((row_lid != INVALID) && (col_lid != INVALID)) {
+        auto row = lclA.row(row_lid);
+        for (LocalOrdinal k = 0; k < row.length; ++k) {
+          if (row.colidx(k) == col_lid)
+            row.value(k) = Teuchos::ScalarTraits<SC>::one();
+          else
+            row.value(k) = Teuchos::ScalarTraits<SC>::zero();
+        }
+      }
+    }
+    crsA->fillComplete();
+
+    fineLevel.Set("A", A);
+    Teuchos::ParameterList mass_Pl;
+    mass_Pl.set("matrixType", "Star2D");
+
+    mass_Pl.set("nx", (GO)nx);
+    mass_Pl.set("ny", (GO)nx);
+    mass_Pl.set("a", 2.88);
+    mass_Pl.set("b", .72);
+    mass_Pl.set("c", .72);
+    mass_Pl.set("d", .72);
+    mass_Pl.set("e", .72);
+    mass_Pl.set("z1", .18);
+    mass_Pl.set("z2", .18);
+    mass_Pl.set("z3", .18);
+    mass_Pl.set("z4", .18);
+    RCP<Matrix> M = TestHelpers_kokkos::TestFactory<SC, LO, GO, NO>::BuildMatrix(mass_Pl, lib);
+    fineLevel.Set("M", M);
+
+    CoalesceDropFactory_kokkos coalesceDropFact;
+    coalesceDropFact.SetDefaultVerbLevel(MueLu::Extreme);
+    coalesceDropFact.SetParameter("aggregation: drop tol", Teuchos::ParameterEntry(.26));
+    coalesceDropFact.SetParameter("filtered matrix: reuse graph", Teuchos::ParameterEntry(false));
+    coalesceDropFact.SetParameter("aggregation: drop scheme", Teuchos::ParameterEntry(std::string("point-wise")));
+    coalesceDropFact.SetParameter("aggregation: strength-of-connection: measure", Teuchos::ParameterEntry(std::string("smoothed aggregation")));
+    coalesceDropFact.SetParameter("aggregation: strength-of-connection: matrix", Teuchos::ParameterEntry(std::string("MinvA")));
+    coalesceDropFact.SetParameter("aggregation: Minv scheme", Teuchos::ParameterEntry(std::string("spai")));
+    fineLevel.Request("Graph", &coalesceDropFact);
+    fineLevel.Request("A", &coalesceDropFact);
+    fineLevel.Request("M", &coalesceDropFact);
+    fineLevel.Request("DofsPerNode", &coalesceDropFact);
+
+    coalesceDropFact.Build(fineLevel);
+
+    filteredA = fineLevel.Get<RCP<Matrix>>("A", &coalesceDropFact);
+  }
+
+  // We picked the drop tolerance such that we drop all entries associated with x coupling
+  // As we have a Dirichlet on lower boundary and because we zero out rows/columns associated
+  // with Dirichlets, we should have 1 nonzero for Dirichlet BC, 2 nonzeros for Neumann bcs
+  // on upper boundary, 3 nonzeros for Neumann bcs on left and right boundary. The interior
+  // dofs not adjacent to Dirichlet all have 3 nonzeros while those adjacent to Dirichlet
+  // have 2. This works out to
+
+  const int interior_with_3nnzs = (nx - 2) * (nx - 3);
+  const int bcs_with_1nnzs      = nx;            //  bottom
+  const int bcs_with_2nnzs      = nx;            //  top;
+  const int bcs_with_3nnzs      = (nx - 3) * 2;  //  left and right;
+  const int DirAdj_with_2nnzs   = nx;
+
+  out << "Global number of nonzeros in original A vs. filteredA is " << A->getGlobalNumEntries() << " vs. " << filteredA->getGlobalNumEntries() << std::endl;
+  TEUCHOS_ASSERT_EQUALITY((int)filteredA->getGlobalNumEntries(), interior_with_3nnzs * 3 + bcs_with_1nnzs + bcs_with_2nnzs * 2 + bcs_with_3nnzs * 3 + DirAdj_with_2nnzs * 2);
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CoalesceDropFactory_kokkos, ClassicalScaledCut, Scalar, LocalOrdinal, GlobalOrdinal, Node) {
@@ -3575,6 +3692,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CoalesceDropFactory_kokkos, CountNegativeDiago
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CoalesceDropFactory_kokkos, SignedClassicalDistanceLaplacian, SC, LO, GO, NO)            \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CoalesceDropFactory_kokkos, SignedClassicalSADistanceLaplacian, SC, LO, GO, NO)          \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CoalesceDropFactory_kokkos, MinvADropsTwoThirdsNNZ, SC, LO, GO, NO)                      \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CoalesceDropFactory_kokkos, MinvADirichletTest, SC, LO, GO, NO)                          \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CoalesceDropFactory_kokkos, CountNegativeDiagonals, SC, LO, GO, NO)
 
 // TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CoalesceDropFactory_kokkos, ClassicBlockWithFiltering,     SC, LO, GO, NO) // not implemented yet

--- a/packages/muelu/test/unit_tests_kokkos/CoalesceDropFactory_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/CoalesceDropFactory_kokkos.cpp
@@ -1198,46 +1198,50 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CoalesceDropFactory_kokkos, MinvADirichletTest
     Level fineLevel;
     TestHelpers_kokkos::TestFactory<SC, LO, GO, NO>::createSingleLevelHierarchy(fineLevel);
 
-    auto crsA = Teuchos::rcp_dynamic_cast<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(A, true)->getCrsMatrix();
-    crsA->resumeFill();
+    {
+      auto crsA = Teuchos::rcp_dynamic_cast<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, GlobalOrdinal, Node>>(A, true)->getCrsMatrix();
+      crsA->resumeFill();
 
-    auto rowmap = A->getRowMap();
-    auto colmap = A->getColMap();
-    auto lclA   = A->getLocalMatrixHost();
+      auto rowmap = A->getRowMap();
+      auto colmap = A->getColMap();
+      auto lclA   = A->getLocalMatrixHost();
 
-    // set first nx rows of A to be Dirichlet
-    for (GO row_gid = 0; row_gid < nx; row_gid++) {
-      auto row_lid = rowmap->getLocalElement(row_gid);
-      auto col_lid = colmap->getLocalElement(row_gid);
-      if ((row_lid != INVALID) && (col_lid != INVALID)) {
-        auto row = lclA.row(row_lid);
-        for (LocalOrdinal k = 0; k < row.length; ++k) {
-          if (row.colidx(k) == col_lid)
-            row.value(k) = Teuchos::ScalarTraits<SC>::one();
-          else
-            row.value(k) = Teuchos::ScalarTraits<SC>::zero();
+      // set first nx rows of A to be Dirichlet
+      for (GO row_gid = 0; row_gid < nx; row_gid++) {
+        auto row_lid = rowmap->getLocalElement(row_gid);
+        auto col_lid = colmap->getLocalElement(row_gid);
+        if ((row_lid != INVALID) && (col_lid != INVALID)) {
+          auto row = lclA.row(row_lid);
+          for (LocalOrdinal k = 0; k < row.length; ++k) {
+            if (row.colidx(k) == col_lid)
+              row.value(k) = Teuchos::ScalarTraits<SC>::one();
+            else
+              row.value(k) = Teuchos::ScalarTraits<SC>::zero();
+          }
         }
       }
+      crsA->fillComplete();
     }
-    crsA->fillComplete();
 
     fineLevel.Set("A", A);
-    Teuchos::ParameterList mass_Pl;
-    mass_Pl.set("matrixType", "Star2D");
+    {
+      Teuchos::ParameterList mass_Pl;
+      mass_Pl.set("matrixType", "Star2D");
 
-    mass_Pl.set("nx", (GO)nx);
-    mass_Pl.set("ny", (GO)nx);
-    mass_Pl.set("a", 2.88);
-    mass_Pl.set("b", .72);
-    mass_Pl.set("c", .72);
-    mass_Pl.set("d", .72);
-    mass_Pl.set("e", .72);
-    mass_Pl.set("z1", .18);
-    mass_Pl.set("z2", .18);
-    mass_Pl.set("z3", .18);
-    mass_Pl.set("z4", .18);
-    RCP<Matrix> M = TestHelpers_kokkos::TestFactory<SC, LO, GO, NO>::BuildMatrix(mass_Pl, lib);
-    fineLevel.Set("M", M);
+      mass_Pl.set("nx", (GO)nx);
+      mass_Pl.set("ny", (GO)nx);
+      mass_Pl.set("a", 2.88);
+      mass_Pl.set("b", .72);
+      mass_Pl.set("c", .72);
+      mass_Pl.set("d", .72);
+      mass_Pl.set("e", .72);
+      mass_Pl.set("z1", .18);
+      mass_Pl.set("z2", .18);
+      mass_Pl.set("z3", .18);
+      mass_Pl.set("z4", .18);
+      RCP<Matrix> M = TestHelpers_kokkos::TestFactory<SC, LO, GO, NO>::BuildMatrix(mass_Pl, lib);
+      fineLevel.Set("M", M);
+    }
 
     CoalesceDropFactory_kokkos coalesceDropFact;
     coalesceDropFact.SetDefaultVerbLevel(MueLu::Extreme);

--- a/packages/muelu/test/unit_tests_kokkos/Utilities_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/Utilities_kokkos.cpp
@@ -129,7 +129,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Utilities_kokkos, DetectDirichletCols, Scalar,
   Kokkos::deep_copy(dcolsHost, dcols);
 
   for (size_t col = 0; col < dcolsHost.extent(0); ++col) {
-    const auto isDirchletCol = col >= 4 and col <= 6;
+    const auto isDirchletCol = col == 5;
     TEST_EQUALITY(dcolsHost(col), isDirchletCol);
   }
 }  // DetectDirichletCols


### PR DESCRIPTION
<!---  COMMENT BLOCK

 Main additions include

        1) added a new sparse approximate inverse factoredsparseapproxinverse (fsai) that computes the Lfactor of A. It is faster and uses less memory than spai.
        2) added code to zero out off-diagonals in dirichlet rows and associated dirichlet columns of Minv A, putting a one on the matrix diagonal for these.
    Fixed a few small related problems
        3) fixed issues with how Galeri's HexStencil operators treat Dirichlet boundary conditions.
        4) changed logic so that only one of the 3 possible MinvA user data matrices (M, Minv, or MinvA) are projected
        5) Added an optional argument to kokkos versoin of ZeroDirichletCols() so that it only changes non-diagonal column entries?
        6) Changed kokkos version of DetectDirichletCols() so that instead of marking all columns in a Dirichlet boundary row as Dirichlet, it only marks columns where the nonzero matrix value is equal to 1.0.
        7) Added a utility GetThresholdedLowerTriangularGrap() to drop matrix entries if they are either small or if they are in the strictly upper triangular part of matrix
        8) Fixed a one character typo that checks whether MinvA is supplied
        9) Added a unit test to test Dirichlet code
       10) Changed a scaling test so that it employs fsai instead of spai.
       11) Added an IsAvailable() check to RebalanceAcFactory so that it does not attempt to rebalance user data that was not created on a coarse level

    One noteworthy thing
       Slightly modified the behavior of the kokkos version of  DetectDirichletCols(). See above. The previous version didn't make too much sense to me, but perhaps they make sense to someone else. While DetectDirichletColsAndDomains() is used in some MueLu Maxell spots, it is not used elsewhere in MueLu. I did not change the non-Kokkos version.

## Motivation
 * SPAI sparse approximate inverse is slow and uses a lot of memory. FSAI is faster and requires less memory.


## Testing
 * Added new unit test to verify MinvA changes to treat Dirichlet BCs. Modified xml for scaling tests so that we now have one test that uses fsai , which also tests that limiting max levels does not cause rebalancing issues. 

-->
