### PR TITLE
Stratimikos: allow an algebraic preconditioner on the innermost Belos solve

### DIFF
--- a/packages/muelu/adapters/stratimikos/Stratimikos_MueLuHelpers.hpp
+++ b/packages/muelu/adapters/stratimikos/Stratimikos_MueLuHelpers.hpp
@@ -21,6 +21,18 @@
 #include "Thyra_MueLuTpetraQ2Q1PreconditionerFactory.hpp"
 #endif
 
+// Support for injecting a MueLu preconditioner into the innermost Belos solve
+// of Stratimikos' "BelosPrecTpetra" preconditioner.  Guarded so the MueLu
+// Stratimikos adapter still builds when Stratimikos is configured without the
+// Belos/Tpetra pieces that supply the factory below.
+#if defined(HAVE_MUELU_STRATIMIKOS) && defined(HAVE_MUELU_BELOS) && defined(HAVE_MUELU_THYRA)
+#include "Thyra_BelosTpetraPreconditionerFactory_decl.hpp"
+#include "Thyra_BelosTpetraPreconditionerFactory_def.hpp"
+#include "MueLu_CreateTpetraPreconditioner.hpp"
+#include "Tpetra_CrsMatrix.hpp"
+#include "Tpetra_Operator.hpp"
+#endif
+
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_TestForException.hpp"
@@ -99,6 +111,98 @@ MUELU_DEPRECATED void enableMueLuTpetraQ2Q1(LinearSolverBuilder<double>& builder
   enableMueLuTpetraQ2Q1<double, LocalOrdinal, GlobalOrdinal, Node>(builder, stratName);
 }
 #endif
+
+/*! \brief Register a MueLu preconditioner as an inner algebraic preconditioner
+    for Stratimikos' "BelosPrecTpetra" preconditioner (the innermost Belos solve).
+
+    Stratimikos lives \e upstream of MueLu (MueLu optionally depends on
+    Stratimikos), so the Belos-as-preconditioner factory cannot call MueLu
+    directly without creating a circular package dependency.  Instead the factory
+    exposes a small builder registry, and MueLu injects itself here (dependency
+    inversion) via \c setInnerPrecBuilder.
+
+    Call this once, before solving, on the same \c MatrixType used with
+    \c enableBelosPrecTpetra (default \c Tpetra::CrsMatrix<Scalar,LO,GO,Node>).
+    Afterwards, an XML block such as
+
+    \code{.xml}
+      <ParameterList name="BelosPrecTpetra">
+        <Parameter name="BelosPrec Solver Type" type="string" value="GmresPoly"/>
+        <Parameter name="Inner Prec Type"       type="string" value="MueLu"/>
+        <Parameter name="Inner Prec Side"       type="string" value="left"/>
+        <ParameterList name="Inner Prec Params"> ... MueLu parameters ... </ParameterList>
+      </ParameterList>
+    \endcode
+
+    builds a MueLu hierarchy on the inner Belos operator and applies it as a
+    left/right preconditioner of that inner solve.
+
+    \param precName  Value of "Inner Prec Type" this builder answers to (default "MueLu").
+*/
+template <typename Scalar        = MueLu::DefaultScalar,
+          typename LocalOrdinal  = MueLu::DefaultLocalOrdinal,
+          typename GlobalOrdinal = MueLu::DefaultGlobalOrdinal,
+          typename Node          = MueLu::DefaultNode>
+void enableBelosPrecMueLu(const std::string& precName = "MueLu") {
+#if defined(HAVE_MUELU_STRATIMIKOS) && defined(HAVE_MUELU_BELOS) && defined(HAVE_MUELU_THYRA)
+  typedef Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> matrix_type;
+  typedef Thyra::BelosTpetraPreconditionerFactory<matrix_type> factory_type;
+  // Tpetra::Operator<Scalar,LO,GO,Node>: the inner solve's forward operator and
+  // the returned preconditioner operator type.
+  typedef typename factory_type::inner_prec_op_type op_type;
+
+  factory_type::setInnerPrecBuilder(
+      precName,
+      [](const Teuchos::RCP<const op_type>& fwdOp,
+         Teuchos::ParameterList& params) -> Teuchos::RCP<const op_type> {
+        // const-operator overload of CreateTpetraPreconditioner; the returned
+        // MueLu::TpetraOperator is-a Tpetra::Operator and upcasts to op_type.
+        return MueLu::CreateTpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(fwdOp, params);
+      });
+#endif
+}
+
+/*! \brief Register a MueLu preconditioner as the inner algebraic preconditioner
+    of a \e half-precision "BelosPrecTpetra" inner Belos solve
+    ("half precision"=true).
+
+    This is the half-precision analog of enableBelosPrecMueLu().  It is a
+    \e separate, opt-in call because it forces MueLu to be instantiated for the
+    half scalar (e.g. \c float when \c Scalar is \c double): calling it in a
+    build whose MueLu ETI does not include the half scalar will fail to link.
+    enableBelosPrecMueLu() (full precision) never pulls in that instantiation, so
+    it stays safe in double-only MueLu builds.
+
+    The whole body compiles to nothing unless a half-precision scalar is
+    available in the build (THYRA_BELOS_PREC_ENABLE_HALF_PRECISION), matching the
+    factory's own half-precision path.  Call it (in addition to, or instead of,
+    enableBelosPrecMueLu()) before solving with "half precision"=true and
+    "Inner Prec Type"="MueLu".
+
+    \param precName  Value of "Inner Prec Type" this builder answers to (default "MueLu").
+*/
+template <typename Scalar        = MueLu::DefaultScalar,
+          typename LocalOrdinal  = MueLu::DefaultLocalOrdinal,
+          typename GlobalOrdinal = MueLu::DefaultGlobalOrdinal,
+          typename Node          = MueLu::DefaultNode>
+void enableBelosPrecMueLuHalf(const std::string& precName = "MueLu") {
+#if defined(HAVE_MUELU_STRATIMIKOS) && defined(HAVE_MUELU_BELOS) && defined(HAVE_MUELU_THYRA) && \
+    defined(THYRA_BELOS_PREC_ENABLE_HALF_PRECISION)
+  typedef Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> matrix_type;
+  typedef Thyra::BelosTpetraPreconditionerFactory<matrix_type> factory_type;
+  // Half-precision scalar (e.g. float) and the matching inner operator type.
+  typedef typename factory_type::half_scalar_type half_scalar_type;
+  typedef typename factory_type::inner_prec_op_half_type op_half_type;
+
+  factory_type::setInnerPrecBuilderHalf(
+      precName,
+      [](const Teuchos::RCP<const op_half_type>& fwdOp,
+         Teuchos::ParameterList& params) -> Teuchos::RCP<const op_half_type> {
+        // MueLu built at the half scalar; requires MueLu ETI for half_scalar_type.
+        return MueLu::CreateTpetraPreconditioner<half_scalar_type, LocalOrdinal, GlobalOrdinal, Node>(fwdOp, params);
+      });
+#endif
+}
 
 }  // namespace Stratimikos
 

