### PR TITLE
Belos: fix solver-factory registry not shared across Windows DLL boundary (blocked by #15556).

### DIFF
--- a/packages/belos/tpetra/src/BelosSolverFactory_Tpetra.hpp
+++ b/packages/belos/tpetra/src/BelosSolverFactory_Tpetra.hpp
@@ -37,4 +37,28 @@ class SolverFactorySelector<SC,Tpetra::MultiVector<SC, LO, GO, NT>,Tpetra::Opera
 } // namespace Impl
 } // namespace Belos
 
+// Every consumer of this header (this DLL's own solver-registrar .cpp files,
+// and any downstream executable or shared library) must import the single,
+// DLL-exported instantiation of SolverFactoryParent defined in
+// BelosSolverFactory_Tpetra_ETI.cpp, rather than silently creating its own
+// private one. SolverFactoryParent's registry (get_solverManagers()) is a
+// function-local static inside a template static method - vague linkage -
+// and Windows PE does not merge vague-linkage template statics across DLL/EXE
+// boundaries the way ELF does, so without this extern template declaration
+// every consumer would get its own, empty, unsynchronized copy of the solver
+// registry.
+#include "BelosTpetra_DLLExportMacro.h"
+#include "TpetraCore_ETIHelperMacros.h"
+
+TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#define BELOS_TPETRA_SOLVERFACTORYPARENT_EXTERN_INSTANT( SC, LO, GO, NT ) \
+  extern template class BELOSTPETRA_LIB_DLL_EXPORT \
+    Belos::Impl::SolverFactoryParent<SC, ::Tpetra::MultiVector<SC,LO,GO,NT>, \
+      ::Tpetra::Operator<SC,LO,GO,NT>, ::Belos::DefaultDenseMatrix<int,SC> >;
+
+TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_SOLVERFACTORYPARENT_EXTERN_INSTANT )
+
+#undef BELOS_TPETRA_SOLVERFACTORYPARENT_EXTERN_INSTANT
+
 #endif // BELOSSOLVERFACTORY_TPETRA_HPP

--- a/packages/belos/tpetra/src/BelosSolverFactory_Tpetra_ETI.cpp
+++ b/packages/belos/tpetra/src/BelosSolverFactory_Tpetra_ETI.cpp
@@ -1,0 +1,34 @@
+// @HEADER
+// *****************************************************************************
+//                 Belos: Block Linear Solvers Package
+//
+// Copyright 2004-2016 NTESS and the Belos contributors.
+// SPDX-License-Identifier: BSD-3-Clause
+// *****************************************************************************
+// @HEADER
+
+// Explicit, DLL-exported instantiation of Belos::Impl::SolverFactoryParent
+// for every Tpetra ETI combination. SolverFactoryParent's registry
+// (get_solverManagers()) is a function-local static inside a template static
+// method - vague linkage - so without this file every consumer of
+// BelosSolverFactory_Tpetra.hpp (this DLL's own registrar .cpp files, and any
+// downstream executable or shared library) would instantiate its own private,
+// unsynchronized copy of the registry across the Windows DLL boundary. This
+// is the one translation unit that owns the real, exported instantiation;
+// BelosSolverFactory_Tpetra.hpp declares the matching extern template for
+// every other translation unit to import instead of re-instantiating.
+
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosTpetra_DLLExportMacro.h"
+#include "TpetraCore_ETIHelperMacros.h"
+
+TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#define BELOS_TPETRA_SOLVERFACTORYPARENT_INSTANT( SC, LO, GO, NT ) \
+  template class BELOSTPETRA_LIB_DLL_EXPORT \
+    Belos::Impl::SolverFactoryParent<SC, ::Tpetra::MultiVector<SC,LO,GO,NT>, \
+      ::Tpetra::Operator<SC,LO,GO,NT>, ::Belos::DefaultDenseMatrix<int,SC> >;
+
+TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_SOLVERFACTORYPARENT_INSTANT )
+
+#undef BELOS_TPETRA_SOLVERFACTORYPARENT_INSTANT

