### PR TITLE
WIP: Move all Action-related behavior into GITHUB_WORKSPACE

### DIFF
--- a/.github/workflows/AT2.yml
+++ b/.github/workflows/AT2.yml
@@ -123,5 +123,5 @@ jobs:
       max-cores-allowed: 29
       num-concurrent-tests: 16
       skip-create-packageenables: true
-      extra-pr-driver-args: --extra-configure-args=-C;${GITHUB_WORKSPACE}/packages/framework/cmake-fragments/ramses/gcc-mpi-openmp.cmake
+      extra-pr-driver-args: --extra-configure-args=-C;${GITHUB_WORKSPACE}/trilinos-src/packages/framework/cmake-fragments/ramses/gcc-mpi-openmp.cmake
       target-branch: ${{ github.base_ref }}

--- a/.github/workflows/actions/summary/action.yml
+++ b/.github/workflows/actions/summary/action.yml
@@ -8,11 +8,11 @@ runs:
   steps:
     - name: "Write job summary"
       shell: bash -e {0}
-      working-directory: /home/Trilinos/build
+      working-directory: trilinos-build
       run: |
-        AT2_URL=$(</home/runner/AT2_URL.txt)
-        AT2_ALL_BUILDS=$(</home/runner/AT2_ALL_BUILDS.txt)
-        GENCONFIG_BUILD_NAME=$(</home/Trilinos/build/genconfig_build_name.txt)
+        AT2_URL=$(<./AT2_URL.txt)
+        AT2_ALL_BUILDS=$(<./AT2_ALL_BUILDS.txt)
+        GENCONFIG_BUILD_NAME=$(<./genconfig_build_name.txt)
 
         cat <<EOF >> $GITHUB_STEP_SUMMARY
         Image:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request && github.ref || inputs.target-branch }}
+          path: trilinos-src
       - name: Print debug outputs
         shell: bash -l {0}
         env:
@@ -91,16 +92,18 @@ jobs:
           git branch -vv
           git branch -a
           echo "::endgroup::"
-      - name: Get CI script dependencies
-        working-directory: ./packages/framework
+      - name: Setup
+        working-directory: trilinos-src
         run: |
-          mkdir -p /home/Trilinos/build
           git fetch origin ${{ inputs.target-branch }}
-          ./get_dependencies.sh
+          ./packages/framework/get_dependencies.sh
       - name: Run build and test driver script
         shell: bash -l {0}
-        working-directory: /home/Trilinos/build
         run: |
+          export BUILD_DIR=${GITHUB_WORKSPACE}/trilinos-build
+          mkdir ${BUILD_DIR}
+          cd ${BUILD_DIR}
+
           # python is python3 hackery
           pwd
           mkdir bin
@@ -109,8 +112,7 @@ jobs:
           export PATH=$(pwd):${PATH}
           popd
 
-          export TRILINOS_DIR=${GITHUB_WORKSPACE:?}
-          export BUILD_DIR=/home/Trilinos/build
+          export TRILINOS_DIR=${GITHUB_WORKSPACE:?}/trilinos-src
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/GenConfig
           export PYTHONPATH=${PYTHONPATH}:${TRILINOS_DIR}/packages/framework/pr_tools
           printf "\n\n\n"
@@ -190,20 +192,21 @@ jobs:
         if: success() || failure()
         shell: bash -l {0}
         run: |
-          build_dir=/home/Trilinos/build
+          build_dir=${GITHUB_WORKSPACE}/trilinos-build
           build_tag=$(head -n 1 ${build_dir}/Testing/TAG)
-          python3 ${GITHUB_WORKSPACE}/packages/framework/pr_tools/ctest_xml_printer.py \
-            --ctest-xml-dir /home/Trilinos/build/Testing/${build_tag}/Build \
+          python3 ${GITHUB_WORKSPACE}/trilinos-src/packages/framework/pr_tools/ctest_xml_printer.py \
+            --ctest-xml-dir ${build_dir}/Testing/${build_tag}/Build \
             --print-errors \
             --github-actions-mode
       - name: Copy artifacts
         if: success() || failure()
         shell: bash -l {0}