--- a/packages/stratimikos/adapters/belos/src/tpetra/Thyra_BelosTpetraPreconditionerFactory_decl.hpp
+++ b/packages/stratimikos/adapters/belos/src/tpetra/Thyra_BelosTpetraPreconditionerFactory_decl.hpp
@@ -12,10 +12,27 @@
 
 #include "Thyra_PreconditionerFactoryBase.hpp"
 
+#include "Tpetra_Operator.hpp"
+#include "Teuchos_ScalarTraits.hpp"
+
+#include <functional>
+#include <map>
+#include <string>
+
 namespace Thyra {
 
 /** \brief Concrete preconditioner factory subclass based on Belos.
  * (Yes, Belos solvers can also be used as preconditioners!)
+ *
+ * The inner Belos solve can optionally be given its own algebraic
+ * preconditioner, selected from XML via the "Inner Prec Type" parameter.
+ * Builders for concrete preconditioner packages are looked up in a static
+ * registry.  The Ifpack2 builder is registered automatically when Stratimikos
+ * is configured with Ifpack2.  Packages that live *downstream* of Stratimikos
+ * (e.g. MueLu, which optionally depends on Stratimikos) cannot be called
+ * directly from here without creating a circular dependency; instead they
+ * inject their own builder via setInnerPrecBuilder() -- see
+ * Stratimikos::enableBelosPrecMueLu().
  */
 template <typename MatrixType>
 class BelosTpetraPreconditionerFactory :
@@ -23,6 +40,62 @@ class BelosTpetraPreconditionerFactory :
 public:
   /** \brief . */
   typedef typename MatrixType::scalar_type scalar_type;
+  /** \brief . */
+  typedef typename MatrixType::local_ordinal_type local_ordinal_type;
+  /** \brief . */
+  typedef typename MatrixType::global_ordinal_type global_ordinal_type;
+  /** \brief . */
+  typedef typename MatrixType::node_type node_type;
+
+  //! Tpetra operator type of the inner algebraic preconditioner.
+  typedef Tpetra::Operator<scalar_type, local_ordinal_type, global_ordinal_type, node_type>
+    inner_prec_op_type;
+
+  //! Half-of-standard-precision scalar (e.g. float when scalar_type is double).
+  typedef typename Teuchos::ScalarTraits<scalar_type>::halfPrecision half_scalar_type;
+
+  //! Tpetra operator type of a *half-precision* inner algebraic preconditioner.
+  typedef Tpetra::Operator<half_scalar_type, local_ordinal_type, global_ordinal_type, node_type>
+    inner_prec_op_half_type;
+
+  /** \brief Callback that builds an inner algebraic preconditioner operator.
+   *
+   * Arguments: the (const) forward Tpetra operator of the inner solve, and the
+   * "Inner Prec Params" parameter list.  Returns the preconditioner operator to
+   * install on the inner Belos LinearProblem.
+   */
+  typedef std::function<
+    Teuchos::RCP<const inner_prec_op_type>(
+      const Teuchos::RCP<const inner_prec_op_type>&,
+      Teuchos::ParameterList&)
+    > InnerPrecBuilder;
+
+  /** \brief Half-precision analog of InnerPrecBuilder, used when the inner Belos
+   * solve is built at half_scalar_type ("half precision"=true).  The forward
+   * operator and the returned preconditioner are both at half_scalar_type. */
+  typedef std::function<
+    Teuchos::RCP<const inner_prec_op_half_type>(
+      const Teuchos::RCP<const inner_prec_op_half_type>&,
+      Teuchos::ParameterList&)
+    > InnerPrecBuilderHalf;
+
+  /** \brief Register (or replace) the inner-preconditioner builder used for a
+   * given "Inner Prec Type" name.  Intended for downstream packages to inject
+   * their own preconditioners (e.g. MueLu). */
+  static void setInnerPrecBuilder(const std::string& precType, InnerPrecBuilder builder);
+
+  /** \brief Whether a builder is registered for the given "Inner Prec Type". */
+  static bool hasInnerPrecBuilder(const std::string& precType);
+
+  /** \brief Register (or replace) the *half-precision* inner-preconditioner
+   * builder used for a given "Inner Prec Type" name, applied when the inner
+   * Belos solve runs at half precision.  Downstream packages inject their own
+   * (e.g. Stratimikos::enableBelosPrecMueLuHalf()); note this requires the
+   * package to be ETI-instantiated for half_scalar_type. */
+  static void setInnerPrecBuilderHalf(const std::string& precType, InnerPrecBuilderHalf builder);
+
+  /** \brief Whether a half-precision builder is registered for the given name. */
+  static bool hasInnerPrecBuilderHalf(const std::string& precType);
 
   /** @name Constructors/initializers/accessors */
   //@{
@@ -82,6 +155,12 @@ public:
 private:
 
   Teuchos::RCP<Teuchos::ParameterList> paramList_;
+
+  //! Registry of inner-preconditioner builders, keyed by "Inner Prec Type".
+  static std::map<std::string, InnerPrecBuilder>& innerPrecRegistry();
+
+  //! Half-precision analog of innerPrecRegistry().
+  static std::map<std::string, InnerPrecBuilderHalf>& innerPrecRegistryHalf();
 
 };
 

