### PR TITLE
MueLu ReitzingerPFactory: Allow zero entries in D0

### DIFF
--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -187,6 +187,7 @@ double Hierarchy<Scalar, LocalOrdinal, GlobalOrdinal, Node>::GetSmootherComplexi
   if (A.is_null()) return -1.0;
   RCP<Matrix> Am = rcp_dynamic_cast<Matrix>(A);
   if (Am.is_null()) return -1.0;
+  if (!Am->haveGlobalConstants()) return -1.0;
   a0_nnz = as<double>(Am->getGlobalNumEntries());
 
   // Get smoother complexity at each level

--- a/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/src/Operators/MueLu_RefMaxwell_def.hpp
@@ -604,7 +604,8 @@ void RefMaxwell<Scalar, LocalOrdinal, GlobalOrdinal, Node>::compute(bool reuse) 
     }
   }
 
-  describe(GetOStream(Runtime0));
+  if (IsPrint(Runtime0))
+    describe(GetOStream(Runtime0));
 
 #ifdef HAVE_MUELU_CUDA
   if (parameterList_.get<bool>("refmaxwell: cuda profile setup", false)) cudaProfilerStop();
@@ -2897,7 +2898,8 @@ void RefMaxwell<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   nnz     = 0;
   if (!A22_.is_null()) {
     numRows = A22_->getGlobalNumRows();
-    nnz     = A22_->getGlobalNumEntries();
+    if (Xpetra::toTpetra(A22_)->haveGlobalConstants())
+      nnz = A22_->getGlobalNumEntries();
   }
   Teuchos::reduceAll(*comm, Teuchos::REDUCE_MAX, numRows, Teuchos::ptr(&numRowsGlobal));
   Teuchos::reduceAll(*comm, Teuchos::REDUCE_MAX, nnz, Teuchos::ptr(&numNNZGlobal));

--- a/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
@@ -180,7 +180,11 @@ void Amesos2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Setup(Level& cu
   if (pL.get<bool>("fix nullspace")) {
     this->GetOStream(Runtime1) << "MueLu::Amesos2Smoother::Setup(): fixing nullspace" << std::endl;
 
-    rowMap            = A->getRowMap();
+    rowMap        = A->getRowMap();
+    auto tpRowMap = Xpetra::toTpetra(rowMap);
+    if (!tpRowMap->haveGlobalConstants()) {
+      Teuchos::rcp_const_cast<Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node> >(tpRowMap)->computeGlobalConstants();
+    }
     size_t gblNumCols = rowMap->getGlobalNumElements();
 
     RCP<MultiVector> NullspaceOrig = Factory::Get<RCP<MultiVector> >(currentLevel, "Nullspace");

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_ReitzingerPFactory_def.hpp
@@ -88,13 +88,14 @@ void ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level
   using execution_space = typename Node::execution_space;
   using memory_space    = typename Node::memory_space;
 
-  const auto one_Scalar      = Teuchos::ScalarTraits<Scalar>::one();
-  const auto one_impl_scalar = ATS::one();
-  const auto zero_LO         = KokkosKernels::ArithTraits<LocalOrdinal>::zero();
-  const auto one_LO          = KokkosKernels::ArithTraits<LocalOrdinal>::one();
-  const auto one_mag         = magATS::one();
-  const auto eps_mag         = magATS::epsilon();
-  const auto INVALID_GO      = Teuchos::OrdinalTraits<GlobalOrdinal>::invalid();
+  const auto one_Scalar       = Teuchos::ScalarTraits<Scalar>::one();
+  const auto one_impl_scalar  = ATS::one();
+  const auto zero_impl_scalar = ATS::zero();
+  const auto zero_LO          = KokkosKernels::ArithTraits<LocalOrdinal>::zero();
+  const auto one_LO           = KokkosKernels::ArithTraits<LocalOrdinal>::one();
+  const auto one_mag          = magATS::one();
+  const auto eps_mag          = magATS::epsilon();
+  const auto INVALID_GO       = Teuchos::OrdinalTraits<GlobalOrdinal>::invalid();
 
   // Using a nodal prolongator Pn and the discrete gradient matrix D0, this factory constructs
   // a coarse discrete gradient matrix D0H and an edge prolongator Pe such that the commuting
@@ -267,6 +268,8 @@ void ReitzingerPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level
                 values(i) = one_LO;
               else if (values_scalar(i) == -one_impl_scalar)
                 values(i) = -one_LO;
+              else if (values_scalar(i) == zero_impl_scalar)
+                values(i) = zero_LO;
               else
                 Kokkos::abort("D0 contains bad values");
             });


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
- Relax a check in ReitzingerP to allow for explicit zeros in the discrete gradient matrix.
- Compute constants in Amesos2Smoother factory if required for nullspace fix
- RefMaxwell: Fix for printing at low verbosity level