-        working-directory: /home/Trilinos/build
+        working-directory: trilinos-build
         run: |
-          cp ./packageEnables.cmake /home/runner/artifacts/
-          cp ./configure_command.txt /home/runner/artifacts/
-          cp ./genconfig_build_name.txt /home/runner/artifacts/
+          mkdir -p ${GITHUB_WORKSPACE}/artifacts
+          cp ./packageEnables.cmake ${GITHUB_WORKSPACE}/artifacts/
+          cp ./configure_command.txt ${GITHUB_WORKSPACE}/artifacts/
+          cp ./genconfig_build_name.txt ${GITHUB_WORKSPACE}/artifacts/
       - name: Upload artifacts
         if: success() || failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -211,8 +214,8 @@ jobs:
           NODE_USE_SYSTEM_CA: 1
         with:
           name: ${{ inputs.genconfig-string }}-artifacts
-          path: /home/runner/artifacts/*
+          path: ${GITHUB_WORKSPACE}/artifacts/*
           retention-days: 90
       - name: Write Summary
         if: ${{ !cancelled() }}
-        uses: ./.github/workflows/actions/summary
+        uses: ./trilinos-src/.github/workflows/actions/summary

--- a/cmake/SimpleTesting/cmake/ctest-cdash-setup.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-cdash-setup.cmake
@@ -126,12 +126,10 @@ message(">>> CDash URL2 = ${build_url2}")
 message(">>> CDash URL3 = ${build_url3}")
 message(">>> CDash URL4 = ${build_url4}")
 
-if (EXISTS /home/runner/)
-    # Write the URL into the filesystem so AT2 can read it later
-    message(">>> Writing URLs to /home/runner/AT2_URL.txt and AT2_ALL_BUILDS.txt")
-    file(WRITE /home/runner/AT2_URL.txt ${build_url3})
-    file(WRITE /home/runner/AT2_ALL_BUILDS.txt ${build_url4})
-endif()
+# Write the URL into the filesystem so AT2 can read it later
+message(">>> Writing URLs to ${CTEST_BINARY_DIRECTORY}/AT2_URL.txt and AT2_ALL_BUILDS.txt")
+file(WRITE ${CTEST_BINARY_DIRECTORY}/AT2_URL.txt ${build_url3})
+file(WRITE ${CTEST_BINARY_DIRECTORY}/AT2_ALL_BUILDS.txt ${build_url4})
 
 # -----------------------------------------------------------
 # -- Optionally update the repository

--- a/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/packages/framework/pr_tools/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -664,8 +664,7 @@ class TrilinosPRConfigurationBase(object):
         enable_map_entry = self.get_multi_property_from_config("ENABLE_MAP", job_name, delimeter=" ")
         # Generate files using ATDM/TriBiTS Scripts
         if enable_map_entry is None:
-            cmd = [os.path.join( self.arg_workspace_dir,
-                                'Trilinos',
+            cmd = [os.path.join(self.arg_source_dir,
                                 'commonTools',
                                 'framework',
                                 'get-changed-trilinos-packages.sh'),


### PR DESCRIPTION
@trilinos/framework 

Move everything into GITHUB_WORKSPACE for cleanliness.  Change the checkout Action step to use a subdirectory to try and keep things appropriately isolated.

## Motivation
Was seeing weird behavior with coverage runs:
```
Cannot find file: /home/Trilinos/build/runner/_work/Trilinos/Trilinos/packages/adelus/src/Adelus.hpp
Cannot find file: /home/Trilinos/build/runner/_work/Trilinos/Trilinos/packages/adelus/src/AdelusVersion.cpp
Cannot find file: /home/Trilinos/build/runner/_work/Trilinos/Trilinos/packages/adelus/src/Adelus_distribute.cpp
Cannot find file: /home/Trilinos/build/runner/_work/Trilinos/Trilinos/packages/adelus/src/Adelus_factor.hpp
```

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-762

## Testing
Ran manual coverage build/test with just Teuchos, confirmed that everything worked (my "normal" directory structure).
Ran same build with paths from CI/AT2, confirmed broken.
Re-ran same build with paths as updated in this PR, confirmed ___________