--- a/packages/stratimikos/adapters/belos/src/tpetra/Thyra_BelosTpetraPreconditionerFactory_def.hpp
+++ b/packages/stratimikos/adapters/belos/src/tpetra/Thyra_BelosTpetraPreconditionerFactory_def.hpp
@@ -21,7 +21,19 @@
 #include "BelosLinearProblem.hpp"
 #include "BelosTpetraAdapter.hpp"
 
+#include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_MixedScalarMultiplyOp.hpp"
+
+// Ifpack2 lives upstream of Stratimikos, so its inner-preconditioner builder is
+// registered directly here (guarded by the TriBITS-generated macro).  MueLu
+// lives downstream of Stratimikos and therefore injects its own builder via
+// setInnerPrecBuilder() -- see Stratimikos::enableBelosPrecMueLu().
+// HAVE_STRATIMIKOS_IFPACK2 is defined in Stratimikos_InternalConfig.h (not the
+// public Stratimikos_Config.h), so it must be included for the guard to work.
+#include "Stratimikos_InternalConfig.h"
+#if defined(HAVE_STRATIMIKOS_IFPACK2)
+#  include "Ifpack2_Factory.hpp"
+#endif
 
 #include "Teuchos_TestForException.hpp"
 #include "Teuchos_Assert.hpp"
