### PR TITLE
Framework: add cuda-12-release-static all package config

### DIFF
--- a/packages/framework/ini-files/config-specs.ini
+++ b/packages/framework/ini-files/config-specs.ini
@@ -1370,6 +1370,10 @@ opt-set-cmake-var Kokkos_CoreUnitTest_Cuda1_EXTRA_ARGS STRING : --gtest_filter=-
 opt-set-cmake-var Kokkos_CoreUnitTest_CudaGraphScratch_EXTRA_ARGS STRING : --gtest_filter=-*sized_functor*
 opt-set-cmake-var Kokkos_CoreUnitTest_Cuda_SmokeTest_EXTRA_ARGS STRING : --gtest_filter=-*sized_functor*
 
+[rhel_cuda-12-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_all]
+use rhel_cuda-12-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables
+use PACKAGE-ENABLES|ALL
+
 [rhel_cuda-12-gcc-openmpi_debug_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_all]
 use rhel_cuda-12-gcc-openmpi_release_static_Ampere80_no-asan_complex_no-fpic_mpi_pt_no-rdc_no-uvm_deprecated-on_no-package-enables
 use BUILD-TYPE|DEBUG


### PR DESCRIPTION

@trilinos/framework 

## Motivation
Writing a tool to test CI configurations with new container builds and found that this config was missing.
