### PR TITLE
Stokhos: fix for link errors in shared allocs (UVM) build

### DIFF
--- a/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest_Cuda.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest_Cuda.cpp
@@ -17,7 +17,7 @@
 #include <Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp>
 
 // Instantiate tests for cuda node
-typedef Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Cuda> CudaWrapperNode;
+typedef Tpetra::KokkosCompat::KokkosCudaWrapperNode CudaWrapperNode;
 CRSMATRIX_MP_VECTOR_TESTS_N( CudaWrapperNode )
 
 int main( int argc, char* argv[] ) {


### PR DESCRIPTION
@trilinos/stokhos
@etphipp 

We see link errors in the `stokhos` tests when we compile Trilinos with `Tpetra_ALLOCATE_IN_SHARED_SPACE` set to `ON`.

```
INFO:root:14550.7 /usr/bin/ld: CMakeFiles/Stokhos_TpetraCrsMatrixMPVectorUnitTest_Cuda.dir/Stokhos_TpetraCrsMatrixMPVectorUnitTest_Cuda.cpp.o:(.data.rel.ro._ZTVN5MueLu14TpetraOperatorIN6Sacado2MP6VectorIN7Stokhos18StaticFixedStorageIidLi16EN6Kokkos4CudaEEEEEixN6Tpetra12KokkosCompat23KokkosDeviceWrapperNodeIS7_NS6_9CudaSpaceEEEEE[_ZTVN5MueLu14TpetraOperatorIN6Sacado2MP6VectorIN7Stokhos18StaticFixedStorageIidLi16EN6Kokkos4CudaEEEEEixN6Tpetra12KokkosCompat23KokkosDeviceWrapperNodeIS7_NS6_9CudaSpaceEEEEE]+0xb8): undefined reference to `virtual thunk to MueLu::TpetraOperator<Sacado::MP::Vector<Stokhos::StaticFixedStorage<int, double, 16, Kokkos::Cuda> >, int, long long, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Cuda, Kokkos::CudaSpace> >::~TpetraOperator()'
INFO:root:14550.7 collect2: error: ld returned 1 exit status
INFO:root:14550.7 gmake[2]: *** [packages/stokhos/test/UnitTest/CMakeFiles/Stokhos_TpetraCrsMatrixMPVectorUnitTest_Cuda.dir/build.make:205: packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest_Cuda.exe] Error 1
INFO:root:14550.7 gmake[1]: *** [CMakeFiles/Makefile2:40832: packages/stokhos/test/UnitTest/CMakeFiles/Stokhos_TpetraCrsMatrixMPVectorUnitTest_Cuda.dir/all] Error 2
INFO:root:14550.7 gmake: *** [Makefile:166: all] Error 2
```

The reason seems to be that with the recent upgrade to Kokkos 5.2, the option `Kokkos_ENABLE_CUDA_UVM` was removed.

The proposed fix is to set the node type using the `Tpetra` type alias that takes into account the shared allocs option.

- https://github.com/trilinos/Trilinos/blob/1eb235bea2bd125d62765c391e00014f50c38ad3/packages/tpetra/core/compat/Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp#L95-L101
