### PR TITLE
Tpetra,Ifpack2,ShyLU: Namespace compatibility update with kokkos-kernels prefix sums

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -2195,11 +2195,19 @@ void performSymbolicPhase(const Teuchos::RCP<const typename BlockHelperDetails::
       // and R_rowptr_remote (aka amd.rowptr_remote) match the total entry counts computed earlier.
       {
         size_type R_rowptr_final;
+#if KOKKOSKERNELS_VERSION >= 50299
+        KokkosKernels::kk_exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr, R_rowptr_final);
+#else
         KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr, R_rowptr_final);
+#endif
         TEUCHOS_ASSERT(R_rowptr_final == R_nnz_owned);
         if (overlap_communication_and_computation) {
           size_type R_rowptr_remote_final;
+#if KOKKOSKERNELS_VERSION >= 50299
+          KokkosKernels::kk_exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr_remote, R_rowptr_remote_final);
+#else
           KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr_remote, R_rowptr_remote_final);
+#endif
           TEUCHOS_ASSERT(R_rowptr_remote_final == R_nnz_remote);
         }
       }

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -2196,7 +2196,7 @@ void performSymbolicPhase(const Teuchos::RCP<const typename BlockHelperDetails::
       {
         size_type R_rowptr_final;
 #if KOKKOSKERNELS_VERSION >= 50299
-        KokkosKernels::exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr, R_rowptr_final);
+        KokkosKernels::exclusive_parallel_prefix_sum(execution_space(), R_rowptr, R_rowptr_final);
 #else
         KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr, R_rowptr_final);
 #endif
@@ -2204,7 +2204,7 @@ void performSymbolicPhase(const Teuchos::RCP<const typename BlockHelperDetails::
         if (overlap_communication_and_computation) {
           size_type R_rowptr_remote_final;
 #if KOKKOSKERNELS_VERSION >= 50299
-          KokkosKernels::exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr_remote, R_rowptr_remote_final);
+          KokkosKernels::exclusive_parallel_prefix_sum(execution_space(), R_rowptr_remote, R_rowptr_remote_final);
 #else
           KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr_remote, R_rowptr_remote_final);
 #endif

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -2196,7 +2196,7 @@ void performSymbolicPhase(const Teuchos::RCP<const typename BlockHelperDetails::
       {
         size_type R_rowptr_final;
 #if KOKKOSKERNELS_VERSION >= 50299
-        KokkosKernels::kk_exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr, R_rowptr_final);
+        KokkosKernels::exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr, R_rowptr_final);
 #else
         KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr, R_rowptr_final);
 #endif
@@ -2204,7 +2204,7 @@ void performSymbolicPhase(const Teuchos::RCP<const typename BlockHelperDetails::
         if (overlap_communication_and_computation) {
           size_type R_rowptr_remote_final;
 #if KOKKOSKERNELS_VERSION >= 50299
-          KokkosKernels::kk_exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr_remote, R_rowptr_remote_final);
+          KokkosKernels::exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr_remote, R_rowptr_remote_final);
 #else
           KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<execution_space>(nrows + 1, R_rowptr_remote, R_rowptr_remote_final);
 #endif

