### PR TITLE
Stokhos: move `InnerProductSpaceTraits` from `Kokkos` to `KokkosKernels` namespace

### DIFF
--- a/packages/stokhos/src/CMakeLists.txt
+++ b/packages/stokhos/src/CMakeLists.txt
@@ -764,7 +764,7 @@ IF (Stokhos_ENABLE_Sacado)
         sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector.hpp
         sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector_Cuda.hpp
         sacado/kokkos/vector/linalg/Kokkos_ArithTraits_MP_Vector.hpp
-        sacado/kokkos/vector/linalg/Kokkos_InnerProductSpaceTraits_MP_Vector.hpp
+        sacado/kokkos/vector/linalg/KokkosKernels_InnerProductSpaceTraits_MP_Vector.hpp
         )
     ENDIF()
     IF(Stokhos_ENABLE_PCE_Scalar_Type)

--- a/packages/stokhos/src/CMakeLists.txt
+++ b/packages/stokhos/src/CMakeLists.txt
@@ -763,7 +763,7 @@ IF (Stokhos_ENABLE_Sacado)
         sacado/kokkos/vector/linalg/Kokkos_Blas1_MP_Vector.hpp
         sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector.hpp
         sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector_Cuda.hpp
-        sacado/kokkos/vector/linalg/Kokkos_ArithTraits_MP_Vector.hpp
+        sacado/kokkos/vector/linalg/KokkosKernels_ArithTraits_MP_Vector.hpp
         sacado/kokkos/vector/linalg/KokkosKernels_InnerProductSpaceTraits_MP_Vector.hpp
         )
     ENDIF()

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas2_gemv_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas2_gemv_MP_Vector.hpp
@@ -16,7 +16,7 @@
 #include "Stokhos_ViewStorage.hpp"
 #include "Sacado_MP_Vector.hpp"
 #include "Kokkos_View_MP_Vector.hpp"
-#include "Kokkos_ArithTraits_MP_Vector.hpp"
+#include "KokkosKernels_ArithTraits_MP_Vector.hpp"
 #include "KokkosBlas.hpp"
 
 #include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas3_gemm_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas3_gemm_MP_Vector.hpp
@@ -16,7 +16,7 @@
 #include "Stokhos_ViewStorage.hpp"
 #include "Sacado_MP_Vector.hpp"
 #include "Kokkos_View_MP_Vector.hpp"
-#include "Kokkos_ArithTraits_MP_Vector.hpp"
+#include "KokkosKernels_ArithTraits_MP_Vector.hpp"
 #include "KokkosBlas.hpp"
 
 namespace KokkosBlas

--- a/packages/stokhos/src/sacado/kokkos/vector/linalg/KokkosKernels_ArithTraits_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/linalg/KokkosKernels_ArithTraits_MP_Vector.hpp
@@ -7,8 +7,8 @@
 // *****************************************************************************
 // @HEADER
 
-#ifndef KOKKOS_ARITHTRAITS_MP_VECTOR_HPP
-#define KOKKOS_ARITHTRAITS_MP_VECTOR_HPP
+#ifndef KOKKOSKERNELS_ARITHTRAITS_MP_VECTOR_HPP
+#define KOKKOSKERNELS_ARITHTRAITS_MP_VECTOR_HPP
 
 #include "Sacado_MP_Vector.hpp"
 #include "KokkosKernels_ArithTraits.hpp"
@@ -190,4 +190,4 @@ namespace KokkosBatched {
 
 }
 
-#endif /* #ifndef KOKKOS_ARITHTRAITS_MP_VECTOR_HPP */
+#endif /* #ifndef KOKKOSKERNELS_ARITHTRAITS_MP_VECTOR_HPP */

--- a/packages/stokhos/src/sacado/kokkos/vector/linalg/KokkosKernels_InnerProductSpaceTraits_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/linalg/KokkosKernels_InnerProductSpaceTraits_MP_Vector.hpp
@@ -15,7 +15,7 @@
 
 #include "Sacado_MP_Vector.hpp"
 #include "KokkosKernels_InnerProductSpaceTraits.hpp"
-#include "Kokkos_ArithTraits_MP_Vector.hpp"
+#include "KokkosKernels_ArithTraits_MP_Vector.hpp"
 
 //----------------------------------------------------------------------------
 // Specializations of KokkosKernels::InnerProductSpaceTraits for Sacado::MP::Vector

--- a/packages/stokhos/src/sacado/kokkos/vector/linalg/KokkosKernels_InnerProductSpaceTraits_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/linalg/KokkosKernels_InnerProductSpaceTraits_MP_Vector.hpp
@@ -7,22 +7,22 @@
 // *****************************************************************************
 // @HEADER
 
-#ifndef KOKKOS_INNER_PRODUCT_SPACE_TRAITS_MP_VECTOR_HPP
-#define KOKKOS_INNER_PRODUCT_SPACE_TRAITS_MP_VECTOR_HPP
+#ifndef KOKKOSKERNELS_INNER_PRODUCT_SPACE_TRAITS_MP_VECTOR_HPP
+#define KOKKOSKERNELS_INNER_PRODUCT_SPACE_TRAITS_MP_VECTOR_HPP
 
 #include "Sacado_ConfigDefs.h"
 #if defined(HAVE_STOKHOS_ENSEMBLE_REDUCT)
 
 #include "Sacado_MP_Vector.hpp"
