### PR TITLE
Tpetra: Ifpack2: fix deprecation warning

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockHelper.hpp
@@ -129,7 +129,7 @@ struct is_sycl {
 };
 #if defined(KOKKOS_ENABLE_SYCL)
 template <>
-struct is_sycl<Kokkos::Experimental::SYCL> {
+struct is_sycl<Kokkos::SYCL> {
   enum : bool { value = true };
 };
 #endif
@@ -177,9 +177,9 @@ struct ExecutionSpaceFactory<Kokkos::HIP> {
 
 #if defined(KOKKOS_ENABLE_SYCL)
 template <>
-struct ExecutionSpaceFactory<Kokkos::Experimental::SYCL> {
-  static void createInstance(Kokkos::Experimental::SYCL &exec_instance) {
-    exec_instance = Kokkos::Experimental::SYCL();
+struct ExecutionSpaceFactory<Kokkos::SYCL> {
+  static void createInstance(Kokkos::SYCL &exec_instance) {
+    exec_instance = Kokkos::SYCL();
   }
 };
 #endif

--- a/packages/tpetra/core/compat/Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp
+++ b/packages/tpetra/core/compat/Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp
@@ -78,9 +78,9 @@ class KokkosDeviceWrapperNode {
 
 #ifdef KOKKOS_ENABLE_SYCL
 #ifdef HAVE_TPETRA_SHARED_ALLOCS
-typedef KokkosDeviceWrapperNode<::Kokkos::Experimental::SYCL, ::Kokkos::Experimental::SYCLSharedUSMSpace> KokkosSYCLWrapperNode;
+typedef KokkosDeviceWrapperNode<::Kokkos::SYCL, ::Kokkos::SYCLSharedUSMSpace> KokkosSYCLWrapperNode;
 #else
-typedef KokkosDeviceWrapperNode<::Kokkos::Experimental::SYCL, ::Kokkos::Experimental::SYCLDeviceUSMSpace> KokkosSYCLWrapperNode;
+typedef KokkosDeviceWrapperNode<::Kokkos::SYCL, ::Kokkos::SYCLDeviceUSMSpace> KokkosSYCLWrapperNode;
 #endif
 #endif
 

--- a/packages/tpetra/core/src/Tpetra_Details_DefaultTypes.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DefaultTypes.hpp
@@ -58,7 +58,7 @@ using global_ordinal_type = unsigned;
 /// \typedef execution_space
 /// \brief Default Tpetra execution space and Node type.
 #if defined(HAVE_TPETRA_DEFAULTNODE_SYCLWRAPPERNODE)
-using execution_space = ::Kokkos::Experimental::SYCL;
+using execution_space = ::Kokkos::SYCL;
 using node_type       = Tpetra::KokkosCompat::KokkosSYCLWrapperNode;
 #elif defined(HAVE_TPETRA_DEFAULTNODE_HIPWRAPPERNODE)
 using execution_space     = ::Kokkos::HIP;
@@ -104,8 +104,8 @@ struct CommBufferMemorySpace<Kokkos::HIP> {
 
 #ifdef KOKKOS_ENABLE_SYCL
 template <>
-struct CommBufferMemorySpace<Kokkos::Experimental::SYCL> {
-  using type = Kokkos::Experimental::SYCLDeviceUSMSpace;
+struct CommBufferMemorySpace<Kokkos::SYCL> {
+  using type = Kokkos::SYCLDeviceUSMSpace;
 };
 #endif
 

--- a/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DistributorActor.hpp
@@ -586,7 +586,7 @@ void DistributorActor::doPostRecvsImpl(const DistributorPlan& plan,
 #endif  // KOKKOS_ENABLE_CUDA
 
 #ifdef KOKKOS_ENABLE_SYCL
-  static_assert(!std::is_same<typename ImpView::memory_space, Kokkos::Experimental::SYCLSharedUSMSpace>::value,
+  static_assert(!std::is_same<typename ImpView::memory_space, Kokkos::SYCLSharedUSMSpace>::value,
                 "Please do not use Tpetra::Distributor with SharedUSM "
                 "allocations.  See GitHub issue #1088 (corresponding to CUDA).");
 #endif  // KOKKOS_ENABLE_SYCL
@@ -729,8 +729,8 @@ void DistributorActor::doPostSendsImpl(const DistributorPlan& plan,
 #endif  // KOKKOS_ENABLE_CUDA
 
 #ifdef KOKKOS_ENABLE_SYCL
-  static_assert(!std::is_same<typename ExpView::memory_space, Kokkos::Experimental::SYCLSharedUSMSpace>::value &&
-                    !std::is_same<typename ImpView::memory_space, Kokkos::Experimental::SYCLSharedUSMSpace>::value,
+  static_assert(!std::is_same<typename ExpView::memory_space, Kokkos::SYCLSharedUSMSpace>::value &&
+                    !std::is_same<typename ImpView::memory_space, Kokkos::SYCLSharedUSMSpace>::value,
                 "Please do not use Tpetra::Distributor with SharedUSM allocations.  "
                 "See Trilinos GitHub issue #1088 (corresponding to CUDA).");
 #endif  // KOKKOS_ENABLE_SYCL

--- a/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.hpp
@@ -133,9 +133,9 @@ using IsHIP = std::enable_if_t<std::is_same_v<Space, Kokkos::HIP>, bool>;
 #endif  // KOKKOS_ENABLE_HIP
 
 #if defined(KOKKOS_ENABLE_SYCL)
-///\brief IsSYCL<Space> is a type if Space is Kokkos::Experimental::SYCL
+///\brief IsSYCL<Space> is a type if Space is Kokkos::SYCL
 template <typename Space>
-using IsSYCL = std::enable_if_t<std::is_same_v<Space, Kokkos::Experimental::SYCL>, bool>;
+using IsSYCL = std::enable_if_t<std::is_same_v<Space, Kokkos::SYCL>, bool>;
 #endif  // KOKKOS_ENABLE_SYCL
 
 /*! \brief Construct a Kokkos execution space instance with the following
@@ -323,7 +323,7 @@ extern TPETRACORE_LIB_DLL_EXPORT InstanceLifetimeManager<Kokkos::OpenMP> openMPS
 extern TPETRACORE_LIB_DLL_EXPORT InstanceLifetimeManager<Kokkos::HIP> HIPSpaces;
 #endif
 #if defined(KOKKOS_ENABLE_SYCL)
-extern TPETRACORE_LIB_DLL_EXPORT InstanceLifetimeManager<Kokkos::Experimental::SYCL> SYCLSpaces;
+extern TPETRACORE_LIB_DLL_EXPORT InstanceLifetimeManager<Kokkos::SYCL> SYCLSpaces;
 #endif
 
 #if defined(KOKKOS_ENABLE_CUDA)
@@ -370,7 +370,7 @@ Teuchos::RCP<const ExecSpace> space_instance(int i = 0) {
 }
 #endif
 #if defined(KOKKOS_ENABLE_SYCL)
-/*! \brief get a strong Teuchos::RCP to Tpetra-managed Kokkos::Experimental::SYCL instance \c
+/*! \brief get a strong Teuchos::RCP to Tpetra-managed Kokkos::SYCL instance \c
  * i
  */
 template <typename ExecSpace, Priority priority = Priority::medium,
@@ -482,7 +482,7 @@ is_gpu_exec_space<Kokkos::HIP>() {
 #if defined(KOKKOS_ENABLE_SYCL)
 template <>
 constexpr KOKKOS_INLINE_FUNCTION bool
-is_gpu_exec_space<Kokkos::Experimental::SYCL>() {
+is_gpu_exec_space<Kokkos::SYCL>() {
   return true;
 }
 #endif

--- a/packages/tpetra/core/src/Tpetra_Details_ExecutionSpacesUser.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_ExecutionSpacesUser.hpp
@@ -135,7 +135,7 @@ class User {
   Slot<Kokkos::HIP> HIPSlot;
 #endif
 #ifdef KOKKOS_ENABLE_SYCL
-  Slot<Kokkos::Experimental::SYCL> SYCLSlot;
+  Slot<Kokkos::SYCL> SYCLSlot;
 #endif
 
 };  // User


### PR DESCRIPTION
Fix namespace deprecation warnings when compiling with SYCL backend.
@trilinos/tpetra @trilinos/ifpack2 

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
