### PR TITLE
Piro: enabling HDSA OED capability for model discrepancy based low-fidelity optimization

### DIFF
--- a/packages/piro/src/Piro_PerformAnalysis.cpp
+++ b/packages/piro/src/Piro_PerformAnalysis.cpp
@@ -38,6 +38,7 @@
 #include "ROL_Bounds.hpp"
 #include "Thyra_VectorDefaultBase.hpp"
 #include "Thyra_DefaultBlockedLinearOp.hpp"
+#include "Thyra_DefaultProductVectorSpace.hpp"
 #include "Piro_CustomLBFGSSecant.hpp"
 #include "ROL_LinearOpScaledThyraVector.hpp"
 
@@ -47,8 +48,10 @@
 #include "Piro_HDSA_MD_ROL_Elliptic_z_Prior_Interface.hpp"
 #include "HDSA_MD_ROL_Opt_Prob_Interface.hpp"
 #include "HDSA_MD_Posterior_Sampling.hpp"
+#include "HDSA_MD_Prior_Sampling.hpp"
 #include "HDSA_MD_Hessian_Analysis.hpp"
 #include "HDSA_MD_Update.hpp"
+#include "HDSA_MD_OED.hpp"
 #endif
 
 #endif
@@ -469,13 +472,13 @@ Piro::PerformROLSteadyAnalysis(
 
   bool useCustomDotProduct = false;
   bool lumpHessianMatrix = false;
-  int reponse_index_dotProd = -1;
+  int response_index_dotProd = -1;
   if(rolParams.isSublist("Matrix Based Dot Product")) {
     const Teuchos::ParameterList& matrixDotProductList = rolParams.sublist("Matrix Based Dot Product");
     auto matrixType = matrixDotProductList.get<std::string>("Matrix Type");
     if(matrixType == "Hessian Of Response") {
       useCustomDotProduct = true;
-      reponse_index_dotProd = matrixDotProductList.sublist("Matrix Types").sublist("Hessian Of Response").get<int>("Response Index");
+      response_index_dotProd = matrixDotProductList.sublist("Matrix Types").sublist("Hessian Of Response").get<int>("Response Index");
       lumpHessianMatrix = matrixDotProductList.sublist("Matrix Types").sublist("Hessian Of Response").get<bool>("Lump Matrix");
     }
     else if (matrixType == "Identity")
@@ -491,7 +494,7 @@ Piro::PerformROLSteadyAnalysis(
   bool useCustomSecant = false;
   int secantMaxStorage = -1;
   double secantScaling(1.0);
-  int reponse_index_secant = -1;
+  int response_index_secant = -1;
   if(rolParams.isSublist("Custom Secant")) {
     Teuchos::ParameterList customSecantList = rolParams.sublist("Custom Secant");
     secantMaxStorage = customSecantList.get<int>("Maximum Storage");
@@ -507,10 +510,10 @@ Piro::PerformROLSteadyAnalysis(
     auto initializationType = customSecantList.get<std::string>("Initialization Type");
 
     if(initializationType == "Hessian Of Response") {
-      reponse_index_secant = customSecantList.sublist("Initialization Types").sublist("Hessian Of Response").get<int>("Response Index");
+      response_index_secant = customSecantList.sublist("Initialization Types").sublist("Hessian Of Response").get<int>("Response Index");
     }
     else if(initializationType == "Identity") {
-      reponse_index_secant = -1;
+      response_index_secant = -1;
     }
     else {
       TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
@@ -536,15 +539,15 @@ Piro::PerformROLSteadyAnalysis(
 
     if (useCustomDotProduct && !model_PME.is_null()) {
       bH_dotP = Teko::createBlockedOp();
-      model_PME->block_diagonal_hessian_22(bH_dotP, *rol_x_ptr, *rol_p_ptr, reponse_index_dotProd);
+      model_PME->block_diagonal_hessian_22(bH_dotP, *rol_x_ptr, *rol_p_ptr, response_index_dotProd);
     }
-    if(useCustomSecant && (reponse_index_secant != -1 ) && !model_PME.is_null()) {
+    if(useCustomSecant && (response_index_secant != -1 ) && !model_PME.is_null()) {
 
-      if (reponse_index_dotProd == reponse_index_secant)
+      if (response_index_dotProd == response_index_secant)
         bH_sec = bH_dotP;
       else {
         bH_sec = Teko::createBlockedOp();
-        model_PME->block_diagonal_hessian_22(bH_sec, *rol_x_ptr, *rol_p_ptr, reponse_index_secant);
+        model_PME->block_diagonal_hessian_22(bH_sec, *rol_x_ptr, *rol_p_ptr, response_index_secant);
       }
     }
     
@@ -574,9 +577,9 @@ Piro::PerformROLSteadyAnalysis(
     }
 
     if(useCustomSecant) {
-      if(reponse_index_secant == -1 ) {// identity initialization 
+      if(response_index_secant == -1 ) {// identity initialization 
         invH_sec = H_sec = Teuchos::rcp(new Thyra::DefaultIdentityLinearOp<double>(p_space));
-      } else if ((reponse_index_dotProd == reponse_index_secant) && Teuchos::nonnull(H_dotP) && Teuchos::nonnull(invH_dotP)) {
+      } else if ((response_index_dotProd == response_index_secant) && Teuchos::nonnull(H_dotP) && Teuchos::nonnull(invH_dotP)) {
         H_sec = H_dotP;
         invH_sec = invH_dotP;
       } else {
@@ -594,8 +597,8 @@ Piro::PerformROLSteadyAnalysis(
   }
 
 #else
-  (void)reponse_index_dotProd;
-  (void)reponse_index_secant;
+  (void)response_index_dotProd;
+  (void)response_index_secant;
   TEUCHOS_TEST_FOR_EXCEPTION(useCustomDotProduct||useCustomSecant, Teuchos::Exceptions::InvalidParameter,
       std::endl << "Piro::PerformROLSteadyAnalysis, ERROR: " <<
       "Teko is required for computing custom dot product or secant"<<std::endl);
@@ -1160,6 +1163,168 @@ Piro::PerformROLAnalysis(
 }
 
 
+#if defined(HAVE_PIRO_ROL) && defined(HAVE_PIRO_HDSALIB)
+
+HDSA::Ptr<HDSA::Dense_Matrix<double>> Vector_To_Dense(const HDSA::Vector<double>& x) {
+  HDSA::Ptr<HDSA::Dense_Matrix<double>> y = HDSA::makePtr<HDSA::Dense_Matrix<double>>(x.Dimension(), 1);
+
+  y->Zeros();
+
+  for (int i = 0; i < x.Dimension(); ++i) {
+    y->Set_Entry(i, 0, x.Get_Entry(i));
+  }
+
+  return y;
+}
+
+
+HDSA::Ptr<HDSA::Dense_Matrix<double>> Append_Betas(const HDSA::Dense_Matrix<double>& old_betas,
+                                                  const HDSA::Dense_Matrix<double>& new_betas) {
+
+  const int old_len = old_betas.Number_of_Rows() * old_betas.Number_of_Columns();
+  const int new_len = new_betas.Number_of_Rows() * new_betas.Number_of_Columns();
+
+  HDSA::Ptr<HDSA::Dense_Matrix<double>> all_betas = HDSA::makePtr<HDSA::Dense_Matrix<double>>(old_len + new_len, 1);
+
+  all_betas->Zeros();
+  {
+    int nrows = old_betas.Number_of_Rows();
+    for (int i = 0; i < old_len; ++i) 
+      all_betas->Set_Entry(i, 0, old_betas(i % nrows, i / nrows));
+  }
+
+  {
+    int nrows = new_betas.Number_of_Rows();
+    for (int i = 0; i < new_len; ++i)
+      all_betas->Set_Entry(old_len + i, 0, new_betas(i % nrows, i / nrows));
+  }
+  
+  return all_betas;
+}
+
+HDSA::Ptr<HDSA::Dense_Matrix<double>>
+Compute_Beta_From_z(
+    const HDSA::Vector<double>& z,
+    const HDSA::Vector<double>& z_opt,
+    const HDSA::MD_z_Prior_Interface<double>& z_prior_interface,
+    const HDSA::MD_OED<double>::Offline_Data& offline)
+{
+  const int r = offline.r;
+
+  // dz = z - z_opt
+  HDSA::Ptr<HDSA::Vector<double>> dz = z_opt.Clone();
+  dz->Set(z);
+  dz->Scaled_Plus(-1.0, z_opt);
+
+  // M_z dz
+  HDSA::Ptr<HDSA::Vector<double>> Mz_dz = z_opt.Clone();
+  z_prior_interface.Apply_M_z(*Mz_dz, *dz);
+
+  // rhs = V^T M_z dz
+  HDSA::Dense_Matrix<double> rhs(r, 1);
+  rhs.Zeros();
+
+  for (int i = 0; i < r; ++i) {
+    rhs.Set_Entry(i, 0, (*offline.V)[i]->Dot(*Mz_dz));
+  }
+
+  // Solve
+  //
+  //   (V^T M_z V) beta = V^T M_z (z - z_opt)
+  //
+  HDSA::Ptr<HDSA::Dense_Matrix<double>> beta =
+      HDSA::makePtr<HDSA::Dense_Matrix<double>>(r, 1);
+  beta->Zeros();
+
+  HDSA::Linear_Algebra::Symmetric_Direct_Linear_Solve<double>(
+      *offline.Vt_Mz_V, *beta, rhs);
+
+  return beta;
+}
+
+double M_z_Norm_Difference(const HDSA::Vector<double>& a, const HDSA::Vector<double>& b,
+                          const HDSA::MD_z_Prior_Interface<double>& z_prior_interface) {
+  HDSA::Ptr<HDSA::Vector<double>> diff = b.Clone();
+  diff->Set(a);
+  diff->Scaled_Plus(static_cast<double>(-1), b);
+
+  HDSA::Ptr<HDSA::Vector<double>> Mz_diff = b.Clone();
+  z_prior_interface.Apply_M_z(*Mz_diff, *diff);
+
+  const double norm_sq = diff->Dot(*Mz_diff);
+
+  return std::sqrt(std::max(static_cast<double>(0), norm_sq));
+}
+
+double Estimate_Trace_Wz_Inverse_Mz(const HDSA::Vector<double>& prototype,
+    const HDSA::MD_z_Prior_Interface<double>& z_prior_interface, const int num_samples)
+{
+  auto xi = prototype.Clone();
+  auto Mz_xi = prototype.Clone();
+  auto Wz_inv_Mz_xi = prototype.Clone();
+
+  double trace_val = 0.0;
+
+  for (int j = 0; j < num_samples; ++j) {
+
+    // Gaussian N(0,1)
+    xi->Randomize_Standard_Normal();
+
+    // Convert Gaussian entries to Rademacher {-1, +1}.
+    auto xi_rol = Teuchos::rcp_dynamic_cast<HDSA::ROL_Vector<double>>(xi);
+    xi_rol->rol_vec->applyUnary(ROL::Elementwise::Sign<double>());
+
+    z_prior_interface.Apply_M_z(*Mz_xi, *xi);
+
+    z_prior_interface.Apply_W_z_Inverse(*Wz_inv_Mz_xi,*Mz_xi);
+
+    trace_val += xi->Dot(*Wz_inv_Mz_xi);
+  }
+  return trace_val / num_samples;
+}
+
+#endif
+
+struct OperatorInfo {
+  bool use_identity = true;
+  int response_index = -1;
+  int param_index = -1;
+};
+
+OperatorInfo
+getOperatorInfo(
+    const Teuchos::ParameterList& hdsaParams,
+    const std::string& operatorName,
+    const bool param_index_required = false)
+{
+  OperatorInfo info;
+
+  if (!hdsaParams.isSublist(operatorName))
+    return info;
+
+  const Teuchos::ParameterList& operatorList = hdsaParams.sublist(operatorName);
+
+  const auto operatorType = operatorList.get<std::string>("Operator Type");
+
+  if (operatorType == "Hessian Of Response") {
+    info.use_identity = false;
+    info.response_index = operatorList.get<int>("Response Index");
+    if(param_index_required)
+      info.param_index =  operatorList.get<int>("Parameter Index");
+  }
+  else if (operatorType == "Identity") {
+    info.use_identity = true;
+  }  else {
+    TEUCHOS_TEST_FOR_EXCEPTION(true,   Teuchos::Exceptions::InvalidParameter, 
+        std::endl  << "Piro::PerformHDSASteadyAnalysis, ERROR: " << 
+        "Operator Type for \"" << operatorName << "\" not recognized. Available options are:\n" <<
+        "\"Identity\" and \"Hessian Of Response\""  << std::endl);
+  }
+
+  return info;
+}
+
+
 int
 Piro::PerformHDSAAnalysis(
     Thyra::ModelEvaluatorDefaultBase<double>& piroModel,
@@ -1179,24 +1344,30 @@ Piro::PerformHDSAAnalysis(
   else // no output
     out = Teuchos::rcp(new Teuchos::oblackholestream());
 
-
 #if defined(HAVE_PIRO_ROL) && defined(HAVE_PIRO_HDSALIB)
+
+  Teuchos::EVerbosityLevel analysisVerbosityLevel;
+  switch(analysisVerbosity) {
+    case 1: analysisVerbosityLevel= Teuchos::VERB_LOW; break;
+    case 2: analysisVerbosityLevel= Teuchos::VERB_MEDIUM; break;
+    case 3: analysisVerbosityLevel= Teuchos::VERB_HIGH; break;
+    case 4: analysisVerbosityLevel= Teuchos::VERB_EXTREME; break;
+    default: analysisVerbosityLevel= Teuchos::VERB_NONE;
+  }
 
   using std::string;
   Teuchos::RCP<Thyra::ModelEvaluatorDefaultBase<double>> model, adjointModel;
   Teuchos::RCP<Piro::SteadyStateSolver<double>> piroSSSolver;
 
   auto hdsaParams = analysisParams.sublist("HDSA");  
-  int num_parameters = hdsaParams.get<int>("Number Of Parameters", 1);
-
-  if(hdsaParams.isParameter("Normal Random Generator Seed")) {
-    //the seed should be rank-dependent (cannot do better than that at the moment)
-    auto seed = hdsaParams.get<int>("Normal Random Generator Seed"); 
-    HDSA::ROL_Vector<double>::nr = ROL::Elementwise::NormalRandom<double>(0.0,1.0,seed);
+  if(analysisVerbosity >= 3) {
+    *out << "\nPiro PerformAnalysis: HDSA options:" << std::endl;
+    hdsaParams.sublist("HDSA Options").print(*out);
+    *out << std::endl;
   }
 
+  int num_parameters = hdsaParams.get<int>("Number Of Parameters", 1);
   std::vector<int> p_indices(num_parameters);
-
   for(int i=0; i<num_parameters; ++i) {
     std::ostringstream ss; ss << "Parameter Vector Index " << i;
     p_indices[i] = hdsaParams.get<int>(ss.str(), i);
@@ -1234,7 +1405,6 @@ Piro::PerformHDSAAnalysis(
   }
 
   //hdsaParams.validateParameters(*Piro::getValidPiroAnalysisHDSAParameters(num_parameters),0);
-
   int g_index = hdsaParams.get<int>("Response Vector Index", 0);  
   auto p_names = Teuchos::rcp(new std::vector<std::string>());
 
@@ -1246,300 +1416,27 @@ Piro::PerformHDSAAnalysis(
     }
   }
 
-  //set names of parameters in the "Optimization StaReftus" sublist
-  piroParams.sublist("Optimization Status").set("Parameter Names", p_names);
-
-  if(hdsaParams.isParameter("Objective Recovery Value"))
-    piroParams.sublist("Optimization Status").set("Objective Recovery Value", hdsaParams.get<double>("Objective Recovery Value"));
   Teuchos::RCP<Thyra::VectorSpaceBase<double> const> p_space = model->get_p_space(0);
-
   p = model->getNominalValues().get_p(0)->clone_v();
   Teuchos::RCP<Thyra::VectorSpaceBase<double> const> x_space = model->get_x_space();
-
   Teuchos::RCP<Thyra::VectorBase<double>> x = model->getNominalValues().get_x()->clone_v();
 
-  Teuchos::EVerbosityLevel analysisVerbosityLevel;
-  switch(analysisVerbosity) {
-    case 1: analysisVerbosityLevel= Teuchos::VERB_LOW; break;
-    case 2: analysisVerbosityLevel= Teuchos::VERB_MEDIUM; break;
-    case 3: analysisVerbosityLevel= Teuchos::VERB_HIGH; break;
-    case 4: analysisVerbosityLevel= Teuchos::VERB_EXTREME; break;
-    default: analysisVerbosityLevel= Teuchos::VERB_NONE;
-  } 
+  if(analysisVerbosity > 2)
+    *out << "\nPiro::PerformHDSAAnalysis: Solve Constraint" << std::endl;
 
-  ROL::Ptr<ROL::Objective_SimOpt<double> > obj_ptr = ROL::makePtr<Piro::ThyraProductME_Objective_SimOpt<double>>(model, g_index, piroParams, analysisVerbosityLevel, observer);
   ROL::Ptr<ROL::Constraint_SimOpt<double> > constr_ptr = ROL::makePtr<Piro::ThyraProductME_Constraint_SimOpt<double>>(model, adjointModel, piroParams, analysisVerbosityLevel, observer);
   constr_ptr->setSolveParameters(hdsaParams.sublist("HDSA Options"));
-
   {
     auto thyra_constr_ptr = ROL::dynamicPtrCast<Piro::ThyraProductME_Constraint_SimOpt<double>>(constr_ptr);
     if(hdsaParams.isParameter("Use NOX Solver") && hdsaParams.get<bool>("Use NOX Solver"))
       thyra_constr_ptr->setExternalSolver(Teuchos::rcpFromRef(piroModel));
     thyra_constr_ptr->setNumResponses(piroSSSolver->num_g());
   }
-
   ROL::Ptr<ROL::Vector<double> > rol_p_ptr = ROL::makePtr<ROL::ThyraVector<double>>(p);
   ROL::Ptr<ROL::Vector<double> > rol_x_ptr = ROL::makePtr<ROL::ThyraVector<double>>(x);
-  int seed = hdsaParams.get<int>("Seed For Thyra Randomize", 42);
-
-  //! set initial guess (or use the one provided by the Model Evaluator)
-  std::string init_guess_type = hdsaParams.get<string>("Parameter Initial Guess Type", "From Model Evaluator");
-  if(init_guess_type == "Uniform Vector")
-    rol_p_ptr->setScalar(hdsaParams.get<double>("Uniform Parameter Guess", 1.0));
-  else if(init_guess_type == "Random Vector") {
-    Teuchos::Array<double> minmax(2); minmax[0] = -1; minmax[1] = 1;
-    auto rol_p_vec = Teuchos::rcp_dynamic_cast<ROL::ThyraVector<double>>(rol_p_ptr);
-    minmax = hdsaParams.get<Teuchos::Array<double> >("Min And Max Of Random Parameter Guess", minmax);
-    ::Thyra::randomize<double>( minmax[0], minmax[1], rol_p_vec->getVector().ptr());
-  }
-  else if(init_guess_type != "From Model Evaluator") {
-    TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
-              std::endl << "Piro::PerformROLSteadyAnalysis, ERROR: " <<
-              "Parameter Initial Guess Type \"" << init_guess_type << "\" is not Known.\nValid options are: \"Parameter Scalar Guess\", \"Uniform Vector\" and \"Random Vector\""<<std::endl);
-  }
-  //! test thyra implementation of ROL vector
-  if(hdsaParams.get<bool>("Test Vector", false)) {
-    Teuchos::RCP<Thyra::VectorBase<double> > rand_vec_x = p->clone_v();
-    Teuchos::RCP<Thyra::VectorBase<double> > rand_vec_y = p->clone_v();
-    Teuchos::RCP<Thyra::VectorBase<double> > rand_vec_z = p->clone_v();
-    ::Thyra::seed_randomize<double>( seed );
-
-    int num_tests = hdsaParams.get<int>("Number Of Vector Tests", 1);
-
-    for(int i=0; i< num_tests; i++) {
-
-      *out << "\nPiro::PerformROLSteadyAnalysis: Performing vector test " << i+1 << " of " << num_tests << std::endl;
-
-      ::Thyra::randomize<double>( -1.0, 1.0, rand_vec_x.ptr());
-      ::Thyra::randomize<double>( -1.0, 1.0, rand_vec_y.ptr());
-      ::Thyra::randomize<double>( -1.0, 1.0, rand_vec_z.ptr());
-
-      ROL::ThyraVector<double> rol_vec_x(rand_vec_x);
-      ROL::ThyraVector<double> rol_vec_y(rand_vec_y);
-      ROL::ThyraVector<double> rol_vec_z(rand_vec_z);
-
-      rol_vec_x.checkVector(rol_vec_y, rol_vec_z, true, *out);
-    }
-  }
-
-  //! check correctness of Gradient prvided by Model Evaluator
-  if(hdsaParams.get<bool>("Check Derivatives", false)) {
-    Teuchos::RCP<Thyra::VectorBase<double> > p_rand_vec1 = p->clone_v();
-    Teuchos::RCP<Thyra::VectorBase<double> > x_rand_vec1 = x->clone_v();
-    Teuchos::RCP<Thyra::VectorBase<double> > p_rand_vec2 = p->clone_v();
-    Teuchos::RCP<Thyra::VectorBase<double> > x_rand_vec2 = x->clone_v();
-
-    ::Thyra::seed_randomize<double>( seed );
-
-    auto rol_x_zero = rol_x_ptr->clone(); rol_x_zero->zero();
-    auto rol_p_zero = rol_p_ptr->clone(); rol_p_zero->zero();
-
-    int num_checks = hdsaParams.sublist("Derivative Checks").get<int>("Number Of Derivative Checks", 1);
-    double norm_p = rol_p_ptr->norm();
-    double norm_x = rol_x_ptr->norm();
-
-    ROL::Vector_SimOpt<double> sopt_vec(rol_x_ptr,rol_p_ptr);
-
-    for(int i=0; i< num_checks; i++) {
-
-      *out << "\nPiro::PerformROLSteadyAnalysis: Performing gradient check " << i+1 << " of " << num_checks << ", at parameter initial guess" << std::endl;
-
-      // compute direction 1
-      ::Thyra::randomize<double>( -1.0, 1.0, p_rand_vec1.ptr());
-      ::Thyra::randomize<double>( -1.0, 1.0, x_rand_vec1.ptr());
-
-      ROL::Ptr<ROL::Vector<double> > rol_p_direction1 = ROL::makePtr<ROL::ThyraVector<double>>(p_rand_vec1);
-      ROL::Ptr<ROL::Vector<double> > rol_x_direction1 = ROL::makePtr<ROL::ThyraVector<double>>(x_rand_vec1);
-
-      double norm_d = rol_p_direction1->norm();
-      if(norm_d*norm_p > 0.0)
-        rol_p_direction1->scale(norm_p/norm_d);
-      norm_d = rol_x_direction1->norm();
-      if(norm_d*norm_x > 0.0)
-        rol_x_direction1->scale(norm_x/norm_d);
-
-      ROL::Vector_SimOpt<double> sopt_vec_direction1(rol_x_direction1, rol_p_direction1);
-      ROL::Vector_SimOpt<double> sopt_vec_direction1_x(rol_x_direction1, rol_p_zero);
-      ROL::Vector_SimOpt<double> sopt_vec_direction1_p(rol_x_zero, rol_p_direction1);
-
-      // compute direction 2
-      ::Thyra::randomize<double>( -1.0, 1.0, p_rand_vec2.ptr());
-      ::Thyra::randomize<double>( -1.0, 1.0, x_rand_vec2.ptr());
-
-      ROL::Ptr<ROL::Vector<double> > rol_p_direction2 = ROL::makePtr<ROL::ThyraVector<double>>(p_rand_vec2);
-      ROL::Ptr<ROL::Vector<double> > rol_x_direction2 = ROL::makePtr<ROL::ThyraVector<double>>(x_rand_vec2);
-
-      norm_d = rol_p_direction2->norm();
-      if(norm_d*norm_p > 0.0)
-        rol_p_direction2->scale(norm_p/norm_d);
-      norm_d = rol_x_direction2->norm();
-      if(norm_d*norm_x > 0.0)
-        rol_x_direction2->scale(norm_x/norm_d);
-
-      ROL::Vector_SimOpt<double> sopt_vec_direction2(rol_x_direction2, rol_p_direction2);
-      ROL::Vector_SimOpt<double> sopt_vec_direction2_x(rol_x_direction2, rol_p_zero);
-      ROL::Vector_SimOpt<double> sopt_vec_direction2_p(rol_x_zero, rol_p_direction2);
-
-
-      int num_steps = 10;
-      int order = 2;
-
-      // Check derivatives.
-
-      *out << "Piro::PerformROLSteadyAnalysis: Checking Accuracy of Objective Gradient " << std::endl;
-      obj_ptr->checkGradient(sopt_vec,sopt_vec_direction1,true,*out,num_steps,order);
-      *out << "Piro::PerformROLSteadyAnalysis: Checking Accuracy of Objective Gradient in x direction" << std::endl;
-      obj_ptr->checkGradient(sopt_vec,sopt_vec_direction1_x,true,*out,num_steps,order);
-      *out << "Piro::PerformROLSteadyAnalysis: Checking Accuracy of Objective Gradient in p direction" << std::endl;
-      obj_ptr->checkGradient(sopt_vec,sopt_vec_direction1_p,true,*out,num_steps,order);
-
-
-      *out << "Piro::PerformROLSteadyAnalysis: Checking Accuracy of Constraint Gradient " << std::endl;
-      constr_ptr->checkApplyJacobian(sopt_vec,sopt_vec_direction1,*rol_x_direction1, true,*out,num_steps,order);
-      *out << "Piro::PerformROLSteadyAnalysis: Checking Accuracy of Constraint Gradient in x direction (Jacobian) " << std::endl;
-      constr_ptr->checkApplyJacobian(sopt_vec,sopt_vec_direction1_x,*rol_x_direction1,true,*out,num_steps,order);
-      *out << "Piro::PerformROLSteadyAnalysis: Checking Accuracy of Constraint Gradient in p direction" << std::endl;
-      constr_ptr->checkApplyJacobian(sopt_vec,sopt_vec_direction1_p,*rol_x_direction1,true,*out,num_steps,order);
-
-      if(hdsaParams.sublist("Derivative Checks").get<bool>("Perform Expensive Derivative Checks", false))
-        constr_ptr->checkApplyAdjointJacobian(sopt_vec,*rol_x_direction1,*rol_x_direction1,sopt_vec,true,*out,num_steps);
-
-      *out << "Piro::PerformROLSteadyAnalysis: Checking Consistency of Constraint Gradient and its adjoint" << std::endl;
-      constr_ptr->checkAdjointConsistencyJacobian(*rol_x_direction1, sopt_vec_direction2, sopt_vec,true,*out);
-
-      obj_ptr->update(*rol_x_ptr,*rol_p_ptr,ROL::UpdateType::Temp);
-      constr_ptr->update(*rol_x_ptr,*rol_p_ptr,ROL::UpdateType::Temp);
-      *out << "Piro::PerformROLSteadyAnalysis: Checking Symmetry of objective Hessian" << std::endl;
-      obj_ptr->checkHessSym(sopt_vec,sopt_vec_direction1, sopt_vec_direction2, true,*out);
-
-      *out << "Piro::PerformROLSteadyAnalysis: Checking Symmetry of objective Hessian (H_xx = H_xx^T)" << std::endl;
-      obj_ptr->checkHessSym(sopt_vec,sopt_vec_direction1_x, sopt_vec_direction2_x, true,*out);
-      *out << "Piro::PerformROLSteadyAnalysis: Checking Symmetry of objective Hessian (H_xp = H_px^T)" << std::endl;
-      obj_ptr->checkHessSym(sopt_vec,sopt_vec_direction1_x, sopt_vec_direction2_p, true,*out);
-      *out << "Piro::PerformROLSteadyAnalysis: Checking Symmetry of objective Hessian (H_pp = H_pp^T)" << std::endl;
-      obj_ptr->checkHessSym(sopt_vec,sopt_vec_direction1_p, sopt_vec_direction2_p, true,*out);
-
-      *out << "Piro::PerformROLSteadyAnalysis: Checking Accuracy of objective Hessian" << std::endl;
-      obj_ptr->checkHessVec(sopt_vec,sopt_vec_direction1,true,*out,num_steps,order);
-
-      *out << "Piro::PerformROLSteadyAnalysis: Checking Accuracy of constraint Hessian" << std::endl;
-      constr_ptr->checkApplyAdjointHessian(sopt_vec, *rol_x_direction1, sopt_vec_direction2, sopt_vec_direction2, true,*out,num_steps,order);
-
-    }
-  }
-  if(analysisVerbosity >= 3) {
-    *out << "\nPiro PerformAnalysis: HDSA options:" << std::endl;
-    hdsaParams.sublist("HDSA Options").print(*out);
-    *out << std::endl;
-  }
-
-  if(analysisVerbosity > 2)
-    *out << "\nPiro::PerformHDSAAnalysis: Solve Constraint" << std::endl;
-
   auto c_ptr = rol_x_ptr->clone();
   double tol = 1e-5;
-  constr_ptr->solve(*c_ptr,*rol_x_ptr,*rol_p_ptr,tol);
-  
-
-
-  bool useIdentityPriorEllOp = true;
-  int prior_ell_reponse_index = -1;
-  if(hdsaParams.isSublist("Prior Elliptic Operator")) {
-    const Teuchos::ParameterList& operatorList = hdsaParams.sublist("Prior Elliptic Operator");
-    auto operatorType = operatorList.get<std::string>("Operator Type");
-    if(operatorType == "Hessian Of Response") {
-      useIdentityPriorEllOp = false;
-      prior_ell_reponse_index = operatorList.get<int>("Response Index");
-    }
-    else if (operatorType == "Identity")
-      useIdentityPriorEllOp = true;
-    else {
-      TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
-          std::endl << "Piro::PerformHDSASteadyAnalysis, ERROR: " <<
-          "Operator Type not recognized. Available options are: \n" <<
-          "\"Identity\" and \"Hessian Of Response\""<<std::endl);
-    }
-  }
-
-  bool useIdentityPriorMassOp = true;
-  int prior_mass_reponse_index = -1;
-  if(hdsaParams.isSublist("Prior Mass Operator")) {
-    const Teuchos::ParameterList& operatorList = hdsaParams.sublist("Prior Mass Operator");
-    auto operatorType = operatorList.get<std::string>("Operator Type");
-    if(operatorType == "Hessian Of Response") {
-      useIdentityPriorMassOp = false;
-      prior_mass_reponse_index = operatorList.get<int>("Response Index");
-    }
-    else if (operatorType == "Identity")
-      useIdentityPriorMassOp = true;
-    else {
-      TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
-          std::endl << "Piro::PerformHDSASteadyAnalysis, ERROR: " <<
-          "Operator Type not recognized. Available options are: \n" <<
-          "\"Identity\" and \"Hessian Of Response\""<<std::endl);
-    }
-  }
-
-  bool useIdentityPriorMassCholOp = true;
-  int prior_mass_chol_reponse_index = -1;
-  if(hdsaParams.isSublist("Prior Mass Cholesky Operator")) {
-    const Teuchos::ParameterList& operatorList = hdsaParams.sublist("Prior Mass Cholesky Operator");
-    auto operatorType = operatorList.get<std::string>("Operator Type");
-    if(operatorType == "Hessian Of Response") {
-      useIdentityPriorMassCholOp = false;
-      prior_mass_chol_reponse_index = operatorList.get<int>("Response Index");
-    }
-    else if (operatorType == "Identity")
-      useIdentityPriorMassCholOp = true;
-    else {
-      TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
-          std::endl << "Piro::PerformHDSASteadyAnalysis, ERROR: " <<
-          "Operator Type not recognized. Available options are: \n" <<
-          "\"Identity\" and \"Hessian Of Response\""<<std::endl);
-    }
-  }
-
-  bool useIdentityStateEllOp = true;
-  int state_ell_reponse_index = -1;
-  int state_ell_param_index = -1;
-  if(hdsaParams.isSublist("State Elliptic Operator")) {
-    const Teuchos::ParameterList& operatorList = hdsaParams.sublist("State Elliptic Operator");
-    auto operatorType = operatorList.get<std::string>("Operator Type");
-    if(operatorType == "Hessian Of Response") {
-      useIdentityStateEllOp = false;
-      state_ell_reponse_index = operatorList.get<int>("Response Index");
-      state_ell_param_index = operatorList.isParameter("Parameter Index") ? operatorList.get<int>("Parameter Index") : 1;
-    }
-    else if (operatorType == "Identity")
-      useIdentityStateEllOp = true;
-    else {
-      TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
-          std::endl << "Piro::PerformHDSASteadyAnalysis, ERROR: " <<
-          "Operator Type not recognized. Available options are: \n" <<
-          "\"Identity\" and \"Hessian Of Response\""<<std::endl);
-    }
-  }
-
-  bool useIdentityStateMassOp = true;
-  int state_mass_reponse_index = -1;
-  int state_mass_param_index = -1;
-  if(hdsaParams.isSublist("State Mass Operator")) {
-    const Teuchos::ParameterList& operatorList = hdsaParams.sublist("State Mass Operator");
-    auto operatorType = operatorList.get<std::string>("Operator Type");
-    if(operatorType == "Hessian Of Response") {
-      useIdentityStateMassOp = false;
-      state_mass_reponse_index = operatorList.get<int>("Response Index");
-      state_mass_param_index = operatorList.isParameter("Parameter Index") ? operatorList.get<int>("Parameter Index") : 1;
-    }
-    else if (operatorType == "Identity")
-      useIdentityStateMassOp = true;
-    else {
-      TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
-          std::endl << "Piro::PerformHDSASteadyAnalysis, ERROR: " <<
-          "Operator Type not recognized. Available options are: \n" <<
-          "\"Identity\" and \"Hessian Of Response\""<<std::endl);
-    }
-  }
+  constr_ptr->solve(*c_ptr,*rol_x_ptr,*rol_p_ptr,tol); 
 
   Teuchos::RCP<Thyra::VectorBase<double> > scaling_vector_p = Teuchos::null;
   Teuchos::RCP<const Thyra::LinearOpBase<double> > priorEllOp(Teuchos::null), invPriorEllOp(Teuchos::null), invEllOp(Teuchos::null), massOp(Teuchos::null), priorMassOp(Teuchos::null), invPriorMassOp(Teuchos::null), priorMassCholOp(Teuchos::null);
@@ -1551,16 +1448,16 @@ Piro::PerformHDSAAnalysis(
       if(analysisVerbosity > 2)
         *out << "\nPiro::PerformHDSAAnalysis: Start the computation of the Prior Elliptic Operator" << std::endl;
 
+      const auto priorEllOpInfo = getOperatorInfo(hdsaParams, "Prior Elliptic Operator");
       Teko::BlockedLinearOp bH;
 
-      if (!useIdentityPriorEllOp && !model_PME.is_null()) {
+      if (!priorEllOpInfo.use_identity && !model_PME.is_null()) {
         bH = Teko::createBlockedOp();
-        model_PME->block_diagonal_hessian_22(bH, *rol_x_ptr, *rol_p_ptr, prior_ell_reponse_index);
+        model_PME->block_diagonal_hessian_22(bH, *rol_x_ptr, *rol_p_ptr, priorEllOpInfo.response_index);
       }
      
-      if (!useIdentityPriorEllOp) {
+      if (!priorEllOpInfo.use_identity) {
         int numBlocks = bH->productRange()->numBlocks();
-        std::cout << "Num Blocks " << numBlocks <<std::endl;
         std::vector<Teko::LinearOp> diag(numBlocks);
         for (int i=0; i<numBlocks; ++i) {
           auto linOp = Teuchos::rcp_dynamic_cast<Thyra::LinearOpWithSolveBase<double>>(
@@ -1578,17 +1475,17 @@ Piro::PerformHDSAAnalysis(
     {
       if(analysisVerbosity > 2)
         *out << "\nPiro::PerformHDSAAnalysis: Start the computation of the Prior Mass Operator" << std::endl;
-
+      
+      const auto priorMassOpInfo = getOperatorInfo(hdsaParams, "Prior Mass Operator");
       Teko::BlockedLinearOp bH;
 
-      if (!useIdentityPriorEllOp && !model_PME.is_null()) {
+      if (!priorMassOpInfo.use_identity && !model_PME.is_null()) {
         bH = Teko::createBlockedOp();
-        model_PME->block_diagonal_hessian_22(bH, *rol_x_ptr, *rol_p_ptr, prior_mass_reponse_index);
+        model_PME->block_diagonal_hessian_22(bH, *rol_x_ptr, *rol_p_ptr, priorMassOpInfo.response_index);
       }
      
-      if (!useIdentityPriorEllOp) {
-        int numBlocks = bH->productRange()->numBlocks();
-        std::cout << "Num Blocks " << numBlocks <<std::endl;
+      if (!priorMassOpInfo.use_identity) {
+        int numBlocks = bH->productRange()->numBlocks();  
         std::vector<Teko::LinearOp> diag(numBlocks);
         for (int i=0; i<numBlocks; ++i) {
           auto linOp = Teuchos::rcp_dynamic_cast<Thyra::LinearOpWithSolveBase<double>>(
@@ -1607,11 +1504,12 @@ Piro::PerformHDSAAnalysis(
       if(analysisVerbosity > 2)
         *out << "\nPiro::PerformHDSAAnalysis: Start the computation of the Prior Mass Cholesky Operator" << std::endl;
 
+      const auto priorMassCholOpInfo = getOperatorInfo(hdsaParams, "Prior Mass Cholesky Operator");
       Teko::BlockedLinearOp bH;
 
-      if (!useIdentityPriorMassCholOp && !model_PME.is_null()) {
+      if (!priorMassCholOpInfo.use_identity && !model_PME.is_null()) {
         bH = Teko::createBlockedOp();
-        model_PME->block_diagonal_hessian_22(bH, *rol_x_ptr, *rol_p_ptr, prior_mass_chol_reponse_index);
+        model_PME->block_diagonal_hessian_22(bH, *rol_x_ptr, *rol_p_ptr, priorMassCholOpInfo.response_index);
         priorMassCholOp = bH;
       }
 
@@ -1623,12 +1521,13 @@ Piro::PerformHDSAAnalysis(
       if(analysisVerbosity > 2)
         *out << "\nPiro::PerformHDSAAnalysis: Start the computation of the State Elliptic Operator" << std::endl;
 
+      const auto stateEllOpInfo = getOperatorInfo(hdsaParams, "State Elliptic Operator", true);
       Teuchos::RCP<Thyra::LinearOpBase<double>> H;
-      if (!useIdentityStateEllOp && !model_PME.is_null()) {        
-        model_PME->block_diagonal_hessian_22(H, *rol_x_ptr, *rol_x_ptr, state_ell_reponse_index, state_ell_param_index);
+      if (!stateEllOpInfo.use_identity && !model_PME.is_null()) {        
+        model_PME->block_diagonal_hessian_22(H, *rol_x_ptr, *rol_x_ptr, stateEllOpInfo.response_index, stateEllOpInfo.param_index);
       }
      
-      if (!useIdentityStateEllOp) {
+      if (!stateEllOpInfo.use_identity) {
         auto linOp = Teuchos::rcp_dynamic_cast<Thyra::LinearOpWithSolveBase<double>>(
         Teuchos::rcp_const_cast<Thyra::LinearOpBase<double>>(H));
         invEllOp = Thyra::nonconstInverse(linOp);
@@ -1642,9 +1541,10 @@ Piro::PerformHDSAAnalysis(
       if(analysisVerbosity > 2)
         *out << "\nPiro::PerformHDSAAnalysis: Start the computation of the State Mass Operator" << std::endl;
 
+      const auto stateMassOpInfo = getOperatorInfo(hdsaParams, "State Mass Operator", true);
       Teuchos::RCP<Thyra::LinearOpBase<double>> H;
-      if (!useIdentityStateMassOp && !model_PME.is_null()) {
-        model_PME->block_diagonal_hessian_22(H, *rol_x_ptr, *rol_x_ptr, state_mass_reponse_index, state_mass_param_index);
+      if (!stateMassOpInfo.use_identity && !model_PME.is_null()) {
+        model_PME->block_diagonal_hessian_22(H, *rol_x_ptr, *rol_x_ptr, stateMassOpInfo.response_index, stateMassOpInfo.param_index);
         massOp = H;
       }
 
@@ -1654,96 +1554,281 @@ Piro::PerformHDSAAnalysis(
   }
 
 #else
-  (void)prior_reponse_index; (void) state_ell_reponse_index; (void) state_mass_reponse_index; //avoid compiler warnings
-  TEUCHOS_TEST_FOR_EXCEPTION(!(useIdentityPriorOp && useIdentityStateEllOp && useIdentityStateMassOp), Teuchos::Exceptions::InvalidParameter,
-      std::endl << "Piro::PerformHDSAAnalysis, ERROR: " <<
-      "Teko is required for computing prior covariance"<<std::endl);
+  TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
+      std::endl << "Piro::PerformHDSAAnalysis, ERROR: Teko is required for HDSA analysis"<<std::endl);
 #endif
 
   // Run Algorithm
-  Teuchos::RCP<ROL::BoundConstraint<double> > boundConstraint;
-  bool boundConstrained = hdsaParams.get<bool>("Bound Constrained", false);
-  if(boundConstrained) {
-    Teuchos::RCP<Thyra::VectorBase<double>> p_lo = model->getLowerBounds().get_p(0)->clone_v();
-    Teuchos::RCP<Thyra::VectorBase<double>> p_up = model->getUpperBounds().get_p(0)->clone_v();
+  int return_status = 0;
 
-    //ROL::Thyra_BoundConstraint<double> boundConstraint(p_lo->clone_v(), p_up->clone_v(), eps_bound);
-    boundConstraint = rcp( new ROL::Bounds<double>(ROL::makePtr<ROL::ThyraVector<double> >(p_lo), ROL::makePtr<ROL::ThyraVector<double> >(p_up)));
+  RolOutputBuffer<char> rolOutputBuffer;
+  auto rolOutputStream = Teuchos::rcp(new std::ostream(&rolOutputBuffer));
+  Teuchos::RCP<Teuchos::FancyOStream> rolOutput = Teuchos::getFancyOStream(rolOutputStream);
+  rolOutput->setOutputToRootOnly(0);
+
+  ROL::Ptr<ROL::Objective_SimOpt<double> > obj_ptr = ROL::makePtr<Piro::ThyraProductME_Objective_SimOpt<double>>(model, g_index, piroParams, analysisVerbosityLevel, observer);
+  HDSA::Ptr<HDSA::MD_Opt_Prob_Interface<double> > opt_prob_interface = HDSA::makePtr<HDSA::MD_ROL_Opt_Prob_Interface<double> >(obj_ptr, constr_ptr, rol_x_ptr, rol_p_ptr);
+  ROL::Ptr<ROL::Vector<double> > rol_opt_p_ptr = rol_p_ptr->clone(); rol_opt_p_ptr->set(*rol_p_ptr);
+  ROL::Ptr<ROL::Vector<double> > rol_opt_x_ptr = rol_x_ptr->clone(); rol_opt_x_ptr->set(*rol_x_ptr);
+  HDSA::Ptr<Piro::HDSA_MD_ROL_Data_Interface<double> > data_interface = HDSA::makePtr<Piro::HDSA_MD_ROL_Data_Interface<double> >(rol_opt_x_ptr, rol_opt_p_ptr);
+
+  double alpha_u = hdsaParams.sublist("MD Prior").get<double>("alpha_u", 0.25);
+  double alpha_z = hdsaParams.sublist("MD Prior").get<double>("alpha_z", 0.0001);
+  
+  bool OED = hdsaParams.get("Perform HDSA Analysis With OED", false);
+  auto seed_oed_init = static_cast<unsigned int>(hdsaParams.sublist("MD OED").get("Seed For Random Initialization", 0));
+  ::Thyra::seed_randomize<double>( seed_oed_init );
+  HDSA::Ptr<HDSA::Vector<double>> dz0;
+  if (OED) {
+    dz0 = data_interface->Get_z_opt()->Clone();
+    dz0->Randomize_Standard_Normal();
   }
 
-    int return_status = 0;
+  auto hdsa_seed = static_cast<unsigned int>(hdsaParams.get("Normal Random Generator Seed", 42));
+  HDSA::Ptr<HDSA::Random_Number_Generator<double> > random_number_generator = HDSA::makePtr<HDSA::Random_Number_Generator<double> >(hdsa_seed);
+  ::Thyra::seed_randomize<double>(hdsa_seed+1);
 
-    RolOutputBuffer<char> rolOutputBuffer;
-    auto rolOutputStream = Teuchos::rcp(new std::ostream(&rolOutputBuffer));
-    Teuchos::RCP<Teuchos::FancyOStream> rolOutput = Teuchos::getFancyOStream(rolOutputStream);
-    rolOutput->setOutputToRootOnly(0);
+  HDSA::Ptr<HDSA::MD_u_Prior_Interface<double> > u_prior_interface = HDSA::makePtr<Piro::HDSA_MD_ROL_Elliptic_u_Prior_Interface<double> >(alpha_u,random_number_generator,invEllOp,massOp);
+  HDSA::Ptr<HDSA::MD_z_Prior_Interface<double> > z_prior_interface = HDSA::makePtr<Piro::HDSA_MD_ROL_Elliptic_z_Prior_Interface<double> >(alpha_z,priorEllOp,invPriorEllOp,priorMassOp,invPriorMassOp, priorMassCholOp);
 
-    HDSA::Ptr<HDSA::MD_Opt_Prob_Interface<double> > opt_prob_interface = HDSA::makePtr<HDSA::MD_ROL_Opt_Prob_Interface<double> >(obj_ptr, constr_ptr, rol_x_ptr, rol_p_ptr);
-    ROL::Ptr<ROL::Vector<double> > rol_opt_p_ptr = rol_p_ptr->clone(); rol_opt_p_ptr->set(*rol_p_ptr);
-    ROL::Ptr<ROL::Vector<double> > rol_opt_x_ptr = rol_x_ptr->clone(); rol_opt_x_ptr->set(*rol_x_ptr);
-    HDSA::Ptr<Piro::HDSA_MD_ROL_Data_Interface<double> > data_interface = HDSA::makePtr<Piro::HDSA_MD_ROL_Data_Interface<double> >(rol_opt_x_ptr, rol_opt_p_ptr);
+  HDSA::Ptr<HDSA::Vector<double> > u_vec = data_interface->Get_u_opt()->Clone();
+  HDSA::Ptr<HDSA::MD_Elliptic_u_Prior_Interface<double> > elliptic_u_prior_interface = HDSA::dynamicPtrCast<HDSA::MD_Elliptic_u_Prior_Interface<double> >(u_prior_interface);
+  int num_sing_vals = hdsaParams.sublist("MD Prior").get<int>("Number Of Singular Values", 50);
+  int oversampling = hdsaParams.sublist("MD Prior").get<int>("Oversampling Factor", 1);
+  int num_subspace_iters = hdsaParams.sublist("MD Prior").get<int>("Number Of Subspace Iterations", 2);
+  int num_prior_samples = hdsaParams.sublist("MD Prior").get("Number Of Prior Samples",100);
+
+  elliptic_u_prior_interface->Compute_E_u_Inverse_GSVD(num_sing_vals, oversampling, num_subspace_iters, *u_vec);
+
+  HDSA::Ptr<HDSA::MD_Hessian_Analysis<double> > hessian_analysis = HDSA::makePtr<HDSA::MD_Hessian_Analysis<double> >(opt_prob_interface,z_prior_interface);
+  int num_evals = hdsaParams.sublist("MD Hessian Analysis").get<int>("Rank", 20);
+  oversampling = hdsaParams.sublist("MD Hessian Analysis").get<int>("Oversampling Factor", 10);
+  hessian_analysis->Compute_Hessian_GEVP(data_interface->Get_z_opt(),num_evals,oversampling);
+  
+  int num_continuation_steps = hdsaParams.sublist("MD Continuation Update").get("Number Of Continuation Steps", 0); 
+  double grad_tol = hdsaParams.sublist("MD Continuation Update").get("Gradient Tolerance", 1e-4); 
+  if(!OED) {
+    *out << "Performing HDSA Analysis. Sample size: " << p_samples.size() << " " << x_diff_at_samples.size() << std::endl;
+    *out << "||p_opt||: " << data_interface->Get_z_opt()->Norm() << ", ||sol||: " << data_interface->Get_u_opt()->Norm() <<std::endl;
     for (int k=0; k<p_samples.size(); k++) {
       auto p_sample = createProductVector(p_samples[k]);
       ROL::Ptr<ROL::Vector<double> > rol_p_samples_ptr = ROL::makePtr<ROL::ThyraVector<double>>(p_sample);
       ROL::Ptr<ROL::Vector<double> > rol_x_diffs_ptr = ROL::makePtr<ROL::ThyraVector<double>>(x_diff_at_samples[k]);
       data_interface->Z_Data_push_back(rol_p_samples_ptr);
       data_interface->Y_Data_push_back(rol_x_diffs_ptr);
+      *out << "||param_" << k << "||: " << rol_p_samples_ptr->norm() << ", ||sol_diff_: " << k << "||: " << rol_x_diffs_ptr->norm() <<std::endl;
     }
 
-    double alpha_u = hdsaParams.sublist("MD Prior").get<double>("alpha_u", 0.25);
-    double alpha_z = hdsaParams.sublist("MD Prior").get<double>("alpha_z", 0.0001);
-    HDSA::Ptr<HDSA::Random_Number_Generator<double> > random_number_generator = HDSA::makePtr<HDSA::Random_Number_Generator<double> >(42);
-    HDSA::Ptr<HDSA::MD_u_Prior_Interface<double> > u_prior_interface = HDSA::makePtr<Piro::HDSA_MD_ROL_Elliptic_u_Prior_Interface<double> >(alpha_u,random_number_generator,invEllOp,massOp);
-    HDSA::Ptr<HDSA::MD_z_Prior_Interface<double> > z_prior_interface = HDSA::makePtr<Piro::HDSA_MD_ROL_Elliptic_z_Prior_Interface<double> >(alpha_z,priorEllOp,invPriorEllOp,priorMassOp,invPriorMassOp, priorMassCholOp);
-
-    HDSA::Ptr<HDSA::Vector<double> > u_vec = data_interface->Get_u_opt()->Clone();
-    HDSA::Ptr<HDSA::MD_Elliptic_u_Prior_Interface<double> > elliptic_u_prior_interface = HDSA::dynamicPtrCast<HDSA::MD_Elliptic_u_Prior_Interface<double> >(u_prior_interface);
-    int num_sing_vals = hdsaParams.sublist("MD Prior").get<int>("Number Of Singular Values", 50);
-    int oversampling = hdsaParams.sublist("MD Prior").get<int>("Oversampling Factor", 1);
-    int num_subspace_iters = hdsaParams.sublist("MD Prior").get<int>("Number Of Subspace Iterations", 2);
-    int num_prior_samples = hdsaParams.sublist("MD Prior").get("Number Of Prior Samples",100);
-
-    elliptic_u_prior_interface->Compute_E_u_Inverse_GSVD(num_sing_vals, oversampling, num_subspace_iters, *u_vec);
-
-    //HDSA::Ptr<HDSA::MD_Prior_Sampling<double> > prior_sampling = HDSA::makePtr<HDSA::MD_Prior_Sampling<double> >(data_interface,u_prior_interface,z_prior_interface);
-    //HDSA::Ptr<HDSA::MultiVector<double> > prior_samples_at_z_opt = prior_sampling->Prior_Discrepancy_Samples_at_z_opt(num_prior_samples);
-  
-    //std::string name = "prior_discrepancy_evaluated_at_z_opt";
-    //prior_samples_at_z_opt->Write_to_File(name);
+    if(num_prior_samples > 0) {
+      HDSA::Ptr<HDSA::MD_Prior_Sampling<double> > prior_sampling = HDSA::makePtr<HDSA::MD_Prior_Sampling<double> >(data_interface,u_prior_interface,z_prior_interface);
+      HDSA::Ptr<HDSA::MultiVector<double> > prior_samples_at_z_opt = prior_sampling->Prior_Discrepancy_Samples_at_z_opt(num_prior_samples);
+    }
     
     HDSA::Ptr<HDSA::MD_Posterior_Sampling<double> > post_sampling = HDSA::makePtr<HDSA::MD_Posterior_Sampling<double> >(data_interface,u_prior_interface,z_prior_interface);
-    int num_post_samples = num_prior_samples;
-    double alpha_d = hdsaParams.sublist("MD Prior").get<double>("alpha_d", 1.0e-5);
+    int num_post_samples = hdsaParams.sublist("MD Posterior").get("Number Of Posterior Samples", num_prior_samples);
+    double alpha_d = hdsaParams.sublist("MD Posterior").get<double>("alpha_d", 1.0e-5);
     post_sampling->Compute_Posterior_Data(alpha_d,num_post_samples);
 
-    HDSA::Ptr<HDSA::MD_Hessian_Analysis<double> > hessian_analysis = HDSA::makePtr<HDSA::MD_Hessian_Analysis<double> >(opt_prob_interface,z_prior_interface);
-    int num_evals = hdsaParams.sublist("MD Hessian Analysis").get<int>("Rank", 20);
-    oversampling = hdsaParams.sublist("MD Hessian Analysis").get<int>("Oversampling Factor", 10);
-    hessian_analysis->Compute_Hessian_GEVP(data_interface->Get_z_opt(),num_evals,oversampling);
-    
-    int num_continuation_steps = hdsaParams.sublist("MD Continuation Update").get("Number of Continuation Steps", 0); 
-    HDSA::Ptr<HDSA::MD_Update<double> > update = HDSA::makePtr<HDSA::MD_Update<double> >(data_interface,u_prior_interface,z_prior_interface,opt_prob_interface,post_sampling,hessian_analysis,random_number_generator,num_continuation_steps);
-  
-    //HDSA::Ptr<HDSA::MD_Posterior_Vectors<double> > posterior_update_samples = update->Posterior_Update_Samples();
-    //HDSA::Ptr<HDSA::Vector<double> > z_update = posterior_update_samples->mean;
+    HDSA::Ptr<HDSA::MD_Update<double> > update = HDSA::makePtr<HDSA::MD_Update<double> >(data_interface,u_prior_interface,z_prior_interface,opt_prob_interface,post_sampling,hessian_analysis,random_number_generator,num_continuation_steps,grad_tol);
 
-    //Alternatively just compute the mean, no sampling needed
-    HDSA::Ptr<HDSA::Vector<double> > z_update = update->Posterior_Update_Mean();   
+    HDSA::Ptr<HDSA::Vector<double> > z_update;
+    if(num_post_samples > 0) {
+      HDSA::Ptr<HDSA::MD_Posterior_Vectors<double> > posterior_update_samples = update->Posterior_Update_Samples();
+      std::string name = "posterior_samples";
+      posterior_update_samples->samples->Write_to_File(name);
+      z_update = posterior_update_samples->mean;
+    } else {
+      //Alternatively just compute the mean, no sampling needed
+      z_update = update->Posterior_Update_Mean(); 
+    }
 
     HDSA::ROL_Vector<double>& z_update_rol = dynamic_cast<HDSA::ROL_Vector<double>&>(*z_update);
-    //double norm_z_update_rol = z_update_rol.norm();
-    //*out <<  "\n\n Z Mean Norm: " << norm_z_update_rol <<std::endl;
     rol_p_ptr->set(*z_update_rol.rol_vec);
 
     constr_ptr->solve(*c_ptr,*rol_x_ptr,*rol_p_ptr,tol);
+  } else {
 
-   if(Teuchos::nonnull(observer)) {
+    /*
+      OED setup and offline reduced matrix construction.
+    */
+    HDSA::Ptr<HDSA::MD_OED<double>> md_oed = HDSA::makePtr<HDSA::MD_OED<double>>(data_interface, u_prior_interface, z_prior_interface, hessian_analysis);
+    md_oed->Offline_Computation();
+    const int r = md_oed->Get_Reduced_Dimension();
+    const typename HDSA::MD_OED<double>::Offline_Data& offline = md_oed->Get_Offline_Data();
+
+    TEUCHOS_TEST_FOR_EXCEPTION(!offline.Is_Initialized(), std::logic_error, "Piro::PerformHDSAAnalysis, ERROR: OED offline data were not initialized." << std::endl);
+
+
+    const int num_data_samples = static_cast<int>(p_samples.size());
+
+    TEUCHOS_TEST_FOR_EXCEPTION(num_data_samples == 0, std::logic_error,
+        "Piro::PerformHDSAAnalysis, ERROR: OED requires at least the initial data sample." << std::endl);
+
+    int num_trace_samples = hdsaParams.sublist("MD OED").get<int>("Number Of Randomized Trace Samples", 50);
+    const double alpha_k_denom = Estimate_Trace_Wz_Inverse_Mz(*data_interface->Get_z_opt(), *z_prior_interface, num_trace_samples);
+
+    typename HDSA::MD_OED<double>::SPG_Options spg_options;
+    spg_options.max_iter = hdsaParams.sublist("MD OED").get<int>("Max Number Of OED Iterations", 300);
+    spg_options.pg_tol = hdsaParams.sublist("MD OED").get("PG Tolerance", 1e-8);
+    spg_options.armijo_c = hdsaParams.sublist("MD OED").get("Armijo Coefficient", 1e-4);
+    spg_options.backtrack_factor = hdsaParams.sublist("MD OED").get("Backtrack Factor", 0.5);
+    spg_options.max_backtracks = hdsaParams.sublist("MD OED").get("Max Number Of Backtrack Steps", 30);
+    spg_options.nonmonotone_window = hdsaParams.sublist("MD OED").get<int>("Nonmonotone Window", 5);
+    spg_options.verbosity = hdsaParams.sublist("MD OED").get("Verbosity", false);
+
+    const int num_post_samples = hdsaParams.sublist("MD Posterior").get("Number Of Posterior Samples", num_prior_samples);
+    const double alpha_d = hdsaParams.sublist("MD Posterior").get<double>("alpha_d", 1.0e-5);
+
+    /*
+    * Initial guess for the OED optimization.
+    */
+    auto Mz_dz0 = dz0->Clone();
+    z_prior_interface->Apply_M_z(*Mz_dz0, *dz0);
+
+    const double dz0_Mz_norm = std::sqrt(dz0->Dot(*Mz_dz0));
+
+    TEUCHOS_TEST_FOR_EXCEPTION(!(dz0_Mz_norm > 0.0), std::logic_error, "Piro::PerformHDSAAnalysis, ERROR: zero M_z norm for the OED initial direction." << std::endl);
+
+    const double scale = 1e-2 / dz0_Mz_norm;
+
+    HDSA::Dense_Matrix<double> beta_0(r, 1);
+    beta_0.Zeros();
+    for (int i = 0; i < r; ++i) {
+      const double beta_i =  scale * (*hessian_analysis->Get_Evecs())[i]->Dot(*Mz_dz0);
+      beta_0.Set_Entry(i, 0, beta_i);
+    }
+
+    /*
+    * betas contains the reduced coordinates of the previously proposed OED parameters: 
+    *   p_samples[1], p_samples[2], ...
+    *   p_samples[0] is z_opt and corresponds to beta = 0, which is included implicitly by the OED formulation.
+    */
+    HDSA::Ptr<HDSA::Dense_Matrix<double>> betas = HDSA::makePtr<HDSA::Dense_Matrix<double>>(0, 1);
+
+    std::vector<HDSA::Ptr<HDSA::Vector<double>>> z_bars;
+
+    HDSA::Ptr<HDSA::Vector<double>> z_lofi = data_interface->Get_z_opt()->Clone();
+    z_lofi->Set(*data_interface->Get_z_opt());
+
+    HDSA::Ptr<HDSA::Dense_Matrix<double>> current_beta_bar =  HDSA::nullPtr;
+
+    *out << "\n=====================================================" << std::endl;
+    *out << "Beginning sequential OED workflow" << std::endl;
+    *out << "Reduced dimension r = " << r << std::endl;
+    *out << "Number of available data samples = " << num_data_samples << std::endl;
+    *out << "====================================================="  << std::endl;
+
+    HDSA::Ptr<HDSA::Vector<double>> hdsa_rol_p_ptr = HDSA::makePtr<HDSA::ROL_Vector<double>>(rol_p_ptr);
+
+    /*
+    * Replay only the posterior updates using the available data.
+    */
+    for (int step = 0; step < num_data_samples; ++step) {
+
+      auto p_sample = createProductVector(p_samples[step]);
+
+      ROL::Ptr<ROL::Vector<double>> rol_p_samples_ptr = ROL::makePtr<ROL::ThyraVector<double>>(p_sample);
+
+      ROL::Ptr<ROL::Vector<double>> rol_x_diffs_ptr = ROL::makePtr<ROL::ThyraVector<double>>(x_diff_at_samples[step]);
+
+      data_interface->Z_Data_push_back(rol_p_samples_ptr);
+      data_interface->Y_Data_push_back(rol_x_diffs_ptr);
+
+      /*
+      * Recover beta for a previously proposed OED parameter.
+      *
+      * sample 0 is z_opt, so beta_0_sample = 0.
+      */
+      if (step > 0) {
+
+        HDSA::Ptr<HDSA::Vector<double>> z_sample =  HDSA::makePtr<HDSA::ROL_Vector<double>>(rol_p_samples_ptr);
+
+        HDSA::Ptr<HDSA::Dense_Matrix<double>> beta_sample = Compute_Beta_From_z(*z_sample, *data_interface->Get_z_opt(), *z_prior_interface, offline);
+
+        betas = Append_Betas(*betas, *beta_sample);
+
+        /*
+        * Optional diagnostic: check how well the current reduced
+        * space represents the actual previously proposed parameter.
+        */
+        {
+          HDSA::Ptr<HDSA::Vector<double>> z_reconstructed = data_interface->Get_z_opt()->Clone();
+
+          z_reconstructed->Set(*data_interface->Get_z_opt());
+
+          for (int i = 0; i < r; ++i) {
+            z_reconstructed->Scaled_Plus((*beta_sample)(i, 0), *(*offline.V)[i]);
+          }
+
+          const double projection_error =  M_z_Norm_Difference(*z_sample, *z_reconstructed, *z_prior_interface);
+
+          *out << "Reduced-space projection error for sample "  << step << " = "  << projection_error << std::endl;
+        }
+      }
+
+      /*
+      * Recompute the discrepancy posterior using all samples available through this step.
+      */
+      HDSA::Ptr<HDSA::MD_Posterior_Sampling<double>> post_sampling =
+          HDSA::makePtr<HDSA::MD_Posterior_Sampling<double>>(data_interface, u_prior_interface, z_prior_interface);
+
+      post_sampling->Compute_Posterior_Data(alpha_d, num_post_samples);
+
+      HDSA::Ptr<HDSA::Vector<double>> u_k = data_interface->Get_u_opt()->Clone();
+      HDSA::Ptr<HDSA::Vector<double>> z_k = data_interface->Get_z_opt()->Clone();
+      HDSA::Ptr<HDSA::Vector<double>> beta_k = HDSA::makePtr<HDSA::Std_Vector<double>>(r);
+
+      HDSA::Ptr<HDSA::MD_Continuation_Update<double>> cont_update = HDSA::makePtr<HDSA::MD_Continuation_Update<double>>(
+        data_interface, z_prior_interface, opt_prob_interface, post_sampling, hessian_analysis, random_number_generator, num_continuation_steps, grad_tol);
+
+      *out << "\nPosterior update using "  << step + 1  << " data sample(s)"  << std::endl;
+
+      cont_update->Posterior_Update_Mean(*u_k, *z_k, *beta_k);
+      current_beta_bar = Vector_To_Dense(*beta_k);
+      z_bars.push_back(z_k);
+    }
+
+    /*
+    * Determine the next OED radius and alpha_k.
+    */
+    HDSA::Ptr<HDSA::Vector<double>> radius_reference;
+
+    if (num_data_samples == 1) {
+      radius_reference = z_lofi;
+    } else {
+      radius_reference = z_bars[num_data_samples - 2];
+    }
+
+    const double prev_z_distance = M_z_Norm_Difference(*z_bars.back(), *radius_reference, *z_prior_interface);
+    const double alpha_k = prev_z_distance * prev_z_distance / alpha_k_denom;
+    const double constr_radius = prev_z_distance;
+
+    *out << "\nNext OED proposal" << std::endl;
+    *out << "-----------------------------------------------------" << std::endl;
+    *out << "Previous posterior movement radius = " << constr_radius << std::endl;
+    *out << "OED covariance coefficient alpha_k = " << alpha_k << std::endl;
+
+    md_oed->Set_Covariance_Coefficient(alpha_k);
+    
+    typename HDSA::MD_OED<double>::Seq_Design_Result seq_result =
+        md_oed->Generate_Seq_Optimal_Design(beta_0, alpha_d, *betas, *current_beta_bar, constr_radius, spg_options);
+
+    *out << "Sequential OED final objective = " << seq_result.optimizer_info.final_objective  << std::endl;
+    *out << "Sequential OED projected-gradient norm = " << seq_result.optimizer_info.projected_gradient_norm  << std::endl;
+
+    /*
+    * Return the newly proposed parameter.
+    */
+    hdsa_rol_p_ptr->Set(*(*seq_result.Z_new)[0]);
+  } 
+
+  if(Teuchos::nonnull(observer)) {
     const ROL::ThyraVector<double>  & thyra_x = dynamic_cast<const ROL::ThyraVector<double>&>(*rol_x_ptr);
     observer->parametersChanged();
     observer->observeSolution(1, *(thyra_x.getVector()), Teuchos::null, Teuchos::null, Teuchos::null);
-   }
+  }
 
-    return 0;
+  return 0;
 
 #else
   (void)piroModel;

--- a/packages/piro/test/CMakeLists.txt
+++ b/packages/piro/test/CMakeLists.txt
@@ -309,6 +309,8 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(copyTestInputFiles
         input_Solve_NOX_AdjointSensitivities_ImplicitAdjointME_Thyra.xml
         input_Solve_NOX_AdjointSensitivities_ExplicitAdjointME_Thyra.xml
         input_Analysis_HDSA.xml
+        input_Analysis_HDSA_continuation.xml
+        input_Analysis_HDSA_OED.xml
         input_Analysis_ROL_Tempus_Transient_MSD.xml
         input_Analysis_ROL_ReducedSpace_LineSearch.xml
         input_Analysis_ROL_ReducedSpace_LineSearch_AdjointSensitivities_CheckGradients.xml

--- a/packages/piro/test/Main_AnalysisDriver_HDSA.cpp
+++ b/packages/piro/test/Main_AnalysisDriver_HDSA.cpp
@@ -81,10 +81,6 @@ int main(int argc, char *argv[]) {
   // Initialize MPI
   Teuchos::GlobalMPISession mpiSession(&argc,&argv);
   int Proc=mpiSession.getRank();
-
-  HDSA::ROL_Vector<double>::nr = ROL::Elementwise::NormalRandom<double>(0.0,1.0,42+Proc);
-
-
   auto appComm = Tpetra::getDefaultComm();
 
   using Teuchos::RCP;
@@ -96,11 +92,13 @@ int main(int argc, char *argv[]) {
 
   Piro::SolverFactory solverFactory;
 
-  for (int iTest=0; iTest<1; iTest++) {
-
+  for (int iTest=0; iTest<3; iTest++) {
+    double expectedRelErr = 0;
     if (doAll) {
       switch (iTest) {
-       case 0: inputFile="input_Analysis_HDSA.xml"; break;
+       case 0: inputFile="input_Analysis_HDSA.xml"; expectedRelErr = 0.002106501; break;
+       case 1: inputFile="input_Analysis_HDSA_continuation.xml"; expectedRelErr = 0.001648131; break;
+       case 2: inputFile="input_Analysis_HDSA_OED.xml"; expectedRelErr = 0.0001228547; break;
        default : std::cout << "iTest logic error " << std::endl; exit(-1);
       }
     }
@@ -143,10 +141,8 @@ int main(int argc, char *argv[]) {
           auto model_tmp = rcp(new MockModelEval_H_Tpetra(appComm,false,probParams,true));
           p_opt = model_tmp->get_p_opt(0);
           true_p_opt = model_tmp->get_true_p_opt(0);
-          for (int k=0; k<2; k++) {
-            p_samples.push_back(model_tmp->get_param_samples(k));
-            u_diff_at_samples.push_back(model_tmp->get_solution_diff_at_samples(k));
-          }
+          p_samples.push_back(model_tmp->get_param_samples(0));
+          u_diff_at_samples.push_back(model_tmp->get_solution_diff_at_samples(0));
           model = rcp(new Piro::ProductModelEvaluator<double>(model_tmp,p_indices));
           if(explicitAdjointME) {
             RCP<Thyra::ModelEvaluator<double>> adjointModel_tmp = rcp(new MockModelEval_H_Tpetra(appComm,true));
@@ -188,7 +184,30 @@ int main(int argc, char *argv[]) {
 
         // Call the analysis routine
         RCP<Thyra::VectorBase<double>> p;  //the parameter nominal value in modelWithSolve is supposed to be the same as p_opt (low fidelity optimal paramer) 
-        status = Piro::PerformAnalysis(*piro, *piroParams, p, Teuchos::null, u_diff_at_samples, p_samples);
+        bool performAnalysisWithOED = piroParams->sublist("Analysis").sublist("HDSA").get("Perform HDSA Analysis With OED", false);
+        auto model_H = Teuchos::rcp_dynamic_cast<MockModelEval_H_Tpetra>(Teuchos::rcp_dynamic_cast<Piro::ProductModelEvaluator<double>>(model)->getModel());
+        if(performAnalysisWithOED) {
+          const int number_OED_steps = piroParams->sublist("Analysis").sublist("HDSA").get<int>("Number Of OED Steps", 1);
+          for (int oed_steps=0; oed_steps<number_OED_steps; oed_steps++) {              
+            status += Piro::PerformAnalysis(*piro, *piroParams, p, Teuchos::null, u_diff_at_samples, p_samples);
+            if(Teuchos::nonnull(model_H)) {
+              p_samples.push_back(p->clone_v());
+              u_diff_at_samples.push_back(model_H->get_solution_diff_at_param(p_samples.back()));
+            }
+          }
+          piroParams->sublist("Analysis").sublist("HDSA").set("Perform HDSA Analysis With OED", false);
+          status += Piro::PerformAnalysis(*piro, *piroParams, p, Teuchos::null, u_diff_at_samples, p_samples);
+        } else {
+          if(Teuchos::nonnull(model_H)) {
+            for (int k=1; k<2; k++) {
+              p_samples.push_back(model_H->get_param_samples(k));
+              u_diff_at_samples.push_back(model_H->get_solution_diff_at_samples(k));
+            }
+          }
+          //the parameter nominal value in modelWithSolve is supposed to be the same as p_opt (low fidelity optimal paramer) 
+          status += Piro::PerformAnalysis(*piro, *piroParams, p, Teuchos::null, u_diff_at_samples, p_samples);
+        }
+
         Teuchos::RCP<const Thyra::ProductVectorBase<double> > p_prodvec = Teuchos::rcp_dynamic_cast<Thyra::ProductVectorBase<double>>(p);
 
         auto p_opt_vec = ConverterT::getConstTpetraVector(p_opt);
@@ -210,17 +229,15 @@ int main(int argc, char *argv[]) {
         // diff = p_vec - true_p_vec
         diff.update(1.0, *p_vec, -1.0, *true_p_vec, 0.0 );
         double relErr = diff.norm2()/true_p_vec->norm2();
-
-        double expectedRelErr = 0.00210408306503;
         
-        double tol = 1e-6;  
+        double tol = 1e-5;  
         if(std::abs(relErr-expectedRelErr) > tol) {
           status+=100;
           if (Proc==0) {
             std::cout << "\nPiro_AnalysisDrvier_HDSA:  Expected relative error: "
                   <<  expectedRelErr << ", but computed relative error: " 
                   <<  relErr <<
-                  "\n Absolute difference grater than tol: " << tol <<   std::endl;
+                  "\n Absolute difference greater than tol: " << tol <<   std::endl;
           }
         }         
 

--- a/packages/piro/test/MockModelEval_H_Tpetra.cpp
+++ b/packages/piro/test/MockModelEval_H_Tpetra.cpp
@@ -303,6 +303,18 @@ MockModelEval_H_Tpetra::get_solution_diff_at_samples(int k) const {
     return diff_out;
 }
 
+Teuchos::RCP<Thyra::VectorBase<double>>
+MockModelEval_H_Tpetra::get_solution_diff_at_param(const Teuchos::RCP<const Thyra::VectorBase<double>> thyra_param_k) const {
+    auto thyra_pv_param_k = Teuchos::rcp_dynamic_cast<const Thyra::DefaultProductVector<double>>(thyra_param_k);
+    Teuchos::RCP<const Tpetra_Vector> param_k = ConverterT::getConstTpetraVector(thyra_pv_param_k->getVectorBlock(0));
+    Teuchos::RCP<Tpetra_Vector> diff = rcp(new Tpetra_Vector(x_map));
+    const int nodeNumElements = x_map->getLocalNumElements();
+    for (int i=0; i<nodeNumElements; i++)
+      diff->getDataNonConst()[i] = 0.2*std::pow(param_k->getData()[i],2);
+    auto diff_out = Thyra::createVector(diff, p_space);
+    return diff_out;
+}
+
 
 Teuchos::RCP<const Thyra::VectorSpaceBase<double>>
 MockModelEval_H_Tpetra::get_p_space(int l) const
@@ -386,7 +398,6 @@ MockModelEval_H_Tpetra::create_hess_g_pp( int j, int l1, int l2 ) const
     H = Teuchos::rcp(new Tpetra_CrsMatrix(hess_crs_graph_p));
   else
     H = Teuchos::rcp(new Tpetra_CrsMatrix(hess_crs_graph_x));
-  std::cout << __FILE__ << " " << __LINE__ << " " << j << " "<< l1 << " " << l2 << std::endl;
 
   return Teuchos::rcp(new MatrixBased_LOWS(Thyra::createLinearOp(H)));
 }

--- a/packages/piro/test/MockModelEval_H_Tpetra.hpp
+++ b/packages/piro/test/MockModelEval_H_Tpetra.hpp
@@ -75,7 +75,7 @@ typedef Thyra::TpetraOperatorVectorExtraction<
  * p_opt = (1+X)
  * x_opt = (1+X)^3
  * 
- * f_true  = x - p^3 + 0.2 p^2
+ * f_true  = x - p^3 - 0.2 p^2
  *
  * p_sample_0 = p_opt
  * p_sample_1 = X + X^2
@@ -166,6 +166,7 @@ class MockModelEval_H_Tpetra
   Teuchos::RCP<Thyra::VectorBase<double>> get_param_samples(int k) const;
   /** \brief . */
   Teuchos::RCP<Thyra::VectorBase<double>> get_solution_diff_at_samples(int k) const;
+  Teuchos::RCP<Thyra::VectorBase<double>> get_solution_diff_at_param(const Teuchos::RCP<const Thyra::VectorBase<double>> thyra_param_k) const;
 
   /** \brief . */
   Teuchos::RCP<Thyra::LinearOpBase<double>>

--- a/packages/piro/test/_input_Analysis_HDSA_OED.xml
+++ b/packages/piro/test/_input_Analysis_HDSA_OED.xml
@@ -19,7 +19,7 @@
                   </ParameterList>
                 </ParameterList>
                 <ParameterList name="VerboseObject">
-                  <Parameter name="Verbosity Level" type="string" value="medium" />
+                  <Parameter name="Verbosity Level" type="string" value="none" />
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -45,7 +45,7 @@
                   </ParameterList>
                 </ParameterList>
                 <ParameterList name="VerboseObject">
-                  <Parameter name="Verbosity Level" type="string" value="medium" />
+                  <Parameter name="Verbosity Level" type="string" value="none" />
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -71,7 +71,7 @@
                   </ParameterList>
                 </ParameterList>
                 <ParameterList name="VerboseObject">
-                  <Parameter name="Verbosity Level" type="string" value="medium" />
+                  <Parameter name="Verbosity Level" type="string" value="none" />
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -97,7 +97,7 @@
                   </ParameterList>
                 </ParameterList>
                 <ParameterList name="VerboseObject">
-                  <Parameter name="Verbosity Level" type="string" value="medium" />
+                  <Parameter name="Verbosity Level" type="string" value="none" />
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -142,7 +142,7 @@
                     </ParameterList>
                   </ParameterList>
                   <ParameterList name="VerboseObject">
-                    <Parameter name="Verbosity Level" type="string" value="low" />
+                    <Parameter name="Verbosity Level" type="string" value="none" />
                   </ParameterList>
                 </ParameterList>
               </ParameterList>
@@ -203,26 +203,27 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="Analysis">
-      <Parameter name="Output Level" type="int" value="4" />
+      <Parameter name="Output Level" type="int" value="2" />
       <Parameter name="Analysis Package" type="string" value="HDSA" />
      
       <ParameterList name="HDSA">
         <Parameter name="Number Of Parameters" type="int" value="1" />
         <Parameter name="Check Derivatives" type="bool" value="false" />
-        <Parameter name="Perform HDSA Analysis With OED" type="bool" value="false" />    
+        <Parameter name="Perform HDSA Analysis With OED" type="bool" value="true" />    
+        <Parameter name="Number Of OED Steps" type="int" value="2" /> 
         <ParameterList name="Derivative Checks">
           <Parameter name="Perform Reduced Derivative Checks" type="bool" value="false" />
           <Parameter name="Perform Expensive Derivative Checks" type="bool" value="false" />
         </ParameterList>
-        <ParameterList name="Prior Elliptic Operator">
+          <ParameterList name="Prior Elliptic Operator">
           <Parameter name="Operator Type" type="string" value="Hessian Of Response" />
           <Parameter name="Response Index" type="int" value="1" />
         </ParameterList>
-        <ParameterList name="Prior Mass Operator">
+          <ParameterList name="Prior Mass Operator">
           <Parameter name="Operator Type" type="string" value="Hessian Of Response" />
           <Parameter name="Response Index" type="int" value="2" />
         </ParameterList>
-        <ParameterList name="Prior Mass Cholesky Operator">
+          <ParameterList name="Prior Mass Cholesky Operator">
           <Parameter name="Operator Type" type="string" value="Hessian Of Response" />
           <Parameter name="Response Index" type="int" value="3" />
         </ParameterList>
@@ -239,18 +240,21 @@
         <ParameterList name="MD Prior">
           <Parameter name="alpha_u" type="double" value="0.25" />
           <Parameter name="alpha_z" type="double" value="0.25" />
-          <Parameter name="Number Of Singular Values" type="int" value="50" />
-          <Parameter name="Oversampling Factor" type="int" value="1" />
-          <Parameter name="Number Of Subspace Iterations" type="int" value="2" />    
+          <Parameter name="Number Of Singular Values" type="int" value="51" />
+          <Parameter name="Oversampling Factor" type="int" value="0" />
+          <Parameter name="Number Of Subspace Iterations" type="int" value="3" />    
           <Parameter name="Number Of Prior Samples" type="int" value="0" />    
         </ParameterList>
         <ParameterList name="MD Posterior">
           <Parameter name="alpha_d" type="double" value="1.e-5" />
-          <Parameter name="Number Of Prior Samples" type="int" value="50" />    
+          <Parameter name="Number Of Posterior Samples" type="int" value="0" />    
         </ParameterList>
         <ParameterList name="MD Hessian Analysis">
-          <Parameter name="Rank"  type="int" value="20" />
+          <Parameter name="Rank"  type="int" value="10" />
           <Parameter name="Oversampling Factor" type="int" value="10" />    
+        </ParameterList>
+        <ParameterList name="MD Continuation Update">
+          <Parameter name="Number Of Continuation Steps" type="int" value="3" />    
         </ParameterList>
       </ParameterList>
     
@@ -283,7 +287,7 @@
         <ParameterList name="ROL Options">
           <!-- =========== BEGIN GENERAL INPUT PARAMETER SUBLIST =========== -->
           <ParameterList name="General">
-            <Parameter name="Output Level" type="int" value="4" />
+            <Parameter name="Output Level" type="int" value="0" />
             <Parameter name="Variable Objective Function" type="bool" value="false" />
             <Parameter name="Scale for Epsilon Active Sets" type="double" value="1.0" />
 

--- a/packages/piro/test/_input_Analysis_HDSA_continuation.xml
+++ b/packages/piro/test/_input_Analysis_HDSA_continuation.xml
@@ -214,15 +214,15 @@
           <Parameter name="Perform Reduced Derivative Checks" type="bool" value="false" />
           <Parameter name="Perform Expensive Derivative Checks" type="bool" value="false" />
         </ParameterList>
-        <ParameterList name="Prior Elliptic Operator">
+          <ParameterList name="Prior Elliptic Operator">
           <Parameter name="Operator Type" type="string" value="Hessian Of Response" />
           <Parameter name="Response Index" type="int" value="1" />
         </ParameterList>
-        <ParameterList name="Prior Mass Operator">
+          <ParameterList name="Prior Mass Operator">
           <Parameter name="Operator Type" type="string" value="Hessian Of Response" />
           <Parameter name="Response Index" type="int" value="2" />
         </ParameterList>
-        <ParameterList name="Prior Mass Cholesky Operator">
+          <ParameterList name="Prior Mass Cholesky Operator">
           <Parameter name="Operator Type" type="string" value="Hessian Of Response" />
           <Parameter name="Response Index" type="int" value="3" />
         </ParameterList>
@@ -252,6 +252,10 @@
           <Parameter name="Rank"  type="int" value="20" />
           <Parameter name="Oversampling Factor" type="int" value="10" />    
         </ParameterList>
+        <ParameterList name="MD Continuation Update">
+          <Parameter name="Number Of Continuation Steps" type="int" value="3" />    
+        </ParameterList>
+
       </ParameterList>
     
       <ParameterList name="ROL">


### PR DESCRIPTION
Enabling HDSA OED capability from HdsaLib. 
Given a set of parameter samples and corresponding differences between the high-fidelity and low fidelity solutions, OED can be used to propose a new parameter sample.  

Added tests exercising OED and continuation capability.

<!---  COMMENT BLOCK

 * Choose `base:develop` and NOT `base:master`!
 * Title should start with "PackageName:  ".
 * Select Reviewers, Assignees, and Labels.
   - Should this PR be in the Release Notes?  Apply "Release Note" label.
 * Notify the appropriate teams.

@trilinos/<teamName>

## Motivation
 * Why is this change needed?  GitHub issue(s)?

## Related Issues
 * Closes `put-issue-number-here`
 * Other relations: `Blocks` `Is blocked by`, `Follows`, `Precedes`, `Related to`, `Part of`, and `Composed of`.

## Stakeholder Feedback
 * Often provided through comments in the PR.

## Testing
 * Testing that was completed, tests added, or reasons testing not completed.

## Additional Information
  Anything else we need to know in evaluating this pull request?
-->