@@ -60,10 +72,8 @@ bool BelosTpetraPreconditionerFactory<MatrixType>::isCompatible(
   const LinearOpSourceBase<scalar_type> &fwdOpSrc
   ) const
 {
-  typedef typename MatrixType::local_ordinal_type local_ordinal_type;
-  typedef typename MatrixType::global_ordinal_type global_ordinal_type;
-  typedef typename MatrixType::node_type node_type;
-
+  // scalar_type, local_ordinal_type, global_ordinal_type and node_type are
+  // member typedefs of the class; do not redeclare them here (-Wshadow).
   const Teuchos::RCP<const LinearOpBase<scalar_type> > fwdOp = fwdOpSrc.getOp();
   using TpetraExtractHelper = TpetraOperatorVectorExtraction<scalar_type, local_ordinal_type, global_ordinal_type, node_type>;
   const auto tpetraFwdOp =  TpetraExtractHelper::getConstTpetraOperator(fwdOp);
@@ -113,10 +123,8 @@ void BelosTpetraPreconditionerFactory<MatrixType>::initializePrec(
   const RCP<const LinearOpBase<scalar_type> > fwdOp = fwdOpSrc->getOp();
   TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(fwdOp));
 
-  typedef typename MatrixType::local_ordinal_type local_ordinal_type;
-  typedef typename MatrixType::global_ordinal_type global_ordinal_type;
-  typedef typename MatrixType::node_type node_type;
-
+  // scalar_type, local_ordinal_type, global_ordinal_type and node_type are
+  // member typedefs of the class; do not redeclare them here (-Wshadow).
   typedef Tpetra::Operator<scalar_type, local_ordinal_type, global_ordinal_type, node_type> TpetraLinOp;
   using TpetraExtractHelper = TpetraOperatorVectorExtraction<scalar_type, local_ordinal_type, global_ordinal_type, node_type>;
   const auto tpetraFwdOp =  TpetraExtractHelper::getConstTpetraOperator(fwdOp);
@@ -131,7 +139,7 @@ void BelosTpetraPreconditionerFactory<MatrixType>::initializePrec(
   // CAG: There is nothing special about the combination double-float,
   //      except that I feel somewhat confident that Trilinos builds
   //      with both scalar types.
-  typedef typename Teuchos::ScalarTraits<scalar_type>::halfPrecision half_scalar_type;
+  // half_scalar_type is a member typedef; do not redeclare it here (-Wshadow).
   typedef Tpetra::Operator<half_scalar_type, local_ordinal_type, global_ordinal_type, node_type> TpetraLinOpHalf;
   typedef Tpetra::MultiVector<half_scalar_type, local_ordinal_type, global_ordinal_type, node_type> TpetraMVHalf;
   typedef Belos::TpetraOperator<half_scalar_type, local_ordinal_type, global_ordinal_type, node_type> BelosTpOpHalf;
@@ -160,6 +168,10 @@ void BelosTpetraPreconditionerFactory<MatrixType>::initializePrec(
   const std::string solverType = Teuchos::getParameter<std::string>(*innerParamList, "BelosPrec Solver Type");
   const RCP<Teuchos::ParameterList> packageParamList = Teuchos::rcpFromRef(innerParamList->sublist("BelosPrec Solver Params"));
 
+  // Optional algebraic preconditioner applied *inside* the inner Belos solve.
+  const std::string innerPrecType = innerParamList->get<std::string>("Inner Prec Type", "None");
+  const std::string innerPrecSide = innerParamList->get<std::string>("Inner Prec Side", "left");
+
   // solverTypeUpper is the upper-case version of solverType.
   std::string solverTypeUpper (solverType);
   std::transform(solverTypeUpper.begin(), solverTypeUpper.end(),solverTypeUpper.begin(), ::toupper);
@@ -181,6 +193,40 @@ void BelosTpetraPreconditionerFactory<MatrixType>::initializePrec(
 
     RCP<BelosTpLinProbHalf> belosLinProbHalf = rcp(new BelosTpLinProbHalf());
     belosLinProbHalf->setOperator(tpetraFwdMatrixHalf);
+
+    // Optionally attach an algebraic preconditioner, built at half_scalar_type
+    // against the down-converted matrix, to the inner (half-precision) Belos
+    // solve.  Same before-the-wrapper contract as the full-precision branch.
+    // The builder must come from a package that is ETI-instantiated for
+    // half_scalar_type (Ifpack2 is registered automatically; MueLu via
+    // Stratimikos::enableBelosPrecMueLuHalf()).
+    if (innerPrecType != "None") {
+      std::map<std::string, InnerPrecBuilderHalf>& registry = innerPrecRegistryHalf();
+      typename std::map<std::string, InnerPrecBuilderHalf>::const_iterator it =
+        registry.find(innerPrecType);
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        it == registry.end(), std::logic_error,
+        "Thyra::BelosTpetraPreconditionerFactory: no *half-precision* inner-preconditioner "
+        "builder is registered for \"Inner Prec Type\"=\"" << innerPrecType << "\". "
+        "\"Ifpack2\" is registered automatically when Stratimikos is configured with "
+        "Ifpack2 and a half-precision scalar is available.  For a downstream package such "
+        "as MueLu, register its half-precision builder before solving, e.g. by calling "
+        "Stratimikos::enableBelosPrecMueLuHalf<...>().");
+
+      Teuchos::ParameterList& ip = innerParamList->sublist("Inner Prec Params");
+      const RCP<const TpetraLinOpHalf> innerPrec = (it->second)(tpetraFwdMatrixHalf, ip);
+
+      if (innerPrecSide == "right") {
+        belosLinProbHalf->setRightPrec(innerPrec);
+      } else if (innerPrecSide == "left") {
+        belosLinProbHalf->setLeftPrec(innerPrec);
+      } else {
+        TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
+          "Thyra::BelosTpetraPreconditionerFactory: unknown \"Inner Prec Side\"=\""
+          << innerPrecSide << "\" (valid: \"left\", \"right\").");
+      }
+    }
+
     RCP<TpetraLinOpHalf> belosOpRCPHalf = rcp(new BelosTpOpHalf(belosLinProbHalf, packageParamList, solverType, true));
     RCP<TpetraLinOp> wrappedOp = rcp(new Tpetra::MixedScalarMultiplyOp<scalar_type,half_scalar_type,local_ordinal_type,global_ordinal_type,node_type>(belosOpRCPHalf));
 
@@ -192,6 +238,37 @@ void BelosTpetraPreconditionerFactory<MatrixType>::initializePrec(
     // Wrap concrete preconditioner
     RCP<BelosTpLinProb> belosLinProb = rcp(new BelosTpLinProb());
     belosLinProb->setOperator(tpetraFwdOp);
+
+    // Optionally attach an algebraic preconditioner to the inner Belos solve.
+    // The preconditioner is set on the LinearProblem *before* it is wrapped in
+    // Belos::TpetraOperator; the wrapper preserves LP_/RP_ (it only resets the
+    // solution/RHS vectors on each apply()), so the inner solve honors it.
+    if (innerPrecType != "None") {
+      std::map<std::string, InnerPrecBuilder>& registry = innerPrecRegistry();
+      typename std::map<std::string, InnerPrecBuilder>::const_iterator it =
+        registry.find(innerPrecType);
+      TEUCHOS_TEST_FOR_EXCEPTION(
+        it == registry.end(), std::logic_error,
+        "Thyra::BelosTpetraPreconditionerFactory: no inner-preconditioner builder "
+        "is registered for \"Inner Prec Type\"=\"" << innerPrecType << "\". "
+        "\"Ifpack2\" is registered automatically when Stratimikos is configured "
+        "with Ifpack2. For a downstream package such as MueLu, register its builder "
+        "before solving, e.g. by calling Stratimikos::enableBelosPrecMueLu<...>().");
+
+      Teuchos::ParameterList& ip = innerParamList->sublist("Inner Prec Params");
+      const RCP<const TpetraLinOp> innerPrec = (it->second)(tpetraFwdOp, ip);
+
+      if (innerPrecSide == "right") {
+        belosLinProb->setRightPrec(innerPrec);
+      } else if (innerPrecSide == "left") {
+        belosLinProb->setLeftPrec(innerPrec);
+      } else {
+        TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
+          "Thyra::BelosTpetraPreconditionerFactory: unknown \"Inner Prec Side\"=\""
+          << innerPrecSide << "\" (valid: \"left\", \"right\").");
+      }
+    }
+
     RCP<TpetraLinOp> belosOpRCP = rcp(new BelosTpOp(belosLinProb, packageParamList, solverType, true));
     thyraPrecOp = Thyra::createLinearOp(belosOpRCP);
   }
@@ -303,6 +380,22 @@ BelosTpetraPreconditionerFactory<MatrixType>::getValidParameters() const
       "BelosPrec Solver Params", false,
       "Belos solver settings that are passed onto the Belos solver itself."
       );
