### PR TITLE
Driver: fix logic error wrt matrix build timing

### DIFF
--- a/packages/muelu/test/scaling/Driver.cpp
+++ b/packages/muelu/test/scaling/Driver.cpp
@@ -432,7 +432,7 @@ int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib& lib, int ar
   // This is because if a StackedTimer is already active, globalTimer will be become a sub-timer of the root.
   RCP<TimeMonitor> globalTimeMonitor = Teuchos::null;
   if (useStackedTimer) {
-    stacked_timer = rcp(new Teuchos::StackedTimer("MueLu_Driver"));
+    stacked_timer = rcp(new Teuchos::StackedTimer("MueLu_Driver", timeMatrixBuild));
     Teuchos::TimeMonitor::setStackedTimer(stacked_timer);
     if (!timeMatrixBuild)
       stacked_timer->disableTimers();  // will be reenabled below after linear system setup
@@ -566,8 +566,10 @@ int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib& lib, int ar
         if (runList.isParameter("tol")) tol = runList.get<double>("tol");
 
         if (resetStackedTimer) {
-          stacked_timer = rcp(new Teuchos::StackedTimer("MueLu_Driver"));
+          stacked_timer = rcp(new Teuchos::StackedTimer("MueLu_Driver", timeMatrixBuild));
           Teuchos::TimeMonitor::setStackedTimer(stacked_timer);
+          if (!timeMatrixBuild)
+            stacked_timer->disableTimers();  // will be reenabled below after linear system setup
         }
       }
 
