### PR TITLE
Tpetra: add missing fences

### DIFF
--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -2838,7 +2838,7 @@ void BlockCrsMatrix<Scalar, LO, GO, Node>::
   size_t rowOffset = 0;
   size_t offset    = 0;
   LO bs            = getBlockSize();
-  execution_space().fence(); // ensure deep_copy to diagOffsetsHost is done
+  execution_space().fence();  // ensure deep_copy to diagOffsetsHost is done
   for (size_t r = 0; r < getLocalNumRows(); r++) {
     // move pointer to start of diagonal block
     offset = rowOffset + diagOffsetsHost(r) * bs * bs;

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -2838,6 +2838,7 @@ void BlockCrsMatrix<Scalar, LO, GO, Node>::
   size_t rowOffset = 0;
   size_t offset    = 0;
   LO bs            = getBlockSize();
+  execution_space().fence(); // ensure deep_copy to diagOffsetsHost is done
   for (size_t r = 0; r < getLocalNumRows(); r++) {
     // move pointer to start of diagonal block
     offset = rowOffset + diagOffsetsHost(r) * bs * bs;

--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_def.hpp
@@ -261,8 +261,8 @@ void BlockMultiVector<Scalar, LO, GO, Node>::
   auto X_dst = getLocalBlockHost(localRowIndex, colIndex, Access::ReadWrite);
   typename const_little_vec_type::host_mirror_type::const_type X_src(reinterpret_cast<const impl_scalar_type*>(vals),
                                                                      getBlockSize());
-  // DEEP_COPY REVIEW - HOSTMIRROR-TO-DEVICE
-  using exec_space = typename device_type::execution_space;
+  // DEEP_COPY REVIEW - HOST-TO-HOST
+  using exec_space = typename host_device_type::execution_space;
   Kokkos::deep_copy(exec_space(), X_dst, X_src);
 }
 

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -3455,6 +3455,8 @@ void CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     output_type offsetsOut(offsets.getRawPtr(), lclNumRows);
     // DEEP_COPY REVIEW - DEVICE-TO-HOST
     Kokkos::deep_copy(execution_space(), offsetsOut, offsetsTmp);
+    // Fence so offsets is safe to access by caller immediately
+    execution_space().fence();
   }
 }
 

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
@@ -844,6 +844,7 @@ void FixedHashTable<KeyType, ValueType, DeviceType>::
     theKeysHost = Kokkos::create_mirror_view(theKeys);
     // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
     Kokkos::deep_copy(execution_space(), theKeysHost, theKeys);
+    execution_space().fence();
     auto countsHost = Kokkos::create_mirror_view(hostMemSpace, counts);
 
     for (offset_type k = 0; k < theNumKeys; ++k) {

--- a/packages/tpetra/core/src/Tpetra_Details_getEntryOnHost.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getEntryOnHost.hpp
@@ -33,6 +33,7 @@ getEntryOnHost(const ViewType& x,
   typename ViewType::non_const_value_type val;
   // DEEP_COPY REVIEW - DEVICE-TO-VALUE
   Kokkos::deep_copy(execution_space(), val, Kokkos::subview(x, ind));
+  execution_space().fence();
   return val;
 }
 

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
@@ -845,6 +845,8 @@ void packCrsMatrix(const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
                                                exports.size());
   // DEEP_COPY REVIEW - DEVICE-TO-HOST
   Kokkos::deep_copy(device_exec_space(), exports_h, exports_dv.view_device());
+  // Fence so numPacketsPerLID and exports are safe to access by caller immediately
+  device_exec_space().fence();
 }
 
 template <typename ST, typename LO, typename GO, typename NT>
@@ -971,6 +973,8 @@ void packCrsMatrixWithOwningPIDs(const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
       Kokkos::View<size_t*, host_dev_type> num_packets_per_lid_h(numPacketsPerLID.getRawPtr(), numPacketsPerLID.size());
       // DEEP_COPY REVIEW - DEVICE-TO-HOST
       Kokkos::deep_copy(execution_space(), num_packets_per_lid_h, num_packets_per_lid_d);
+      // Fence so numPacketsPerLID is safe to access by caller immediately
+      execution_space().fence();
     } catch (std::exception& e) {
       if (verbose) {
         std::ostringstream os;

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
@@ -624,6 +624,7 @@ void unpackAndCombineIntoCrsMatrix(
 
   auto batch_info_h = Kokkos::create_mirror_view(host_space, batch_info);
 
+  XS().fence();
   (void)compute_batch_info(batches_per_lid_h, batch_info_h);
   // DEEP_COPY REVIEW - HOSTMIRROR-TO-DEVICE
   Kokkos::deep_copy(XS(), batch_info, batch_info_h);

--- a/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
@@ -877,6 +877,8 @@ void lowCommunicationMakeColMapAndReindex(
   // For now, we copy back into colind_LID_host (which also overwrites the colind_LID Teuchos array)
   // When colind_LID becomes a Kokkos View we can delete this
   Kokkos::deep_copy(exec, colind_LID_host, colind_LID_view);
+  // fence so colind_LID is safe to access by caller immediately
+  exec.fence();
 }
 
 template <typename LocalOrdinal, typename GlobalOrdinal, typename Node>

--- a/packages/tpetra/core/test/ImportExport/GDSW_Proxy_def.hpp
+++ b/packages/tpetra/core/test/ImportExport/GDSW_Proxy_def.hpp
@@ -271,6 +271,7 @@ class NumPacketsAndOffsetsFunctorRestricted {
     auto error_h = Kokkos::create_mirror_view(error_);
     // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
     Kokkos::deep_copy(execution_space(), error_h, error_);
+    execution_space().fence();
     return error_h();
   }
 


### PR DESCRIPTION
Try to address the remaining missing fence cases mentioned in #13373.

@trilinos/tpetra

## Motivation
 * Avoids potential crashes or incorrect results from accessing the destination view of an in-progress async deep_copy.
 * Should address most of #13373 which identified one specific missing fence (fixed in #13380) but also said that there are several more bugs like it.

Most of the added fences are obviously needed because the deep_copy and unsafe host access were in the same function. This PR also adds 4 less obvious fences where functions were returning host data while a deep_copy was in progress.

- ``CrsMatrix::getLocalDiagOffsets(ArrayRCP& offsets)`` at `Tpetra_CrsMatrix_def.hpp:3421`: deep_copy to offsets
- ``Details::packCrsMatrix`` at `Tpetra_Details_packCrsMatrix_def.hpp:788`: deep copies to `numPacketsPerLID` and exports
- ``Details::packCrsMatrixWithOwningPIDs`` at `Tpetra_Details_packCrsMatrix_def.hpp:882`: deep_copy to numPacketsPerLID
- ``Import_Util::lowCommunicationMakeColMapAndReindex`` at `Tpetra_Import_Util2.hpp:851`: deep_copy to colind_LID