### PR TITLE
Tpetra: fix specification of execution space of parallel for in matrix-matrix deduplication

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -1191,7 +1191,8 @@ void kokkos_kernels_mult_A_B_newmatrix(
         &kh, AnumRows, BnumRows, BnumCols, Aint.graph.row_map, Aint.graph.entries, Aint.values, false,
         Bint.graph.row_map, Bint.graph.entries, Bint.values, false, int_row_mapC, entriesC, valuesC);
     Kokkos::parallel_for(
-        int_row_mapC.size(), KOKKOS_LAMBDA(const int i) { row_mapC(i) = int_row_mapC(i); });
+        Kokkos::RangePolicy<typename device_t::execution_space>(0, int_row_mapC.size()),
+        KOKKOS_LAMBDA(const int i) { row_mapC(i) = int_row_mapC(i); });
     kh.destroy_spgemm_handle();
 
   } else {
@@ -1539,7 +1540,8 @@ void kokkos_kernels_jacobi_A_B_newmatrix(typename Teuchos::ScalarTraits<Scalar>:
     }
     // transfer the integer rowptrs back to the correct rowptr type
     Kokkos::parallel_for(
-        int_row_mapC.size(), KOKKOS_LAMBDA(int i) { row_mapC(i) = int_row_mapC(i); });
+        Kokkos::RangePolicy<typename device_t::execution_space>(0, int_row_mapC.size()),
+        KOKKOS_LAMBDA(int i) { row_mapC(i) = int_row_mapC(i); });
     kh.destroy_spgemm_handle();
   } else {
     handle_t kh;


### PR DESCRIPTION
@trilinos/tpetra

We see runtime segmentation faults in multi-rank Tpetra tests for Trilinos builds in which we enable both a GPU backend and the OpenMP backend.

```
2026-08-28T01:17:07.3226958Z INFO:root:[0x743f29e35249] Kokkos::Impl::save_stacktrace()
2026-08-28T01:17:07.3227160Z INFO:root:[0x743f29dfb6a0] Kokkos::Impl::host_abort(char const*)
2026-08-28T01:17:07.3227429Z INFO:root:[0x743f29e4049b] Kokkos::Impl::cuda_internal_error_abort(cudaError, char const*, char const*, int)
2026-08-28T01:17:07.3227818Z INFO:root:[0x743f29e405dd] Kokkos::Impl::cuda_device_synchronize(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
2026-08-28T01:17:07.3228278Z INFO:root:[0x743f29e1c33d] Kokkos::Impl::ExecSpaceManager::static_fence(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
2026-08-28T01:17:07.3228685Z INFO:root:[0x743f29e26a65] Kokkos::HostSpace::deallocate(char const*, void*, unsigned long, unsigned long) const
2026-08-28T01:17:07.3229064Z INFO:root:[0x743f29e26efa] Kokkos::Impl::SharedAllocationRecordCommon<Kokkos::HostSpace>::~SharedAllocationRecordCommon()
2026-08-28T01:17:07.3229584Z INFO:root:[0x624250b8de55] void Kokkos::Impl::deallocate<Kokkos::HostSpace, Kokkos::Impl::ViewValueFunctor<Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace>, int> >(Kokkos::Impl::SharedAllocationRecord<void, void>*)
2026-08-28T01:17:07.3230118Z INFO:root:[0x743f29e350ff] Kokkos::Impl::SharedAllocationRecord<void, void>::decrement(Kokkos::Impl::SharedAllocationRecord<void, void>*)
2026-08-28T01:17:07.3232304Z INFO:root:[0x743f3b3cc318] void Tpetra::MMdetails::kokkos_kernels_mult_A_B_newmatrix<double, int, long long, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace>, Kokkos::View<int*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace> > >(Tpetra::CrsMatrixStruct<double, int, long long, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> >&, Tpetra::CrsMatrixStruct<double, int, long long, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> >&, Kokkos::View<int*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace> > const&, Kokkos::View<int*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace> > const&, Kokkos::View<int*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace> > const&, Kokkos::View<int*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace> > const&, Tpetra::CrsMatrix<double, int, long long, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> >&, Teuchos::RCP<Tpetra::Import<int, long long, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > const>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Teuchos::RCP<Teuchos::ParameterList> const&)
```

The reason appears to be a missing specification of the execution space type in parallel for regions in the `kokkos_kernels_mult_A_B_newmatrix` function.

Tagging @ndellingwood as this issue may be related to recent work on deduplicating matrix-matrix functionalities.
