### PR TITLE
Panzer: fix for link errors in shared allocs (UVM) build

### DIFF
--- a/packages/panzer/dof-mgr/src/Panzer_NodeType.hpp
+++ b/packages/panzer/dof-mgr/src/Panzer_NodeType.hpp
@@ -14,7 +14,7 @@
 //#include <Tpetra_KokkosCompat_DefaultNode.hpp>
 //#include "Tpetra_Map.hpp"
 #include "Phalanx_KokkosDeviceTypes.hpp"
-#include <Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp>
+#include <Tpetra_KokkosCompat_DefaultNode.hpp>
 
 namespace panzer {
 
@@ -32,7 +32,7 @@ namespace panzer {
    * this typedef wherever a Tpetra node type template argument is
    * needed, e.g. `Tpetra::Map<LocalOrdinal,GlobalOrdinal,TpetraNodeType>`.
    */
-  typedef typename Tpetra::KokkosCompat::KokkosDeviceWrapperNode<PHX::Device> TpetraNodeType;
+  typedef typename Tpetra::KokkosClassic::DefaultNode::DefaultNodeType TpetraNodeType;
 
 }
 


### PR DESCRIPTION
@trilinos/panzer
@rppawlo 

We see link errors in the `panzer` tests when we compile Trilinos with `Tpetra_ALLOCATE_IN_SHARED_SPACE` set to ON.

```
INFO:root:#24 4472.1 /Trilinos-sources/packages/panzer/dof-mgr/test/dofmngr_test/tGlobalIndexerUtilities.cpp(160): error: no suitable user-defined conversion from "Tpetra::Vector<int, int, panzer::GlobalOrdinal, Tpetra::Details::DefaultTypes::node_type>" (aka "Tpetra::Vector<int, int, long long, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Cuda, Kokkos::CudaUVMSpace>>") to "const Tpetra::Vector<int, int, panzer::GlobalOrdinal, panzer::TpetraNodeType>" (aka "const Tpetra::Vector<int, int, long long, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Cuda, Kokkos::CudaSpace>>") exists
INFO:root:#24 4472.1      Tpetra::Vector<int,int,panzer::GlobalOrdinal> reducedUDataVector(getFieldMap(uFieldNum,*reducedFieldVector));
```

The reason seems to be that with the recent upgrade to Kokkos 5.2, the option `Kokkos_ENABLE_CUDA_UVM` was removed.

In a CUDA build, with the option `Tpetra_ALLOCATE_IN_SHARED_SPACE` set to `ON`, `Tpetra` will allocate by default in `Kokkos::CudaUVMSpace`. But, now without the `Kokkos_ENABLE_CUDA_UVM` option, `panzer` will allocate by default in `Kokkos::CudaSpace`.

The proposed fix is to get the node type from `Tpetra_KokkosCompat_DefaultNode.hpp`, which takes into account `Tpetra_ALLOCATE_IN_SHARED_SPACE`.



