### PR TITLE
Tpetra/Stokhos: clean up old KK version ifdefs

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_CrsMatrix_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_CrsMatrix_UQ_PCE.hpp
@@ -1436,12 +1436,8 @@ public:
 namespace KokkosSparse {
 
 template <
-#if KOKKOSKERNELS_VERSION >= 40199
           typename ExecutionSpace,
-#endif
-#if KOKKOSKERNELS_VERSION >= 40299
           typename Handle,
-#endif
           typename AlphaType,
           typename BetaType,
           typename MatrixType,
@@ -1452,30 +1448,18 @@ template <
 typename std::enable_if<
   Kokkos::is_view_uq_pce< Kokkos::View< InputType, InputP... > >::value &&
   Kokkos::is_view_uq_pce< Kokkos::View< OutputType, OutputP... > >::value
-#if KOKKOSKERNELS_VERSION >= 40299
   && KokkosSparse::is_crs_matrix_v<MatrixType>
   && (Kokkos::View< OutputType, OutputP... >::rank() == 1)
-#endif
   >::type
 spmv(
-#if KOKKOSKERNELS_VERSION >= 40199
   const ExecutionSpace& space,
-#endif
-#if KOKKOSKERNELS_VERSION < 40299
-  KokkosKernels::Experimental::Controls,
-#else
   Handle* handle,
-#endif
   const char mode[],
   const AlphaType& a,
   const MatrixType& A,
   const Kokkos::View< InputType, InputP... >& x,
   const BetaType& b,
-  const Kokkos::View< OutputType, OutputP... >& y
-#if KOKKOSKERNELS_VERSION < 40299
-  , const RANK_ONE
-#endif
-  )
+  const Kokkos::View< OutputType, OutputP... >& y)
 {
   typedef Kokkos::View< OutputType, OutputP... > OutputVectorType;
   typedef Kokkos::View< InputType, InputP... > InputVectorType;
@@ -1484,12 +1468,10 @@ spmv(
   typedef Stokhos::MeanMultiply<MatrixType, typename InputVectorType::const_type,
                                 OutputVectorType> mean_multiply_type;
 
-#if KOKKOSKERNELS_VERSION >= 40199
   if(space != ExecutionSpace()) {
     Kokkos::Impl::raise_error(
       "Stokhos spmv not implemented for non-default execution space instance");
   }
-#endif
   if(mode[0]!='N') {
     Kokkos::Impl::raise_error(
       "Stokhos spmv not implemented for transposed or conjugated matrix-vector multiplies");
@@ -1511,12 +1493,8 @@ spmv(
 }
 
 template <
-#if KOKKOSKERNELS_VERSION >= 40199
           typename ExecutionSpace,
-#endif
-#if KOKKOSKERNELS_VERSION >= 40299
           typename Handle,
-#endif
           typename AlphaType,
           typename BetaType,
           typename MatrixType,
@@ -1527,37 +1505,23 @@ template <
 typename std::enable_if<
   Kokkos::is_view_uq_pce< Kokkos::View< InputType, InputP... > >::value &&
   Kokkos::is_view_uq_pce< Kokkos::View< OutputType, OutputP... > >::value
-#if KOKKOSKERNELS_VERSION >= 40299
   && KokkosSparse::is_crs_matrix_v<MatrixType>
   && (Kokkos::View< OutputType, OutputP... >::rank() == 2)
-#endif
   >::type
 spmv(
-#if KOKKOSKERNELS_VERSION >= 40199
   const ExecutionSpace& space,
-#endif
-#if KOKKOSKERNELS_VERSION < 40299
-  KokkosKernels::Experimental::Controls,
-#else
   Handle* handle,
-#endif
   const char mode[],
   const AlphaType& a,
   const MatrixType& A,
   const Kokkos::View< InputType, InputP... >& x,
   const BetaType& b,
-  const Kokkos::View< OutputType, OutputP... >& y
-#if KOKKOSKERNELS_VERSION < 40299
-  , const RANK_TWO
-#endif
-  )
+  const Kokkos::View< OutputType, OutputP... >& y)
 {
-#if KOKKOSKERNELS_VERSION >= 40199
   if(space != ExecutionSpace()) {
     Kokkos::Impl::raise_error(
       "Stokhos spmv not implemented for non-default execution space instance");
   }
-#endif
   if(mode[0]!='N') {
     Kokkos::Impl::raise_error(
       "Stokhos spmv not implemented for transposed or conjugated matrix-vector multiplies");
@@ -1565,13 +1529,7 @@ spmv(
   if (y.extent(1) == 1) {
     auto y_1D = subview(y, Kokkos::ALL(), 0);
     auto x_1D = subview(x, Kokkos::ALL(), 0);
-#if KOKKOSKERNELS_VERSION >= 40299
     spmv(space, handle, mode, a, A, x_1D, b, y_1D);
-#elif (KOKKOSKERNELS_VERSION < 40299) && (KOKKOSKERNELS_VERSION >= 40199)
-    spmv(space, KokkosKernels::Experimental::Controls(), mode, a, A, x_1D, b, y_1D, RANK_ONE());
-#else
-    spmv(KokkosKernels::Experimental::Controls(), mode, a, A, x_1D, b, y_1D, RANK_ONE());
-#endif
   }
   else {
     typedef Kokkos::View< OutputType, OutputP... > OutputVectorType;

--- a/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector.hpp
@@ -498,12 +498,8 @@ public:
 namespace KokkosSparse {
 
 template <
-#if KOKKOSKERNELS_VERSION >= 40199
           typename ExecutionSpace,
-#endif
-#if KOKKOSKERNELS_VERSION >= 40299
           typename Handle,
-#endif
           typename AlphaType,
           typename BetaType,
           typename MatrixType,
@@ -514,29 +510,18 @@ template <
 typename std::enable_if<
   Kokkos::is_view_mp_vector< Kokkos::View< InputType, InputP... > >::value &&
   Kokkos::is_view_mp_vector< Kokkos::View< OutputType, OutputP... > >::value
-#if KOKKOSKERNELS_VERSION >= 40299
   && KokkosSparse::is_crs_matrix_v<MatrixType>
   && (Kokkos::View< OutputType, OutputP... >::rank() == 1)
-#endif
   >::type
 spmv(
-#if KOKKOSKERNELS_VERSION >= 40199
   const ExecutionSpace& space,
-#endif
-#if KOKKOSKERNELS_VERSION < 40299
-  KokkosKernels::Experimental::Controls,
-#else
   Handle* handle,
-#endif
   const char mode[],
   const AlphaType& a,
   const MatrixType& A,
   const Kokkos::View< InputType, InputP... >& x,
   const BetaType& b,
   const Kokkos::View< OutputType, OutputP... >& y
-#if KOKKOSKERNELS_VERSION < 40299
-  , const RANK_ONE
-#endif
 )
 {
   typedef Kokkos::View< OutputType, OutputP... > OutputVectorType;
@@ -548,12 +533,10 @@ spmv(
   typedef std::remove_const_t<typename InputVectorType::element_type::value_type> value_type;
 #endif
 
-#if KOKKOSKERNELS_VERSION >= 40199
   if(space != ExecutionSpace()) {
     Kokkos::Impl::raise_error(
       "Stokhos spmv not implemented for non-default execution space instance");
   }
-#endif
   if(mode[0]!='N') {
     Kokkos::Impl::raise_error(
       "Stokhos spmv not implemented for transposed or conjugated matrix-vector multiplies");
@@ -613,12 +596,8 @@ spmv(
 }
 
 template <
-#if KOKKOSKERNELS_VERSION >= 40199
           typename ExecutionSpace,
-#endif
-#if KOKKOSKERNELS_VERSION >= 40299
           typename Handle,
-#endif
           typename AlphaType,
           typename BetaType,
           typename MatrixType,
@@ -629,37 +608,23 @@ template <
 typename std::enable_if<
   Kokkos::is_view_mp_vector< Kokkos::View< InputType, InputP... > >::value &&
   Kokkos::is_view_mp_vector< Kokkos::View< OutputType, OutputP... > >::value
-#if KOKKOSKERNELS_VERSION >= 40299
   && KokkosSparse::is_crs_matrix_v<MatrixType>
   && (Kokkos::View< OutputType, OutputP... >::rank() == 2)
-#endif
   >::type
 spmv(
-#if KOKKOSKERNELS_VERSION >= 40199
   const ExecutionSpace& space,
-#endif
-#if KOKKOSKERNELS_VERSION < 40299
-  KokkosKernels::Experimental::Controls,
-#else
   Handle* handle,
-#endif
   const char mode[],
   const AlphaType& a,
   const MatrixType& A,
   const Kokkos::View< InputType, InputP... >& x,
   const BetaType& b,
-  const Kokkos::View< OutputType, OutputP... >& y
-#if KOKKOSKERNELS_VERSION < 40299
-  , const RANK_TWO
-#endif
-  )
+  const Kokkos::View< OutputType, OutputP... >& y)
 {
-#if KOKKOSKERNELS_VERSION >= 40199
   if(space != ExecutionSpace()) {
     Kokkos::Impl::raise_error(
       "Stokhos spmv not implemented for non-default execution space instance");
   }
-#endif
   if(mode[0]!='N') {
     Kokkos::Impl::raise_error(
       "Stokhos spmv not implemented for transposed or conjugated matrix-vector multiplies");
@@ -667,13 +632,7 @@ spmv(
   if (y.extent(1) == 1) {
     auto y_1D = subview(y, Kokkos::ALL(), 0);
     auto x_1D = subview(x, Kokkos::ALL(), 0);
-#if KOKKOSKERNELS_VERSION >= 40299
     spmv(space, handle, mode, a, A, x_1D, b, y_1D);
-#elif (KOKKOSKERNELS_VERSION < 40299) && (KOKKOSKERNELS_VERSION >= 40199)
-    spmv(space, KokkosKernels::Experimental::Controls(), mode, a, A, x_1D, b, y_1D, RANK_ONE());
-#else
-    spmv(KokkosKernels::Experimental::Controls(), mode, a, A, x_1D, b, y_1D, RANK_ONE());
-#endif
   }
   else {
     typedef Kokkos::View< OutputType, OutputP... > OutputVectorType;

--- a/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
@@ -2127,9 +2127,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, threaded_add_sorted, SC, LO, GO
   Tpetra::MMdetails::AddKernels<SC, LO, GO, NT>::addSorted(
       valsCRS[0], rowptrsCRS[0], colindsCRS[0], one,
       valsCRS[1], rowptrsCRS[1], colindsCRS[1], one,
-#if KOKKOSKERNELS_VERSION >= 40299
       nrows,  // assumes square matrices
-#endif
       valsCRS[2], rowptrsCRS[2], colindsCRS[2]);
 
   ExecSpace().fence();


### PR DESCRIPTION
Clean up old #ifdef branches based on the KokkosKernels version, where the branch is either always or never true anymore.

@trilinos/tpetra
@trilinos/stokhos