### PR TITLE
Turn off ccache for coverage builds

### DIFF
--- a/cmake/SimpleTesting/cmake/ctest-stage-configure.cmake
+++ b/cmake/SimpleTesting/cmake/ctest-stage-configure.cmake
@@ -14,6 +14,11 @@ banner("START configure step")
 message(">>> CTEST_SOURCE_DIRECTORY: ${CTEST_SOURCE_DIRECTORY}")
 message(">>> CTEST_BINARY_DIRECTORY: ${CTEST_BINARY_DIRECTORY}")
 
+if(CTEST_BUILD_NAME MATCHES ".*coverage.*")
+    message("Disabling CCache for coverage build")
+    set(ENV{CCACHE_NODISABLE})
+endif()
+
 ctest_configure(SOURCE ${CTEST_SOURCE_DIRECTORY}
                 BUILD  ${CTEST_BINARY_DIRECTORY}
                 RETURN_VALUE configure_error


### PR DESCRIPTION
`-fprofile-abs-path` does not work with ccache, so ccache removes it, causing our path resolution in coverage results to not work.  This isn't the best fix ever, but it does work.  Slows down the coverage builds a good amount though....

@trilinos/framework 

## Motivation
Prefer slow coverage results to none at all.

## Related Issues
https://sems-atlassian-son.sandia.gov/jira/browse/TRILFRAME-762

## Testing
Tested locally with only Teuchos.