+    validParamList->set(
+      "Inner Prec Type", "None",
+      "Algebraic preconditioner applied inside the inner Belos solve: "
+      "\"None\", \"Ifpack2\", or \"MueLu\"."
+      );
+    validParamList->set(
+      "Inner Prec Side", "left",
+      "Side on which to apply the inner algebraic preconditioner: \"left\" or \"right\"."
+      );
+    validParamList->sublist(
+      "Inner Prec Params", false,
+      "Parameters passed to the inner algebraic preconditioner. For Ifpack2, the "
+      "string \"Prec Type\" selects the Ifpack2 method (e.g. \"RELAXATION\", \"ILUT\", "
+      "\"SCHWARZ\") and the remaining entries are the Ifpack2 settings; for MueLu this "
+      "is a standard MueLu parameter list."
+      );
     Teuchos::setupVerboseObjectSublist(validParamList.getRawPtr());
   }
 
@@ -316,6 +409,119 @@ template <typename MatrixType>
 std::string BelosTpetraPreconditionerFactory<MatrixType>::description() const
 {
   return "Thyra::BelosTpetraPreconditionerFactory";
+}
+
+
+// Inner-preconditioner builder registry
+
+
+template <typename MatrixType>
+std::map<std::string, typename BelosTpetraPreconditionerFactory<MatrixType>::InnerPrecBuilder>&
+BelosTpetraPreconditionerFactory<MatrixType>::innerPrecRegistry()
+{
+  // Function-local static: one registry per template specialization, safely
+  // initialized on first use.  The Ifpack2 builder is seeded here because
+  // Ifpack2 is upstream of Stratimikos; downstream packages add their own via
+  // setInnerPrecBuilder().
+  static std::map<std::string, InnerPrecBuilder> registry = [] {
+    std::map<std::string, InnerPrecBuilder> m;
+#if defined(HAVE_STRATIMIKOS_IFPACK2)
+    m["Ifpack2"] = [](const Teuchos::RCP<const inner_prec_op_type>& fwdOp,
+                      Teuchos::ParameterList& ip)
+        -> Teuchos::RCP<const inner_prec_op_type> {
+      // Ifpack2 needs the concrete matrix, not just the operator.
+      const Teuchos::RCP<const MatrixType> mat =
+        Teuchos::rcp_dynamic_cast<const MatrixType>(fwdOp, true);
+      const std::string ifpackType = ip.get<std::string>("Prec Type", "RELAXATION");
+      Teuchos::RCP<Ifpack2::Preconditioner<scalar_type, local_ordinal_type,
+        global_ordinal_type, node_type> > prec =
+          Ifpack2::Factory::create<MatrixType>(ifpackType, mat);
+      // Do not forward our "Prec Type" selector key on to Ifpack2 itself.
+      Teuchos::ParameterList ifpackParams(ip);
+      ifpackParams.remove("Prec Type", false);
+      prec->setParameters(ifpackParams);
+      prec->initialize();
+      prec->compute();
+      return prec;
+    };
+#endif
+    return m;
+  }();
+  return registry;
+}
+
+
+template <typename MatrixType>
+void BelosTpetraPreconditionerFactory<MatrixType>::setInnerPrecBuilder(
+  const std::string& precType, InnerPrecBuilder builder)
+{
+  innerPrecRegistry()[precType] = builder;
+}
+
+
+template <typename MatrixType>
+bool BelosTpetraPreconditionerFactory<MatrixType>::hasInnerPrecBuilder(
+  const std::string& precType)
+{
+  return innerPrecRegistry().count(precType) != 0;
+}
+
+
+// Half-precision inner-preconditioner builder registry
+
+
+template <typename MatrixType>
+std::map<std::string, typename BelosTpetraPreconditionerFactory<MatrixType>::InnerPrecBuilderHalf>&
+BelosTpetraPreconditionerFactory<MatrixType>::innerPrecRegistryHalf()
+{
+  // Parallel to innerPrecRegistry(), but the builders produce operators at
+  // half_scalar_type for the half-precision inner Belos solve.  The Ifpack2
+  // builder is seeded only when a half-precision scalar is actually available
+  // (THYRA_BELOS_PREC_ENABLE_HALF_PRECISION); in that configuration Ifpack2 is
+  // ETI-instantiated for the half scalar too.
+  static std::map<std::string, InnerPrecBuilderHalf> registry = [] {
+    std::map<std::string, InnerPrecBuilderHalf> m;
+#if defined(HAVE_STRATIMIKOS_IFPACK2) && defined(THYRA_BELOS_PREC_ENABLE_HALF_PRECISION)
+    m["Ifpack2"] = [](const Teuchos::RCP<const inner_prec_op_half_type>& fwdOp,
+                      Teuchos::ParameterList& ip)
+        -> Teuchos::RCP<const inner_prec_op_half_type> {
+      // The half-precision matrix produced by MatrixType::convert<half_scalar_type>().
+      typedef Tpetra::CrsMatrix<half_scalar_type, local_ordinal_type,
+        global_ordinal_type, node_type> matrix_half_type;
+      const Teuchos::RCP<const matrix_half_type> mat =
+        Teuchos::rcp_dynamic_cast<const matrix_half_type>(fwdOp, true);
+      const std::string ifpackType = ip.get<std::string>("Prec Type", "RELAXATION");
+      Teuchos::RCP<Ifpack2::Preconditioner<half_scalar_type, local_ordinal_type,
+        global_ordinal_type, node_type> > prec =
+          Ifpack2::Factory::create<matrix_half_type>(ifpackType, mat);
+      // Do not forward our "Prec Type" selector key on to Ifpack2 itself.
+      Teuchos::ParameterList ifpackParams(ip);
+      ifpackParams.remove("Prec Type", false);
+      prec->setParameters(ifpackParams);
+      prec->initialize();
+      prec->compute();
+      return prec;
+    };
+#endif
+    return m;
+  }();
+  return registry;
+}
+
+
+template <typename MatrixType>
+void BelosTpetraPreconditionerFactory<MatrixType>::setInnerPrecBuilderHalf(
+  const std::string& precType, InnerPrecBuilderHalf builder)
+{
+  innerPrecRegistryHalf()[precType] = builder;
+}
+
+
+template <typename MatrixType>
+bool BelosTpetraPreconditionerFactory<MatrixType>::hasInnerPrecBuilderHalf(
+  const std::string& precType)
+{
+  return innerPrecRegistryHalf().count(precType) != 0;
 }
 
 

