### PR TITLE
Amesos2: fix for link errors in shared allocs (UVM) build

### DIFF
--- a/packages/amesos2/src/Amesos2_Kokkos_Impl.hpp
+++ b/packages/amesos2/src/Amesos2_Kokkos_Impl.hpp
@@ -29,7 +29,7 @@
     typename NODE_TYPE::device_type>,                                                           \
     Kokkos::View<S**, Kokkos::LayoutLeft, typename NODE_TYPE::device_type> >;
 
-#ifdef KOKKOS_ENABLE_CUDA_UVM
+#if defined(KOKKOS_ENABLE_CUDA) && defined(HAVE_TPETRA_SHARED_ALLOCS)
 #define AMESOS2_KOKKOS_LOCAL_INSTANT_KOKKOS_ADAPTER_UVM_OFF(S,LO)       \
   template class Amesos2::AMESOS2_KOKKOS_IMPL_SOLVER_NAME<KokkosSparse::CrsMatrix<S, LO,          \
     Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace>>,                                              \


### PR DESCRIPTION
@trilinos/amesos2
@iyamazaki 

We see link errors in the `amesos2` tests when we compile Trilinos with `Tpetra_ALLOCATE_IN_SHARED_SPACE` set to `ON`.

```
INFO:root:#24 6288.2 /usr/bin/ld: CMakeFiles/Amesos2_Solver_Test.dir/Solver_Test.cpp.o: in function `Teuchos::RCP<Amesos2::Solver<KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long>, Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > > > Amesos2::create<KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long>, Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Teuchos::RCP<KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long> const>, Teuchos::RCP<Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >, Teuchos::RCP<Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > const>)':
INFO:root:#24 6288.2 tmpxft_00022a4e_00000000-6_Solver_Test.cudafe1.cpp:(.text._ZN7Amesos26createIN12KokkosSparse9CrsMatrixIdiN6Kokkos6DeviceINS3_4CudaENS3_9CudaSpaceEEEvmEENS3_4ViewIPPdJNS3_10LayoutLeftES7_EEEEEN7Teuchos3RCPINS_6SolverIT_T0_EEEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENSF_IKSH_EENSF_ISI_EENSF_IKSI_EE[_ZN7Amesos26createIN12KokkosSparse9CrsMatrixIdiN6Kokkos6DeviceINS3_4CudaENS3_9CudaSpaceEEEvmEENS3_4ViewIPPdJNS3_10LayoutLeftES7_EEEEEN7Teuchos3RCPINS_6SolverIT_T0_EEEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENSF_IKSH_EENSF_ISI_EENSF_IKSI_EE]+0x297): undefined reference to `Amesos2::Basker<KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long>, Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >::Basker(Teuchos::RCP<KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long> const>, Teuchos::RCP<Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >, Teuchos::RCP<Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > const>)'
INFO:root:#24 6288.2 /usr/bin/ld: tmpxft_00022a4e_00000000-6_Solver_Test.cudafe1.cpp:(.text._ZN7Amesos26createIN12KokkosSparse9CrsMatrixIdiN6Kokkos6DeviceINS3_4CudaENS3_9CudaSpaceEEEvmEENS3_4ViewIPPdJNS3_10LayoutLeftES7_EEEEEN7Teuchos3RCPINS_6SolverIT_T0_EEEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENSF_IKSH_EENSF_ISI_EENSF_IKSI_EE[_ZN7Amesos26createIN12KokkosSparse9CrsMatrixIdiN6Kokkos6DeviceINS3_4CudaENS3_9CudaSpaceEEEvmEENS3_4ViewIPPdJNS3_10LayoutLeftES7_EEEEEN7Teuchos3RCPINS_6SolverIT_T0_EEEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENSF_IKSH_EENSF_ISI_EENSF_IKSI_EE]+0x727): undefined reference to `Amesos2::cuSOLVER<KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long>, Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >::cuSOLVER(Teuchos::RCP<KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long> const>, Teuchos::RCP<Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >, Teuchos::RCP<Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > const>)'
INFO:root:#24 6288.2 /usr/bin/ld: tmpxft_00022a4e_00000000-6_Solver_Test.cudafe1.cpp:(.text._ZN7Amesos26createIN12KokkosSparse9CrsMatrixIdiN6Kokkos6DeviceINS3_4CudaENS3_9CudaSpaceEEEvmEENS3_4ViewIPPdJNS3_10LayoutLeftES7_EEEEEN7Teuchos3RCPINS_6SolverIT_T0_EEEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENSF_IKSH_EENSF_ISI_EENSF_IKSI_EE[_ZN7Amesos26createIN12KokkosSparse9CrsMatrixIdiN6Kokkos6DeviceINS3_4CudaENS3_9CudaSpaceEEEvmEENS3_4ViewIPPdJNS3_10LayoutLeftES7_EEEEEN7Teuchos3RCPINS_6SolverIT_T0_EEEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENSF_IKSH_EENSF_ISI_EENSF_IKSI_EE]+0xaa4): undefined reference to `Amesos2::KLU2<KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long>, Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >::KLU2(Teuchos::RCP<KokkosSparse::CrsMatrix<double, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long> const>, Teuchos::RCP<Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >, Teuchos::RCP<Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > const>)'
INFO:root:#24 6288.2 /usr/bin/ld: CMakeFiles/Amesos2_Solver_Test.dir/Solver_Test.cpp.o: in function `Teuchos::RCP<Amesos2::Solver<KokkosSparse::CrsMatrix<Kokkos::complex<double>, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long>, Kokkos::View<Kokkos::complex<double>**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > > > Amesos2::create<KokkosSparse::CrsMatrix<Kokkos::complex<double>, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long>, Kokkos::View<Kokkos::complex<double>**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Teuchos::RCP<KokkosSparse::CrsMatrix<Kokkos::complex<double>, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long> const>, Teuchos::RCP<Kokkos::View<Kokkos::complex<double>**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >, Teuchos::RCP<Kokkos::View<Kokkos::complex<double>**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > const>)':
INFO:root:#24 6288.2 tmpxft_00022a4e_00000000-6_Solver_Test.cudafe1.cpp:(.text._ZN7Amesos26createIN12KokkosSparse9CrsMatrixIN6Kokkos7complexIdEEiNS3_6DeviceINS3_4CudaENS3_9CudaSpaceEEEvmEENS3_4ViewIPPS5_JNS3_10LayoutLeftES9_EEEEEN7Teuchos3RCPINS_6SolverIT_T0_EEEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENSH_IKSJ_EENSH_ISK_EENSH_IKSK_EE[_ZN7Amesos26createIN12KokkosSparse9CrsMatrixIN6Kokkos7complexIdEEiNS3_6DeviceINS3_4CudaENS3_9CudaSpaceEEEvmEENS3_4ViewIPPS5_JNS3_10LayoutLeftES9_EEEEEN7Teuchos3RCPINS_6SolverIT_T0_EEEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENSH_IKSJ_EENSH_ISK_EENSH_IKSK_EE]+0x297): undefined reference to `Amesos2::Basker<KokkosSparse::CrsMatrix<Kokkos::complex<double>, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long>, Kokkos::View<Kokkos::complex<double>**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >::Basker(Teuchos::RCP<KokkosSparse::CrsMatrix<Kokkos::complex<double>, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long> const>, Teuchos::RCP<Kokkos::View<Kokkos::complex<double>**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >, Teuchos::RCP<Kokkos::View<Kokkos::complex<double>**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > const>)'
INFO:root:#24 6288.2 /usr/bin/ld: tmpxft_00022a4e_00000000-6_Solver_Test.cudafe1.cpp:(.text._ZN7Amesos26createIN12KokkosSparse9CrsMatrixIN6Kokkos7complexIdEEiNS3_6DeviceINS3_4CudaENS3_9CudaSpaceEEEvmEENS3_4ViewIPPS5_JNS3_10LayoutLeftES9_EEEEEN7Teuchos3RCPINS_6SolverIT_T0_EEEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENSH_IKSJ_EENSH_ISK_EENSH_IKSK_EE[_ZN7Amesos26createIN12KokkosSparse9CrsMatrixIN6Kokkos7complexIdEEiNS3_6DeviceINS3_4CudaENS3_9CudaSpaceEEEvmEENS3_4ViewIPPS5_JNS3_10LayoutLeftES9_EEEEEN7Teuchos3RCPINS_6SolverIT_T0_EEEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENSH_IKSJ_EENSH_ISK_EENSH_IKSK_EE]+0x727): undefined reference to `Amesos2::cuSOLVER<KokkosSparse::CrsMatrix<Kokkos::complex<double>, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long>, Kokkos::View<Kokkos::complex<double>**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >::cuSOLVER(Teuchos::RCP<KokkosSparse::CrsMatrix<Kokkos::complex<double>, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long> const>, Teuchos::RCP<Kokkos::View<Kokkos::complex<double>**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >, Teuchos::RCP<Kokkos::View<Kokkos::complex<double>**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > const>)'
INFO:root:#24 6288.2 /usr/bin/ld: tmpxft_00022a4e_00000000-6_Solver_Test.cudafe1.cpp:(.text._ZN7Amesos26createIN12KokkosSparse9CrsMatrixIN6Kokkos7complexIdEEiNS3_6DeviceINS3_4CudaENS3_9CudaSpaceEEEvmEENS3_4ViewIPPS5_JNS3_10LayoutLeftES9_EEEEEN7Teuchos3RCPINS_6SolverIT_T0_EEEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENSH_IKSJ_EENSH_ISK_EENSH_IKSK_EE[_ZN7Amesos26createIN12KokkosSparse9CrsMatrixIN6Kokkos7complexIdEEiNS3_6DeviceINS3_4CudaENS3_9CudaSpaceEEEvmEENS3_4ViewIPPS5_JNS3_10LayoutLeftES9_EEEEEN7Teuchos3RCPINS_6SolverIT_T0_EEEERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENSH_IKSJ_EENSH_ISK_EENSH_IKSK_EE]+0xaa4): undefined reference to `Amesos2::KLU2<KokkosSparse::CrsMatrix<Kokkos::complex<double>, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long>, Kokkos::View<Kokkos::complex<double>**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >::KLU2(Teuchos::RCP<KokkosSparse::CrsMatrix<Kokkos::complex<double>, int, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, void, unsigned long> const>, Teuchos::RCP<Kokkos::View<Kokkos::complex<double>**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > >, Teuchos::RCP<Kokkos::View<Kokkos::complex<double>**, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> > const>)'
INFO:root:#24 6288.3 collect2: error: ld returned 1 exit status
INFO:root:#24 6288.3 gmake[2]: *** [packages/amesos2/test/solvers/CMakeFiles/Amesos2_Solver_Test.dir/build.make:157: packages/amesos2/test/solvers/Amesos2_Solver_Test.exe] Error 1
INFO:root:#24 6288.3 gmake[1]: *** [CMakeFiles/Makefile2:25185: packages/amesos2/test/solvers/CMakeFiles/Amesos2_Solver_Test.dir/all] Error 2
```

The reason seems to be that with the recent upgrade to Kokkos 5.2, the option `Kokkos_ENABLE_CUDA_UVM` was removed.

In a CUDA build, with the option `Tpetra_ALLOCATE_IN_SHARED_SPACE` set to `ON`, `Tpetra` will allocate by default in `Kokkos::CudaUVMSpace`. In `Amesos2`, a number of tests are explicitly instantiated for the `Kokkos::CudaSpace` even in a shared allocs (UVM) build (the "cudauvmoff" configuration in the `Amesos2` tests).

- https://github.com/trilinos/Trilinos/blob/1eb235bea2bd125d62765c391e00014f50c38ad3/packages/amesos2/test/solvers/Solver_Test.cpp#L1496  

In the `amesos2` code, this explicit instantiation is still controlled by the `KOKKOS_ENABLE_CUDA_UVM` variable, but this no longer works because this option has been removed.

The proposed fix is to control the explicit instantiation instead by using the `HAVE_TPETRA_SHARED_ALLOCS` variable.