-#include "Kokkos_InnerProductSpaceTraits.hpp"
+#include "KokkosKernels_InnerProductSpaceTraits.hpp"
 #include "Kokkos_ArithTraits_MP_Vector.hpp"
 
 //----------------------------------------------------------------------------
-// Specializations of Kokkos::InnerProductSpaceTraits for Sacado::MP::Vector
+// Specializations of KokkosKernels::InnerProductSpaceTraits for Sacado::MP::Vector
 // scalar type
 //----------------------------------------------------------------------------
 
-namespace Kokkos {
+namespace KokkosKernels {
 namespace Details {
 
 template <typename S>
@@ -118,4 +118,4 @@ public:
 
 #endif
 
-#endif /* #ifndef KOKKOS_INNER_PRODUCT_SPACE_TRAITS_MP_VECTOR_HPP */
+#endif /* #ifndef KOKKOSKERNELS_INNER_PRODUCT_SPACE_TRAITS_MP_VECTOR_HPP */

--- a/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_Blas1_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_Blas1_MP_Vector.hpp
@@ -14,7 +14,7 @@
 
 #include "Sacado_MP_Vector.hpp"
 #include "Kokkos_View_MP_Vector.hpp"
-#include "Kokkos_InnerProductSpaceTraits_MP_Vector.hpp"
+#include "KokkosKernels_InnerProductSpaceTraits_MP_Vector.hpp"
 #include "KokkosBlas.hpp"
 
 //----------------------------------------------------------------------------
@@ -30,7 +30,7 @@ template <typename XD, typename ... XP,
 typename std::enable_if<
   Kokkos::is_view_mp_vector< Kokkos::View<XD,XP...> >::value &&
   Kokkos::is_view_mp_vector< Kokkos::View<YD,YP...> >::value,
-  typename Kokkos::Details::InnerProductSpaceTraits<
+  typename KokkosKernels::Details::InnerProductSpaceTraits<
     typename Kokkos::View<XD,XP...>::non_const_value_type >::dot_type
   >::type
 dot(const Kokkos::View<XD,XP...>& x,

--- a/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector.hpp
@@ -15,7 +15,7 @@
 #include "Sacado_MP_Vector.hpp"
 #include "Kokkos_View_MP_Vector.hpp"
 #include "KokkosSparse_CrsMatrix.hpp"
-#include "Kokkos_ArithTraits_MP_Vector.hpp"
+#include "KokkosKernels_ArithTraits_MP_Vector.hpp"
 #include "KokkosSparse_spmv.hpp"
 #include "Kokkos_Blas1_MP_Vector.hpp" // for some utilities
 

--- a/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_MV_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_MV_MP_Vector.hpp
@@ -12,7 +12,7 @@
 
 #include "Sacado_MP_Vector.hpp"
 #include "Kokkos_View_MP_Vector.hpp"
-#include "Kokkos_InnerProductSpaceTraits_MP_Vector.hpp"
+#include "KokkosKernels_InnerProductSpaceTraits_MP_Vector.hpp"
 #include "Kokkos_Blas1_MP_Vector.hpp"
 
 //----------------------------------------------------------------------------

--- a/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_MP_Vector.hpp
@@ -27,7 +27,7 @@
 
 // Kokkos-Linalg
 #include "Kokkos_ArithTraits_MP_Vector.hpp"
-#include "Kokkos_InnerProductSpaceTraits_MP_Vector.hpp"
+#include "KokkosKernels_InnerProductSpaceTraits_MP_Vector.hpp"
 #include "Kokkos_MV_MP_Vector.hpp"
 
 // Order may be important here because Cuda provides a slightly more

--- a/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_MP_Vector.hpp
@@ -26,7 +26,7 @@
 #endif
 
 // Kokkos-Linalg
-#include "Kokkos_ArithTraits_MP_Vector.hpp"
+#include "KokkosKernels_ArithTraits_MP_Vector.hpp"
 #include "KokkosKernels_InnerProductSpaceTraits_MP_Vector.hpp"
 #include "Kokkos_MV_MP_Vector.hpp"
 


### PR DESCRIPTION
@trilinos/stokhos
@etphipp 

Recent work in `kokkos-kernels` moved `InnerProductSpaceTraits` from the `Kokkos` to the `KokkosKernels` namespace. A template alias was defined for backward compatibility. However, Stokhos specialises this class, leading to compilation errors like:

```
error: specialization of alias template 'template<class T> using Kokkos::Details::InnerProductSpaceTraits = KokkosKernels::Details::InnerProductSpaceTraits<T>'
INFO:root:2290.3    73 | class InnerProductSpaceTraits< const Sacado::MP::Vector<S> > {
INFO:root:2290.3       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO:root:2290.3 gmake[2]: *** [packages/stokhos/src/CMakeFiles/stokhos_tpetra_sd_mp_16_serial.dir/build.make:79: packages/stokhos/src/CMakeFiles/stokhos_tpetra_sd_mp_16_serial.dir/Tpetra_SD_LocalCrsMatrixOperator_MP_Vector_16_Serial.cpp.o] Error 1
```

This PR thus proposes to move `InnerProductSpaceTraits` from the `Kokkos` to the `KokkosKernels` namespace in Stokhos too. I'll mark the main change in the changed files with a comment. The other changes are just corresponding renamings of files.