--- a/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
@@ -231,10 +231,10 @@ namespace FROSch {
 
             // make it into offsets
 #if KOKKOSKERNELS_VERSION >= 50299
-            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
+            KokkosKernels::inclusive_parallel_prefix_sum<execution_space>
               (1+numLocalRows, Rowptr);
 #else
-            KokkosKernels::kk_inclusive_parallel_prefix_sum<execution_space>
+            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
               (1+numLocalRows, Rowptr);
 #endif
 

--- a/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
@@ -231,8 +231,7 @@ namespace FROSch {
 
             // make it into offsets
 #if KOKKOSKERNELS_VERSION >= 50299
-            KokkosKernels::inclusive_parallel_prefix_sum<execution_space>
-              (1+numLocalRows, Rowptr);
+            KokkosKernels::inclusive_parallel_prefix_sum(execution_space(), Rowptr);
 #else
             KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
               (1+numLocalRows, Rowptr);

--- a/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
@@ -230,11 +230,11 @@ namespace FROSch {
             Kokkos::fence();
 
             // make it into offsets
-#if KOKKOSKERNELS_VERSION >= 40199
+#if KOKKOSKERNELS_VERSION >= 50299
             KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
               (1+numLocalRows, Rowptr);
 #else
-            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<rowptr_type, execution_space>
+            KokkosKernels::kk_inclusive_parallel_prefix_sum<execution_space>
               (1+numLocalRows, Rowptr);
 #endif
 

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_def.hpp
@@ -540,8 +540,7 @@ namespace FROSch {
 
                 // make it into offsets
 #if KOKKOSKERNELS_VERSION >= 50299
-                KokkosKernels::inclusive_parallel_prefix_sum<execution_space>
-                    (1+numRows, Rowptr);
+                KokkosKernels::inclusive_parallel_prefix_sum(execution_space(), Rowptr);
 #else
                 KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
                     (1+numRows, Rowptr);

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_def.hpp
@@ -540,7 +540,7 @@ namespace FROSch {
 
                 // make it into offsets
 #if KOKKOSKERNELS_VERSION >= 50299
-                KokkosKernels::kk_inclusive_parallel_prefix_sum<execution_space>
+                KokkosKernels::inclusive_parallel_prefix_sum<execution_space>
                     (1+numRows, Rowptr);
 #else
                 KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_HarmonicCoarseOperator_def.hpp
@@ -539,8 +539,13 @@ namespace FROSch {
                 Kokkos::fence();
 
                 // make it into offsets
+#if KOKKOSKERNELS_VERSION >= 50299
+                KokkosKernels::kk_inclusive_parallel_prefix_sum<execution_space>
+                    (1+numRows, Rowptr);
+#else
                 KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
                     (1+numRows, Rowptr);
+#endif
                 Kokkos::fence();
 
                 // allocate local matrix

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_ExtractSubmatrices_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_ExtractSubmatrices_def.hpp
@@ -354,23 +354,23 @@ namespace FROSch {
                 nnzJJ);
 
             // make it into offsets
-#if KOKKOSKERNELS_VERSION >= 40199
-            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
+#if KOKKOSKERNELS_VERSION >= 50299
+            KokkosKernels::kk_inclusive_parallel_prefix_sum<execution_space>
                 (1+numRowsI, RowptrII);
-            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
+            KokkosKernels::kk_inclusive_parallel_prefix_sum<execution_space>
                 (1+numRowsI, RowptrIJ);
-            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
+            KokkosKernels::kk_inclusive_parallel_prefix_sum<execution_space>
                 (1+numRowsJ, RowptrJI);
-            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
+            KokkosKernels::kk_inclusive_parallel_prefix_sum<execution_space>
                 (1+numRowsJ, RowptrJJ);
 #else
-            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<rowptr_type, execution_space>
+            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
                 (1+numRowsI, RowptrII);
-            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<rowptr_type, execution_space>
+            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
                 (1+numRowsI, RowptrIJ);
-            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<rowptr_type, execution_space>
+            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
                 (1+numRowsJ, RowptrJI);
-            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<rowptr_type, execution_space>
+            KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
                 (1+numRowsJ, RowptrJJ);
 #endif
 

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_ExtractSubmatrices_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_ExtractSubmatrices_def.hpp
@@ -355,14 +355,10 @@ namespace FROSch {
 
             // make it into offsets
 #if KOKKOSKERNELS_VERSION >= 50299
-            KokkosKernels::inclusive_parallel_prefix_sum<execution_space>
-                (1+numRowsI, RowptrII);
-            KokkosKernels::inclusive_parallel_prefix_sum<execution_space>
-                (1+numRowsI, RowptrIJ);
-            KokkosKernels::inclusive_parallel_prefix_sum<execution_space>
-                (1+numRowsJ, RowptrJI);
-            KokkosKernels::inclusive_parallel_prefix_sum<execution_space>
-                (1+numRowsJ, RowptrJJ);
+            KokkosKernels::inclusive_parallel_prefix_sum(execution_space(), RowptrII);
+            KokkosKernels::inclusive_parallel_prefix_sum(execution_space(), RowptrIJ);
+            KokkosKernels::inclusive_parallel_prefix_sum(execution_space(), RowptrJI);
+            KokkosKernels::inclusive_parallel_prefix_sum(execution_space(), RowptrJJ);
 #else
             KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>
                 (1+numRowsI, RowptrII);

--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_ExtractSubmatrices_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_ExtractSubmatrices_def.hpp
@@ -355,13 +355,13 @@ namespace FROSch {
 
             // make it into offsets
 #if KOKKOSKERNELS_VERSION >= 50299
-            KokkosKernels::kk_inclusive_parallel_prefix_sum<execution_space>
+            KokkosKernels::inclusive_parallel_prefix_sum<execution_space>
                 (1+numRowsI, RowptrII);
-            KokkosKernels::kk_inclusive_parallel_prefix_sum<execution_space>
+            KokkosKernels::inclusive_parallel_prefix_sum<execution_space>
                 (1+numRowsI, RowptrIJ);
-            KokkosKernels::kk_inclusive_parallel_prefix_sum<execution_space>
+            KokkosKernels::inclusive_parallel_prefix_sum<execution_space>
                 (1+numRowsJ, RowptrJI);
-            KokkosKernels::kk_inclusive_parallel_prefix_sum<execution_space>
+            KokkosKernels::inclusive_parallel_prefix_sum<execution_space>
                 (1+numRowsJ, RowptrJJ);
 #else
             KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
@@ -658,8 +658,13 @@ fillLogicalBlocks(const Tpetra::CrsMatrix<Scalar, LO, GO, Node> &pointMatrix, co
   }
 
   Ordinal nnz_block_count = 0;
+#if KOKKOSKERNELS_VERSION >= 50299
   KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<
       execution_space>(active_block_row_map.extent(0), active_block_row_map, nnz_block_count);
+#else
+  KokkosKernels::kk_exclusive_parallel_prefix_sum<
+      execution_space>(active_block_row_map.extent(0), active_block_row_map, nnz_block_count);
+#endif
   dev_col_view_t block_col_ids("block_col_ids", nnz_block_count);
 
   // Find active blocks
@@ -768,8 +773,13 @@ fillLogicalBlocks(const Tpetra::CrsMatrix<Scalar, LO, GO, Node> &pointMatrix, co
       });
 
   Ordinal new_nnz_count = 0;
+#if KOKKOSKERNELS_VERSION >= 50299
+  KokkosKernels::kk_exclusive_parallel_prefix_sum<
+      execution_space>(new_rowmap.extent(0), new_rowmap, new_nnz_count);
+#else
   KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<
       execution_space>(new_rowmap.extent(0), new_rowmap, new_nnz_count);
+#endif
   // Now populate cols and vals
   dev_col_view_t new_col_ids("new_col_ids", new_nnz_count);
   dev_val_view_t new_vals("new_vals", new_nnz_count);
@@ -844,8 +854,13 @@ unfillFormerBlockCrs(const Tpetra::CrsMatrix<Scalar, LO, GO, Node> &pointMatrix)
       });
 
   Ordinal real_nnzs = 0;
+#if KOKKOSKERNELS_VERSION >= 50299
+  KokkosKernels::kk_exclusive_parallel_prefix_sum<
+      execution_space>(new_rowmap.extent(0), new_rowmap, real_nnzs);
+#else
   KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<
       execution_space>(new_rowmap.extent(0), new_rowmap, real_nnzs);
+#endif
   // Now populate cols and vals
   dev_col_view_t new_col_ids("new_col_ids", real_nnzs);
   dev_val_view_t new_vals("new_vals", real_nnzs);

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
@@ -659,8 +659,7 @@ fillLogicalBlocks(const Tpetra::CrsMatrix<Scalar, LO, GO, Node> &pointMatrix, co
 
   Ordinal nnz_block_count = 0;
 #if KOKKOSKERNELS_VERSION >= 50299
-  KokkosKernels::exclusive_parallel_prefix_sum<
-      execution_space>(active_block_row_map.extent(0), active_block_row_map, nnz_block_count);
+  KokkosKernels::exclusive_parallel_prefix_sum(execution_space(), active_block_row_map, nnz_block_count);
 #else
   KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<
       execution_space>(active_block_row_map.extent(0), active_block_row_map, nnz_block_count);
@@ -774,8 +773,7 @@ fillLogicalBlocks(const Tpetra::CrsMatrix<Scalar, LO, GO, Node> &pointMatrix, co
 
   Ordinal new_nnz_count = 0;
 #if KOKKOSKERNELS_VERSION >= 50299
-  KokkosKernels::exclusive_parallel_prefix_sum<
-      execution_space>(new_rowmap.extent(0), new_rowmap, new_nnz_count);
+  KokkosKernels::exclusive_parallel_prefix_sum(execution_space(), new_rowmap, new_nnz_count);
 #else
   KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<
       execution_space>(new_rowmap.extent(0), new_rowmap, new_nnz_count);
@@ -855,8 +853,7 @@ unfillFormerBlockCrs(const Tpetra::CrsMatrix<Scalar, LO, GO, Node> &pointMatrix)
 
   Ordinal real_nnzs = 0;
 #if KOKKOSKERNELS_VERSION >= 50299
-  KokkosKernels::exclusive_parallel_prefix_sum<
-      execution_space>(new_rowmap.extent(0), new_rowmap, real_nnzs);
+  KokkosKernels::exclusive_parallel_prefix_sum(execution_space(), new_rowmap, real_nnzs);
 #else
   KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<
       execution_space>(new_rowmap.extent(0), new_rowmap, real_nnzs);

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
@@ -659,7 +659,7 @@ fillLogicalBlocks(const Tpetra::CrsMatrix<Scalar, LO, GO, Node> &pointMatrix, co
 
   Ordinal nnz_block_count = 0;
 #if KOKKOSKERNELS_VERSION >= 50299
-  KokkosKernels::kk_exclusive_parallel_prefix_sum<
+  KokkosKernels::exclusive_parallel_prefix_sum<
       execution_space>(active_block_row_map.extent(0), active_block_row_map, nnz_block_count);
 #else
   KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<
@@ -774,7 +774,7 @@ fillLogicalBlocks(const Tpetra::CrsMatrix<Scalar, LO, GO, Node> &pointMatrix, co
 
   Ordinal new_nnz_count = 0;
 #if KOKKOSKERNELS_VERSION >= 50299
-  KokkosKernels::kk_exclusive_parallel_prefix_sum<
+  KokkosKernels::exclusive_parallel_prefix_sum<
       execution_space>(new_rowmap.extent(0), new_rowmap, new_nnz_count);
 #else
   KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<
@@ -855,7 +855,7 @@ unfillFormerBlockCrs(const Tpetra::CrsMatrix<Scalar, LO, GO, Node> &pointMatrix)
 
   Ordinal real_nnzs = 0;
 #if KOKKOSKERNELS_VERSION >= 50299
-  KokkosKernels::kk_exclusive_parallel_prefix_sum<
+  KokkosKernels::exclusive_parallel_prefix_sum<
       execution_space>(new_rowmap.extent(0), new_rowmap, real_nnzs);
 #else
   KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
@@ -659,10 +659,10 @@ fillLogicalBlocks(const Tpetra::CrsMatrix<Scalar, LO, GO, Node> &pointMatrix, co
 
   Ordinal nnz_block_count = 0;
 #if KOKKOSKERNELS_VERSION >= 50299
-  KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<
+  KokkosKernels::kk_exclusive_parallel_prefix_sum<
       execution_space>(active_block_row_map.extent(0), active_block_row_map, nnz_block_count);
 #else
-  KokkosKernels::kk_exclusive_parallel_prefix_sum<
+  KokkosKernels::Impl::kk_exclusive_parallel_prefix_sum<
       execution_space>(active_block_row_map.extent(0), active_block_row_map, nnz_block_count);
 #endif
   dev_col_view_t block_col_ids("block_col_ids", nnz_block_count);

--- a/packages/tpetra/core/src/Tpetra_CrsSingletonFilter_LinearProblem_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsSingletonFilter_LinearProblem_def.hpp
@@ -1128,7 +1128,7 @@ void CrsSingletonFilter_LinearProblem<Scalar, LocalOrdinal, GlobalOrdinal, Node>
 
         // convert to rowptrs
 #if KOKKOSKERNELS_VERSION >= 50299
-        KokkosKernels::kk_inclusive_parallel_prefix_sum<execution_space>(1 + localNumReducedRows, rowmap_view);
+        KokkosKernels::inclusive_parallel_prefix_sum<execution_space>(1 + localNumReducedRows, rowmap_view);
 #else
         KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>(1 + localNumReducedRows, rowmap_view);
 #endif

--- a/packages/tpetra/core/src/Tpetra_CrsSingletonFilter_LinearProblem_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsSingletonFilter_LinearProblem_def.hpp
@@ -1128,7 +1128,7 @@ void CrsSingletonFilter_LinearProblem<Scalar, LocalOrdinal, GlobalOrdinal, Node>
 
         // convert to rowptrs
 #if KOKKOSKERNELS_VERSION >= 50299
-        KokkosKernels::inclusive_parallel_prefix_sum<execution_space>(1 + localNumReducedRows, rowmap_view);
+        KokkosKernels::inclusive_parallel_prefix_sum(execution_space(), rowmap_view);
 #else
         KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>(1 + localNumReducedRows, rowmap_view);
 #endif

--- a/packages/tpetra/core/src/Tpetra_CrsSingletonFilter_LinearProblem_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsSingletonFilter_LinearProblem_def.hpp
@@ -1127,7 +1127,11 @@ void CrsSingletonFilter_LinearProblem<Scalar, LocalOrdinal, GlobalOrdinal, Node>
         }
 
         // convert to rowptrs
+#if KOKKOSKERNELS_VERSION >= 50299
+        KokkosKernels::kk_inclusive_parallel_prefix_sum<execution_space>(1 + localNumReducedRows, rowmap_view);
+#else
         KokkosKernels::Impl::kk_inclusive_parallel_prefix_sum<execution_space>(1 + localNumReducedRows, rowmap_view);
+#endif
 
         // insert non-zero entries
         {


### PR DESCRIPTION
@trilinos/tpetra @trilinos/ifpack2 @trilinos/shylu 
@brian-kelley 

## Motivation

Resolve compilation errors with nightly integration testing with kokkos-kernels@develop

* Compatibility update for https://github.com/kokkos/kokkos-kernels/pull/3254
    
* Move prefix sums inclusive_parallel_prefix_sum and exclusive_parallel_prefix_sum out of Impl namespace into public namespace for KOKKOSKERNELS_VERSION >= 50299



<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
