### PR TITLE
Stamp out Kokkos::Experimental::SYCL* warnings

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -2411,7 +2411,7 @@ static inline int ExtractAndFactorizeRecommendedSYCLTeamSize(const int blksize,
   return 2 * total_team_size / vector_size;
 }
 template <>
-struct ExtractAndFactorizeTridiagsDefaultModeAndAlgo<Kokkos::Experimental::SYCLDeviceUSMSpace> {
+struct ExtractAndFactorizeTridiagsDefaultModeAndAlgo<Kokkos::SYCLDeviceUSMSpace> {
   typedef KB::Mode::Team mode_type;
   typedef KB::Algo::Level3::Unblocked algo_type;
   static int recommended_team_size(const int blksize,
@@ -2421,7 +2421,7 @@ struct ExtractAndFactorizeTridiagsDefaultModeAndAlgo<Kokkos::Experimental::SYCLD
   }
 };
 template <>
-struct ExtractAndFactorizeTridiagsDefaultModeAndAlgo<Kokkos::Experimental::SYCLSharedUSMSpace> {
+struct ExtractAndFactorizeTridiagsDefaultModeAndAlgo<Kokkos::SYCLSharedUSMSpace> {
   typedef KB::Mode::Team mode_type;
   typedef KB::Algo::Level3::Unblocked algo_type;
   static int recommended_team_size(const int blksize,
@@ -4029,7 +4029,7 @@ static inline int SolveTridiagsRecommendedSYCLTeamSize(const int blksize,
 }
 
 template <>
-struct SolveTridiagsDefaultModeAndAlgo<Kokkos::Experimental::SYCLSharedUSMSpace> {
+struct SolveTridiagsDefaultModeAndAlgo<Kokkos::SYCLSharedUSMSpace> {
   typedef KB::Mode::Team mode_type;
   typedef KB::Algo::Level2::Unblocked single_vector_algo_type;
   typedef KB::Algo::Level3::Unblocked multi_vector_algo_type;
@@ -4040,7 +4040,7 @@ struct SolveTridiagsDefaultModeAndAlgo<Kokkos::Experimental::SYCLSharedUSMSpace>
   }
 };
 template <>
-struct SolveTridiagsDefaultModeAndAlgo<Kokkos::Experimental::SYCLDeviceUSMSpace> {
+struct SolveTridiagsDefaultModeAndAlgo<Kokkos::SYCLDeviceUSMSpace> {
   typedef KB::Mode::Team mode_type;
   typedef KB::Algo::Level2::Unblocked single_vector_algo_type;
   typedef KB::Algo::Level3::Unblocked multi_vector_algo_type;

--- a/packages/muelu/test/perf_tests_kokkos/KokkosKernels.cpp
+++ b/packages/muelu/test/perf_tests_kokkos/KokkosKernels.cpp
@@ -380,7 +380,7 @@ int main(int argc, char* argv[]) {
 #endif
   } else if (node == "sycl") {
 #ifdef KOKKOS_ENABLE_SYCL
-    return main_<double, int, Kokkos::Experimental::SYCL>(argc, argv);
+    return main_<double, int, Kokkos::SYCL>(argc, argv);
 #else
     std::cout << "Error: SYCL node type is disabled" << std::endl;
 #endif

--- a/packages/panzer/dof-mgr/test/fe_assembly/test_fe_assembly_HEX.hpp
+++ b/packages/panzer/dof-mgr/test/fe_assembly/test_fe_assembly_HEX.hpp
@@ -163,9 +163,9 @@ int feAssemblyHex(int argc, char *argv[]) {
                        Kokkos::HIPManagedSpace>::value
 #elif defined(KOKKOS_ENABLE_SYCL)
           || std::is_same<mem_space,
-                          Kokkos::Experimental::SYCLSharedUSMSpace>::value ||
+                          Kokkos::SYCLSharedUSMSpace>::value ||
           std::is_same<mem_space,
-                       Kokkos::Experimental::SYCLHostUSMSpace>::value
+                       Kokkos::SYCLHostUSMSpace>::value
 #endif
       ,
       mem_space, Kokkos::HostSpace>;
@@ -176,7 +176,7 @@ int feAssemblyHex(int argc, char *argv[]) {
 #elif defined(KOKKOS_ENABLE_HIP)
       std::is_same<exec_space, Kokkos::HIP>::value ||
 #elif defined(KOKKOS_ENABLE_SYCL)
-      std::is_same<exec_space, Kokkos::Experimental::SYCL>::value ||
+      std::is_same<exec_space, Kokkos::SYCL>::value ||
 #elif defined(KOKKOS_ENABLE_OPENMPTARGET)
       std::is_same<exec_space,
                    Kokkos::Experimental::OpenMPTarget>::value ||

--- a/packages/shylu/shylu_node/tacho/src/CMakeLists.txt
+++ b/packages/shylu/shylu_node/tacho/src/CMakeLists.txt
@@ -102,7 +102,7 @@ IF (Kokkos_ENABLE_HIP)
 ENDIF()
 IF (Kokkos_ENABLE_SYCL)
   LIST(APPEND TACHO_ETI_DEVICE_NAME "SYCL")
-  LIST(APPEND TACHO_ETI_DEVICE_TYPE "Kokkos::Device<Kokkos::Experimental::SYCL,Kokkos::Experimental::SYCLDeviceUSMSpace>")
+  LIST(APPEND TACHO_ETI_DEVICE_TYPE "Kokkos::Device<Kokkos::SYCL,Kokkos::SYCLDeviceUSMSpace>")
   LIST(APPEND TACHO_ETI_WITH_TASK "0")
 ENDIF()
 

--- a/packages/shylu/shylu_node/tacho/src/Tacho.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho.hpp
@@ -102,16 +102,16 @@ template <typename T> struct UseThisFuture<T, Kokkos::HIP> {
 };
 #endif
 #if defined(KOKKOS_ENABLE_SYCL)
-template <> struct UseThisDevice<Kokkos::Experimental::SYCL> {
-  using type = Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>;
+template <> struct UseThisDevice<Kokkos::SYCL> {
+  using type = Kokkos::Device<Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace>;
   using device_type = type;
 };
-template <> struct UseThisScheduler<Kokkos::Experimental::SYCL> {
-  using type = DummyTaskScheduler<Kokkos::Experimental::SYCL>;
+template <> struct UseThisScheduler<Kokkos::SYCL> {
+  using type = DummyTaskScheduler<Kokkos::SYCL>;
   using scheduler_type = type;
 };
-template <typename T> struct UseThisFuture<T, Kokkos::Experimental::SYCL> {
-  using type = DummyFuture<T, Kokkos::Experimental::SYCL>;
+template <typename T> struct UseThisFuture<T, Kokkos::SYCL> {
+  using type = DummyFuture<T, Kokkos::SYCL>;
   using future_type = type;
 };
 #endif

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_Factory.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools_Factory.hpp
@@ -392,10 +392,10 @@ public:
 
 #if defined(KOKKOS_ENABLE_SYCL)
 template <typename ValueType>
-class NumericToolsFactory<ValueType, typename UseThisDevice<Kokkos::Experimental::SYCL>::type> {
+class NumericToolsFactory<ValueType, typename UseThisDevice<Kokkos::SYCL>::type> {
 public:
   using value_type = ValueType;
-  using device_type = typename UseThisDevice<Kokkos::Experimental::SYCL>::type;
+  using device_type = typename UseThisDevice<Kokkos::SYCL>::type;
   using numeric_tools_base_type = NumericToolsBase<value_type, device_type>;
   using numeric_tools_serial_type = NumericToolsSerial<value_type, device_type>;
   using numeric_tools_levelset_var0_type = NumericToolsLevelSet<value_type, device_type, 0>;

--- a/packages/tpetra/core/compat/Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.cpp
+++ b/packages/tpetra/core/compat/Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.cpp
@@ -65,12 +65,12 @@ std::string KokkosDeviceWrapperNode<Kokkos::HIP, Kokkos::HIPSpace>::name() {
 #ifdef KOKKOS_ENABLE_SYCL
 #ifdef HAVE_TPETRA_SHARED_ALLOCS
 template <>
-std::string KokkosDeviceWrapperNode<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLSharedUSMSpace>::name() {
+std::string KokkosDeviceWrapperNode<Kokkos::SYCL, Kokkos::SYCLSharedUSMSpace>::name() {
   return std::string("SYCL/Wrapper");
 }
 #else
 template <>
-std::string KokkosDeviceWrapperNode<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace>::name() {
+std::string KokkosDeviceWrapperNode<Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace>::name() {
   return std::string("SYCL/Wrapper");
 }
 #endif

--- a/packages/tpetra/core/compat/cmake/Tpetra_KokkosClassic_DefaultNode_config.h.in
+++ b/packages/tpetra/core/compat/cmake/Tpetra_KokkosClassic_DefaultNode_config.h.in
@@ -6,7 +6,7 @@
 // For backwards compatibility ONLY.
 #define TPETRA_KOKKOSCLASSIC_DEFAULTNODE TPETRA_DEFAULTNODE
 
-// Defined if and only if Tpetra's default execution space is Kokkos::Experimental::SYCL.
+// Defined if and only if Tpetra's default execution space is Kokkos::SYCL.
 #cmakedefine HAVE_TPETRA_DEFAULTNODE_SYCLWRAPPERNODE
 // For backwards compatibility ONLY.
 #ifdef HAVE_TPETRA_DEFAULTNODE_SYCLWRAPPERNODE

--- a/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_ExecutionSpaces.cpp
@@ -68,7 +68,7 @@ void lazy_init() {
 /*extern*/ InstanceLifetimeManager<Kokkos::HIP> HIPSpaces;
 #endif
 #ifdef KOKKOS_ENABLE_SYCL
-/*extern*/ InstanceLifetimeManager<Kokkos::Experimental::SYCL> SYCLSpaces;
+/*extern*/ InstanceLifetimeManager<Kokkos::SYCL> SYCLSpaces;
 #endif
 
 }  // namespace Spaces

--- a/packages/tpetra/core/src/Tpetra_Details_StaticView.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_StaticView.cpp
@@ -93,7 +93,7 @@ size_t sycl_memory_size_ = 0;
 
 void finalize_sycl_memory() {
   if (sycl_memory_ != nullptr) {
-    Kokkos::kokkos_free<Kokkos::Experimental::SYCLDeviceUSMSpace>(sycl_memory_);
+    Kokkos::kokkos_free<Kokkos::SYCLDeviceUSMSpace>(sycl_memory_);
     sycl_memory_      = nullptr;
     sycl_memory_size_ = 0;
   }
@@ -104,7 +104,7 @@ size_t sycl_shared_memory_size_ = 0;
 
 void finalize_sycl_shared_memory() {
   if (sycl_shared_memory_ != nullptr) {
-    Kokkos::kokkos_free<Kokkos::Experimental::SYCLSharedUSMSpace>(sycl_shared_memory_);
+    Kokkos::kokkos_free<Kokkos::SYCLSharedUSMSpace>(sycl_shared_memory_);
     sycl_shared_memory_      = nullptr;
     sycl_shared_memory_size_ = 0;
   }
@@ -245,10 +245,10 @@ void* StaticKokkosAllocation<Kokkos::HIPHostPinnedSpace>::
 #ifdef KOKKOS_ENABLE_SYCL
 
 template <>
-void* StaticKokkosAllocation<Kokkos::Experimental::SYCLDeviceUSMSpace>::
-    resize(Kokkos::Experimental::SYCLDeviceUSMSpace /* space */,
+void* StaticKokkosAllocation<Kokkos::SYCLDeviceUSMSpace>::
+    resize(Kokkos::SYCLDeviceUSMSpace /* space */,
            const size_t size) {
-  using memory_space                = Kokkos::Experimental::SYCLDeviceUSMSpace;
+  using memory_space                = Kokkos::SYCLDeviceUSMSpace;
   static bool created_finalize_hook = false;
 
   if (size > sycl_memory_size_) {
@@ -268,10 +268,10 @@ void* StaticKokkosAllocation<Kokkos::Experimental::SYCLDeviceUSMSpace>::
 }
 
 template <>
-void* StaticKokkosAllocation<Kokkos::Experimental::SYCLSharedUSMSpace>::
-    resize(Kokkos::Experimental::SYCLSharedUSMSpace /* space */,
+void* StaticKokkosAllocation<Kokkos::SYCLSharedUSMSpace>::
+    resize(Kokkos::SYCLSharedUSMSpace /* space */,
            const size_t size) {
-  using memory_space                = Kokkos::Experimental::SYCLSharedUSMSpace;
+  using memory_space                = Kokkos::SYCLSharedUSMSpace;
   static bool created_finalize_hook = false;
 
   const size_t req_size = size > minimum_initial_size ? size : minimum_initial_size;

--- a/packages/tpetra/core/test/Comm/gpuAwareMpi.cpp
+++ b/packages/tpetra/core/test/Comm/gpuAwareMpi.cpp
@@ -47,7 +47,7 @@ typedef Tpetra::KokkosCompat::KokkosCudaWrapperNode test_node_type;
 typedef Kokkos::Device<Kokkos::HIP, Kokkos::HIPSpace> test_device_type;
 typedef Tpetra::KokkosCompat::KokkosHIPWrapperNode test_node_type;
 #elif defined(KOKKOS_ENABLE_SYCL)
-typedef Kokkos::Device<Kokkos::Experimental::SYCL, Kokkos::Experimental::SYCLDeviceUSMSpace> test_device_type;
+typedef Kokkos::Device<Kokkos::SYCL, Kokkos::SYCLDeviceUSMSpace> test_device_type;
 typedef Tpetra::KokkosCompat::KokkosSYCLWrapperNode test_node_type;
 #endif
 typedef Tpetra::Map<>::local_ordinal_type LO;

--- a/packages/tpetra/core/test/Distributor/Issue1454.cpp
+++ b/packages/tpetra/core/test/Distributor/Issue1454.cpp
@@ -65,8 +65,8 @@ TEUCHOS_UNIT_TEST(Distributor, Issue1454) {
       typename device_type::memory_space>::type;
 #elif defined(KOKKOS_ENABLE_SYCL)
   using buffer_memory_space = typename std::conditional<
-      std::is_same<typename device_type::execution_space, Kokkos::Experimental::SYCL>::value,
-      Kokkos::Experimental::SYCLDeviceUSMSpace,
+      std::is_same<typename device_type::execution_space, Kokkos::SYCL>::value,
+      Kokkos::SYCLDeviceUSMSpace,
       typename device_type::memory_space>::type;
 #else
   using buffer_memory_space = typename device_type::memory_space;

--- a/packages/tpetra/core/test/PerformanceCGSolve/cg_solve_file.cpp
+++ b/packages/tpetra/core/test/PerformanceCGSolve/cg_solve_file.cpp
@@ -329,7 +329,7 @@ int main(int argc, char* argv[]) {
 
   if (!useSYCL && !useHIP && !useCuda && !useOpenMP && !useThreads && !useSerial) {
 #ifdef HAVE_TPETRA_INST_SYCL
-    if (std::is_same<default_exec, Kokkos::Experimental::SYCL>::value) {
+    if (std::is_same<default_exec, Kokkos::SYCL>::value) {
       if (myRank == 0) std::cout << "No node specified in command-line args, so using default (SYCL)\n";
       useSYCL = true;
     }

--- a/packages/tpetra/core/test/Spaces/SpaceUser.cpp
+++ b/packages/tpetra/core/test/Spaces/SpaceUser.cpp
@@ -93,8 +93,8 @@ int main(int argc, char **argv) {
 #endif
 
 #if defined(KOKKOS_ENABLE_SYCL)
-  test_priority<Kokkos::Experimental::SYCL>(success, *out);
-  test_reuse<Kokkos::Experimental::SYCL>(success, *out);
+  test_priority<Kokkos::SYCL>(success, *out);
+  test_reuse<Kokkos::SYCL>(success, *out);
 #endif
 
   if (success) {

--- a/packages/tpetra/core/test/Spaces/Spaces.cpp
+++ b/packages/tpetra/core/test/Spaces/Spaces.cpp
@@ -177,10 +177,10 @@ int main(int argc, char **argv) {
 #endif
 
 #if defined(KOKKOS_ENABLE_SYCL)
-  test_exec_space_wait<Kokkos::Experimental::SYCL>(success, *out);
-  test_make_instance<Kokkos::Experimental::SYCL>(success, *out);
-  test_space_instance<Kokkos::Experimental::SYCL>(success, *out);
-  test_is_gpu_exec_space<Kokkos::Experimental::SYCL, true>(success, *out);
+  test_exec_space_wait<Kokkos::SYCL>(success, *out);
+  test_make_instance<Kokkos::SYCL>(success, *out);
+  test_space_instance<Kokkos::SYCL>(success, *out);
+  test_is_gpu_exec_space<Kokkos::SYCL, true>(success, *out);
 #endif
 
   if (success) {


### PR DESCRIPTION
This should get all of the remaining deprecation warnings about Kokkos::Experimental::SYCL<blah>.
<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
