### PR TITLE
RTOp: Improve generation of random vector

### DIFF
--- a/packages/rtop/src/ops_lib/RTOpPack_TOpRandomize.hpp
+++ b/packages/rtop/src/ops_lib/RTOpPack_TOpRandomize.hpp
@@ -16,18 +16,47 @@
 
 namespace RTOpPack {
 
+namespace random_impl {
 
-/** \brief Generate a random vector in the range [l,u]: <tt>z0[i] =
- * 0.5*((u-l)*Teuchos::ScalarTraits<Scalar>::random()+(u+l)), i=0...n-1</tt>.
+inline std::uint64_t mix64(std::uint64_t x)
+{
+  x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+  x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
+  return x ^ (x >> 31);
+}
+
+inline double unit_uniform(
+    const std::uint64_t seed,
+    const std::uint64_t counter,
+    const std::uint64_t global_index)
+{
+  std::uint64_t x = mix64(seed+0x9e3779b97f4a7c15ULL);
+  x = mix64(x + mix64(counter));
+  x = mix64(x + mix64(global_index));
+
+  // Shift right by 11 to keep the top 53 high-quality bits
+  // and multiply by 2^-53 to produce a double in [0,1).
+  return static_cast<double>(x >> 11) * 0x1.0p-53;
+}
+}
+
+
+/** \brief Generate a uniform random vector in the range [l,u].
  *
  * The seed for the random number generator can be set by
- * <tt>TOpRandomize<Scalar>::set_seed(s)</tt> where <tt>s</tt> is some
- * unsigned integer.  Note that this class generates random numbers based on
- * the initial seed and the global element ID so this should produce the same
+ * <tt>TOpRandomize<Scalar>::set_static_seed(s)</tt> where <tt>s</tt> is some
+ * unsigned integer. 
+ * A counter is incremented every time a new object is created. 
+ * This class generates random numbers based on the initial seed, the counter, and the global element ID so this produces the same
  * pseudo-random elements independent of the number of processors being used.
+ * The counter is set to zero when the static seed is set via <tt>TOpRandomize<Scalar>::set_static_seed(s)</tt>.
+ * The implementation is based on the Stateless SplitMix64 finalizer.
+ * See:
+ * G. L. Steele Jr., D. Lea, C. H. Flood,
+ * "Fast Splittable Pseudorandom Number Generators",
+ * OOPSLA 2014, DOI: 10.1145/2660193.2660195.
  *
- * The seed changes every time a new object is created in order to improve the
- * randomness to some degree.
+ * When available it might be worth adopting the philox_engine counter-based random generator that should be part of C++26.
  */
 template<class Scalar>
 class TOpRandomize : public RTOpT<Scalar> {
@@ -35,27 +64,38 @@ public:
   using RTOpT<Scalar>::apply_op;
   /** \brief . */
   static void set_static_seed( const unsigned int static_seed )
-    { static_seed_ = static_seed; }
+  { 
+    static_seed_ = static_seed;
+    static_counter_ = 0;
+  }
+
   /** \brief . */
   static unsigned int get_static_seed() { return static_seed_; }
+
   /** \brief . */
   TOpRandomize(
     const Scalar& l = -ScalarTraits<Scalar>::one(),
     const Scalar& u = +ScalarTraits<Scalar>::one()
-    )
+    ) : seed_(static_seed_), counter_(static_counter_++), l_(l), u_(u)
     {
       this->setOpNameBase("TOpRandomize");
-      set_bounds(l, u);
-      set_seed(static_seed_);
-      ++static_seed_; // By default we will just increment the seed!
     }
+
   /** \brief . */
-  void set_bounds( const Scalar& l, const Scalar& u )
-    { l_ = l; u_ = u; }
+  void set_bounds( const Scalar& l, const Scalar& u ) { l_ = l; u_ = u; }
+
   /** \brief . */
   void set_seed( const unsigned int seed ) { seed_ = seed; }
+
+  /** \brief . */
+  void set_counter( const unsigned int counter ) { counter_ = counter; }
+
   /** \brief . */
   unsigned int get_seed() const { return seed_; }
+
+  /** \brief . */
+  unsigned int get_counter() const { return counter_; }
+
   /** @name Overridden from RTOpT */
   //@{
   /** \brief . */
@@ -86,15 +126,21 @@ public:
       const Scalar b = Scalar(0.5)*(u_ + l_);
       for( index_type i = 0; i < subDim; ++i, z0_val += z0_s )
       {
-        Teuchos::ScalarTraits<Scalar>::seedrandom(seed_+globalOffset+i);
-        *z0_val = a * Teuchos::ScalarTraits<Scalar>::random() + b;
+        auto rand = random_impl::unit_uniform(
+                     static_cast<std::uint64_t>(seed_),
+                     static_cast<std::uint64_t>(counter_),
+                     static_cast<std::uint64_t>(globalOffset+i)
+                    );
+        *z0_val = a * static_cast<Scalar>(rand) + b;
         // Above should be in the range [l,b]
       }
     }
   //@}
 private:
   static unsigned int static_seed_;
+  static unsigned int static_counter_;
   unsigned int seed_;
+  unsigned int counter_;
   Scalar l_;
   Scalar u_;
 };
@@ -102,6 +148,9 @@ private:
 
 template<class Scalar>
 unsigned int TOpRandomize<Scalar>::static_seed_ = 0;
+
+template<class Scalar>
+unsigned int TOpRandomize<Scalar>::static_counter_ = 0;
 
 
 } // namespace RTOpPack


### PR DESCRIPTION
Current RTOp implementation could lead to the generation of highly correlated vectors. 
Every time the constructor is called the static_seed is incremented by one. This can lead to having two subsequent random vectors u and v be such that
v(i) = u(i+1) 

The new implementation, based on SplitMix64, and separating the static seed from the static counter (incremented each time the constructor is called), avoid this issue. 
More statistically robust implementations, such as philox-engine counter-based random generators should be considered in the future (philox generators should be shipped with C++26, or they could be imported as header-only TPL).

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/RTOp

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
