### PR TITLE
Tpetra,MueLu: Global constants fix

### DIFF
--- a/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RepartitionFactory_def.hpp
@@ -257,6 +257,11 @@ void RepartitionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level&
     auto mapParams = Teuchos::rcp(new Teuchos::ParameterList);
     mapParams->set("compute global constants", IsPrint(Statistics1));
     newRowMap = MapFactory ::Build(lib, rowMap->getGlobalNumElements(), myGIDs(), indexBase, origComm, mapParams);
+    if (!IsPrint(Statistics1) && Xpetra::toTpetra(rowMap)->haveGlobalConstants()) {
+      // Copy global constants
+      auto tpMap = Xpetra::toTpetra(newRowMap->getMap());
+      Teuchos::rcp_const_cast<Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >(tpMap)->copyGlobalConstants(*Xpetra::toTpetra(rowMap));
+    }
   }
 
   RCP<const Import> rowMapImporter;

--- a/packages/muelu/test/interface/default/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_np4_tpetra.gold
@@ -111,4 +111,27 @@ Computing Ac (MueLu::RebalanceAcFactory)
 repartition: use subcommunicators = 0
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
-Caught exception: "Map::getMaxAllGlobalIndex" called, but global constants have not been computed with "Map::computeGlobalConstants".
+presmoother -> 
+ Amesos2 -> 
+  [empty list]
+
+--------------------------------------------------------------------------------
+---                            Multigrid Summary                             ---
+--------------------------------------------------------------------------------
+Number of levels    = 3
+Operator complexity = 0.00
+Smoother complexity = <ignored>
+Cycle type          = V
+
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335    N/A              3.00      4
+  2    1112   3340     3.00     3.00      4
+
+Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335]}
+
+Smoother (level 2) pre  : <Direct> solver interface
+Smoother (level 2) post : no smoother
+

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
@@ -109,4 +109,27 @@ Computing Ac (MueLu::RebalanceAcFactory)
 repartition: use subcommunicators = 0
 Max coarse size (<= 2000) achieved
 Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
-Caught exception: "Map::getMaxAllGlobalIndex" called, but global constants have not been computed with "Map::computeGlobalConstants".
+presmoother -> 
+ Amesos2 -> 
+  [empty list]
+
+--------------------------------------------------------------------------------
+---                            Multigrid Summary                             ---
+--------------------------------------------------------------------------------
+Number of levels    = 3
+Operator complexity = 0.00
+Smoother complexity = <ignored>
+Cycle type          = V
+
+level  rows    nnz  nnz/row  c ratio  procs
+  0    9999  29995     3.00               4
+  1    3335    N/A              3.00      4
+  2    1112   3340     3.00     3.00      4
+
+Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
+
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335]}
+
+Smoother (level 2) pre  : <Direct> solver interface
+Smoother (level 2) post : no smoother
+

--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -146,6 +146,7 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(
     smoother_complex.xml
     smooVec.mm
     smooVecCoalesce.xml
+    test.globalConstants.xml
     tripleMatrixProduct.xml
     zeroAggTest.xml
   CATEGORIES BASIC PERFORMANCE
@@ -924,5 +925,14 @@ TRIBITS_ADD_TEST(
   COMM mpi
   NUM_MPI_PROCS 4
   ARGS "--matrix=A_rankWithoutUnknowns.m --rowmap=map_rankWithoutUnknowns.m --coords=coords_rankWithoutUnknowns.m --xml=rankWithoutUnknowns.xml"
+  PASS_REGULAR_EXPRESSION "Belos converged"
+)
+
+TRIBITS_ADD_TEST(
+  Driver
+  NAME GlobalConstants
+  COMM mpi
+  NUM_MPI_PROCS 4
+  ARGS "--nx=400 --ny=400 --xml=test.globalConstants.xml"
   PASS_REGULAR_EXPRESSION "Belos converged"
 )

--- a/packages/muelu/test/scaling/test.globalConstants.xml
+++ b/packages/muelu/test/scaling/test.globalConstants.xml
@@ -1,0 +1,23 @@
+<ParameterList name="MueLu">
+  <Parameter        name="verbosity"                        type="string"   value="none"/>
+  <Parameter        name="coarse: max size"                 type="int"      value="2000"/>
+
+  <Parameter        name="smoother: type"                   type="string"   value="CHEBYSHEV"/>
+  
+  <Parameter        name="aggregation: type"                type="string"   value="uncoupled"/>
+  <Parameter        name="aggregation: drop tol"            type="double"   value="0.005"/>
+  <Parameter        name="aggregation: drop scheme"         type="string"   value="distance laplacian"/>
+
+  <Parameter        name="repartition: enable"              type="bool"     value="true"/>
+  <Parameter        name="repartition: min rows per proc"   type="int"      value="8000"/>
+  <Parameter        name="repartition: start level"         type="int"      value="1"/>
+  <Parameter        name="repartition: max imbalance"       type="double"   value="1.327"/>
+  <Parameter        name="repartition: partitioner"         type="string"   value="zoltan2"/>
+
+  <ParameterList name="level 2">
+    <Parameter        name="repartition: min rows per proc"   type="int"      value="1500"/>
+  </ParameterList>
+
+  <!-- This results in a 4 levels with 4, 3, 2, 1 ranks -->
+  
+</ParameterList>

--- a/packages/tpetra/core/src/Tpetra_Map_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_decl.hpp
@@ -1213,6 +1213,12 @@ class Map : public Teuchos::Describable {
   /// communicator.
   void computeGlobalConstants() const;
 
+  /// \brief Copy global constants from a different map.
+  ///
+  /// This is useful when two maps have the same global IDs but different
+  /// distributions. This situation arise for example in repartitioning.
+  void copyGlobalConstants(const Map<local_ordinal_type, global_ordinal_type, Node>& map);
+
   /// \brief A mapping from local IDs to global IDs.
   ///
   /// By definition, this mapping is local; it only contains global

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -1108,6 +1108,16 @@ void Map<LocalOrdinal, GlobalOrdinal, Node>::computeGlobalConstants() const {
 }
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
+void Map<LocalOrdinal, GlobalOrdinal, Node>::copyGlobalConstants(const Map<local_ordinal_type, global_ordinal_type, Node>& map) {
+  TEUCHOS_TEST_FOR_EXCEPTION(!map.haveGlobalConstants(), std::invalid_argument, "Map needs to have global constants");
+
+  minAllGID_           = map.getMinAllGlobalIndex();
+  maxAllGID_           = map.getMaxAllGlobalIndex();
+  haveGlobalConstants_ = true;
+  distributed_         = (getComm()->getSize() > 1) && map.distributed_;
+}
+
+template <class LocalOrdinal, class GlobalOrdinal, class Node>
 Map<LocalOrdinal, GlobalOrdinal, Node>::~Map() {
   if (!Kokkos::is_initialized()) {
     std::ostringstream os;


### PR DESCRIPTION
@trilinos/tpetra @trilinos/muelu 

## Motivation
- Tpetra: Add a method that allows to copy global constants from one map to another (and hence skip global reductions).
- MueLu: Add a test that reproduces #15634 and fix it by copying global constants in `RepartitionFactory`.