@@ -588,8 +590,11 @@ int main_(Teuchos::CommandLineProcessor& clp, Xpetra::UnderlyingLib& lib, int ar
       size_t kokkos_context_id = 0;
 
       // Timers might have been disabled by option --no-time-matrix-build.
-      if (useStackedTimer)
+      // In that case, base timer itself won't be running.
+      if (useStackedTimer && !timeMatrixBuild) {
+        stacked_timer->startBaseTimer();
         stacked_timer->enableTimers();
+      }
       // =========================================================================
       // Loop over the setup/solve pairs
       // =========================================================================


### PR DESCRIPTION
Ensure base stacked timer itself is stopped/started properly

@trilinos/muelu 

```
mpirun -np 4 ./MueLu_Driver.exe --matrixType=Laplace3D --nx=500 --ny=400 --nz=400 --stacked-timer --no-sacrificial-setup  --no-sacrificial-solve --xml=scaling.xml --solver=none

Memory use after preconditioner setup (GB): 2.03682
Enforcing boundary conditions on initial guess
*** Teuchos::StackedTimer::report() - Remainder for a level will be ***
*** incorrect if a timer in the level does not exist on every rank  ***
*** of the MPI Communicator.                                        ***
MueLu_Driver: 2.00217 [1] {min=2.00188, max=2.00238, std dev=0.000214256} <1, 0, 0, 0, 0, 1, 0, 1, 0, 1>
|   Driver: 1 - Matrix Build: 1.83024 - 91.4127% [1] {min=1.83024, max=1.83024, std dev=2.34739e-06} <1, 0, 1, 0, 1, 0, 0, 0, 0, 1>
|   |   Galeri: Laplace 3D generation: 1.6036 - 87.617% [1] {min=1.60339, max=1.60373, std dev=0.000154934} <1, 0, 0, 0, 0, 1, 0, 0, 0, 2>
|   |   |   Galeri: Laplace 3D generation: rowptr: 0.0197659 - 1.2326% [1] {min=0.0196334, max=0.0198771, std dev=0.000100747} <1, 0, 0, 0, 0, 1, 1, 0, 0, 1>
|   |   |   Galeri: Laplace 3D generation: column map: 1.17604 - 73.3372% [1] {min=1.17587, max=1.17621, std dev=0.000140793} <1, 0, 0, 1, 0, 1, 0, 0, 0, 1>
|   |   |   Galeri: Laplace 3D generation: fill: 0.407787 - 25.4295% [1] {min=0.407613, max=0.407976, std dev=0.000156196} <1, 0, 1, 0, 0, 0, 1, 0, 0, 1>
|   |   |   Remainder: 1.11732e-05 - 0.00069676%
|   |   Remainder: 0.226639 - 12.383%
|   Driver: 2 - MueLu Setup: 0.16097 - 8.03975% [1] {min=0.160905, max=0.161044, std dev=6.14748e-05} <1, 0, 1, 0, 0, 0, 1, 0, 0, 1>
|   |   MueLu: ParameterListInterpreter (ParameterList): 0.00212827 - 1.32215% [1] {min=0.0020741, max=0.0022278, std dev=6.82526e-05} <1, 1, 1, 0, 0, 0, 0, 0, 0, 1>
|   |   MueLu: Laplace3D: Hierarchy: Setup (total, level=0): 0.156538 - 97.2468% [1] {min=0.156439, max=0.156665, std dev=9.91584e-05} <1, 1, 0, 0, 0, 1, 0, 0, 0, 1>
|   |   |   MueLu: Laplace3D: Ifpack2Smoother: Setup Smoother (total): 0.156389 - 99.905% [1] {min=0.156296, max=0.156509, std dev=9.34008e-05} <1, 0, 1, 0, 0, 1, 0, 0, 0, 1>
|   |   |   |   MueLu: Ifpack2Smoother: SetPrecParameters: 2.08185e-05 - 0.013312% [1] {min=1.9277e-05, max=2.2353e-05, std dev=1.70419e-06} <2, 0, 0, 0, 0, 0, 0, 0, 0, 2>
|   |   |   |   MueLu: Laplace3D: Ifpack2Smoother: Preconditioner init (sub, total): 2.22875e-06 - 0.00142513% [1] {min=2.15e-06, max=2.328e-06, std dev=7.94287e-08} <1, 1, 0, 0, 0, 1, 0, 0, 0, 1>
|   |   |   |   MueLu: Laplace3D: Ifpack2Smoother: Preconditioner compute (sub, total): 0.156316 - 99.9536% [1] {min=0.156226, max=0.156443, std dev=9.41607e-05} <1, 1, 0, 0, 1, 0, 0, 0, 0, 1>
|   |   |   |   |   Ifpack2::Chebyshev::compute: 0.156314 - 99.9987% [1] {min=0.156224, max=0.156441, std dev=9.41497e-05} <1, 1, 0, 0, 1, 0, 0, 0, 0, 1>
|   |   |   |   |   Remainder: 2.041e-06 - 0.00130569%
|   |   |   |   Remainder: 4.95675e-05 - 0.031695%
|   |   |   Remainder: 0.000148747 - 0.0950229%
|   |   Remainder: 0.00230355 - 1.43105%
|   Driver: 3 - LHS and RHS initialization: 0.00114624 - 0.0572499% [1] {min=0.00109734, max=0.00118727, std dev=4.74347e-05} <1, 1, 0, 0, 0, 0, 0, 0, 0, 2>
|   Remainder: 0.0098157 - 0.490253%
```

```
mpirun -np 4 ./MueLu_Driver.exe --matrixType=Laplace3D --nx=500 --ny=400 --nz=400 --stacked-timer --no-sacrificial-setup  --no-sacrificial-solve --xml=scaling.xml --solver=none  --no-time-matrix-build

Memory use after preconditioner setup (GB): 2.0366
Enforcing boundary conditions on initial guess
*** Teuchos::StackedTimer::report() - Remainder for a level will be ***
*** incorrect if a timer in the level does not exist on every rank  ***
*** of the MPI Communicator.                                        ***
MueLu_Driver: 0.169747 [1] {min=0.169569, max=0.169958, std dev=0.000160052} <1, 0, 0, 1, 1, 0, 0, 0, 0, 1>
|   Driver: 2 - MueLu Setup: 0.162116 - 95.5046% [1] {min=0.162057, max=0.16218, std dev=5.17942e-05} <1, 0, 0, 1, 0, 1, 0, 0, 0, 1>
|   |   MueLu: ParameterListInterpreter (ParameterList): 0.00204071 - 1.2588% [1] {min=0.00197316, max=0.00211444, std dev=5.77949e-05} <1, 0, 0, 0, 2, 0, 0, 0, 0, 1>
|   |   MueLu: Laplace3D: Hierarchy: Setup (total, level=0): 0.157645 - 97.2422% [1] {min=0.157364, max=0.157887, std dev=0.000216169} <1, 0, 0, 0, 0, 1, 1, 0, 0, 1>
|   |   |   MueLu: Laplace3D: Ifpack2Smoother: Setup Smoother (total): 0.157491 - 99.9026% [1] {min=0.157175, max=0.157736, std dev=0.000233754} <1, 0, 0, 0, 0, 1, 1, 0, 0, 1>
|   |   |   |   MueLu: Ifpack2Smoother: SetPrecParameters: 2.1239e-05 - 0.0134858% [1] {min=1.9879e-05, max=2.2279e-05, std dev=1.05228e-06} <1, 0, 0, 0, 1, 0, 0, 0, 1, 1>
|   |   |   |   MueLu: Laplace3D: Ifpack2Smoother: Preconditioner init (sub, total): 2.44425e-06 - 0.00155199% [1] {min=2.12e-06, max=2.919e-06, std dev=3.4237e-07} <1, 0, 1, 1, 0, 0, 0, 0, 0, 1>
|   |   |   |   MueLu: Laplace3D: Ifpack2Smoother: Preconditioner compute (sub, total): 0.157415 - 99.9517% [1] {min=0.157078, max=0.157665, std dev=0.000245957} <1, 0, 0, 0, 0, 0, 2, 0, 0, 1>
|   |   |   |   |   Ifpack2::Chebyshev::compute: 0.157413 - 99.9986% [1] {min=0.157075, max=0.157663, std dev=0.000246388} <1, 0, 0, 0, 0, 0, 2, 0, 0, 1>
|   |   |   |   |   Remainder: 2.1895e-06 - 0.00139091%
|   |   |   |   Remainder: 5.24583e-05 - 0.0333086%
|   |   |   Remainder: 0.000153607 - 0.0974384%
|   |   Remainder: 0.00243011 - 1.499%
|   Driver: 3 - LHS and RHS initialization: 0.00117003 - 0.689282% [1] {min=0.00116603, max=0.00118007, std dev=6.70632e-06} <3, 0, 0, 0, 0, 0, 0, 0, 0, 1>
|   Remainder: 0.00646073 - 3.8061%
```