--- a/packages/belos/tpetra/src/CMakeLists.txt
+++ b/packages/belos/tpetra/src/CMakeLists.txt
@@ -4,6 +4,10 @@
 # A) Package-specific configuration options
 #
 
+SET(CURRENT_PACKAGE BELOSTPETRA)
+CONFIGURE_FILE("${Trilinos_SOURCE_DIR}/packages/Trilinos_DLLExportMacro.h.in"
+  ${CMAKE_CURRENT_BINARY_DIR}/BelosTpetra_DLLExportMacro.h)
+
 #
 # B) Define the header and source files (and directories)
 #
@@ -16,6 +20,9 @@ SET(HEADERS "")
 SET(SOURCES "")
 
 TRIBITS_INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
+APPEND_SET(HEADERS
+  ${CMAKE_CURRENT_BINARY_DIR}/BelosTpetra_DLLExportMacro.h
+  )
 
 #
 # Core Files
@@ -39,6 +46,7 @@ APPEND_SET(SOURCES
   BelosTpetraAdapter.cpp
   Belos_Details_Tpetra_registerLinearSolverFactory.cpp
   Belos_Details_Tpetra_registerSolverFactory.cpp
+  BelosSolverFactory_Tpetra_ETI.cpp
   )
 
 APPEND_SET(HEADERS
@@ -136,4 +144,5 @@ TRIBITS_ADD_LIBRARY(
   HEADERS ${HEADERS}
   SOURCES ${SOURCES}
   DEPLIBS belos
+  DEFINES -DBELOSTPETRA_LIB_EXPORTS_MODE
   )


### PR DESCRIPTION
@trilinos/belos

## Motivation

`Belos::Impl::SolverFactoryParent`'s solver registry is a template-static Meyers singleton defined in a header, so it silently gets a separate, empty copy in every Windows DLL/EXE that touches it - `belostpetra.dll` registers solvers into its own copy, and any consumer executable (or another shared lib, e.g. MueLu/FROSch) reads from its own, always-empty copy. Result: every Tpetra solver lookup fails with `std::invalid_argument`, reproduced live via `Ifpack2_small_gmres_belos`. Fix: explicit `template class` instantiation + `extern template` + a new `BELOSTPETRA_LIB_DLL_EXPORT` macro (existing `Trilinos_DLLExportMacro.h.in` pattern, same one already used by `packages/anasazi/tpetra/util/ModeLaplace`) so there is exactly one exported instantiation and every consumer imports it instead of re-instantiating its own. Touches only `packages/belos/tpetra/src/` (3 files, 1 new). The one real open risk - this exact `extern template class` + dllexport/dllimport combo on a class template had zero precedent anywhere else in Trilinos - is now **[confirmed]** resolved: built clean and `Ifpack2_small_gmres_belos` passes (see Testing). Xpetra has the same bug independently and is explicitly *not* fixed here (#14816 stays open). **Blocked by #15556** landing first (see header) - `develop` does not link as a Windows shared build without it.

## Environment

| Item       | Value                                            |
| ---------- | ------------------------------------------------ |
| OS         | Windows 11 Pro x64, Build 26100                  |
| CPU        | Intel Core i9-12900H (20 logical cores)          |
| CMake      | 4.3.2                                           |
| MSVC       | 19.51.36246 for x64 (VS 2026 Community)                  |
| clang-cl   | 21.1.5;x86_64-pc-windows-msvc;thread-model:posix |
| Ninja      | 1.12.1                                           |
| Build type | RelWithDebInfo, shared libs, C++20 |

## Build

> P.S. use `x64 Native Tools Command Prompt for VS`.

<details>
  <summary>Build Command</summary>

```cmd
cmake ^

           # --- Generator, source tree, build directory, configuration type (Trilinos) ---
           -G ^
           Ninja ^
           -DCMAKE_C_COMPILER=D:/local/LLVM/bin/clang-cl.exe ^
           -DCMAKE_CXX_COMPILER=D:/local/LLVM/bin/clang-cl.exe ^
           -S ^
           D:/Develop/Trilinos ^
           -B ^
           D:/Develop/Trilinos/bifpack2serial ^
           -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ^
           -DCMAKE_CXX_STANDARD=20 ^
           -DBUILD_SHARED_LIBS=ON ^
           "-DCMAKE_CXX_FLAGS=-Wno-everything -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined" ^
           "-DCMAKE_C_FLAGS=-Wno-everything -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined" ^
           -DTPL_ENABLE_DLlib=OFF ^
           "-DCMAKE_EXE_LINKER_FLAGS=/LIBPATH:"D:/local/LLVM/lib/clang/21/lib/windows" clang_rt.asan_dynamic_runtime_thunk-x86_64.lib clang_rt.asan_dynamic-x86_64.lib /LIBPATH:"D:/local/LLVM/lib/clang/21/lib/windows" clang_rt.ubsan_standalone-x86_64.lib clang_rt.ubsan_standalone_cxx-x86_64.lib" ^
           "-DCMAKE_SHARED_LINKER_FLAGS=/LIBPATH:"D:/local/LLVM/lib/clang/21/lib/windows" clang_rt.asan_dynamic_runtime_thunk-x86_64.lib clang_rt.asan_dynamic-x86_64.lib /LIBPATH:"D:/local/LLVM/lib/clang/21/lib/windows" clang_rt.ubsan_standalone-x86_64.lib clang_rt.ubsan_standalone_cxx-x86_64.lib" ^
           "-DCMAKE_MODULE_LINKER_FLAGS=/LIBPATH:"D:/local/LLVM/lib/clang/21/lib/windows" clang_rt.asan_dynamic_runtime_thunk-x86_64.lib clang_rt.asan_dynamic-x86_64.lib /LIBPATH:"D:/local/LLVM/lib/clang/21/lib/windows" clang_rt.ubsan_standalone-x86_64.lib clang_rt.ubsan_standalone_cxx-x86_64.lib" ^
           -DCMAKE_POLICY_DEFAULT_CMP0091=NEW ^
           -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL ^
           -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON ^

           # --- Ninja: explicit x64 linker and manifest tools ---
           "-DCMAKE_LINKER=C:/Program Files/Microsoft Visual Studio/18/Community/VC/Tools/MSVC/14.51.36231/bin/HostX64/x64/link.exe" ^
           "-DCMAKE_RC_COMPILER=C:/Program Files (x86)/Windows Kits/10/Bin/10.0.26100.0/x64/rc.exe" ^
           "-DCMAKE_MT=C:/Program Files (x86)/Windows Kits/10/Bin/10.0.26100.0/x64/mt.exe" ^

           # --- vcpkg toolchain and CMAKE_PREFIX_PATH ---
           -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake ^
           -DCMAKE_PREFIX_PATH=C:/vcpkg/installed/x64-windows ^

           # --- Third-party BLAS/LAPACK (OpenBLAS + lapack) ---
           -DTPL_ENABLE_BLAS=ON ^
           -DBLAS_LIBRARY_DIRS=C:/vcpkg/installed/x64-windows/lib ^
           -DBLAS_LIBRARY_NAMES=openblas ^
           -DTPL_ENABLE_LAPACK=ON ^
           -DLAPACK_LIBRARY_DIRS=C:/vcpkg/installed/x64-windows/lib ^
           -DLAPACK_LIBRARY_NAMES=lapack ^

           # --- Google Test (TriBITS TPL_gtest paths) ---
           -DTPL_gtest_INCLUDE_DIRS=C:/vcpkg/installed/x64-windows/include ^
           -DTPL_gtest_LIBRARIES=C:/vcpkg/installed/x64-windows/lib/gtest.lib ^

           # --- Kokkos backend: Serial ---
           -DKokkos_ENABLE_SERIAL=ON ^
           -DKokkos_ENABLE_OPENMP=OFF ^
           -DTPL_ENABLE_CUDA=OFF ^
           -DTPL_ENABLE_MPI=OFF ^

           # --- Trilinos package toggles (auto-enabling Windows-disabled required deps: Tpetra) ---
           -DTrilinos_ENABLE_ALL_PACKAGES=OFF ^
           -DTrilinos_ENABLE_Ifpack2=ON ^
           -DTrilinos_ENABLE_Tpetra=ON ^

           # --- Tests, examples, PyTrilinos2, complex ---
           -DTrilinos_ENABLE_TESTS=ON ^
           -DTrilinos_ENABLE_EXAMPLES=ON ^
           -DTrilinos_ENABLE_PyTrilinos2=OFF ^
           -DTrilinos_ENABLE_COMPLEX_DOUBLE=ON ^
           -DTrilinos_ENABLE_COMPLEX_FLOAT=OFF ^
           -DTrilinos_ENABLE_FLOAT=OFF ^
           -DTpetra_INST_FLOAT=OFF ^
           -DTpetra_INST_COMPLEX_FLOAT=OFF
```

</details>

## Related Issues

|Description|Link|
|:-|:-|
|Root issue | https://github.com/trilinos/Trilinos/issues/14816 |
|Windows build checklist table | https://github.com/trilinos/Trilinos/issues/15557 |
|Started testing from|https://github.com/trilinos/Trilinos/pull/15556|
|Published LLVM Issue| https://github.com/llvm/llvm-project/issues/223073 |

## Stakeholder Feedback

@cgcgcg

## Testing

Test command (targeted for `Ifpack2_small_gmres_belos`):

```powershell
$savedPath = $env:PATH
$buildDir  = "D:\Develop\Trilinos\bifpack2serial"
$env:PATH  = "$buildDir\lib;$env:PATH"
try {
    Push-Location "$buildDir"
    & ctest -VV --debug --output-on-failure -R Ifpack2_small_gmres_belos
}
finally {
    Pop-Location
    $env:PATH = $savedPath
}
```

### Before

<details>
  <summary>Before fix</summary>

```log
176: Test command: D:\Develop\Trilinos\bifpack2serial\packages\ifpack2\test\belos\Ifpack2_tif_belos.exe "--xml_file=test_gmres_small_sym_mm.xml"
176: Working Directory: D:/Develop/Trilinos/bifpack2serial/packages/ifpack2/test/belos
   Current_Time: Sep 11 18:30 Russia TZ 2 Standard Time
176: Test timeout computed to be: 1500
176: Every proc reading parameters from xml_file: test_gmres_small_sym_mm.xml
176: Matrix Market file for sparse matrix A: small_sym.mtx
176: =================================================================
176: ==110900==ERROR: AddressSanitizer: access-violation on unknown address 0x000000000000 (pc 0x7ff68c435859 bp 0x0093071ce540 sp 0x0093071cb140 T0)
176: ==110900==The signal is caused by a READ memory access.
176: ==110900==Hint: address points to the zero page.
176:     #0 0x7ff68c435858 in build_solver<double, class Tpetra::MultiVector<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Tpetra::Operator<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>>(class Teuchos::ParameterList &, class Teuchos::RCP<class Belos::LinearProblem<double, class Tpetra::MultiVector<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Tpetra::Operator<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Teuchos::SerialDenseMatrix<int, double>>>) D:\Develop\Trilinos\packages\ifpack2\test\belos\build_solver.hpp:40
176:     #1 0x7ffe0078baff  (C:\Windows\SYSTEM32\VCRUNTIME140.dll+0x18001baff)
176:     #2 0x7ffe007733c6  (C:\Windows\SYSTEM32\VCRUNTIME140.dll+0x1800033c6)
176:     #3 0x7ffe19f841b5  (C:\Windows\SYSTEM32\ntdll.dll+0x1801241b5)
176:     #4 0x7ff68c434c4c in build_solver<double, class Tpetra::MultiVector<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Tpetra::Operator<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>>(class Teuchos::ParameterList &, class Teuchos::RCP<class Belos::LinearProblem<double, class Tpetra::MultiVector<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Tpetra::Operator<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Teuchos::SerialDenseMatrix<int, double>>>) D:\Develop\Trilinos\packages\ifpack2\test\belos\build_solver.hpp:38
176:     #5 0x7ff68c414b5f in main D:\Develop\Trilinos\packages\ifpack2\test\belos\belos_solve.cpp:165
176:     #6 0x7ff68c4686be in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
176:     #7 0x7ff68c4686be in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
176:     #8 0x7ffe188fcd86  (C:\Windows\System32\KERNEL32.DLL+0x18002cd86)
176:     #9 0x7ffe19f0caeb  (C:\Windows\SYSTEM32\ntdll.dll+0x1800acaeb)
176: 
176: ==110900==Register values:
176: rax = 0  rbx = 93071ce4c0  rcx = 0  rdx = 1a12e380000  
176: rdi = 93071cbf70  rsi = 7ffe008c43b0  rbp = 93071ce540  rsp = 93071cb140  
176: r8  = 7ffffffffffffffc  r9  = 93071cafa8  r10 = 203a6e6f  r11 = 0  
176: r12 = 93071cb250  r13 = 0  r14 = 93071cc0c0  r15 = 0  
176: AddressSanitizer can not provide additional info.
176: SUMMARY: AddressSanitizer: access-violation D:\Develop\Trilinos\packages\ifpack2\test\belos\build_solver.hpp:40 in build_solver<double, class Tpetra::MultiVector<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Tpetra::Operator<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>>(class Teuchos::ParameterList &, class Teuchos::RCP<class Belos::LinearProblem<double, class Tpetra::MultiVector<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Tpetra::Operator<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Teuchos::SerialDenseMatrix<int, double>>>)
176: ==110900==ABORTING
1/1 Test #176: Ifpack2_small_gmres_belos ........Testing Ifpack2_small_gmres_belos ... ***Failed  Required regular expression not found. Regex=[End Result: TEST PASSED
]  0.37 sec
Every proc reading parameters from xml_file: test_gmres_small_sym_mm.xml
Matrix Market file for sparse matrix A: small_sym.mtx
=================================================================
==110900==ERROR: AddressSanitizer: access-violation on unknown address 0x000000000000 (pc 0x7ff68c435859 bp 0x0093071ce540 sp 0x0093071cb140 T0)
==110900==The signal is caused by a READ memory access.
==110900==Hint: address points to the zero page.
    #0 0x7ff68c435858 in build_solver<double, class Tpetra::MultiVector<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Tpetra::Operator<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>>(class Teuchos::ParameterList &, class Teuchos::RCP<class Belos::LinearProblem<double, class Tpetra::MultiVector<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Tpetra::Operator<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Teuchos::SerialDenseMatrix<int, double>>>) D:\Develop\Trilinos\packages\ifpack2\test\belos\build_solver.hpp:40
    #1 0x7ffe0078baff  (C:\Windows\SYSTEM32\VCRUNTIME140.dll+0x18001baff)
    #2 0x7ffe007733c6  (C:\Windows\SYSTEM32\VCRUNTIME140.dll+0x1800033c6)
    #3 0x7ffe19f841b5  (C:\Windows\SYSTEM32\ntdll.dll+0x1801241b5)
    #4 0x7ff68c434c4c in build_solver<double, class Tpetra::MultiVector<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Tpetra::Operator<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>>(class Teuchos::ParameterList &, class Teuchos::RCP<class Belos::LinearProblem<double, class Tpetra::MultiVector<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Tpetra::Operator<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Teuchos::SerialDenseMatrix<int, double>>>) D:\Develop\Trilinos\packages\ifpack2\test\belos\build_solver.hpp:38
    #5 0x7ff68c414b5f in main D:\Develop\Trilinos\packages\ifpack2\test\belos\belos_solve.cpp:165
    #6 0x7ff68c4686be in invoke_main D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
    #7 0x7ff68c4686be in __scrt_common_main_seh D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
    #8 0x7ffe188fcd86  (C:\Windows\System32\KERNEL32.DLL+0x18002cd86)
    #9 0x7ffe19f0caeb  (C:\Windows\SYSTEM32\ntdll.dll+0x1800acaeb)

==110900==Register values:
rax = 0  rbx = 93071ce4c0  rcx = 0  rdx = 1a12e380000  
rdi = 93071cbf70  rsi = 7ffe008c43b0  rbp = 93071ce540  rsp = 93071cb140  
r8  = 7ffffffffffffffc  r9  = 93071cafa8  r10 = 203a6e6f  r11 = 0  
r12 = 93071cb250  r13 = 0  r14 = 93071cc0c0  r15 = 0  
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: access-violation D:\Develop\Trilinos\packages\ifpack2\test\belos\build_solver.hpp:40 in build_solver<double, class Tpetra::MultiVector<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Tpetra::Operator<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>>(class Teuchos::ParameterList &, class Teuchos::RCP<class Belos::LinearProblem<double, class Tpetra::MultiVector<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Tpetra::Operator<double, int, __int64, class Tpetra::KokkosCompat::KokkosDeviceWrapperNode<class Kokkos::Serial, class Kokkos::HostSpace>>, class Teuchos::SerialDenseMatrix<int, double>>>)
==110900==ABORTING

   Current_Time: Sep 11 18:30 Russia TZ 2 Standard Time
   Current_Time: Sep 11 18:30 Russia TZ 2 Standard Time
   Current_Time: Sep 11 18:30 Russia TZ 2 Standard Time

0% tests passed, 1 tests failed out of 1

Subproject Time Summary:
Ifpack2    =   0.37 sec*proc (1 test)

Total Test time (real) =   0.50 sec

The following tests FAILED:
	176 - Ifpack2_small_gmres_belos (Failed)                Ifpack2
Errors while running CTest
```

</details>

### After

<details>
  <summary>After fix:</summary>

```log
176: Test command: D:\Develop\Trilinos\bifpack2serial\packages\ifpack2\test\belos\Ifpack2_tif_belos.exe "--xml_file=test_gmres_small_sym_mm.xml"
176: Working Directory: D:/Develop/Trilinos/bifpack2serial/packages/ifpack2/test/belos
   Current_Time: Sep 12 00:51 Russia TZ 2 Standard Time
176: Test timeout computed to be: 1500
176: Every proc reading parameters from xml_file: test_gmres_small_sym_mm.xml
176: Matrix Market file for sparse matrix A: small_sym.mtx
176: 
176: *******************************************************
176: ***** Belos Iterative Solver:  Block Gmres 
176: ***** Maximum Iterations: 1000
176: ***** Block Size: 1
176: ***** Residual Test: 
176: *****   Test 1 : Belos::StatusTestImpResNorm<>: (2-Norm Res Vec) / (2-Norm Prec Res0), tol = 1e-07
176: *******************************************************
176: Iter    0, [ 1] :    1.000000e+00
176: Iter    1, [ 1] :    3.848066e-01
176: Iter    2, [ 1] :    1.927501e-01
176: Iter    3, [ 1] :    1.111079e-01
176: Iter    4, [ 1] :    8.256339e-02
176: Iter    5, [ 1] :    6.135220e-02
176: Iter    6, [ 1] :    3.536555e-02
176: Iter    7, [ 1] :    1.771464e-02
176: Iter    8, [ 1] :    6.816713e-03
176: Iter    9, [ 1] :    2.623116e-03
176: Iter   10, [ 1] :    1.313922e-03
176: Iter   11, [ 1] :    7.573904e-04
176: Iter   12, [ 1] :    5.628109e-04
176: Iter   13, [ 1] :    4.182203e-04
176: Iter   14, [ 1] :    2.410768e-04
176: Iter   15, [ 1] :    1.207556e-04
176: Iter   16, [ 1] :    4.646757e-05
176: Iter   17, [ 1] :    1.788103e-05
176: Iter   18, [ 1] :    8.956628e-06
176: Iter   19, [ 1] :    5.162913e-06
176: Iter   20, [ 1] :    3.836520e-06
176: Iter   21, [ 1] :    2.850888e-06
176: Iter   22, [ 1] :    1.643351e-06
176: Iter   23, [ 1] :    8.231565e-07
176: Iter   24, [ 1] :    3.167561e-07
176: Iter   25, [ 1] :    1.218898e-07
176: Iter   26, [ 1] :    6.105476e-08
176: Converged in 26 iterations.
176: 2-Norm of 0th RHS      vec: 1.28667
176: 2-Norm of 0th residual vec: 7.85574e-08 -> 6.10548e-08
176: Achieved tolerance: 6.10548e-08, Requested tolerance: 1e-07
176: proc 0 total program time: 0.061
176: End Result: TEST PASSED
1/1 Test #176: Ifpack2_small_gmres_belos ........Testing Ifpack2_small_gmres_belos ...    Passed    0.21 sec
   Current_Time: Sep 12 00:51 Russia TZ 2 Standard Time
   Current_Time: Sep 12 00:51 Russia TZ 2 Standard Time
   Current_Time: Sep 12 00:51 Russia TZ 2 Standard Time

The following tests passed:
	Ifpack2_small_gmres_belos

100% tests passed, 0 tests failed out of 1

Subproject Time Summary:
Ifpack2    =   0.21 sec*proc (1 test)

Total Test time (real) =   0.33 sec
```

</details>

### Full

```log
251/251 Test #251: Ifpack2_BlockTriDiLargeBlockJacobir2
95% tests passed, 13 tests failed out of 251

Subproject Time Summary:
Ifpack2    = 143.86 sec*proc (76 tests)
Tpetra     = 223.36 sec*proc (175 tests)

Total Test time (real) = 368.47 sec

The following tests FAILED:
	 35 - TpetraCore_CrsGraph_UnitTests0 (Failed)           Tpetra
	 44 - TpetraCore_CrsMatrix_UnitTests (Failed)           Tpetra
	 45 - TpetraCore_CrsMatrix_UnitTests2 (Failed)          Tpetra
	 47 - TpetraCore_CrsMatrix_UnitTests4 (Failed)          Tpetra
	 48 - TpetraCore_CrsMatrix_NewCopyAndPermute (Failed)   Tpetra
	 54 - TpetraCore_CrsMatrix_WithGraph_Serial (Failed)    Tpetra
	 69 - TpetraCore_Directory_UnitTests (Failed)           Tpetra
	109 - TpetraCore_MultiVector_UnitTests (Failed)         Tpetra
	229 - Ifpack2_unit_tests (Failed)                       Ifpack2
	230 - Ifpack2_AdditiveSchwarz (Failed)                  Ifpack2
	235 - Ifpack2_RILUKSingleProcessUnitTests (Failed)      Ifpack2
	236 - Ifpack2_ILUTSingleProcessUnitTests (Failed)       Ifpack2
	239 - Ifpack2_SolverFactory (Failed)                    Ifpack2
Errors while running CTest
```

As we can see all the `SEGFAULT`s from #15556 are eliminated and we can see clear noise-free output.

Full log (usefull to view other ASan reported issues): [14816-tpetra-solver-factory-dll-registry-after-fix.log](https://github.com/user-attachments/files/32131902/14816-tpetra-solver-factory-dll-registry-after-fix.log).
