### PR TITLE
Panzer: Add interface to allow external applications to add GEDs to AE InArgs

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_ModelEvaluator.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ModelEvaluator.hpp
@@ -202,6 +202,11 @@ public:
   void addNonParameterGlobalEvaluationData(const std::string & name,
                                            const Teuchos::RCP<GlobalEvaluationData> & ged);
 
+  // Add generic global evaluation data to include in Assembly Engine input arguments
+  void addGlobalEvaluationDataToAssemblyInArgs(
+      const std::string & name,
+      const Teuchos::RCP<GlobalEvaluationData> & ged);
+
   /** Add a response specified by a list of WorksetDescriptor objects. The specifics of the
     * response are specified by the response factory builder. This version supports computing derivatives with
     * respect to both the state ('x') and control ('p') variables and is thus ``flexible''.
@@ -670,6 +675,7 @@ private: // data members
 
   GlobalEvaluationDataContainer nonParamGlobalEvaluationData_;
   GlobalEvaluationDataContainer distrParamGlobalEvaluationData_;
+  GlobalEvaluationDataContainer assemblyGlobalEvaluationData_;
 
   mutable bool oneTimeDirichletBeta_on_;
   mutable Scalar oneTimeDirichletBeta_;

--- a/packages/panzer/disc-fe/src/Panzer_ModelEvaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ModelEvaluator_impl.hpp
@@ -544,6 +544,7 @@ setupAssemblyInArgs(const Thyra::ModelEvaluatorBase::InArgs<Scalar> & inArgs,
   }
 
   ae_inargs.addGlobalEvaluationData(distrParamGlobalEvaluationData_);
+  ae_inargs.addGlobalEvaluationData(assemblyGlobalEvaluationData_);
 
   // here we are building a container, this operation is fast, simply allocating a struct
   const RCP<panzer::ThyraObjContainer<Scalar> > thGlobalContainer =
@@ -841,6 +842,14 @@ addNonParameterGlobalEvaluationData(const std::string & key,
                                     const Teuchos::RCP<GlobalEvaluationData> & ged)
 {
    nonParamGlobalEvaluationData_.addDataObject(key,ged);
+}
+
+template <typename Scalar>
+void panzer::ModelEvaluator<Scalar>::
+addGlobalEvaluationDataToAssemblyInArgs(const std::string & key,
+                                        const Teuchos::RCP<GlobalEvaluationData> & ged)
+{
+   assemblyGlobalEvaluationData_.addDataObject(key, ged);
 }
 
 template <typename Scalar>


### PR DESCRIPTION
@trilinos/panzer

## Motivation
In its current state, the Panzer model evaluator does not allow for external/derived applications to add global evaluation data objects to the assembly engine input arguments, so that their containers are accessible to various operators at runtime. In our Trilinos-based application, we are scattering and gathering non-DOF variables and require that the containers which hold the data vectors to be available to these evaluators. This PR adds a third global evaluation data container to the model evaluator, as well as a helper function to allow for users to add GEDs to the container. During evaluation, the new GEDC is added to the assembly engine input arguments so that its containers are accessible by evaluators.

## Related Issues
* Addresses issue which was discussed privately with Roger P.

## Stakeholder Feedback
 * Pending review.

## Testing
 * Testing has not been completed with the Trilinos test suite, but these modifications are relatively non-intrusive and work seamlessly with our Trilinos-based application.

## Additional Information
N/A