--- a/packages/stratimikos/test/CMakeLists.txt
+++ b/packages/stratimikos/test/CMakeLists.txt
@@ -96,6 +96,32 @@ IF (${PROJECT_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_ThyraTpetraAdapters
     EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_FLOAT
     )
 
+  # Inner Belos solve preconditioned by an Ifpack2 algebraic preconditioner,
+  # configured purely from XML (exercises the "Inner Prec *" keys added to the
+  # BelosPrecTpetra preconditioner factory).
+  IF (${PACKAGE_NAME}_ENABLE_Ifpack2)
+    TRIBITS_ADD_TEST(
+      test_tpetra_belos
+      NAME test_tpetra_belos_prec_ifpack2
+      ARGS
+        "--input-file=stratimikos_BelosPrecIfpack2_ParameterList.xml --show-timer-summary"
+      COMM serial mpi
+      NUM_MPI_PROCS 4
+      )
+
+    # Same, but the inner Belos solve (and its Ifpack2 prec) run at half
+    # precision.  Requires a half-precision scalar, hence the FLOAT guard.
+    TRIBITS_ADD_TEST(
+      test_tpetra_belos
+      NAME test_tpetra_belos_half_prec_ifpack2
+      ARGS
+        "--input-file=stratimikos_HalfBelosPrecIfpack2_ParameterList.xml --show-timer-summary"
+      COMM serial mpi
+      NUM_MPI_PROCS 4
+      EXCLUDE_IF_NOT_TRUE ${PROJECT_NAME}_ENABLE_FLOAT
+      )
+  ENDIF()
+
   ASSERT_DEFINED(Belos_SOURCE_DIR)
 
   TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyTpetraTestMtxFiles
@@ -111,6 +137,8 @@ IF (${PROJECT_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_ThyraTpetraAdapters
       stratimikos_BelosPrec_ParameterList.xml
       stratimikos_HalfBelosPrec_ParameterList.xml
       stratimikos_GMRES_IR_ParameterList.xml
+      stratimikos_BelosPrecIfpack2_ParameterList.xml
+      stratimikos_HalfBelosPrecIfpack2_ParameterList.xml
     EXEDEPS test_tpetra_belos
   )
 

--- a/packages/stratimikos/test/stratimikos_BelosPrecIfpack2_ParameterList.xml
+++ b/packages/stratimikos/test/stratimikos_BelosPrecIfpack2_ParameterList.xml
@@ -1,0 +1,61 @@
+<ParameterList>
+  <Parameter name="Matrix File" type="string" value="bcsstk12.mtx"/>
+  <ParameterList name="Linear Solver Builder">
+
+  <!-- ================================================== -->
+  <!-- OUTER KRYLOV SOLVER CONFIGURATION                  -->
+  <!-- ================================================== -->
+
+    <Parameter name="Linear Solver Type" type="string" value="Belos"/>
+    <ParameterList name="Linear Solver Types">
+      <ParameterList name="Belos">
+        <Parameter name="Solver Type" type="string" value="Pseudo Block GMRES"/>
+
+        <ParameterList name="Solver Types">
+          <ParameterList name="Pseudo Block GMRES">
+            <Parameter name="Convergence Tolerance" type="double" value="1e-06"/>
+            <Parameter name="Maximum Iterations" type="int" value="400"/>
+            <Parameter name="Num Blocks" type="int" value="50"/>
+            <Parameter name="Output Frequency" type="int" value="20"/>
+            <Parameter name="Output Style" type="int" value="1"/>
+            <Parameter name="Verbosity" type="int" value="33"/>
+          </ParameterList>
+        </ParameterList>
+
+        <ParameterList name="VerboseObject">
+          <Parameter name="Verbosity Level" type="string" value="high"/>
+        </ParameterList>
+
+      </ParameterList>
+    </ParameterList>
+
+  <!-- ================================================== -->
+  <!-- PRECONDITIONER CONFIGURATION                       -->
+  <!--   Inner Belos solve (GmresPoly) that itself is     -->
+  <!--   preconditioned by an Ifpack2 relaxation prec,    -->
+  <!--   configured entirely from this XML.               -->
+  <!-- ================================================== -->
+    <Parameter name="Preconditioner Type" type="string" value="BelosPrecTpetra"/>
+    <ParameterList name="Preconditioner Types">
+
+      <ParameterList name="BelosPrecTpetra">
+        <Parameter name="BelosPrec Solver Type" type="string" value="GmresPoly"/>
+        <ParameterList name="BelosPrec Solver Params">
+          <Parameter name="Maximum Degree" type="int" value="8"/>
+        </ParameterList>
+
+        <!-- NEW: algebraic preconditioner injected into the inner Belos solve -->
+        <Parameter name="Inner Prec Type" type="string" value="Ifpack2"/>
+        <Parameter name="Inner Prec Side" type="string" value="left"/>
+        <ParameterList name="Inner Prec Params">
+          <Parameter name="Prec Type" type="string" value="RELAXATION"/>
+          <Parameter name="relaxation: type" type="string" value="Symmetric Gauss-Seidel"/>
+          <Parameter name="relaxation: sweeps" type="int" value="2"/>
+        </ParameterList>
+      </ParameterList>
+
+    </ParameterList>
+
+  <!-- ================================================== -->
+  </ParameterList>
+</ParameterList>

--- a/packages/stratimikos/test/stratimikos_HalfBelosPrecIfpack2_ParameterList.xml
+++ b/packages/stratimikos/test/stratimikos_HalfBelosPrecIfpack2_ParameterList.xml
@@ -1,0 +1,68 @@
+<ParameterList>
+  <Parameter name="Matrix File" type="string" value="bcsstk12.mtx"/>
+  <ParameterList name="Linear Solver Builder">
+
+  <!-- ================================================== -->
+  <!-- OUTER KRYLOV SOLVER CONFIGURATION                  -->
+  <!-- ================================================== -->
+
+    <Parameter name="Linear Solver Type" type="string" value="Belos"/>
+    <ParameterList name="Linear Solver Types">
+      <ParameterList name="Belos">
+        <Parameter name="Solver Type" type="string" value="Pseudo Block GMRES"/>
+
+        <ParameterList name="Solver Types">
+          <ParameterList name="Pseudo Block GMRES">
+            <Parameter name="Convergence Tolerance" type="double" value="1e-06"/>
+            <Parameter name="Maximum Iterations" type="int" value="400"/>
+            <Parameter name="Num Blocks" type="int" value="50"/>
+            <Parameter name="Output Frequency" type="int" value="20"/>
+            <Parameter name="Output Style" type="int" value="1"/>
+            <Parameter name="Verbosity" type="int" value="33"/>
+          </ParameterList>
+        </ParameterList>
+
+        <ParameterList name="VerboseObject">
+          <Parameter name="Verbosity Level" type="string" value="high"/>
+        </ParameterList>
+
+      </ParameterList>
+    </ParameterList>
+
+  <!-- ================================================== -->
+  <!-- PRECONDITIONER CONFIGURATION                       -->
+  <!--   HALF-PRECISION inner Belos solve (GmresPoly) that -->
+  <!--   is itself preconditioned by a half-precision      -->
+  <!--   Ifpack2 relaxation prec, configured from XML.     -->
+  <!--   Exercises the "Inner Prec *" keys together with   -->
+  <!--   "half precision"=true.                            -->
+  <!-- ================================================== -->
+    <Parameter name="Preconditioner Type" type="string" value="BelosPrecTpetra"/>
+    <ParameterList name="Preconditioner Types">
+
+      <ParameterList name="BelosPrecTpetra">
+        <Parameter name="half precision" type="bool" value="true"/>
+        <Parameter name="BelosPrec Solver Type" type="string" value="GmresPoly"/>
+        <ParameterList name="BelosPrec Solver Params">
+          <Parameter name="Maximum Degree" type="int" value="8"/>
+        </ParameterList>
+
+        <!-- algebraic preconditioner injected into the (half) inner Belos solve -->
+        <Parameter name="Inner Prec Type" type="string" value="Ifpack2"/>
+        <Parameter name="Inner Prec Side" type="string" value="left"/>
+        <ParameterList name="Inner Prec Params">
+          <Parameter name="Prec Type" type="string" value="RELAXATION"/>
+          <Parameter name="relaxation: type" type="string" value="Symmetric Gauss-Seidel"/>
+          <Parameter name="relaxation: sweeps" type="int" value="2"/>
+        </ParameterList>
+
+        <ParameterList name="VerboseObject">
+          <Parameter name="Verbosity Level" type="string" value="high"/>
+        </ParameterList>
+      </ParameterList>
+
+    </ParameterList>
+
+  <!-- ================================================== -->
+  </ParameterList>
+</ParameterList>


### PR DESCRIPTION
@trilinos/muelu @trilinos/stratimikos @iyamazaki 

The BelosPrecTpetra preconditioner (a Belos solve used to precondition an outer Belos solve) previously built its inner Belos LinearProblem with setOperator() only, so the innermost solve could not itself carry an algebraic preconditioner from XML.

Add an XML-selectable inner preconditioner via new keys on the BelosPrecTpetra sublist:

  Inner Prec Type   ("None" | "Ifpack2" | "MueLu")
  Inner Prec Side   ("left" | "right")
  Inner Prec Params (package-specific list)

The preconditioner is attached to the inner Belos LinearProblem with setLeftPrec/setRightPrec before it is wrapped in Belos::TpetraOperator, which preserves LP_/RP_ across apply(), so the inner solve honors it.

Because MueLu depends optionally on Stratimikos, Stratimikos cannot depend on MueLu without creating a circular package dependency. Instead the factory exposes a small name->builder registry (setInnerPrecBuilder): the Ifpack2 builder is registered directly (Ifpack2 is upstream), and MueLu injects its own builder via the new Stratimikos::enableBelosPrecMueLu<...>() helper in the MueLu Stratimikos adapter (dependency inversion, no circular dep).

- Thyra_BelosTpetraPreconditionerFactory_{decl,def}.hpp: registry + Ifpack2 builtin, new XML params, half-precision guard. Include Stratimikos_InternalConfig.h so HAVE_STRATIMIKOS_IFPACK2 is visible.
- Stratimikos_MueLuHelpers.hpp: enableBelosPrecMueLu() registers a MueLu::CreateTpetraPreconditioner builder into the factory registry.
- test: stratimikos_BelosPrecIfpack2_ParameterList.xml + a ctest (test_tpetra_belos_prec_ifpack2), guarded by Ifpack2.

Assisted-by: Claude:Sonnet-5