### PR TITLE
MiniTensor: let the optimizer see that sizes fit their static storage

### DIFF
--- a/packages/minitensor/src/MiniTensor_Storage.h
+++ b/packages/minitensor/src/MiniTensor_Storage.h
@@ -61,6 +61,29 @@ struct check_static {
 };
 
 ///
+/// Bound a run-time dimension by the static dimension N, when there is one.
+///
+/// A statically sized tensor stores its run-time dimension as a plain
+/// integer that set_dimension() has already checked against N, but the check
+/// is an assert and the optimizer cannot see it. Loops bounded by
+/// get_dimension() then look unbounded, and GCC reports the iterations that a
+/// static tensor can never reach as out-of-bounds or uninitialized accesses
+/// to its storage. Bounding the dimension by N states the invariant in a form
+/// the optimizer can use; the value is unchanged whenever the invariant holds.
+///
+template<Index N>
+KOKKOS_INLINE_FUNCTION
+constexpr Index
+bound_dimension(Index const dimension)
+{
+  if constexpr (N == DYNAMIC) {
+    return dimension;
+  } else {
+    return dimension <= N ? dimension : N;
+  }
+}
+
+///
 /// Validate a run-time dimension for dynamic storage.
 ///
 template<typename Store>
@@ -413,7 +436,12 @@ public:
   Index
   size() const
   {
-    return size_;
+    // resize() asserts size_ <= N, but the assert is gone from optimized
+    // builds and the optimizer cannot see the invariant. Stating it here lets
+    // GCC prove that every loop bounded by size() indexes within storage_,
+    // instead of reporting -Warray-bounds and -Wstringop-overflow at the
+    // writes those loops make through operator[].
+    return size_ <= N ? size_ : N;
   }
 
   ///

--- a/packages/minitensor/src/MiniTensor_Tensor.h
+++ b/packages/minitensor/src/MiniTensor_Tensor.h
@@ -1389,7 +1389,7 @@ KOKKOS_INLINE_FUNCTION
 Index
 Tensor<T, N>::get_dimension() const
 {
-  return TensorBase<T, Store>::get_dimension(ORDER);
+  return bound_dimension<N>(TensorBase<T, Store>::get_dimension(ORDER));
 }
 
 //

--- a/packages/minitensor/src/MiniTensor_Tensor3.h
+++ b/packages/minitensor/src/MiniTensor_Tensor3.h
@@ -519,7 +519,7 @@ KOKKOS_INLINE_FUNCTION
 Index
 Tensor3<T, N>::get_dimension() const
 {
-  return TensorBase<T, Store>::get_dimension(ORDER);
+  return bound_dimension<N>(TensorBase<T, Store>::get_dimension(ORDER));
 }
 
 //

--- a/packages/minitensor/src/MiniTensor_Tensor4.h
+++ b/packages/minitensor/src/MiniTensor_Tensor4.h
@@ -808,7 +808,7 @@ KOKKOS_INLINE_FUNCTION
 Index
 Tensor4<T, N>::get_dimension() const
 {
-  return TensorBase<T, Store>::get_dimension(ORDER);
+  return bound_dimension<N>(TensorBase<T, Store>::get_dimension(ORDER));
 }
 
 //

--- a/packages/minitensor/src/MiniTensor_TensorBase.h
+++ b/packages/minitensor/src/MiniTensor_TensorBase.h
@@ -872,11 +872,8 @@ TensorBase<T, ST>::set_number_components(Index const number_components)
   Index const
   old_size = get_number_components();
 
-  Index const
-  new_size = number_components;
-
-  if (new_size < old_size) {
-    for (auto i = new_size; i < old_size; ++i) {
+  if (number_components < old_size) {
+    for (auto i = number_components; i < old_size; ++i) {
       auto & entry = (*this)[i];
       fill_AD<T>(entry, not_a_number<S>());
       entry = not_a_number<T>();
@@ -884,6 +881,13 @@ TensorBase<T, ST>::set_number_components(Index const number_components)
   }
 
   components_.resize(number_components);
+
+  // Bound the growth loop by the size the storage reports after the resize,
+  // which static storage clamps to its capacity, rather than by the requested
+  // count, which the optimizer cannot bound. The two are equal whenever the
+  // resize was valid.
+  Index const
+  new_size = get_number_components();
 
   if (new_size > old_size) {
     for (auto i = old_size; i < new_size; ++i) {

--- a/packages/minitensor/src/MiniTensor_Vector.h
+++ b/packages/minitensor/src/MiniTensor_Vector.h
@@ -994,7 +994,7 @@ KOKKOS_INLINE_FUNCTION
 Index
 Vector<T, N>::get_dimension() const
 {
-  return TensorBase<T, Store>::get_dimension(ORDER);
+  return bound_dimension<N>(TensorBase<T, Store>::get_dimension(ORDER));
 }
 
 //


### PR DESCRIPTION
## Motivation

A statically sized MiniTensor object carries two run-time integers, the number of components its storage holds and its dimension. Both are checked against the static capacity only by asserts, which optimized builds drop. The loops bounded by them therefore look unbounded to the compiler, and GCC reports the iterations that a static tensor can never take as accesses past its storage: `-Warray-bounds` and `-Wmaybe-uninitialized` on GCC 13 and later, `-Wstringop-overflow` on GCC 11 and 12.

Typical reports, from an LCM build:

```
MiniTensor_Scalar.h:433:5: warning: array subscript 'Sacado::Fad::StaticStorage<double, 2>[2]' is partly outside array bounds of 'minitensor::Vector<Sacado::Fad::GeneralFad<Sacado::Fad::StaticStorage<double, 2> >, 2> [1]' [-Warray-bounds=]
MiniTensor_Scalar.h:433:5: warning: 'void* __builtin_memset(void*, int, long unsigned int)' writing between 144 and 34359738360 bytes into a region of size 88 overflows the destination [-Wstringop-overflow=]
```

## Change

State the invariants where the compiler can use them:

- `Storage<T, N>::size()` reports a size no larger than `N`.
- The growth loop of `TensorBase::set_number_components` runs to the size the storage reports after the resize rather than to the requested count.
- `Vector`, `Tensor`, `Tensor3` and `Tensor4` bound `get_dimension()` by `N` through a new helper, `bound_dimension<N>`, which is the identity for dynamic storage.

Nothing changes whenever the invariants hold, which the asserts still verify in debug builds. This is the same idea as the `dimension_reachable` change to the determinant and inverse dispatch, applied to the loops that remained.

## Verification

GCC 16.2, LCM (Albany fork) built with `-Wall -Wextra`: 34 MiniTensor reports before, none after, and the Sacado reports the same loops provoked roughly halved. The full LCM test suite (201 tests) passes.

## Checklist

- [x] Signed-off-by
- [ ] Release Note: not needed, no API or behavior change
